### PR TITLE
Fix MCP & title bar

### DIFF
--- a/e2e-tests/snapshots/mcp.spec.ts_mcp---call-calculator-1.txt
+++ b/e2e-tests/snapshots/mcp.spec.ts_mcp---call-calculator-1.txt
@@ -41,6 +41,7 @@ This applies to simple apps like:
 - **Never write HTML, CSS, JavaScript, TypeScript, or any programming code**
 - **Do not create component examples or code snippets**  
 - **Do not provide implementation details or syntax**
+- **Do not use <dyad-write>, <dyad-edit>, <dyad-add-dependency> OR ANY OTHER <dyad-*> tags**
 - Your job ends with information gathering and requirement analysis
 - All actual development happens in the next phase
 

--- a/src/app/TitleBar.tsx
+++ b/src/app/TitleBar.tsx
@@ -235,14 +235,6 @@ export function AICreditStatus({ userBudget }: { userBudget: UserBudgetInfo }) {
       </TooltipTrigger>
       <TooltipContent>
         <div>
-          <p>
-            You have used {Math.round(userBudget.usedCredits)} credits out of{" "}
-            {userBudget.totalCredits}.
-          </p>
-          <p>
-            Your budget resets on{" "}
-            {userBudget.budgetResetDate.toLocaleDateString()}
-          </p>
           <p>Note: there is a slight delay in updating the credit status.</p>
         </div>
       </TooltipContent>

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -8,6 +8,7 @@ import {
   ToolSet,
   TextStreamPart,
   stepCountIs,
+  hasToolCall,
 } from "ai";
 
 import { db } from "../../db";
@@ -69,6 +70,7 @@ import { prompts as promptsTable } from "../../db/schema";
 import { inArray } from "drizzle-orm";
 import { replacePromptReference } from "../utils/replacePromptReference";
 import { mcpManager } from "../utils/mcp_manager";
+import z from "zod";
 
 type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
 
@@ -766,7 +768,7 @@ This conversation includes one or more image attachments. When the user uploads 
             temperature: await getTemperature(settings.selectedModel),
             maxRetries: 2,
             model: modelClient.model,
-            stopWhen: stepCountIs(3),
+            stopWhen: [stepCountIs(3), hasToolCall("edit-code")],
             providerOptions,
             system: systemPromptOverride,
             tools,
@@ -836,7 +838,15 @@ This conversation includes one or more image attachments. When the user uploads 
           const { fullStream } = await simpleStreamText({
             chatMessages: limitedHistoryChatMessages,
             modelClient,
-            tools,
+            tools: {
+              ...tools,
+              "edit-code": {
+                description:
+                  "Signal to switch to code editing. Does nothing and ends generation.",
+                inputSchema: z.object({}),
+                execute: async () => "",
+              },
+            },
             systemPromptOverride: constructSystemPrompt({
               aiRules: await readAiRules(getDyadAppPath(updatedChat.app.path)),
               chatMode: "agent",

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -840,9 +840,9 @@ This conversation includes one or more image attachments. When the user uploads 
             modelClient,
             tools: {
               ...tools,
-              "edit-code": {
+              "generate-code": {
                 description:
-                  "Signal to switch to code editing. Does nothing and ends generation.",
+                  "ALWAYS use this tool whenever generating or editing code for the codebase.",
                 inputSchema: z.object({}),
                 execute: async () => "",
               },

--- a/src/prompts/system_prompt.ts
+++ b/src/prompts/system_prompt.ts
@@ -491,6 +491,7 @@ This applies to simple apps like:
 - **Never write HTML, CSS, JavaScript, TypeScript, or any programming code**
 - **Do not create component examples or code snippets**  
 - **Do not provide implementation details or syntax**
+- **Do not use <dyad-write>, <dyad-edit>, <dyad-add-dependency> OR ANY OTHER <dyad-*> tags**
 - Your job ends with information gathering and requirement analysis
 - All actual development happens in the next phase
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes MCP handoff by detecting an edit-code tool call and stopping generation. Simplifies the title bar credit tooltip; also blocks dyad-* tags in the system prompt and updates tests.

- **Bug Fixes**
  - Stop generation on edit-code via hasToolCall; add a no-op edit-code tool to signal handoff.
  - Combine tool-call stop with existing step limit for reliability.
  - Forbid <dyad-*> tags in the system prompt to prevent misuse.
  - Remove credit usage/reset details from the title bar tooltip; keep the delay note.
  - Update e2e snapshot to reflect the new prompt rule.

<!-- End of auto-generated description by cubic. -->

