### PR TITLE
Skip flaky test dyad write - edit and save flow

### DIFF
--- a/e2e-tests/chat_mode.spec.ts
+++ b/e2e-tests/chat_mode.spec.ts
@@ -23,7 +23,7 @@ test("chat mode selector - ask mode", async ({ po }) => {
   await po.snapshotMessages({ replaceDumpPath: true });
 });
 
-test("dyadwrite edit and save - basic flow", async ({ po }) => {
+test.skip("dyadwrite edit and save - basic flow", async ({ po }) => {
   await po.setUp({ autoApprove: true });
   await po.importApp("minimal");
   await po.clickNewChat();


### PR DESCRIPTION
@princeaden1 can you take a look at why this test is flaking often later? for now, i think we can just skip it since it's not a super critical feature (users can always edit the file using the regular code panel)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Skips the flaky "dyadwrite edit and save - basic flow" e2e test in `e2e-tests/chat_mode.spec.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12de571a1a5d2f9c6c98e90ae19fd67a3fb2e6b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->