### PR TITLE
update contributing.md so that it refers to the architecture doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,9 @@ Dyad is still a very early-stage project, thus the codebase is rapidly changing.
 
 Before opening a pull request, please open an issue and discuss whether the change makes sense in Dyad. Ensuring a cohesive user experience sometimes means we can't include every possible feature or we need to consider the long-term design of how we want to support a feature area.
 
+For a high-level overview of how Dyad works, please see the [Architecture Guide](./docs/architecture.md). Understanding the architecture will help ensure your contributions align with the overall design of the project.
+
+
 ## More than code contributions
 
 Something that I really appreciate are all the non-code contributions, such as reporting bugs, writing feature requests and participating on [Dyad's sub-reddit](https://www.reddit.com/r/dyadbuilders).


### PR DESCRIPTION
This PR adds a reference to the architecture doc in contributing.md .
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a link to the Architecture Guide in CONTRIBUTING.md to give contributors a high-level overview and ensure changes align with the project architecture.

<!-- End of auto-generated description by cubic. -->

