### PR TITLE
Bump to v0.24.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dyad",
   "productName": "dyad",
-  "version": "0.23.0-beta.1",
+  "version": "0.24.0-beta.1",
   "description": "Free, local, open-source AI app builder",
   "main": ".vite/build/main.js",
   "repository": {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Update package.json version from 0.23.0-beta.1 to 0.24.0-beta.1 to prepare the 0.24 beta release. This unblocks tagging and publishing for the bump-beta-0-24 branch.

<!-- End of auto-generated description by cubic. -->

