### PR TITLE
Bump to v0.19.0 (stable)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dyad",
   "productName": "dyad",
-  "version": "0.19.0-beta.1",
+  "version": "0.19.0",
   "description": "Free, local, open-source AI app builder",
   "main": ".vite/build/main.js",
   "repository": {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Promote v0.19.0 from beta to stable. Updates package.json version to 0.19.0 for the 0.19.x release line.

<!-- End of auto-generated description by cubic. -->

