### PR TITLE
Add GPT 5 Codex and Sonnet 4.5

### DIFF
--- a/e2e-tests/snapshots/engine.spec.ts_send-message-to-engine---anthropic-claude-sonnet-4-1.txt
+++ b/e2e-tests/snapshots/engine.spec.ts_send-message-to-engine---anthropic-claude-sonnet-4-1.txt
@@ -1,7 +1,7 @@
 {
   "body": {
     "model": "anthropic/claude-sonnet-4-20250514",
-    "max_tokens": 16000,
+    "max_tokens": 32000,
     "temperature": 0,
     "messages": [
       {

--- a/e2e-tests/snapshots/gateway.spec.ts_claude-4-sonnet-1.txt
+++ b/e2e-tests/snapshots/gateway.spec.ts_claude-4-sonnet-1.txt
@@ -1,7 +1,7 @@
 {
   "body": {
     "model": "anthropic/claude-sonnet-4-20250514",
-    "max_tokens": 16000,
+    "max_tokens": 32000,
     "temperature": 0,
     "messages": [
       {

--- a/src/ipc/shared/language_model_constants.ts
+++ b/src/ipc/shared/language_model_constants.ts
@@ -19,6 +19,18 @@ export interface ModelOption {
 
 export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
   openai: [
+    // https://platform.openai.com/docs/models/gpt-5-codex
+    {
+      name: "gpt-5-codex",
+      displayName: "GPT 5 Codex",
+      description: "OpenAI's flagship model optimized for coding",
+      // Technically it's 128k but OpenAI errors if you set max_tokens instead of max_completion_tokens
+      maxOutputTokens: undefined,
+      contextWindow: 400_000,
+      // Requires temperature to be default value (1)
+      temperature: 1,
+      dollarSigns: 3,
+    },
     // https://platform.openai.com/docs/models/gpt-5
     {
       name: "gpt-5",
@@ -72,11 +84,22 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
   // https://docs.anthropic.com/en/docs/about-claude/models/all-models#model-comparison-table
   anthropic: [
     {
+      name: "claude-sonnet-4-5-20250929",
+      displayName: "Claude 4.5 Sonnet",
+      description:
+        "Anthropic's best model for coding (note: >200k tokens is very expensive!)",
+      // Set to 32k since context window is 1M tokens
+      maxOutputTokens: 32_000,
+      contextWindow: 1_000_000,
+      temperature: 0,
+      dollarSigns: 5,
+    },
+    {
       name: "claude-sonnet-4-20250514",
       displayName: "Claude 4 Sonnet",
       description: "Excellent coder (note: >200k tokens is very expensive!)",
-      // See comment below for Claude 3.7 Sonnet for why we set this to 16k
-      maxOutputTokens: 16_000,
+      // Set to 32k since context window is 1M tokens
+      maxOutputTokens: 32_000,
       contextWindow: 1_000_000,
       temperature: 0,
       dollarSigns: 5,
@@ -252,6 +275,14 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
     },
   ],
   azure: [
+    {
+      name: "gpt-5-codex",
+      displayName: "GPT-5",
+      description: "Azure OpenAI GPT-5 Codex model",
+      maxOutputTokens: 128_000,
+      contextWindow: 400_000,
+      temperature: 0,
+    },
     {
       name: "gpt-5",
       displayName: "GPT-5",

--- a/src/ipc/shared/language_model_constants.ts
+++ b/src/ipc/shared/language_model_constants.ts
@@ -277,7 +277,7 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
   azure: [
     {
       name: "gpt-5-codex",
-      displayName: "GPT-5",
+      displayName: "GPT-5 Codex",
       description: "Azure OpenAI GPT-5 Codex model",
       maxOutputTokens: 128_000,
       contextWindow: 400_000,

--- a/src/ipc/shared/language_model_constants.ts
+++ b/src/ipc/shared/language_model_constants.ts
@@ -348,10 +348,19 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
   ],
   bedrock: [
     {
+      name: "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+      displayName: "Claude 4.5 Sonnet",
+      description:
+        "Anthropic's best model for coding (note: >200k tokens is very expensive!)",
+      maxOutputTokens: 32_000,
+      contextWindow: 1_000_000,
+      temperature: 0,
+    },
+    {
       name: "us.anthropic.claude-sonnet-4-20250514-v1:0",
       displayName: "Claude 4 Sonnet",
       description: "Excellent coder (note: >200k tokens is very expensive!)",
-      maxOutputTokens: 16_000,
+      maxOutputTokens: 32_000,
       contextWindow: 1_000_000,
       temperature: 0,
     },

--- a/src/ipc/shared/language_model_constants.ts
+++ b/src/ipc/shared/language_model_constants.ts
@@ -279,41 +279,46 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
       name: "gpt-5-codex",
       displayName: "GPT-5 Codex",
       description: "Azure OpenAI GPT-5 Codex model",
-      maxOutputTokens: 128_000,
+      // See OpenAI comment above
+      // maxOutputTokens: 128_000,
       contextWindow: 400_000,
-      temperature: 0,
+      temperature: 1,
     },
     {
       name: "gpt-5",
       displayName: "GPT-5",
       description: "Azure OpenAI GPT-5 model with reasoning capabilities",
-      maxOutputTokens: 128_000,
+      // See OpenAI comment above
+      // maxOutputTokens: 128_000,
       contextWindow: 400_000,
-      temperature: 0,
+      temperature: 1,
     },
     {
       name: "gpt-5-mini",
       displayName: "GPT-5 Mini",
       description: "Azure OpenAI GPT-5 Mini model",
-      maxOutputTokens: 128_000,
+      // See OpenAI comment above
+      // maxOutputTokens: 128_000,
       contextWindow: 400_000,
-      temperature: 0,
+      temperature: 1,
     },
     {
       name: "gpt-5-nano",
       displayName: "GPT-5 Nano",
       description: "Azure OpenAI GPT-5 Nano model",
-      maxOutputTokens: 128_000,
+      // See OpenAI comment above
+      // maxOutputTokens: 128_000,
       contextWindow: 400_000,
-      temperature: 0,
+      temperature: 1,
     },
     {
       name: "gpt-5-chat",
       displayName: "GPT-5 Chat",
       description: "Azure OpenAI GPT-5 Chat model",
-      maxOutputTokens: 16_384,
+      // See OpenAI comment above
+      // maxOutputTokens: 16_384,
       contextWindow: 128_000,
-      temperature: 0,
+      temperature: 1,
     },
   ],
   xai: [


### PR DESCRIPTION
Fixes #1405 
    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds GPT-5 Codex (OpenAI and Azure) and Claude 4.5 Sonnet to the model options to enable newer coding models and larger contexts. Also increases Claude 4 Sonnet max output tokens to 32k.

<!-- End of auto-generated description by cubic. -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds GPT-5 Codex (OpenAI/Azure) and Claude 4.5 Sonnet (Anthropic/Bedrock), increases Claude 4 Sonnet max output to 32k, updates Azure GPT-5 configs and e2e snapshots.
> 
> - **Models**:
>   - Add `openai/gpt-5-codex` and `azure/gpt-5-codex` with `temperature: 1`, `contextWindow: 400_000`.
>   - Add `anthropic/claude-sonnet-4-5-20250929` and `bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0` (32k max output, 1M context).
>   - Increase `claude-sonnet-4-20250514` max output tokens to `32_000` (Anthropic and Bedrock).
>   - Adjust Azure `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-chat`: set `temperature: 1`; remove explicit `maxOutputTokens` per OpenAI constraints.
> - **Tests**:
>   - Update e2e snapshots to expect `max_tokens: 32000` for `anthropic/claude-sonnet-4-20250514`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bfc8d84a63d18a15392ab269e3a4108260fda641. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->