### PR TITLE
Switch to OpenAI GPT-5 bot (cheaper)

### DIFF
--- a/.github/workflows/duplicate-issues.yml
+++ b/.github/workflows/duplicate-issues.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Check for duplicate issues
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENCODE_PERMISSION: |
             {

--- a/.github/workflows/duplicate-issues.yml
+++ b/.github/workflows/duplicate-issues.yml
@@ -37,7 +37,7 @@ jobs:
               "webfetch": "deny"
             }
         run: |
-          opencode run -m anthropic/claude-sonnet-4-20250514 "A new issue has been created:'
+          opencode run -m openai/gpt-5 "A new issue has been created:'
 
           Issue number:
           ${{ github.event.issue.number }}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Switches the duplicate-issues GitHub Action from anthropic/claude-sonnet-4-20250514 to openai/gpt-5 to reduce cost. Updates the workflow to use OPENAI_API_KEY instead of ANTHROPIC_API_KEY.

<!-- End of auto-generated description by cubic. -->

