### PR TITLE
Bump better better-sqlite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dyad",
-  "version": "0.24.0",
+  "version": "0.25.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dyad",
-      "version": "0.24.0",
+      "version": "0.25.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/amazon-bedrock": "^3.0.15",
@@ -51,7 +51,7 @@
         "@vercel/sdk": "^1.10.0",
         "@vitejs/plugin-react": "^4.3.4",
         "ai": "^5.0.15",
-        "better-sqlite3": "^11.9.1",
+        "better-sqlite3": "^12.4.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -8126,14 +8126,17 @@
       "license": "Apache-2.0"
     },
     "node_modules/better-sqlite3": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
-      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.4.1.tgz",
+      "integrity": "sha512-3yVdyZhklTiNrtg+4WqHpJpFDd+WHTg2oM7UcR80GqL05AOV0xEJzc6qNvFYoEtE+hRp1n9MpN6/+4yhlGkDXQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x"
       }
     },
     "node_modules/bignumber.js": {

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "@vercel/sdk": "^1.10.0",
     "@vitejs/plugin-react": "^4.3.4",
     "ai": "^5.0.15",
-    "better-sqlite3": "^11.9.1",
+    "better-sqlite3": "^12.4.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps app to 0.25.0-beta.1 and upgrades better-sqlite3 to 12.4.1 with updated engine constraints.
> 
> - **Versioning**: Set `package.json` and lockfile version to `0.25.0-beta.1`.
> - **Dependencies**:
>   - Upgrade `better-sqlite3` from `^11.9.1` to `^12.4.1` (lockfile resolves to `12.4.1`).
>   - Add/update `better-sqlite3` engine constraints to `node: 20.x || 22.x || 23.x || 24.x`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e45156ac3a3340c68ef61200416860a0175eb4b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->