### PR TITLE
feat: add copy functionality for ai responses with Dyad tag formatting (#1290)

### DIFF
--- a/e2e-tests/copy_chat.spec.ts
+++ b/e2e-tests/copy_chat.spec.ts
@@ -44,7 +44,7 @@ test("copy message content - dyad-write conversion", async ({ po }) => {
 
   // Should convert dyad-write to markdown format (flexible path matching)
   expect(clipboardContent).toContain("### File:");
-  expect(clipboardContent).toMatch(/```\w*\n[\s\S]*```/);
+  expect(clipboardContent).toContain("```");
   expect(clipboardContent).not.toContain("<dyad-write");
 });
 

--- a/e2e-tests/copy_chat.spec.ts
+++ b/e2e-tests/copy_chat.spec.ts
@@ -1,0 +1,71 @@
+import { test } from "./helpers/test_helper";
+import { expect } from "@playwright/test";
+
+test("copy message content - basic functionality", async ({ po }) => {
+  await po.setUp({ autoApprove: true });
+  await po.importApp("minimal");
+
+  await po.sendPrompt("[dump] Just say hello without creating any files");
+
+  await po.page
+    .context()
+    .grantPermissions(["clipboard-read", "clipboard-write"]);
+
+  const copyButton = po.page.getByTestId("copy-message-button").first();
+  await copyButton.click();
+
+  const clipboardContent = await po.page.evaluate(() =>
+    navigator.clipboard.readText(),
+  );
+
+  // Test that copy functionality works
+  expect(clipboardContent.length).toBeGreaterThan(0);
+  expect(clipboardContent).not.toContain("<dyad-");
+});
+
+test("copy message content - dyad-write conversion", async ({ po }) => {
+  await po.setUp({ autoApprove: true });
+  await po.importApp("minimal");
+
+  await po.sendPrompt(
+    "Create a simple React component in src/components/Button.tsx",
+  );
+
+  await po.page
+    .context()
+    .grantPermissions(["clipboard-read", "clipboard-write"]);
+
+  const copyButton = po.page.getByTestId("copy-message-button").first();
+  await copyButton.click();
+
+  const clipboardContent = await po.page.evaluate(() =>
+    navigator.clipboard.readText(),
+  );
+
+  // Should convert dyad-write to markdown format (flexible path matching)
+  expect(clipboardContent).toContain("### File:");
+  expect(clipboardContent).toMatch(/```\w*\n[\s\S]*```/);
+  expect(clipboardContent).not.toContain("<dyad-write");
+});
+
+test("copy button tooltip states", async ({ po }) => {
+  await po.setUp({ autoApprove: true });
+  await po.importApp("minimal");
+
+  await po.sendPrompt("Say hello");
+
+  const copyButton = po.page.getByTestId("copy-message-button").first();
+
+  // Check initial tooltip
+  await copyButton.hover();
+  const tooltip = po.page.locator('[role="tooltip"]');
+  await expect(tooltip).toHaveText("Copy");
+
+  // Copy and check "Copied!" state
+  await po.page
+    .context()
+    .grantPermissions(["clipboard-read", "clipboard-write"]);
+  await copyButton.click();
+  await copyButton.hover();
+  await expect(tooltip).toHaveText("Copied!");
+});

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -5,12 +5,26 @@ import {
 } from "./DyadMarkdownParser";
 import { motion } from "framer-motion";
 import { useStreamChat } from "@/hooks/useStreamChat";
-import { CheckCircle, XCircle, Clock, GitCommit } from "lucide-react";
+import {
+  CheckCircle,
+  XCircle,
+  Clock,
+  GitCommit,
+  Copy,
+  Check,
+} from "lucide-react";
 import { formatDistanceToNow, format } from "date-fns";
 import { useVersions } from "@/hooks/useVersions";
 import { useAtomValue } from "jotai";
 import { selectedAppIdAtom } from "@/atoms/appAtoms";
 import { useMemo } from "react";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "../ui/tooltip";
 
 interface ChatMessageProps {
   message: Message;
@@ -21,6 +35,11 @@ const ChatMessage = ({ message, isLastMessage }: ChatMessageProps) => {
   const { isStreaming } = useStreamChat();
   const appId = useAtomValue(selectedAppIdAtom);
   const { versions: liveVersions } = useVersions(appId);
+  //handle copy chat
+  const { copyMessageContent, copied } = useCopyToClipboard();
+  const handleCopyFormatted = async () => {
+    await copyMessageContent(message.content);
+  };
   // Find the version that was active when this message was sent
   const messageVersion = useMemo(() => {
     if (
@@ -123,21 +142,51 @@ const ChatMessage = ({ message, isLastMessage }: ChatMessageProps) => {
               )}
             </div>
           )}
-          {message.approvalState && (
-            <div className="mt-2 flex items-center justify-end space-x-1 text-xs">
-              {message.approvalState === "approved" ? (
-                <>
-                  <CheckCircle className="h-4 w-4 text-green-500" />
-                  <span>Approved</span>
-                </>
-              ) : message.approvalState === "rejected" ? (
-                <>
-                  <XCircle className="h-4 w-4 text-red-500" />
-                  <span>Rejected</span>
-                </>
-              ) : null}
+          {(message.role === "assistant" && message.content && !isStreaming) ||
+          message.approvalState ? (
+            <div className="mt-2 flex items-center justify-between text-xs">
+              {message.role === "assistant" &&
+                message.content &&
+                !isStreaming && (
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          data-testid="copy-message-button"
+                          onClick={handleCopyFormatted}
+                          className="flex items-center space-x-1 px-2 py-1 text-xs text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 rounded transition-colors duration-200 cursor-pointer"
+                        >
+                          {copied ? (
+                            <Check className="h-4 w-4 text-green-500" />
+                          ) : (
+                            <Copy className="h-4 w-4" />
+                          )}
+                          <span className="hidden sm:inline"></span>
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        {copied ? "Copied!" : "Copy"}
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                )}
+              {message.approvalState && (
+                <div className="flex items-center space-x-1">
+                  {message.approvalState === "approved" ? (
+                    <>
+                      <CheckCircle className="h-4 w-4 text-green-500" />
+                      <span>Approved</span>
+                    </>
+                  ) : message.approvalState === "rejected" ? (
+                    <>
+                      <XCircle className="h-4 w-4 text-red-500" />
+                      <span>Rejected</span>
+                    </>
+                  ) : null}
+                </div>
+              )}
             </div>
-          )}
+          ) : null}
         </div>
         {/* Timestamp and commit info for assistant messages - only visible on hover */}
         {message.role === "assistant" && message.createdAt && (

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -144,7 +144,16 @@ const ChatMessage = ({ message, isLastMessage }: ChatMessageProps) => {
           )}
           {(message.role === "assistant" && message.content && !isStreaming) ||
           message.approvalState ? (
-            <div className="mt-2 flex items-center justify-between text-xs">
+            <div
+              className={`mt-2 flex items-center ${
+                message.role === "assistant" &&
+                message.content &&
+                !isStreaming &&
+                message.approvalState
+                  ? "justify-between"
+                  : ""
+              } text-xs`}
+            >
               {message.role === "assistant" &&
                 message.content &&
                 !isStreaming && (

--- a/src/components/preview_panel/FileEditor.tsx
+++ b/src/components/preview_panel/FileEditor.tsx
@@ -15,6 +15,7 @@ import {
 import { useQueryClient } from "@tanstack/react-query";
 import { useSettings } from "@/hooks/useSettings";
 import { useCheckProblems } from "@/hooks/useCheckProblems";
+import { getLanguage } from "@/utils/get_language";
 
 interface FileEditorProps {
   appId: number | null;
@@ -188,35 +189,6 @@ export const FileEditor = ({ appId, filePath }: FileEditorProps) => {
       isSavingRef.current = false;
       setIsSaving(false);
     }
-  };
-
-  // Determine language based on file extension
-  const getLanguage = (filePath: string) => {
-    const extension = filePath.split(".").pop()?.toLowerCase() || "";
-    const languageMap: Record<string, string> = {
-      js: "javascript",
-      jsx: "javascript",
-      ts: "typescript",
-      tsx: "typescript",
-      html: "html",
-      css: "css",
-      json: "json",
-      md: "markdown",
-      py: "python",
-      java: "java",
-      c: "c",
-      cpp: "cpp",
-      cs: "csharp",
-      go: "go",
-      rs: "rust",
-      rb: "ruby",
-      php: "php",
-      swift: "swift",
-      kt: "kotlin",
-      // Add more as needed
-    };
-
-    return languageMap[extension] || "plaintext";
   };
 
   if (loading) {

--- a/src/hooks/useCopyToClipboard.ts
+++ b/src/hooks/useCopyToClipboard.ts
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from "react";
-
+import { getLanguage } from "@/utils/get_language";
 export const useCopyToClipboard = () => {
   const [copied, setCopied] = useState(false);
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -71,7 +71,7 @@ export const useCopyToClipboard = () => {
       case "dyad-write": {
         const writePath = attributes.path || "file";
         const writeDesc = attributes.description || "";
-        const language = detectLanguage(writePath);
+        const language = getLanguage(writePath);
 
         let writeResult = `### File: ${writePath}\n\n`;
         if (writeDesc && writeDesc !== writePath) {
@@ -84,7 +84,7 @@ export const useCopyToClipboard = () => {
       case "dyad-edit": {
         const editPath = attributes.path || "file";
         const editDesc = attributes.description || "";
-        const editLang = detectLanguage(editPath);
+        const editLang = getLanguage(editPath);
 
         let editResult = `### Edit: ${editPath}\n\n`;
         if (editDesc && editDesc !== editPath) {
@@ -289,45 +289,5 @@ export const useCopyToClipboard = () => {
     return { processedContent };
   };
 
-  // Detect programming language from file extension
-  const detectLanguage = (filename: string): string => {
-    const ext = filename.split(".").pop()?.toLowerCase();
-    const languageMap: Record<string, string> = {
-      js: "javascript",
-      jsx: "jsx",
-      ts: "typescript",
-      tsx: "tsx",
-      py: "python",
-      java: "java",
-      cpp: "cpp",
-      c: "c",
-      cs: "csharp",
-      php: "php",
-      rb: "ruby",
-      go: "go",
-      rs: "rust",
-      kt: "kotlin",
-      swift: "swift",
-      dart: "dart",
-      vue: "vue",
-      svelte: "svelte",
-      html: "html",
-      css: "css",
-      scss: "scss",
-      sass: "sass",
-      less: "less",
-      json: "json",
-      xml: "xml",
-      yaml: "yaml",
-      yml: "yaml",
-      md: "markdown",
-      sql: "sql",
-      sh: "bash",
-      bash: "bash",
-      zsh: "zsh",
-      fish: "fish",
-    };
-    return ext ? languageMap[ext] || ext : "";
-  };
   return { copyMessageContent, copied };
 };

--- a/src/hooks/useCopyToClipboard.ts
+++ b/src/hooks/useCopyToClipboard.ts
@@ -1,5 +1,21 @@
 import { useState, useRef, useEffect } from "react";
 import { getLanguage } from "@/utils/get_language";
+
+const CUSTOM_TAG_NAMES = [
+  "dyad-write",
+  "dyad-rename",
+  "dyad-delete",
+  "dyad-add-dependency",
+  "dyad-execute-sql",
+  "dyad-add-integration",
+  "dyad-output",
+  "dyad-problem-report",
+  "dyad-chat-summary",
+  "dyad-edit",
+  "dyad-codebase-context",
+  "think",
+  "dyad-command",
+];
 export const useCopyToClipboard = () => {
   const [copied, setCopied] = useState(false);
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -181,24 +197,8 @@ export const useCopyToClipboard = () => {
   const parseCustomTags = (content: string) => {
     const { processedContent } = preprocessUnclosedTags(content);
 
-    const customTagNames = [
-      "dyad-write",
-      "dyad-rename",
-      "dyad-delete",
-      "dyad-add-dependency",
-      "dyad-execute-sql",
-      "dyad-add-integration",
-      "dyad-output",
-      "dyad-problem-report",
-      "dyad-chat-summary",
-      "dyad-edit",
-      "dyad-codebase-context",
-      "think",
-      "dyad-command",
-    ];
-
     const tagPattern = new RegExp(
-      `<(${customTagNames.join("|")})\\s*([^>]*)>(.*?)<\\/\\1>`,
+      `<(${CUSTOM_TAG_NAMES.join("|")})\\s*([^>]*)>(.*?)<\\/\\1>`,
       "gs",
     );
 
@@ -253,25 +253,9 @@ export const useCopyToClipboard = () => {
 
   // Simplified version of preprocessUnclosedTags
   const preprocessUnclosedTags = (content: string) => {
-    const customTagNames = [
-      "dyad-write",
-      "dyad-rename",
-      "dyad-delete",
-      "dyad-add-dependency",
-      "dyad-execute-sql",
-      "dyad-add-integration",
-      "dyad-output",
-      "dyad-problem-report",
-      "dyad-chat-summary",
-      "dyad-edit",
-      "dyad-codebase-context",
-      "think",
-      "dyad-command",
-    ];
-
     let processedContent = content;
 
-    for (const tagName of customTagNames) {
+    for (const tagName of CUSTOM_TAG_NAMES) {
       const openTagPattern = new RegExp(`<${tagName}(?:\\s[^>]*)?>`, "g");
       const closeTagPattern = new RegExp(`</${tagName}>`, "g");
 

--- a/src/hooks/useCopyToClipboard.ts
+++ b/src/hooks/useCopyToClipboard.ts
@@ -1,0 +1,319 @@
+import { useState } from "react";
+
+export const useCopyToClipboard = () => {
+  const [copied, setCopied] = useState(false);
+
+  const copyMessageContent = async (messageContent: string) => {
+    try {
+      // Use the same parsing logic as DyadMarkdownParser but convert to clean text
+      const formattedContent = convertDyadContentToMarkdown(messageContent);
+
+      // Copy to clipboard
+      await navigator.clipboard.writeText(formattedContent);
+
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+      return true;
+    } catch (error) {
+      console.error("Failed to copy content:", error);
+      return false;
+    }
+  };
+
+  // Convert Dyad content to clean markdown using the same parsing logic as DyadMarkdownParser
+  const convertDyadContentToMarkdown = (content: string): string => {
+    if (!content) return "";
+
+    // Use the same parsing functions from DyadMarkdownParser
+    const contentPieces = parseCustomTags(content);
+
+    let result = "";
+
+    contentPieces.forEach((piece) => {
+      if (piece.type === "markdown") {
+        // Add regular markdown content as-is
+        result += piece.content || "";
+      } else {
+        // Convert custom tags to markdown format
+        const markdownVersion = convertCustomTagToMarkdown(piece.tagInfo);
+        result += markdownVersion;
+      }
+    });
+
+    // Clean up the final result
+    return result
+      .replace(/\n{3,}/g, "\n\n") // Max 2 consecutive newlines
+      .trim();
+  };
+
+  // Convert individual custom tags to markdown (reuse the same logic from DyadMarkdownParser)
+  const convertCustomTagToMarkdown = (tagInfo: any): string => {
+    const { tag, attributes, content } = tagInfo;
+
+    switch (tag) {
+      case "think":
+        return `### Thinking\n\n${content}\n\n`;
+
+      case "dyad-write": {
+        const writePath = attributes.path || "file";
+        const writeDesc = attributes.description || "";
+        const language = detectLanguage(writePath);
+
+        let writeResult = `### File: ${writePath}\n\n`;
+        if (writeDesc && writeDesc !== writePath) {
+          writeResult += `${writeDesc}\n\n`;
+        }
+        writeResult += `\`\`\`${language}\n${content}\n\`\`\`\n\n`;
+        return writeResult;
+      }
+
+      case "dyad-edit": {
+        const editPath = attributes.path || "file";
+        const editDesc = attributes.description || "";
+        const editLang = detectLanguage(editPath);
+
+        let editResult = `### Edit: ${editPath}\n\n`;
+        if (editDesc && editDesc !== editPath) {
+          editResult += `${editDesc}\n\n`;
+        }
+        editResult += `\`\`\`${editLang}\n${content}\n\`\`\`\n\n`;
+        return editResult;
+      }
+
+      case "dyad-rename": {
+        const from = attributes.from || "";
+        const to = attributes.to || "";
+        return `### Rename: ${from} → ${to}\n\n`;
+      }
+
+      case "dyad-delete": {
+        const deletePath = attributes.path || "";
+        return `### Delete: ${deletePath}\n\n`;
+      }
+
+      case "dyad-add-dependency": {
+        const packages = attributes.packages || "";
+        return `### Add Dependencies\n\n\`\`\`bash\n${packages}\n\`\`\`\n\n`;
+      }
+
+      case "dyad-execute-sql": {
+        const sqlDesc = attributes.description || "";
+        let sqlResult = `### Execute SQL\n\n`;
+        if (sqlDesc) {
+          sqlResult += `${sqlDesc}\n\n`;
+        }
+        sqlResult += `\`\`\`sql\n${content}\n\`\`\`\n\n`;
+        return sqlResult;
+      }
+
+      case "dyad-add-integration": {
+        const provider = attributes.provider || "";
+        return `### Add Integration: ${provider}\n\n`;
+      }
+
+      case "dyad-codebase-context": {
+        const files = attributes.files || "";
+        let contextResult = `### Codebase Context\n\n`;
+        if (files) {
+          contextResult += `Files: ${files}\n\n`;
+        }
+        contextResult += `\`\`\`\n${content}\n\`\`\`\n\n`;
+        return contextResult;
+      }
+
+      case "dyad-output": {
+        const outputType = attributes.type || "info";
+        const message = attributes.message || "";
+        const emoji =
+          outputType === "error"
+            ? "❌"
+            : outputType === "warning"
+              ? "⚠️"
+              : "ℹ️";
+
+        let outputResult = `${emoji} **${outputType.toUpperCase()}**`;
+        if (message) {
+          outputResult += `: ${message}`;
+        }
+        if (content) {
+          outputResult += `\n\n${content}`;
+        }
+        return outputResult + "\n\n";
+      }
+
+      case "dyad-problem-report": {
+        const summary = attributes.summary || "";
+        let problemResult = `### Problem Report\n\n`;
+        if (summary) {
+          problemResult += `**Summary:** ${summary}\n\n`;
+        }
+        if (content) {
+          problemResult += content;
+        }
+        return problemResult + "\n\n";
+      }
+
+      case "dyad-chat-summary":
+      case "dyad-command":
+        // Don't include these in copy
+        return "";
+
+      default:
+        return content ? `${content}\n\n` : "";
+    }
+  };
+
+  // Reuse the same parsing functions from DyadMarkdownParser but simplified
+  const parseCustomTags = (content: string) => {
+    const { processedContent } = preprocessUnclosedTags(content);
+
+    const customTagNames = [
+      "dyad-write",
+      "dyad-rename",
+      "dyad-delete",
+      "dyad-add-dependency",
+      "dyad-execute-sql",
+      "dyad-add-integration",
+      "dyad-output",
+      "dyad-problem-report",
+      "dyad-chat-summary",
+      "dyad-edit",
+      "dyad-codebase-context",
+      "think",
+      "dyad-command",
+    ];
+
+    const tagPattern = new RegExp(
+      `<(${customTagNames.join("|")})\\s*([^>]*)>(.*?)<\\/\\1>`,
+      "gs",
+    );
+
+    const contentPieces: any[] = [];
+    let lastIndex = 0;
+    let match;
+
+    while ((match = tagPattern.exec(processedContent)) !== null) {
+      const [fullMatch, tag, attributesStr, tagContent] = match;
+      const startIndex = match.index;
+
+      // Add markdown content before this tag
+      if (startIndex > lastIndex) {
+        contentPieces.push({
+          type: "markdown",
+          content: processedContent.substring(lastIndex, startIndex),
+        });
+      }
+
+      // Parse attributes
+      const attributes: Record<string, string> = {};
+      const attrPattern = /(\w+)="([^"]*)"/g;
+      let attrMatch;
+      while ((attrMatch = attrPattern.exec(attributesStr)) !== null) {
+        attributes[attrMatch[1]] = attrMatch[2];
+      }
+
+      // Add the tag info
+      contentPieces.push({
+        type: "custom-tag",
+        tagInfo: {
+          tag,
+          attributes,
+          content: tagContent,
+          fullMatch,
+        },
+      });
+
+      lastIndex = startIndex + fullMatch.length;
+    }
+
+    // Add remaining markdown content
+    if (lastIndex < processedContent.length) {
+      contentPieces.push({
+        type: "markdown",
+        content: processedContent.substring(lastIndex),
+      });
+    }
+
+    return contentPieces;
+  };
+
+  // Simplified version of preprocessUnclosedTags
+  const preprocessUnclosedTags = (content: string) => {
+    const customTagNames = [
+      "dyad-write",
+      "dyad-rename",
+      "dyad-delete",
+      "dyad-add-dependency",
+      "dyad-execute-sql",
+      "dyad-add-integration",
+      "dyad-output",
+      "dyad-problem-report",
+      "dyad-chat-summary",
+      "dyad-edit",
+      "dyad-codebase-context",
+      "think",
+      "dyad-command",
+    ];
+
+    let processedContent = content;
+
+    for (const tagName of customTagNames) {
+      const openTagPattern = new RegExp(`<${tagName}(?:\\s[^>]*)?>`, "g");
+      const closeTagPattern = new RegExp(`</${tagName}>`, "g");
+
+      const openCount = (processedContent.match(openTagPattern) || []).length;
+      const closeCount = (processedContent.match(closeTagPattern) || []).length;
+
+      const missingCloseTags = openCount - closeCount;
+      if (missingCloseTags > 0) {
+        processedContent += Array(missingCloseTags)
+          .fill(`</${tagName}>`)
+          .join("");
+      }
+    }
+
+    return { processedContent };
+  };
+
+  // Detect programming language from file extension
+  const detectLanguage = (filename: string): string => {
+    const ext = filename.split(".").pop()?.toLowerCase();
+    const languageMap: Record<string, string> = {
+      js: "javascript",
+      jsx: "jsx",
+      ts: "typescript",
+      tsx: "tsx",
+      py: "python",
+      java: "java",
+      cpp: "cpp",
+      c: "c",
+      cs: "csharp",
+      php: "php",
+      rb: "ruby",
+      go: "go",
+      rs: "rust",
+      kt: "kotlin",
+      swift: "swift",
+      dart: "dart",
+      vue: "vue",
+      svelte: "svelte",
+      html: "html",
+      css: "css",
+      scss: "scss",
+      sass: "sass",
+      less: "less",
+      json: "json",
+      xml: "xml",
+      yaml: "yaml",
+      yml: "yaml",
+      md: "markdown",
+      sql: "sql",
+      sh: "bash",
+      bash: "bash",
+      zsh: "zsh",
+      fish: "fish",
+    };
+    return ext ? languageMap[ext] || ext : "";
+  };
+  return { copyMessageContent, copied };
+};

--- a/src/hooks/useCopyToClipboard.ts
+++ b/src/hooks/useCopyToClipboard.ts
@@ -1,7 +1,15 @@
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 
 export const useCopyToClipboard = () => {
   const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
 
   const copyMessageContent = async (messageContent: string) => {
     try {
@@ -12,7 +20,13 @@ export const useCopyToClipboard = () => {
       await navigator.clipboard.writeText(formattedContent);
 
       setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      // Clear existing timeout if any
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+
+      // Set new timeout and store reference
+      timeoutRef.current = setTimeout(() => setCopied(false), 2000);
       return true;
     } catch (error) {
       console.error("Failed to copy content:", error);

--- a/src/utils/get_language.ts
+++ b/src/utils/get_language.ts
@@ -1,0 +1,29 @@
+// Determine language based on file extension
+const getLanguage = (filePath: string) => {
+  const extension = filePath.split(".").pop()?.toLowerCase() || "";
+  const languageMap: Record<string, string> = {
+    js: "javascript",
+    jsx: "javascript",
+    ts: "typescript",
+    tsx: "typescript",
+    html: "html",
+    css: "css",
+    json: "json",
+    md: "markdown",
+    py: "python",
+    java: "java",
+    c: "c",
+    cpp: "cpp",
+    cs: "csharp",
+    go: "go",
+    rs: "rust",
+    rb: "ruby",
+    php: "php",
+    swift: "swift",
+    kt: "kotlin",
+    // Add more as needed
+  };
+
+  return languageMap[extension] || "plaintext";
+};
+export { getLanguage };


### PR DESCRIPTION
## Summary
Adds AI response copy functionality to chat messages that preserves formatting and converts Dyad-specific tags to clean, readable markdown.

## Changes
- **New `useCopyToClipboard` hook**: Parses Dyad tags and converts them to professional markdown format
- **Updated `ChatMessage` component**: Positions copy button on left side of approval status
- **Dyad tag conversion**: Transforms custom tags to readable format:
  - `<dyad-write>` → `### File: path/to/file.js` + code block
  - `<dyad-edit>` → `### Edit: path/to/file.js` + code block  
  - `<dyad-execute-sql>` → `### Execute SQL` + ```sql block
  - `<think>` → `### Thinking` + content

## Features
- ✅ Automatic programming language detection from file extensions  
- ✅ Professional markdown formatting with proper headings and code blocks
- ✅ Tooltip showing "Copied" confirmation
- ✅ Reuses existing DyadMarkdownParser logic for consistency

closes (#1290)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a Copy button to assistant messages that copies a clean Markdown version of the response by converting Dyad tags and preserving code blocks. Improves shareability and removes Dyad-only markup; addresses Linear #1290.

- **New Features**
  - Added useCopyToClipboard hook that parses Dyad tags to Markdown, auto-detects code language, and cleans spacing.
  - Updated ChatMessage to show a Copy button (with Copy/Copied tooltip) to the left of approval status; disabled while streaming.
  - Tag conversions: think → "### Thinking"; dyad-write/edit → "### File/Edit: path" + fenced code; dyad-execute-sql → "### Execute SQL" + sql block; other Dyad tags map to concise headings; chat-summary/command are omitted.
  - Added e2e tests for clipboard copy, Dyad tag stripping/formatting, and tooltip states.

<!-- End of auto-generated description by cubic. -->

