### PR TITLE
Add support for adding/deleting files in editor (#681)

### DIFF
--- a/e2e-tests/file_manage.spec.ts
+++ b/e2e-tests/file_manage.spec.ts
@@ -1,0 +1,34 @@
+import { test } from "./helpers/test_helper";
+import { expect } from "@playwright/test";
+
+test("create and delete file from editor sidebar", async ({ po }) => {
+  await po.setUp();
+  await po.importApp("version-integrity");
+
+  await po.clickTogglePreviewPanel();
+  await po.selectPreviewMode("code");
+
+  // Create a new file via the top-level plus button
+  const newFileName = "new-file.txt";
+  await po.page.once("dialog", async (dialog) => {
+    await dialog.accept(newFileName);
+  });
+  // The header contains a single button (the "+" create button)
+  await po.page.locator(".file-tree").getByRole("button").first().click();
+
+  // Verify file appears in the sidebar
+  await expect(po.page.getByText(newFileName)).toBeVisible();
+
+  // Delete the file using the inline trash button on the file row
+  await po.page.once("dialog", async (dialog) => {
+    await dialog.accept();
+  });
+  const fileRow = po.page.locator("div", { hasText: newFileName }).first();
+  await fileRow.hover();
+  await fileRow.locator("button").first().click();
+
+  // Verify the file disappears from the sidebar
+  await expect(po.page.getByText(newFileName)).toBeHidden();
+});
+
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dyad",
-  "version": "0.25.0-beta.1",
+  "version": "0.26.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dyad",
-      "version": "0.25.0-beta.1",
+      "version": "0.26.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/amazon-bedrock": "^3.0.15",

--- a/src/components/preview_panel/CodeView.tsx
+++ b/src/components/preview_panel/CodeView.tsx
@@ -49,7 +49,7 @@ export const CodeView = ({ loading, app }: CodeViewProps) => {
         {/* Content */}
         <div className="flex flex-1 overflow-hidden">
           <div className="w-1/3 overflow-auto border-r">
-            <FileTree files={app.files} />
+            <FileTree files={app.files} appId={app.id ?? null} />
           </div>
           <div className="w-2/3">
             {selectedFile ? (

--- a/src/hooks/useFileManagement.ts
+++ b/src/hooks/useFileManagement.ts
@@ -1,0 +1,59 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { IpcClient } from "@/ipc/ipc_client";
+import { showError, showSuccess } from "@/lib/toast";
+
+interface CreateFileParams {
+  appId: number;
+  filePath: string;
+  content?: string;
+}
+
+interface DeleteFileParams {
+  appId: number;
+  filePath: string;
+}
+
+export const useFileManagement = (appId: number | null) => {
+  const queryClient = useQueryClient();
+
+  const createFile = useMutation({
+    mutationFn: async (params: CreateFileParams) => {
+      if (!appId) throw new Error("App ID is required");
+      
+      const ipcClient = IpcClient.getInstance();
+      await ipcClient.createAppFile(appId, params.filePath, params.content);
+    },
+    onSuccess: () => {
+      // Invalidate app data to refresh file list
+      queryClient.invalidateQueries({ queryKey: ["app", appId] });
+      showSuccess("File created successfully");
+    },
+    onError: (error) => {
+      showError(error);
+    },
+  });
+
+  const deleteFile = useMutation({
+    mutationFn: async (params: DeleteFileParams) => {
+      if (!appId) throw new Error("App ID is required");
+      
+      const ipcClient = IpcClient.getInstance();
+      await ipcClient.deleteAppFile(appId, params.filePath);
+    },
+    onSuccess: () => {
+      // Invalidate app data to refresh file list
+      queryClient.invalidateQueries({ queryKey: ["app", appId] });
+      showSuccess("File deleted successfully");
+    },
+    onError: (error) => {
+      showError(error);
+    },
+  });
+
+  return {
+    createFile: createFile.mutateAsync,
+    deleteFile: deleteFile.mutateAsync,
+    isCreating: createFile.isPending,
+    isDeleting: deleteFile.isPending,
+  };
+};

--- a/src/ipc/ipc_client.ts
+++ b/src/ipc/ipc_client.ts
@@ -382,6 +382,30 @@ export class IpcClient {
     });
   }
 
+  // Create a new file in an app directory
+  public async createAppFile(
+    appId: number,
+    filePath: string,
+    content?: string,
+  ): Promise<void> {
+    return this.ipcRenderer.invoke("create-app-file", {
+      appId,
+      filePath,
+      content: content || "",
+    });
+  }
+
+  // Delete a file from an app directory
+  public async deleteAppFile(
+    appId: number,
+    filePath: string,
+  ): Promise<void> {
+    return this.ipcRenderer.invoke("delete-app-file", {
+      appId,
+      filePath,
+    });
+  }
+
   // New method for streaming responses
   public streamMessage(
     prompt: string,

--- a/src/ipc/ipc_types.ts
+++ b/src/ipc/ipc_types.ts
@@ -285,6 +285,17 @@ export interface EditAppFileReturnType {
   warning?: string;
 }
 
+export interface CreateAppFileParams {
+  appId: number;
+  filePath: string;
+  content?: string;
+}
+
+export interface DeleteAppFileParams {
+  appId: number;
+  filePath: string;
+}
+
 export interface EnvVar {
   key: string;
   value: string;

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -32,6 +32,8 @@ const validInvokeChannels = [
   "set-app-env-vars",
   "edit-app-file",
   "read-app-file",
+  "create-app-file",
+  "delete-app-file",
   "run-app",
   "stop-app",
   "restart-app",


### PR DESCRIPTION
Issue Number : #681
- Added UI buttons to add and delete files from the editor
- Updated file system logic to sync file changes
- Improves usability for managing project files directly in the editor

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds create and delete file actions to the file tree so users can manage files without leaving the editor. Operations run via IPC with safe file writes/deletes, optional git commits, and automatic UI refresh.

- **New Features**
  - File tree UI: + button (root/folders) and delete on items, with tooltips and confirm; disabled when busy or no app ID.
  - State: useFileManagement hook (React Query) calls IPC, shows toasts, and invalidates ["app", appId] to refresh files.
  - IPC: create-app-file/delete-app-file validate app-scoped paths, create dirs as needed, write/unlink files, and git add+commit if .git exists.
  - Integrations: store Neon timestamp before changes; deploy Supabase functions when creating server functions; log errors without blocking file creation.

<!-- End of auto-generated description by cubic. -->

