### PR TITLE
Support GPT-5.1: smarter, faster, and more conversational for complex tasks

### DIFF
--- a/src/ipc/shared/language_model_constants.ts
+++ b/src/ipc/shared/language_model_constants.ts
@@ -20,6 +20,32 @@ export interface ModelOption {
 
 export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
   openai: [
+    // https://platform.openai.com/docs/models/gpt-5.1-codex
+    {
+      name: "gpt-5.1-codex",
+      displayName: "GPT 5.1 Codex",
+      description: "OpenAI's latest model optimized for coding",
+      // Technically it's 128k but OpenAI errors if you set max_tokens instead of max_completion_tokens
+      maxOutputTokens: undefined,
+      contextWindow: 400_000,
+      // Requires temperature to be default value (1)
+      temperature: 1,
+      dollarSigns: 3,
+    },
+    // https://platform.openai.com/docs/models/gpt-5.1
+    {
+      name: "gpt-5.1",
+      displayName: "GPT 5.1",
+      description:
+        "OpenAI's flagship model- smarter, faster, and more conversational",
+      // Technically it's 128k but OpenAI errors if you set max_tokens instead of max_completion_tokens
+      maxOutputTokens: undefined,
+      contextWindow: 400_000,
+      // Requires temperature to be default value (1)
+      temperature: 1,
+      dollarSigns: 3,
+    },
+
     // https://platform.openai.com/docs/models/gpt-5-codex
     {
       name: "gpt-5-codex",

--- a/src/ipc/shared/language_model_constants.ts
+++ b/src/ipc/shared/language_model_constants.ts
@@ -20,30 +20,6 @@ export interface ModelOption {
 
 export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
   openai: [
-    // https://platform.openai.com/docs/models/gpt-5.1-codex-mini
-    {
-      name: "gpt-5.1-codex-mini",
-      displayName: "GPT 5.1 Codex Mini",
-      description: "OpenAI's compact and efficient coding model",
-      // Technically it's 128k but OpenAI errors if you set max_tokens instead of max_completion_tokens
-      maxOutputTokens: undefined,
-      contextWindow: 400_000,
-      // Requires temperature to be default value (1)
-      temperature: 1,
-      dollarSigns: 2,
-    },
-    // https://platform.openai.com/docs/models/gpt-5.1-codex
-    {
-      name: "gpt-5.1-codex",
-      displayName: "GPT 5.1 Codex",
-      description: "OpenAI's advanced coding workflows",
-      // Technically it's 128k but OpenAI errors if you set max_tokens instead of max_completion_tokens
-      maxOutputTokens: undefined,
-      contextWindow: 400_000,
-      // Requires temperature to be default value (1)
-      temperature: 1,
-      dollarSigns: 3,
-    },
     // https://platform.openai.com/docs/models/gpt-5.1
     {
       name: "gpt-5.1",
@@ -57,12 +33,11 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
       temperature: 1,
       dollarSigns: 3,
     },
-
-    // https://platform.openai.com/docs/models/gpt-5-codex
+    // https://platform.openai.com/docs/models/gpt-5.1-codex
     {
-      name: "gpt-5-codex",
-      displayName: "GPT 5 Codex",
-      description: "OpenAI's flagship model optimized for coding",
+      name: "gpt-5.1-codex",
+      displayName: "GPT 5.1 Codex",
+      description: "OpenAI's advanced coding workflows",
       // Technically it's 128k but OpenAI errors if you set max_tokens instead of max_completion_tokens
       maxOutputTokens: undefined,
       contextWindow: 400_000,
@@ -70,11 +45,36 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
       temperature: 1,
       dollarSigns: 3,
     },
+    // https://platform.openai.com/docs/models/gpt-5.1-codex-mini
+    {
+      name: "gpt-5.1-codex-mini",
+      displayName: "GPT 5.1 Codex Mini",
+      description: "OpenAI's compact and efficient coding model",
+      // Technically it's 128k but OpenAI errors if you set max_tokens instead of max_completion_tokens
+      maxOutputTokens: undefined,
+      contextWindow: 400_000,
+      // Requires temperature to be default value (1)
+      temperature: 1,
+      dollarSigns: 2,
+    },
+
     // https://platform.openai.com/docs/models/gpt-5
     {
       name: "gpt-5",
       displayName: "GPT 5",
       description: "OpenAI's flagship model",
+      // Technically it's 128k but OpenAI errors if you set max_tokens instead of max_completion_tokens
+      maxOutputTokens: undefined,
+      contextWindow: 400_000,
+      // Requires temperature to be default value (1)
+      temperature: 1,
+      dollarSigns: 3,
+    },
+    // https://platform.openai.com/docs/models/gpt-5-codex
+    {
+      name: "gpt-5-codex",
+      displayName: "GPT 5 Codex",
+      description: "OpenAI's flagship model optimized for coding",
       // Technically it's 128k but OpenAI errors if you set max_tokens instead of max_completion_tokens
       maxOutputTokens: undefined,
       contextWindow: 400_000,
@@ -336,9 +336,9 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
   ],
   azure: [
     {
-      name: "gpt-5.1-codex-mini",
-      displayName: "GPT-5.1 Codex Mini",
-      description: "Azure OpenAI GPT-5.1 Codex Mini model",
+      name: "gpt-5.1",
+      displayName: "GPT-5.1",
+      description: "Azure OpenAI GPT-5.1 model",
       // See OpenAI comment above
       // maxOutputTokens: 128_000,
       contextWindow: 400_000,
@@ -354,9 +354,9 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
       temperature: 1,
     },
     {
-      name: "gpt-5.1",
-      displayName: "GPT-5.1",
-      description: "Azure OpenAI GPT-5.1 model",
+      name: "gpt-5.1-codex-mini",
+      displayName: "GPT-5.1 Codex Mini",
+      description: "Azure OpenAI GPT-5.1 Codex Mini model",
       // See OpenAI comment above
       // maxOutputTokens: 128_000,
       contextWindow: 400_000,

--- a/src/ipc/shared/language_model_constants.ts
+++ b/src/ipc/shared/language_model_constants.ts
@@ -20,11 +20,23 @@ export interface ModelOption {
 
 export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
   openai: [
+    // https://platform.openai.com/docs/models/gpt-5.1-codex-mini
+    {
+      name: "gpt-5.1-codex-mini",
+      displayName: "GPT 5.1 Codex Mini",
+      description: "OpenAI's compact and efficient coding model",
+      // Technically it's 128k but OpenAI errors if you set max_tokens instead of max_completion_tokens
+      maxOutputTokens: undefined,
+      contextWindow: 400_000,
+      // Requires temperature to be default value (1)
+      temperature: 1,
+      dollarSigns: 2,
+    },
     // https://platform.openai.com/docs/models/gpt-5.1-codex
     {
       name: "gpt-5.1-codex",
       displayName: "GPT 5.1 Codex",
-      description: "OpenAI's latest model optimized for coding",
+      description: "OpenAI's advanced coding workflows",
       // Technically it's 128k but OpenAI errors if you set max_tokens instead of max_completion_tokens
       maxOutputTokens: undefined,
       contextWindow: 400_000,
@@ -323,6 +335,33 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
     },
   ],
   azure: [
+    {
+      name: "gpt-5.1-codex-mini",
+      displayName: "GPT-5.1 Codex Mini",
+      description: "Azure OpenAI GPT-5.1 Codex Mini model",
+      // See OpenAI comment above
+      // maxOutputTokens: 128_000,
+      contextWindow: 400_000,
+      temperature: 1,
+    },
+    {
+      name: "gpt-5.1-codex",
+      displayName: "GPT-5.1 Codex",
+      description: "Azure OpenAI GPT-5.1 Codex model",
+      // See OpenAI comment above
+      // maxOutputTokens: 128_000,
+      contextWindow: 400_000,
+      temperature: 1,
+    },
+    {
+      name: "gpt-5.1",
+      displayName: "GPT-5.1",
+      description: "Azure OpenAI GPT-5.1 model",
+      // See OpenAI comment above
+      // maxOutputTokens: 128_000,
+      contextWindow: 400_000,
+      temperature: 1,
+    },
     {
       name: "gpt-5-codex",
       displayName: "GPT-5 Codex",


### PR DESCRIPTION
Added to OpenAI and Azure

GPT-5.1: adaptive reasoning 
GPT-5.1-codex: advanced coding workflows
GPT-5.1-codex-mini: compact and efficient








<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added support for OpenAI and Azure GPT-5.1, including GPT-5.1 Codex and Codex Mini, for smarter conversations and better coding tasks. All models use a 400k context window, require temperature 1, and leave max output tokens unspecified to align with API behavior.

<sup>Written for commit 9788541c88732aa7d522fc70bfb20f22c3544982. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->








<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds GPT-5.1, GPT-5.1 Codex, and Codex Mini to OpenAI and Azure model catalogs with 400k context and temperature 1 (max output tokens unspecified).
> 
> - **Model registry updates (`src/ipc/shared/language_model_constants.ts`)**:
>   - **OpenAI**:
>     - Add `gpt-5.1`, `gpt-5.1-codex`, `gpt-5.1-codex-mini` (400k `contextWindow`, `temperature: 1`, `maxOutputTokens: undefined`).
>     - Keep existing `gpt-5`, `gpt-5-codex`, `gpt-5-mini`, `gpt-5-nano`, `o4-mini`.
>   - **Azure**:
>     - Add `gpt-5.1`, `gpt-5.1-codex`, `gpt-5.1-codex-mini` with matching settings (400k `contextWindow`, `temperature: 1`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9788541c88732aa7d522fc70bfb20f22c3544982. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->