### PR TITLE
fix: show dyad-command buttons within assistant responses instead of hiding tags (#1421)

### DIFF
--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -556,7 +556,7 @@ function KeepGoingButton() {
   );
 }
 
-function mapActionToButton(action: SuggestedAction) {
+export function mapActionToButton(action: SuggestedAction) {
   switch (action.id) {
     case "summarize-in-new-chat":
       return <SummarizeInNewChatButton />;

--- a/src/components/chat/DyadMarkdownParser.tsx
+++ b/src/components/chat/DyadMarkdownParser.tsx
@@ -500,19 +500,13 @@ function renderCustomTag(
       return null;
 
     case "dyad-command":
-      try {
-        let action;
-        if (attributes.type) {
-          action = {
-            id: attributes.type,
-          } as SuggestedAction;
-        } else {
-          return null;
-        }
+      if (attributes.type) {
+        const action = {
+          id: attributes.type,
+        } as SuggestedAction;
         return <>{mapActionToButton(action)}</>;
-      } catch {
-        return null;
       }
+      return null;
 
     default:
       return null;

--- a/src/components/chat/DyadMarkdownParser.tsx
+++ b/src/components/chat/DyadMarkdownParser.tsx
@@ -502,25 +502,14 @@ function renderCustomTag(
     case "dyad-command":
       try {
         let action;
-        if (attributes.id || attributes.action) {
+        if (attributes.type) {
           action = {
-            id: attributes.id || attributes.action,
-            path: attributes.path,
-          } as SuggestedAction;
-        } else if (Object.keys(attributes).length > 0) {
-          const firstKey = Object.keys(attributes)[0];
-          action = {
-            id: attributes[firstKey],
-            ...attributes,
+            id: attributes.type,
           } as SuggestedAction;
         } else {
           return null;
         }
-        return (
-          <div className="my-2 flex items-center space-x-2">
-            {mapActionToButton(action)}
-          </div>
-        );
+        return <>{mapActionToButton(action)}</>;
       } catch {
         return null;
       }

--- a/src/components/chat/DyadMarkdownParser.tsx
+++ b/src/components/chat/DyadMarkdownParser.tsx
@@ -22,6 +22,8 @@ import { DyadMcpToolResult } from "./DyadMcpToolResult";
 import { DyadWebSearchResult } from "./DyadWebSearchResult";
 import { DyadWebSearch } from "./DyadWebSearch";
 import { DyadRead } from "./DyadRead";
+import { mapActionToButton } from "./ChatInput";
+import { SuggestedAction } from "@/lib/schemas";
 
 interface DyadMarkdownParserProps {
   content: string;
@@ -498,8 +500,30 @@ function renderCustomTag(
       return null;
 
     case "dyad-command":
-      // Don't render anything for dyad-command
-      return null;
+      try {
+        let action;
+        if (attributes.id || attributes.action) {
+          action = {
+            id: attributes.id || attributes.action,
+            path: attributes.path,
+          } as SuggestedAction;
+        } else if (Object.keys(attributes).length > 0) {
+          const firstKey = Object.keys(attributes)[0];
+          action = {
+            id: attributes[firstKey],
+            ...attributes,
+          } as SuggestedAction;
+        } else {
+          return null;
+        }
+        return (
+          <div className="my-2 flex items-center space-x-2">
+            {mapActionToButton(action)}
+          </div>
+        );
+      } catch {
+        return null;
+      }
 
     default:
       return null;


### PR DESCRIPTION

### Problem
Users were confused because `<dyad-command>` tags were being hidden, making it unclear what actions were available.

### Solution
Render dyad-command tags as visible buttons, so users can see and interact with available commands (e.g., "restart").

Closes #1421
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Show dyad-command tags as visible buttons in assistant responses so users can see and trigger actions (e.g., restart). Closes #1421.

- **Bug Fixes**
  - Render dyad-command tags to buttons in DyadMarkdownParser.
  - Export mapActionToButton from ChatInput for reuse.
  - Support id/action/path attributes; safely no-op if parsing fails.

<!-- End of auto-generated description by cubic. -->

