### PR TITLE
Fix: Custom Model Not Updating (#1817)

### DIFF
--- a/src/components/EditCustomModelDialog.tsx
+++ b/src/components/EditCustomModelDialog.tsx
@@ -91,8 +91,7 @@ export function EditCustomModelDialog({
       // Then create the new model
       await ipcClient.createCustomLanguageModel(newParams);
     },
-    onSuccess: () => {
-      showSuccess("Custom model updated successfully!");
+    onSuccess: async () => {
       if (
         settings?.selectedModel?.name === model?.apiName &&
         settings?.selectedModel?.provider === providerId
@@ -101,8 +100,14 @@ export function EditCustomModelDialog({
           ...settings.selectedModel,
           name: apiName,
         };
-        updateSettings({ selectedModel: newModel });
+        try {
+          await updateSettings({ selectedModel: newModel });
+        } catch {
+          showError("Failed to update settings");
+          return; // stop closing dialog
+        }
       }
+      showSuccess("Custom model updated successfully!");
       onSuccess();
       onClose();
     },

--- a/src/components/EditCustomModelDialog.tsx
+++ b/src/components/EditCustomModelDialog.tsx
@@ -11,6 +11,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { IpcClient } from "@/ipc/ipc_client";
+import { useSettings } from "@/hooks/useSettings";
 import { useMutation } from "@tanstack/react-query";
 import { showError, showSuccess } from "@/lib/toast";
 
@@ -44,6 +45,7 @@ export function EditCustomModelDialog({
   const [description, setDescription] = useState("");
   const [maxOutputTokens, setMaxOutputTokens] = useState<string>("");
   const [contextWindow, setContextWindow] = useState<string>("");
+  const { settings, updateSettings } = useSettings();
 
   const ipcClient = IpcClient.getInstance();
 
@@ -91,6 +93,16 @@ export function EditCustomModelDialog({
     },
     onSuccess: () => {
       showSuccess("Custom model updated successfully!");
+      if (
+        settings?.selectedModel?.name === model?.apiName &&
+        settings?.selectedModel?.provider === providerId
+      ) {
+        const newModel = {
+          ...settings.selectedModel,
+          name: apiName,
+        };
+        updateSettings({ selectedModel: newModel });
+      }
       onSuccess();
       onClose();
     },


### PR DESCRIPTION
Closes (#1817)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the bug where editing a custom model didn’t update the currently selected model. The selection now stays in sync after renaming or editing.

- **Bug Fixes**
  - Use useSettings to detect if the edited model is the active one (match provider and apiName).
  - Update settings.selectedModel with the new apiName; on failure show an error and keep the dialog open; otherwise show success, call onSuccess, then close.

<sup>Written for commit 88045165a3989277e703a8f31712fcf1dfeaa32a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



