### PR TITLE
Add security policy for supported versions and reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Supported Versions
+
+We will provide security fixes for the latest version of Dyad and encourage Dyad users through auto-updates to use the latest version of the app.
+
+## Reporting a Vulnerability
+
+Please file security vulnerabilities by using [report a vulnerability](https://github.com/dyad-sh/dyad/security/advisories/new). Please do not file security vulnerabilities as a regular issue as the information could be used to exploit Dyad users.


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add SECURITY.md defining our security policy: we only provide security fixes for the latest Dyad version and direct vulnerability reports to GitHub Security Advisories (not public issues). This clarifies expectations and guides responsible disclosure.

<!-- End of auto-generated description by cubic. -->

