### PR TITLE
test env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,13 +27,15 @@ jobs:
         os: [
             # npm install is very slow
             # { name: "windows-arm", image: "windows-11-arm" },
-            { name: "windows", image: "windows-latest" },
+            # { name: "windows", image: "windows-latest" },
             { name: "macos", image: "macos-latest" },
           ]
         shard: [1, 2, 3, 4]
         shardTotal: [4]
     runs-on: ${{ matrix.os.image }}
     steps:
+      - name: Print all environment variables
+        run: env | sort
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Initialize environment


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add an early CI step to print all environment variables for easier debugging. Temporarily disable the Windows runner to simplify the matrix (macOS only) while we diagnose the test environment.

<!-- End of auto-generated description by cubic. -->

