### PR TITLE
Fix Azure e2e test so it doesn't leak

### DIFF
--- a/e2e-tests/azure_send_message.spec.ts
+++ b/e2e-tests/azure_send_message.spec.ts
@@ -1,11 +1,16 @@
-import { testSkipIfWindows } from "./helpers/test_helper";
+import { testWithConfigSkipIfWindows } from "./helpers/test_helper";
 
 // Set environment variables before the test runs to enable Azure testing
-process.env.TEST_AZURE_BASE_URL = "http://localhost:3500/azure";
-process.env.AZURE_API_KEY = "fake-azure-key-for-testing";
-process.env.AZURE_RESOURCE_NAME = "fake-resource-for-testing";
 
-testSkipIfWindows("send message through Azure OpenAI", async ({ po }) => {
+const testAzure = testWithConfigSkipIfWindows({
+  preLaunchHook: async () => {
+    process.env.TEST_AZURE_BASE_URL = "http://localhost:3500/azure";
+    process.env.AZURE_API_KEY = "fake-azure-key-for-testing";
+    process.env.AZURE_RESOURCE_NAME = "fake-resource-for-testing";
+  },
+});
+
+testAzure("send message through Azure OpenAI", async ({ po }) => {
   // Set up Azure without test provider
   await po.setUpAzure();
 

--- a/e2e-tests/helpers/test_helper.ts
+++ b/e2e-tests/helpers/test_helper.ts
@@ -1149,6 +1149,17 @@ export function testWithConfig(config: ElectronConfig) {
   });
 }
 
+export function testWithConfigSkipIfWindows(config: ElectronConfig) {
+  if (os.platform() === "win32") {
+    return test.skip;
+  }
+  return test.extend({
+    electronConfig: async ({}, use) => {
+      await use(config);
+    },
+  });
+}
+
 // Wrapper that skips tests on Windows platform
 export const testSkipIfWindows = os.platform() === "win32" ? test.skip : test;
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Scoped Azure e2e test env setup to prevent leaking variables across tests. Added testWithConfigSkipIfWindows and moved Azure env vars into a per-test preLaunchHook; the Azure test now skips on Windows.

<!-- End of auto-generated description by cubic. -->

