### PR TITLE
Remove URL assertions for setup.spec.ts (fails on windows)

### DIFF
--- a/e2e-tests/setup.spec.ts
+++ b/e2e-tests/setup.spec.ts
@@ -12,7 +12,6 @@ testSetup("setup ai provider", async ({ po }) => {
   await expect(
     po.page.getByRole("heading", { name: "Configure Google" }),
   ).toBeVisible();
-  expect(po.page.url()).toEqual("file:///providers/google");
 
   await po.page.getByRole("button", { name: "Go Back" }).click();
   await po.page
@@ -21,11 +20,9 @@ testSetup("setup ai provider", async ({ po }) => {
   await expect(
     po.page.getByRole("heading", { name: "Configure OpenRouter" }),
   ).toBeVisible();
-  expect(po.page.url()).toEqual("file:///providers/openrouter");
 
   await po.page.getByRole("button", { name: "Go Back" }).click();
   await po.page
     .getByRole("button", { name: "Setup other AI providers" })
     .click();
-  expect(po.page.url()).toEqual("file:///settings");
 });


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed hard-coded file:// URL assertions from e2e-tests/setup.spec.ts to fix Windows E2E failures. The test now relies on UI visibility checks, making it OS-agnostic.

<!-- End of auto-generated description by cubic. -->

