### PR TITLE
feat: add .env.example for local development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,8 +12,6 @@ GOOGLE_API_KEY=
 # Set these if you are running local AI models like Ollama or LM Studio.
 # Default for Ollama is http://127.0.0.1:11434
 OLLAMA_HOST=
-LM_STUDIO_BASE_URL=
-
 
 # GitHub Integration (Optional)
 # Needed for features that interact with GitHub repositories.

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,39 @@
+# Environment variables needed for dyad local development.
+# To use, copy this file to a new file named ".env" and fill in your private keys and settings.
+# Your actual .env file should NOT be committed.
+
+# AI Provider API Keys(Optional)
+OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
+GOOGLE_API_KEY=
+
+
+# Local AI Model Configuration (Optional)
+# Set these if you are running local AI models like Ollama or LM Studio.
+# Default for Ollama is http://127.0.0.1:11434
+OLLAMA_HOST=
+LM_STUDIO_BASE_URL=
+
+
+# GitHub Integration (Optional)
+# Needed for features that interact with GitHub repositories.
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+GITHUB_TOKEN=
+
+
+# Apple Notarization (macOS Build Only)
+# Only required if you are building and signing a release version for macOS.
+APPLE_ID=
+APPLE_PASSWORD=
+APPLE_TEAM_ID=
+SM_CODE_SIGNING_CERT_SHA1=
+
+
+# Development & Testing Variables (Advanced)
+# These are typically not needed for standard contribution.
+# NODE_ENV=development
+# E2E_TEST_BUILD=
+# CI=
+# DYAD_ENGINE_URL=
+# DYAD_GATEWAY_URL=


### PR DESCRIPTION
Closes #820; adds a .env.example file to document required environment variables and streamline the setup process for new developers.