### PR TITLE
resizable chat input

### DIFF
--- a/src/components/chat/LexicalChatInput.tsx
+++ b/src/components/chat/LexicalChatInput.tsx
@@ -380,7 +380,7 @@ export function LexicalChatInput({
         <PlainTextPlugin
           contentEditable={
             <ContentEditable
-              className="flex-1 p-2 focus:outline-none overflow-y-auto min-h-[40px] max-h-[200px] resize-none"
+              className="flex-1 p-2 focus:outline-none overflow-y-auto min-h-[40px] max-h-[200px] resize-y"
               aria-placeholder={placeholder}
               placeholder={
                 <div className="absolute top-2 left-2 text-muted-foreground pointer-events-none select-none">


### PR DESCRIPTION
closes #1805 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enabled vertical resizing of the chat input so users can expand the field for longer messages. Switched ContentEditable from resize-none to resize-y, keeping the existing 40 to 200px height limits.

<sup>Written for commit a8e357b4956f8900c1e769aad90553a2880b2d67. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

