### PR TITLE
Inject proxy script in all routes

### DIFF
--- a/worker/proxy_server.js
+++ b/worker/proxy_server.js
@@ -85,7 +85,9 @@ try {
 
 /* ---------------------- helper: need to inject? ------------------------ */
 function needsInjection(pathname) {
-  return pathname.endsWith("index.html") || pathname === "/";
+  // Inject for routes without a file extension (e.g., "/foo", "/foo/bar", "/")
+  const ext = path.extname(pathname).toLowerCase();
+  return ext === "" || ext === ".html";
 }
 
 function injectHTML(buf) {
@@ -171,7 +173,7 @@ const server = http.createServer((clientReq, clientRes) => {
       delete headers.referer;
     }
   }
-  if (needsInjection) {
+  if (needsInjection(target.pathname)) {
     // Request uncompressed content from upstream
     delete headers["accept-encoding"];
   }

--- a/worker/proxy_server.js
+++ b/worker/proxy_server.js
@@ -176,10 +176,9 @@ const server = http.createServer((clientReq, clientRes) => {
   if (needsInjection(target.pathname)) {
     // Request uncompressed content from upstream
     delete headers["accept-encoding"];
-  }
-
-  if (headers["if-none-match"] && needsInjection(target.pathname))
+    // Avoid getting cached resources.
     delete headers["if-none-match"];
+  }
 
   const upOpts = {
     protocol: target.protocol,

--- a/worker/proxy_server.js
+++ b/worker/proxy_server.js
@@ -191,7 +191,16 @@ const server = http.createServer((clientReq, clientRes) => {
   };
 
   const upReq = lib.request(upOpts, (upRes) => {
-    const inject = needsInjection(target.pathname);
+    const wantsInjection = needsInjection(target.pathname);
+    // Only inject when upstream indicates HTML content
+    const contentTypeHeader = upRes.headers["content-type"];
+    const contentType = Array.isArray(contentTypeHeader)
+      ? contentTypeHeader[0]
+      : contentTypeHeader || "";
+    const isHtml =
+      typeof contentType === "string" &&
+      contentType.toLowerCase().includes("text/html");
+    const inject = wantsInjection && isHtml;
 
     if (!inject) {
       clientRes.writeHead(upRes.statusCode, upRes.headers);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Broaden injection to extensionless and .html routes, gate by Content-Type, and conditionally strip caching/compression headers only when injecting.
> 
> - **Proxy HTML injection**:
>   - Update `needsInjection(pathname)` to inject for routes without extensions and `.html` files (e.g., `/`, `/foo`, `/foo/bar`, `*.html`).
>   - Only request uncompressed content and remove `if-none-match` when `needsInjection(target.pathname)` is true.
>   - During upstream response, inject only if `Content-Type` includes `text/html`; otherwise pass through without modification.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2986ceccea64e7881a2197a2a0b202216f21d27d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->