### PR TITLE
feat: generate project names from initial prompt

### DIFF
--- a/src/ipc/ipc_types.ts
+++ b/src/ipc/ipc_types.ts
@@ -40,9 +40,11 @@ export interface ChatProblemsEvent {
   problems: ProblemReport;
 }
 
-export interface CreateAppParams {
+export type CreateAppParams = {
   name: string;
-}
+  prompt: string; // create app funtion will now accept the prompt
+  template?: string;
+};
 
 export interface CreateAppResult {
   app: {

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -118,7 +118,8 @@ export default function HomePage() {
       setIsLoading(true);
       // Create the chat and navigate
       const result = await IpcClient.getInstance().createApp({
-        name: generateCuteAppName(),
+        name: generateCuteAppName(), // fallback
+        prompt: inputValue,         // sends the user's prompt to the backend
       });
 
       // Stream the message with attachments

--- a/src/prompts/generate_name_system_prompt.ts
+++ b/src/prompts/generate_name_system_prompt.ts
@@ -1,0 +1,10 @@
+export const GENERATE_NAME_SYSTEM_PROMPT = `
+You are an expert project namer. Based on the user's prompt, suggest a short, descriptive project name.
+The name must be in kebab-case.
+The name should be 2-4 words long.
+Do not provide any other explanation, preamble, or markdown formatting. Only output the name itself.
+
+Example:
+User prompt: "a simple todo list app with a plus button to add tasks"
+Your output: "simple-todo-app"
+`.trim();


### PR DESCRIPTION
The goal of this commit is to implement the requested feature on issue #711 to replace the random name generator with an AI-powered one. The backend now uses the initial user prompt to ask a language model for a descriptive, kebab-case name. The main goal of this code is to help users that use this application heavily like @dank-ubiq have a seamless experience by making projects easy to identify and manage, resolving the issue of a cluttered project list with non-descriptive names.