### PR TITLE
fix: change time now to correct created and updated time

### DIFF
--- a/src/pages/app-details.tsx
+++ b/src/pages/app-details.tsx
@@ -299,13 +299,13 @@ export default function AppDetailsPage() {
             <span className="block text-gray-500 dark:text-gray-400 mb-0.5 text-xs">
               Created
             </span>
-            <span>{new Date().toLocaleString()}</span>
+            <span>{selectedApp.createdAt.toString()}</span>
           </div>
           <div>
             <span className="block text-gray-500 dark:text-gray-400 mb-0.5 text-xs">
               Last Updated
             </span>
-            <span>{new Date().toLocaleString()}</span>
+            <span>{selectedApp.updatedAt.toString()}</span>
           </div>
           <div className="col-span-2">
             <span className="block text-gray-500 dark:text-gray-400 mb-0.5 text-xs">


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix incorrect "Created" and "Last Updated" timestamps in App Details. The page now uses selectedApp.createdAt and selectedApp.updatedAt instead of the current time.

<sup>Written for commit 4b2459b23b4c3e6592c45076276d50070d8df749. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

