### PR TITLE
fix : hiding upgrade banner on unrelated errors

### DIFF
--- a/src/components/chat/ChatErrorBox.tsx
+++ b/src/components/chat/ChatErrorBox.tsx
@@ -99,6 +99,14 @@ export function ChatErrorBox({
     <ChatErrorContainer onDismiss={onDismiss}>
       {error}
       <div className="mt-2 space-y-2 space-x-2">
+        {!isDyadProEnabled && !error.includes("TypeError: terminated") && (
+          <ExternalLink
+            href="https://dyad.sh/pro?utm_source=dyad-app&utm_medium=app&utm_campaign=general-error"
+            variant="primary"
+          >
+            Upgrade to Dyad Pro
+          </ExternalLink>
+        )}
         <ExternalLink href="https://www.dyad.sh/docs/faq">
           Read docs
         </ExternalLink>

--- a/src/components/chat/ChatErrorBox.tsx
+++ b/src/components/chat/ChatErrorBox.tsx
@@ -99,15 +99,6 @@ export function ChatErrorBox({
     <ChatErrorContainer onDismiss={onDismiss}>
       {error}
       <div className="mt-2 space-y-2 space-x-2">
-        {!isDyadProEnabled && (
-          <ExternalLink
-            href="https://dyad.sh/pro?utm_source=dyad-app&utm_medium=app&utm_campaign=general-error"
-            variant="primary"
-          >
-            Upgrade to Dyad Pro
-          </ExternalLink>
-        )}
-
         <ExternalLink href="https://www.dyad.sh/docs/faq">
           Read docs
         </ExternalLink>


### PR DESCRIPTION
This PR solves the issue #1666 
To solve this i removed the upgrade link from the general case since errors related to pro mode are already handled in the specific if-blocks



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the Dyad Pro upgrade banner on termination errors to reduce confusion. The generic upgrade link in ChatErrorBox is now suppressed when the error includes "TypeError: terminated" and only shows when Pro is disabled otherwise.

<sup>Written for commit 1edf665. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



