### PR TITLE
bump to beta v0.19 1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dyad",
-  "version": "0.18.0-beta.1",
+  "version": "0.19.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dyad",
-      "version": "0.18.0-beta.1",
+      "version": "0.19.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dyad",
   "productName": "dyad",
-  "version": "0.18.0",
+  "version": "0.19.0-beta.1",
   "description": "Free, local, open-source AI app builder",
   "main": ".vite/build/main.js",
   "repository": {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Bump version to 0.19.0-beta.1 in package.json and package-lock.json. Preps the repo for publishing the 0.19 beta build.

<!-- End of auto-generated description by cubic. -->

