### PR TITLE
Feat: Add inline code editor (#1156) (#1232) (#1220)

### DIFF
--- a/e2e-tests/chat_mode.spec.ts
+++ b/e2e-tests/chat_mode.spec.ts
@@ -26,6 +26,7 @@ test("chat mode selector - ask mode", async ({ po }) => {
 test("dyadwrite edit and save - basic flow", async ({ po }) => {
   await po.setUp({ autoApprove: true });
   await po.importApp("minimal");
+  await po.clickNewChat();
 
   await po.sendPrompt(
     "Create a simple React component in src/components/Hello.tsx",
@@ -43,6 +44,7 @@ test("dyadwrite edit and save - basic flow", async ({ po }) => {
 test("dyadwrite edit and cancel", async ({ po }) => {
   await po.setUp({ autoApprove: true });
   await po.importApp("minimal");
+  await po.clickNewChat();
 
   await po.sendPrompt("Create a utility function in src/utils/helper.ts");
   await po.waitForChatCompletion();

--- a/e2e-tests/chat_mode.spec.ts
+++ b/e2e-tests/chat_mode.spec.ts
@@ -22,3 +22,35 @@ test("chat mode selector - ask mode", async ({ po }) => {
   await po.snapshotServerDump("all-messages");
   await po.snapshotMessages({ replaceDumpPath: true });
 });
+
+test("dyadwrite edit and save - basic flow", async ({ po }) => {
+  await po.setUp({ autoApprove: true });
+  await po.importApp("minimal");
+
+  await po.sendPrompt(
+    "Create a simple React component in src/components/Hello.tsx",
+  );
+  await po.waitForChatCompletion();
+
+  await po.clickEditButton();
+  await po.editFileContent("// Test modification\n");
+
+  await po.saveFile();
+
+  await po.snapshotMessages({ replaceDumpPath: true });
+});
+
+test("dyadwrite edit and cancel", async ({ po }) => {
+  await po.setUp({ autoApprove: true });
+  await po.importApp("minimal");
+
+  await po.sendPrompt("Create a utility function in src/utils/helper.ts");
+  await po.waitForChatCompletion();
+
+  await po.clickEditButton();
+
+  await po.editFileContent("// This should be discarded\n");
+  await po.cancelEdit();
+
+  await po.snapshotMessages({ replaceDumpPath: true });
+});

--- a/e2e-tests/helpers/test_helper.ts
+++ b/e2e-tests/helpers/test_helper.ts
@@ -431,6 +431,27 @@ export class PageObject {
   async clickRestart() {
     await this.page.getByRole("button", { name: "Restart" }).click();
   }
+  ////////////////////////////////
+  // Inline code editor
+  ////////////////////////////////
+  async clickEditButton() {
+    await this.page.locator('button:has-text("Edit")').first().click();
+  }
+
+  async editFileContent(content: string) {
+    const editor = this.page.locator(".monaco-editor textarea").first();
+    await editor.focus();
+    await editor.press("Home");
+    await editor.type(content);
+  }
+
+  async saveFile() {
+    await this.page.locator('[data-testid="save-file-button"]').click();
+  }
+
+  async cancelEdit() {
+    await this.page.locator('button:has-text("Cancel")').first().click();
+  }
 
   ////////////////////////////////
   // Preview panel

--- a/e2e-tests/snapshots/chat_mode.spec.ts_dyadwrite-edit-and-cancel-1.aria.yml
+++ b/e2e-tests/snapshots/chat_mode.spec.ts_dyadwrite-edit-and-cancel-1.aria.yml
@@ -1,4 +1,4 @@
-- paragraph: /Generate an AI_RULES\.md file for this app\. Describe the tech stack in 5-\d+ bullet points and describe clear rules about what libraries to use for what\./
+- paragraph: Create a utility function in src/utils/helper.ts
 - img
 - text: file1.txt
 - button "Edit":
@@ -7,20 +7,6 @@
 - text: file1.txt typescript
 - button "Copy":
   - img
-- paragraph: More EOM
-- img
-- text: Approved
-- img
-- text: less than a minute ago
-- img
-- text: wrote 1 file(s)
-- paragraph: Create a utility function in src/utils/helper.ts
-- img
-- text: file1.txt
-- button "Edit":
-  - img
-- img
-- text: file1.txt
 - paragraph: More EOM
 - img
 - text: Approved

--- a/e2e-tests/snapshots/chat_mode.spec.ts_dyadwrite-edit-and-cancel-1.aria.yml
+++ b/e2e-tests/snapshots/chat_mode.spec.ts_dyadwrite-edit-and-cancel-1.aria.yml
@@ -1,0 +1,34 @@
+- paragraph: /Generate an AI_RULES\.md file for this app\. Describe the tech stack in 5-\d+ bullet points and describe clear rules about what libraries to use for what\./
+- img
+- text: file1.txt
+- button "Edit":
+  - img
+- img
+- text: file1.txt typescript
+- button "Copy":
+  - img
+- paragraph: More EOM
+- img
+- text: Approved
+- img
+- text: less than a minute ago
+- img
+- text: wrote 1 file(s)
+- paragraph: Create a utility function in src/utils/helper.ts
+- img
+- text: file1.txt
+- button "Edit":
+  - img
+- img
+- text: file1.txt
+- paragraph: More EOM
+- img
+- text: Approved
+- img
+- text: less than a minute ago
+- img
+- text: wrote 1 file(s)
+- button "Undo":
+  - img
+- button "Retry":
+  - img

--- a/e2e-tests/snapshots/chat_mode.spec.ts_dyadwrite-edit-and-save---basic-flow-1.aria.yml
+++ b/e2e-tests/snapshots/chat_mode.spec.ts_dyadwrite-edit-and-save---basic-flow-1.aria.yml
@@ -1,4 +1,4 @@
-- paragraph: /Generate an AI_RULES\.md file for this app\. Describe the tech stack in 5-\d+ bullet points and describe clear rules about what libraries to use for what\./
+- paragraph: Create a simple React component in src/components/Hello.tsx
 - img
 - text: file1.txt
 - button "Cancel":
@@ -11,20 +11,6 @@
 - code:
   - textbox "Editor content"
   - list
-- paragraph: More EOM
-- img
-- text: Approved
-- img
-- text: less than a minute ago
-- img
-- text: wrote 1 file(s)
-- paragraph: Create a simple React component in src/components/Hello.tsx
-- img
-- text: file1.txt
-- button "Edit":
-  - img
-- img
-- text: file1.txt
 - paragraph: More EOM
 - img
 - text: Approved

--- a/e2e-tests/snapshots/chat_mode.spec.ts_dyadwrite-edit-and-save---basic-flow-1.aria.yml
+++ b/e2e-tests/snapshots/chat_mode.spec.ts_dyadwrite-edit-and-save---basic-flow-1.aria.yml
@@ -1,0 +1,38 @@
+- paragraph: /Generate an AI_RULES\.md file for this app\. Describe the tech stack in 5-\d+ bullet points and describe clear rules about what libraries to use for what\./
+- img
+- text: file1.txt
+- button "Cancel":
+  - img
+- img
+- text: file1.txt file1.txt
+- button [disabled]:
+  - img
+- img
+- code:
+  - textbox "Editor content"
+  - list
+- paragraph: More EOM
+- img
+- text: Approved
+- img
+- text: less than a minute ago
+- img
+- text: wrote 1 file(s)
+- paragraph: Create a simple React component in src/components/Hello.tsx
+- img
+- text: file1.txt
+- button "Edit":
+  - img
+- img
+- text: file1.txt
+- paragraph: More EOM
+- img
+- text: Approved
+- img
+- text: less than a minute ago
+- img
+- text: wrote 1 file(s)
+- button "Undo":
+  - img
+- button "Retry":
+  - img

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -119,7 +119,7 @@ const ChatMessage = ({ message, isLastMessage }: ChatMessageProps) => {
                   )}
                 </>
               ) : (
-                <DyadMarkdownParser content={message.content} />
+                <VanillaMarkdownParser content={message.content} />
               )}
             </div>
           )}

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -119,7 +119,7 @@ const ChatMessage = ({ message, isLastMessage }: ChatMessageProps) => {
                   )}
                 </>
               ) : (
-                <VanillaMarkdownParser content={message.content} />
+                <DyadMarkdownParser content={message.content} />
               )}
             </div>
           )}

--- a/src/components/chat/DyadWrite.tsx
+++ b/src/components/chat/DyadWrite.tsx
@@ -112,14 +112,18 @@ export const DyadWrite: React.FC<DyadWriteProps> = ({
 
   // Extract filename from path
   const fileName = path ? path.split("/").pop() : "";
-  const handleSave = () => {
+  const handleSave = async () => {
     if (!chatId) {
       return;
     }
     const prompt = `Edit ${path}:\n\n\`\`\`${getLanguage(path)}\n${code}\n\`\`\``;
-    streamMessage({ prompt, chatId });
-    setIsEditing(false);
-    setOriginalCode(code); // Update original code to current code
+    try {
+      await streamMessage({ prompt, chatId });
+      setIsEditing(false);
+      setOriginalCode(code); // Update original code to current code
+    } catch (error) {
+      // Handle error appropriately
+    }
   };
 
   const handleCancel = () => {
@@ -132,7 +136,6 @@ export const DyadWrite: React.FC<DyadWriteProps> = ({
     setIsEditing(true);
     setIsContentVisible(true);
   };
-  const editorPath = `inmemory://${fileName || "untitled"}-${Math.random().toString(36).slice(2)}`;
 
   return (
     <div

--- a/src/components/chat/DyadWrite.tsx
+++ b/src/components/chat/DyadWrite.tsx
@@ -62,11 +62,16 @@ export const DyadWrite: React.FC<DyadWriteProps> = ({
     setOriginalCode(newCode);
   }, [children]);
 
+  const [isDarkMode, setIsDarkMode] = useState(false);
   // Determine if dark mode based on theme
-  const isDarkMode =
-    theme === "dark" ||
-    (theme === "system" &&
-      window.matchMedia("(prefers-color-scheme: dark)").matches);
+  useEffect(() => {
+    // Safe access to window APIs
+    const isDark =
+      theme === "dark" ||
+      (theme === "system" &&
+        window.matchMedia("(prefers-color-scheme: dark)").matches);
+    setIsDarkMode(isDark);
+  }, [theme]);
   const editorTheme = isDarkMode ? "dyad-dark" : "dyad-light";
 
   // Determine language based on file extension
@@ -111,7 +116,7 @@ export const DyadWrite: React.FC<DyadWriteProps> = ({
     if (!chatId) {
       return;
     }
-    const prompt = `Edit <dyad-edit path="${path}">${code}</dyad-edit>`;
+    const prompt = `Edit ${path}:\n\n\`\`\`${getLanguage(path)}\n${code}\n\`\`\``;
     streamMessage({ prompt, chatId });
     setIsEditing(false);
     setOriginalCode(code); // Update original code to current code
@@ -167,7 +172,7 @@ export const DyadWrite: React.FC<DyadWriteProps> = ({
               {isEditing ? (
                 <>
                   <button
-                    onClick={handleCancel}
+                    onClick={(e) => { e.stopPropagation(); handleCancel(); }}
                     className="flex items-center gap-1 text-xs text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 px-2 py-1 rounded cursor-pointer"
                   >
                     <X size={14} />
@@ -175,7 +180,7 @@ export const DyadWrite: React.FC<DyadWriteProps> = ({
                   </button>
 
                   <button
-                    onClick={handleSave}
+                    onClick={(e) => { e.stopPropagation(); handleSave(); }}
                     className="flex items-center gap-1 text-xs bg-blue-500 hover:bg-blue-600 text-white px-2 py-1 rounded cursor-pointer"
                   >
                     <Save size={14} />

--- a/src/components/chat/DyadWrite.tsx
+++ b/src/components/chat/DyadWrite.tsx
@@ -1,6 +1,6 @@
 import type React from "react";
 import type { ReactNode } from "react";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import {
   ChevronsDownUp,
   ChevronsUpDown,
@@ -8,16 +8,13 @@ import {
   Loader,
   CircleX,
   Edit,
-  Save,
   X,
 } from "lucide-react";
 import { CodeHighlight } from "./CodeHighlight";
 import { CustomTagState } from "./stateTypes";
-import Editor from "@monaco-editor/react";
-import { useStreamChat } from "@/hooks/useStreamChat";
-import { selectedChatIdAtom } from "@/atoms/chatAtoms";
+import { FileEditor } from "../preview_panel/FileEditor";
 import { useAtomValue } from "jotai";
-import { useTheme } from "@/contexts/ThemeContext";
+import { selectedAppIdAtom } from "@/atoms/appAtoms";
 
 interface DyadWriteProps {
   children?: ReactNode;
@@ -33,109 +30,27 @@ export const DyadWrite: React.FC<DyadWriteProps> = ({
   description: descriptionProp,
 }) => {
   const [isContentVisible, setIsContentVisible] = useState(false);
-  const [isEditing, setIsEditing] = useState(false);
-  const [code, setCode] = useState(
-    children
-      ? Array.isArray(children)
-        ? children.join("")
-        : String(children)
-      : "",
-  );
-  const [originalCode, setOriginalCode] = useState(
-    children
-      ? Array.isArray(children)
-        ? children.join("")
-        : String(children)
-      : "",
-  );
-  const { streamMessage } = useStreamChat();
-  const chatId = useAtomValue(selectedChatIdAtom);
-  const { theme } = useTheme();
-
-  useEffect(() => {
-    const newCode = children
-      ? Array.isArray(children)
-        ? children.join("")
-        : String(children)
-      : "";
-    setCode(newCode);
-    setOriginalCode(newCode);
-  }, [children]);
-
-  const [isDarkMode, setIsDarkMode] = useState(false);
-  // Determine if dark mode based on theme
-  useEffect(() => {
-    // Safe access to window APIs
-    const isDark =
-      theme === "dark" ||
-      (theme === "system" &&
-        window.matchMedia("(prefers-color-scheme: dark)").matches);
-    setIsDarkMode(isDark);
-  }, [theme]);
-  const editorTheme = isDarkMode ? "dyad-dark" : "dyad-light";
-
-  // Determine language based on file extension
-  const getLanguage = (filePath: string) => {
-    const extension = filePath.split(".").pop()?.toLowerCase() || "";
-    const languageMap: Record<string, string> = {
-      js: "javascript",
-      jsx: "javascript",
-      ts: "typescript",
-      tsx: "typescript",
-      html: "html",
-      css: "css",
-      json: "json",
-      md: "markdown",
-      py: "python",
-      java: "java",
-      c: "c",
-      cpp: "cpp",
-      cs: "csharp",
-      go: "go",
-      rs: "rust",
-      rb: "ruby",
-      php: "php",
-      swift: "swift",
-      kt: "kotlin",
-      // Add more as needed
-    };
-
-    return languageMap[extension] || "plaintext";
-  };
 
   // Use props directly if provided, otherwise extract from node
   const path = pathProp || node?.properties?.path || "";
   const description = descriptionProp || node?.properties?.description || "";
   const state = node?.properties?.state as CustomTagState;
-  const inProgress = state === "pending";
-  const aborted = state === "aborted";
 
-  // Extract filename from path
-  const fileName = path ? path.split("/").pop() : "";
-  const handleSave = async () => {
-    if (!chatId) {
-      return;
-    }
-    const prompt = `Edit ${path}:\n\n\`\`\`${getLanguage(path)}\n${code}\n\`\`\``;
-    try {
-      await streamMessage({ prompt, chatId });
-      setIsEditing(false);
-      setOriginalCode(code); // Update original code to current code
-    } catch (error) {
-      // Handle error appropriately
-    }
-  };
+  const aborted = state === "aborted";
+  const appId = useAtomValue(selectedAppIdAtom);
+  const [isEditing, setIsEditing] = useState(false);
+  const inProgress = state === "pending";
 
   const handleCancel = () => {
-    setCode(originalCode); // Revert to original code
     setIsEditing(false);
   };
 
   const handleEdit = () => {
-    setOriginalCode(code); // Save current state as original before editing
     setIsEditing(true);
     setIsContentVisible(true);
   };
+  // Extract filename from path
+  const fileName = path ? path.split("/").pop() : "";
 
   return (
     <div
@@ -175,19 +90,14 @@ export const DyadWrite: React.FC<DyadWriteProps> = ({
               {isEditing ? (
                 <>
                   <button
-                    onClick={(e) => { e.stopPropagation(); handleCancel(); }}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleCancel();
+                    }}
                     className="flex items-center gap-1 text-xs text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 px-2 py-1 rounded cursor-pointer"
                   >
                     <X size={14} />
                     Cancel
-                  </button>
-
-                  <button
-                    onClick={(e) => { e.stopPropagation(); handleSave(); }}
-                    className="flex items-center gap-1 text-xs bg-blue-500 hover:bg-blue-600 text-white px-2 py-1 rounded cursor-pointer"
-                  >
-                    <Save size={14} />
-                    Save
                   </button>
                 </>
               ) : (
@@ -234,22 +144,9 @@ export const DyadWrite: React.FC<DyadWriteProps> = ({
           onClick={(e) => e.stopPropagation()}
         >
           {isEditing ? (
-            <Editor
-              height="300px"
-              defaultLanguage={getLanguage(path)}
-              value={code}
-              theme={editorTheme}
-              onChange={(value) => setCode(value || "")}
-              options={{
-                minimap: { enabled: true },
-                scrollBeyondLastLine: false,
-                wordWrap: "on",
-                automaticLayout: true,
-                fontFamily: "monospace",
-                fontSize: 13,
-                lineNumbers: "on",
-              }}
-            />
+            <div className="h-96 min-h-96 border border-gray-200 dark:border-gray-700 rounded overflow-hidden">
+              <FileEditor appId={appId ?? null} filePath={path} />
+            </div>
           ) : (
             <CodeHighlight className="language-typescript">
               {children}


### PR DESCRIPTION
## 🚀 Feature: Inline Code Editor

This PR adds a comprehensive inline code editing experience to the DyadWrite component.

### ✨ What's New

- **Inline Monaco Editor**: Edit code directly within the component using Monaco Editor
- **Cancel/Revert**: Cancel changes and revert to original code state
- **Language Detection**: Automatic syntax highlighting based on file extensions
- **Theme Support**: Proper dark/light mode theming integration


https://github.com/user-attachments/assets/c44ab622-6b86-403c-904d-3f327f9719e8


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds an inline Monaco-based code editor to DyadWrite so users can edit code blocks in place, then save or cancel changes. Saves stream edits back to the chat as a dyad-edit block.

- **New Features**
  - Inline editor with Edit, Save, and Cancel; preserves original code and auto-expands when editing.
  - Language detection from file extension and dark/light theme support.
  - Save streams edits via useStreamChat as <dyad-edit path="...">...</dyad-edit> tied to the selected chat.
  - Non-edit view still uses CodeHighlight; visibility toggle and in-progress state respected.

- **Refactors**
  - ChatMessage now uses DyadMarkdownParser instead of VanillaMarkdownParser.

<!-- End of auto-generated description by cubic. -->

