### PR TITLE
Auto-commit extra files

### DIFF
--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -58,7 +58,7 @@ import { useVersions } from "@/hooks/useVersions";
 import { useAttachments } from "@/hooks/useAttachments";
 import { AttachmentsList } from "./AttachmentsList";
 import { DragDropOverlay } from "./DragDropOverlay";
-import { showError, showUncommittedFilesWarning } from "@/lib/toast";
+import { showError, showExtraFilesToast } from "@/lib/toast";
 import { ChatInputControls } from "../ChatInputControls";
 const showTokenBarAtom = atom(false);
 
@@ -183,8 +183,11 @@ export function ChatInput({ chatId }: { chatId?: number }) {
         chatId,
         messageId,
       });
-      if (result.uncommittedFiles) {
-        showUncommittedFilesWarning(result.uncommittedFiles);
+      if (result.extraFiles) {
+        showExtraFilesToast({
+          files: result.extraFiles,
+          error: result.extraFilesError,
+        });
       }
     } catch (err) {
       console.error("Error approving proposal:", err);

--- a/src/components/chat/MessagesList.tsx
+++ b/src/components/chat/MessagesList.tsx
@@ -133,7 +133,6 @@ export const MessagesList = forwardRef<HTMLDivElement, MessagesListProps>(
                     console.error("No chat selected");
                     return;
                   }
-                  debugger;
 
                   setIsRetryLoading(true);
                   try {

--- a/src/components/chat/MessagesList.tsx
+++ b/src/components/chat/MessagesList.tsx
@@ -133,6 +133,7 @@ export const MessagesList = forwardRef<HTMLDivElement, MessagesListProps>(
                     console.error("No chat selected");
                     return;
                   }
+                  debugger;
 
                   setIsRetryLoading(true);
                   try {

--- a/src/hooks/useStreamChat.ts
+++ b/src/hooks/useStreamChat.ts
@@ -14,7 +14,7 @@ import { useChats } from "./useChats";
 import { useLoadApp } from "./useLoadApp";
 import { selectedAppIdAtom } from "@/atoms/appAtoms";
 import { useVersions } from "./useVersions";
-import { showUncommittedFilesWarning } from "@/lib/toast";
+import { showExtraFilesToast } from "@/lib/toast";
 import { useProposal } from "./useProposal";
 import { useSearch } from "@tanstack/react-router";
 import { useRunApp } from "./useRunApp";
@@ -87,8 +87,11 @@ export function useStreamChat({
               setIsPreviewOpen(true);
               refreshAppIframe();
             }
-            if (response.uncommittedFiles) {
-              showUncommittedFilesWarning(response.uncommittedFiles);
+            if (response.extraFiles) {
+              showExtraFilesToast({
+                files: response.extraFiles,
+                error: response.extraFilesError,
+              });
             }
             refreshProposal(chatId);
 

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -535,7 +535,8 @@ This conversation includes one or more image attachments. When the user uploads 
           event.sender.send("chat:response:end", {
             chatId: req.chatId,
             updatedFiles: status.updatedFiles ?? false,
-            uncommittedFiles: status.uncommittedFiles,
+            extraFiles: status.extraFiles,
+            extraFilesError: status.extraFilesError,
           } satisfies ChatResponseEnd);
         } else {
           event.sender.send("chat:response:end", {

--- a/src/ipc/handlers/proposal_handlers.ts
+++ b/src/ipc/handlers/proposal_handlers.ts
@@ -30,6 +30,8 @@ import { extractCodebase } from "../../utils/codebase";
 import { getDyadAppPath } from "../../paths/paths";
 import { withLock } from "../utils/lock_utils";
 import { createLoggedHandler } from "./safe_handle";
+import { ApproveProposalResult } from "../ipc_types";
+
 const logger = log.scope("proposal_handlers");
 const handle = createLoggedHandler(logger);
 // Cache for codebase token counts
@@ -317,9 +319,7 @@ const getProposalHandler = async (
 const approveProposalHandler = async (
   _event: IpcMainInvokeEvent,
   { chatId, messageId }: { chatId: number; messageId: number },
-): Promise<{
-  uncommittedFiles?: string[];
-}> => {
+): Promise<ApproveProposalResult> => {
   // 1. Fetch the specific assistant message
   const messageToApprove = await db.query.messages.findFirst({
     where: and(
@@ -355,7 +355,10 @@ const approveProposalHandler = async (
     );
   }
 
-  return { uncommittedFiles: processResult.uncommittedFiles };
+  return {
+    extraFiles: processResult.extraFiles,
+    extraFilesError: processResult.extraFilesError,
+  };
 };
 
 // Handler to reject a proposal (just update message state)

--- a/src/ipc/ipc_client.ts
+++ b/src/ipc/ipc_client.ts
@@ -26,6 +26,7 @@ import type {
   CreateCustomLanguageModelProviderParams,
   CreateCustomLanguageModelParams,
   DoesReleaseNoteExistParams,
+  ApproveProposalResult,
 } from "./ipc_types";
 import type { ProposalResult } from "@/lib/schemas";
 import { showError } from "@/lib/toast";
@@ -601,9 +602,7 @@ export class IpcClient {
   }: {
     chatId: number;
     messageId: number;
-  }): Promise<{
-    uncommittedFiles?: string[];
-  }> {
+  }): Promise<ApproveProposalResult> {
     return this.ipcRenderer.invoke("approve-proposal", {
       chatId,
       messageId,

--- a/src/ipc/ipc_types.ts
+++ b/src/ipc/ipc_types.ts
@@ -24,7 +24,8 @@ export interface ChatStreamParams {
 export interface ChatResponseEnd {
   chatId: number;
   updatedFiles: boolean;
-  uncommittedFiles?: string[];
+  extraFiles?: string[];
+  extraFilesError?: string;
 }
 
 export interface CreateAppParams {
@@ -184,4 +185,9 @@ export interface CreateCustomLanguageModelParams {
 
 export interface DoesReleaseNoteExistParams {
   version: string;
+}
+
+export interface ApproveProposalResult {
+  extraFiles?: string[];
+  extraFilesError?: string;
 }

--- a/src/lib/toast.ts
+++ b/src/lib/toast.ts
@@ -58,11 +58,23 @@ export const showLoading = <T>(
   });
 };
 
-export const showUncommittedFilesWarning = (files: string[]) => {
-  showWarning(
-    `Some changed files were not committed. Please use git to manually commit them.
+export const showExtraFilesToast = ({
+  files,
+  error,
+}: {
+  files: string[];
+  error?: string;
+}) => {
+  if (error) {
+    showError(
+      `Error committing files ${files.join(", ")} changed outside of Dyad: ${error}`,
+    );
+  } else {
+    showWarning(
+      `Files changed outside of Dyad have automatically been committed:
     \n\n${files.join("\n")}`,
-  );
+    );
+  }
 };
 
 // Re-export for direct use


### PR DESCRIPTION
Whenever Dyad does a commit from a proposal, it will automatically amend the commit with outside changes (e.g. made outside of Dyad).

This helps avoid a lot of user confusion, e.g.
https://github.com/dyad-sh/dyad/issues/187
https://www.reddit.com/r/dyadbuilders/comments/1kjysc0/error_pushing_images/

Edge cases:
If a user adds a file outside of Dyad, and then they hit retry, it will revert these outside changes, but it's still technically in the version history, so I think it's OK. This should also be a pretty unusual situation.

Fixes #164 
Fixes #187