### PR TITLE
Enable iframe sandbox

### DIFF
--- a/e2e-tests/preview_iframe.spec.ts
+++ b/e2e-tests/preview_iframe.spec.ts
@@ -1,0 +1,10 @@
+import { testSkipIfWindows } from "./helpers/test_helper";
+import { expect } from "@playwright/test";
+
+testSkipIfWindows("preview iframe has sandbox attributes", async ({ po }) => {
+  await po.setUp();
+  await po.sendPrompt("hi");
+  expect(
+    await po.getPreviewIframeElement().getAttribute("sandbox"),
+  ).toMatchSnapshot();
+});

--- a/e2e-tests/snapshots/preview_iframe.spec.ts_preview-iframe-has-sandbox-attributes-1.txt
+++ b/e2e-tests/snapshots/preview_iframe.spec.ts_preview-iframe-has-sandbox-attributes-1.txt
@@ -1,0 +1,1 @@
+allow-same-origin allow-scripts allow-forms allow-popups allow-modals allow-orientation-lock allow-pointer-lock allow-presentation allow-downloads

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dyad",
-  "version": "0.19.0-beta.1",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dyad",
-      "version": "0.19.0-beta.1",
+      "version": "0.19.0",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^2.0.4",

--- a/src/components/preview_panel/PreviewIframe.tsx
+++ b/src/components/preview_panel/PreviewIframe.tsx
@@ -544,6 +544,7 @@ export const PreviewIframe = ({ loading }: { loading: boolean }) => {
           </div>
         ) : (
           <iframe
+            sandbox="allow-same-origin allow-scripts allow-forms allow-popups allow-modals allow-orientation-lock allow-pointer-lock allow-presentation allow-downloads"
             data-testid="preview-iframe-element"
             onLoad={() => {
               setErrorMessage(undefined);


### PR DESCRIPTION
This allows almost all the iframe sandbox tokens https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/iframe#sandbox except notably for allow-top-navigation*

Note: allow-same-origin should be OK because the main window is under the `file://` origin while the iframe window is served on `localhost:####`

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enable sandboxing on the preview iframe to isolate preview content while preserving needed capabilities (allow-same-origin, scripts, forms, popups, modals, orientation/pointer lock, presentation, downloads). Top-level navigation remains disallowed; allow-same-origin is safe because the app is file:// and the iframe runs on localhost.

<!-- End of auto-generated description by cubic. -->

