### PR TITLE
Fix DyadThink react hook usage

### DIFF
--- a/src/components/chat/DyadThink.tsx
+++ b/src/components/chat/DyadThink.tsx
@@ -22,6 +22,13 @@ export const DyadThink: React.FC<DyadThinkProps> = ({ children, node }) => {
         )
       : null;
 
+  // Collapse when transitioning from in-progress to not-in-progress
+  useEffect(() => {
+    if (!inProgress && isExpanded) {
+      setIsExpanded(false);
+    }
+  }, [inProgress]);
+
   // If it's token savings format, render DyadTokenSavings component
   if (tokenSavingsMatch) {
     const originalTokens = parseFloat(tokenSavingsMatch[1]);
@@ -33,13 +40,6 @@ export const DyadThink: React.FC<DyadThinkProps> = ({ children, node }) => {
       />
     );
   }
-
-  // Collapse when transitioning from in-progress to not-in-progress
-  useEffect(() => {
-    if (!inProgress && isExpanded) {
-      setIsExpanded(false);
-    }
-  }, [inProgress]);
 
   return (
     <div


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Reorders the collapse useEffect to run before the token-savings early return so hooks are always called unconditionally.
> 
> - **Frontend**
>   - **`src/components/chat/DyadThink.tsx`**:
>     - Move collapse `useEffect` above the token-savings early return to ensure hooks are called unconditionally.
>     - Maintains collapse behavior when `inProgress` transitions to false.
>     - `DyadTokenSavings` rendering path remains unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6c7d20ab037043bff26deec1364f2d9008fbf33. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->