### PR TITLE
implementing app naming feature

### DIFF
--- a/src/ipc/handlers/app_handlers.ts
+++ b/src/ipc/handlers/app_handlers.ts
@@ -51,10 +51,11 @@ import { isServerFunction } from "@/supabase_admin/supabase_utils";
 import { getVercelTeamSlug } from "../utils/vercel_utils";
 import { storeDbTimestampAtCurrentVersion } from "../utils/neon_timestamp_utils";
 import { AppSearchResult } from "@/lib/schemas";
+import { renameApp } from "../utils/rename_app";
 
 const DEFAULT_COMMAND =
   "(pnpm install && pnpm run dev --port 32100) || (npm install --legacy-peer-deps && npm run dev -- --port 32100)";
-async function copyDir(
+export async function copyDir(
   source: string,
   destination: string,
   filter?: (source: string) => boolean,
@@ -1085,122 +1086,7 @@ export function registerAppHandlers() {
         appPath,
       }: { appId: number; appName: string; appPath: string },
     ): Promise<void> => {
-      return withLock(appId, async () => {
-        // Check if app exists
-        const app = await db.query.apps.findFirst({
-          where: eq(apps.id, appId),
-        });
-
-        if (!app) {
-          throw new Error("App not found");
-        }
-
-        // Check for conflicts with existing apps
-        const nameConflict = await db.query.apps.findFirst({
-          where: eq(apps.name, appName),
-        });
-
-        const pathConflict = await db.query.apps.findFirst({
-          where: eq(apps.path, appPath),
-        });
-
-        if (nameConflict && nameConflict.id !== appId) {
-          throw new Error(`An app with the name '${appName}' already exists`);
-        }
-
-        if (pathConflict && pathConflict.id !== appId) {
-          throw new Error(`An app with the path '${appPath}' already exists`);
-        }
-
-        // Stop the app if it's running
-        if (runningApps.has(appId)) {
-          const appInfo = runningApps.get(appId)!;
-          try {
-            await stopAppByInfo(appId, appInfo);
-          } catch (error: any) {
-            logger.error(`Error stopping app ${appId} before renaming:`, error);
-            throw new Error(
-              `Failed to stop app before renaming: ${error.message}`,
-            );
-          }
-        }
-
-        const oldAppPath = getDyadAppPath(app.path);
-        const newAppPath = getDyadAppPath(appPath);
-        // Only move files if needed
-        if (newAppPath !== oldAppPath) {
-          // Move app files
-          try {
-            // Check if destination directory already exists
-            if (fs.existsSync(newAppPath)) {
-              throw new Error(
-                `Destination path '${newAppPath}' already exists`,
-              );
-            }
-
-            // Create parent directory if it doesn't exist
-            await fsPromises.mkdir(path.dirname(newAppPath), {
-              recursive: true,
-            });
-
-            // Copy the directory without node_modules
-            await copyDir(oldAppPath, newAppPath);
-          } catch (error: any) {
-            logger.error(
-              `Error moving app files from ${oldAppPath} to ${newAppPath}:`,
-              error,
-            );
-            throw new Error(`Failed to move app files: ${error.message}`);
-          }
-
-          try {
-            // Delete the old directory
-            await fsPromises.rm(oldAppPath, { recursive: true, force: true });
-          } catch (error: any) {
-            // Why is this just a warning? This happens quite often on Windows
-            // because it has an aggressive file lock.
-            //
-            // Not deleting the old directory is annoying, but not a big deal
-            // since the user can do it themselves if they need to.
-            logger.warn(
-              `Error deleting old app directory ${oldAppPath}:`,
-              error,
-            );
-          }
-        }
-
-        // Update app in database
-        try {
-          await db
-            .update(apps)
-            .set({
-              name: appName,
-              path: appPath,
-            })
-            .where(eq(apps.id, appId))
-            .returning();
-
-          return;
-        } catch (error: any) {
-          // Attempt to rollback the file move
-          if (newAppPath !== oldAppPath) {
-            try {
-              // Copy back from new to old
-              await copyDir(newAppPath, oldAppPath);
-              // Delete the new directory
-              await fsPromises.rm(newAppPath, { recursive: true, force: true });
-            } catch (rollbackError) {
-              logger.error(
-                `Failed to rollback file move during rename error:`,
-                rollbackError,
-              );
-            }
-          }
-
-          logger.error(`Error updating app ${appId} in database:`, error);
-          throw new Error(`Failed to update app in database: ${error.message}`);
-        }
-      });
+      return renameApp(appId, appName, appPath, logger);
     },
   );
 

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -69,6 +69,7 @@ import { prompts as promptsTable } from "../../db/schema";
 import { inArray } from "drizzle-orm";
 import { replacePromptReference } from "../utils/replacePromptReference";
 import { mcpManager } from "../utils/mcp_manager";
+import { renameApp } from "../utils/rename_app";
 
 type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
 
@@ -1083,6 +1084,17 @@ ${problemReport.problems
           /<dyad-chat-summary>(.*?)<\/dyad-chat-summary>/,
         );
         if (chatTitle) {
+          const appChats = await db.query.chats.findMany({
+            where: eq(chats.appId, updatedChat.app.id),
+          });
+          if (
+            appChats.length === 1 &&
+            appChats[0].id === updatedChat.id &&
+            appChats[0].title == null
+          ) {
+            renameApp(updatedChat.app.id, chatTitle[1], chatTitle[1], logger);
+          }
+
           await db
             .update(chats)
             .set({ title: chatTitle[1] })

--- a/src/ipc/utils/rename_app.ts
+++ b/src/ipc/utils/rename_app.ts
@@ -1,0 +1,130 @@
+import { db } from "../../db";
+import { apps } from "../../db/schema";
+import { eq } from "drizzle-orm";
+import fs from "node:fs";
+import path from "node:path";
+import { getDyadAppPath } from "../../paths/paths";
+import { promises as fsPromises } from "node:fs";
+
+// Import our utility modules
+import { withLock } from "../utils/lock_utils";
+import { runningApps, stopAppByInfo } from "../utils/process_manager";
+import log from "electron-log";
+import { copyDir } from "../handlers/app_handlers";
+
+export async function renameApp(
+  appId: number,
+  appName: string,
+  appPath: string,
+  logger: log.LogFunctions,
+) {
+  return withLock(appId, async () => {
+    // Check if app exists
+    const app = await db.query.apps.findFirst({
+      where: eq(apps.id, appId),
+    });
+
+    if (!app) {
+      throw new Error("App not found");
+    }
+
+    // Check for conflicts with existing apps
+    const nameConflict = await db.query.apps.findFirst({
+      where: eq(apps.name, appName),
+    });
+
+    const pathConflict = await db.query.apps.findFirst({
+      where: eq(apps.path, appPath),
+    });
+
+    if (nameConflict && nameConflict.id !== appId) {
+      throw new Error(`An app with the name '${appName}' already exists`);
+    }
+
+    if (pathConflict && pathConflict.id !== appId) {
+      throw new Error(`An app with the path '${appPath}' already exists`);
+    }
+
+    // Stop the app if it's running
+    if (runningApps.has(appId)) {
+      const appInfo = runningApps.get(appId)!;
+      try {
+        await stopAppByInfo(appId, appInfo);
+      } catch (error: any) {
+        logger.error(`Error stopping app ${appId} before renaming:`, error);
+        throw new Error(`Failed to stop app before renaming: ${error.message}`);
+      }
+    }
+
+    const oldAppPath = getDyadAppPath(app.path);
+    const newAppPath = getDyadAppPath(appPath);
+    // Only move files if needed
+    if (newAppPath !== oldAppPath) {
+      // Move app files
+      try {
+        // Check if destination directory already exists
+        if (fs.existsSync(newAppPath)) {
+          throw new Error(`Destination path '${newAppPath}' already exists`);
+        }
+
+        // Create parent directory if it doesn't exist
+        await fsPromises.mkdir(path.dirname(newAppPath), {
+          recursive: true,
+        });
+
+        // Copy the directory without node_modules
+        await copyDir(oldAppPath, newAppPath);
+      } catch (error: any) {
+        logger.error(
+          `Error moving app files from ${oldAppPath} to ${newAppPath}:`,
+          error,
+        );
+        throw new Error(`Failed to move app files: ${error.message}`);
+      }
+
+      try {
+        // Delete the old directory
+        await fsPromises.rm(oldAppPath, { recursive: true, force: true });
+      } catch (error: any) {
+        // Why is this just a warning? This happens quite often on Windows
+        // because it has an aggressive file lock.
+        //
+        // Not deleting the old directory is annoying, but not a big deal
+        // since the user can do it themselves if they need to.
+        logger.warn(`Error deleting old app directory ${oldAppPath}:`, error);
+      }
+    }
+
+    // Update app in database
+    try {
+      await db
+        .update(apps)
+        .set({
+          name: appName,
+          path: appPath,
+        })
+        .where(eq(apps.id, appId))
+        .returning();
+
+      return;
+    } catch (error: any) {
+      // Attempt to rollback the file move
+      if (newAppPath !== oldAppPath) {
+        try {
+          // Copy back from new to old
+          await copyDir(newAppPath, oldAppPath);
+          // Delete the new directory
+          await fsPromises.rm(newAppPath, { recursive: true, force: true });
+        } catch (rollbackError) {
+          logger.error(
+            `Failed to rollback file move during rename error:`,
+            rollbackError,
+          );
+        }
+      }
+
+      logger.error(`Error updating app ${appId} in database:`, error);
+      throw new Error(`Failed to update app in database: ${error.message}`);
+    }
+  });
+}


### PR DESCRIPTION
This PR implements automatic app naming
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds automatic app naming from the first chat summary and centralizes rename logic for safer, consistent behavior. Improves UX by naming new apps automatically and reduces duplication.

- **New Features**
  - Auto-rename app to the chat’s <dyad-chat-summary> when it’s the only, untitled chat.
  - Safe rename: locks per app, checks name/path conflicts, stops running app, moves files if needed, rolls back on failure, and updates the DB.

- **Refactors**
  - Extracted rename flow to src/ipc/utils/rename_app.ts and used in handlers.
  - Exported copyDir for reuse.

<!-- End of auto-generated description by cubic. -->

