### PR TITLE
custom templates

### DIFF
--- a/e2e-tests/template-custom.spec.ts
+++ b/e2e-tests/template-custom.spec.ts
@@ -1,0 +1,242 @@
+import { test } from "./helpers/test_helper";
+import { expect } from "@playwright/test";
+import path from "path";
+import fs from "fs";
+import os from "os";
+
+test("custom template - add, select, delete", async ({ po }) => {
+  // Create a temporary folder to use as a custom template
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "dyad-custom-template-"));
+  
+  // Create a simple index.html in the temp folder to make it a valid template
+  fs.writeFileSync(
+    path.join(tempDir, "index.html"),
+    "<html><body>Custom Template Test</body></html>",
+  );
+  fs.writeFileSync(
+    path.join(tempDir, "package.json"),
+    JSON.stringify({ name: "custom-template-test", version: "1.0.0" }),
+  );
+
+  try {
+    await po.goToHubTab();
+
+    // Initially, "Your templates" section should show empty state
+    await expect(
+      po.page.getByText("No custom templates yet"),
+    ).toBeVisible();
+
+    // Click "Add Your First Template" button
+    await po.page
+      .getByRole("button", { name: "Add Your First Template" })
+      .click();
+
+    // Dialog should be visible
+    await expect(
+      po.page.getByRole("heading", { name: "Add Custom Template" }),
+    ).toBeVisible();
+
+    // Fill in template details
+    await po.page.getByLabel("Template Name").fill("Test Custom Template");
+    await po.page
+      .getByLabel("Description")
+      .fill("A test template for E2E testing");
+
+    // Mock the folder selection dialog
+    await po.electronApp.evaluate(
+      async ({ dialog }, folderPath) => {
+        // Mock dialog.showOpenDialog to return our temp directory
+        const originalShowOpenDialog = dialog.showOpenDialog;
+        dialog.showOpenDialog = async () => ({
+          canceled: false,
+          filePaths: [folderPath],
+        });
+        // Restore after one call
+        setTimeout(() => {
+          dialog.showOpenDialog = originalShowOpenDialog;
+        }, 100);
+      },
+      tempDir,
+    );
+
+    // Click browse button to trigger folder selection
+    await po.page.getByRole("button", { name: "Browse" }).click();
+
+    // Wait a bit for the mock to work
+    await po.page.waitForTimeout(200);
+
+    // Verify folder path is set
+    await expect(po.page.getByPlaceholder("Select a folder...")).toHaveValue(
+      tempDir,
+    );
+
+    // Submit the form
+    await po.page.getByRole("button", { name: "Add Template" }).click();
+
+    // Wait for success message and dialog to close
+    await po.page.waitForTimeout(1000);
+
+    // Verify the custom template appears in the list
+    await expect(
+      po.page.getByRole("heading", { name: "Test Custom Template" }),
+    ).toBeVisible();
+
+    // Select the custom template
+    await po.page.getByRole("img", { name: "Test Custom Template" }).click();
+
+    // Verify it's selected
+    await expect(po.page.getByText("Selected")).toBeVisible();
+
+    // Snapshot settings to verify the custom template is stored
+    await po.snapshotSettings();
+
+    // Hover over the template card to reveal delete button
+    await po.page.getByRole("img", { name: "Test Custom Template" }).hover();
+
+    // Click delete button
+    await po.page
+      .getByRole("button", { title: "Delete custom template" })
+      .click();
+
+    // Confirm deletion in the browser confirm dialog
+    po.page.on("dialog", async (dialog) => {
+      expect(dialog.message()).toContain(
+        'Are you sure you want to delete "Test Custom Template"',
+      );
+      await dialog.accept();
+    });
+
+    // Wait for deletion to complete
+    await po.page.waitForTimeout(1000);
+
+    // Verify the template is removed and empty state is shown again
+    await expect(
+      po.page.getByText("No custom templates yet"),
+    ).toBeVisible();
+
+    // Snapshot settings to verify the custom template is removed
+    await po.snapshotSettings();
+  } finally {
+    // Clean up temp directory
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("custom template - create app from custom template", async ({ po }) => {
+  // Create a temporary folder with a simple React-like structure
+  const tempDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "dyad-custom-template-app-"),
+  );
+
+  // Create files for the template
+  fs.writeFileSync(
+    path.join(tempDir, "index.html"),
+    `<!DOCTYPE html>
+<html>
+  <head><title>Custom Template App</title></head>
+  <body>
+    <div id="root">Custom Template from E2E Test</div>
+  </body>
+</html>`,
+  );
+
+  fs.writeFileSync(
+    path.join(tempDir, "package.json"),
+    JSON.stringify({
+      name: "custom-template-app",
+      version: "1.0.0",
+      scripts: {
+        dev: "echo 'Custom template running'",
+      },
+    }),
+  );
+
+  try {
+    await po.setUp();
+    await po.goToHubTab();
+
+    // Add custom template using the "Add Custom Template" button in header
+    await po.page
+      .getByRole("button", { name: "Add Custom Template" })
+      .first()
+      .click();
+
+    await po.page.getByLabel("Template Name").fill("E2E App Template");
+    await po.page
+      .getByLabel("Description")
+      .fill("Template for creating test apps");
+
+    // Mock folder selection
+    await po.electronApp.evaluate(
+      async ({ dialog }, folderPath) => {
+        const originalShowOpenDialog = dialog.showOpenDialog;
+        dialog.showOpenDialog = async () => ({
+          canceled: false,
+          filePaths: [folderPath],
+        });
+        setTimeout(() => {
+          dialog.showOpenDialog = originalShowOpenDialog;
+        }, 100);
+      },
+      tempDir,
+    );
+
+    await po.page.getByRole("button", { name: "Browse" }).click();
+    await po.page.waitForTimeout(200);
+
+    await po.page.getByRole("button", { name: "Add Template" }).click();
+    await po.page.waitForTimeout(1000);
+
+    // Select the custom template
+    await po.page.getByRole("img", { name: "E2E App Template" }).click();
+
+    // Go back to apps and create an app
+    await po.goToAppsTab();
+    await po.sendPrompt("tc=create-app-from-custom-template");
+    await po.approveProposal();
+
+    // Verify the app was created with custom template
+    await expect(po.page.getByTestId("file-tree")).toBeVisible();
+
+    // Snapshot settings to confirm custom template selection
+    await po.snapshotSettings();
+  } finally {
+    // Clean up
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("custom template - validation", async ({ po }) => {
+  await po.goToHubTab();
+
+  // Click add template button
+  await po.page
+    .getByRole("button", { name: "Add Custom Template" })
+    .first()
+    .click();
+
+  // Try to submit without filling fields
+  await po.page.getByRole("button", { name: "Add Template" }).click();
+
+  // Error should be shown (we expect toast notification)
+  await expect(po.page.getByText(/Please fill in all fields/)).toBeVisible({
+    timeout: 2000,
+  });
+
+  // Fill only title
+  await po.page.getByLabel("Template Name").fill("Test");
+  await po.page.getByRole("button", { name: "Add Template" }).click();
+
+  // Error should still be shown
+  await expect(po.page.getByText(/Please fill in all fields/)).toBeVisible({
+    timeout: 2000,
+  });
+
+  // Cancel the dialog
+  await po.page.getByRole("button", { name: "Cancel" }).click();
+
+  // Dialog should be closed
+  await expect(
+    po.page.getByRole("heading", { name: "Add Custom Template" }),
+  ).not.toBeVisible();
+});

--- a/src/components/AddCustomTemplateDialog.tsx
+++ b/src/components/AddCustomTemplateDialog.tsx
@@ -1,0 +1,195 @@
+import React, { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { IpcClient } from "@/ipc/ipc_client";
+import { showError, showSuccess } from "@/lib/toast";
+import { Folder, Image } from "lucide-react";
+
+interface AddCustomTemplateDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onTemplateAdded?: () => void;
+}
+
+export const AddCustomTemplateDialog: React.FC<
+  AddCustomTemplateDialogProps
+> = ({ open, onOpenChange, onTemplateAdded }) => {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [folderPath, setFolderPath] = useState("");
+  const [imageUrl, setImageUrl] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSelectFolder = async () => {
+    const ipcClient = IpcClient.getInstance();
+    const path = await ipcClient.selectFolder();
+    if (path) {
+      setFolderPath(path);
+    }
+  };
+
+  const handleSelectImage = async () => {
+    const ipcClient = IpcClient.getInstance();
+    const path = await ipcClient.selectImage();
+    if (path) {
+      setImageUrl(path);
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!title.trim() || !description.trim() || !folderPath) {
+      showError("Please fill in all fields and select a folder");
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const ipcClient = IpcClient.getInstance();
+      const result = await ipcClient.addCustomTemplate({
+        title: title.trim(),
+        description: description.trim(),
+        folderPath,
+        imageUrl: imageUrl || undefined,
+      });
+
+      if (result.success) {
+        showSuccess("Custom template added successfully!");
+        setTitle("");
+        setDescription("");
+        setFolderPath("");
+        setImageUrl("");
+        onOpenChange(false);
+        onTemplateAdded?.();
+      } else {
+        showError(result.error || "Failed to add custom template");
+      }
+    } catch (error) {
+      showError(
+        error instanceof Error ? error.message : "Failed to add custom template",
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleCancel = () => {
+    setTitle("");
+    setDescription("");
+    setFolderPath("");
+    setImageUrl("");
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[500px]">
+        <DialogHeader>
+          <DialogTitle>Add Custom Template</DialogTitle>
+          <DialogDescription>
+            Create a custom template from an existing project folder. This
+            folder will be used as the base for new projects.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="title">Template Name</Label>
+            <Input
+              id="title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="e.g., My React Template"
+              disabled={isSubmitting}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="description">Description</Label>
+            <Textarea
+              id="description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Describe what this template includes..."
+              rows={3}
+              disabled={isSubmitting}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="folderPath">Template Folder</Label>
+            <div className="flex gap-2">
+              <Input
+                id="folderPath"
+                value={folderPath}
+                readOnly
+                placeholder="Select a folder..."
+                className="flex-1"
+              />
+              <Button
+                type="button"
+                onClick={handleSelectFolder}
+                variant="outline"
+                disabled={isSubmitting}
+              >
+                <Folder className="h-4 w-4 mr-2" />
+                Browse
+              </Button>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="imageUrl">Template Image (Optional)</Label>
+            <div className="flex gap-2">
+              <Input
+                id="imageUrl"
+                value={imageUrl}
+                readOnly
+                placeholder="Select an image or leave empty for auto-generated..."
+                className="flex-1"
+              />
+              <Button
+                type="button"
+                onClick={handleSelectImage}
+                variant="outline"
+                disabled={isSubmitting}
+              >
+                <Image className="h-4 w-4 mr-2" />
+                Browse
+              </Button>
+            </div>
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              If not provided, a text-based placeholder will be generated using
+              the template name.
+            </p>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleCancel}
+              disabled={isSubmitting}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? "Adding..." : "Add Template"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/EditCustomTemplateDialog.tsx
+++ b/src/components/EditCustomTemplateDialog.tsx
@@ -1,0 +1,199 @@
+import React, { useState, useEffect } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { IpcClient } from "@/ipc/ipc_client";
+import { showError, showSuccess } from "@/lib/toast";
+import { Folder, Image } from "lucide-react";
+import type { Template } from "@/shared/templates";
+
+interface EditCustomTemplateDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  template: Template | null;
+  onTemplateEdited?: () => void;
+}
+
+export const EditCustomTemplateDialog: React.FC<
+  EditCustomTemplateDialogProps
+> = ({ open, onOpenChange, template, onTemplateEdited }) => {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [folderPath, setFolderPath] = useState("");
+  const [imageUrl, setImageUrl] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // Update state when template changes
+  useEffect(() => {
+    if (template) {
+      setTitle(template.title);
+      setDescription(template.description);
+      setFolderPath(template.folderPath || "");
+      setImageUrl(template.imageUrl || "");
+    }
+  }, [template]);
+
+  const handleSelectFolder = async () => {
+    const ipcClient = IpcClient.getInstance();
+    const path = await ipcClient.selectFolder();
+    if (path) {
+      setFolderPath(path);
+    }
+  };
+
+  const handleSelectImage = async () => {
+    const ipcClient = IpcClient.getInstance();
+    const path = await ipcClient.selectImage();
+    if (path) {
+      setImageUrl(path);
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!template || !title.trim() || !description.trim() || !folderPath) {
+      showError("Please fill in all fields and select a folder");
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const ipcClient = IpcClient.getInstance();
+      const result = await ipcClient.editCustomTemplate({
+        templateId: template.id,
+        title: title.trim(),
+        description: description.trim(),
+        folderPath,
+        imageUrl: imageUrl || undefined,
+      });
+
+      if (result.success) {
+        showSuccess("Template updated successfully!");
+        onOpenChange(false);
+        onTemplateEdited?.();
+      } else {
+        showError(result.error || "Failed to update template");
+      }
+    } catch (error) {
+      showError(
+        error instanceof Error ? error.message : "Failed to update template",
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleCancel = () => {
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[500px]">
+        <DialogHeader>
+          <DialogTitle>Edit Custom Template</DialogTitle>
+          <DialogDescription>
+            Update the details of your custom template.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="title">Template Name</Label>
+            <Input
+              id="title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="e.g., My React Template"
+              disabled={isSubmitting}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="description">Description</Label>
+            <Textarea
+              id="description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Describe what this template includes..."
+              rows={3}
+              disabled={isSubmitting}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="folderPath">Template Folder</Label>
+            <div className="flex gap-2">
+              <Input
+                id="folderPath"
+                value={folderPath}
+                readOnly
+                placeholder="Select a folder..."
+                className="flex-1"
+              />
+              <Button
+                type="button"
+                onClick={handleSelectFolder}
+                variant="outline"
+                disabled={isSubmitting}
+              >
+                <Folder className="h-4 w-4 mr-2" />
+                Browse
+              </Button>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="imageUrl">Template Image (Optional)</Label>
+            <div className="flex gap-2">
+              <Input
+                id="imageUrl"
+                value={imageUrl}
+                readOnly
+                placeholder="Select an image or leave empty for auto-generated..."
+                className="flex-1"
+              />
+              <Button
+                type="button"
+                onClick={handleSelectImage}
+                variant="outline"
+                disabled={isSubmitting}
+              >
+                <Image className="h-4 w-4 mr-2" />
+                Browse
+              </Button>
+            </div>
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              If not provided, a text-based placeholder will be generated using
+              the template name.
+            </p>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleCancel}
+              disabled={isSubmitting}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? "Saving..." : "Save Changes"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/ipc/handlers/createFromTemplate.ts
+++ b/src/ipc/handlers/createFromTemplate.ts
@@ -27,6 +27,14 @@ export async function createFromTemplate({
   }
 
   const template = await getTemplateOrThrow(templateId);
+
+  // Handle custom templates
+  if (template.isCustom && template.folderPath) {
+    logger.info(`Using custom template from ${template.folderPath}`);
+    await copyDirectoryRecursive(template.folderPath, fullAppPath);
+    return;
+  }
+
   if (!template.githubUrl) {
     throw new Error(`Template ${templateId} has no GitHub URL`);
   }

--- a/src/ipc/handlers/template_handlers.ts
+++ b/src/ipc/handlers/template_handlers.ts
@@ -2,6 +2,10 @@ import { createLoggedHandler } from "./safe_handle";
 import log from "electron-log";
 import { getAllTemplates } from "../utils/template_utils";
 import { localTemplatesData, type Template } from "../../shared/templates";
+import { readSettings, writeSettings } from "../../main/settings";
+import { v4 as uuidv4 } from "uuid";
+import fs from "node:fs";
+import { dialog } from "electron";
 
 const logger = log.scope("template_handlers");
 const handle = createLoggedHandler(logger);
@@ -15,5 +19,184 @@ export function registerTemplateHandlers() {
       logger.error("Error fetching templates:", error);
       return localTemplatesData;
     }
+  });
+
+  handle(
+    "add-custom-template",
+    async (
+      _,
+      params: {
+        title: string;
+        description: string;
+        folderPath: string;
+        imageUrl?: string;
+      },
+    ): Promise<{ success: boolean; templateId?: string; error?: string }> => {
+      try {
+        // Validate folder path exists
+        if (!fs.existsSync(params.folderPath)) {
+          return {
+            success: false,
+            error: "Folder path does not exist",
+          };
+        }
+
+        const settings = readSettings();
+        const customTemplates = settings.customTemplates || [];
+
+        // Generate unique ID
+        const templateId = `custom-${uuidv4()}`;
+
+        // Add new template
+        const newTemplate = {
+          id: templateId,
+          title: params.title,
+          description: params.description,
+          folderPath: params.folderPath,
+          imageUrl: params.imageUrl,
+        };
+
+        customTemplates.push(newTemplate);
+
+        // Save to settings
+        writeSettings({ customTemplates });
+
+        logger.info("Added custom template:", templateId);
+        return { success: true, templateId };
+      } catch (error) {
+        logger.error("Error adding custom template:", error);
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : "Unknown error",
+        };
+      }
+    },
+  );
+
+  handle(
+    "delete-custom-template",
+    async (_, templateId: string): Promise<{ success: boolean; error?: string }> => {
+      try {
+        const settings = readSettings();
+        const customTemplates = settings.customTemplates || [];
+
+        // Remove template with matching ID
+        const filteredTemplates = customTemplates.filter(
+          (t) => t.id !== templateId,
+        );
+
+        if (filteredTemplates.length === customTemplates.length) {
+          return {
+            success: false,
+            error: "Template not found",
+          };
+        }
+
+        writeSettings({ customTemplates: filteredTemplates });
+
+        logger.info("Deleted custom template:", templateId);
+        return { success: true };
+      } catch (error) {
+        logger.error("Error deleting custom template:", error);
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : "Unknown error",
+        };
+      }
+    },
+  );
+
+  handle(
+    "edit-custom-template",
+    async (
+      _,
+      params: {
+        templateId: string;
+        title?: string;
+        description?: string;
+        folderPath?: string;
+        imageUrl?: string;
+      },
+    ): Promise<{ success: boolean; error?: string }> => {
+      try {
+        const settings = readSettings();
+        const customTemplates = settings.customTemplates || [];
+
+        // Find template index
+        const templateIndex = customTemplates.findIndex(
+          (t) => t.id === params.templateId,
+        );
+
+        if (templateIndex === -1) {
+          return {
+            success: false,
+            error: "Template not found",
+          };
+        }
+
+        // Update template fields
+        const template = customTemplates[templateIndex];
+        if (params.title !== undefined) template.title = params.title;
+        if (params.description !== undefined)
+          template.description = params.description;
+        if (params.folderPath !== undefined) {
+          // Validate folder path exists
+          if (!fs.existsSync(params.folderPath)) {
+            return {
+              success: false,
+              error: "Folder path does not exist",
+            };
+          }
+          template.folderPath = params.folderPath;
+        }
+        if (params.imageUrl !== undefined) template.imageUrl = params.imageUrl;
+
+        customTemplates[templateIndex] = template;
+
+        // Save to settings
+        writeSettings({ customTemplates });
+
+        logger.info("Edited custom template:", params.templateId);
+        return { success: true };
+      } catch (error) {
+        logger.error("Error editing custom template:", error);
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : "Unknown error",
+        };
+      }
+    },
+  );
+
+  handle("select-folder", async (): Promise<string | null> => {
+    const result = await dialog.showOpenDialog({
+      properties: ["openDirectory"],
+      title: "Select Template Folder",
+    });
+
+    if (result.canceled || result.filePaths.length === 0) {
+      return null;
+    }
+
+    return result.filePaths[0];
+  });
+
+  handle("select-image", async (): Promise<string | null> => {
+    const result = await dialog.showOpenDialog({
+      properties: ["openFile"],
+      title: "Select Template Image",
+      filters: [
+        {
+          name: "Images",
+          extensions: ["jpg", "jpeg", "png", "gif", "webp", "svg"],
+        },
+      ],
+    });
+
+    if (result.canceled || result.filePaths.length === 0) {
+      return null;
+    }
+
+    return result.filePaths[0];
   });
 }

--- a/src/ipc/ipc_client.ts
+++ b/src/ipc/ipc_client.ts
@@ -1266,6 +1266,39 @@ export class IpcClient {
     return this.ipcRenderer.invoke("get-templates");
   }
 
+  public async addCustomTemplate(params: {
+    title: string;
+    description: string;
+    folderPath: string;
+    imageUrl?: string;
+  }): Promise<{ success: boolean; templateId?: string; error?: string }> {
+    return this.ipcRenderer.invoke("add-custom-template", params);
+  }
+
+  public async deleteCustomTemplate(
+    templateId: string,
+  ): Promise<{ success: boolean; error?: string }> {
+    return this.ipcRenderer.invoke("delete-custom-template", templateId);
+  }
+
+  public async editCustomTemplate(params: {
+    templateId: string;
+    title?: string;
+    description?: string;
+    folderPath?: string;
+    imageUrl?: string;
+  }): Promise<{ success: boolean; error?: string }> {
+    return this.ipcRenderer.invoke("edit-custom-template", params);
+  }
+
+  public async selectFolder(): Promise<string | null> {
+    return this.ipcRenderer.invoke("select-folder");
+  }
+
+  public async selectImage(): Promise<string | null> {
+    return this.ipcRenderer.invoke("select-image");
+  }
+
   // --- Prompts Library ---
   public async listPrompts(): Promise<PromptDto[]> {
     return this.ipcRenderer.invoke("prompts:list");

--- a/src/ipc/utils/template_utils.ts
+++ b/src/ipc/utils/template_utils.ts
@@ -4,6 +4,7 @@ import {
   localTemplatesData,
 } from "../../shared/templates";
 import log from "electron-log";
+import { readSettings } from "../../main/settings";
 
 const logger = log.scope("template_utils");
 
@@ -62,10 +63,27 @@ export async function fetchApiTemplates(): Promise<Template[]> {
   return apiTemplatesFetchPromise;
 }
 
-// Get all templates (local + API)
+// Get custom templates from user settings
+function getCustomTemplates(): Template[] {
+  const settings = readSettings();
+  const customTemplates = settings.customTemplates || [];
+
+  return customTemplates.map((ct) => ({
+    id: ct.id,
+    title: ct.title,
+    description: ct.description,
+    imageUrl: ct.imageUrl || "", // Empty string if no custom image - frontend will generate placeholder
+    isOfficial: false,
+    isCustom: true,
+    folderPath: ct.folderPath,
+  }));
+}
+
+// Get all templates (local + custom + API)
 export async function getAllTemplates(): Promise<Template[]> {
   const apiTemplates = await fetchApiTemplates();
-  return [...localTemplatesData, ...apiTemplates];
+  const customTemplates = getCustomTemplates();
+  return [...localTemplatesData, ...customTemplates, ...apiTemplates];
 }
 
 export async function getTemplateOrThrow(

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -236,6 +236,17 @@ export const UserSettingsSchema = z.object({
   enableProWebSearch: z.boolean().optional(),
   proSmartContextOption: z.enum(["balanced", "conservative"]).optional(),
   selectedTemplateId: z.string(),
+  customTemplates: z
+    .array(
+      z.object({
+        id: z.string(),
+        title: z.string(),
+        description: z.string(),
+        folderPath: z.string(),
+        imageUrl: z.string().optional(),
+      }),
+    )
+    .optional(),
   enableSupabaseWriteSqlMigration: z.boolean().optional(),
   selectedChatMode: ChatModeSchema.optional(),
   acceptedCommunityCode: z.boolean().optional(),

--- a/src/lib/template-placeholder.ts
+++ b/src/lib/template-placeholder.ts
@@ -1,0 +1,76 @@
+/**
+ * Generates a data URL for a text-based placeholder image
+ * for templates without a custom image
+ */
+export function generateTemplatePlaceholder(templateName: string): string {
+  // Create a simple gradient background with the template name
+  const colors = [
+    { bg: "#667eea", text: "#ffffff" }, // Purple
+    { bg: "#f093fb", text: "#ffffff" }, // Pink
+    { bg: "#4facfe", text: "#ffffff" }, // Blue
+    { bg: "#43e97b", text: "#ffffff" }, // Green
+    { bg: "#fa709a", text: "#ffffff" }, // Rose
+    { bg: "#feca57", text: "#2d3436" }, // Yellow
+    { bg: "#48dbfb", text: "#2d3436" }, // Cyan
+    { bg: "#ff6b6b", text: "#ffffff" }, // Red
+  ];
+
+  // Use template name to consistently select a color
+  const hash = templateName.split("").reduce((acc, char) => {
+    return char.charCodeAt(0) + ((acc << 5) - acc);
+  }, 0);
+  const colorIndex = Math.abs(hash) % colors.length;
+  const color = colors[colorIndex];
+
+  // Truncate name if too long
+  const displayName =
+    templateName.length > 25 ? templateName.substring(0, 25) + "..." : templateName;
+
+  // Create SVG
+  const svg = `
+    <svg width="800" height="600" xmlns="http://www.w3.org/2000/svg">
+      <defs>
+        <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+          <stop offset="0%" style="stop-color:${color.bg};stop-opacity:1" />
+          <stop offset="100%" style="stop-color:${color.bg};stop-opacity:0.7" />
+        </linearGradient>
+      </defs>
+      <rect width="800" height="600" fill="url(#grad)"/>
+      <text 
+        x="50%" 
+        y="50%" 
+        font-family="system-ui, -apple-system, sans-serif" 
+        font-size="48" 
+        font-weight="600" 
+        fill="${color.text}" 
+        text-anchor="middle" 
+        dominant-baseline="middle"
+      >
+        ${escapeXml(displayName)}
+      </text>
+    </svg>
+  `;
+
+  // Convert to data URL
+  const base64 = btoa(svg);
+  return `data:image/svg+xml;base64,${base64}`;
+}
+
+function escapeXml(unsafe: string): string {
+  return unsafe.replace(/[<>&'"]/g, (c) => {
+    switch (c) {
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case "&":
+        return "&amp;";
+      case "'":
+        return "&apos;";
+      case '"':
+        return "&quot;";
+      default:
+        return c;
+    }
+  });
+}

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -34,6 +34,7 @@ const DEFAULT_SETTINGS: UserSettings = {
   enableAutoUpdate: true,
   releaseChannel: "stable",
   selectedTemplateId: DEFAULT_TEMPLATE_ID,
+  customTemplates: [],
 };
 
 const SETTINGS_FILE = "user-settings.json";

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -109,6 +109,12 @@ const validInvokeChannels = [
   "check-problems",
   "restart-dyad",
   "get-templates",
+  // Template management
+  "add-custom-template",
+  "edit-custom-template",
+  "delete-custom-template",
+  "select-folder",
+  "select-image",
   "portal:migrate-create",
   // MCP
   "mcp:list-servers",

--- a/src/shared/templates.ts
+++ b/src/shared/templates.ts
@@ -7,6 +7,8 @@ export interface Template {
   isOfficial: boolean;
   isExperimental?: boolean;
   requiresNeon?: boolean;
+  isCustom?: boolean;
+  folderPath?: string;
 }
 
 // API Template interface from the external API


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add full support for custom templates. Users can add a template from a local folder, edit or delete it, and create apps directly from it with an auto-generated image if none is provided.

- **New Features**
  - Add/Edit/Delete custom templates via dialogs with folder and optional image selection.
  - Create apps from custom templates by copying the selected folder (no GitHub required).
  - Persist custom templates in user settings (customTemplates) and include them in the templates list.
  - Auto-generate a placeholder image when no template image is provided.
  - Community consent dialog excludes custom templates.
  - E2E tests for add/select/delete, app creation, and validation.

- **Migration**
  - No action needed. Settings schema adds customTemplates with a safe default.

<!-- End of auto-generated description by cubic. -->

