### PR TITLE
feat: Support for Claude sonnet 4.5 (Best coding model)

### DIFF
--- a/src/ipc/shared/language_model_constants.ts
+++ b/src/ipc/shared/language_model_constants.ts
@@ -330,7 +330,7 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
       displayName: "Claude Sonnet 4.5",
       description: "Best coding model in the world, strongest for agents",
       maxOutputTokens: 64_000,
-      contextWindow: 2000_000,
+      contextWindow: 200_000,
       temperature: 0,
     },
     {

--- a/src/ipc/shared/language_model_constants.ts
+++ b/src/ipc/shared/language_model_constants.ts
@@ -72,6 +72,15 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
   // https://docs.anthropic.com/en/docs/about-claude/models/all-models#model-comparison-table
   anthropic: [
     {
+      name: "claude-sonnet-4-5-20250929",
+      displayName: "Claude Sonnet 4.5",
+      description: "Best coding model in the world, strongest for agents",
+      maxOutputTokens: 64_000,
+      contextWindow: 200_000,
+      temperature: 0,
+      dollarSigns: 4,
+    },
+    {
       name: "claude-sonnet-4-20250514",
       displayName: "Claude 4 Sonnet",
       description: "Excellent coder (note: >200k tokens is very expensive!)",
@@ -316,6 +325,14 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
     },
   ],
   bedrock: [
+    {
+      name: "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+      displayName: "Claude Sonnet 4.5",
+      description: "Best coding model in the world, strongest for agents",
+      maxOutputTokens: 64_000,
+      contextWindow: 2000_000,
+      temperature: 0,
+    },
     {
       name: "us.anthropic.claude-sonnet-4-20250514-v1:0",
       displayName: "Claude 4 Sonnet",


### PR DESCRIPTION
## Add Claude Sonnet 4.5 (the best coding model) to Anthropic and Amazon Bedrock
Description
This PR adds support for Claude Sonnet 4.5 (released September 29, 2025), currently the world's best coding model.

What's Added
Claude Sonnet 4.5

Anthropic API: claude-sonnet-4-5-20250929
Amazon Bedrock: anthropic.claude-sonnet-4-5-20250929-v1:0
Context Window: 200K tokens 
Max Output: 16K tokens
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds support for Claude Sonnet 4.5 so it’s selectable via both Anthropic and Amazon Bedrock.

- New Features
  - Anthropic model: claude-sonnet-4-5-20250929
  - Bedrock model: global.anthropic.claude-sonnet-4-5-20250929-v1:0
  - Default temperature set to 0; context and output limits configured per provider

<!-- End of auto-generated description by cubic. -->

