### PR TITLE
Support 1M tokens for anthropic (drive-by: make aws bedrock secondary…

### DIFF
--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -686,6 +686,7 @@ This conversation includes one or more image attachments. When the user uploads 
           const providerId = modelClient.builtinProviderId;
           const isVertex = providerId === "vertex";
           const isGoogle = providerId === "google";
+          const isAnthropic = providerId === "anthropic";
           const isPartnerModel = selectedModelName.includes("/");
           const isGeminiModel = selectedModelName.startsWith("gemini");
           const isFlashLite = selectedModelName.includes("flash-lite");
@@ -707,8 +708,12 @@ This conversation includes one or more image attachments. When the user uploads 
               },
             } satisfies GoogleGenerativeAIProviderOptions;
           }
-
           return streamText({
+            headers: isAnthropic
+              ? {
+                  "anthropic-beta": "context-1m-2025-08-07",
+                }
+              : undefined,
             maxOutputTokens: await getMaxTokens(settings.selectedModel),
             temperature: await getTemperature(settings.selectedModel),
             maxRetries: 2,

--- a/src/ipc/shared/language_model_helpers.ts
+++ b/src/ipc/shared/language_model_helpers.ts
@@ -80,12 +80,12 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
     {
       name: "claude-sonnet-4-20250514",
       displayName: "Claude 4 Sonnet",
-      description: "Excellent coder",
+      description: "Excellent coder (note: >200k tokens is very expensive!)",
       // See comment below for Claude 3.7 Sonnet for why we set this to 16k
       maxOutputTokens: 16_000,
-      contextWindow: 200_000,
+      contextWindow: 1_000_000,
       temperature: 0,
-      dollarSigns: 4,
+      dollarSigns: 5,
     },
     {
       name: "claude-3-7-sonnet-latest",
@@ -287,9 +287,9 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
     {
       name: "us.anthropic.claude-sonnet-4-20250514-v1:0",
       displayName: "Claude 4 Sonnet",
-      description: "Excellent coder",
+      description: "Excellent coder (note: >200k tokens is very expensive!)",
       maxOutputTokens: 16_000,
-      contextWindow: 200_000,
+      contextWindow: 1_000_000,
       temperature: 0,
     },
     {
@@ -387,6 +387,7 @@ export const CLOUD_PROVIDERS: Record<
     hasFreeTier: false,
     websiteUrl: "https://console.aws.amazon.com/bedrock/",
     gatewayPrefix: "bedrock/",
+    secondary: true,
   },
 };
 


### PR DESCRIPTION
… provider)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enables 1M-token context for Anthropic Claude 4 Sonnet and marks AWS Bedrock as a secondary provider. Adds the required Anthropic beta header and updates model metadata and pricing indicator.

- **New Features**
  - Send header anthropic-beta: context-1m-2025-08-07 when using the Anthropic provider.
  - Update Claude 4 Sonnet configs: contextWindow to 1,000,000; add cost warning; increase pricing tier to 5 (applies to Anthropic and Bedrock model IDs).
  - Set AWS Bedrock as a secondary provider.

<!-- End of auto-generated description by cubic. -->

