### PR TITLE
Allow passthrough for provider schemas

### DIFF
--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -114,9 +114,16 @@ export const VertexProviderSettingSchema = z.object({
 export const ProviderSettingSchema = z.union([
   // Must use more specific type first!
   // Zod uses the first type that matches.
-  AzureProviderSettingSchema,
-  VertexProviderSettingSchema,
-  RegularProviderSettingSchema,
+  //
+  // We use passthrough as a hack because Azure and Vertex
+  // will match together since their required fields overlap.
+  //
+  // In addition, there may be future provider settings that
+  // we may want to preserve (e.g. user downgrades to older version)
+  // so doing passthrough keeps these extra fields.
+  AzureProviderSettingSchema.passthrough(),
+  VertexProviderSettingSchema.passthrough(),
+  RegularProviderSettingSchema.passthrough(),
 ]);
 
 /**


### PR DESCRIPTION
Fixes #1472 

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches `ProviderSettingSchema` union to `.passthrough()` variants to accept extra fields and avoid overlapping schema conflicts.
> 
> - **Schemas**:
>   - **`src/lib/schemas.ts`**: Update `ProviderSettingSchema` to use `.passthrough()` on `AzureProviderSettingSchema`, `VertexProviderSettingSchema`, and `RegularProviderSettingSchema` so unknown fields are preserved and overlapping required fields don’t cause mis-matches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7afa4b83d713b9eb433d4cce28c7fee73cd7545b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->