### PR TITLE
Make Azure OpenAI Provider Configuration UI-Only

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dyad",
-  "version": "0.20.0",
+  "version": "0.21.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dyad",
-      "version": "0.20.0",
+      "version": "0.21.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/amazon-bedrock": "^3.0.15",

--- a/src/components/settings/ApiKeyConfiguration.tsx
+++ b/src/components/settings/ApiKeyConfiguration.tsx
@@ -48,9 +48,9 @@ export function ApiKeyConfiguration({
   onDeleteKey,
   isDyad,
 }: ApiKeyConfigurationProps) {
-  // Special handling for Azure OpenAI which requires environment variables
+  // Special handling for Azure OpenAI which uses UI-only configuration
   if (provider === "azure") {
-    return <AzureConfiguration envVars={envVars} />;
+    return <AzureConfiguration />;
   }
   // Special handling for Google Vertex AI which uses service account credentials
   if (provider === "vertex") {

--- a/src/components/settings/AzureConfiguration.tsx
+++ b/src/components/settings/AzureConfiguration.tsx
@@ -46,7 +46,7 @@ export function AzureConfiguration() {
           azure: {
             ...existing,
             azureApiKey: azureApiKey.trim() ? { value: azureApiKey.trim() } : undefined,
-            resourceName: resourceName || undefined,
+            resourceName: resourceName.trim() || undefined,
           },
         },
       };

--- a/src/components/settings/AzureConfiguration.tsx
+++ b/src/components/settings/AzureConfiguration.tsx
@@ -11,7 +11,7 @@ export function AzureConfiguration() {
   const existing =
     (settings?.providerSettings?.azure as AzureProviderSetting) ?? {};
 
-  const [azureApiKey, setAzureApiKey] = useState(existing.apiKey || "");
+  const [azureApiKey, setAzureApiKey] = useState(existing.apiKey?.value || "");
   const [resourceName, setResourceName] = useState(existing.resourceName || "");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/src/components/settings/AzureConfiguration.tsx
+++ b/src/components/settings/AzureConfiguration.tsx
@@ -71,8 +71,7 @@ export function AzureConfiguration() {
   };
 
   const isConfigured = Boolean(
-    (azureApiKey.trim() && resourceName.trim()) ||
-      (existing.azureApiKey?.value?.trim() && existing.resourceName?.trim()),
+    azureApiKey.trim() && resourceName.trim()
   );
 
   return (

--- a/src/components/settings/AzureConfiguration.tsx
+++ b/src/components/settings/AzureConfiguration.tsx
@@ -30,8 +30,11 @@ export function AzureConfiguration() {
 
     try {
       // Validate that both fields have values
-      if (azureApiKey && resourceName) {
-        JSON.parse("{}"); // Simple validation placeholder
+      if (azureApiKey) {
+        JSON.parse(azureApiKey);
+      }
+      if (resourceName) {
+        JSON.parse(resourceName);
       }
     } catch (e: any) {
       setError("Invalid configuration: " + e.message);
@@ -45,7 +48,9 @@ export function AzureConfiguration() {
           ...settings?.providerSettings,
           azure: {
             ...existing,
-            azureApiKey: azureApiKey.trim() ? { value: azureApiKey.trim() } : undefined,
+            azureApiKey: azureApiKey.trim()
+              ? { value: azureApiKey.trim() }
+              : undefined,
             resourceName: resourceName.trim() || undefined,
           },
         },

--- a/src/components/settings/AzureConfiguration.tsx
+++ b/src/components/settings/AzureConfiguration.tsx
@@ -63,6 +63,7 @@ export function AzureConfiguration() {
       setSaved(true);
     } catch (e: any) {
       setError(e?.message || "Failed to save Azure settings");
+      setSaved(false); // Reset saved state when error occurs
     } finally {
       setSaving(false);
     }

--- a/src/components/settings/AzureConfiguration.tsx
+++ b/src/components/settings/AzureConfiguration.tsx
@@ -28,17 +28,17 @@ export function AzureConfiguration() {
 
     try {
       // Validate that both fields have values
-      if (azureApiKey) {
-        // Validate that the API key is a non-empty string
-        if (typeof azureApiKey !== "string" || azureApiKey.trim() === "") {
-          throw new Error("API key cannot be empty");
-        }
+      // First check that both required fields are present
+      if (!azureApiKey || !resourceName) {
+        throw new Error("Both API key and resource name are required");
       }
-      if (resourceName) {
-        // Validate that the resource name is a non-empty string
-        if (typeof resourceName !== "string" || resourceName.trim() === "") {
-          throw new Error("Resource name cannot be empty");
-        }
+      // Validate that the API key is a non-empty string
+      if (typeof azureApiKey !== "string" || azureApiKey.trim() === "") {
+        throw new Error("API key cannot be empty");
+      }
+      // Validate that the resource name is a non-empty string
+      if (typeof resourceName !== "string" || resourceName.trim() === "") {
+        throw new Error("Resource name cannot be empty");
       }
     } catch (e: any) {
       setError("Invalid configuration: " + e.message);

--- a/src/components/settings/AzureConfiguration.tsx
+++ b/src/components/settings/AzureConfiguration.tsx
@@ -45,7 +45,7 @@ export function AzureConfiguration() {
           ...settings?.providerSettings,
           azure: {
             ...existing,
-            azureApiKey: azureApiKey ? { value: azureApiKey } : undefined,
+            azureApiKey: azureApiKey.trim() ? { value: azureApiKey.trim() } : undefined,
             resourceName: resourceName || undefined,
           },
         },

--- a/src/components/settings/AzureConfiguration.tsx
+++ b/src/components/settings/AzureConfiguration.tsx
@@ -61,7 +61,7 @@ export function AzureConfiguration() {
 
   const isConfigured = Boolean(
     (azureApiKey.trim() && resourceName.trim()) ||
-      (existing.azureApiKey?.value && existing.resourceName),
+      (existing.azureApiKey?.value?.trim() && existing.resourceName?.trim()),
   );
 
   return (

--- a/src/components/settings/AzureConfiguration.tsx
+++ b/src/components/settings/AzureConfiguration.tsx
@@ -31,10 +31,16 @@ export function AzureConfiguration() {
     try {
       // Validate that both fields have values
       if (azureApiKey) {
-        JSON.parse(azureApiKey);
+        // Validate that the API key is a non-empty string
+        if (typeof azureApiKey !== 'string' || azureApiKey.trim() === '') {
+          throw new Error('API key cannot be empty');
+        }
       }
       if (resourceName) {
-        JSON.parse(resourceName);
+        // Validate that the resource name is a non-empty string
+        if (typeof resourceName !== 'string' || resourceName.trim() === '') {
+          throw new Error('Resource name cannot be empty');
+        }
       }
     } catch (e: any) {
       setError("Invalid configuration: " + e.message);

--- a/src/components/settings/AzureConfiguration.tsx
+++ b/src/components/settings/AzureConfiguration.tsx
@@ -11,16 +11,14 @@ export function AzureConfiguration() {
   const existing =
     (settings?.providerSettings?.azure as AzureProviderSetting) ?? {};
 
-  const [azureApiKey, setAzureApiKey] = useState(
-    existing.azureApiKey?.value || "",
-  );
+  const [azureApiKey, setAzureApiKey] = useState(existing.apiKey || "");
   const [resourceName, setResourceName] = useState(existing.resourceName || "");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
 
   useEffect(() => {
-    setAzureApiKey(existing.azureApiKey?.value || "");
+    setAzureApiKey(existing.apiKey?.value || "");
     setResourceName(existing.resourceName || "");
   }, [settings?.providerSettings?.azure]);
 
@@ -32,14 +30,14 @@ export function AzureConfiguration() {
       // Validate that both fields have values
       if (azureApiKey) {
         // Validate that the API key is a non-empty string
-        if (typeof azureApiKey !== 'string' || azureApiKey.trim() === '') {
-          throw new Error('API key cannot be empty');
+        if (typeof azureApiKey !== "string" || azureApiKey.trim() === "") {
+          throw new Error("API key cannot be empty");
         }
       }
       if (resourceName) {
         // Validate that the resource name is a non-empty string
-        if (typeof resourceName !== 'string' || resourceName.trim() === '') {
-          throw new Error('Resource name cannot be empty');
+        if (typeof resourceName !== "string" || resourceName.trim() === "") {
+          throw new Error("Resource name cannot be empty");
         }
       }
     } catch (e: any) {
@@ -54,7 +52,7 @@ export function AzureConfiguration() {
           ...settings?.providerSettings,
           azure: {
             ...existing,
-            azureApiKey: azureApiKey.trim()
+            apiKey: azureApiKey.trim()
               ? { value: azureApiKey.trim() }
               : undefined,
             resourceName: resourceName.trim() || undefined,
@@ -70,9 +68,7 @@ export function AzureConfiguration() {
     }
   };
 
-  const isConfigured = Boolean(
-    azureApiKey.trim() && resourceName.trim()
-  );
+  const isConfigured = Boolean(azureApiKey.trim() && resourceName.trim());
 
   return (
     <div className="space-y-4">

--- a/src/components/settings/AzureConfiguration.tsx
+++ b/src/components/settings/AzureConfiguration.tsx
@@ -1,3 +1,6 @@
+import { useState, useEffect } from "react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import {
   Accordion,
@@ -5,115 +8,296 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
-import { Info, KeyRound } from "lucide-react";
+import { CheckCircle2, KeyRound, Trash2 } from "lucide-react";
+import { useSettings } from "@/hooks/useSettings";
+import type { UserSettings, AzureProviderSetting } from "@/lib/schemas";
 
 interface AzureConfigurationProps {
   envVars: Record<string, string | undefined>;
 }
 
 export function AzureConfiguration({ envVars }: AzureConfigurationProps) {
-  const azureApiKey = envVars["AZURE_API_KEY"];
-  const azureResourceName = envVars["AZURE_RESOURCE_NAME"];
+  const { settings, updateSettings } = useSettings();
+  const existing =
+    (settings?.providerSettings?.azure as AzureProviderSetting) ?? {};
 
-  const isAzureConfigured = !!(azureApiKey && azureResourceName);
+  const [azureApiKey, setAzureApiKey] = useState(
+    existing.azureApiKey?.value || "",
+  );
+  const [resourceName, setResourceName] = useState(existing.resourceName || "");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  // Environment variables
+  const envAzureApiKey = envVars["AZURE_API_KEY"];
+  const envAzureResourceName = envVars["AZURE_RESOURCE_NAME"];
+
+  useEffect(() => {
+    setAzureApiKey(existing.azureApiKey?.value || "");
+    setResourceName(existing.resourceName || "");
+  }, [settings?.providerSettings?.azure]);
+
+  const onSave = async () => {
+    setError(null);
+    setSaved(false);
+
+    if (!azureApiKey.trim()) {
+      setError("Azure API Key is required");
+      return;
+    }
+
+    if (!resourceName.trim()) {
+      setError("Azure Resource Name is required");
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const settingsUpdate: Partial<UserSettings> = {
+        providerSettings: {
+          ...settings?.providerSettings,
+          azure: {
+            ...existing,
+            azureApiKey: { value: azureApiKey.trim() },
+            resourceName: resourceName.trim(),
+          },
+        },
+      };
+      await updateSettings(settingsUpdate);
+      setSaved(true);
+    } catch (e: any) {
+      setError(e?.message || "Failed to save Azure settings");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const onDelete = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const settingsUpdate: Partial<UserSettings> = {
+        providerSettings: {
+          ...settings?.providerSettings,
+          azure: {
+            azureApiKey: undefined,
+            resourceName: undefined,
+          },
+        },
+      };
+      await updateSettings(settingsUpdate);
+      setAzureApiKey("");
+      setResourceName("");
+      setSaved(true);
+    } catch (e: any) {
+      setError(e?.message || "Failed to delete Azure settings");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const isSettingsConfigured = Boolean(
+    (azureApiKey.trim() && resourceName.trim()) ||
+      (existing.azureApiKey?.value && existing.resourceName),
+  );
+
+  const isEnvConfigured = !!(envAzureApiKey && envAzureResourceName);
+
+  const activeKeySource = isSettingsConfigured
+    ? "settings"
+    : isEnvConfigured
+      ? "env"
+      : "none";
 
   return (
-    <div className="space-y-4">
-      <Alert
-        variant={isAzureConfigured ? "default" : "destructive"}
-        className={
-          isAzureConfigured
-            ? ""
-            : "border-red-200 bg-red-100 dark:border-red-800/50 dark:bg-red-800/20"
-        }
+    <Accordion
+      type="multiple"
+      className="w-full space-y-4"
+      defaultValue={
+        isSettingsConfigured || !isEnvConfigured ? ["settings-config"] : []
+      }
+    >
+      <AccordionItem
+        value="settings-config"
+        className="border rounded-lg px-4 bg-(--background-lightest)"
       >
-        <Info
-          className={`h-4 w-4 ${isAzureConfigured ? "" : "text-red-800 dark:text-red-400"}`}
-        />
-        <AlertTitle
-          className={isAzureConfigured ? "" : "text-red-800 dark:text-red-400"}
-        >
-          Azure OpenAI Configuration
-        </AlertTitle>
-        <AlertDescription
-          className={isAzureConfigured ? "" : "text-red-800 dark:text-red-400"}
-        >
-          Azure OpenAI requires both an API key and resource name to be
-          configured via environment variables.
-        </AlertDescription>
-      </Alert>
+        <AccordionTrigger className="text-lg font-medium hover:no-underline cursor-pointer">
+          Azure Configuration from Settings
+        </AccordionTrigger>
+        <AccordionContent className="pt-4">
+          {isSettingsConfigured && (
+            <Alert variant="default" className="mb-4">
+              <KeyRound className="h-4 w-4" />
+              <AlertTitle className="flex justify-between items-center">
+                <span>Current Azure Configuration (Settings)</span>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={onDelete}
+                  disabled={saving}
+                  className="flex items-center gap-1 h-7 px-2"
+                >
+                  <Trash2 className="h-4 w-4" />
+                  {saving ? "Deleting..." : "Delete"}
+                </Button>
+              </AlertTitle>
+              <AlertDescription>
+                <div className="space-y-1">
+                  <p className="font-mono text-sm">
+                    Resource: {existing.resourceName}
+                  </p>
+                  <p className="font-mono text-sm">
+                    API Key:{" "}
+                    {existing.azureApiKey?.value ? "••••••••" : "Not Set"}
+                  </p>
+                  {activeKeySource === "settings" && (
+                    <p className="text-xs text-green-600 dark:text-green-400 mt-1">
+                      This configuration is currently active.
+                    </p>
+                  )}
+                </div>
+              </AlertDescription>
+            </Alert>
+          )}
 
-      <Accordion
-        type="multiple"
-        className="w-full space-y-4"
-        defaultValue={["azure-config"]}
+          <div className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium mb-1">
+                Azure Resource Name
+              </label>
+              <Input
+                value={resourceName}
+                onChange={(e) => setResourceName(e.target.value)}
+                placeholder="your-azure-openai-resource-name"
+              />
+              <p className="mt-1 text-xs text-muted-foreground">
+                The name you gave your Azure OpenAI resource in the Azure portal
+              </p>
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">
+                Azure API Key
+              </label>
+              <Input
+                type="password"
+                value={azureApiKey}
+                onChange={(e) => setAzureApiKey(e.target.value)}
+                placeholder="Enter your Azure OpenAI API key"
+              />
+              <p className="mt-1 text-xs text-muted-foreground">
+                Get this from Keys and Endpoint in your Azure OpenAI resource
+              </p>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2 mt-4">
+            <Button
+              onClick={onSave}
+              disabled={saving || !azureApiKey.trim() || !resourceName.trim()}
+            >
+              {saving ? "Saving..." : "Save Azure Configuration"}
+            </Button>
+            {saved && !error && (
+              <span className="flex items-center text-green-600 text-sm">
+                <CheckCircle2 className="h-4 w-4 mr-1" /> Saved
+              </span>
+            )}
+          </div>
+
+          {error && (
+            <Alert variant="destructive" className="mt-4">
+              <AlertTitle>Save Error</AlertTitle>
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-3">
+            Setting configuration here will override environment variables (if
+            set). No app restart required.
+          </p>
+        </AccordionContent>
+      </AccordionItem>
+
+      <AccordionItem
+        value="env-config"
+        className="border rounded-lg px-4 bg-(--background-lightest)"
       >
-        <AccordionItem
-          value="azure-config"
-          className="border rounded-lg px-4 bg-background"
-        >
-          <AccordionTrigger className="text-lg font-medium hover:no-underline cursor-pointer">
-            Environment Variables Configuration
-          </AccordionTrigger>
-          <AccordionContent className="pt-4">
-            <div className="space-y-4">
-              <div>
-                <h4 className="font-medium mb-2">
-                  Required Environment Variables:
-                </h4>
-                <div className="space-y-3 text-sm">
-                  <div className="flex justify-between items-center p-3 bg-muted rounded border">
-                    <code className="font-mono text-foreground">
-                      AZURE_API_KEY
-                    </code>
-                    <span
-                      className={`px-2 py-1 rounded text-xs font-medium ${azureApiKey ? "bg-green-100 text-green-800 dark:bg-green-800/20 dark:text-green-400" : "bg-red-100 text-red-800 dark:bg-red-800/20 dark:text-red-400"}`}
-                    >
-                      {azureApiKey ? "Set" : "Not Set"}
-                    </span>
-                  </div>
-                  <div className="flex justify-between items-center p-3 bg-muted rounded border">
-                    <code className="font-mono text-foreground">
-                      AZURE_RESOURCE_NAME
-                    </code>
-                    <span
-                      className={`px-2 py-1 rounded text-xs font-medium ${azureResourceName ? "bg-green-100 text-green-800 dark:bg-green-800/20 dark:text-green-400" : "bg-red-100 text-red-800 dark:bg-red-800/20 dark:text-red-400"}`}
-                    >
-                      {azureResourceName ? "Set" : "Not Set"}
-                    </span>
-                  </div>
+        <AccordionTrigger className="text-lg font-medium hover:no-underline cursor-pointer">
+          Environment Variables Configuration
+        </AccordionTrigger>
+        <AccordionContent className="pt-4">
+          <div className="space-y-4">
+            <div>
+              <h4 className="font-medium mb-2">
+                Environment Variables Status:
+              </h4>
+              <div className="space-y-3 text-sm">
+                <div className="flex justify-between items-center p-3 bg-muted rounded border">
+                  <code className="font-mono text-foreground">
+                    AZURE_API_KEY
+                  </code>
+                  <span
+                    className={`px-2 py-1 rounded text-xs font-medium ${envAzureApiKey ? "bg-green-100 text-green-800 dark:bg-green-800/20 dark:text-green-400" : "bg-red-100 text-red-800 dark:bg-red-800/20 dark:text-red-400"}`}
+                  >
+                    {envAzureApiKey ? "Set" : "Not Set"}
+                  </span>
+                </div>
+                <div className="flex justify-between items-center p-3 bg-muted rounded border">
+                  <code className="font-mono text-foreground">
+                    AZURE_RESOURCE_NAME
+                  </code>
+                  <span
+                    className={`px-2 py-1 rounded text-xs font-medium ${envAzureResourceName ? "bg-green-100 text-green-800 dark:bg-green-800/20 dark:text-green-400" : "bg-red-100 text-red-800 dark:bg-red-800/20 dark:text-red-400"}`}
+                  >
+                    {envAzureResourceName ? "Set" : "Not Set"}
+                  </span>
                 </div>
               </div>
-
-              <div className="mt-4 p-4 bg-blue-50 dark:bg-blue-950/30 rounded border border-blue-200 dark:border-blue-700">
-                <h5 className="font-medium mb-2 text-blue-900 dark:text-blue-200">
-                  How to configure:
-                </h5>
-                <ol className="list-decimal list-inside space-y-1 text-sm text-blue-800 dark:text-blue-300">
-                  <li>Get your API key from the Azure portal</li>
-                  <li>
-                    Find your resource name (the name you gave your Azure OpenAI
-                    resource)
-                  </li>
-                  <li>Set these environment variables before starting Dyad</li>
-                  <li>Restart Dyad after setting the environment variables</li>
-                </ol>
-              </div>
-
-              {isAzureConfigured && (
-                <Alert>
+              {isEnvConfigured && (
+                <Alert className="mt-4">
                   <KeyRound className="h-4 w-4" />
-                  <AlertTitle>Azure OpenAI Configured</AlertTitle>
+                  <AlertTitle>Environment Variables Set</AlertTitle>
                   <AlertDescription>
-                    Both required environment variables are set. You can now use
-                    Azure OpenAI models.
+                    {activeKeySource === "env" && (
+                      <p className="text-xs text-green-600 dark:text-green-400 mt-1">
+                        Environment variables are currently active (no settings
+                        configuration set).
+                      </p>
+                    )}
+                    {activeKeySource === "settings" && (
+                      <p className="text-xs text-yellow-600 dark:text-yellow-400 mt-1">
+                        Environment variables are set but being overridden by
+                        the settings configuration above.
+                      </p>
+                    )}
                   </AlertDescription>
                 </Alert>
               )}
             </div>
-          </AccordionContent>
-        </AccordionItem>
-      </Accordion>
-    </div>
+
+            <div className="mt-4 p-4 bg-blue-50 dark:bg-blue-950/30 rounded border border-blue-200 dark:border-blue-700">
+              <h5 className="font-medium mb-2 text-blue-900 dark:text-blue-200">
+                How to set environment variables:
+              </h5>
+              <ol className="list-decimal list-inside space-y-1 text-sm text-blue-800 dark:text-blue-300">
+                <li>Get your API key from the Azure portal</li>
+                <li>
+                  Find your resource name (the name you gave your Azure OpenAI
+                  resource)
+                </li>
+                <li>Set these environment variables before starting Dyad</li>
+                <li>Restart Dyad after setting the environment variables</li>
+              </ol>
+            </div>
+
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-3">
+              Environment variables are used only if no settings configuration
+              is set above. Requires app restart to detect changes.
+            </p>
+          </div>
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
   );
 }

--- a/src/components/settings/AzureConfiguration.tsx
+++ b/src/components/settings/AzureConfiguration.tsx
@@ -120,7 +120,7 @@ export function AzureConfiguration({ envVars }: AzureConfigurationProps) {
     >
       <AccordionItem
         value="settings-config"
-        className="border rounded-lg px-4 bg-background"
+        className="border rounded-lg px-4 bg-(--background-lightest)"
       >
         <AccordionTrigger className="text-lg font-medium hover:no-underline cursor-pointer">
           Azure Configuration from Settings
@@ -221,7 +221,7 @@ export function AzureConfiguration({ envVars }: AzureConfigurationProps) {
 
       <AccordionItem
         value="env-config"
-        className="border rounded-lg px-4 bg-background"
+        className="border rounded-lg px-4 bg-(--background-lightest)"
       >
         <AccordionTrigger className="text-lg font-medium hover:no-underline cursor-pointer">
           Environment Variables Configuration

--- a/src/components/settings/AzureConfiguration.tsx
+++ b/src/components/settings/AzureConfiguration.tsx
@@ -2,6 +2,12 @@ import { useState, useEffect } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
 import { CheckCircle2, KeyRound, Trash2 } from "lucide-react";
 import { useSettings } from "@/hooks/useSettings";
 import type { UserSettings, AzureProviderSetting } from "@/lib/schemas";
@@ -105,148 +111,193 @@ export function AzureConfiguration({ envVars }: AzureConfigurationProps) {
       : "none";
 
   return (
-    <div className="space-y-4">
-      {isSettingsConfigured && (
-        <Alert variant="default" className="mb-4">
-          <KeyRound className="h-4 w-4" />
-          <AlertTitle className="flex justify-between items-center">
-            <span>Current Azure Configuration (Settings)</span>
-            <Button
-              variant="destructive"
-              size="sm"
-              onClick={onDelete}
-              disabled={saving}
-              className="flex items-center gap-1 h-7 px-2"
-            >
-              <Trash2 className="h-4 w-4" />
-              {saving ? "Deleting..." : "Delete"}
-            </Button>
-          </AlertTitle>
-          <AlertDescription>
-            <div className="space-y-1">
-              <p className="font-mono text-sm">
-                Resource: {existing.resourceName}
+    <Accordion
+      type="multiple"
+      className="w-full space-y-4"
+      defaultValue={
+        isSettingsConfigured || !isEnvConfigured ? ["settings-config"] : []
+      }
+    >
+      <AccordionItem
+        value="settings-config"
+        className="border rounded-lg px-4 bg-background"
+      >
+        <AccordionTrigger className="text-lg font-medium hover:no-underline cursor-pointer">
+          Azure Configuration from Settings
+        </AccordionTrigger>
+        <AccordionContent className="pt-4">
+          {isSettingsConfigured && (
+            <Alert variant="default" className="mb-4">
+              <KeyRound className="h-4 w-4" />
+              <AlertTitle className="flex justify-between items-center">
+                <span>Current Azure Configuration (Settings)</span>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={onDelete}
+                  disabled={saving}
+                  className="flex items-center gap-1 h-7 px-2"
+                >
+                  <Trash2 className="h-4 w-4" />
+                  {saving ? "Deleting..." : "Delete"}
+                </Button>
+              </AlertTitle>
+              <AlertDescription>
+                <div className="space-y-1">
+                  <p className="font-mono text-sm">
+                    Resource: {existing.resourceName}
+                  </p>
+                  <p className="font-mono text-sm">
+                    API Key:{" "}
+                    {existing.azureApiKey?.value ? "••••••••" : "Not Set"}
+                  </p>
+                  {activeKeySource === "settings" && (
+                    <p className="text-xs text-green-600 dark:text-green-400 mt-1">
+                      This configuration is currently active.
+                    </p>
+                  )}
+                </div>
+              </AlertDescription>
+            </Alert>
+          )}
+
+          <div className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium mb-1">
+                Azure Resource Name
+              </label>
+              <Input
+                value={resourceName}
+                onChange={(e) => setResourceName(e.target.value)}
+                placeholder="your-azure-openai-resource-name"
+              />
+              <p className="mt-1 text-xs text-muted-foreground">
+                The name you gave your Azure OpenAI resource in the Azure portal
               </p>
-              <p className="font-mono text-sm">
-                API Key: {existing.azureApiKey?.value ? "••••••••" : "Not Set"}
-              </p>
-              {activeKeySource === "settings" && (
-                <p className="text-xs text-green-600 dark:text-green-400 mt-1">
-                  This configuration is currently active.
-                </p>
-              )}
             </div>
-          </AlertDescription>
-        </Alert>
-      )}
+            <div>
+              <label className="block text-sm font-medium mb-1">
+                Azure API Key
+              </label>
+              <Input
+                type="password"
+                value={azureApiKey}
+                onChange={(e) => setAzureApiKey(e.target.value)}
+                placeholder="Enter your Azure OpenAI API key"
+              />
+              <p className="mt-1 text-xs text-muted-foreground">
+                Get this from Keys and Endpoint in your Azure OpenAI resource
+              </p>
+            </div>
+          </div>
 
-      <div className="grid grid-cols-1 gap-4">
-        <div>
-          <label className="block text-sm font-medium mb-1">
-            Azure Resource Name
-          </label>
-          <Input
-            value={resourceName}
-            onChange={(e) => setResourceName(e.target.value)}
-            placeholder="your-azure-openai-resource-name"
-          />
-          <p className="mt-1 text-xs text-muted-foreground">
-            The name you gave your Azure OpenAI resource in the Azure portal
+          <div className="flex items-center gap-2 mt-4">
+            <Button
+              onClick={onSave}
+              disabled={saving || !azureApiKey.trim() || !resourceName.trim()}
+            >
+              {saving ? "Saving..." : "Save Azure Configuration"}
+            </Button>
+            {saved && !error && (
+              <span className="flex items-center text-green-600 text-sm">
+                <CheckCircle2 className="h-4 w-4 mr-1" /> Saved
+              </span>
+            )}
+          </div>
+
+          {error && (
+            <Alert variant="destructive" className="mt-4">
+              <AlertTitle>Save Error</AlertTitle>
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-3">
+            Setting configuration here will override environment variables (if
+            set). No app restart required.
           </p>
-        </div>
-        <div>
-          <label className="block text-sm font-medium mb-1">
-            Azure API Key
-          </label>
-          <Input
-            type="password"
-            value={azureApiKey}
-            onChange={(e) => setAzureApiKey(e.target.value)}
-            placeholder="Enter your Azure OpenAI API key"
-          />
-          <p className="mt-1 text-xs text-muted-foreground">
-            Get this from Keys and Endpoint in your Azure OpenAI resource
-          </p>
-        </div>
-      </div>
+        </AccordionContent>
+      </AccordionItem>
 
-      <div className="flex items-center gap-2">
-        <Button
-          onClick={onSave}
-          disabled={saving || !azureApiKey.trim() || !resourceName.trim()}
-        >
-          {saving ? "Saving..." : "Save Azure Configuration"}
-        </Button>
-        {saved && !error && (
-          <span className="flex items-center text-green-600 text-sm">
-            <CheckCircle2 className="h-4 w-4 mr-1" /> Saved
-          </span>
-        )}
-      </div>
-
-      {error && (
-        <Alert variant="destructive" className="mt-4">
-          <AlertTitle>Save Error</AlertTitle>
-          <AlertDescription>{error}</AlertDescription>
-        </Alert>
-      )}
-
-      {isEnvConfigured && (
-        <Alert className="mt-4">
-          <KeyRound className="h-4 w-4" />
-          <AlertTitle>Environment Variables Detected</AlertTitle>
-          <AlertDescription>
-            <div className="space-y-2">
-              <div className="space-y-1 text-sm">
-                <div className="flex justify-between items-center">
-                  <code className="font-mono">AZURE_API_KEY</code>
-                  <span className="px-2 py-1 rounded text-xs font-medium bg-green-100 text-green-800 dark:bg-green-800/20 dark:text-green-400">
-                    Set
+      <AccordionItem
+        value="env-config"
+        className="border rounded-lg px-4 bg-background"
+      >
+        <AccordionTrigger className="text-lg font-medium hover:no-underline cursor-pointer">
+          Environment Variables Configuration
+        </AccordionTrigger>
+        <AccordionContent className="pt-4">
+          <div className="space-y-4">
+            <div>
+              <h4 className="font-medium mb-2">
+                Environment Variables Status:
+              </h4>
+              <div className="space-y-3 text-sm">
+                <div className="flex justify-between items-center p-3 bg-muted rounded border">
+                  <code className="font-mono text-foreground">
+                    AZURE_API_KEY
+                  </code>
+                  <span
+                    className={`px-2 py-1 rounded text-xs font-medium ${envAzureApiKey ? "bg-green-100 text-green-800 dark:bg-green-800/20 dark:text-green-400" : "bg-red-100 text-red-800 dark:bg-red-800/20 dark:text-red-400"}`}
+                  >
+                    {envAzureApiKey ? "Set" : "Not Set"}
                   </span>
                 </div>
-                <div className="flex justify-between items-center">
-                  <code className="font-mono">AZURE_RESOURCE_NAME</code>
-                  <span className="px-2 py-1 rounded text-xs font-medium bg-green-100 text-green-800 dark:bg-green-800/20 dark:text-green-400">
-                    Set
+                <div className="flex justify-between items-center p-3 bg-muted rounded border">
+                  <code className="font-mono text-foreground">
+                    AZURE_RESOURCE_NAME
+                  </code>
+                  <span
+                    className={`px-2 py-1 rounded text-xs font-medium ${envAzureResourceName ? "bg-green-100 text-green-800 dark:bg-green-800/20 dark:text-green-400" : "bg-red-100 text-red-800 dark:bg-red-800/20 dark:text-red-400"}`}
+                  >
+                    {envAzureResourceName ? "Set" : "Not Set"}
                   </span>
                 </div>
               </div>
-              {activeKeySource === "env" && (
-                <p className="text-xs text-green-600 dark:text-green-400">
-                  Environment variables are currently active (no settings
-                  configuration set).
-                </p>
-              )}
-              {activeKeySource === "settings" && (
-                <p className="text-xs text-yellow-600 dark:text-yellow-400">
-                  Environment variables are set but being overridden by the
-                  settings configuration above.
-                </p>
+              {isEnvConfigured && (
+                <Alert className="mt-4">
+                  <KeyRound className="h-4 w-4" />
+                  <AlertTitle>Environment Variables Set</AlertTitle>
+                  <AlertDescription>
+                    {activeKeySource === "env" && (
+                      <p className="text-xs text-green-600 dark:text-green-400 mt-1">
+                        Environment variables are currently active (no settings
+                        configuration set).
+                      </p>
+                    )}
+                    {activeKeySource === "settings" && (
+                      <p className="text-xs text-yellow-600 dark:text-yellow-400 mt-1">
+                        Environment variables are set but being overridden by
+                        the settings configuration above.
+                      </p>
+                    )}
+                  </AlertDescription>
+                </Alert>
               )}
             </div>
-          </AlertDescription>
-        </Alert>
-      )}
 
-      <div className="mt-4 p-4 bg-blue-50 dark:bg-blue-950/30 rounded border border-blue-200 dark:border-blue-700">
-        <h5 className="font-medium mb-2 text-blue-900 dark:text-blue-200">
-          Alternative: Environment Variables
-        </h5>
-        <p className="text-sm text-blue-800 dark:text-blue-300 mb-2">
-          You can also configure Azure OpenAI using environment variables
-          instead of the form above:
-        </p>
-        <ol className="list-decimal list-inside space-y-1 text-sm text-blue-800 dark:text-blue-300">
-          <li>
-            Set AZURE_API_KEY and AZURE_RESOURCE_NAME environment variables
-          </li>
-          <li>Restart Dyad to detect the changes</li>
-        </ol>
-        <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
-          Environment variables are used only if no settings configuration is
-          set above.
-        </p>
-      </div>
-    </div>
+            <div className="mt-4 p-4 bg-blue-50 dark:bg-blue-950/30 rounded border border-blue-200 dark:border-blue-700">
+              <h5 className="font-medium mb-2 text-blue-900 dark:text-blue-200">
+                How to set environment variables:
+              </h5>
+              <ol className="list-decimal list-inside space-y-1 text-sm text-blue-800 dark:text-blue-300">
+                <li>Get your API key from the Azure portal</li>
+                <li>
+                  Find your resource name (the name you gave your Azure OpenAI
+                  resource)
+                </li>
+                <li>Set these environment variables before starting Dyad</li>
+                <li>Restart Dyad after setting the environment variables</li>
+              </ol>
+            </div>
+
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-3">
+              Environment variables are used only if no settings configuration
+              is set above. Requires app restart to detect changes.
+            </p>
+          </div>
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
   );
 }

--- a/src/components/settings/AzureConfiguration.tsx
+++ b/src/components/settings/AzureConfiguration.tsx
@@ -120,7 +120,7 @@ export function AzureConfiguration({ envVars }: AzureConfigurationProps) {
     >
       <AccordionItem
         value="settings-config"
-        className="border rounded-lg px-4 bg-(--background-lightest)"
+        className="border rounded-lg px-4 bg-background"
       >
         <AccordionTrigger className="text-lg font-medium hover:no-underline cursor-pointer">
           Azure Configuration from Settings
@@ -221,7 +221,7 @@ export function AzureConfiguration({ envVars }: AzureConfigurationProps) {
 
       <AccordionItem
         value="env-config"
-        className="border rounded-lg px-4 bg-(--background-lightest)"
+        className="border rounded-lg px-4 bg-background"
       >
         <AccordionTrigger className="text-lg font-medium hover:no-underline cursor-pointer">
           Environment Variables Configuration

--- a/src/components/settings/AzureConfiguration.tsx
+++ b/src/components/settings/AzureConfiguration.tsx
@@ -2,12 +2,6 @@ import { useState, useEffect } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "@/components/ui/accordion";
 import { CheckCircle2, KeyRound, Trash2 } from "lucide-react";
 import { useSettings } from "@/hooks/useSettings";
 import type { UserSettings, AzureProviderSetting } from "@/lib/schemas";
@@ -111,193 +105,148 @@ export function AzureConfiguration({ envVars }: AzureConfigurationProps) {
       : "none";
 
   return (
-    <Accordion
-      type="multiple"
-      className="w-full space-y-4"
-      defaultValue={
-        isSettingsConfigured || !isEnvConfigured ? ["settings-config"] : []
-      }
-    >
-      <AccordionItem
-        value="settings-config"
-        className="border rounded-lg px-4 bg-background"
-      >
-        <AccordionTrigger className="text-lg font-medium hover:no-underline cursor-pointer">
-          Azure Configuration from Settings
-        </AccordionTrigger>
-        <AccordionContent className="pt-4">
-          {isSettingsConfigured && (
-            <Alert variant="default" className="mb-4">
-              <KeyRound className="h-4 w-4" />
-              <AlertTitle className="flex justify-between items-center">
-                <span>Current Azure Configuration (Settings)</span>
-                <Button
-                  variant="destructive"
-                  size="sm"
-                  onClick={onDelete}
-                  disabled={saving}
-                  className="flex items-center gap-1 h-7 px-2"
-                >
-                  <Trash2 className="h-4 w-4" />
-                  {saving ? "Deleting..." : "Delete"}
-                </Button>
-              </AlertTitle>
-              <AlertDescription>
-                <div className="space-y-1">
-                  <p className="font-mono text-sm">
-                    Resource: {existing.resourceName}
-                  </p>
-                  <p className="font-mono text-sm">
-                    API Key:{" "}
-                    {existing.azureApiKey?.value ? "••••••••" : "Not Set"}
-                  </p>
-                  {activeKeySource === "settings" && (
-                    <p className="text-xs text-green-600 dark:text-green-400 mt-1">
-                      This configuration is currently active.
-                    </p>
-                  )}
-                </div>
-              </AlertDescription>
-            </Alert>
-          )}
-
-          <div className="space-y-4">
-            <div>
-              <label className="block text-sm font-medium mb-1">
-                Azure Resource Name
-              </label>
-              <Input
-                value={resourceName}
-                onChange={(e) => setResourceName(e.target.value)}
-                placeholder="your-azure-openai-resource-name"
-              />
-              <p className="mt-1 text-xs text-muted-foreground">
-                The name you gave your Azure OpenAI resource in the Azure portal
-              </p>
-            </div>
-            <div>
-              <label className="block text-sm font-medium mb-1">
-                Azure API Key
-              </label>
-              <Input
-                type="password"
-                value={azureApiKey}
-                onChange={(e) => setAzureApiKey(e.target.value)}
-                placeholder="Enter your Azure OpenAI API key"
-              />
-              <p className="mt-1 text-xs text-muted-foreground">
-                Get this from Keys and Endpoint in your Azure OpenAI resource
-              </p>
-            </div>
-          </div>
-
-          <div className="flex items-center gap-2 mt-4">
+    <div className="space-y-4">
+      {isSettingsConfigured && (
+        <Alert variant="default" className="mb-4">
+          <KeyRound className="h-4 w-4" />
+          <AlertTitle className="flex justify-between items-center">
+            <span>Current Azure Configuration (Settings)</span>
             <Button
-              onClick={onSave}
-              disabled={saving || !azureApiKey.trim() || !resourceName.trim()}
+              variant="destructive"
+              size="sm"
+              onClick={onDelete}
+              disabled={saving}
+              className="flex items-center gap-1 h-7 px-2"
             >
-              {saving ? "Saving..." : "Save Azure Configuration"}
+              <Trash2 className="h-4 w-4" />
+              {saving ? "Deleting..." : "Delete"}
             </Button>
-            {saved && !error && (
-              <span className="flex items-center text-green-600 text-sm">
-                <CheckCircle2 className="h-4 w-4 mr-1" /> Saved
-              </span>
-            )}
-          </div>
+          </AlertTitle>
+          <AlertDescription>
+            <div className="space-y-1">
+              <p className="font-mono text-sm">
+                Resource: {existing.resourceName}
+              </p>
+              <p className="font-mono text-sm">
+                API Key: {existing.azureApiKey?.value ? "••••••••" : "Not Set"}
+              </p>
+              {activeKeySource === "settings" && (
+                <p className="text-xs text-green-600 dark:text-green-400 mt-1">
+                  This configuration is currently active.
+                </p>
+              )}
+            </div>
+          </AlertDescription>
+        </Alert>
+      )}
 
-          {error && (
-            <Alert variant="destructive" className="mt-4">
-              <AlertTitle>Save Error</AlertTitle>
-              <AlertDescription>{error}</AlertDescription>
-            </Alert>
-          )}
-
-          <p className="text-xs text-gray-500 dark:text-gray-400 mt-3">
-            Setting configuration here will override environment variables (if
-            set). No app restart required.
+      <div className="grid grid-cols-1 gap-4">
+        <div>
+          <label className="block text-sm font-medium mb-1">
+            Azure Resource Name
+          </label>
+          <Input
+            value={resourceName}
+            onChange={(e) => setResourceName(e.target.value)}
+            placeholder="your-azure-openai-resource-name"
+          />
+          <p className="mt-1 text-xs text-muted-foreground">
+            The name you gave your Azure OpenAI resource in the Azure portal
           </p>
-        </AccordionContent>
-      </AccordionItem>
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">
+            Azure API Key
+          </label>
+          <Input
+            type="password"
+            value={azureApiKey}
+            onChange={(e) => setAzureApiKey(e.target.value)}
+            placeholder="Enter your Azure OpenAI API key"
+          />
+          <p className="mt-1 text-xs text-muted-foreground">
+            Get this from Keys and Endpoint in your Azure OpenAI resource
+          </p>
+        </div>
+      </div>
 
-      <AccordionItem
-        value="env-config"
-        className="border rounded-lg px-4 bg-background"
-      >
-        <AccordionTrigger className="text-lg font-medium hover:no-underline cursor-pointer">
-          Environment Variables Configuration
-        </AccordionTrigger>
-        <AccordionContent className="pt-4">
-          <div className="space-y-4">
-            <div>
-              <h4 className="font-medium mb-2">
-                Environment Variables Status:
-              </h4>
-              <div className="space-y-3 text-sm">
-                <div className="flex justify-between items-center p-3 bg-muted rounded border">
-                  <code className="font-mono text-foreground">
-                    AZURE_API_KEY
-                  </code>
-                  <span
-                    className={`px-2 py-1 rounded text-xs font-medium ${envAzureApiKey ? "bg-green-100 text-green-800 dark:bg-green-800/20 dark:text-green-400" : "bg-red-100 text-red-800 dark:bg-red-800/20 dark:text-red-400"}`}
-                  >
-                    {envAzureApiKey ? "Set" : "Not Set"}
+      <div className="flex items-center gap-2">
+        <Button
+          onClick={onSave}
+          disabled={saving || !azureApiKey.trim() || !resourceName.trim()}
+        >
+          {saving ? "Saving..." : "Save Azure Configuration"}
+        </Button>
+        {saved && !error && (
+          <span className="flex items-center text-green-600 text-sm">
+            <CheckCircle2 className="h-4 w-4 mr-1" /> Saved
+          </span>
+        )}
+      </div>
+
+      {error && (
+        <Alert variant="destructive" className="mt-4">
+          <AlertTitle>Save Error</AlertTitle>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {isEnvConfigured && (
+        <Alert className="mt-4">
+          <KeyRound className="h-4 w-4" />
+          <AlertTitle>Environment Variables Detected</AlertTitle>
+          <AlertDescription>
+            <div className="space-y-2">
+              <div className="space-y-1 text-sm">
+                <div className="flex justify-between items-center">
+                  <code className="font-mono">AZURE_API_KEY</code>
+                  <span className="px-2 py-1 rounded text-xs font-medium bg-green-100 text-green-800 dark:bg-green-800/20 dark:text-green-400">
+                    Set
                   </span>
                 </div>
-                <div className="flex justify-between items-center p-3 bg-muted rounded border">
-                  <code className="font-mono text-foreground">
-                    AZURE_RESOURCE_NAME
-                  </code>
-                  <span
-                    className={`px-2 py-1 rounded text-xs font-medium ${envAzureResourceName ? "bg-green-100 text-green-800 dark:bg-green-800/20 dark:text-green-400" : "bg-red-100 text-red-800 dark:bg-red-800/20 dark:text-red-400"}`}
-                  >
-                    {envAzureResourceName ? "Set" : "Not Set"}
+                <div className="flex justify-between items-center">
+                  <code className="font-mono">AZURE_RESOURCE_NAME</code>
+                  <span className="px-2 py-1 rounded text-xs font-medium bg-green-100 text-green-800 dark:bg-green-800/20 dark:text-green-400">
+                    Set
                   </span>
                 </div>
               </div>
-              {isEnvConfigured && (
-                <Alert className="mt-4">
-                  <KeyRound className="h-4 w-4" />
-                  <AlertTitle>Environment Variables Set</AlertTitle>
-                  <AlertDescription>
-                    {activeKeySource === "env" && (
-                      <p className="text-xs text-green-600 dark:text-green-400 mt-1">
-                        Environment variables are currently active (no settings
-                        configuration set).
-                      </p>
-                    )}
-                    {activeKeySource === "settings" && (
-                      <p className="text-xs text-yellow-600 dark:text-yellow-400 mt-1">
-                        Environment variables are set but being overridden by
-                        the settings configuration above.
-                      </p>
-                    )}
-                  </AlertDescription>
-                </Alert>
+              {activeKeySource === "env" && (
+                <p className="text-xs text-green-600 dark:text-green-400">
+                  Environment variables are currently active (no settings
+                  configuration set).
+                </p>
+              )}
+              {activeKeySource === "settings" && (
+                <p className="text-xs text-yellow-600 dark:text-yellow-400">
+                  Environment variables are set but being overridden by the
+                  settings configuration above.
+                </p>
               )}
             </div>
+          </AlertDescription>
+        </Alert>
+      )}
 
-            <div className="mt-4 p-4 bg-blue-50 dark:bg-blue-950/30 rounded border border-blue-200 dark:border-blue-700">
-              <h5 className="font-medium mb-2 text-blue-900 dark:text-blue-200">
-                How to set environment variables:
-              </h5>
-              <ol className="list-decimal list-inside space-y-1 text-sm text-blue-800 dark:text-blue-300">
-                <li>Get your API key from the Azure portal</li>
-                <li>
-                  Find your resource name (the name you gave your Azure OpenAI
-                  resource)
-                </li>
-                <li>Set these environment variables before starting Dyad</li>
-                <li>Restart Dyad after setting the environment variables</li>
-              </ol>
-            </div>
-
-            <p className="text-xs text-gray-500 dark:text-gray-400 mt-3">
-              Environment variables are used only if no settings configuration
-              is set above. Requires app restart to detect changes.
-            </p>
-          </div>
-        </AccordionContent>
-      </AccordionItem>
-    </Accordion>
+      <div className="mt-4 p-4 bg-blue-50 dark:bg-blue-950/30 rounded border border-blue-200 dark:border-blue-700">
+        <h5 className="font-medium mb-2 text-blue-900 dark:text-blue-200">
+          Alternative: Environment Variables
+        </h5>
+        <p className="text-sm text-blue-800 dark:text-blue-300 mb-2">
+          You can also configure Azure OpenAI using environment variables
+          instead of the form above:
+        </p>
+        <ol className="list-decimal list-inside space-y-1 text-sm text-blue-800 dark:text-blue-300">
+          <li>
+            Set AZURE_API_KEY and AZURE_RESOURCE_NAME environment variables
+          </li>
+          <li>Restart Dyad to detect the changes</li>
+        </ol>
+        <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
+          Environment variables are used only if no settings configuration is
+          set above.
+        </p>
+      </div>
+    </div>
   );
 }

--- a/src/components/settings/AzureConfiguration.tsx
+++ b/src/components/settings/AzureConfiguration.tsx
@@ -2,21 +2,11 @@ import { useState, useEffect } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "@/components/ui/accordion";
-import { CheckCircle2, KeyRound, Trash2 } from "lucide-react";
+import { Info, CheckCircle2 } from "lucide-react";
 import { useSettings } from "@/hooks/useSettings";
 import type { UserSettings, AzureProviderSetting } from "@/lib/schemas";
 
-interface AzureConfigurationProps {
-  envVars: Record<string, string | undefined>;
-}
-
-export function AzureConfiguration({ envVars }: AzureConfigurationProps) {
+export function AzureConfiguration() {
   const { settings, updateSettings } = useSettings();
   const existing =
     (settings?.providerSettings?.azure as AzureProviderSetting) ?? {};
@@ -29,10 +19,6 @@ export function AzureConfiguration({ envVars }: AzureConfigurationProps) {
   const [error, setError] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
 
-  // Environment variables
-  const envAzureApiKey = envVars["AZURE_API_KEY"];
-  const envAzureResourceName = envVars["AZURE_RESOURCE_NAME"];
-
   useEffect(() => {
     setAzureApiKey(existing.azureApiKey?.value || "");
     setResourceName(existing.resourceName || "");
@@ -42,13 +28,13 @@ export function AzureConfiguration({ envVars }: AzureConfigurationProps) {
     setError(null);
     setSaved(false);
 
-    if (!azureApiKey.trim()) {
-      setError("Azure API Key is required");
-      return;
-    }
-
-    if (!resourceName.trim()) {
-      setError("Azure Resource Name is required");
+    try {
+      // Validate that both fields have values
+      if (azureApiKey && resourceName) {
+        JSON.parse("{}"); // Simple validation placeholder
+      }
+    } catch (e: any) {
+      setError("Invalid configuration: " + e.message);
       return;
     }
 
@@ -59,8 +45,8 @@ export function AzureConfiguration({ envVars }: AzureConfigurationProps) {
           ...settings?.providerSettings,
           azure: {
             ...existing,
-            azureApiKey: { value: azureApiKey.trim() },
-            resourceName: resourceName.trim(),
+            azureApiKey: azureApiKey ? { value: azureApiKey } : undefined,
+            resourceName: resourceName || undefined,
           },
         },
       };
@@ -73,231 +59,71 @@ export function AzureConfiguration({ envVars }: AzureConfigurationProps) {
     }
   };
 
-  const onDelete = async () => {
-    setSaving(true);
-    setError(null);
-    try {
-      const settingsUpdate: Partial<UserSettings> = {
-        providerSettings: {
-          ...settings?.providerSettings,
-          azure: {
-            azureApiKey: undefined,
-            resourceName: undefined,
-          },
-        },
-      };
-      await updateSettings(settingsUpdate);
-      setAzureApiKey("");
-      setResourceName("");
-      setSaved(true);
-    } catch (e: any) {
-      setError(e?.message || "Failed to delete Azure settings");
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const isSettingsConfigured = Boolean(
+  const isConfigured = Boolean(
     (azureApiKey.trim() && resourceName.trim()) ||
       (existing.azureApiKey?.value && existing.resourceName),
   );
 
-  const isEnvConfigured = !!(envAzureApiKey && envAzureResourceName);
-
-  const activeKeySource = isSettingsConfigured
-    ? "settings"
-    : isEnvConfigured
-      ? "env"
-      : "none";
-
   return (
-    <Accordion
-      type="multiple"
-      className="w-full space-y-4"
-      defaultValue={
-        isSettingsConfigured || !isEnvConfigured ? ["settings-config"] : []
-      }
-    >
-      <AccordionItem
-        value="settings-config"
-        className="border rounded-lg px-4 bg-(--background-lightest)"
-      >
-        <AccordionTrigger className="text-lg font-medium hover:no-underline cursor-pointer">
-          Azure Configuration from Settings
-        </AccordionTrigger>
-        <AccordionContent className="pt-4">
-          {isSettingsConfigured && (
-            <Alert variant="default" className="mb-4">
-              <KeyRound className="h-4 w-4" />
-              <AlertTitle className="flex justify-between items-center">
-                <span>Current Azure Configuration (Settings)</span>
-                <Button
-                  variant="destructive"
-                  size="sm"
-                  onClick={onDelete}
-                  disabled={saving}
-                  className="flex items-center gap-1 h-7 px-2"
-                >
-                  <Trash2 className="h-4 w-4" />
-                  {saving ? "Deleting..." : "Delete"}
-                </Button>
-              </AlertTitle>
-              <AlertDescription>
-                <div className="space-y-1">
-                  <p className="font-mono text-sm">
-                    Resource: {existing.resourceName}
-                  </p>
-                  <p className="font-mono text-sm">
-                    API Key:{" "}
-                    {existing.azureApiKey?.value ? "••••••••" : "Not Set"}
-                  </p>
-                  {activeKeySource === "settings" && (
-                    <p className="text-xs text-green-600 dark:text-green-400 mt-1">
-                      This configuration is currently active.
-                    </p>
-                  )}
-                </div>
-              </AlertDescription>
-            </Alert>
-          )}
-
-          <div className="space-y-4">
-            <div>
-              <label className="block text-sm font-medium mb-1">
-                Azure Resource Name
-              </label>
-              <Input
-                value={resourceName}
-                onChange={(e) => setResourceName(e.target.value)}
-                placeholder="your-azure-openai-resource-name"
-              />
-              <p className="mt-1 text-xs text-muted-foreground">
-                The name you gave your Azure OpenAI resource in the Azure portal
-              </p>
-            </div>
-            <div>
-              <label className="block text-sm font-medium mb-1">
-                Azure API Key
-              </label>
-              <Input
-                type="password"
-                value={azureApiKey}
-                onChange={(e) => setAzureApiKey(e.target.value)}
-                placeholder="Enter your Azure OpenAI API key"
-              />
-              <p className="mt-1 text-xs text-muted-foreground">
-                Get this from Keys and Endpoint in your Azure OpenAI resource
-              </p>
-            </div>
-          </div>
-
-          <div className="flex items-center gap-2 mt-4">
-            <Button
-              onClick={onSave}
-              disabled={saving || !azureApiKey.trim() || !resourceName.trim()}
-            >
-              {saving ? "Saving..." : "Save Azure Configuration"}
-            </Button>
-            {saved && !error && (
-              <span className="flex items-center text-green-600 text-sm">
-                <CheckCircle2 className="h-4 w-4 mr-1" /> Saved
-              </span>
-            )}
-          </div>
-
-          {error && (
-            <Alert variant="destructive" className="mt-4">
-              <AlertTitle>Save Error</AlertTitle>
-              <AlertDescription>{error}</AlertDescription>
-            </Alert>
-          )}
-
-          <p className="text-xs text-gray-500 dark:text-gray-400 mt-3">
-            Setting configuration here will override environment variables (if
-            set). No app restart required.
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 gap-4">
+        <div>
+          <label className="block text-sm font-medium mb-1">
+            Azure Resource Name
+          </label>
+          <Input
+            value={resourceName}
+            onChange={(e) => setResourceName(e.target.value)}
+            placeholder="your-azure-openai-resource"
+          />
+          <p className="mt-1 text-xs text-muted-foreground">
+            The name you gave your Azure OpenAI resource in the Azure portal
           </p>
-        </AccordionContent>
-      </AccordionItem>
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">
+            Azure API Key
+          </label>
+          <Input
+            type="password"
+            value={azureApiKey}
+            onChange={(e) => setAzureApiKey(e.target.value)}
+            placeholder="Enter your Azure OpenAI API key"
+          />
+          <p className="mt-1 text-xs text-muted-foreground">
+            Get this from Keys and Endpoint in your Azure OpenAI resource
+          </p>
+        </div>
+      </div>
 
-      <AccordionItem
-        value="env-config"
-        className="border rounded-lg px-4 bg-(--background-lightest)"
-      >
-        <AccordionTrigger className="text-lg font-medium hover:no-underline cursor-pointer">
-          Environment Variables Configuration
-        </AccordionTrigger>
-        <AccordionContent className="pt-4">
-          <div className="space-y-4">
-            <div>
-              <h4 className="font-medium mb-2">
-                Environment Variables Status:
-              </h4>
-              <div className="space-y-3 text-sm">
-                <div className="flex justify-between items-center p-3 bg-muted rounded border">
-                  <code className="font-mono text-foreground">
-                    AZURE_API_KEY
-                  </code>
-                  <span
-                    className={`px-2 py-1 rounded text-xs font-medium ${envAzureApiKey ? "bg-green-100 text-green-800 dark:bg-green-800/20 dark:text-green-400" : "bg-red-100 text-red-800 dark:bg-red-800/20 dark:text-red-400"}`}
-                  >
-                    {envAzureApiKey ? "Set" : "Not Set"}
-                  </span>
-                </div>
-                <div className="flex justify-between items-center p-3 bg-muted rounded border">
-                  <code className="font-mono text-foreground">
-                    AZURE_RESOURCE_NAME
-                  </code>
-                  <span
-                    className={`px-2 py-1 rounded text-xs font-medium ${envAzureResourceName ? "bg-green-100 text-green-800 dark:bg-green-800/20 dark:text-green-400" : "bg-red-100 text-red-800 dark:bg-red-800/20 dark:text-red-400"}`}
-                  >
-                    {envAzureResourceName ? "Set" : "Not Set"}
-                  </span>
-                </div>
-              </div>
-              {isEnvConfigured && (
-                <Alert className="mt-4">
-                  <KeyRound className="h-4 w-4" />
-                  <AlertTitle>Environment Variables Set</AlertTitle>
-                  <AlertDescription>
-                    {activeKeySource === "env" && (
-                      <p className="text-xs text-green-600 dark:text-green-400 mt-1">
-                        Environment variables are currently active (no settings
-                        configuration set).
-                      </p>
-                    )}
-                    {activeKeySource === "settings" && (
-                      <p className="text-xs text-yellow-600 dark:text-yellow-400 mt-1">
-                        Environment variables are set but being overridden by
-                        the settings configuration above.
-                      </p>
-                    )}
-                  </AlertDescription>
-                </Alert>
-              )}
-            </div>
+      <div className="flex items-center gap-2">
+        <Button onClick={onSave} disabled={saving}>
+          {saving ? "Saving..." : "Save Settings"}
+        </Button>
+        {saved && !error && (
+          <span className="flex items-center text-green-600 text-sm">
+            <CheckCircle2 className="h-4 w-4 mr-1" /> Saved
+          </span>
+        )}
+      </div>
 
-            <div className="mt-4 p-4 bg-blue-50 dark:bg-blue-950/30 rounded border border-blue-200 dark:border-blue-700">
-              <h5 className="font-medium mb-2 text-blue-900 dark:text-blue-200">
-                How to set environment variables:
-              </h5>
-              <ol className="list-decimal list-inside space-y-1 text-sm text-blue-800 dark:text-blue-300">
-                <li>Get your API key from the Azure portal</li>
-                <li>
-                  Find your resource name (the name you gave your Azure OpenAI
-                  resource)
-                </li>
-                <li>Set these environment variables before starting Dyad</li>
-                <li>Restart Dyad after setting the environment variables</li>
-              </ol>
-            </div>
+      {!isConfigured && (
+        <Alert variant="default">
+          <Info className="h-4 w-4" />
+          <AlertTitle>Configuration Required</AlertTitle>
+          <AlertDescription>
+            Provide both Azure Resource Name and API Key to use Azure OpenAI
+            models.
+          </AlertDescription>
+        </Alert>
+      )}
 
-            <p className="text-xs text-gray-500 dark:text-gray-400 mt-3">
-              Environment variables are used only if no settings configuration
-              is set above. Requires app restart to detect changes.
-            </p>
-          </div>
-        </AccordionContent>
-      </AccordionItem>
-    </Accordion>
+      {error && (
+        <Alert variant="destructive">
+          <AlertTitle>Save Error</AlertTitle>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+    </div>
   );
 }

--- a/src/components/settings/ProviderSettingsPage.tsx
+++ b/src/components/settings/ProviderSettingsPage.tsx
@@ -73,7 +73,7 @@ export function ProviderSettingsPage({ provider }: ProviderSettingsPageProps) {
   const azureSettings = settings?.providerSettings?.azure as any;
   const isAzureConfigured =
     provider === "azure"
-      ? !!(azureSettings?.azureApiKey?.value && azureSettings?.resourceName)
+      ? !!(azureSettings?.apiKey?.value && azureSettings?.resourceName)
       : false;
 
   // Special handling for Vertex configuration status (settings-only)

--- a/src/components/settings/ProviderSettingsPage.tsx
+++ b/src/components/settings/ProviderSettingsPage.tsx
@@ -69,17 +69,14 @@ export function ProviderSettingsPage({ provider }: ProviderSettingsPageProps) {
     userApiKey !== "Not Set";
   const hasEnvKey = !!(envVarName && envVars[envVarName]);
 
-  // Special handling for Azure OpenAI configuration
+  // Special handling for Azure OpenAI configuration (settings-only)
   const azureSettings = settings?.providerSettings?.azure as any;
   const isAzureConfigured =
     provider === "azure"
-      ? !!(
-          (azureSettings?.azureApiKey?.value && azureSettings?.resourceName) ||
-          (envVars["AZURE_API_KEY"] && envVars["AZURE_RESOURCE_NAME"])
-        )
+      ? !!(azureSettings?.azureApiKey?.value && azureSettings?.resourceName)
       : false;
 
-  // Special handling for Vertex configuration status
+  // Special handling for Vertex configuration status (settings-only)
   const vertexSettings = settings?.providerSettings?.vertex as any;
   const isVertexConfigured = Boolean(
     vertexSettings?.projectId &&
@@ -92,7 +89,7 @@ export function ProviderSettingsPage({ provider }: ProviderSettingsPageProps) {
       ? isAzureConfigured
       : provider === "vertex"
         ? isVertexConfigured
-        : isValidUserKey || hasEnvKey; // Configured if either is set
+        : isValidUserKey || hasEnvKey; // Standard providers: configured if either is set
 
   // --- Save Handler ---
   const handleSaveKey = async () => {

--- a/src/components/settings/ProviderSettingsPage.tsx
+++ b/src/components/settings/ProviderSettingsPage.tsx
@@ -70,9 +70,13 @@ export function ProviderSettingsPage({ provider }: ProviderSettingsPageProps) {
   const hasEnvKey = !!(envVarName && envVars[envVarName]);
 
   // Special handling for Azure OpenAI configuration
+  const azureSettings = settings?.providerSettings?.azure as any;
   const isAzureConfigured =
     provider === "azure"
-      ? !!(envVars["AZURE_API_KEY"] && envVars["AZURE_RESOURCE_NAME"])
+      ? !!(
+          (azureSettings?.azureApiKey?.value && azureSettings?.resourceName) ||
+          (envVars["AZURE_API_KEY"] && envVars["AZURE_RESOURCE_NAME"])
+        )
       : false;
 
   // Special handling for Vertex configuration status

--- a/src/hooks/useLanguageModelProviders.ts
+++ b/src/hooks/useLanguageModelProviders.ts
@@ -36,11 +36,11 @@ export function useLanguageModelProviders() {
       }
       return false;
     }
-    // Azure uses UI-only configuration with azureApiKey and resourceName
+    // Azure uses UI-only configuration with apiKey and resourceName
     if (provider === "azure") {
       const azureSettings = providerSettings as AzureProviderSetting;
       if (
-        azureSettings?.azureApiKey?.value?.trim() &&
+        azureSettings?.apiKey?.value?.trim() &&
         azureSettings?.resourceName?.trim()
       ) {
         return true;

--- a/src/hooks/useLanguageModelProviders.ts
+++ b/src/hooks/useLanguageModelProviders.ts
@@ -40,8 +40,8 @@ export function useLanguageModelProviders() {
     if (provider === "azure") {
       const azureSettings = providerSettings as AzureProviderSetting;
       if (
-        azureSettings?.apiKey?.value?.trim() &&
-        azureSettings?.resourceName?.trim()
+        (azureSettings?.apiKey?.value || '').trim() &&
+        (azureSettings?.resourceName || '').trim()
       ) {
         return true;
       }

--- a/src/hooks/useLanguageModelProviders.ts
+++ b/src/hooks/useLanguageModelProviders.ts
@@ -2,7 +2,11 @@ import { useQuery } from "@tanstack/react-query";
 import { IpcClient } from "@/ipc/ipc_client";
 import type { LanguageModelProvider } from "@/ipc/ipc_types";
 import { useSettings } from "./useSettings";
-import { cloudProviders, VertexProviderSetting } from "@/lib/schemas";
+import {
+  cloudProviders,
+  VertexProviderSetting,
+  AzureProviderSetting,
+} from "@/lib/schemas";
 
 export function useLanguageModelProviders() {
   const ipcClient = IpcClient.getInstance();
@@ -27,6 +31,17 @@ export function useLanguageModelProviders() {
         vertexSettings?.serviceAccountKey?.value &&
         vertexSettings?.projectId &&
         vertexSettings?.location
+      ) {
+        return true;
+      }
+      return false;
+    }
+    // Azure uses UI-only configuration with azureApiKey and resourceName
+    if (provider === "azure") {
+      const azureSettings = providerSettings as AzureProviderSetting;
+      if (
+        azureSettings?.azureApiKey?.value?.trim() &&
+        azureSettings?.resourceName?.trim()
       ) {
         return true;
       }

--- a/src/ipc/handlers/app_handlers.ts
+++ b/src/ipc/handlers/app_handlers.ts
@@ -732,10 +732,6 @@ export function registerAppHandlers() {
       if (provider.envVarName) {
         envVars[provider.envVarName] = getEnvVar(provider.envVarName);
       }
-      // Special case for Azure: also read AZURE_RESOURCE_NAME
-      if (provider.id === "azure") {
-        envVars["AZURE_RESOURCE_NAME"] = getEnvVar("AZURE_RESOURCE_NAME");
-      }
     }
     return envVars;
   });

--- a/src/ipc/handlers/app_handlers.ts
+++ b/src/ipc/handlers/app_handlers.ts
@@ -732,6 +732,10 @@ export function registerAppHandlers() {
       if (provider.envVarName) {
         envVars[provider.envVarName] = getEnvVar(provider.envVarName);
       }
+      // Special case for Azure: also read AZURE_RESOURCE_NAME
+      if (provider.id === "azure") {
+        envVars["AZURE_RESOURCE_NAME"] = getEnvVar("AZURE_RESOURCE_NAME");
+      }
     }
     return envVars;
   });

--- a/src/ipc/utils/get_model_client.ts
+++ b/src/ipc/utils/get_model_client.ts
@@ -340,7 +340,7 @@ function getRegularModelClient(
       ] as AzureProviderSetting;
 
       const resourceName = azureSettings?.resourceName;
-      const azureApiKey = azureSettings?.azureApiKey?.value;
+      const azureApiKey = azureSettings?.apiKey;
 
       if (!resourceName) {
         throw new Error(

--- a/src/ipc/utils/get_model_client.ts
+++ b/src/ipc/utils/get_model_client.ts
@@ -340,7 +340,7 @@ function getRegularModelClient(
       ] as AzureProviderSetting;
 
       const resourceName = azureSettings?.resourceName;
-      const azureApiKey = azureSettings?.apiKey;
+      const azureApiKey = azureSettings?.apiKey?.value;
 
       if (!resourceName) {
         throw new Error(

--- a/src/ipc/utils/get_model_client.ts
+++ b/src/ipc/utils/get_model_client.ts
@@ -334,33 +334,23 @@ function getRegularModelClient(
         };
       }
 
-      // Azure OpenAI configuration priority: Settings first, then environment variables
+      // Azure OpenAI configuration from settings only
       const azureSettings = settings.providerSettings?.[
         model.provider
       ] as AzureProviderSetting;
 
-      // Check settings first
-      let resourceName = azureSettings?.resourceName;
-      let azureApiKey = azureSettings?.azureApiKey?.value;
-
-      // Fall back to environment variables if settings not configured
-      if (!resourceName || !azureApiKey) {
-        const envResourceName = getEnvVar("AZURE_RESOURCE_NAME");
-        const envAzureApiKey = getEnvVar("AZURE_API_KEY");
-
-        resourceName = resourceName || envResourceName;
-        azureApiKey = azureApiKey || envAzureApiKey;
-      }
+      const resourceName = azureSettings?.resourceName;
+      const azureApiKey = azureSettings?.azureApiKey?.value;
 
       if (!resourceName) {
         throw new Error(
-          "Azure OpenAI resource name is required. Please configure it in Settings or set the AZURE_RESOURCE_NAME environment variable.",
+          "Azure OpenAI resource name is required. Please configure it in the Azure provider settings.",
         );
       }
 
       if (!azureApiKey) {
         throw new Error(
-          "Azure OpenAI API key is required. Please configure it in Settings or set the AZURE_API_KEY environment variable.",
+          "Azure OpenAI API key is required. Please configure it in the Azure provider settings.",
         );
       }
 

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -93,8 +93,8 @@ export const VertexProviderSettingSchema = z.object({
 });
 
 export const AzureProviderSettingSchema = z.object({
-  // We make this undefined so that it makes existing callsites easier.
-  apiKey: z.undefined(),
+  // Azure uses the standard apiKey field for Azure API key
+  apiKey: SecretSchema.optional(),
   resourceName: z.string().optional(),
 });
 

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -95,15 +95,13 @@ export const VertexProviderSettingSchema = z.object({
 export const AzureProviderSettingSchema = z.object({
   // We make this undefined so that it makes existing callsites easier.
   apiKey: z.undefined(),
-  azureApiKey: SecretSchema.optional(),
   resourceName: z.string().optional(),
 });
 
 export const ProviderSettingSchema = z.union([
-  // Must use more specific type first!
-  // Zod uses the first type that matches.
-  AzureProviderSettingSchema,
   VertexProviderSettingSchema,
+  AzureProviderSettingSchema,
+  // Regular providers are the fallback
   RegularProviderSettingSchema,
 ]);
 

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -92,9 +92,17 @@ export const VertexProviderSettingSchema = z.object({
   serviceAccountKey: SecretSchema.optional(),
 });
 
+export const AzureProviderSettingSchema = z.object({
+  // We make this undefined so that it makes existing callsites easier.
+  apiKey: z.undefined(),
+  azureApiKey: SecretSchema.optional(),
+  resourceName: z.string().optional(),
+});
+
 export const ProviderSettingSchema = z.union([
   // Must use more specific type first!
   // Zod uses the first type that matches.
+  AzureProviderSettingSchema,
   VertexProviderSettingSchema,
   RegularProviderSettingSchema,
 ]);
@@ -107,6 +115,7 @@ export type RegularProviderSetting = z.infer<
   typeof RegularProviderSettingSchema
 >;
 export type VertexProviderSetting = z.infer<typeof VertexProviderSettingSchema>;
+export type AzureProviderSetting = z.infer<typeof AzureProviderSettingSchema>;
 
 export const RuntimeModeSchema = z.enum(["web-sandbox", "local-node", "unset"]);
 export type RuntimeMode = z.infer<typeof RuntimeModeSchema>;


### PR DESCRIPTION
Previously: configured AZURE_API_KEY and AZURE_RESOURCE_NAME by setting them in the terminal before running.

Now: Set them directly within the UI settings.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Moves Azure OpenAI configuration to UI-only. Users now enter Azure Resource Name and API Key in Settings; environment variables are no longer used.

- **New Features**
  - Added Azure settings form with Resource Name and API Key fields, save, and success/error states.
  - Persist Azure credentials in settings (AzureProviderSetting: azureApiKey, resourceName).
  - Provider status now checks settings, not env vars.
  - Model client initializes Azure via createAzure(...) using saved settings, with clearer missing-config errors.

- **Migration**
  - Stop using AZURE_API_KEY and AZURE_RESOURCE_NAME environment variables.
  - Go to Settings → Providers → Azure and save Resource Name and API Key.
  - If you previously relied on env vars, Azure will appear unconfigured until saved in the UI.

<!-- End of auto-generated description by cubic. -->

