### PR TITLE
Max step count is 20 for toolcalls

### DIFF
--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -777,7 +777,7 @@ This conversation includes one or more image attachments. When the user uploads 
             temperature: await getTemperature(settings.selectedModel),
             maxRetries: 2,
             model: modelClient.model,
-            stopWhen: [stepCountIs(3), hasToolCall("edit-code")],
+            stopWhen: [stepCountIs(20), hasToolCall("edit-code")],
             providerOptions,
             system: systemPromptOverride,
             tools,


### PR DESCRIPTION
getting user feedback that the max of 3 is not enough and it's ending abruptly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase `stopWhen` step threshold from 3 to 20 in `chat_stream_handlers.ts` to allow more toolcall steps before stopping.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca421cb2cc9178dc3a9698915424f22f3d001f44. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->