### PR TITLE
fix: hide setup banner if any custom providers are configured

### DIFF
--- a/src/hooks/useLanguageModelProviders.ts
+++ b/src/hooks/useLanguageModelProviders.ts
@@ -61,7 +61,18 @@ export function useLanguageModelProviders() {
   };
 
   const isAnyProviderSetup = () => {
-    return cloudProviders.some((provider) => isProviderSetup(provider));
+    // Check hardcoded cloud providers
+    if (cloudProviders.some((provider) => isProviderSetup(provider))) {
+      return true;
+    }
+
+    // Check custom providers
+    const customProviders = queryResult.data?.filter(
+      (provider) => provider.type === "custom",
+    );
+    return (
+      customProviders?.some((provider) => isProviderSetup(provider.id)) ?? false
+    );
   };
 
   return {


### PR DESCRIPTION
Fixes #1108

## Summary
The "Setup AI Access" banner was not being hidden when custom providers were configured. This was because the `isAnyProviderSetup()` function only checked hardcoded cloud providers and didn't account for custom providers.

## Changes
Updated `useLanguageModelProviders.ts` to check for configured custom providers in addition to the hardcoded cloud providers.

## Test plan
- Configure a custom provider without setting up any cloud providers
- Verify that the "Setup AI Access" banner is now hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the "Setup AI Access" banner when any provider is configured, including custom providers. Fixes a logic gap where only hardcoded cloud providers were checked.

- **Bug Fixes**
  - Extend isAnyProviderSetup to check custom providers from query data (by id).
  - Banner no longer shows when a custom provider is configured without cloud providers.

<sup>Written for commit 2ecef7aac52da0b4d43c69fc5d3afb7bafa5706a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

