### PR TITLE
verify jwt to false

### DIFF
--- a/src/supabase_admin/supabase_management_client.ts
+++ b/src/supabase_admin/supabase_management_client.ts
@@ -187,6 +187,8 @@ export async function deploySupabaseFunctions({
     JSON.stringify({
       entrypoint_path: "index.ts",
       name: functionName,
+      // See: https://github.com/dyad-sh/dyad/issues/1010
+      verify_jwt: false,
     }),
   );
   formData.append("file", new Blob([content]), "index.ts");


### PR DESCRIPTION
fixes #1010 
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Disable automatic JWT verification for Supabase Edge Functions and update prompts/templates to require and demonstrate manual auth handling. Fixes #1010.

- **Bug Fixes**
  - Set verify_jwt: false in function deployment.
  - Updated Supabase prompt with an Authentication section and guidance to manually verify tokens.
  - Adjusted the hello function template to check the Authorization header and return 401 when missing.

<!-- End of auto-generated description by cubic. -->

