### PR TITLE
feat: add spell check suggestions to context menu

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -170,7 +170,6 @@ const createWindow = () => {
     event.preventDefault();
 
     const template: Electron.MenuItemConstructorOptions[] = [];
-
     if (params.isEditable) {
       template.push(
         { role: "undo" },
@@ -180,9 +179,29 @@ const createWindow = () => {
         { role: "copy" },
         { role: "paste" },
         { role: "delete" },
-        { type: "separator" },
-        { role: "selectAll" },
       );
+      if (params.misspelledWord) {
+        const suggestions: Electron.MenuItemConstructorOptions[] =
+          params.dictionarySuggestions.slice(0, 5).map((suggestion) => ({
+            label: suggestion,
+            click: () => {
+              try {
+                mainWindow?.webContents.replaceMisspelling(suggestion);
+              } catch (error) {
+                logger.error("Failed to replace misspelling:", error);
+              }
+            },
+          }));
+        template.push(
+          { type: "separator" },
+          {
+            type: "submenu",
+            label: `Correct "${params.misspelledWord}"`,
+            submenu: suggestions,
+          },
+        );
+      }
+      template.push({ type: "separator" }, { role: "selectAll" });
     } else {
       if (params.selectionText && params.selectionText.length > 0) {
         template.push({ role: "copy" });


### PR DESCRIPTION
This PR implements spelling correction feature requested in issue #271 
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add spell check suggestions to the context menu in editable fields. Right-clicking a misspelled word shows up to five suggestions for one-click replacement.

- **New Features**
  - Shows a “Correct "<misspelled>"” submenu when a misspelled word is detected.
  - Provides up to 5 dictionary suggestions; clicking replaces the word via replaceMisspelling.
  - Keeps standard edit actions and tidies menu order with separators; logs errors on failure.

<!-- End of auto-generated description by cubic. -->

