### PR TITLE
implementing switch chat side feature

### DIFF
--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -13,12 +13,16 @@ interface ChatPanelProps {
   chatId?: number;
   isPreviewOpen: boolean;
   onTogglePreview: () => void;
+  onSwitchChatSide: () => void;
+  isChatOnLeft: boolean;
 }
 
 export function ChatPanel({
   chatId,
   isPreviewOpen,
   onTogglePreview,
+  onSwitchChatSide,
+  isChatOnLeft,
 }: ChatPanelProps) {
   const [messages, setMessages] = useAtom(chatMessagesAtom);
   const [isVersionPaneOpen, setIsVersionPaneOpen] = useState(false);
@@ -121,6 +125,8 @@ export function ChatPanel({
         isPreviewOpen={isPreviewOpen}
         onTogglePreview={onTogglePreview}
         onVersionClick={() => setIsVersionPaneOpen(!isVersionPaneOpen)}
+        onSwitchChatSide={onSwitchChatSide}
+        isChatOnLeft={isChatOnLeft}
       />
       <div className="flex flex-1 overflow-hidden">
         {!isVersionPaneOpen && (

--- a/src/components/chat/ChatHeader.tsx
+++ b/src/components/chat/ChatHeader.tsx
@@ -4,6 +4,8 @@ import {
   PlusCircle,
   GitBranch,
   Info,
+  ArrowRightFromLine,
+  ArrowLeftFromLine,
 } from "lucide-react";
 import { PanelRightClose } from "lucide-react";
 import { useAtom, useAtomValue } from "jotai";
@@ -34,6 +36,8 @@ interface ChatHeaderProps {
   isPreviewOpen: boolean;
   onTogglePreview: () => void;
   onVersionClick: () => void;
+  onSwitchChatSide: () => void;
+  isChatOnLeft: boolean;
 }
 
 export function ChatHeader({
@@ -41,6 +45,8 @@ export function ChatHeader({
   isPreviewOpen,
   onTogglePreview,
   onVersionClick,
+  onSwitchChatSide,
+  isChatOnLeft,
 }: ChatHeaderProps) {
   const appId = useAtomValue(selectedAppIdAtom);
   const { versions, loading: versionsLoading } = useVersions(appId);
@@ -200,18 +206,29 @@ export function ChatHeader({
               : `Version ${versions.length}${versionPostfix}`}
           </Button>
         </div>
-
-        <button
-          data-testid="toggle-preview-panel-button"
-          onClick={onTogglePreview}
-          className="cursor-pointer p-2 hover:bg-(--background-lightest) rounded-md"
-        >
-          {isPreviewOpen ? (
-            <PanelRightClose size={20} />
-          ) : (
-            <PanelRightOpen size={20} />
-          )}
-        </button>
+        <div>
+          <button
+            data-testid="toggle-preview-panel-button"
+            onClick={onTogglePreview}
+            className="cursor-pointer p-2 hover:bg-(--background-lightest) rounded-md"
+          >
+            {isPreviewOpen ? (
+              <PanelRightClose size={20} />
+            ) : (
+              <PanelRightOpen size={20} />
+            )}
+          </button>
+          <button
+            onClick={onSwitchChatSide}
+            className="cursor-pointer p-2 hover:bg-(--background-lightest) rounded-md m-1"
+          >
+            {isChatOnLeft ? (
+              <ArrowRightFromLine size={20} />
+            ) : (
+              <ArrowLeftFromLine size={20} />
+            )}
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/chat.tsx
+++ b/src/pages/chat.tsx
@@ -22,6 +22,7 @@ export default function ChatPage() {
   const selectedAppId = useAtomValue(selectedAppIdAtom);
   const setSelectedAppId = useSetAtom(selectedAppIdAtom);
   const { chats, loading } = useChats(selectedAppId);
+  const [isChatOnLeft, setIsChatOnLeft] = useState(true);
 
   useEffect(() => {
     if (!chatId && chats.length && !loading) {
@@ -43,28 +44,40 @@ export default function ChatPage() {
 
   return (
     <PanelGroup autoSaveId="persistence" direction="horizontal">
-      <Panel id="chat-panel" minSize={30}>
-        <div className="h-full w-full">
-          <ChatPanel
-            chatId={chatId}
-            isPreviewOpen={isPreviewOpen}
-            onTogglePreview={() => {
-              setIsPreviewOpen(!isPreviewOpen);
-              if (isPreviewOpen) {
-                ref.current?.collapse();
-              } else {
-                ref.current?.expand();
-              }
-            }}
-          />
-        </div>
-      </Panel>
+      <div className="flex w-full h-full">
+        <Panel
+          id="chat-panel"
+          minSize={30}
+          className={cn(isChatOnLeft ? "order-1" : "order-3", "flex-1 h-full")}
+        >
+          <div className="h-full w-full">
+            <ChatPanel
+              chatId={chatId}
+              isPreviewOpen={isPreviewOpen}
+              onTogglePreview={() => {
+                setIsPreviewOpen(!isPreviewOpen);
+                if (isPreviewOpen) {
+                  ref.current?.collapse();
+                } else {
+                  ref.current?.expand();
+                }
+              }}
+              onSwitchChatSide={() => {
+                setIsChatOnLeft(!isChatOnLeft);
+              }}
+              isChatOnLeft={isChatOnLeft}
+            />
+          </div>
+        </Panel>
 
-      <>
         <PanelResizeHandle
           onDragging={(e) => setIsResizing(e)}
-          className="w-1 bg-gray-200 hover:bg-gray-300 dark:bg-gray-800 dark:hover:bg-gray-700 transition-colors cursor-col-resize"
+          className={cn(
+            "w-1 bg-gray-200 hover:bg-gray-300 dark:bg-gray-800 dark:hover:bg-gray-700 transition-colors cursor-col-resize",
+            isChatOnLeft ? "order-2" : "order-2",
+          )}
         />
+
         <Panel
           collapsible
           ref={ref}
@@ -72,11 +85,13 @@ export default function ChatPage() {
           minSize={20}
           className={cn(
             !isResizing && "transition-all duration-100 ease-in-out",
+            isChatOnLeft ? "order-3" : "order-1",
+            "flex-1 h-full",
           )}
         >
           <PreviewPanel />
         </Panel>
-      </>
+      </div>
     </PanelGroup>
   );
 }


### PR DESCRIPTION
This PR implements switch chat side feature mentioned in issue #1200 
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a toggle to switch the chat panel between the left and right side of the page. Implements the “switch chat side” feature from issue #1200.

- **New Features**
  - Added a header button to move the chat panel left/right (ArrowLeftFromLine/ArrowRightFromLine).
  - Reorders panels using Tailwind order classes so layout flips without remounting content.
  - Manages isChatOnLeft state in chat.tsx and wires it through ChatPanel and ChatHeader props.

<!-- End of auto-generated description by cubic. -->

