### PR TITLE
Support web crawl  for website replication (PRO)

### DIFF
--- a/src/components/chat/DyadMarkdownParser.tsx
+++ b/src/components/chat/DyadMarkdownParser.tsx
@@ -22,6 +22,7 @@ import { DyadMcpToolCall } from "./DyadMcpToolCall";
 import { DyadMcpToolResult } from "./DyadMcpToolResult";
 import { DyadWebSearchResult } from "./DyadWebSearchResult";
 import { DyadWebSearch } from "./DyadWebSearch";
+import { DyadWebCrawl } from "./DyadWebCrawl";
 import { DyadRead } from "./DyadRead";
 import { mapActionToButton } from "./ChatInput";
 import { SuggestedAction } from "@/lib/schemas";
@@ -134,6 +135,7 @@ function preprocessUnclosedTags(content: string): {
     "dyad-codebase-context",
     "dyad-web-search-result",
     "dyad-web-search",
+    "dyad-web-crawl",
     "dyad-read",
     "think",
     "dyad-command",
@@ -207,6 +209,7 @@ function parseCustomTags(content: string): ContentPiece[] {
     "dyad-codebase-context",
     "dyad-web-search-result",
     "dyad-web-search",
+    "dyad-web-crawl",
     "dyad-read",
     "think",
     "dyad-command",
@@ -318,6 +321,16 @@ function renderCustomTag(
         >
           {content}
         </DyadWebSearch>
+      );
+    case "dyad-web-crawl":
+      return (
+        <DyadWebCrawl
+          node={{
+            properties: {},
+          }}
+        >
+          {content}
+        </DyadWebCrawl>
       );
     case "dyad-web-search-result":
       return (

--- a/src/components/chat/DyadWebCrawl.tsx
+++ b/src/components/chat/DyadWebCrawl.tsx
@@ -1,0 +1,31 @@
+import type React from "react";
+import type { ReactNode } from "react";
+import { Rabbit } from "lucide-react";
+
+interface DyadWebCrawlProps {
+  children?: ReactNode;
+  node?: any;
+  query?: string;
+}
+
+export const DyadWebCrawl: React.FC<DyadWebCrawlProps> = ({
+  children,
+  node: _node,
+  query: queryProp,
+}) => {
+  const query = queryProp || (typeof children === "string" ? children : "");
+
+  return (
+    <div className="bg-(--background-lightest) rounded-lg px-4 py-2 border my-2">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Rabbit size={16} className="text-blue-600" />
+          <div className="text-xs text-blue-600 font-medium">Web Crawl</div>
+        </div>
+      </div>
+      <div className="text-sm italic text-gray-600 dark:text-gray-300 mt-2">
+        {query || children}
+      </div>
+    </div>
+  );
+};

--- a/src/components/chat/DyadWebCrawl.tsx
+++ b/src/components/chat/DyadWebCrawl.tsx
@@ -5,16 +5,12 @@ import { Rabbit } from "lucide-react";
 interface DyadWebCrawlProps {
   children?: ReactNode;
   node?: any;
-  query?: string;
 }
 
 export const DyadWebCrawl: React.FC<DyadWebCrawlProps> = ({
   children,
   node: _node,
-  query: queryProp,
 }) => {
-  const query = queryProp || (typeof children === "string" ? children : "");
-
   return (
     <div className="bg-(--background-lightest) rounded-lg px-4 py-2 border my-2">
       <div className="flex items-center justify-between">
@@ -24,7 +20,7 @@ export const DyadWebCrawl: React.FC<DyadWebCrawlProps> = ({
         </div>
       </div>
       <div className="text-sm italic text-gray-600 dark:text-gray-300 mt-2">
-        {query || children}
+        {children}
       </div>
     </div>
   );

--- a/src/components/chat/DyadWebCrawl.tsx
+++ b/src/components/chat/DyadWebCrawl.tsx
@@ -1,6 +1,6 @@
 import type React from "react";
 import type { ReactNode } from "react";
-import { Rabbit } from "lucide-react";
+import { ScanQrCode } from "lucide-react";
 
 interface DyadWebCrawlProps {
   children?: ReactNode;
@@ -15,7 +15,7 @@ export const DyadWebCrawl: React.FC<DyadWebCrawlProps> = ({
     <div className="bg-(--background-lightest) rounded-lg px-4 py-2 border my-2">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <Rabbit size={16} className="text-blue-600" />
+          <ScanQrCode size={16} className="text-blue-600" />
           <div className="text-xs text-blue-600 font-medium">Web Crawl</div>
         </div>
       </div>


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added support for the dyad-web-crawl tag to render a Web Crawl UI in chat, enabling website replication flows. Messages with <dyad-web-crawl> now show a styled card with crawl details.

- **New Features**
  - Added DyadWebCrawl component with label and updated icon.
  - Updated DyadMarkdownParser to parse and render dyad-web-crawl.

<sup>Written for commit 45903364b5d6cbdcfc5c3a37579e9eda05e01db3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





