### PR TITLE
bump to 0.28.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dyad",
   "productName": "dyad",
-  "version": "0.27.1",
+  "version": "0.28.0-beta.1",
   "description": "Free, local, open-source AI app builder",
   "main": ".vite/build/main.js",
   "repository": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps `package.json` version from `0.27.1` to `0.28.0-beta.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 767e200f378205413e8a23fff7674149239a92d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the app version to 0.28.0-beta.1 to start the 0.28 beta release channel. Enables publishing and tracking prerelease builds separate from stable.

<sup>Written for commit 767e200f378205413e8a23fff7674149239a92d5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

