### PR TITLE
Don't show upgrade button for non AI streaming errors

### DIFF
--- a/src/components/chat/ChatErrorBox.tsx
+++ b/src/components/chat/ChatErrorBox.tsx
@@ -1,4 +1,5 @@
 import { IpcClient } from "@/ipc/ipc_client";
+import { AI_STREAMING_ERROR_MESSAGE_PREFIX } from "@/shared/texts";
 import {
   X,
   ExternalLink as ExternalLinkIcon,
@@ -99,14 +100,16 @@ export function ChatErrorBox({
     <ChatErrorContainer onDismiss={onDismiss}>
       {error}
       <div className="mt-2 space-y-2 space-x-2">
-        {!isDyadProEnabled && !error.includes("TypeError: terminated") && (
-          <ExternalLink
-            href="https://dyad.sh/pro?utm_source=dyad-app&utm_medium=app&utm_campaign=general-error"
-            variant="primary"
-          >
-            Upgrade to Dyad Pro
-          </ExternalLink>
-        )}
+        {!isDyadProEnabled &&
+          error.includes(AI_STREAMING_ERROR_MESSAGE_PREFIX) &&
+          !error.includes("TypeError: terminated") && (
+            <ExternalLink
+              href="https://dyad.sh/pro?utm_source=dyad-app&utm_medium=app&utm_campaign=general-error"
+              variant="primary"
+            >
+              Upgrade to Dyad Pro
+            </ExternalLink>
+          )}
         <ExternalLink href="https://www.dyad.sh/docs/faq">
           Read docs
         </ExternalLink>

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -80,6 +80,7 @@ import { replacePromptReference } from "../utils/replacePromptReference";
 import { mcpManager } from "../utils/mcp_manager";
 import z from "zod";
 import { isTurboEditsV2Enabled } from "@/lib/schemas";
+import { AI_STREAMING_ERROR_MESSAGE_PREFIX } from "@/shared/texts";
 
 type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
 
@@ -853,7 +854,7 @@ This conversation includes one or more image attachments. When the user uploads 
                 : "";
               event.sender.send("chat:response:error", {
                 chatId: req.chatId,
-                error: `Sorry, there was an error from the AI: ${requestIdPrefix}${message}`,
+                error: `${AI_STREAMING_ERROR_MESSAGE_PREFIX}${requestIdPrefix}${message}`,
               });
               // Clean up the abort controller
               activeStreams.delete(req.chatId);

--- a/src/shared/texts.ts
+++ b/src/shared/texts.ts
@@ -1,0 +1,2 @@
+export const AI_STREAMING_ERROR_MESSAGE_PREFIX =
+  "Sorry, there was an error from the AI: ";


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Show the upgrade button only for AI streaming errors by checking a shared error prefix; introduce and use a shared constant for consistent error messages.
> 
> - **Chat UI**
>   - Update `ChatErrorBox.tsx` to display "Upgrade to Dyad Pro" only when `error` includes `AI_STREAMING_ERROR_MESSAGE_PREFIX` and user is not Pro (still hides on `TypeError: terminated`).
> - **IPC/Streaming**
>   - In `chat_stream_handlers.ts`, prefix emitted streaming errors with `AI_STREAMING_ERROR_MESSAGE_PREFIX` instead of hardcoded text for consistency.
> - **Shared**
>   - Add `AI_STREAMING_ERROR_MESSAGE_PREFIX` in `src/shared/texts.ts` and import where needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83b1aa3555a3c1e710ee644f7bfb64cabc0ff5e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->