### PR TITLE
fix(ui): turbo edit -  prevent code editor content click from toggling accordion

### DIFF
--- a/src/components/chat/DyadEdit.tsx
+++ b/src/components/chat/DyadEdit.tsx
@@ -99,7 +99,10 @@ export const DyadEdit: React.FC<DyadEditProps> = ({
         </div>
       )}
       {isContentVisible && (
-        <div className="text-xs">
+        <div
+          className="text-xs cursor-text"
+          onClick={(e) => e.stopPropagation()}
+        >
           <CodeHighlight className="language-typescript">
             {children}
           </CodeHighlight>


### PR DESCRIPTION
Hovering over the turbo edit code block previously showed a pointer cursor, and clicking inside would collapse/expand the accordion. This PR updates the DyadEdit component to use cursor-text and adds e.stopPropagation() so clicks inside the code block no longer toggle the accordion.



https://github.com/user-attachments/assets/1b23be66-6d8f-4e4b-a390-d59f9a2bcee8



    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Prevented the Turbo Edit accordion from toggling when clicking inside the code block and updated the cursor to text to signal editing.

- **Bug Fixes**
  - Stop click propagation inside the code block to avoid accordion toggle.
  - Apply cursor-text on the code container for proper text-selection affordance.

<!-- End of auto-generated description by cubic. -->

