### PR TITLE
Fix #186 by only fetching normal functions for supabase context

### DIFF
--- a/src/supabase_admin/supabase_schema_query.ts
+++ b/src/supabase_admin/supabase_schema_query.ts
@@ -77,7 +77,7 @@ export const SUPABASE_SCHEMA_QUERY = `
             FROM pg_proc p
             LEFT JOIN pg_description d ON p.oid = d.objoid
             LEFT JOIN pg_language l ON p.prolang = l.oid
-            WHERE p.pronamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'public')
+            WHERE p.pronamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'public') AND p.prokind = 'f' -- 'f' = normal function (otherwise source code fetch fails)
         ),
         triggers_result AS (
             SELECT


### PR DESCRIPTION
Fixes #186, #168.

**From o3:**

pg_get_functiondef (and the helper routines pg_get_function_result / pg_get_function_arguments that you also call) only work for normal SQL, PL/pgSQL, C-language … functions.
If you pass it the OID of an aggregate it raises error 42809:

ERROR : 42809 : "name" is an aggregate function

Your functions_result CTE selects every entry that lives in the schema public and is stored in pg_proc:

FROM pg_proc p
…
WHERE p.pronamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'public')

The PostGIS extension installs its aggregates (ST_Collect, ST_Extent, …) in the
public schema.
Therefore the row that represents the aggregate ST_Collect is returned,
and when pg_get_functiondef(p.oid) is executed on that row PostgreSQL throws

“st_collect” is an aggregate function.

How to avoid the error

Filter pg_proc so that only real functions are processed, e.g.

On PostgreSQL ≥ 11 (recommended):
… WHERE p.pronamespace = (SELECT oid
FROM pg_namespace
WHERE nspname = 'public')
AND p.prokind = 'f'       -- ‘f’ = normal function
…

2. On older versions:

… WHERE p.pronamespace = (SELECT oid
FROM pg_namespace
WHERE nspname = 'public')
AND NOT EXISTS (SELECT 1
FROM pg_aggregate a
WHERE a.aggfnoid = p.oid)

Either condition excludes aggregates, so pg_get_functiondef is only called on
regular functions and the query finishes without error.

