### PR TITLE
Add dupe issue bot

### DIFF
--- a/.github/workflows/duplicate-issues.yml
+++ b/.github/workflows/duplicate-issues.yml
@@ -1,0 +1,63 @@
+# This was copied from https://github.com/sst/opencode/blob/d7a9f343c53d481802c134ce25691a8c150d59d2/.github/workflows/duplicate-issues.yml
+# MIT License
+# Copyright (c) 2025 opencode
+
+name: Duplicate Issue Detection
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  check-duplicates:
+    environment: ai-bots
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Install opencode
+        run: curl -fsSL https://opencode.ai/install | bash
+
+      - name: Check for duplicate issues
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENCODE_PERMISSION: |
+            {
+              "bash": {
+                "gh issue*": "allow",
+                "*": "deny" 
+              }, 
+              "webfetch": "deny"
+            }
+        run: |
+          opencode run -m anthropic/claude-sonnet-4-20250514 "A new issue has been created:'
+
+          Issue number:
+          ${{ github.event.issue.number }}
+
+          Lookup this issue and search through existing issues (excluding #${{ github.event.issue.number }}) in this repository to find any potential duplicates of this new issue.
+          Consider:
+          1. Similar titles or descriptions
+          2. Same error messages or symptoms
+          3. Related functionality or components
+          4. Similar feature requests
+
+          If you find any potential duplicates, please comment on the new issue with:
+          - A brief explanation of why it might be a duplicate
+          - Links to the potentially duplicate issues
+          - A suggestion to check those issues first
+
+          Use this format for the comment:
+          'This issue might be a duplicate of existing issues. Please check:
+          - #[issue_number]: [brief description of similarity]
+
+          Feel free to ignore if none of these address your specific case.'
+
+          If no clear duplicates are found, do not comment."


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds a GitHub Action to detect and comment on potential duplicate issues when a new issue is opened. This reduces triage time and keeps issue lists clean.

- **New Features**
  - Adds .github/workflows/duplicate-issues.yml triggered on issues: opened.
  - Uses opencode with Anthropic Claude Sonnet 4 to scan existing issues and comment with links if duplicates are likely; stays silent otherwise.
  - Runs with minimal permissions; allows gh issue commands and denies webfetch.

- **Migration**
  - Create the ai-bots environment and add the ANTHROPIC_API_KEY secret (GITHUB_TOKEN is provided by GitHub).

<!-- End of auto-generated description by cubic. -->

