### PR TITLE
fix text overflow in chat messages

### DIFF
--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -104,7 +104,7 @@ const ChatMessage = ({ message, isLastMessage }: ChatMessageProps) => {
             </div>
           ) : (
             <div
-              className="prose dark:prose-invert prose-headings:mb-2 prose-p:my-1 prose-pre:my-0 max-w-none"
+              className="prose dark:prose-invert prose-headings:mb-2 prose-p:my-1 prose-pre:my-0 max-w-none break-words"
               suppressHydrationWarning
             >
               {message.role === "assistant" ? (


### PR DESCRIPTION
This PR fixes the issue #1072 where long words in chat messages overflow outside the message container.  
The fix applies Tailwind’s `break-words` utility to ensure that overly long words wrap properly within the chat bubble.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes text overflow in chat messages by adding Tailwind’s break-words to the message content. Long words and URLs now wrap inside the bubble instead of spilling out.

<!-- End of auto-generated description by cubic. -->

