### PR TITLE
Label issues filed from pro members

### DIFF
--- a/src/components/HelpDialog.tsx
+++ b/src/components/HelpDialog.tsx
@@ -110,7 +110,11 @@ ${debugInfo.logs.slice(-3_500) || "No logs available"}
       // Create the GitHub issue URL with the pre-filled body
       const encodedBody = encodeURIComponent(issueBody);
       const encodedTitle = encodeURIComponent("[bug] <WRITE TITLE HERE>");
-      const githubIssueUrl = `https://github.com/dyad-sh/dyad/issues/new?title=${encodedTitle}&labels=bug,filed-from-app&body=${encodedBody}`;
+      const labels = ["bug"];
+      if (isDyadProUser) {
+        labels.push("pro");
+      }
+      const githubIssueUrl = `https://github.com/dyad-sh/dyad/issues/new?title=${encodedTitle}&labels=${labels}&body=${encodedBody}`;
 
       // Open the pre-filled GitHub issue page
       IpcClient.getInstance().openExternalUrl(githubIssueUrl);
@@ -230,7 +234,11 @@ Session ID: ${sessionId}
 
     const encodedBody = encodeURIComponent(issueBody);
     const encodedTitle = encodeURIComponent("[session report] <add title>");
-    const githubIssueUrl = `https://github.com/dyad-sh/dyad/issues/new?title=${encodedTitle}&labels=support&body=${encodedBody}`;
+    const labels = ["support"];
+    if (isDyadProUser) {
+      labels.push("pro");
+    }
+    const githubIssueUrl = `https://github.com/dyad-sh/dyad/issues/new?title=${encodedTitle}&labels=${labels}&body=${encodedBody}`;
 
     IpcClient.getInstance().openExternalUrl(githubIssueUrl);
     handleClose();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Conditionally appends the `pro` label to prefilled GitHub issue URLs for Dyad Pro users.
> 
> - **Help dialog issue links**:
>   - For `Report a Bug`: build `labels` array starting with `bug`, append `pro` when `isDyadProUser` is true; pass labels via `labels=${labels}`.
>   - For `Session Report`: build `labels` array starting with `support`, append `pro` when `isDyadProUser` is true; pass labels via `labels=${labels}`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b0928f201ff9f38284445ee2f29ae2966a59403. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->