### PR TITLE
Add Claude Haiku 4.5 to model selector

### DIFF
--- a/src/ipc/shared/language_model_constants.ts
+++ b/src/ipc/shared/language_model_constants.ts
@@ -99,7 +99,11 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
       name: "claude-haiku-4-5",
       displayName: "Claude 4.5 Haiku",
       description: "Fast and affordable Claude 4.5 variant",
-      maxOutputTokens: 64_000,
+       // Technically the max output tokens is 64k, *however* if the user has a lot of input tokens,
+      // then setting a high max output token will cause the request to fail because
+      // the max output tokens is *included* in the context window limit, see:
+      // https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#max-tokens-and-context-window-size-with-extended-thinking
+      maxOutputTokens: 16_000,
       contextWindow: 200_000,
       temperature: 0,
       dollarSigns: 3,

--- a/src/ipc/shared/language_model_constants.ts
+++ b/src/ipc/shared/language_model_constants.ts
@@ -96,6 +96,15 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
       dollarSigns: 5,
     },
     {
+      name: "claude-haiku-4-5",
+      displayName: "Claude 4.5 Haiku",
+      description: "Fast and affordable Claude 4.5 variant",
+      maxOutputTokens: 64_000,
+      contextWindow: 200_000,
+      temperature: 0,
+      dollarSigns: 3,
+    },
+    {
       name: "claude-sonnet-4-20250514",
       displayName: "Claude 4 Sonnet",
       description: "Excellent coder (note: >200k tokens is very expensive!)",


### PR DESCRIPTION
This PR adds Claude Haiku 4.5 to the model selector, a coding model competitive with gpt-5-medium and sonnet 4 for only $5 per 1M output tokens.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added Claude 4.5 Haiku to the model selector as a fast, affordable option.

Configured max output tokens to 16k (to avoid context window failures), 200k context window, temperature 0, and pricing indicator set to 3 dollar signs.

<!-- End of auto-generated description by cubic. -->

