### PR TITLE
feat: text-to-speech for AI responses

### DIFF
--- a/e2e-tests/text_to_speech.spec.ts
+++ b/e2e-tests/text_to_speech.spec.ts
@@ -3,7 +3,6 @@ import { expect } from "@playwright/test";
 
 test("text to speech - basic functionality", async ({ po }) => {
   await po.setUp({ autoApprove: true });
-  await po.importApp("minimal");
 
   // Mock speechSynthesis API
   await po.page.addInitScript(() => {
@@ -34,6 +33,7 @@ test("text to speech - basic functionality", async ({ po }) => {
       speak: (utterance: MockSpeechSynthesisUtterance) => {
         isPlaying = true;
         setTimeout(() => utterance.onstart?.(), 10);
+        setTimeout(() => utterance.onend?.(), 100);
       },
       cancel: () => {
         isPlaying = false;
@@ -45,6 +45,7 @@ test("text to speech - basic functionality", async ({ po }) => {
     };
   });
 
+  await po.importApp("minimal");
   await po.sendPrompt("Say hello");
 
   const ttsButton = po.page.getByTestId("tts-button").first();

--- a/e2e-tests/text_to_speech.spec.ts
+++ b/e2e-tests/text_to_speech.spec.ts
@@ -1,0 +1,55 @@
+import { test } from "./helpers/test_helper";
+import { expect } from "@playwright/test";
+
+test("text to speech - basic functionality", async ({ po }) => {
+  await po.setUp({ autoApprove: true });
+  await po.importApp("minimal");
+
+  // Mock speechSynthesis API
+  await po.page.addInitScript(() => {
+    let isPlaying = false;
+
+    class MockSpeechSynthesisUtterance {
+      onstart: (() => void) | null = null;
+      onend: (() => void) | null = null;
+      constructor(public text: string) {}
+    }
+
+    interface MockSpeechSynthesis {
+      speak: (utterance: MockSpeechSynthesisUtterance) => void;
+      cancel: () => void;
+      getVoices: () => Array<{ name: string; default: boolean }>;
+      readonly speaking: boolean;
+    }
+
+    (
+      globalThis as {
+        SpeechSynthesisUtterance: typeof MockSpeechSynthesisUtterance;
+      }
+    ).SpeechSynthesisUtterance = MockSpeechSynthesisUtterance;
+
+    (
+      globalThis as unknown as { speechSynthesis: MockSpeechSynthesis }
+    ).speechSynthesis = {
+      speak: (utterance: MockSpeechSynthesisUtterance) => {
+        isPlaying = true;
+        setTimeout(() => utterance.onstart?.(), 10);
+      },
+      cancel: () => {
+        isPlaying = false;
+      },
+      getVoices: () => [{ name: "Test Voice", default: true }],
+      get speaking() {
+        return isPlaying;
+      },
+    };
+  });
+
+  await po.sendPrompt("Say hello");
+
+  const ttsButton = po.page.getByTestId("tts-button").first();
+  await ttsButton.click();
+
+  // Verify button changes to stop state
+  await expect(ttsButton.locator('text="Stop"')).toBeVisible();
+});

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -210,7 +210,6 @@ const ChatMessage = ({ message, isLastMessage }: ChatMessageProps) => {
                               ) : (
                                 <Volume2 className="h-4 w-4" />
                               )}
-                              <span className="hidden sm:inline"></span>
                             </button>
                           </TooltipTrigger>
                           <TooltipContent>

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -205,7 +205,7 @@ const ChatMessage = ({ message, isLastMessage }: ChatMessageProps) => {
                               {isPlaying ? (
                                 <>
                                   <CircleStop className="h-4 w-4 text-green-500" />
-                                  <span className="sm:inline">Stop</span>
+                                  <span>Stop</span>
                                 </>
                               ) : (
                                 <Volume2 className="h-4 w-4" />

--- a/src/hooks/useTextToSpeech.ts
+++ b/src/hooks/useTextToSpeech.ts
@@ -1,0 +1,214 @@
+import { useState, useRef, useEffect } from "react";
+
+export const useTextToSpeech = () => {
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [isPaused, setIsPaused] = useState(false);
+  const utteranceRef = useRef<SpeechSynthesisUtterance | null>(null);
+  const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([]);
+  const [selectedVoice, setSelectedVoice] =
+    useState<SpeechSynthesisVoice | null>(null);
+
+  // Load available voices
+  useEffect(() => {
+    const loadVoices = () => {
+      const availableVoices = speechSynthesis.getVoices();
+      setVoices(availableVoices);
+
+      // Set default voice (prefer English voices)
+      if (availableVoices.length > 0 && !selectedVoice) {
+        const englishVoice =
+          availableVoices.find(
+            (voice) => voice.lang.startsWith("en-") && voice.default,
+          ) ||
+          availableVoices.find((voice) => voice.lang.startsWith("en-")) ||
+          availableVoices[0];
+
+        setSelectedVoice(englishVoice);
+      }
+    };
+
+    loadVoices();
+    speechSynthesis.addEventListener("voiceschanged", loadVoices);
+
+    return () => {
+      speechSynthesis.removeEventListener("voiceschanged", loadVoices);
+    };
+  }, [selectedVoice]);
+
+  // Clean up on unmount
+  useEffect(() => {
+    return () => {
+      if (utteranceRef.current) {
+        speechSynthesis.cancel();
+      }
+    };
+  }, []);
+
+  // Convert message content to clean text for TTS
+  const cleanTextForSpeech = (content: string): string => {
+    if (!content) return "";
+
+    let cleanText = content;
+
+    // Remove Dyad tags and replace with descriptive text
+    cleanText = cleanText.replace(
+      /<dyad-write[^>]*path="([^"]*)"[^>]*>([\s\S]*?)<\/dyad-write>/g,
+      (match, path, code) => `Writing file ${path}. ${code}`,
+    );
+
+    cleanText = cleanText.replace(
+      /<dyad-edit[^>]*path="([^"]*)"[^>]*>([\s\S]*?)<\/dyad-edit>/g,
+      (match, path, code) => `Editing file ${path}. ${code}`,
+    );
+
+    cleanText = cleanText.replace(
+      /<dyad-execute-sql[^>]*>([\s\S]*?)<\/dyad-execute-sql>/g,
+      (match, sql) => `Executing SQL query. ${sql}`,
+    );
+
+    cleanText = cleanText.replace(
+      /<dyad-delete[^>]*path="([^"]*)"[^>]*>/g,
+      "Deleting file $1",
+    );
+
+    cleanText = cleanText.replace(
+      /<dyad-rename[^>]*from="([^"]*)"[^>]*to="([^"]*)"[^>]*>/g,
+      "Renaming $1 to $2",
+    );
+
+    cleanText = cleanText.replace(
+      /<dyad-add-dependency[^>]*packages="([^"]*)"[^>]*>/g,
+      "Adding dependencies $1",
+    );
+
+    cleanText = cleanText.replace(
+      /<think>([\s\S]*?)<\/think>/g,
+      (match, thought) => `Thinking: ${thought}`,
+    );
+
+    // Remove any remaining HTML tags
+    cleanText = cleanText.replace(/<[^>]*>/g, "");
+
+    // Clean up markdown formatting
+    cleanText = cleanText.replace(/```[\s\S]*?```/g, ""); // Remove code blocks
+    cleanText = cleanText.replace(/`([^`]+)`/g, "$1"); // Remove inline code formatting
+    cleanText = cleanText.replace(/\*\*([^*]+)\*\*/g, "$1"); // Remove bold
+    cleanText = cleanText.replace(/\*([^*]+)\*/g, "$1"); // Remove italic
+    cleanText = cleanText.replace(/#{1,6}\s/g, ""); // Remove markdown headers
+    cleanText = cleanText.replace(/^\s*[-*+]\s/gm, ""); // Remove list markers
+    cleanText = cleanText.replace(/^\s*\d+\.\s/gm, ""); // Remove numbered list markers
+
+    // Clean up whitespace and decode entities
+    cleanText = cleanText
+      .replace(/\n{2,}/g, ". ") // Replace multiple newlines with period
+      .replace(/\n/g, " ") // Replace single newlines with space
+      .replace(/\s{2,}/g, " ") // Replace multiple spaces with single space
+      .replace(/&lt;/g, "<")
+      .replace(/&gt;/g, ">")
+      .replace(/&amp;/g, "&")
+      .replace(/&quot;/g, '"')
+      .trim();
+
+    return cleanText;
+  };
+
+  const speak = (
+    text: string,
+    options?: { rate?: number; pitch?: number; volume?: number },
+  ) => {
+    if (!text.trim()) return;
+
+    // Stop any current speech
+    speechSynthesis.cancel();
+
+    const cleanText = cleanTextForSpeech(text);
+    if (!cleanText.trim()) return;
+
+    const utterance = new SpeechSynthesisUtterance(cleanText);
+    utteranceRef.current = utterance;
+
+    // Set voice and options
+    if (selectedVoice) {
+      utterance.voice = selectedVoice;
+    }
+
+    utterance.rate = options?.rate || 1;
+    utterance.pitch = options?.pitch || 1;
+    utterance.volume = options?.volume || 1;
+
+    // Event handlers
+    utterance.onstart = () => {
+      setIsPlaying(true);
+      setIsPaused(false);
+    };
+
+    utterance.onend = () => {
+      setIsPlaying(false);
+      setIsPaused(false);
+      utteranceRef.current = null;
+    };
+
+    utterance.onerror = () => {
+      setIsPlaying(false);
+      setIsPaused(false);
+      utteranceRef.current = null;
+    };
+
+    speechSynthesis.speak(utterance);
+  };
+
+  const pause = () => {
+    if (speechSynthesis.speaking && !speechSynthesis.paused) {
+      speechSynthesis.pause();
+      setIsPaused(true);
+    }
+  };
+
+  const resume = () => {
+    if (speechSynthesis.paused) {
+      speechSynthesis.resume();
+      setIsPaused(false);
+    }
+  };
+
+  const stop = () => {
+    speechSynthesis.cancel();
+    setIsPlaying(false);
+    setIsPaused(false);
+    utteranceRef.current = null;
+  };
+
+  const toggle = (
+    text?: string,
+    options?: { rate?: number; pitch?: number; volume?: number },
+  ) => {
+    speechSynthesis.cancel();
+    if (isPlaying) {
+      if (isPaused) {
+        resume();
+      } else {
+        pause();
+      }
+    } else {
+      if (text) {
+        speak(text, options);
+      }
+    }
+  };
+
+  // Check if TTS is supported
+  const isSupported = "speechSynthesis" in window;
+  return {
+    speak,
+    pause,
+    resume,
+    stop,
+    toggle,
+    isPlaying,
+    isPaused,
+    isSupported,
+    voices,
+    selectedVoice,
+    setSelectedVoice,
+  };
+};

--- a/src/hooks/useTextToSpeech.ts
+++ b/src/hooks/useTextToSpeech.ts
@@ -140,10 +140,9 @@ export const useTextToSpeech = () => {
     utterance.volume = options?.volume ?? 1;
 
     // Event handlers
-    utterance.onstart = () => {
-      setIsPlaying(true);
-      setIsPaused(false);
-    };
+
+    setIsPlaying(true);
+    setIsPaused(false);
 
     utterance.onend = () => {
       setIsPlaying(false);

--- a/src/hooks/useTextToSpeech.ts
+++ b/src/hooks/useTextToSpeech.ts
@@ -11,7 +11,10 @@ export const useTextToSpeech = () => {
   // Load available voices
   useEffect(() => {
     const loadVoices = () => {
-      const availableVoices = speechSynthesis.getVoices();
+      const availableVoices =
+        typeof window !== "undefined" && "speechSynthesis" in window
+          ? window.speechSynthesis.getVoices()
+          : [];
       setVoices(availableVoices);
 
       // Set default voice (prefer English voices)
@@ -134,7 +137,7 @@ export const useTextToSpeech = () => {
 
     utterance.rate = options?.rate || 1;
     utterance.pitch = options?.pitch || 1;
-    utterance.volume = options?.volume || 1;
+    utterance.volume = options?.volume ?? 1;
 
     // Event handlers
     utterance.onstart = () => {
@@ -182,7 +185,6 @@ export const useTextToSpeech = () => {
     text?: string,
     options?: { rate?: number; pitch?: number; volume?: number },
   ) => {
-    speechSynthesis.cancel();
     if (isPlaying) {
       if (isPaused) {
         resume();
@@ -197,7 +199,8 @@ export const useTextToSpeech = () => {
   };
 
   // Check if TTS is supported
-  const isSupported = "speechSynthesis" in window;
+  const isSupported =
+    typeof window !== "undefined" && "speechSynthesis" in window;
   return {
     speak,
     pause,


### PR DESCRIPTION
# feat: text-to-speech for AI responses

Add text-to-speech functionality to AI chat responses with e2e testing.

## Changes
- **TTS Button**: Play/stop button for AI messages with state management
- **Voice Support**: Uses browser's Web Speech API with voice selection
- **UI States**: Visual feedback with play/stop icons and tooltips
- **E2E Tests**: Complete test coverage following existing patterns


https://github.com/user-attachments/assets/3891652d-2295-47eb-9de8-3c34d3f1b164


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds text-to-speech to assistant messages so users can listen to chat replies. Includes a play/stop control and end-to-end tests.

- New Features
  - Play/stop button on assistant messages with icons and tooltips
  - Web Speech API integration with voice selection and support check
  - Text cleaning strips markdown, HTML, and Dyad tags before reading
  - E2E test mocks speechSynthesis and verifies state changes

<!-- End of auto-generated description by cubic. -->

