### PR TITLE
chore: ignore venv dirs

### DIFF
--- a/src/utils/codebase.ts
+++ b/src/utils/codebase.ts
@@ -56,7 +56,15 @@ const ALLOWED_EXTENSIONS = [
 // be conservative and never include these directories.
 //
 // ex: https://github.com/dyad-sh/dyad/issues/727
-const EXCLUDED_DIRS = ["node_modules", ".git", "dist", "build", ".next"];
+const EXCLUDED_DIRS = [
+  "node_modules",
+  ".git",
+  "dist",
+  "build",
+  ".next",
+  ".venv",
+  "venv",
+];
 
 // Files to always exclude
 const EXCLUDED_FILES = ["pnpm-lock.yaml", "package-lock.json"];


### PR DESCRIPTION
# Description

This pull request ignore `venv` directories and closes #1415
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Exclude Python virtual environment directories (.venv, venv) from codebase scanning to reduce noise and avoid indexing dependencies. This aligns with existing excludes like node_modules and build outputs.

<!-- End of auto-generated description by cubic. -->

