### PR TITLE
fix: add Node.js version check for capacitor cmds

### DIFF
--- a/src/ipc/handlers/capacitor_handlers.ts
+++ b/src/ipc/handlers/capacitor_handlers.ts
@@ -40,6 +40,17 @@ export function registerCapacitorHandlers() {
     async (_, { appId }: { appId: number }): Promise<boolean> => {
       const app = await getApp(appId);
       const appPath = getDyadAppPath(app.path);
+
+      // check for the required Node.js version before running any commands
+      const currentNodeVersion = process.version; 
+      const majorVersion = parseInt(currentNodeVersion.slice(1).split('.')[0], 10);
+
+      if (majorVersion < 20) {
+        // version is too old? stop and throw a clear error
+        throw new Error(
+          `Capacitor requires Node.js v20 or higher, but you are using ${currentNodeVersion}. Please upgrade your Node.js and try again.`
+        );
+      }
       return isCapacitorInstalled(appPath);
     },
   );

--- a/src/ipc/handlers/capacitor_handlers.ts
+++ b/src/ipc/handlers/capacitor_handlers.ts
@@ -42,13 +42,16 @@ export function registerCapacitorHandlers() {
       const appPath = getDyadAppPath(app.path);
 
       // check for the required Node.js version before running any commands
-      const currentNodeVersion = process.version; 
-      const majorVersion = parseInt(currentNodeVersion.slice(1).split('.')[0], 10);
+      const currentNodeVersion = process.version;
+      const majorVersion = parseInt(
+        currentNodeVersion.slice(1).split(".")[0],
+        10,
+      );
 
       if (majorVersion < 20) {
         // version is too old? stop and throw a clear error
         throw new Error(
-          `Capacitor requires Node.js v20 or higher, but you are using ${currentNodeVersion}. Please upgrade your Node.js and try again.`
+          `Capacitor requires Node.js v20 or higher, but you are using ${currentNodeVersion}. Please upgrade your Node.js and try again.`,
         );
       }
       return isCapacitorInstalled(appPath);


### PR DESCRIPTION
Resolves #787. Prevents crashes when running capacitor commands on a system with an incompatible (older) Node.js version.