### PR TITLE
Polish follow-up prompt and pad interaction

### DIFF
--- a/packages/dyad_core/src/dyad/prompts/prompts.py
+++ b/packages/dyad_core/src/dyad/prompts/prompts.py
@@ -201,22 +201,13 @@ DYAD_BEST_PRACTICES_PAD_PROMPT = """
 
 # AI coding best practices pad
 
-# Guidelines for Generating a Prompting Best Practices Pad
-
 When a user writes a prompt or makes a request, the AI should automatically respond with a dynamic pad containing prompting best practices tailored specifically based on the content and intent of the user's prompt. 
 
-- If the user has written a prompt that is unclear (e.g. "fix this code", "improve this module") - do NOT generate code. 
-do NOT guess what the user wants.
-- If there are MULTIPLE, high-level ways to implement or interpret the  user's request. FIRST ASK which
-option they want. DO NOT START GENERATING CODE UNTIL YOU ARE SURE WHAT THE USER WANTS.
+## Pad Placement
 
-WAIT for the user to give you input before generating code. 
-Instead clarify the user's intent by providing them a few options to select from AND generate this best practice pad
-which teaches them how to write high-quality prompts with good specificity.
+The pad should go at the VERY END of the AI response, after the follow-up prompts (if any).
 
-MAKE SURE YOU DO NOT GENERATE CODE ONCE YOU HAVE ASKED A QUESTION.
-
-### Dynamic Content Rules for the Best Practices Pad
+## Dynamic Content Rules for the Best Practices Pad
 
 1. **Clarity and Specificity:**  
    - Suggest improvements for clearly defining the scope, goals, and requirements of their request.
@@ -337,7 +328,7 @@ You can include follow-up prompts to guide the user on the next steps after they
 Place follow-up prompts in the most logical location based on their purpose:
 
 1. **Mid-response prompts**: Use when presenting different paths for unclear questions or when immediate clarification is needed before proceeding
-2. **End-response prompts**: Use for suggesting next steps, debugging options, or extensions after the main response is complete
+2. **End-response prompts**: Use for suggesting next steps, debugging options, or extensions after the main response is complete. You should place this BEFORE the pad.
 
 ## Format
 

--- a/packages/dyad_core/src/dyad/public/chat_message.py
+++ b/packages/dyad_core/src/dyad/public/chat_message.py
@@ -71,6 +71,7 @@ class Checkpoint(BaseModel):
 
 class ContentError(BaseModel):
     message: str
+    source: Literal["user", "system"] = "system"
 
 
 class LanguageModelCallMetadata(BaseModel):

--- a/src/dyad_app/logic/chat_logic.py
+++ b/src/dyad_app/logic/chat_logic.py
@@ -8,7 +8,7 @@ from dyad.message_cache import message_cache
 from dyad.public.chat_message import (
     ChatMessage,
     Content,
-    ErrorChunk,
+    ContentError,
 )
 from dyad.settings.user_settings import get_user_settings
 from dyad.storage.models.chat import save_chat
@@ -131,7 +131,9 @@ def submit_follow_up_prompt(input: str) -> Generator[None, None, None]:
     """Handles submitting a chat message."""
     state = me.state(State)
     if state.in_progress:
-        return
+        state.is_chat_cancelled = True
+        yield
+        time.sleep(0.15)
     user_message = ChatMessage(role="user", content=Content.from_text(input))
     state.current_chat.add_message(user_message)
     _prepare_chat_state_for_response()
@@ -200,8 +202,8 @@ def _handle_response(
 
     except GeneratorExit:
         # Handle cancellation
-        current_assistant_message.content.children[-1].append_chunk(
-            ErrorChunk(message="Cancelled by user")
+        current_assistant_message.content.children[-1].errors.append(
+            ContentError(message="Cancelled by user", source="user")
         )
     finally:
         message_cache().set(

--- a/src/dyad_app/logic/chat_logic.py
+++ b/src/dyad_app/logic/chat_logic.py
@@ -201,10 +201,14 @@ def _handle_response(
                 yield
 
     except GeneratorExit:
-        # Handle cancellation
-        current_assistant_message.content.children[-1].errors.append(
-            ContentError(message="Cancelled by user", source="user")
-        )
+        if current_assistant_message.content.children:
+            current_assistant_message.content.children[-1].errors.append(
+                ContentError(message="Cancelled by user", source="user")
+            )
+        else:
+            current_assistant_message.content.errors.append(
+                ContentError(message="Cancelled by user", source="user")
+            )
     finally:
         message_cache().set(
             key=current_user_message.id,


### PR DESCRIPTION
- Improve system prompt so pad is always at the bottom
- Clicking on follow-up prompt will cancel ongoing response (e.g. pad is being generated)
- Soften the error UI when user cancels to draw less attention