### PR TITLE
bump to v0.22 beta 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dyad",
   "productName": "dyad",
-  "version": "0.21.0",
+  "version": "0.22.0-beta.1",
   "description": "Free, local, open-source AI app builder",
   "main": ".vite/build/main.js",
   "repository": {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Bump version from 0.21.0 to 0.22.0-beta.1 to prepare the v0.22 beta release. Enables packaging and distribution under the new beta tag.

<!-- End of auto-generated description by cubic. -->

