### PR TITLE
Disable encryption for e2e tests

### DIFF
--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -6,6 +6,7 @@ import { safeStorage } from "electron";
 import { v4 as uuidv4 } from "uuid";
 import log from "electron-log";
 import { DEFAULT_TEMPLATE_ID } from "@/shared/templates";
+import { IS_TEST_BUILD } from "@/ipc/utils/test_utils";
 
 const logger = log.scope("settings");
 
@@ -179,7 +180,7 @@ export function writeSettings(settings: Partial<UserSettings>): void {
 }
 
 export function encrypt(data: string): Secret {
-  if (safeStorage.isEncryptionAvailable()) {
+  if (safeStorage.isEncryptionAvailable() && !IS_TEST_BUILD) {
     return {
       value: safeStorage.encryptString(data).toString("base64"),
       encryptionType: "electron-safe-storage",


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Disable Electron safeStorage encryption in test builds so e2e runs are consistent and don’t require the OS keychain. Added an IS_TEST_BUILD guard in encrypt() to force the unencrypted fallback during tests.

<!-- End of auto-generated description by cubic. -->

