### PR TITLE
Use npm install --legacy-peer-deps

### DIFF
--- a/src/ipc/handlers/app_handlers.ts
+++ b/src/ipc/handlers/app_handlers.ts
@@ -69,7 +69,7 @@ async function executeAppLocalNode({
   event: Electron.IpcMainInvokeEvent;
 }): Promise<void> {
   const process = spawn(
-    "(pnpm install --force && pnpm run dev --port 32100) || (npm install --legacy-peer-deps && npm run dev -- --port 32100)",
+    "(pnpm install && pnpm run dev --port 32100) || (npm install --legacy-peer-deps && npm run dev -- --port 32100)",
     [],
     {
       cwd: appPath,

--- a/src/ipc/handlers/app_handlers.ts
+++ b/src/ipc/handlers/app_handlers.ts
@@ -69,7 +69,7 @@ async function executeAppLocalNode({
   event: Electron.IpcMainInvokeEvent;
 }): Promise<void> {
   const process = spawn(
-    "(pnpm install && pnpm run dev --port 32100) || (npm install && npm run dev -- --port 32100)",
+    "(pnpm install --force && pnpm run dev --port 32100) || (npm install --legacy-peer-deps && npm run dev -- --port 32100)",
     [],
     {
       cwd: appPath,

--- a/src/ipc/processors/executeAddDependency.ts
+++ b/src/ipc/processors/executeAddDependency.ts
@@ -19,7 +19,7 @@ export async function executeAddDependency({
   const packageStr = packages.join(" ");
 
   const { stdout, stderr } = await execPromise(
-    `(pnpm add ${packageStr}) || (npm install ${packageStr})`,
+    `(pnpm add ${packageStr}) || (npm install --legacy-peer-deps ${packageStr})`,
     {
       cwd: appPath,
     },


### PR DESCRIPTION
Fixes #309 

Unfortunately a lot of React.js apps have this problem with peer deps because older dependencies specify pre-v19. Because Dyad app templates do (and should) explicitly specify React as a dependnecy, using `--legacy-peer-deps` gives us the right behavior where it effectively does not install peer deps and avoids the React version errors.

For pnpm, we have an explicit lockfiles for our templates so there isn't an issue.

Context: https://stackoverflow.com/questions/66239691/what-does-npm-install-legacy-peer-deps-do-exactly-when-is-it-recommended-wh