### PR TITLE
Gemini 3

### DIFF
--- a/src/ipc/shared/language_model_constants.ts
+++ b/src/ipc/shared/language_model_constants.ts
@@ -138,6 +138,18 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
     },
   ],
   google: [
+    // https://ai.google.dev/gemini-api/docs/models#gemini-3-pro
+    {
+      name: "gemini-3-pro-preview",
+      displayName: "Gemini 3 Pro (Preview)",
+      description: "Google's latest Gemini model",
+      // See Flash 2.5 comment below (go 1 below just to be safe, even though it seems OK now).
+      maxOutputTokens: 65_536 - 1,
+      // Gemini context window = input token + output token
+      contextWindow: 1_048_576,
+      temperature: 1.0,
+      dollarSigns: 4,
+    },
     // https://ai.google.dev/gemini-api/docs/models#gemini-2.5-pro-preview-03-25
     {
       name: "gemini-2.5-pro",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `gemini-3-pro-preview` to Google model options with 1,048,576 context window and 65,535 max output tokens.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6aefc4449908e862476f61c0bcb2a625111256a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added Gemini 3 Pro (Preview) to the Google model list so users can select it in the app. Sets a 1,048,576-token context window and a safe max output of 65,535 tokens, with temperature 1.0.

<sup>Written for commit 6aefc4449908e862476f61c0bcb2a625111256a3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

