### PR TITLE
bump v0.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dyad",
   "productName": "dyad",
-  "version": "0.22.0-beta.1",
+  "version": "0.22.0",
   "description": "Free, local, open-source AI app builder",
   "main": ".vite/build/main.js",
   "repository": {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Promoted v0.22.0 from beta to stable to ship the 0.22.x release.
Updated package.json version from 0.22.0-beta.1 to 0.22.0.

<!-- End of auto-generated description by cubic. -->

