### PR TITLE
add editable custom model

### DIFF
--- a/e2e-tests/edit_custom_models.spec.ts
+++ b/e2e-tests/edit_custom_models.spec.ts
@@ -1,0 +1,55 @@
+import { test } from "./helpers/test_helper";
+import { expect } from "@playwright/test";
+
+test("edit custom model", async ({ po }) => {
+  await po.setUp();
+  await po.goToSettingsTab();
+  await po.page.getByText("test-provider").click();
+
+  // test edit model by double clicking the model panel
+  await po.page
+    .locator(".text-lg.font-semibold", { hasText: "test-model" })
+    .dblclick({ delay: 100 });
+  await po.page.locator("#edit-model-id").clear();
+  await po.page.locator("#edit-model-id").fill("new-model-id");
+  await po.page.locator("#edit-model-name").clear();
+  await po.page.locator("#edit-model-name").fill("new-model-name");
+  await po.page.getByRole("button", { name: "Update Model" }).click();
+
+  // assert that the model was updated
+  await po.page
+    .locator(".text-lg.font-semibold", { hasText: "new-model-name" })
+    .dblclick({ delay: 100 });
+  await expect(po.page.locator("#edit-model-id")).toHaveValue("new-model-id");
+  await expect(po.page.locator("#edit-model-name")).toHaveValue(
+    "new-model-name",
+  );
+  await po.page.getByRole("button", { name: "Cancel" }).click();
+
+  // test edit model by clicking the edit button
+  await po.page
+    .locator('button svg path[d*="M11 5H6a2"]')
+    .locator("..")
+    .locator("..")
+    .click();
+  await po.page.locator("#edit-model-id").clear();
+  await po.page.locator("#edit-model-id").fill("another-model-id");
+  await po.page.locator("#edit-model-name").clear();
+  await po.page.locator("#edit-model-name").fill("another-model-name");
+  await po.page.getByRole("button", { name: "Update Model" }).click();
+
+  // assert that the model was updated
+  await po.page
+    .locator(".text-lg.font-semibold", { hasText: "another-model-name" })
+    .dblclick({ delay: 100 });
+  await expect(po.page.locator("#edit-model-id")).toHaveValue(
+    "another-model-id",
+  );
+  await expect(po.page.locator("#edit-model-name")).toHaveValue(
+    "another-model-name",
+  );
+  await po.page.getByRole("button", { name: "Cancel" }).click();
+
+  // Make sure UI hasn't freezed
+  await po.goToAppsTab();
+});

--- a/src/components/EditCustomModelDialog.tsx
+++ b/src/components/EditCustomModelDialog.tsx
@@ -1,0 +1,227 @@
+import React, { useState, useEffect } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { IpcClient } from "@/ipc/ipc_client";
+import { useMutation } from "@tanstack/react-query";
+import { showError, showSuccess } from "@/lib/toast";
+
+interface Model {
+  apiName: string;
+  displayName: string;
+  description?: string;
+  maxOutputTokens?: number;
+  contextWindow?: number;
+  type: "cloud" | "custom";
+  tag?: string;
+}
+
+interface EditCustomModelDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+  providerId: string;
+  model: Model | null;
+}
+
+export function EditCustomModelDialog({
+  isOpen,
+  onClose,
+  onSuccess,
+  providerId,
+  model,
+}: EditCustomModelDialogProps) {
+  const [apiName, setApiName] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [description, setDescription] = useState("");
+  const [maxOutputTokens, setMaxOutputTokens] = useState<string>("");
+  const [contextWindow, setContextWindow] = useState<string>("");
+
+  const ipcClient = IpcClient.getInstance();
+
+  useEffect(() => {
+    if (model) {
+      setApiName(model.apiName);
+      setDisplayName(model.displayName);
+      setDescription(model.description || "");
+      setMaxOutputTokens(model.maxOutputTokens?.toString() || "");
+      setContextWindow(model.contextWindow?.toString() || "");
+    }
+  }, [model]);
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!model) throw new Error("No model to edit");
+
+      const params = {
+        oldApiName: model.apiName,
+        apiName,
+        displayName,
+        providerId,
+        description: description || undefined,
+        maxOutputTokens: maxOutputTokens
+          ? parseInt(maxOutputTokens, 10)
+          : undefined,
+        contextWindow: contextWindow ? parseInt(contextWindow, 10) : undefined,
+      };
+
+      if (!params.apiName) throw new Error("Model API name is required");
+      if (!params.displayName)
+        throw new Error("Model display name is required");
+      if (maxOutputTokens && isNaN(params.maxOutputTokens ?? NaN))
+        throw new Error("Max Output Tokens must be a valid number");
+      if (contextWindow && isNaN(params.contextWindow ?? NaN))
+        throw new Error("Context Window must be a valid number");
+
+      await ipcClient.updateCustomLanguageModel(params);
+    },
+    onSuccess: () => {
+      showSuccess("Custom model updated successfully!");
+      resetForm();
+      onSuccess();
+      onClose();
+    },
+    onError: (error) => {
+      showError(error);
+    },
+  });
+
+  const resetForm = () => {
+    setApiName("");
+    setDisplayName("");
+    setDescription("");
+    setMaxOutputTokens("");
+    setContextWindow("");
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    mutation.mutate();
+  };
+
+  const handleClose = () => {
+    if (!mutation.isPending) {
+      resetForm();
+      onClose();
+    }
+  };
+
+  if (!model) return null;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-[525px]">
+        <DialogHeader>
+          <DialogTitle>Edit Custom Model</DialogTitle>
+          <DialogDescription>
+            Modify the configuration of the selected language model.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit}>
+          <div className="grid gap-4 py-4">
+            <div className="grid grid-cols-4 items-center gap-4">
+              <Label htmlFor="edit-model-id" className="text-right">
+                Model ID*
+              </Label>
+              <Input
+                id="edit-model-id"
+                value={apiName}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setApiName(e.target.value)
+                }
+                className="col-span-3"
+                placeholder="This must match the model expected by the API"
+                required
+                disabled={mutation.isPending}
+              />
+            </div>
+            <div className="grid grid-cols-4 items-center gap-4">
+              <Label htmlFor="edit-model-name" className="text-right">
+                Name*
+              </Label>
+              <Input
+                id="edit-model-name"
+                value={displayName}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setDisplayName(e.target.value)
+                }
+                className="col-span-3"
+                placeholder="Human-friendly name for the model"
+                required
+                disabled={mutation.isPending}
+              />
+            </div>
+            <div className="grid grid-cols-4 items-center gap-4">
+              <Label htmlFor="edit-description" className="text-right">
+                Description
+              </Label>
+              <Input
+                id="edit-description"
+                value={description}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setDescription(e.target.value)
+                }
+                className="col-span-3"
+                placeholder="Optional: Describe the model's capabilities"
+                disabled={mutation.isPending}
+              />
+            </div>
+            <div className="grid grid-cols-4 items-center gap-4">
+              <Label htmlFor="edit-max-output-tokens" className="text-right">
+                Max Output Tokens
+              </Label>
+              <Input
+                id="edit-max-output-tokens"
+                type="number"
+                value={maxOutputTokens}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setMaxOutputTokens(e.target.value)
+                }
+                className="col-span-3"
+                placeholder="Optional: e.g., 4096"
+                disabled={mutation.isPending}
+              />
+            </div>
+            <div className="grid grid-cols-4 items-center gap-4">
+              <Label htmlFor="edit-context-window" className="text-right">
+                Context Window
+              </Label>
+              <Input
+                id="edit-context-window"
+                type="number"
+                value={contextWindow}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setContextWindow(e.target.value)
+                }
+                className="col-span-3"
+                placeholder="Optional: e.g., 8192"
+                disabled={mutation.isPending}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleClose}
+              disabled={mutation.isPending}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={mutation.isPending}>
+              {mutation.isPending ? "Updating..." : "Update Model"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/EditCustomModelDialog.tsx
+++ b/src/components/EditCustomModelDialog.tsx
@@ -99,14 +99,6 @@ export function EditCustomModelDialog({
     },
   });
 
-  const resetForm = () => {
-    setApiName("");
-    setDisplayName("");
-    setDescription("");
-    setMaxOutputTokens("");
-    setContextWindow("");
-  };
-
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     mutation.mutate();


### PR DESCRIPTION
Now users can free to edit their custom models by double clicking any custom models created in each provider.
Before this, they have to delete -> create a new one.
I simply add an edit panel (which looks the same as 'Add Custom Model') and integrate that process into the "update" button.

There is one more issue that if a user deletes a model that he was using in chat, then back to chat, that model would still appear (and work) unless user chooses a new one.
Tried to modify "delete-custom-model" in language_model_handlers.ts by the logic that if the name of that model matches the latest using one -> switch to auto (or default) model. Yet I failed, maybe need more explanation for this :)