### PR TITLE
feat(gpt5): support requiresMaxCompletion and fixed temperature handling

### DIFF
--- a/src/ipc/shared/language_model_helpers.ts
+++ b/src/ipc/shared/language_model_helpers.ts
@@ -38,6 +38,22 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
       maxOutputTokens: 32_768,
       contextWindow: 1_047_576,
     },
+    // GPT-5 family (requires max_completion_tokens)
+    {
+      name: "gpt-5",
+      displayName: "GPT 5",
+      description: "OpenAI's latest flagship model",
+      // Use a conservative default; actual effective cap is provider-managed
+      maxOutputTokens: 32_000,
+      contextWindow: 400_000,
+    },
+    {
+      name: "gpt-5-mini",
+      displayName: "GPT 5 Mini",
+      description: "OpenAI's lightweight GPT-5 variant",
+      maxOutputTokens: 32_000,
+      contextWindow: 400_000,
+    },
     // https://platform.openai.com/docs/models/o3-mini
     {
       name: "o3-mini",

--- a/src/ipc/utils/token_utils.ts
+++ b/src/ipc/utils/token_utils.ts
@@ -31,3 +31,35 @@ export async function getMaxTokens(model: LargeLanguageModel) {
   const modelOption = await findLanguageModel(model);
   return modelOption?.maxOutputTokens || DEFAULT_MAX_TOKENS;
 }
+
+/**
+ * Determines if we should use `max_completion_tokens` instead of `max_tokens` for the given model.
+ * Currently applies to OpenAI o-series (o1/o3/o4) and GPT-5 family models.
+ */
+export function requiresMaxCompletionTokens(
+  model: LargeLanguageModel,
+): boolean {
+  if (model.provider !== "openai") return false;
+  const name = model.name.toLowerCase();
+  return (
+    name.startsWith("o1") ||
+    name.startsWith("o3") ||
+    name.startsWith("o4") ||
+    name.startsWith("gpt-5")
+  );
+}
+
+/**
+ * Determines if the model requires using the default temperature (1) and does not accept explicit values.
+ * Applies to OpenAI GPT-5 and o-series.
+ */
+export function requiresDefaultTemperature(model: LargeLanguageModel): boolean {
+  if (model.provider !== "openai") return false;
+  const name = model.name.toLowerCase();
+  return (
+    name.startsWith("gpt-5") ||
+    name.startsWith("o1") ||
+    name.startsWith("o3") ||
+    name.startsWith("o4")
+  );
+}

--- a/src/ipc/utils/token_utils.ts
+++ b/src/ipc/utils/token_utils.ts
@@ -45,8 +45,9 @@ export function requiresMaxCompletionTokens(
     name.startsWith("o1") ||
     name.startsWith("o3") ||
     name.startsWith("o4") ||
-    name.startsWith("gpt-5")
+    (name.startsWith("gpt-5") && !name.includes("nano"))
   );
+}
 }
 
 /**


### PR DESCRIPTION
- Update chat_stream_handlers for GPT-5 token management
- Add token_utils.requiresMaxCompletionTokens
- Expand language_model_helpers for GPT-5 family (except nano) & o1, o3, o4 models

Note: Limited minimal fix to allow GPT-5 usage.
tokens_utils.ts now identifies models for which to apply fix. 
Scope and logic for model identification limited.