### PR TITLE
Update links in README.md to use HTTPS for better security

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Dyad is a local, open-source AI app builder. It's fast, private, and fully under your control — like Lovable, v0, or Bolt, but running right on your machine.
 
-[![Image](https://github.com/user-attachments/assets/f6c83dfc-6ffd-4d32-93dd-4b9c46d17790)](http://dyad.sh/)
+[![Image](https://github.com/user-attachments/assets/f6c83dfc-6ffd-4d32-93dd-4b9c46d17790)](https://dyad.sh/)
 
-More info at: [http://dyad.sh/](http://dyad.sh/)
+More info at: [https://dyad.sh/](https://dyad.sh/)
 
 ## 🚀 Features
 


### PR DESCRIPTION
Pull request summary from GitHub Copilot:

> This pull request updates the `README.md` file to use secure HTTPS links instead of HTTP for the Dyad website. This improves security and ensures users are directed to the correct, secure version of the site. 
> 
> - Documentation improvements:
>   * Changed all `http://dyad.sh/` links to `https://dyad.sh/` in the `README.md` file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated README links from http to https for dyad.sh to ensure secure, correct navigation.
This avoids insecure redirects and aligns with best practices.

<sup>Written for commit fbfd253f49495e6e9c1f72cca28213eb65303b5b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

