### PR TITLE
Add support for LLMGateway integration and models

### DIFF
--- a/src/components/SetupBanner.tsx
+++ b/src/components/SetupBanner.tsx
@@ -267,7 +267,7 @@ export function SetupBanner() {
                         Setup other AI providers
                       </h4>
                       <p className="text-xs text-gray-600 dark:text-gray-400">
-                        OpenAI, Anthropic, OpenRouter and more
+                        OpenAI, Anthropic, OpenRouter, LLMGateway and more
                       </p>
                     </div>
                   </div>

--- a/src/ipc/shared/language_model_helpers.ts
+++ b/src/ipc/shared/language_model_helpers.ts
@@ -149,6 +149,29 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
       contextWindow: 128_000,
     },
   ],
+  llmgateway: [
+    {
+      name: "gpt-4.1",
+      displayName: "GPT-4.1",
+      description: "OpenAI GPT-4.1 via LLMGateway",
+      maxOutputTokens: 32_768,
+      contextWindow: 1_047_576,
+    },
+    {
+      name: "claude-sonnet-4-20250514",
+      displayName: "Claude 4 Sonnet",
+      description: "Anthropic Claude 4 Sonnet via LLMGateway",
+      maxOutputTokens: 16_000,
+      contextWindow: 200_000,
+    },
+    {
+      name: "kimi-k2",
+      displayName: "Kimi K2",
+      description: "Kimi K2 via LLMGateway",
+      maxOutputTokens: 32_000,
+      contextWindow: 131_000,
+    },
+  ],
   auto: [
     {
       name: "auto",
@@ -169,6 +192,7 @@ export const PROVIDER_TO_ENV_VAR: Record<string, string> = {
   anthropic: "ANTHROPIC_API_KEY",
   google: "GEMINI_API_KEY",
   openrouter: "OPENROUTER_API_KEY",
+  llmgateway: "LLMGATEWAY_API_KEY",
 };
 
 export const CLOUD_PROVIDERS: Record<
@@ -203,6 +227,12 @@ export const CLOUD_PROVIDERS: Record<
     hasFreeTier: true,
     websiteUrl: "https://openrouter.ai/settings/keys",
     gatewayPrefix: "openrouter/",
+  },
+  llmgateway: {
+    displayName: "LLMGateway",
+    hasFreeTier: false,
+    websiteUrl: "https://api.llmgateway.io",
+    gatewayPrefix: "llmgateway/",
   },
   auto: {
     displayName: "Dyad",

--- a/src/ipc/utils/get_model_client.ts
+++ b/src/ipc/utils/get_model_client.ts
@@ -219,6 +219,20 @@ function getRegularModelClient(
         backupModelClients: [],
       };
     }
+    case "llmgateway": {
+      const provider = createOpenAICompatible({
+        name: "llmgateway",
+        baseURL: "https://api.llmgateway.io/v1",
+        apiKey,
+      });
+      return {
+        modelClient: {
+          model: provider(model.name),
+          builtinProviderId: providerId,
+        },
+        backupModelClients: [],
+      };
+    }
     case "ollama": {
       // Ollama typically runs locally and doesn't require an API key in the same way
       const provider = createOllama({

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -32,6 +32,7 @@ const providers = [
   "google",
   "auto",
   "openrouter",
+  "llmgateway",
   "ollama",
   "lmstudio",
 ] as const;


### PR DESCRIPTION
We would love to add support for https://github.com/theopenco/llmgateway, a self-hostable & fully open source LLM Gateway which allows anyone to use any model easily, plus deep insights and observability.

fix #845
