### PR TITLE
docs: fix typo "pull requet" to "pull request" in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ npm start
 
 ## Setup
 
-If you'd like to contribute a pull request, we highly recommend setting the pre-commit hooks which will run the formatter and linter before each git commit. This is a great way of catching issues early on without waiting to run the GitHub Actions for your pull requet.
+If you'd like to contribute a pull request, we highly recommend setting the pre-commit hooks which will run the formatter and linter before each git commit. This is a great way of catching issues early on without waiting to run the GitHub Actions for your pull request.
 
 Simply run this once in your repo:
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fix typo in CONTRIBUTING.md by correcting "pull requet" to "pull request" in the setup section, improving clarity for contributors.

<!-- End of auto-generated description by cubic. -->

