### PR TITLE
remove smart auto

### DIFF
--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -138,8 +138,6 @@ export function ModelPicker() {
     return null;
   }
   const selectedModel = settings?.selectedModel;
-  const isSmartAutoEnabled =
-    settings.enableProSmartFilesContextMode && isDyadProEnabled(settings);
   const modelDisplayName = getModelDisplayName();
   // Split providers into primary and secondary groups (excluding auto)
   const providerEntries =
@@ -231,19 +229,9 @@ export function ModelPicker() {
                       >
                         <div className="flex justify-between items-start w-full">
                           <span className="flex flex-col items-start">
-                            <span>
-                              {isSmartAutoEnabled && model.apiName === "auto"
-                                ? "Smart Auto"
-                                : model.displayName}
-                            </span>
+                            <span>{model.displayName}</span>
                           </span>
                           <div className="flex items-center gap-1.5">
-                            {isSmartAutoEnabled &&
-                              !model.displayName.includes("(Pro)") && (
-                                <span className="text-[11px] bg-gradient-to-r from-indigo-600 via-indigo-500 to-indigo-600 bg-[length:200%_100%] animate-[shimmer_5s_ease-in-out_infinite] text-white px-1.5 py-0.5 rounded-full font-medium">
-                                  Pro only
-                                </span>
-                              )}
                             {model.tag && (
                               <span
                                 className={cn(
@@ -259,15 +247,7 @@ export function ModelPicker() {
                       </DropdownMenuItem>
                     </TooltipTrigger>
                     <TooltipContent side="right">
-                      {isSmartAutoEnabled && model.apiName === "auto" ? (
-                        <p>
-                          <strong>Smart Auto</strong> uses a cheaper model for
-                          easier tasks
-                          <br /> and a flagship model for harder tasks
-                        </p>
-                      ) : (
-                        model.description
-                      )}
+                      {model.description}
                     </TooltipContent>
                   </Tooltip>
                 ))}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes Smart Auto labels/tooltip and related checks from the model picker, showing standard model names and descriptions only.
> 
> - **UI (Model Picker)**: `src/components/ModelPicker.tsx`
>   - Remove Smart Auto-specific labeling and tooltip logic for `auto` models.
>   - Drop "Pro only" badge tied to Smart Auto state.
>   - Always render `model.displayName` and `model.description` without Smart Auto overrides.
>   - Remove Smart Auto enablement check previously derived from settings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 211be087933f3f240a78c017b26a37633f1228d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->