### PR TITLE
Preventing invalid characters in app names

### DIFF
--- a/src/ipc/handlers/app_handlers.ts
+++ b/src/ipc/handlers/app_handlers.ts
@@ -1202,6 +1202,20 @@ export function registerAppHandlers() {
           throw new Error("App not found");
         }
 
+        const pathChanged = appPath !== app.path;
+
+        if (pathChanged) {
+          const invalidChars = /[<>:"|?*\/\\]/;
+          const hasInvalidChars =
+            invalidChars.test(appPath) || /[\x00-\x1f]/.test(appPath);
+
+          if (hasInvalidChars) {
+            throw new Error(
+              `App path "${appPath}" contains characters that are not allowed in folder names: < > : " | ? * / \\ or control characters. Please use a different path.`,
+            );
+          }
+        }
+
         // Check for conflicts with existing apps
         const nameConflict = await db.query.apps.findFirst({
           where: eq(apps.name, appName),

--- a/src/pages/app-details.tsx
+++ b/src/pages/app-details.tsx
@@ -128,11 +128,10 @@ export default function AppDetailsPage() {
       await refreshApps();
     } catch (error) {
       console.error("Failed to rename app:", error);
-      alert(
-        `Error renaming app: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
+      const errorMessage = (
+        error instanceof Error ? error.message : String(error)
+      ).replace(/^Error invoking remote method 'rename-app': Error: /, "");
+      showError(errorMessage);
     } finally {
       setIsRenaming(false);
     }
@@ -143,7 +142,6 @@ export default function AppDetailsPage() {
 
     try {
       setIsRenamingFolder(true);
-
       await IpcClient.getInstance().renameApp({
         appId,
         appName: selectedApp.name, // Keep the app name the same
@@ -154,11 +152,10 @@ export default function AppDetailsPage() {
       await refreshApps();
     } catch (error) {
       console.error("Failed to rename folder:", error);
-      alert(
-        `Error renaming folder: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
+      const errorMessage = (
+        error instanceof Error ? error.message : String(error)
+      ).replace(/^Error invoking remote method 'rename-app': Error: /, "");
+      showError(errorMessage);
     } finally {
       setIsRenamingFolder(false);
     }


### PR DESCRIPTION
closes #1823

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks invalid characters in app folder paths during rename and shows cleaner error messages in App Details. Prevents OS rename failures and removes confusing IPC prefixes from errors.

- **Bug Fixes**
  - Validate new appPath on rename; reject < > : " | ? * / \ and control characters when the path changes, with a clear error message.
  - Replace alert() with showError() and strip the IPC wrapper text for user-friendly errors.

<sup>Written for commit 14b3c0978c1da3b97ca6d33e67684c7ff872ab0a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

