### PR TITLE
fix: hide <dyad-command> tags from generated text output (#945)

### DIFF
--- a/src/components/chat/DyadMarkdownParser.tsx
+++ b/src/components/chat/DyadMarkdownParser.tsx
@@ -123,6 +123,7 @@ function preprocessUnclosedTags(content: string): {
     "dyad-edit",
     "dyad-codebase-context",
     "think",
+    "dyad-command",
   ];
 
   let processedContent = content;
@@ -189,6 +190,7 @@ function parseCustomTags(content: string): ContentPiece[] {
     "dyad-edit",
     "dyad-codebase-context",
     "think",
+    "dyad-command",
   ];
 
   const tagPattern = new RegExp(
@@ -416,6 +418,10 @@ function renderCustomTag(
 
     case "dyad-chat-summary":
       // Don't render anything for dyad-chat-summary
+      return null;
+
+    case "dyad-command":
+      // Don't render anything for dyad-command
       return null;
 
     default:


### PR DESCRIPTION
### Summary
This PR hides `<dyad-command type="refresh"></dyad-command>` tags from generated text outputs. These elements are not intended for end users and clutter the response text.

### Changes
- Filter out `<dyad-command>` tags from generated text.
- Ensure no regressions in rendering or formatting of user-visible output.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Hide dyad-command tags from chat output so internal commands never appear in user-visible text. Updates DyadMarkdownParser to detect and drop these tags during preprocessing, parsing, and rendering.

<!-- End of auto-generated description by cubic. -->

