### PR TITLE
see why setup is failing

### DIFF
--- a/e2e-tests/setup.spec.ts
+++ b/e2e-tests/setup.spec.ts
@@ -5,7 +5,10 @@ const testSetup = testWithConfig({
   showSetupScreen: true,
 });
 
-testSetup("setup ai provider", async ({ po }) => {
+testSetup.only("setup ai provider", async ({ po }) => {
+  await po.goToSettingsTab();
+  await po.page.getByRole("button", { name: "Model Providers" }).dblclick();
+
   await po.page
     .getByRole("button", { name: "Setup Google Gemini API Key" })
     .click();


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Update setup E2E to navigate to Settings → Model Providers before opening the Google Gemini key dialog. Run this test only to reproduce the setup failure.

- **Bug Fixes**
  - Navigate to Settings, then double-click Model Providers before pressing "Setup Google Gemini API Key".
  - Use testSetup.only to isolate the setup test during investigation.

<!-- End of auto-generated description by cubic. -->

