### PR TITLE
Add workflow for publishing release to WinGet

### DIFF
--- a/.github/workflows/winget-release.yml
+++ b/.github/workflows/winget-release.yml
@@ -9,5 +9,5 @@ jobs:
       - uses: vedantmgoyal9/winget-releaser@19e706d4c9121098010096f9c495a70a7518b30f
         with:
           identifier: Dyad.Dyad
-          installers-regex: 'dyad-.*\.Setup.exe'
+          installers-regex: 'dyad-.*\.Setup\.exe'
           token: ${{ secrets.WINGET_ACC_TOKEN }}

--- a/.github/workflows/winget-release.yml
+++ b/.github/workflows/winget-release.yml
@@ -1,0 +1,13 @@
+name: Publish release to WinGet
+on:
+  release:
+    types: [released]
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - uses: vedantmgoyal9/winget-releaser@main
+        with:
+          identifier: Dyad.Dyad
+          installers-regex: 'dyad-.*\.Setup.exe'
+          token: ${{ secrets.WINGET_ACC_TOKEN }}

--- a/.github/workflows/winget-release.yml
+++ b/.github/workflows/winget-release.yml
@@ -6,7 +6,7 @@ jobs:
   publish:
     runs-on: windows-latest
     steps:
-      - uses: vedantmgoyal9/winget-releaser@main
+      - uses: vedantmgoyal9/winget-releaser@19e706d4c9121098010096f9c495a70a7518b30f
         with:
           identifier: Dyad.Dyad
           installers-regex: 'dyad-.*\.Setup.exe'


### PR DESCRIPTION
This PR uses [winget-releaser](https://github.com/vedantmgoyal9/winget-releaser) (which uses Komac). It requires a `Classic Github Personal Access Token` with `public_repo` scope is created, following [this link](https://github.com/settings/tokens/new), then the Token can be added to the repo as a secret named `WINGET_ACC_TOKEN`. See below, that user also will have to fork the winget-pkgs repository.

> Notes:
> You will need to create a *classic* Personal Access Token (PAT) with `public_repo` scope. New fine-grained PATs aren't supported by the action. Review #172 for information.
> Fork [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) under the same account/organization as the project's repository. If you are forking winget-pkgs on a different account (e.g. bot/personal account), you can use the fork-user input to specify the username of the account where the fork is present.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically publishes Dyad releases to WinGet when a GitHub release is published.

- **New Features**
  - Adds .github/workflows/winget-release.yml triggered on release.
  - Uses vedantmgoyal9/winget-releaser@main with identifier Dyad.Dyad and installers-regex 'dyad-.*\.Setup.exe'.

- **Migration**
  - Add repo secret WINGET_ACC_TOKEN with a classic PAT (public_repo). Fine-grained PATs are not supported.
  - Fork microsoft/winget-pkgs under the same account, or set fork-user accordingly.
  - Ensure the release asset name matches the regex: dyad-*.Setup.exe.

<!-- End of auto-generated description by cubic. -->

