### PR TITLE
disabling enter keyboard when approve/reject pending

### DIFF
--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -307,6 +307,7 @@ export function ChatInput({ chatId }: { chatId?: number }) {
               onPaste={handlePaste}
               placeholder="Ask Dyad to build..."
               excludeCurrentApp={true}
+              disableSendButton={disableSendButton}
             />
 
             {isStreaming ? (

--- a/src/components/chat/HomeChatInput.tsx
+++ b/src/components/chat/HomeChatInput.tsx
@@ -86,6 +86,7 @@ export function HomeChatInput({
               placeholder="Ask Dyad to build..."
               disabled={isStreaming}
               excludeCurrentApp={false}
+              disableSendButton={false}
             />
 
             {/* File attachment dropdown */}

--- a/src/components/chat/LexicalChatInput.tsx
+++ b/src/components/chat/LexicalChatInput.tsx
@@ -90,7 +90,13 @@ function CustomMenu({ loading: _loading, ...props }: any) {
 }
 
 // Plugin to handle Enter key
-function EnterKeyPlugin({ onSubmit }: { onSubmit: () => void }) {
+function EnterKeyPlugin({
+  onSubmit,
+  disableSendButton,
+}: {
+  onSubmit: () => void;
+  disableSendButton: boolean;
+}) {
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {
@@ -109,7 +115,7 @@ function EnterKeyPlugin({ onSubmit }: { onSubmit: () => void }) {
           return false;
         }
 
-        if (!event.shiftKey) {
+        if (!event.shiftKey && !disableSendButton) {
           event.preventDefault();
           onSubmit();
           return true;
@@ -231,6 +237,7 @@ interface LexicalChatInputProps {
   placeholder?: string;
   disabled?: boolean;
   excludeCurrentApp: boolean;
+  disableSendButton: boolean;
 }
 
 function onError(error: Error) {
@@ -245,6 +252,7 @@ export function LexicalChatInput({
   excludeCurrentApp,
   placeholder = "Ask Dyad to build...",
   disabled = false,
+  disableSendButton,
 }: LexicalChatInputProps) {
   const { apps } = useLoadApps();
   const { prompts } = usePrompts();
@@ -402,7 +410,10 @@ export function LexicalChatInput({
         />
         <OnChangePlugin onChange={handleEditorChange} />
         <HistoryPlugin />
-        <EnterKeyPlugin onSubmit={handleSubmit} />
+        <EnterKeyPlugin
+          onSubmit={handleSubmit}
+          disableSendButton={disableSendButton}
+        />
         <ExternalValueSyncPlugin
           value={value}
           promptsById={Object.fromEntries(

--- a/src/components/chat/LexicalChatInput.tsx
+++ b/src/components/chat/LexicalChatInput.tsx
@@ -124,7 +124,7 @@ function EnterKeyPlugin({
       },
       COMMAND_PRIORITY_HIGH, // Use higher priority to catch before mentions plugin
     );
-  }, [editor, onSubmit]);
+  }, [editor, onSubmit, disableSendButton]);
 
   return null;
 }


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disable Enter-to-send when approve/reject is pending to prevent accidental message submission. Enter now respects the disableSendButton state; Shift+Enter still adds a newline.

- **Bug Fixes**
  - Pass disableSendButton from ChatInput to LexicalChatInput.
  - Update EnterKeyPlugin to ignore Enter when disableSendButton is true, while keeping Shift+Enter for newline.

<sup>Written for commit 7b13908826e25ebf0f2699137c648e20de520f61. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





