### PR TITLE
bump to v0.20 stable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dyad",
   "productName": "dyad",
-  "version": "0.20.0-beta.1",
+  "version": "0.20.0",
   "description": "Free, local, open-source AI app builder",
   "main": ".vite/build/main.js",
   "repository": {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Publish v0.20 stable by bumping the app version from 0.20.0-beta.1 to 0.20.0 in package.json. This ensures packaging, installers, and update checks target the stable release channel.

<!-- End of auto-generated description by cubic. -->

