### PR TITLE
replace qwen3 coder with glm 4.6 turbo

### DIFF
--- a/src/ipc/shared/language_model_constants.ts
+++ b/src/ipc/shared/language_model_constants.ts
@@ -412,13 +412,13 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
 
 export const TURBO_MODELS: LanguageModel[] = [
   {
-    apiName: "qwen3-coder:turbo",
-    displayName: "Qwen3 Coder",
-    description: "Qwen's best coding model (very fast)",
+    apiName: "glm-4.6:turbo",
+    displayName: "GLM 4.6",
+    description: "Strong coding model (very fast)",
     maxOutputTokens: 32_000,
     contextWindow: 131_000,
     temperature: 0,
-    dollarSigns: 2,
+    dollarSigns: 3,
     type: "cloud",
   },
   {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces the turbo model from Qwen3 Coder to GLM 4.6 and adjusts pricing indicator.
> 
> - **Models**:
>   - **`TURBO_MODELS`**:
>     - Replace `qwen3-coder:turbo` with `glm-4.6:turbo`.
>     - Update display name to `GLM 4.6` and description to "Strong coding model (very fast)".
>     - Increase `dollarSigns` from `2` to `3`.
>     - Keep other parameters (e.g., `maxOutputTokens`, `contextWindow`, `temperature`, `type`) aligned with turbo defaults.
>   - `kimi-k2:turbo` entry remains unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e44056b5644e60784f6be0085519d9fb533f0ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched Turbo mode to use GLM 4.6 instead of Qwen3 Coder, giving users a fast, strong coding model.

Updated apiName, display name, description, and pricing indicator (from $$ to $$$); max output tokens, context window, and temperature remain unchanged.

<sup>Written for commit 5e44056b5644e60784f6be0085519d9fb533f0ce. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

