### PR TITLE
Add missing app description

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dyad",
   "productName": "dyad",
   "version": "0.16.0",
-  "description": "My Electron application description",
+  "description": "Free, local, open-source AI app builder",
   "main": ".vite/build/main.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The description for the program/app is set to the default placeholder. Making it look like [this](https://imgur.com/a/gsIgSx4) in systems like Linux.

So all I did was adding part of the GitHub description as it. Everything else is okay.

Linked image, tho.
<img width="587" height="141" alt="Screenshot_20250806_102625" src="https://github.com/user-attachments/assets/98764d70-4b07-4978-a91a-d0c69e939433" />