### PR TITLE
fix supabase prompt

### DIFF
--- a/src/prompts/supabase_prompt.ts
+++ b/src/prompts/supabase_prompt.ts
@@ -57,17 +57,24 @@ Below code snippets are provided for reference:
 Login state management:
 
 useEffect(() => {
-  const { data: { subscription } } = supabase.auth.onAuthStateChange(async (event, session) => {
-    if (event === 'USER_UPDATED' || event === 'SIGNED_IN') {
-      const { error } = await supabase.auth.getSession();
-      // Other code here
+  const { data } = supabase.auth.onAuthStateChange((event, session) => {
+    if (event === 'INITIAL_SESSION') {
+      // handle initial session
+    } else if (event === 'SIGNED_IN') {
+      // handle sign in event
+    } else if (event === 'SIGNED_OUT') {
+      // handle sign out event
+    } else if (event === 'PASSWORD_RECOVERY') {
+      // handle password recovery event
+    } else if (event === 'TOKEN_REFRESHED') {
+      // handle token refreshed event
+    } else if (event === 'USER_UPDATED') {
+      // handle user updated event
     }
-    if (event === 'SIGNED_OUT') {
-      // Other code here
-    }
-  });
+  })
 
-  return () => subscription.unsubscribe();
+  // call unsubscribe to remove the callback
+  return () => data.subscription.unsubscribe();
 }, []);
 
 


### PR DESCRIPTION
Fixes #1364

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refreshes the Supabase prompt’s login state example to use the latest onAuthStateChange event handling and unsubscribe pattern.
> 
> - **Prompts**:
>   - **Supabase system prompt (`src/prompts/supabase_prompt.ts`)**:
>     - Revise login state management example to use `supabase.auth.onAuthStateChange` with explicit events: `INITIAL_SESSION`, `SIGNED_IN`, `SIGNED_OUT`, `PASSWORD_RECOVERY`, `TOKEN_REFRESHED`, `USER_UPDATED`.
>     - Update unsubscribe usage to `data.subscription.unsubscribe()` and remove outdated async/getSession snippet.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 239d20769a02d102d168126f973a6cb4bf6d9e48. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->