### PR TITLE
Add AppImage support

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -3,6 +3,7 @@ import { MakerSquirrel } from "@electron-forge/maker-squirrel";
 import { MakerZIP } from "@electron-forge/maker-zip";
 import { MakerDeb } from "@electron-forge/maker-deb";
 import { MakerRpm } from "@electron-forge/maker-rpm";
+import { MakerAppImage } from "@reforged/maker-appimage";
 import { VitePlugin } from "@electron-forge/plugin-vite";
 import { FusesPlugin } from "@electron-forge/plugin-fuses";
 import { FuseV1Options, FuseVersion } from "@electron/fuses";
@@ -91,6 +92,7 @@ const config: ForgeConfig = {
         mimeType: ["x-scheme-handler/dyad"],
       },
     }),
+    new MakerAppImage({}),
   ],
   publishers: [
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -97,6 +97,7 @@
         "@electron-forge/publisher-github": "^7.8.0",
         "@electron/fuses": "^1.8.0",
         "@playwright/test": "^1.52.0",
+        "@reforged/maker-appimage": "^5.0.0",
         "@testing-library/react": "^16.3.0",
         "@types/better-sqlite3": "^7.6.13",
         "@types/glob": "^8.1.0",
@@ -5590,6 +5591,37 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@reforged/maker-appimage": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@reforged/maker-appimage/-/maker-appimage-5.0.0.tgz",
+      "integrity": "sha512-25nli9nt5MVMRladnoJ3uP5W+2KpND5mzA36rc/Duj/R71oGcOj3t9Uoc/dDmaED8afAEeaSYpVE7VPPe9T54A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@electron-forge/maker-base": "^6.0.0 || ^7.0.0",
+        "@reforged/maker-types": "^1.0.0",
+        "@spacingbat3/lss": "^1.0.0",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=19.0.0 || ^18.11.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/SpacingBat3/ReForged?sponsor=1"
+      }
+    },
+    "node_modules/@reforged/maker-types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@reforged/maker-types/-/maker-types-1.0.1.tgz",
+      "integrity": "sha512-gjLr6O7rS8XzjbqCEo/BxT4mrevWuYKdMzc0uO6dNcWDXinfhJVHT3aEZmtMyn1nx+ZbffzpCFPgGNYZtwGXxQ==",
+      "dev": true,
+      "license": "ISC",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/SpacingBat3/ReForged?sponsor=1"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -5996,6 +6028,13 @@
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
+    },
+    "node_modules/@spacingbat3/lss": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@spacingbat3/lss/-/lss-1.2.0.tgz",
+      "integrity": "sha512-aywhxHNb6l7COooF3m439eT/6QN8E/RSl5IVboSKthMHcp0GlZYMSoS7546rqDLmFRxTD8f1tu/NIS9vtDwYAg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@electron-forge/publisher-github": "^7.8.0",
     "@electron/fuses": "^1.8.0",
     "@playwright/test": "^1.52.0",
+    "@reforged/maker-appimage": "^5.0.0",
     "@testing-library/react": "^16.3.0",
     "@types/better-sqlite3": "^7.6.13",
     "@types/glob": "^8.1.0",

--- a/scripts/verify-release-assets.js
+++ b/scripts/verify-release-assets.js
@@ -74,7 +74,7 @@ async function verifyReleaseAssets() {
           // NuGet removes the dot: 0.14.0-beta.1 -> 0.14.0-beta1
           return version.replace("-beta.", "-beta");
         default:
-          // Windows installer and macOS zips keep original format
+          // Windows installer, macOS zips, and AppImage keep original format
           return version;
       }
     };
@@ -87,6 +87,7 @@ async function verifyReleaseAssets() {
       `dyad-darwin-arm64-${version}.zip`,
       `dyad-darwin-x64-${version}.zip`,
       `dyad_${normalizeVersionForPlatform(version, "deb")}_amd64.deb`,
+      `dyad-${version}-x64.AppImage`,
       "RELEASES",
     ];
 


### PR DESCRIPTION
Resolves #817.

After merging, an AppImage file should appear in every release going forward.

Note that this adds an npm library, [@reforged/maker-appimage](https://github.com/SpacingBat3/ReForged/tree/master/makers/appimage). Electron Forge doesn't support building AppImages by default, so we either need a library (which is the option I chose for this PR) or to write our own maker. The library is still immature according to its author. From what I've tested, though, it seems to work perfectly fine.

I've also added the AppImage file to the expected assets in the `verify-release-assets.js` script, so this shouldn't mess up the `release` GH Action assuming that I've done it correctly. 

Let me know if there are any issues with this; I can definitely revise it if necessary.