### PR TITLE
[FIX] sanitize GitHub repo names to prevent space-to-dash mismatch

### DIFF
--- a/e2e-tests/github.spec.ts
+++ b/e2e-tests/github.spec.ts
@@ -143,3 +143,35 @@ test("create and sync to existing repo - custom branch", async ({ po }) => {
     operation: "create",
   });
 });
+
+test("create repo with spaces in name - should sanitize blank spaces to dashes", async ({
+  po,
+}) => {
+  await po.setUp();
+  await po.sendPrompt("tc=basic");
+
+  await po.getTitleBarAppNameButton().click();
+  await po.githubConnector.connect();
+
+  await expect(po.githubConnector.getCreateNewRepoModeButton()).toHaveClass(
+    /bg-primary/,
+  );
+
+  await po.githubConnector.fillCreateRepoName("test repo with spaces");
+
+  await po.page.waitForSelector("text=Repository name is available!", {
+    timeout: 5000,
+  });
+
+  await po.githubConnector.clickCreateRepoButton();
+
+  await po.githubConnector.clickSyncToGithubButton();
+
+  await po.githubConnector.snapshotConnectedRepo();
+
+  await po.githubConnector.verifyPushEvent({
+    repo: "test-repo-with-spaces",
+    branch: "main",
+    operation: "create",
+  });
+});


### PR DESCRIPTION
Fixes issue where GitHub automatically converts spaces to dashes in repo names but Dyad continued referencing the original names with spaces, causing connection and push failures.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Sanitizes GitHub repo and local app folder names (spaces → dashes) to match GitHub behavior. Fixes failures when creating, connecting, or pushing to repos with spaces.

- **Bug Fixes**
  - Added sanitizeAppFolderName and ensureAppFolderSanitized to rename folders, update DB (path/githubRepo), and guard against conflicts.
  - Create repo: always uses sanitized folder name; stores sanitized repo; repo param is now optional.
  - Connect existing: sanitizes repo before lookup and save; clearer error includes attempted sanitized name.
  - Push: sanitizes folder first; normalizes and persists githubRepo before building the remote URL.
  - Updated IPC handler typing for github:create-repo.

<!-- End of auto-generated description by cubic. -->

