### PR TITLE
fix: Add Node.js version check before dependency install

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,39 @@
+# Environment variables needed for dyad local development.
+# To use, copy this file to a new file named ".env" and fill in your private keys and settings.
+# Your actual .env file should NOT be committed.
+
+# AI Provider API Keys(Optional)
+OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
+GOOGLE_API_KEY=
+
+
+# Local AI Model Configuration (Optional)
+# Set these if you are running local AI models like Ollama or LM Studio.
+# Default for Ollama is http://127.0.0.1:11434
+OLLAMA_HOST=
+LM_STUDIO_BASE_URL=
+
+
+# GitHub Integration (Optional)
+# Needed for features that interact with GitHub repositories.
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+GITHUB_TOKEN=
+
+
+# Apple Notarization (macOS Build Only)
+# Only required if you are building and signing a release version for macOS.
+APPLE_ID=
+APPLE_PASSWORD=
+APPLE_TEAM_ID=
+SM_CODE_SIGNING_CERT_SHA1=
+
+
+# Development & Testing Variables (Advanced)
+# These are typically not needed for standard contribution.
+# NODE_ENV=development
+# E2E_TEST_BUILD=
+# CI=
+# DYAD_ENGINE_URL=
+# DYAD_GATEWAY_URL=

--- a/src/ipc/handlers/app_handlers.ts
+++ b/src/ipc/handlers/app_handlers.ts
@@ -76,6 +76,17 @@ let proxyWorker: Worker | null = null;
 // to find node/pnpm.
 fixPath();
 
+function assertNodeVersionForInstall() {
+  const currentNodeVersion = process.version;
+  const majorVersion = parseInt(currentNodeVersion.slice(1).split('.')[0], 10);
+
+  if (majorVersion < 16) {
+    throw new Error(
+      `This project's dependencies require Node.js v16 or higher, but you are using ${currentNodeVersion}. Please upgrade your Node.js and try again.`
+    );
+  }
+}
+
 async function executeApp({
   appPath,
   appId,
@@ -101,6 +112,9 @@ async function executeAppLocalNode({
   appId: number;
   event: Electron.IpcMainInvokeEvent;
 }): Promise<void> {
+  //call the helper function to check the Node.js version
+  assertNodeVersionForInstall();
+  
   const process = spawn(
     "(pnpm install && pnpm run dev --port 32100) || (npm install --legacy-peer-deps && npm run dev -- --port 32100)",
     [],


### PR DESCRIPTION
Resolves #838; prevents a crash when running `pnpm install` on a system with an incompatible Node.js version.