### PR TITLE
style(chat): solve the issue where the SetupBanner is cut off

### DIFF
--- a/src/components/chat/MessagesList.tsx
+++ b/src/components/chat/MessagesList.tsx
@@ -53,7 +53,7 @@ export const MessagesList = forwardRef<HTMLDivElement, MessagesListProps>(
           ))
         ) : (
           <div className="flex flex-col items-center justify-center h-full max-w-2xl mx-auto">
-            <div className="flex items-center justify-center h-full text-gray-500">
+            <div className="flex flex-1 items-center justify-center text-gray-500">
               No messages yet
             </div>
             {!isAnyProviderSetup() && <SetupBanner />}


### PR DESCRIPTION
Fixes #1077 
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix the SetupBanner being cut off in the empty chat state. The placeholder message now uses flex-1 instead of h-full so the banner renders fully.

<!-- End of auto-generated description by cubic. -->

