### PR TITLE
fix: error on first custom provider deletion

### DIFF
--- a/src/ipc/handlers/language_model_handlers.ts
+++ b/src/ipc/handlers/language_model_handlers.ts
@@ -250,9 +250,9 @@ export function registerLanguageModelHandlers() {
       }
 
       // Use a transaction to ensure atomicity
-      await db.transaction(async (tx) => {
+      db.transaction((tx) => {
         // 1. Delete associated models
-        const deleteModelsResult = await tx
+        const deleteModelsResult = tx
           .delete(languageModelsSchema)
           .where(eq(languageModelsSchema.customProviderId, providerId))
           .run();
@@ -261,7 +261,7 @@ export function registerLanguageModelHandlers() {
         );
 
         // 2. Delete the provider
-        const deleteProviderResult = await tx
+        const deleteProviderResult = tx
           .delete(languageModelProvidersSchema)
           .where(eq(languageModelProvidersSchema.id, providerId))
           .run();


### PR DESCRIPTION
fixes #1109 

https://github.com/WiseLibs/better-sqlite3/blob/master/docs/api.md#transactionfunction---function

> Transaction functions do not work with async functions. Technically speaking, async functions always return after the first await, which means the transaction will already be committed before any async code executes. 

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes a runtime error when deleting the first custom provider by using a synchronous DB transaction. Ensures associated models and the provider are removed atomically without failing.

- **Bug Fixes**
  - Replace async transaction callback with a synchronous one and remove awaits on tx operations to match the DB API and prevent the first-delete error.

<!-- End of auto-generated description by cubic. -->

