### PR TITLE
super value

### DIFF
--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -26,6 +26,7 @@ import { useLanguageModelProviders } from "@/hooks/useLanguageModelProviders";
 import { useSettings } from "@/hooks/useSettings";
 import { PriceBadge } from "@/components/PriceBadge";
 import { TURBO_MODELS } from "@/ipc/shared/language_model_constants";
+import { cn } from "@/lib/utils";
 
 export function ModelPicker() {
   const { settings, updateSettings } = useSettings();
@@ -112,7 +113,7 @@ export function ModelPicker() {
           if (
             settings &&
             !isDyadProEnabled(settings) &&
-            model.apiName === "turbo"
+            ["turbo", "value"].includes(model.apiName)
           ) {
             return false;
           }
@@ -237,13 +238,19 @@ export function ModelPicker() {
                             </span>
                           </span>
                           <div className="flex items-center gap-1.5">
-                            {isSmartAutoEnabled && (
-                              <span className="text-[10px] bg-gradient-to-r from-indigo-600 via-indigo-500 to-indigo-600 bg-[length:200%_100%] animate-[shimmer_5s_ease-in-out_infinite] text-white px-1.5 py-0.5 rounded-full font-medium">
-                                Pro only
-                              </span>
-                            )}
+                            {isSmartAutoEnabled &&
+                              !model.displayName.includes("(Pro)") && (
+                                <span className="text-[11px] bg-gradient-to-r from-indigo-600 via-indigo-500 to-indigo-600 bg-[length:200%_100%] animate-[shimmer_5s_ease-in-out_infinite] text-white px-1.5 py-0.5 rounded-full font-medium">
+                                  Pro only
+                                </span>
+                              )}
                             {model.tag && (
-                              <span className="text-[10px] bg-primary/10 text-primary px-1.5 py-0.5 rounded-full font-medium">
+                              <span
+                                className={cn(
+                                  "text-[11px] bg-primary/10 text-primary px-1.5 py-0.5 rounded-full font-medium",
+                                  model.tagColor,
+                                )}
+                              >
                                 {model.tag}
                               </span>
                             )}

--- a/src/ipc/ipc_types.ts
+++ b/src/ipc/ipc_types.ts
@@ -186,6 +186,7 @@ export type LanguageModel =
       displayName: string;
       description: string;
       tag?: string;
+      tagColor?: string;
       maxOutputTokens?: number;
       contextWindow?: number;
       temperature?: number;
@@ -197,6 +198,7 @@ export type LanguageModel =
       displayName: string;
       description: string;
       tag?: string;
+      tagColor?: string;
       maxOutputTokens?: number;
       contextWindow?: number;
       temperature?: number;

--- a/src/ipc/shared/language_model_constants.ts
+++ b/src/ipc/shared/language_model_constants.ts
@@ -13,6 +13,7 @@ export interface ModelOption {
   dollarSigns?: number;
   temperature?: number;
   tag?: string;
+  tagColor?: string;
   maxOutputTokens?: number;
   contextWindow?: number;
 }
@@ -249,6 +250,18 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
       maxOutputTokens: 32_000,
       contextWindow: 256_000,
       temperature: 0,
+      tag: "Fast",
+      tagColor: "bg-rose-800 text-white",
+    },
+    {
+      name: "value",
+      displayName: "Super Value (Pro)",
+      description: "Uses the most cost-effective models available",
+      maxOutputTokens: 32_000,
+      contextWindow: 256_000,
+      temperature: 0,
+      tag: "Budget",
+      tagColor: "bg-emerald-700 text-white",
     },
   ],
   azure: [


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a new `auto` model `value` (Super Value Pro), adds configurable tag colors across model types, and updates Model Picker filtering and badges.
> 
> - **Models and Types**:
>   - Add new auto model `value` ("Super Value (Pro)") with `tag: Budget` and `tagColor`.
>   - Enhance `turbo` auto model with `tag: Fast` and `tagColor`.
>   - Extend `LanguageModel` and `ModelOption` with optional `tagColor`.
> - **Model Picker UI**:
>   - Render model tags with configurable colors via `tagColor` and `cn` utility.
>   - Update "Pro only" badge logic (hide when display name already includes "(Pro)"); adjust badge text size.
>   - Refine auto model visibility: non‑Pro hides `turbo` and `value`; Pro hides `free`.
>   - Minor styling/labeling tweaks in tag and badge rendering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4485fddad502237d4bceb43732043d3eaa60eaa0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->