### PR TITLE
glm 4.6

### DIFF
--- a/src/ipc/shared/language_model_constants.ts
+++ b/src/ipc/shared/language_model_constants.ts
@@ -213,6 +213,15 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
       dollarSigns: 0,
     },
     {
+      name: "z-ai/glm-4.6",
+      displayName: "GLM 4.6",
+      description: "Z-AI's best coding model",
+      maxOutputTokens: 32_000,
+      contextWindow: 200_000,
+      temperature: 0,
+      dollarSigns: 2,
+    },
+    {
       name: "qwen/qwen3-coder",
       displayName: "Qwen3 Coder",
       description: "Qwen's best coding model",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `z-ai/glm-4.6` (GLM 4.6) to OpenRouter model options.
> 
> - **Models**:
>   - **OpenRouter**: Add `z-ai/glm-4.6` ("GLM 4.6") with `maxOutputTokens: 32_000`, `contextWindow: 200_000`, `temperature: 0`, `dollarSigns: 2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e434b7d049c839504c726b096bf5fa4c22f162b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->