### PR TITLE
feat: Allow chat titles to be renamed

### DIFF
--- a/src/components/ChatList.tsx
+++ b/src/components/ChatList.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
 
 import { formatDistanceToNow } from "date-fns";
-import { PlusCircle, MoreVertical, Trash2 } from "lucide-react";
+import { PlusCircle, MoreVertical, Trash2, FileEdit } from "lucide-react";
 import { useAtom } from "jotai";
 import { selectedChatIdAtom } from "@/atoms/chatAtoms";
 import { selectedAppIdAtom } from "@/atoms/appAtoms";
@@ -90,6 +90,24 @@ export function ChatList({ show }: { show?: boolean }) {
     }
   };
 
+  const handleRenameChat = async (chatId: number) => {
+    const chat = chats.find((c) => c.id === chatId);
+    const currentTitle = chat?.title || "New Chat";
+    const newTitle = window.prompt("Enter new chat name:", currentTitle);
+
+    if (!newTitle) {
+      return; // User cancelled or entered an empty string
+    }
+
+    try {
+      await IpcClient.getInstance().renameChat(chatId, newTitle);
+      showSuccess("Chat renamed successfully");
+      await refreshChats();
+    } catch (error) {
+      showError(`Failed to rename chat: ${(error as any).toString()}`);
+    }
+  };
+
   const handleDeleteChat = async (chatId: number) => {
     try {
       await IpcClient.getInstance().deleteChat(chatId);
@@ -173,6 +191,12 @@ export function ChatList({ show }: { show?: boolean }) {
                           </Button>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end">
+                          <DropdownMenuItem
+                            onClick={() => handleRenameChat(chat.id)}
+                          >
+                            <FileEdit className="mr-2 h-4 w-4" />
+                            <span>Rename Chat</span>
+                          </DropdownMenuItem>
                           <DropdownMenuItem
                             variant="destructive"
                             onClick={() => handleDeleteChat(chat.id)}

--- a/src/ipc/handlers/chat_handlers.ts
+++ b/src/ipc/handlers/chat_handlers.ts
@@ -107,6 +107,16 @@ export function registerChatHandlers() {
     await db.delete(chats).where(eq(chats.id, chatId));
   });
 
+  handle(
+    "rename-chat",
+    async (_, { chatId, newTitle }: { chatId: number; newTitle: string }) => {
+      await db
+        .update(chats)
+        .set({ title: newTitle })
+        .where(eq(chats.id, chatId));
+    },
+  );
+
   handle("delete-messages", async (_, chatId: number): Promise<void> => {
     await db.delete(messages).where(eq(messages.chatId, chatId));
   });

--- a/src/ipc/ipc_client.ts
+++ b/src/ipc/ipc_client.ts
@@ -310,6 +310,13 @@ export class IpcClient {
     await this.ipcRenderer.invoke("delete-chat", chatId);
   }
 
+  public async renameChat(
+    chatId: number,
+    newTitle: string,
+  ): Promise<void> {
+    await this.ipcRenderer.invoke("rename-chat", { chatId, newTitle });
+  }
+
   public async deleteMessages(chatId: number): Promise<void> {
     await this.ipcRenderer.invoke("delete-messages", chatId);
   }


### PR DESCRIPTION
This commit introduces the ability for you to rename chat titles.

Key changes include:
- Added an IPC handler (`rename-chat`) in `src/ipc/handlers/chat_handlers.ts` to update chat titles in the database.
- Updated `IpcClient` in `src/ipc/ipc_client.ts` with a `renameChat` method to invoke the new IPC handler.
- Added a "Rename Chat" option to the overflow menu in `src/components/ChatList.tsx`, including a `FileEdit` icon.
- Implemented the `handleRenameChat` function in `src/components/ChatList.tsx` which:
    - Prompts you for a new chat title using `window.prompt()`.
    - Pre-fills the prompt with the current title or "New Chat".
    - Calls the `renameChat` IPC method.
    - Displays success or error toasts.
    - Refreshes the chat list to reflect the change.
- Ensured all necessary imports are in place.
- Verified functionality through manual review.