### PR TITLE
Bump to 0.21.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dyad",
   "productName": "dyad",
-  "version": "0.20.0",
+  "version": "0.21.0-beta.1",
   "description": "Free, local, open-source AI app builder",
   "main": ".vite/build/main.js",
   "repository": {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Update package version to 0.21.0-beta.1 to start the 0.21 beta cycle and enable pre-release builds and distribution. No functional code changes.

<!-- End of auto-generated description by cubic. -->

