### PR TITLE
fix contrib format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,6 @@ Before opening a pull request, please open an issue and discuss whether the chan
 
 For a high-level overview of how Dyad works, please see the [Architecture Guide](./docs/architecture.md). Understanding the architecture will help ensure your contributions align with the overall design of the project.
 
-
 ## More than code contributions
 
 Something that I really appreciate are all the non-code contributions, such as reporting bugs, writing feature requests and participating on [Dyad's sub-reddit](https://www.reddit.com/r/dyadbuilders).


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fix CONTRIBUTING.md formatting by removing an extra blank line before the "More than code contributions" header. This ensures consistent Markdown rendering and cleaner spacing.

<!-- End of auto-generated description by cubic. -->

