### PR TITLE
Read JSON

### DIFF
--- a/e2e-tests/fixtures/import-app/context-manage/manual/baz.json
+++ b/e2e-tests/fixtures/import-app/context-manage/manual/baz.json
@@ -1,1 +1,1 @@
-["should not be included b/c it's json"]
+["even json is included"]

--- a/e2e-tests/snapshots/context_manage.spec.ts_exclude-paths-basic
+++ b/e2e-tests/snapshots/context_manage.spec.ts_exclude-paths-basic
@@ -46,7 +46,8 @@ You need to first add Supabase to your app and then we can add auth.
 ===
 role: user
 message: This is my codebase. <dyad-file path="manual/baz.json">
-// File contents excluded from context
+["even json is included"]
+
 </dyad-file>
 
 <dyad-file path="manual/file.ts">

--- a/e2e-tests/snapshots/context_manage.spec.ts_exclude-paths-precedence
+++ b/e2e-tests/snapshots/context_manage.spec.ts_exclude-paths-precedence
@@ -46,7 +46,8 @@ You need to first add Supabase to your app and then we can add auth.
 ===
 role: user
 message: This is my codebase. <dyad-file path="manual/baz.json">
-// File contents excluded from context
+["even json is included"]
+
 </dyad-file>
 
 <dyad-file path="manual/file.ts">

--- a/e2e-tests/snapshots/context_manage.spec.ts_manage-context---smart-context---auto-includes-only-1.txt
+++ b/e2e-tests/snapshots/context_manage.spec.ts_manage-context---smart-context---auto-includes-only-1.txt
@@ -48,7 +48,7 @@
         },
         {
           "path": "manual/baz.json",
-          "content": "// File contents excluded from context",
+          "content": "[\"even json is included\"]\n",
           "force": true
         },
         {

--- a/e2e-tests/snapshots/context_manage.spec.ts_manage-context---smart-context-1.txt
+++ b/e2e-tests/snapshots/context_manage.spec.ts_manage-context---smart-context-1.txt
@@ -28,7 +28,7 @@
         },
         {
           "path": "manual/baz.json",
-          "content": "// File contents excluded from context",
+          "content": "[\"even json is included\"]\n",
           "force": true
         },
         {

--- a/e2e-tests/snapshots/context_manage.spec.ts_manage-context---smart-context-4.txt
+++ b/e2e-tests/snapshots/context_manage.spec.ts_manage-context---smart-context-4.txt
@@ -64,7 +64,7 @@
         },
         {
           "path": "manual/baz.json",
-          "content": "// File contents excluded from context",
+          "content": "[\"even json is included\"]\n",
           "force": false
         },
         {

--- a/e2e-tests/snapshots/engine.spec.ts_regular-auto-should-send-message-to-engine-1.txt
+++ b/e2e-tests/snapshots/engine.spec.ts_regular-auto-should-send-message-to-engine-1.txt
@@ -33,7 +33,7 @@
         },
         {
           "path": "components.json",
-          "content": "// File contents excluded from context",
+          "content": "{\n  \"$schema\": \"https://ui.shadcn.com/schema.json\",\n  \"style\": \"default\",\n  \"rsc\": false,\n  \"tsx\": true,\n  \"tailwind\": {\n    \"config\": \"tailwind.config.ts\",\n    \"css\": \"src/index.css\",\n    \"baseColor\": \"slate\",\n    \"cssVariables\": true,\n    \"prefix\": \"\"\n  },\n  \"aliases\": {\n    \"components\": \"@/components\",\n    \"utils\": \"@/lib/utils\",\n    \"ui\": \"@/components/ui\",\n    \"lib\": \"@/lib\",\n    \"hooks\": \"@/hooks\"\n  }\n}\n",
           "force": false
         },
         {
@@ -388,17 +388,17 @@
         },
         {
           "path": "tsconfig.app.json",
-          "content": "// File contents excluded from context",
+          "content": "{\n  \"compilerOptions\": {\n    \"target\": \"ES2020\",\n    \"useDefineForClassFields\": true,\n    \"lib\": [\"ES2020\", \"DOM\", \"DOM.Iterable\"],\n    \"module\": \"ESNext\",\n    \"skipLibCheck\": true,\n\n    /* Bundler mode */\n    \"moduleResolution\": \"bundler\",\n    \"allowImportingTsExtensions\": true,\n    \"isolatedModules\": true,\n    \"moduleDetection\": \"force\",\n    \"noEmit\": true,\n    \"jsx\": \"react-jsx\",\n\n    /* Linting */\n    \"strict\": false,\n    \"noUnusedLocals\": false,\n    \"noUnusedParameters\": false,\n    \"noImplicitAny\": false,\n    \"noFallthroughCasesInSwitch\": false,\n\n    \"baseUrl\": \".\",\n    \"paths\": {\n      \"@/*\": [\"./src/*\"]\n    }\n  },\n  \"include\": [\"src\"]\n}\n",
           "force": false
         },
         {
           "path": "tsconfig.json",
-          "content": "// File contents excluded from context",
+          "content": "{\n  \"files\": [],\n  \"references\": [\n    { \"path\": \"./tsconfig.app.json\" },\n    { \"path\": \"./tsconfig.node.json\" }\n  ],\n  \"compilerOptions\": {\n    \"baseUrl\": \".\",\n    \"paths\": {\n      \"@/*\": [\"./src/*\"]\n    },\n    \"noImplicitAny\": false,\n    \"noUnusedParameters\": false,\n    \"skipLibCheck\": true,\n    \"allowJs\": true,\n    \"noUnusedLocals\": false,\n    \"strictNullChecks\": false\n  }\n}\n",
           "force": false
         },
         {
           "path": "tsconfig.node.json",
-          "content": "// File contents excluded from context",
+          "content": "{\n  \"compilerOptions\": {\n    \"target\": \"ES2022\",\n    \"lib\": [\"ES2023\"],\n    \"module\": \"ESNext\",\n    \"skipLibCheck\": true,\n\n    /* Bundler mode */\n    \"moduleResolution\": \"bundler\",\n    \"allowImportingTsExtensions\": true,\n    \"isolatedModules\": true,\n    \"moduleDetection\": \"force\",\n    \"noEmit\": true,\n\n    /* Linting */\n    \"strict\": true,\n    \"noUnusedLocals\": false,\n    \"noUnusedParameters\": false,\n    \"noFallthroughCasesInSwitch\": true\n  },\n  \"include\": [\"vite.config.ts\"]\n}\n",
           "force": false
         },
         {

--- a/e2e-tests/snapshots/engine.spec.ts_send-message-to-engine---anthropic-claude-sonnet-4-1.txt
+++ b/e2e-tests/snapshots/engine.spec.ts_send-message-to-engine---anthropic-claude-sonnet-4-1.txt
@@ -28,7 +28,7 @@
         },
         {
           "path": "components.json",
-          "content": "// File contents excluded from context",
+          "content": "{\n  \"$schema\": \"https://ui.shadcn.com/schema.json\",\n  \"style\": \"default\",\n  \"rsc\": false,\n  \"tsx\": true,\n  \"tailwind\": {\n    \"config\": \"tailwind.config.ts\",\n    \"css\": \"src/index.css\",\n    \"baseColor\": \"slate\",\n    \"cssVariables\": true,\n    \"prefix\": \"\"\n  },\n  \"aliases\": {\n    \"components\": \"@/components\",\n    \"utils\": \"@/lib/utils\",\n    \"ui\": \"@/components/ui\",\n    \"lib\": \"@/lib\",\n    \"hooks\": \"@/hooks\"\n  }\n}\n",
           "force": false
         },
         {
@@ -383,17 +383,17 @@
         },
         {
           "path": "tsconfig.app.json",
-          "content": "// File contents excluded from context",
+          "content": "{\n  \"compilerOptions\": {\n    \"target\": \"ES2020\",\n    \"useDefineForClassFields\": true,\n    \"lib\": [\"ES2020\", \"DOM\", \"DOM.Iterable\"],\n    \"module\": \"ESNext\",\n    \"skipLibCheck\": true,\n\n    /* Bundler mode */\n    \"moduleResolution\": \"bundler\",\n    \"allowImportingTsExtensions\": true,\n    \"isolatedModules\": true,\n    \"moduleDetection\": \"force\",\n    \"noEmit\": true,\n    \"jsx\": \"react-jsx\",\n\n    /* Linting */\n    \"strict\": false,\n    \"noUnusedLocals\": false,\n    \"noUnusedParameters\": false,\n    \"noImplicitAny\": false,\n    \"noFallthroughCasesInSwitch\": false,\n\n    \"baseUrl\": \".\",\n    \"paths\": {\n      \"@/*\": [\"./src/*\"]\n    }\n  },\n  \"include\": [\"src\"]\n}\n",
           "force": false
         },
         {
           "path": "tsconfig.json",
-          "content": "// File contents excluded from context",
+          "content": "{\n  \"files\": [],\n  \"references\": [\n    { \"path\": \"./tsconfig.app.json\" },\n    { \"path\": \"./tsconfig.node.json\" }\n  ],\n  \"compilerOptions\": {\n    \"baseUrl\": \".\",\n    \"paths\": {\n      \"@/*\": [\"./src/*\"]\n    },\n    \"noImplicitAny\": false,\n    \"noUnusedParameters\": false,\n    \"skipLibCheck\": true,\n    \"allowJs\": true,\n    \"noUnusedLocals\": false,\n    \"strictNullChecks\": false\n  }\n}\n",
           "force": false
         },
         {
           "path": "tsconfig.node.json",
-          "content": "// File contents excluded from context",
+          "content": "{\n  \"compilerOptions\": {\n    \"target\": \"ES2022\",\n    \"lib\": [\"ES2023\"],\n    \"module\": \"ESNext\",\n    \"skipLibCheck\": true,\n\n    /* Bundler mode */\n    \"moduleResolution\": \"bundler\",\n    \"allowImportingTsExtensions\": true,\n    \"isolatedModules\": true,\n    \"moduleDetection\": \"force\",\n    \"noEmit\": true,\n\n    /* Linting */\n    \"strict\": true,\n    \"noUnusedLocals\": false,\n    \"noUnusedParameters\": false,\n    \"noFallthroughCasesInSwitch\": true\n  },\n  \"include\": [\"vite.config.ts\"]\n}\n",
           "force": false
         },
         {

--- a/e2e-tests/snapshots/engine.spec.ts_send-message-to-engine---openai-gpt-4-1-1.txt
+++ b/e2e-tests/snapshots/engine.spec.ts_send-message-to-engine---openai-gpt-4-1-1.txt
@@ -29,7 +29,7 @@
         },
         {
           "path": "components.json",
-          "content": "// File contents excluded from context",
+          "content": "{\n  \"$schema\": \"https://ui.shadcn.com/schema.json\",\n  \"style\": \"default\",\n  \"rsc\": false,\n  \"tsx\": true,\n  \"tailwind\": {\n    \"config\": \"tailwind.config.ts\",\n    \"css\": \"src/index.css\",\n    \"baseColor\": \"slate\",\n    \"cssVariables\": true,\n    \"prefix\": \"\"\n  },\n  \"aliases\": {\n    \"components\": \"@/components\",\n    \"utils\": \"@/lib/utils\",\n    \"ui\": \"@/components/ui\",\n    \"lib\": \"@/lib\",\n    \"hooks\": \"@/hooks\"\n  }\n}\n",
           "force": false
         },
         {
@@ -384,17 +384,17 @@
         },
         {
           "path": "tsconfig.app.json",
-          "content": "// File contents excluded from context",
+          "content": "{\n  \"compilerOptions\": {\n    \"target\": \"ES2020\",\n    \"useDefineForClassFields\": true,\n    \"lib\": [\"ES2020\", \"DOM\", \"DOM.Iterable\"],\n    \"module\": \"ESNext\",\n    \"skipLibCheck\": true,\n\n    /* Bundler mode */\n    \"moduleResolution\": \"bundler\",\n    \"allowImportingTsExtensions\": true,\n    \"isolatedModules\": true,\n    \"moduleDetection\": \"force\",\n    \"noEmit\": true,\n    \"jsx\": \"react-jsx\",\n\n    /* Linting */\n    \"strict\": false,\n    \"noUnusedLocals\": false,\n    \"noUnusedParameters\": false,\n    \"noImplicitAny\": false,\n    \"noFallthroughCasesInSwitch\": false,\n\n    \"baseUrl\": \".\",\n    \"paths\": {\n      \"@/*\": [\"./src/*\"]\n    }\n  },\n  \"include\": [\"src\"]\n}\n",
           "force": false
         },
         {
           "path": "tsconfig.json",
-          "content": "// File contents excluded from context",
+          "content": "{\n  \"files\": [],\n  \"references\": [\n    { \"path\": \"./tsconfig.app.json\" },\n    { \"path\": \"./tsconfig.node.json\" }\n  ],\n  \"compilerOptions\": {\n    \"baseUrl\": \".\",\n    \"paths\": {\n      \"@/*\": [\"./src/*\"]\n    },\n    \"noImplicitAny\": false,\n    \"noUnusedParameters\": false,\n    \"skipLibCheck\": true,\n    \"allowJs\": true,\n    \"noUnusedLocals\": false,\n    \"strictNullChecks\": false\n  }\n}\n",
           "force": false
         },
         {
           "path": "tsconfig.node.json",
-          "content": "// File contents excluded from context",
+          "content": "{\n  \"compilerOptions\": {\n    \"target\": \"ES2022\",\n    \"lib\": [\"ES2023\"],\n    \"module\": \"ESNext\",\n    \"skipLibCheck\": true,\n\n    /* Bundler mode */\n    \"moduleResolution\": \"bundler\",\n    \"allowImportingTsExtensions\": true,\n    \"isolatedModules\": true,\n    \"moduleDetection\": \"force\",\n    \"noEmit\": true,\n\n    /* Linting */\n    \"strict\": true,\n    \"noUnusedLocals\": false,\n    \"noUnusedParameters\": false,\n    \"noFallthroughCasesInSwitch\": true\n  },\n  \"include\": [\"vite.config.ts\"]\n}\n",
           "force": false
         },
         {

--- a/e2e-tests/snapshots/engine.spec.ts_send-message-to-engine---smart-context-balanced-1.txt
+++ b/e2e-tests/snapshots/engine.spec.ts_send-message-to-engine---smart-context-balanced-1.txt
@@ -33,7 +33,7 @@
         },
         {
           "path": "components.json",
-          "content": "// File contents excluded from context",
+          "content": "{\n  \"$schema\": \"https://ui.shadcn.com/schema.json\",\n  \"style\": \"default\",\n  \"rsc\": false,\n  \"tsx\": true,\n  \"tailwind\": {\n    \"config\": \"tailwind.config.ts\",\n    \"css\": \"src/index.css\",\n    \"baseColor\": \"slate\",\n    \"cssVariables\": true,\n    \"prefix\": \"\"\n  },\n  \"aliases\": {\n    \"components\": \"@/components\",\n    \"utils\": \"@/lib/utils\",\n    \"ui\": \"@/components/ui\",\n    \"lib\": \"@/lib\",\n    \"hooks\": \"@/hooks\"\n  }\n}\n",
           "force": false
         },
         {
@@ -388,17 +388,17 @@
         },
         {
           "path": "tsconfig.app.json",
-          "content": "// File contents excluded from context",
+          "content": "{\n  \"compilerOptions\": {\n    \"target\": \"ES2020\",\n    \"useDefineForClassFields\": true,\n    \"lib\": [\"ES2020\", \"DOM\", \"DOM.Iterable\"],\n    \"module\": \"ESNext\",\n    \"skipLibCheck\": true,\n\n    /* Bundler mode */\n    \"moduleResolution\": \"bundler\",\n    \"allowImportingTsExtensions\": true,\n    \"isolatedModules\": true,\n    \"moduleDetection\": \"force\",\n    \"noEmit\": true,\n    \"jsx\": \"react-jsx\",\n\n    /* Linting */\n    \"strict\": false,\n    \"noUnusedLocals\": false,\n    \"noUnusedParameters\": false,\n    \"noImplicitAny\": false,\n    \"noFallthroughCasesInSwitch\": false,\n\n    \"baseUrl\": \".\",\n    \"paths\": {\n      \"@/*\": [\"./src/*\"]\n    }\n  },\n  \"include\": [\"src\"]\n}\n",
           "force": false
         },
         {
           "path": "tsconfig.json",
-          "content": "// File contents excluded from context",
+          "content": "{\n  \"files\": [],\n  \"references\": [\n    { \"path\": \"./tsconfig.app.json\" },\n    { \"path\": \"./tsconfig.node.json\" }\n  ],\n  \"compilerOptions\": {\n    \"baseUrl\": \".\",\n    \"paths\": {\n      \"@/*\": [\"./src/*\"]\n    },\n    \"noImplicitAny\": false,\n    \"noUnusedParameters\": false,\n    \"skipLibCheck\": true,\n    \"allowJs\": true,\n    \"noUnusedLocals\": false,\n    \"strictNullChecks\": false\n  }\n}\n",
           "force": false
         },
         {
           "path": "tsconfig.node.json",
-          "content": "// File contents excluded from context",
+          "content": "{\n  \"compilerOptions\": {\n    \"target\": \"ES2022\",\n    \"lib\": [\"ES2023\"],\n    \"module\": \"ESNext\",\n    \"skipLibCheck\": true,\n\n    /* Bundler mode */\n    \"moduleResolution\": \"bundler\",\n    \"allowImportingTsExtensions\": true,\n    \"isolatedModules\": true,\n    \"moduleDetection\": \"force\",\n    \"noEmit\": true,\n\n    /* Linting */\n    \"strict\": true,\n    \"noUnusedLocals\": false,\n    \"noUnusedParameters\": false,\n    \"noFallthroughCasesInSwitch\": true\n  },\n  \"include\": [\"vite.config.ts\"]\n}\n",
           "force": false
         },
         {

--- a/e2e-tests/snapshots/engine.spec.ts_send-message-to-engine-1.txt
+++ b/e2e-tests/snapshots/engine.spec.ts_send-message-to-engine-1.txt
@@ -33,7 +33,7 @@
         },
         {
           "path": "components.json",
-          "content": "// File contents excluded from context",
+          "content": "{\n  \"$schema\": \"https://ui.shadcn.com/schema.json\",\n  \"style\": \"default\",\n  \"rsc\": false,\n  \"tsx\": true,\n  \"tailwind\": {\n    \"config\": \"tailwind.config.ts\",\n    \"css\": \"src/index.css\",\n    \"baseColor\": \"slate\",\n    \"cssVariables\": true,\n    \"prefix\": \"\"\n  },\n  \"aliases\": {\n    \"components\": \"@/components\",\n    \"utils\": \"@/lib/utils\",\n    \"ui\": \"@/components/ui\",\n    \"lib\": \"@/lib\",\n    \"hooks\": \"@/hooks\"\n  }\n}\n",
           "force": false
         },
         {
@@ -388,17 +388,17 @@
         },
         {
           "path": "tsconfig.app.json",
-          "content": "// File contents excluded from context",
+          "content": "{\n  \"compilerOptions\": {\n    \"target\": \"ES2020\",\n    \"useDefineForClassFields\": true,\n    \"lib\": [\"ES2020\", \"DOM\", \"DOM.Iterable\"],\n    \"module\": \"ESNext\",\n    \"skipLibCheck\": true,\n\n    /* Bundler mode */\n    \"moduleResolution\": \"bundler\",\n    \"allowImportingTsExtensions\": true,\n    \"isolatedModules\": true,\n    \"moduleDetection\": \"force\",\n    \"noEmit\": true,\n    \"jsx\": \"react-jsx\",\n\n    /* Linting */\n    \"strict\": false,\n    \"noUnusedLocals\": false,\n    \"noUnusedParameters\": false,\n    \"noImplicitAny\": false,\n    \"noFallthroughCasesInSwitch\": false,\n\n    \"baseUrl\": \".\",\n    \"paths\": {\n      \"@/*\": [\"./src/*\"]\n    }\n  },\n  \"include\": [\"src\"]\n}\n",
           "force": false
         },
         {
           "path": "tsconfig.json",
-          "content": "// File contents excluded from context",
+          "content": "{\n  \"files\": [],\n  \"references\": [\n    { \"path\": \"./tsconfig.app.json\" },\n    { \"path\": \"./tsconfig.node.json\" }\n  ],\n  \"compilerOptions\": {\n    \"baseUrl\": \".\",\n    \"paths\": {\n      \"@/*\": [\"./src/*\"]\n    },\n    \"noImplicitAny\": false,\n    \"noUnusedParameters\": false,\n    \"skipLibCheck\": true,\n    \"allowJs\": true,\n    \"noUnusedLocals\": false,\n    \"strictNullChecks\": false\n  }\n}\n",
           "force": false
         },
         {
           "path": "tsconfig.node.json",
-          "content": "// File contents excluded from context",
+          "content": "{\n  \"compilerOptions\": {\n    \"target\": \"ES2022\",\n    \"lib\": [\"ES2023\"],\n    \"module\": \"ESNext\",\n    \"skipLibCheck\": true,\n\n    /* Bundler mode */\n    \"moduleResolution\": \"bundler\",\n    \"allowImportingTsExtensions\": true,\n    \"isolatedModules\": true,\n    \"moduleDetection\": \"force\",\n    \"noEmit\": true,\n\n    /* Linting */\n    \"strict\": true,\n    \"noUnusedLocals\": false,\n    \"noUnusedParameters\": false,\n    \"noFallthroughCasesInSwitch\": true\n  },\n  \"include\": [\"vite.config.ts\"]\n}\n",
           "force": false
         },
         {

--- a/e2e-tests/snapshots/engine.spec.ts_smart-auto-should-send-message-to-engine-1.txt
+++ b/e2e-tests/snapshots/engine.spec.ts_smart-auto-should-send-message-to-engine-1.txt
@@ -33,7 +33,7 @@
         },
         {
           "path": "components.json",
-          "content": "// File contents excluded from context",
+          "content": "{\n  \"$schema\": \"https://ui.shadcn.com/schema.json\",\n  \"style\": \"default\",\n  \"rsc\": false,\n  \"tsx\": true,\n  \"tailwind\": {\n    \"config\": \"tailwind.config.ts\",\n    \"css\": \"src/index.css\",\n    \"baseColor\": \"slate\",\n    \"cssVariables\": true,\n    \"prefix\": \"\"\n  },\n  \"aliases\": {\n    \"components\": \"@/components\",\n    \"utils\": \"@/lib/utils\",\n    \"ui\": \"@/components/ui\",\n    \"lib\": \"@/lib\",\n    \"hooks\": \"@/hooks\"\n  }\n}\n",
           "force": false
         },
         {
@@ -388,17 +388,17 @@
         },
         {
           "path": "tsconfig.app.json",
-          "content": "// File contents excluded from context",
+          "content": "{\n  \"compilerOptions\": {\n    \"target\": \"ES2020\",\n    \"useDefineForClassFields\": true,\n    \"lib\": [\"ES2020\", \"DOM\", \"DOM.Iterable\"],\n    \"module\": \"ESNext\",\n    \"skipLibCheck\": true,\n\n    /* Bundler mode */\n    \"moduleResolution\": \"bundler\",\n    \"allowImportingTsExtensions\": true,\n    \"isolatedModules\": true,\n    \"moduleDetection\": \"force\",\n    \"noEmit\": true,\n    \"jsx\": \"react-jsx\",\n\n    /* Linting */\n    \"strict\": false,\n    \"noUnusedLocals\": false,\n    \"noUnusedParameters\": false,\n    \"noImplicitAny\": false,\n    \"noFallthroughCasesInSwitch\": false,\n\n    \"baseUrl\": \".\",\n    \"paths\": {\n      \"@/*\": [\"./src/*\"]\n    }\n  },\n  \"include\": [\"src\"]\n}\n",
           "force": false
         },
         {
           "path": "tsconfig.json",
-          "content": "// File contents excluded from context",
+          "content": "{\n  \"files\": [],\n  \"references\": [\n    { \"path\": \"./tsconfig.app.json\" },\n    { \"path\": \"./tsconfig.node.json\" }\n  ],\n  \"compilerOptions\": {\n    \"baseUrl\": \".\",\n    \"paths\": {\n      \"@/*\": [\"./src/*\"]\n    },\n    \"noImplicitAny\": false,\n    \"noUnusedParameters\": false,\n    \"skipLibCheck\": true,\n    \"allowJs\": true,\n    \"noUnusedLocals\": false,\n    \"strictNullChecks\": false\n  }\n}\n",
           "force": false
         },
         {
           "path": "tsconfig.node.json",
-          "content": "// File contents excluded from context",
+          "content": "{\n  \"compilerOptions\": {\n    \"target\": \"ES2022\",\n    \"lib\": [\"ES2023\"],\n    \"module\": \"ESNext\",\n    \"skipLibCheck\": true,\n\n    /* Bundler mode */\n    \"moduleResolution\": \"bundler\",\n    \"allowImportingTsExtensions\": true,\n    \"isolatedModules\": true,\n    \"moduleDetection\": \"force\",\n    \"noEmit\": true,\n\n    /* Linting */\n    \"strict\": true,\n    \"noUnusedLocals\": false,\n    \"noUnusedParameters\": false,\n    \"noFallthroughCasesInSwitch\": true\n  },\n  \"include\": [\"vite.config.ts\"]\n}\n",
           "force": false
         },
         {

--- a/e2e-tests/snapshots/thinking_budget.spec.ts_thinking-budget-2.txt
+++ b/e2e-tests/snapshots/thinking_budget.spec.ts_thinking-budget-2.txt
@@ -41,7 +41,7 @@
         },
         {
           "path": "components.json",
-          "content": "// File contents excluded from context",
+          "content": "{\n  \"$schema\": \"https://ui.shadcn.com/schema.json\",\n  \"style\": \"default\",\n  \"rsc\": false,\n  \"tsx\": true,\n  \"tailwind\": {\n    \"config\": \"tailwind.config.ts\",\n    \"css\": \"src/index.css\",\n    \"baseColor\": \"slate\",\n    \"cssVariables\": true,\n    \"prefix\": \"\"\n  },\n  \"aliases\": {\n    \"components\": \"@/components\",\n    \"utils\": \"@/lib/utils\",\n    \"ui\": \"@/components/ui\",\n    \"lib\": \"@/lib\",\n    \"hooks\": \"@/hooks\"\n  }\n}\n",
           "force": false
         },
         {
@@ -396,17 +396,17 @@
         },
         {
           "path": "tsconfig.app.json",
-          "content": "// File contents excluded from context",
+          "content": "{\n  \"compilerOptions\": {\n    \"target\": \"ES2020\",\n    \"useDefineForClassFields\": true,\n    \"lib\": [\"ES2020\", \"DOM\", \"DOM.Iterable\"],\n    \"module\": \"ESNext\",\n    \"skipLibCheck\": true,\n\n    /* Bundler mode */\n    \"moduleResolution\": \"bundler\",\n    \"allowImportingTsExtensions\": true,\n    \"isolatedModules\": true,\n    \"moduleDetection\": \"force\",\n    \"noEmit\": true,\n    \"jsx\": \"react-jsx\",\n\n    /* Linting */\n    \"strict\": false,\n    \"noUnusedLocals\": false,\n    \"noUnusedParameters\": false,\n    \"noImplicitAny\": false,\n    \"noFallthroughCasesInSwitch\": false,\n\n    \"baseUrl\": \".\",\n    \"paths\": {\n      \"@/*\": [\"./src/*\"]\n    }\n  },\n  \"include\": [\"src\"]\n}\n",
           "force": false
         },
         {
           "path": "tsconfig.json",
-          "content": "// File contents excluded from context",
+          "content": "{\n  \"files\": [],\n  \"references\": [\n    { \"path\": \"./tsconfig.app.json\" },\n    { \"path\": \"./tsconfig.node.json\" }\n  ],\n  \"compilerOptions\": {\n    \"baseUrl\": \".\",\n    \"paths\": {\n      \"@/*\": [\"./src/*\"]\n    },\n    \"noImplicitAny\": false,\n    \"noUnusedParameters\": false,\n    \"skipLibCheck\": true,\n    \"allowJs\": true,\n    \"noUnusedLocals\": false,\n    \"strictNullChecks\": false\n  }\n}\n",
           "force": false
         },
         {
           "path": "tsconfig.node.json",
-          "content": "// File contents excluded from context",
+          "content": "{\n  \"compilerOptions\": {\n    \"target\": \"ES2022\",\n    \"lib\": [\"ES2023\"],\n    \"module\": \"ESNext\",\n    \"skipLibCheck\": true,\n\n    /* Bundler mode */\n    \"moduleResolution\": \"bundler\",\n    \"allowImportingTsExtensions\": true,\n    \"isolatedModules\": true,\n    \"moduleDetection\": \"force\",\n    \"noEmit\": true,\n\n    /* Linting */\n    \"strict\": true,\n    \"noUnusedLocals\": false,\n    \"noUnusedParameters\": false,\n    \"noFallthroughCasesInSwitch\": true\n  },\n  \"include\": [\"vite.config.ts\"]\n}\n",
           "force": false
         },
         {

--- a/e2e-tests/snapshots/thinking_budget.spec.ts_thinking-budget-4.txt
+++ b/e2e-tests/snapshots/thinking_budget.spec.ts_thinking-budget-4.txt
@@ -49,7 +49,7 @@
         },
         {
           "path": "components.json",
-          "content": "// File contents excluded from context",
+          "content": "{\n  \"$schema\": \"https://ui.shadcn.com/schema.json\",\n  \"style\": \"default\",\n  \"rsc\": false,\n  \"tsx\": true,\n  \"tailwind\": {\n    \"config\": \"tailwind.config.ts\",\n    \"css\": \"src/index.css\",\n    \"baseColor\": \"slate\",\n    \"cssVariables\": true,\n    \"prefix\": \"\"\n  },\n  \"aliases\": {\n    \"components\": \"@/components\",\n    \"utils\": \"@/lib/utils\",\n    \"ui\": \"@/components/ui\",\n    \"lib\": \"@/lib\",\n    \"hooks\": \"@/hooks\"\n  }\n}\n",
           "force": false
         },
         {
@@ -404,17 +404,17 @@
         },
         {
           "path": "tsconfig.app.json",
-          "content": "// File contents excluded from context",
+          "content": "{\n  \"compilerOptions\": {\n    \"target\": \"ES2020\",\n    \"useDefineForClassFields\": true,\n    \"lib\": [\"ES2020\", \"DOM\", \"DOM.Iterable\"],\n    \"module\": \"ESNext\",\n    \"skipLibCheck\": true,\n\n    /* Bundler mode */\n    \"moduleResolution\": \"bundler\",\n    \"allowImportingTsExtensions\": true,\n    \"isolatedModules\": true,\n    \"moduleDetection\": \"force\",\n    \"noEmit\": true,\n    \"jsx\": \"react-jsx\",\n\n    /* Linting */\n    \"strict\": false,\n    \"noUnusedLocals\": false,\n    \"noUnusedParameters\": false,\n    \"noImplicitAny\": false,\n    \"noFallthroughCasesInSwitch\": false,\n\n    \"baseUrl\": \".\",\n    \"paths\": {\n      \"@/*\": [\"./src/*\"]\n    }\n  },\n  \"include\": [\"src\"]\n}\n",
           "force": false
         },
         {
           "path": "tsconfig.json",
-          "content": "// File contents excluded from context",
+          "content": "{\n  \"files\": [],\n  \"references\": [\n    { \"path\": \"./tsconfig.app.json\" },\n    { \"path\": \"./tsconfig.node.json\" }\n  ],\n  \"compilerOptions\": {\n    \"baseUrl\": \".\",\n    \"paths\": {\n      \"@/*\": [\"./src/*\"]\n    },\n    \"noImplicitAny\": false,\n    \"noUnusedParameters\": false,\n    \"skipLibCheck\": true,\n    \"allowJs\": true,\n    \"noUnusedLocals\": false,\n    \"strictNullChecks\": false\n  }\n}\n",
           "force": false
         },
         {
           "path": "tsconfig.node.json",
-          "content": "// File contents excluded from context",
+          "content": "{\n  \"compilerOptions\": {\n    \"target\": \"ES2022\",\n    \"lib\": [\"ES2023\"],\n    \"module\": \"ESNext\",\n    \"skipLibCheck\": true,\n\n    /* Bundler mode */\n    \"moduleResolution\": \"bundler\",\n    \"allowImportingTsExtensions\": true,\n    \"isolatedModules\": true,\n    \"moduleDetection\": \"force\",\n    \"noEmit\": true,\n\n    /* Linting */\n    \"strict\": true,\n    \"noUnusedLocals\": false,\n    \"noUnusedParameters\": false,\n    \"noFallthroughCasesInSwitch\": true\n  },\n  \"include\": [\"vite.config.ts\"]\n}\n",
           "force": false
         },
         {

--- a/e2e-tests/snapshots/thinking_budget.spec.ts_thinking-budget-6.txt
+++ b/e2e-tests/snapshots/thinking_budget.spec.ts_thinking-budget-6.txt
@@ -57,7 +57,7 @@
         },
         {
           "path": "components.json",
-          "content": "// File contents excluded from context",
+          "content": "{\n  \"$schema\": \"https://ui.shadcn.com/schema.json\",\n  \"style\": \"default\",\n  \"rsc\": false,\n  \"tsx\": true,\n  \"tailwind\": {\n    \"config\": \"tailwind.config.ts\",\n    \"css\": \"src/index.css\",\n    \"baseColor\": \"slate\",\n    \"cssVariables\": true,\n    \"prefix\": \"\"\n  },\n  \"aliases\": {\n    \"components\": \"@/components\",\n    \"utils\": \"@/lib/utils\",\n    \"ui\": \"@/components/ui\",\n    \"lib\": \"@/lib\",\n    \"hooks\": \"@/hooks\"\n  }\n}\n",
           "force": false
         },
         {
@@ -412,17 +412,17 @@
         },
         {
           "path": "tsconfig.app.json",
-          "content": "// File contents excluded from context",
+          "content": "{\n  \"compilerOptions\": {\n    \"target\": \"ES2020\",\n    \"useDefineForClassFields\": true,\n    \"lib\": [\"ES2020\", \"DOM\", \"DOM.Iterable\"],\n    \"module\": \"ESNext\",\n    \"skipLibCheck\": true,\n\n    /* Bundler mode */\n    \"moduleResolution\": \"bundler\",\n    \"allowImportingTsExtensions\": true,\n    \"isolatedModules\": true,\n    \"moduleDetection\": \"force\",\n    \"noEmit\": true,\n    \"jsx\": \"react-jsx\",\n\n    /* Linting */\n    \"strict\": false,\n    \"noUnusedLocals\": false,\n    \"noUnusedParameters\": false,\n    \"noImplicitAny\": false,\n    \"noFallthroughCasesInSwitch\": false,\n\n    \"baseUrl\": \".\",\n    \"paths\": {\n      \"@/*\": [\"./src/*\"]\n    }\n  },\n  \"include\": [\"src\"]\n}\n",
           "force": false
         },
         {
           "path": "tsconfig.json",
-          "content": "// File contents excluded from context",
+          "content": "{\n  \"files\": [],\n  \"references\": [\n    { \"path\": \"./tsconfig.app.json\" },\n    { \"path\": \"./tsconfig.node.json\" }\n  ],\n  \"compilerOptions\": {\n    \"baseUrl\": \".\",\n    \"paths\": {\n      \"@/*\": [\"./src/*\"]\n    },\n    \"noImplicitAny\": false,\n    \"noUnusedParameters\": false,\n    \"skipLibCheck\": true,\n    \"allowJs\": true,\n    \"noUnusedLocals\": false,\n    \"strictNullChecks\": false\n  }\n}\n",
           "force": false
         },
         {
           "path": "tsconfig.node.json",
-          "content": "// File contents excluded from context",
+          "content": "{\n  \"compilerOptions\": {\n    \"target\": \"ES2022\",\n    \"lib\": [\"ES2023\"],\n    \"module\": \"ESNext\",\n    \"skipLibCheck\": true,\n\n    /* Bundler mode */\n    \"moduleResolution\": \"bundler\",\n    \"allowImportingTsExtensions\": true,\n    \"isolatedModules\": true,\n    \"moduleDetection\": \"force\",\n    \"noEmit\": true,\n\n    /* Linting */\n    \"strict\": true,\n    \"noUnusedLocals\": false,\n    \"noUnusedParameters\": false,\n    \"noFallthroughCasesInSwitch\": true\n  },\n  \"include\": [\"vite.config.ts\"]\n}\n",
           "force": false
         },
         {

--- a/src/utils/codebase.ts
+++ b/src/utils/codebase.ts
@@ -71,11 +71,23 @@ const ALWAYS_OMITTED_FILES = [".env", ".env.local"];
 //
 // Why are we not using path.join here?
 // Because we have already normalized the path to use /.
+//
+// Note: these files are only omitted when NOT using smart context.
+//
+// Why do we omit these files when not using smart context?
+//
+// Because these files are typically low-signal and adding them
+// to the context can cause users to much more quickly hit their
+// free rate limits.
 const OMITTED_FILES = [
   ...ALWAYS_OMITTED_FILES,
   "src/components/ui",
   "eslint.config",
   "tsconfig.json",
+  "tsconfig.app.json",
+  "tsconfig.node.json",
+  "tsconfig.base.json",
+  "components.json",
 ];
 
 // Maximum file size to include (in bytes) - 1MB

--- a/src/utils/codebase.ts
+++ b/src/utils/codebase.ts
@@ -30,6 +30,8 @@ const ALLOWED_EXTENSIONS = [
   ".scss",
   ".sass",
   ".less",
+  // Oftentimes used as config (e.g. package.json, vercel.json) or data files (e.g. translations)
+  ".json",
   // GitHub Actions
   ".yml",
   ".yaml",
@@ -58,7 +60,7 @@ const EXCLUDED_DIRS = ["node_modules", ".git", "dist", "build", ".next"];
 const EXCLUDED_FILES = ["pnpm-lock.yaml", "package-lock.json"];
 
 // Files to always include, regardless of extension
-const ALWAYS_INCLUDE_FILES = ["package.json", "vercel.json", ".gitignore"];
+const ALWAYS_INCLUDE_FILES = [".gitignore"];
 
 // File patterns to always omit (contents will be replaced with a placeholder)
 // We don't want to send environment variables to the LLM because they


### PR DESCRIPTION
Fixes #1037 
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enable JSON file support in codebase scanning so common configs and data (e.g., package.json, vercel.json, translations) are included. Adds .json to the allowed extensions and removes special-casing for package.json/vercel.json.

<!-- End of auto-generated description by cubic. -->

