### PR TITLE
Prompt enhance

### DIFF
--- a/e2e-tests/enhance_button.spec.ts
+++ b/e2e-tests/enhance_button.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from "@playwright/test";
+
+// This test suite assumes IS_TEST_BUILD so prompt enhancement returns "[enhanced] <text>"
+
+test.describe("Prompt enhancement - button mode", () => {
+  test("Home: Enhance button enhances and starts chat", async ({ page }) => {
+    // Go to settings
+    await page.goto("/");
+    await page.getByRole("link", { name: "Settings" }).click();
+
+    // Navigate to AI Settings -> Prompt Enhancement and choose Button
+    await page.locator("text=AI Settings").scrollIntoViewIfNeeded();
+    await page.locator("text=Prompt Enhancement").scrollIntoViewIfNeeded();
+    await page.getByRole("button", { name: "Button (Enhance+Send)" }).click();
+
+    // Go home
+    await page.goto("/");
+
+    const HOME_INPUT = page.getByPlaceholder("Ask Dyad to build...");
+    await HOME_INPUT.click();
+    await HOME_INPUT.fill("make a simple hello world app");
+
+    await page.getByRole("button", { name: /Enhance/ }).click();
+
+    // Should navigate to chat and show an assistant message processing
+    await page.waitForURL(/\/chat\?id=.*/);
+
+    // Wait for the user message to be recorded with [enhanced]
+    await expect(page.locator("text=[enhanced] make a simple hello world app")).toBeVisible({ timeout: 30000 });
+  });
+});

--- a/e2e-tests/templates_user.spec.ts
+++ b/e2e-tests/templates_user.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect } from "./helpers/test_helper";
+import { test } from "./helpers/test_helper";
+import { expect } from "@playwright/test";
 import * as eph from "electron-playwright-helpers";
 import path from "path";
 

--- a/e2e-tests/templates_user.spec.ts
+++ b/e2e-tests/templates_user.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from "./helpers/test_helper";
+import * as eph from "electron-playwright-helpers";
+import path from "path";
+
+// E2E: Your templates section - add and delete user template
+
+test("hub: your templates section supports add and delete", async ({ po }) => {
+  await po.goToHubTab();
+
+  // Open AddUserTemplateDialog by selecting the "Import your own template" card
+  // Stub select folder dialog to a known fixture directory
+  await eph.stubDialog(po.electronApp, "showOpenDialog", {
+    filePaths: [path.join(__dirname, "fixtures", "import-app", "app-basic")],
+  });
+
+  // Click the card image by accessible name
+  await po.page.getByRole("img", { name: "Import your own template" }).click();
+
+  // In the dialog, click Select Folder (will use stubbed path)
+  await po.page.getByRole("button", { name: "Select Folder" }).click();
+
+  // Title auto-fills from folder; save
+  await po.page.getByRole("button", { name: "Save to Hub" }).click();
+
+  // Verify the new template appears under "Your templates" section
+  const yourSection = po.page.getByRole("region", { name: "your-templates" });
+  await expect(yourSection).toBeVisible();
+  await expect(
+    yourSection.getByRole("img", { name: /app-basic/i })
+  ).toBeVisible();
+
+  // Select the user template to ensure it's selectable
+  await yourSection.getByRole("img", { name: /app-basic/i }).click();
+
+  // Delete the user template
+  await yourSection
+    .getByRole("img", { name: /app-basic/i })
+    .locator("xpath=ancestor::*[@class][1]")
+    .getByRole("button", { name: "Delete template" })
+    .click();
+
+  // Verify it's removed
+  await expect(
+    yourSection.getByRole("img", { name: /app-basic/i })
+  ).toBeHidden();
+});

--- a/src/components/AddUserTemplateDialog.tsx
+++ b/src/components/AddUserTemplateDialog.tsx
@@ -1,0 +1,168 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { IpcClient } from "@/ipc/ipc_client";
+import { useSettings } from "@/hooks/useSettings";
+import { showError, showSuccess } from "@/lib/toast";
+import { Folder, Loader2, X } from "lucide-react";
+
+interface AddUserTemplateDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onAdded?: () => void;
+}
+
+export function AddUserTemplateDialog({ open, onOpenChange, onAdded }: AddUserTemplateDialogProps) {
+  const { settings, updateSettings } = useSettings();
+  const [selectedPath, setSelectedPath] = useState<string | null>(null);
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [imageUrl, setImageUrl] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  // Derive a default id from title
+  const defaultId = useMemo(() => {
+    const base = title
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9-_]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "user-template";
+    const existing = new Set((settings?.userTemplates || []).map((t: any) => t.id));
+    let id = `user:${base}`;
+    let i = 1;
+    while (existing.has(id)) {
+      id = `user:${base}-${i++}`;
+    }
+    return id;
+  }, [title, settings?.userTemplates]);
+
+  // When a folder is chosen, set default title from folder name
+  const handleSelectFolder = async () => {
+    try {
+      setBusy(true);
+      const res = await IpcClient.getInstance().selectAppFolder();
+      if (!res.path || !res.name) return;
+      setSelectedPath(res.path);
+      if (!title) setTitle(res.name);
+    } catch (e: any) {
+      showError(e?.message || String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleClear = () => {
+    setSelectedPath(null);
+    setTitle("");
+    setDescription("");
+    setImageUrl("");
+  };
+
+  const handleSave = async () => {
+    if (!selectedPath || !title.trim()) return;
+    try {
+      setBusy(true);
+      // Append to userTemplates in settings
+      const existing = settings?.userTemplates || [];
+      const next = [
+        ...existing,
+        {
+          id: defaultId,
+          title: title.trim(),
+          description: description.trim() || undefined,
+          imageUrl: imageUrl.trim() || undefined,
+          source: { type: "folder" as const, path: selectedPath },
+        },
+      ];
+      await updateSettings({ userTemplates: next });
+      showSuccess("Template added to Hub");
+      onOpenChange(false);
+      handleClear();
+      onAdded?.();
+    } catch (e: any) {
+      showError(e?.message || String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // Reset state when dialog toggles
+  useEffect(() => {
+    if (!open) {
+      handleClear();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  const canSave = Boolean(selectedPath && title.trim() && !busy);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[520px]">
+        <DialogHeader>
+          <DialogTitle>Add template to Hub</DialogTitle>
+          <DialogDescription>
+            Register an existing project folder as a reusable template. It will appear under Community templates.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          {!selectedPath ? (
+            <Button onClick={handleSelectFolder} className="w-full" disabled={busy}>
+              {busy ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Folder className="mr-2 h-4 w-4" />}
+              Select Folder
+            </Button>
+          ) : (
+            <div className="rounded-md border p-4">
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-medium">Selected folder:</p>
+                  <p className="text-sm text-muted-foreground break-all">{selectedPath}</p>
+                </div>
+                <Button variant="ghost" size="sm" onClick={handleClear} className="h-8 w-8 p-0" disabled={busy}>
+                  <X className="h-4 w-4" />
+                  <span className="sr-only">Clear selection</span>
+                </Button>
+              </div>
+            </div>
+          )}
+
+          <div className="grid gap-2">
+            <Label>Title</Label>
+            <Input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="My Template" disabled={busy} />
+          </div>
+
+          <div className="grid gap-2">
+            <Label>Description (optional)</Label>
+            <Input value={description} onChange={(e) => setDescription(e.target.value)} placeholder="Short description" disabled={busy} />
+          </div>
+
+          <div className="grid gap-2">
+            <Label>Image URL (optional)</Label>
+            <Input value={imageUrl} onChange={(e) => setImageUrl(e.target.value)} placeholder="https://..." disabled={busy} />
+          </div>
+
+          <div className="text-xs text-muted-foreground">Template ID preview: <code>{defaultId}</code></div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={busy}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={!canSave} className="bg-indigo-600 hover:bg-indigo-700">
+            {busy ? <><Loader2 className="mr-2 h-4 w-4 animate-spin" />Saving...</> : "Save to Hub"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/TemplateCard.tsx
+++ b/src/components/TemplateCard.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, Trash2 } from "lucide-react";
 import { IpcClient } from "@/ipc/ipc_client";
 import { useSettings } from "@/hooks/useSettings";
 import { CommunityCodeConsentDialog } from "./CommunityCodeConsentDialog";
@@ -13,6 +13,8 @@ interface TemplateCardProps {
   isSelected: boolean;
   onSelect: (templateId: string) => void;
   onCreateApp: () => void;
+  deletable?: boolean;
+  onDelete?: (templateId: string) => void;
 }
 
 export const TemplateCard: React.FC<TemplateCardProps> = ({
@@ -20,6 +22,8 @@ export const TemplateCard: React.FC<TemplateCardProps> = ({
   isSelected,
   onSelect,
   onCreateApp,
+  deletable,
+  onDelete,
 }) => {
   const { settings, updateSettings } = useSettings();
   const [showConsentDialog, setShowConsentDialog] = useState(false);
@@ -63,6 +67,13 @@ export const TemplateCard: React.FC<TemplateCardProps> = ({
     }
   };
 
+  const handleDeleteClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (deletable && onDelete) {
+      onDelete(template.id);
+    }
+  };
+
   return (
     <>
       <div
@@ -86,6 +97,15 @@ export const TemplateCard: React.FC<TemplateCardProps> = ({
               isSelected ? "opacity-75" : ""
             }`}
           />
+          {deletable && (
+            <button
+              title="Delete template"
+              onClick={handleDeleteClick}
+              className="absolute top-3 right-3 bg-red-600/90 hover:bg-red-700 text-white p-1.5 rounded-md shadow focus:outline-none"
+            >
+              <Trash2 className="w-4 h-4" />
+            </button>
+          )}
           {isSelected && (
             <span className="absolute top-3 right-3 bg-blue-600 text-white text-xs font-bold px-3 py-1.5 rounded-md shadow-lg">
               Selected

--- a/src/components/TemplateCard.tsx
+++ b/src/components/TemplateCard.tsx
@@ -100,8 +100,9 @@ export const TemplateCard: React.FC<TemplateCardProps> = ({
           {deletable && (
             <button
               title="Delete template"
+              aria-label="Delete template"
               onClick={handleDeleteClick}
-              className="absolute top-3 right-3 bg-red-600/90 hover:bg-red-700 text-white p-1.5 rounded-md shadow focus:outline-none"
+              className="absolute top-3 left-3 bg-red-600/90 hover:bg-red-700 text-white p-1.5 rounded-md shadow focus:outline-none"
             >
               <Trash2 className="w-4 h-4" />
             </button>

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -11,7 +11,7 @@ function Switch({
     <SwitchPrimitive.Root
       data-slot="switch"
       className={cn(
-        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 p-[2px]",
         className,
       )}
       {...props}
@@ -19,7 +19,7 @@ function Switch({
       <SwitchPrimitive.Thumb
         data-slot="switch-thumb"
         className={cn(
-          "bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0",
+          "bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-3 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%+2px)] data-[state=unchecked]:translate-x-[2px]",
         )}
       />
     </SwitchPrimitive.Root>

--- a/src/ipc/handlers/createFromTemplate.ts
+++ b/src/ipc/handlers/createFromTemplate.ts
@@ -18,6 +18,15 @@ export async function createFromTemplate({
   const settings = readSettings();
   const templateId = settings.selectedTemplateId;
 
+  // If user selected a custom template stored in settings and it's a local folder, copy from it
+  const userTemplate = (settings.userTemplates || []).find(
+    (t) => t.id === templateId,
+  );
+  if (userTemplate && userTemplate.source?.type === "folder") {
+    await copyDirectoryRecursive(userTemplate.source.path, fullAppPath);
+    return;
+  }
+
   if (templateId === "react") {
     await copyDirectoryRecursive(
       path.join(__dirname, "..", "..", "scaffold"),

--- a/src/ipc/ipc_client.ts
+++ b/src/ipc/ipc_client.ts
@@ -1062,6 +1062,17 @@ export class IpcClient {
     }
   }
 
+  // Enhance a user prompt via the selected model
+  public async enhancePrompt(text: string): Promise<string> {
+    try {
+      const result = await this.ipcRenderer.invoke("prompt:enhance", { text });
+      return (result as string) ?? text;
+    } catch (error) {
+      showError(error);
+      return text;
+    }
+  }
+
   // Window control methods
   public async minimizeWindow(): Promise<void> {
     try {

--- a/src/ipc/utils/template_utils.ts
+++ b/src/ipc/utils/template_utils.ts
@@ -4,6 +4,7 @@ import {
   localTemplatesData,
 } from "../../shared/templates";
 import log from "electron-log";
+import { readSettings } from "@/main/settings";
 
 const logger = log.scope("template_utils");
 
@@ -65,7 +66,18 @@ export async function fetchApiTemplates(): Promise<Template[]> {
 // Get all templates (local + API)
 export async function getAllTemplates(): Promise<Template[]> {
   const apiTemplates = await fetchApiTemplates();
-  return [...localTemplatesData, ...apiTemplates];
+  const settings = readSettings();
+  const userTemplates = (settings.userTemplates || []).map<Template>((t) => ({
+    id: t.id, // already unique, stored in settings
+    title: t.title,
+    description: t.description || "User template",
+    imageUrl:
+      t.imageUrl ||
+      "https://dummyimage.com/800x350/111827/ffffff&text=User+template",
+    isOfficial: false,
+    // no githubUrl for local folder templates
+  }));
+  return [...localTemplatesData, ...apiTemplates, ...userTemplates];
 }
 
 export async function getTemplateOrThrow(

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -254,6 +254,10 @@ export const UserSettingsSchema = z.object({
   releaseChannel: ReleaseChannelSchema,
   runtimeMode2: RuntimeMode2Schema.optional(),
 
+  // Prompt auto-enhancement settings
+  enablePromptAutoEnhance: z.boolean().optional(),
+  promptEnhanceControl: z.enum(["toggle", "button"]).optional(),
+
   ////////////////////////////////
   // E2E TESTING ONLY.
   ////////////////////////////////

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -229,6 +229,21 @@ export const UserSettingsSchema = z.object({
   enableProWebSearch: z.boolean().optional(),
   proSmartContextOption: z.enum(["balanced", "conservative"]).optional(),
   selectedTemplateId: z.string(),
+  // Custom user templates persisted with settings
+  userTemplates: z
+    .array(
+      z.object({
+        id: z.string(),
+        title: z.string(),
+        description: z.string().optional(),
+        imageUrl: z.string().optional(),
+        source: z.union([
+          z.object({ type: z.literal("folder"), path: z.string() }),
+          z.object({ type: z.literal("github"), url: z.string() }),
+        ]),
+      }),
+    )
+    .optional(),
   enableSupabaseWriteSqlMigration: z.boolean().optional(),
   selectedChatMode: ChatModeSchema.optional(),
   acceptedCommunityCode: z.boolean().optional(),

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -310,6 +310,7 @@ export function WorkflowSettings() {
   );
 }
 export function AISettings() {
+  const { settings, updateSettings } = useSettings();
   return (
     <div
       id="ai-settings"
@@ -325,6 +326,45 @@ export function AISettings() {
 
       <div className="mt-4">
         <MaxChatTurnsSelector />
+      </div>
+
+      {/* Prompt Enhancement */}
+      <div className="mt-6 space-y-3">
+        <h3 className="text-md font-medium text-gray-900 dark:text-white">Prompt Enhancement</h3>
+        <div className="text-sm text-gray-500 dark:text-gray-400">
+          Choose whether the chat input shows a persistent auto-enhance toggle, or a one-time Enhance+Send button.
+        </div>
+
+        <div className="flex items-center gap-3 mt-2">
+          <Label className="text-sm w-48">Control Type</Label>
+          <div className="flex gap-2">
+            <button
+              className={`px-3 py-1.5 text-sm rounded-md border ${settings?.promptEnhanceControl !== 'button' ? 'bg-(--background-lightest) border-border' : 'border-transparent'}`}
+              onClick={() => updateSettings({ promptEnhanceControl: 'toggle' })}
+            >
+              Toggle (per-message)
+            </button>
+            <button
+              className={`px-3 py-1.5 text-sm rounded-md border ${settings?.promptEnhanceControl === 'button' ? 'bg-(--background-lightest) border-border' : 'border-transparent'}`}
+              onClick={() => updateSettings({ promptEnhanceControl: 'button' })}
+            >
+              Button (Enhance+Send)
+            </button>
+          </div>
+        </div>
+
+        {settings?.promptEnhanceControl !== 'button' && (
+          <div className="flex items-center space-x-2 mt-2">
+            <Switch
+              id="enable-prompt-auto-enhance"
+              checked={!!settings?.enablePromptAutoEnhance}
+              onCheckedChange={(checked) =>
+                updateSettings({ enablePromptAutoEnhance: checked })
+              }
+            />
+            <Label htmlFor="enable-prompt-auto-enhance">Auto-enhance by default</Label>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -127,6 +127,8 @@ const validInvokeChannels = [
   "prompts:create",
   "prompts:update",
   "prompts:delete",
+  // Prompt enhancement
+  "prompt:enhance",
   // adding app to favorite
   "add-to-favorite",
   // Test-only channels


### PR DESCRIPTION
a prompt enchaner button + toggle

<img width="1280" height="700" alt="image" src="https://github.com/user-attachments/assets/50f89fd7-68fe-4d9c-8d3c-82230eee249a" />


added a prompt enhancer that uses the model you have setup to enhance prompts. it can be toggled on for auto enhance or just clicked when needed if you switch it to "button mode" in settings. 
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added prompt enhancement to chat inputs with a button or auto-enhance toggle, using your configured model to improve prompts before sending. Also added “Your templates” in the Hub: import a local folder, manage templates, and use them when creating apps.

- **New Features**
  - Prompt Enhancement: choose Button (Enhance+Send) or Toggle in Settings; optional auto-enhance default.
  - Works in Home and Chat inputs; uses the selected model (test builds return “[enhanced] <text>”).
  - Your templates: import a project folder via a dialog; templates are listed under “Your templates”.
  - Delete user templates with confirmation; app creation copies from the selected user template folder.
  - E2E coverage for Enhance button mode and add/delete user templates.

<!-- End of auto-generated description by cubic. -->

