### PR TITLE
Support deep linking MCP

### DIFF
--- a/src/app/TitleBar.tsx
+++ b/src/app/TitleBar.tsx
@@ -49,16 +49,17 @@ export const TitleBar = () => {
     setIsSuccessDialogOpen(true);
   };
 
-  const { lastDeepLink } = useDeepLink();
+  const { lastDeepLink, clearLastDeepLink } = useDeepLink();
   useEffect(() => {
     const handleDeepLink = async () => {
       if (lastDeepLink?.type === "dyad-pro-return") {
         await refreshSettings();
         showDyadProSuccessDialog();
+        clearLastDeepLink();
       }
     };
     handleDeepLink();
-  }, [lastDeepLink]);
+  }, [lastDeepLink?.timestamp]);
 
   // Get selected app name
   const selectedApp = apps.find((app) => app.id === selectedAppId);

--- a/src/components/NeonConnector.tsx
+++ b/src/components/NeonConnector.tsx
@@ -11,7 +11,7 @@ import { NeonDisconnectButton } from "@/components/NeonDisconnectButton";
 
 export function NeonConnector() {
   const { settings, refreshSettings } = useSettings();
-  const { lastDeepLink } = useDeepLink();
+  const { lastDeepLink, clearLastDeepLink } = useDeepLink();
   const { isDarkMode } = useTheme();
 
   useEffect(() => {
@@ -19,10 +19,11 @@ export function NeonConnector() {
       if (lastDeepLink?.type === "neon-oauth-return") {
         await refreshSettings();
         toast.success("Successfully connected to Neon!");
+        clearLastDeepLink();
       }
     };
     handleDeepLink();
-  }, [lastDeepLink]);
+  }, [lastDeepLink?.timestamp]);
 
   if (settings?.neon?.accessToken) {
     return (

--- a/src/components/SupabaseConnector.tsx
+++ b/src/components/SupabaseConnector.tsx
@@ -40,17 +40,18 @@ import { useTheme } from "@/contexts/ThemeContext";
 export function SupabaseConnector({ appId }: { appId: number }) {
   const { settings, refreshSettings } = useSettings();
   const { app, refreshApp } = useLoadApp(appId);
-  const { lastDeepLink } = useDeepLink();
+  const { lastDeepLink, clearLastDeepLink } = useDeepLink();
   const { isDarkMode } = useTheme();
   useEffect(() => {
     const handleDeepLink = async () => {
       if (lastDeepLink?.type === "supabase-oauth-return") {
         await refreshSettings();
         await refreshApp();
+        clearLastDeepLink();
       }
     };
     handleDeepLink();
-  }, [lastDeepLink]);
+  }, [lastDeepLink?.timestamp]);
   const {
     projects,
     loading,

--- a/src/contexts/DeepLinkContext.tsx
+++ b/src/contexts/DeepLinkContext.tsx
@@ -1,31 +1,47 @@
 import React, { createContext, useContext, useEffect, useState } from "react";
-import { IpcClient, DeepLinkData } from "../ipc/ipc_client";
+import { IpcClient } from "../ipc/ipc_client";
+import { DeepLinkData } from "../ipc/deep_link_data";
+import { useScrollAndNavigateTo } from "@/hooks/useScrollAndNavigateTo";
 
 type DeepLinkContextType = {
   lastDeepLink: (DeepLinkData & { timestamp: number }) | null;
+  clearLastDeepLink: () => void;
 };
 
 const DeepLinkContext = createContext<DeepLinkContextType>({
   lastDeepLink: null,
+  clearLastDeepLink: () => {},
 });
 
 export function DeepLinkProvider({ children }: { children: React.ReactNode }) {
   const [lastDeepLink, setLastDeepLink] = useState<
     (DeepLinkData & { timestamp: number }) | null
   >(null);
-
+  const scrollAndNavigateTo = useScrollAndNavigateTo("/settings", {
+    behavior: "smooth",
+    block: "start",
+  });
   useEffect(() => {
     const ipcClient = IpcClient.getInstance();
     const unsubscribe = ipcClient.onDeepLinkReceived((data) => {
       // Update with timestamp to ensure state change even if same type comes twice
       setLastDeepLink({ ...data, timestamp: Date.now() });
+      if (data.type === "add-mcp-server") {
+        // Navigate to tools-mcp section
+        scrollAndNavigateTo("tools-mcp");
+      }
     });
 
     return unsubscribe;
   }, []);
 
   return (
-    <DeepLinkContext.Provider value={{ lastDeepLink }}>
+    <DeepLinkContext.Provider
+      value={{
+        lastDeepLink,
+        clearLastDeepLink: () => setLastDeepLink(null),
+      }}
+    >
       {children}
     </DeepLinkContext.Provider>
   );

--- a/src/ipc/deep_link_data.ts
+++ b/src/ipc/deep_link_data.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+export const AddMcpServerConfigSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.enum(["stdio"]),
+    command: z.string(),
+  }),
+  z.object({
+    type: z.enum(["http"]),
+    url: z.string(),
+  }),
+]);
+
+export type AddMcpServerConfig = z.infer<typeof AddMcpServerConfigSchema>;
+export type AddMcpServerPayload = {
+  name: string;
+  config: AddMcpServerConfig;
+};
+export type AddMcpServerDeepLinkData = {
+  type: "add-mcp-server";
+  payload: AddMcpServerPayload;
+};
+export type DeepLinkData =
+  | AddMcpServerDeepLinkData
+  | {
+      type: string;
+    };

--- a/src/ipc/ipc_client.ts
+++ b/src/ipc/ipc_client.ts
@@ -77,6 +77,7 @@ import type {
   ProposalResult,
 } from "@/lib/schemas";
 import { showError } from "@/lib/toast";
+import { DeepLinkData } from "./deep_link_data";
 
 export interface ChatStreamCallbacks {
   onUpdate: (messages: Message[]) => void;
@@ -100,10 +101,6 @@ export interface GitHubDeviceFlowSuccessData {
 
 export interface GitHubDeviceFlowErrorData {
   error: string;
-}
-
-export interface DeepLinkData {
-  type: string;
 }
 
 interface DeleteCustomModelParams {

--- a/src/main.ts
+++ b/src/main.ts
@@ -335,16 +335,26 @@ function handleDeepLinkReturn(url: string) {
       dialog.showErrorBox("Invalid URL", "Expected name and config");
       return;
     }
-    const decodedName = decodeURIComponent(name);
-    const decodedConfig = JSON.parse(atob(decodeURIComponent(config)));
-    const parsedConfig = AddMcpServerConfigSchema.parse(decodedConfig);
-    mainWindow?.webContents.send("deep-link-received", {
-      type: parsed.hostname,
-      payload: {
-        name: decodedName,
-        config: parsedConfig,
-      } as AddMcpServerPayload,
-    });
+
+    try {
+      const decodedConfigJson = atob(config);
+      const decodedConfig = JSON.parse(decodedConfigJson);
+      const parsedConfig = AddMcpServerConfigSchema.parse(decodedConfig);
+
+      mainWindow?.webContents.send("deep-link-received", {
+        type: parsed.hostname,
+        payload: {
+          name,
+          config: parsedConfig,
+        } as AddMcpServerPayload,
+      });
+    } catch (error) {
+      logger.error("Failed to parse add-mcp-server deep link:", error);
+      dialog.showErrorBox(
+        "Invalid MCP Server Configuration",
+        "The deep link contains malformed configuration data. Please check the URL and try again.",
+      );
+    }
     return;
   }
   dialog.showErrorBox("Invalid deep link URL", url);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds support for `dyad://add-mcp-server` deep links that prefill MCP server settings, and updates deep link context/consumers to use timestamp-based effects and clearing to avoid repeat handling.
> 
> - **Deep Link Infrastructure**:
>   - Introduce `src/ipc/deep_link_data.ts` with zod schema (`AddMcpServerConfigSchema`) and typed `DeepLinkData`.
>   - Extend `DeepLinkContext` with `clearLastDeepLink`, timestamped events, and auto-navigate to `/settings#tools-mcp` on `add-mcp-server`.
> - **Main Process**:
>   - Handle `dyad://add-mcp-server?name=...&config=...`:
>     - Base64-decode and validate `config`; send `deep-link-received` with typed payload or show error.
> - **Settings UI (MCP)**:
>   - In `ToolsMcpSettings`, prefill form from `add-mcp-server` payload (supports `stdio` command/args and `http` url) and show info toast; clear deep link after handling.
> - **Connectors/UI**:
>   - Update `TitleBar`, `NeonConnector`, `SupabaseConnector` to:
>     - Depend on `lastDeepLink?.timestamp` and call `clearLastDeepLink()` after handling (`dyad-pro-return`, `neon-oauth-return`, `supabase-oauth-return`).
> - **IPC Renderer**:
>   - Use centralized `DeepLinkData` types in `ipc_client.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 294a9c6f38442241b54e9bcbe19a7a772d338ee0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->