### PR TITLE
Set minimum window size to prevent UI breakage

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -133,7 +133,9 @@ const createWindow = () => {
   // Create the browser window.
   mainWindow = new BrowserWindow({
     width: process.env.NODE_ENV === "development" ? 1280 : 960,
+    minWidth: 800,
     height: 700,
+    minHeight: 500,
     titleBarStyle: "hidden",
     titleBarOverlay: false,
     trafficLightPosition: {


### PR DESCRIPTION
This PR solves issue #1194 by setting a minimum height and width
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Set a minimum window size to prevent UI breakage when the app is resized too small. The BrowserWindow now enforces minWidth 800 and minHeight 500 so layouts stay stable and controls remain accessible.

<!-- End of auto-generated description by cubic. -->

