### PR TITLE
fix pro banners

### DIFF
--- a/src/components/ProBanner.tsx
+++ b/src/components/ProBanner.tsx
@@ -13,14 +13,15 @@ import { useUserBudgetInfo } from "@/hooks/useUserBudgetInfo";
 export function ProBanner() {
   const { settings } = useSettings();
   const { userBudget } = useUserBudgetInfo();
-  if (settings?.enableDyadPro || userBudget) {
-    return null;
-  }
 
   const [selectedBanner] = useState<"ai" | "smart" | "turbo">(() => {
     const options = ["ai", "smart", "turbo"] as const;
     return options[Math.floor(Math.random() * options.length)];
   });
+
+  if (settings?.enableDyadPro || userBudget) {
+    return null;
+  }
 
   return (
     <div className="mt-6 max-w-2xl mx-auto">


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes ProBanner hook order so the component no longer throws or flickers; banners render reliably and still hide when Dyad Pro is enabled or the user has a budget. Moves the early return below the useState initialization to follow React Hooks rules.

<!-- End of auto-generated description by cubic. -->

