### PR TITLE
feat: Support Voice input 

### DIFF
--- a/e2e-tests/voice_transcription.spec.ts
+++ b/e2e-tests/voice_transcription.spec.ts
@@ -1,0 +1,83 @@
+import { expect } from "@playwright/test";
+import { test, testSkipIfWindows, Timeout } from "./helpers/test_helper";
+
+const E2E_TRANSCRIBED_TEXT = "E2E transcribed text";
+
+/**
+ * Mocks navigator.mediaDevices.getUserMedia to return a silent audio stream
+ * (AudioContext + oscillator + MediaStreamDestination). Required for E2E
+ * because CI has no microphone; the real MediaRecorder records this stream,
+ * and the fake-llm-server returns mock transcription.
+ */
+async function mockGetUserMedia(page: {
+  evaluate: (fn: () => void) => Promise<void>;
+}) {
+  await page.evaluate(() => {
+    const AudioContextClass =
+      (window as any).AudioContext || (window as any).webkitAudioContext;
+    const ctx = new AudioContextClass();
+    const dest = ctx.createMediaStreamDestination();
+    const osc = ctx.createOscillator();
+    osc.connect(dest);
+    osc.start(0);
+    (window as any).__voiceTestStream = dest.stream;
+    const orig = navigator.mediaDevices.getUserMedia.bind(
+      navigator.mediaDevices,
+    );
+    (navigator.mediaDevices as any).getUserMedia = function (constraints: any) {
+      if (constraints?.audio) return Promise.resolve(dest.stream);
+      return orig(constraints);
+    };
+  });
+}
+
+testSkipIfWindows(
+  "voice transcription - home chat: record, transcribe, append to input",
+  async ({ po }) => {
+    await po.setUpDyadPro();
+
+    await mockGetUserMedia(po.page);
+
+    await expect(po.getHomeChatInputContainer()).toBeVisible({
+      timeout: Timeout.MEDIUM,
+    });
+
+    const voiceBtn = po
+      .getHomeChatInputContainer()
+      .getByTestId("voice-input-button");
+    await expect(voiceBtn).toBeVisible();
+    await expect(voiceBtn).toHaveAttribute("title", "Start voice input");
+
+    await voiceBtn.click();
+
+    await expect(po.page.getByTestId("voice-waveform")).toBeVisible({
+      timeout: Timeout.MEDIUM,
+    });
+
+    await expect(voiceBtn).toHaveAttribute("title", "Stop recording");
+    await voiceBtn.click();
+
+    await expect(voiceBtn).toHaveAttribute("title", "Start voice input", {
+      timeout: Timeout.MEDIUM,
+    });
+
+    await expect(po.getChatInput()).toContainText(E2E_TRANSCRIBED_TEXT);
+  },
+);
+
+test("voice input - non-Pro user sees Pro-only disabled state", async ({
+  po,
+}) => {
+  await po.setUp();
+
+  await expect(po.getHomeChatInputContainer()).toBeVisible({
+    timeout: Timeout.MEDIUM,
+  });
+
+  const voiceBtn = po
+    .getHomeChatInputContainer()
+    .getByTestId("voice-input-button");
+  await expect(voiceBtn).toBeVisible();
+  await expect(voiceBtn).toHaveAttribute("title", "Pro feature only");
+  await expect(voiceBtn).toBeDisabled();
+});

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -7,6 +7,7 @@ import {
   AlertOctagon,
   FileText,
   Check,
+  Loader,
   Loader2,
   Package,
   FileX,
@@ -16,6 +17,8 @@ import {
   ChevronsDownUp,
   SendHorizontalIcon,
   Lock,
+  Mic,
+  Square,
 } from "lucide-react";
 import type React from "react";
 import { useCallback, useEffect, useState } from "react";
@@ -81,6 +84,9 @@ import { VisualEditingChangesDialog } from "@/components/preview_panel/VisualEdi
 import { useUserBudgetInfo } from "@/hooks/useUserBudgetInfo";
 import { useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "@/lib/queryKeys";
+import { useAudioRecorder } from "@/hooks/useAudioRecorder";
+
+import { VoiceWaveform } from "./VoiceWaveform";
 
 const showTokenBarAtom = atom(false);
 
@@ -151,6 +157,50 @@ export function ChatInput({ chatId }: { chatId?: number }) {
   } = useProposal(chatId);
   const { proposal, messageId } = proposalResult ?? {};
   useChatModeToggle();
+
+  const [isTranscribing, setIsTranscribing] = useState(false);
+
+  const handleRecordingComplete = useCallback(
+    async (blob: Blob) => {
+      setIsTranscribing(true);
+      try {
+        const reader = new FileReader();
+        reader.readAsDataURL(blob);
+        reader.onloadend = async () => {
+          const base64data = reader.result as string;
+          // Remove data URL prefix
+          const base64Content = base64data.split(",")[1];
+
+          const text = await IpcClient.getInstance().transcribeAudio(
+            base64Content,
+            "webm",
+          );
+
+          if (text) {
+            setInputValue((prev) => (prev ? `${prev} ${text}` : text));
+          }
+          setIsTranscribing(false);
+        };
+      } catch (err) {
+        console.error("Transcription failed", err);
+        setError("Failed to transcribe audio");
+        setIsTranscribing(false);
+      }
+    },
+    [setInputValue, setError],
+  );
+
+  // Audio Recorder
+  const { isRecording, startRecording, stopRecording, analyser } =
+    useAudioRecorder(handleRecordingComplete);
+
+  const handleMicClick = () => {
+    if (isRecording) {
+      stopRecording();
+    } else {
+      startRecording();
+    }
+  };
 
   const lastMessage = (chatId ? (messagesById.get(chatId) ?? []) : []).at(-1);
   const disableSendButton =
@@ -445,15 +495,19 @@ export function ChatInput({ chatId }: { chatId?: number }) {
           <DragDropOverlay isDraggingOver={isDraggingOver} />
 
           <div className="flex items-start space-x-2 ">
-            <LexicalChatInput
-              value={inputValue}
-              onChange={setInputValue}
-              onSubmit={handleSubmit}
-              onPaste={handlePaste}
-              placeholder="Ask Dyad to build..."
-              excludeCurrentApp={true}
-              disableSendButton={disableSendButton}
-            />
+            {isRecording ? (
+              <VoiceWaveform analyser={analyser} />
+            ) : (
+              <LexicalChatInput
+                value={inputValue}
+                onChange={setInputValue}
+                onSubmit={handleSubmit}
+                onPaste={handlePaste}
+                placeholder="Ask Dyad to build..."
+                excludeCurrentApp={true}
+                disableSendButton={disableSendButton}
+              />
+            )}
 
             {isStreaming ? (
               <button
@@ -464,17 +518,45 @@ export function ChatInput({ chatId }: { chatId?: number }) {
                 <StopCircleIcon size={20} />
               </button>
             ) : (
-              <button
-                onClick={handleSubmit}
-                disabled={
-                  (!inputValue.trim() && attachments.length === 0) ||
-                  disableSendButton
-                }
-                className="px-2 py-2 mt-1 mr-1 hover:bg-(--background-darkest) text-(--sidebar-accent-fg) rounded-lg disabled:opacity-50"
-                title="Send message"
-              >
-                <SendHorizontalIcon size={20} />
-              </button>
+              <div className="flex items-center mt-1 mr-1">
+                <button
+                  onClick={handleMicClick}
+                  className={`px-2 py-2 rounded-lg transition-colors ${
+                    isRecording
+                      ? "bg-red-500/10 text-red-500 animate-pulse"
+                      : isTranscribing
+                        ? "bg-yellow-500/10 text-yellow-500"
+                        : "hover:bg-(--background-darkest) text-(--sidebar-accent-fg)"
+                  }`}
+                  title={
+                    isRecording
+                      ? "Stop recording"
+                      : isTranscribing
+                        ? "Transcribing..."
+                        : "Start voice input"
+                  }
+                  disabled={isTranscribing}
+                >
+                  {isRecording ? (
+                    <Square size={20} fill="currentColor" />
+                  ) : isTranscribing ? (
+                    <Loader size={20} className="animate-spin" />
+                  ) : (
+                    <Mic size={20} />
+                  )}
+                </button>
+                <button
+                  onClick={handleSubmit}
+                  disabled={
+                    (!inputValue.trim() && attachments.length === 0) ||
+                    disableSendButton
+                  }
+                  className="px-2 py-2 hover:bg-(--background-darkest) text-(--sidebar-accent-fg) rounded-lg disabled:opacity-50"
+                  title="Send message"
+                >
+                  <SendHorizontalIcon size={20} />
+                </button>
+              </div>
             )}
           </div>
           <div className="pl-2 pr-1 flex items-center justify-between pb-2">

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -16,8 +16,6 @@ import {
   ChevronsDownUp,
   SendHorizontalIcon,
   Lock,
-  Mic,
-  Square,
 } from "lucide-react";
 import type React from "react";
 import { useCallback, useEffect, useState } from "react";

--- a/src/components/chat/HomeChatInput.tsx
+++ b/src/components/chat/HomeChatInput.tsx
@@ -14,6 +14,9 @@ import { LexicalChatInput } from "./LexicalChatInput";
 import { useChatModeToggle } from "@/hooks/useChatModeToggle";
 import { useTypingPlaceholder } from "@/hooks/useTypingPlaceholder";
 import { AuxiliaryActionsMenu } from "./AuxiliaryActionsMenu";
+import { useVoiceInput } from "@/hooks/useAudioRecorder";
+import { VoiceWaveform } from "./VoiceWaveform";
+import { VoiceInputButton } from "./VoiceInputButton";
 
 export function HomeChatInput({
   onSubmit,
@@ -27,6 +30,15 @@ export function HomeChatInput({
     hasChatId: false,
   }); // eslint-disable-line @typescript-eslint/no-unused-vars
   useChatModeToggle();
+  // Use the voice input hook
+  const { isTranscribing, isRecording, analyser, handleMicClick } =
+    useVoiceInput({
+      appendText: (text) => {
+        if (text) {
+          setInputValue((prev) => (prev ? `${prev} ${text}` : text));
+        }
+      },
+    });
 
   const typingText = useTypingPlaceholder([
     "an ecommerce store...",
@@ -89,16 +101,20 @@ export function HomeChatInput({
           <DragDropOverlay isDraggingOver={isDraggingOver} />
 
           <div className="flex items-start space-x-2 ">
-            <LexicalChatInput
-              value={inputValue}
-              onChange={setInputValue}
-              onSubmit={handleCustomSubmit}
-              onPaste={handlePaste}
-              placeholder={placeholder}
-              disabled={isStreaming}
-              excludeCurrentApp={false}
-              disableSendButton={false}
-            />
+            {isRecording ? (
+              <VoiceWaveform analyser={analyser} />
+            ) : (
+              <LexicalChatInput
+                value={inputValue}
+                onChange={setInputValue}
+                onSubmit={handleCustomSubmit}
+                onPaste={handlePaste}
+                placeholder={placeholder}
+                disabled={isStreaming}
+                excludeCurrentApp={false}
+                disableSendButton={false}
+              />
+            )}
 
             {isStreaming ? (
               <button
@@ -108,14 +124,21 @@ export function HomeChatInput({
                 <StopCircleIcon size={20} />
               </button>
             ) : (
-              <button
-                onClick={handleCustomSubmit}
-                disabled={!inputValue.trim() && attachments.length === 0}
-                className="px-2 py-2 mt-1 mr-1 hover:bg-(--background-darkest) text-(--sidebar-accent-fg) rounded-lg disabled:opacity-50"
-                title="Send message"
-              >
-                <SendIcon size={20} />
-              </button>
+              <div className="flex items-center mt-1 mr-1">
+                <VoiceInputButton
+                  isRecording={isRecording}
+                  isTranscribing={isTranscribing}
+                  onClick={handleMicClick}
+                />
+                <button
+                  onClick={handleCustomSubmit}
+                  disabled={!inputValue.trim() && attachments.length === 0}
+                  className="px-2 py-2 mt-1 mr-1 hover:bg-(--background-darkest) text-(--sidebar-accent-fg) rounded-lg disabled:opacity-50"
+                  title="Send message"
+                >
+                  <SendIcon size={20} />
+                </button>
+              </div>
             )}
           </div>
           <div className="pl-2 pr-1 flex items-center justify-between pb-2">

--- a/src/components/chat/VoiceInputButton.tsx
+++ b/src/components/chat/VoiceInputButton.tsx
@@ -48,6 +48,7 @@ export function VoiceInputButton({
 
   const button = (
     <button
+      data-testid="voice-input-button"
       onClick={proModeTogglable ? onClick : undefined}
       className={className}
       title={title}

--- a/src/components/chat/VoiceInputButton.tsx
+++ b/src/components/chat/VoiceInputButton.tsx
@@ -1,0 +1,75 @@
+import { Mic, Square, Loader } from "lucide-react";
+import { hasDyadProKey } from "@/lib/schemas";
+import { useSettings } from "@/hooks/useSettings";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "../ui/tooltip";
+
+type VoiceInputButtonProps = {
+  isRecording: boolean;
+  isTranscribing: boolean;
+  onClick: () => void;
+};
+
+export function VoiceInputButton({
+  isRecording,
+  isTranscribing,
+  onClick,
+}: VoiceInputButtonProps) {
+  const { settings } = useSettings();
+  const hasProKey = settings ? hasDyadProKey(settings) : false;
+  const proModeTogglable = hasProKey && Boolean(settings?.enableDyadPro);
+
+  const isDisabled = isTranscribing || !proModeTogglable;
+
+  const className = `
+    px-2 py-2 rounded-lg transition-colors
+    ${
+      isRecording
+        ? "bg-red-500/10 text-red-500 animate-pulse"
+        : isTranscribing
+          ? "bg-yellow-500/10 text-yellow-500"
+          : proModeTogglable
+            ? "hover:bg-(--background-darkest) text-(--sidebar-accent-fg)"
+            : "opacity-50 cursor-not-allowed"
+    }
+  `;
+
+  const title = isRecording
+    ? "Stop recording"
+    : isTranscribing
+      ? "Transcribing..."
+      : proModeTogglable
+        ? "Start voice input"
+        : "Pro feature only";
+
+  const button = (
+    <button
+      onClick={proModeTogglable ? onClick : undefined}
+      className={className}
+      title={title}
+      disabled={isDisabled}
+    >
+      {isRecording ? (
+        <Square size={20} fill="currentColor" />
+      ) : isTranscribing ? (
+        <Loader size={20} className="animate-spin" />
+      ) : (
+        <Mic size={20} />
+      )}
+    </button>
+  );
+  return proModeTogglable ? (
+    button
+  ) : (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>{button}</TooltipTrigger>
+        <TooltipContent>{title}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/src/components/chat/VoiceWaveform.tsx
+++ b/src/components/chat/VoiceWaveform.tsx
@@ -1,0 +1,74 @@
+import React, { useEffect, useRef } from "react";
+
+interface VoiceWaveformProps {
+  analyser: AnalyserNode | null;
+}
+
+export function VoiceWaveform({ analyser }: VoiceWaveformProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    if (!analyser || !canvasRef.current) return;
+
+    const canvas = canvasRef.current;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const bufferLength = analyser.frequencyBinCount;
+    const dataArray = new Uint8Array(bufferLength);
+
+    let animationId: number;
+
+    const draw = () => {
+      animationId = requestAnimationFrame(draw);
+
+      analyser.getByteFrequencyData(dataArray);
+
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+      const barWidth = (canvas.width / bufferLength) * 2.5;
+      let barHeight;
+      let x = 0;
+
+      // Draw bars
+      for (let i = 0; i < bufferLength; i++) {
+        barHeight = dataArray[i] / 2; // Scale down height
+
+        // Create gradient
+        const gradient = ctx.createLinearGradient(0, 0, 0, canvas.height);
+        gradient.addColorStop(0, "#a855f7"); // Purple
+        gradient.addColorStop(1, "#3b82f6"); // Blue
+
+        ctx.fillStyle = gradient;
+
+        // Center vertically
+        const y = (canvas.height - barHeight) / 2;
+
+        // Rounded caps simulation (simple rect for now)
+        ctx.fillRect(x, y, barWidth, barHeight);
+
+        x += barWidth + 1;
+      }
+    };
+
+    draw();
+
+    return () => {
+      cancelAnimationFrame(animationId);
+    };
+  }, [analyser]);
+
+  return (
+    <div className="w-full h-[52px] flex items-center justify-center bg-muted/30 rounded-md overflow-hidden border border-border/50">
+      <canvas
+        ref={canvasRef}
+        width={600}
+        height={100}
+        className="w-full h-full opacity-80"
+      />
+      <div className="absolute text-xs font-medium text-muted-foreground animate-pulse">
+        Listening...
+      </div>
+    </div>
+  );
+}

--- a/src/components/chat/VoiceWaveform.tsx
+++ b/src/components/chat/VoiceWaveform.tsx
@@ -59,14 +59,17 @@ export function VoiceWaveform({ analyser }: VoiceWaveformProps) {
   }, [analyser]);
 
   return (
-    <div className="w-full h-[52px] flex items-center justify-center bg-muted/30 rounded-md overflow-hidden border border-border/50">
+    <div
+      data-testid="voice-waveform"
+      className="relative w-full h-[52px] flex items-center justify-center bg-muted/30 rounded-md overflow-hidden border border-border/50"
+    >
       <canvas
         ref={canvasRef}
         width={600}
         height={100}
         className="w-full h-full opacity-80"
       />
-      <div className="absolute text-xs font-medium text-muted-foreground animate-pulse">
+      <div className="absolute inset-0 flex items-center justify-center text-xs font-medium text-muted-foreground animate-pulse">
         Listening...
       </div>
     </div>

--- a/src/hooks/useAudioRecorder.ts
+++ b/src/hooks/useAudioRecorder.ts
@@ -112,8 +112,10 @@ export function useVoiceInput({ appendText, onError }: UseVoiceInputOptions) {
 
         reader.onloadend = async () => {
           try {
-            const base64data = reader.result as string;
+            const base64data = reader.result as string | null;
+            if (!base64data) return;
             const base64Content = base64data.split(",")[1];
+            if (!base64Content) return;
 
             const text = await IpcClient.getInstance().transcribeAudio(
               base64Content,

--- a/src/hooks/useAudioRecorder.ts
+++ b/src/hooks/useAudioRecorder.ts
@@ -1,0 +1,94 @@
+import { useState, useRef, useCallback } from "react";
+
+export interface AudioRecorderState {
+  isRecording: boolean;
+  recordingTime: number;
+  audioBlob: Blob | null;
+}
+
+export function useAudioRecorder(onRecordingComplete?: (blob: Blob) => void) {
+  const [isRecording, setIsRecording] = useState(false);
+  const [recordingTime, setRecordingTime] = useState(0);
+  const [audioBlob, setAudioBlob] = useState<Blob | null>(null);
+
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+  const analyserRef = useRef<AnalyserNode | null>(null);
+  const audioContextRef = useRef<AudioContext | null>(null);
+
+  const startRecording = useCallback(async () => {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+
+      // Setup Audio Context for visualization
+      const audioContext = new AudioContext();
+      const source = audioContext.createMediaStreamSource(stream);
+      const analyser = audioContext.createAnalyser();
+      analyser.fftSize = 256;
+      source.connect(analyser);
+
+      analyserRef.current = analyser;
+      audioContextRef.current = audioContext;
+
+      const mediaRecorder = new MediaRecorder(stream);
+
+      mediaRecorderRef.current = mediaRecorder;
+      chunksRef.current = [];
+
+      mediaRecorder.ondataavailable = (e) => {
+        if (e.data.size > 0) {
+          chunksRef.current.push(e.data);
+        }
+      };
+
+      mediaRecorder.onstop = () => {
+        const blob = new Blob(chunksRef.current, { type: "audio/webm" });
+        setAudioBlob(blob);
+        if (onRecordingComplete) {
+          onRecordingComplete(blob);
+        }
+        stream.getTracks().forEach((track) => track.stop());
+
+        // Cleanup AudioContext
+        if (audioContextRef.current) {
+          audioContextRef.current.close();
+          audioContextRef.current = null;
+        }
+        analyserRef.current = null;
+      };
+
+      mediaRecorder.start();
+      setIsRecording(true);
+      setRecordingTime(0);
+      setAudioBlob(null);
+
+      timerRef.current = setInterval(() => {
+        setRecordingTime((prev) => prev + 1);
+      }, 1000);
+    } catch (err) {
+      console.error("Error starting recording:", err);
+      throw err;
+    }
+  }, [onRecordingComplete]);
+
+  const stopRecording = useCallback(() => {
+    if (mediaRecorderRef.current && isRecording) {
+      mediaRecorderRef.current.stop();
+      setIsRecording(false);
+      if (timerRef.current) {
+        clearInterval(timerRef.current);
+        timerRef.current = null;
+      }
+    }
+  }, [isRecording]);
+
+  return {
+    isRecording,
+    recordingTime,
+    audioBlob,
+    startRecording,
+    stopRecording,
+    analyser: analyserRef.current,
+  };
+}

--- a/src/ipc/handlers/transcription_handlers.ts
+++ b/src/ipc/handlers/transcription_handlers.ts
@@ -1,9 +1,10 @@
 import { readSettings } from "../../main/settings";
 import log from "electron-log";
 import { v4 as uuidv4 } from "uuid";
-const logger = log.scope("chat_handlers");
 import { createLoggedHandler } from "./safe_handle";
 import { transcribeWithDyadEngine } from "../utils/llm_engine_provider";
+
+const logger = log.scope("transcription");
 const handle = createLoggedHandler(logger);
 
 export function registerTranscriptionHandlers() {
@@ -18,21 +19,19 @@ export function registerTranscriptionHandlers() {
         const dyadEngineUrl = process.env.DYAD_ENGINE_URL;
         const dyadApiKey = settings.providerSettings?.auto?.apiKey?.value;
 
-        // Convert base64 to buffer
         const buffer = Buffer.from(audioData, "base64");
         const filename = `recording-${Date.now()}.${format}`;
-        let requestId: string | undefined = uuidv4();
+        const requestId = uuidv4();
 
         logger.info("Using Dyad Engine for transcription");
         return await transcribeWithDyadEngine(buffer, filename, requestId, {
           apiKey: dyadApiKey,
           baseURL: dyadEngineUrl ?? "https://engine.dyad.sh/v1",
-          originalProviderId: "openai",
           dyadOptions: {},
           settings,
         });
       } catch (error) {
-        console.error("Transcription error:", error);
+        logger.error("Transcription error:", error);
         throw new Error(`Transcription failed: ${(error as Error).message}`);
       }
     },

--- a/src/ipc/handlers/transcription_handlers.ts
+++ b/src/ipc/handlers/transcription_handlers.ts
@@ -1,0 +1,62 @@
+import { readSettings } from "../../main/settings";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import OpenAI from "openai";
+import log from "electron-log";
+const logger = log.scope("chat_handlers");
+import { createLoggedHandler } from "./safe_handle";
+const handle = createLoggedHandler(logger);
+
+export function registerTranscriptionHandlers() {
+  handle(
+    "chat:transcribe",
+    async (
+      event,
+      { audioData, format }: { audioData: string; format: string },
+    ) => {
+      try {
+        const settings = readSettings();
+
+        // Get OpenAI API Key
+        const apiKey = settings.providerSettings?.openai?.apiKey?.value;
+
+        if (!apiKey) {
+          throw new Error(
+            "OpenAI API Key not found. Please configure it in settings.",
+          );
+        }
+
+        const openai = new OpenAI({ apiKey });
+
+        // Create a temporary file for the audio
+        const tempDir = os.tmpdir();
+        const tempFilePath = path.join(
+          tempDir,
+          `recording-${Date.now()}.${format}`,
+        );
+
+        // Convert base64 to buffer
+        const buffer = Buffer.from(audioData, "base64");
+        fs.writeFileSync(tempFilePath, buffer);
+
+        try {
+          const transcription = await openai.audio.transcriptions.create({
+            file: fs.createReadStream(tempFilePath),
+            model: "whisper-1",
+          });
+
+          return transcription.text;
+        } finally {
+          // Clean up temp file
+          if (fs.existsSync(tempFilePath)) {
+            fs.unlinkSync(tempFilePath);
+          }
+        }
+      } catch (error) {
+        console.error("Transcription error:", error);
+        throw new Error(`Transcription failed: ${(error as Error).message}`);
+      }
+    },
+  );
+}

--- a/src/ipc/ipc_client.ts
+++ b/src/ipc/ipc_client.ts
@@ -1067,6 +1067,7 @@ export class IpcClient {
       })
       .catch((err) => {
         showError(err);
+        throw err;
       });
   }
   // --- End Audio Transcription ---

--- a/src/ipc/ipc_client.ts
+++ b/src/ipc/ipc_client.ts
@@ -1055,6 +1055,18 @@ export class IpcClient {
 
   // --- End GitHub Repo Management ---
 
+  // --- Audio Transcription ---
+  public async transcribeAudio(
+    audioData: string,
+    format: string,
+  ): Promise<string> {
+    return this.ipcRenderer.invoke("chat:transcribe", {
+      audioData,
+      format,
+    });
+  }
+  // --- End Audio Transcription ---
+
   // --- Vercel Token Management ---
   public async saveVercelAccessToken(
     params: SaveVercelAccessTokenParams,

--- a/src/ipc/ipc_client.ts
+++ b/src/ipc/ipc_client.ts
@@ -1060,10 +1060,14 @@ export class IpcClient {
     audioData: string,
     format: string,
   ): Promise<string> {
-    return this.ipcRenderer.invoke("chat:transcribe", {
-      audioData,
-      format,
-    });
+    return this.ipcRenderer
+      .invoke("chat:transcribe", {
+        audioData,
+        format,
+      })
+      .catch((err) => {
+        showError(err);
+      });
   }
   // --- End Audio Transcription ---
 

--- a/src/ipc/ipc_host.ts
+++ b/src/ipc/ipc_host.ts
@@ -36,6 +36,7 @@ import { registerMcpHandlers } from "./handlers/mcp_handlers";
 import { registerSecurityHandlers } from "./handlers/security_handlers";
 import { registerVisualEditingHandlers } from "../pro/main/ipc/handlers/visual_editing_handlers";
 import { registerAgentToolHandlers } from "../pro/main/ipc/handlers/local_agent/agent_tool_handlers";
+import { registerTranscriptionHandlers } from "./handlers/transcription_handlers";
 
 export function registerIpcHandlers() {
   // Register all IPC handlers by category
@@ -77,4 +78,5 @@ export function registerIpcHandlers() {
   registerSecurityHandlers();
   registerVisualEditingHandlers();
   registerAgentToolHandlers();
+  registerTranscriptionHandlers();
 }

--- a/src/ipc/utils/llm_engine_provider.ts
+++ b/src/ipc/utils/llm_engine_provider.ts
@@ -10,7 +10,6 @@ import log from "electron-log";
 import { getExtraProviderOptions } from "./thinking_utils";
 import type { UserSettings } from "../../lib/schemas";
 import type { LanguageModel } from "ai";
-import OpenAI from "openai";
 
 const logger = log.scope("llm_engine_provider");
 
@@ -228,24 +227,6 @@ export function createDyadEngine(
   return provider;
 }
 
-export function createDyadOpenAIClient(
-  options: ExampleProviderSettings,
-): OpenAI {
-  const baseURL = withoutTrailingSlash(options.baseURL);
-
-  const apiKey = loadApiKey({
-    apiKey: options.apiKey,
-    environmentVariableName: "DYAD_PRO_API_KEY",
-    description: "Dyad Pro API key",
-  });
-
-  return new OpenAI({
-    apiKey,
-    baseURL,
-    defaultHeaders: options.headers,
-    fetch: options.fetch,
-  });
-}
 export async function transcribeWithDyadEngine(
   audioBuffer: Buffer,
   filename: string,

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -162,6 +162,7 @@ const validInvokeChannels = [
   "prompts:create",
   "prompts:update",
   "prompts:delete",
+  "chat:transcribe",
   // adding app to favorite
   "add-to-favorite",
   "github:clone-repo-from-url",

--- a/testing/fake-llm-server/index.ts
+++ b/testing/fake-llm-server/index.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import { createServer } from "http";
 import cors from "cors";
+import multer from "multer";
 import { createChatCompletionHandler } from "./chatCompletionHandler";
 import { createResponsesHandler } from "./responsesHandler";
 import {
@@ -238,6 +239,13 @@ app.post("/engine/v1/tools/code-search", (req, res) => {
     console.error(`* code-search error:`, error);
     res.status(400).json({ error: String(error) });
   }
+});
+
+// Dyad Engine audio transcription endpoint (Whisper-style)
+const upload = multer();
+app.post("/engine/v1/audio/transcriptions", upload.any(), (req, res) => {
+  console.log("* audio/transcriptions: received request");
+  res.json({ text: "E2E transcribed text" });
 });
 
 // Start the server

--- a/testing/fake-llm-server/package-lock.json
+++ b/testing/fake-llm-server/package-lock.json
@@ -11,11 +11,13 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
+        "multer": "^2.0.2",
         "stream": "0.0.2"
       },
       "devDependencies": {
         "@types/cors": "^2.8.18",
         "@types/express": "^4.17.21",
+        "@types/multer": "^2.0.0",
         "@types/node": "^20.17.46",
         "git-http-mock-server": "^2.0.0",
         "ts-node": "^10.9.2",
@@ -132,11 +134,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/multer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.0.0.tgz",
+      "integrity": "sha512-C3Z9v9Evij2yST3RSBktxP9STm6OdMc5uR1xF1SGr98uv8dUlAL2hqwrZ3GVB3uyMyiegnscEK6PGtYvNrjTjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "20.17.46",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -238,6 +249,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
     },
     "node_modules/arg": {
       "version": "4.1.3",
@@ -355,6 +372,31 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/busboy/node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "license": "MIT",
@@ -425,6 +467,21 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -1041,7 +1098,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1057,9 +1113,39 @@
         "minimist": "^1.2.5"
       }
     },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "license": "MIT"
+    },
+    "node_modules/multer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.2.tgz",
+      "integrity": "sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "mkdirp": "^0.5.6",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.18",
+        "xtend": "^4.0.2"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      }
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -1191,6 +1277,20 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/safe-buffer": {
@@ -1417,6 +1517,15 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -1524,11 +1633,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.8.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1585,6 +1699,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "license": "MIT",
@@ -1617,6 +1737,15 @@
       "integrity": "sha512-2l5hmDymDUIuKT53v/nYxofTMUDQuu5P/Y3qHOjQiih6QUHBCgWpbpL3I8BoE5TVfUVTMmUQ0jdUAimTGc9UIg==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/yn": {
       "version": "3.1.1",

--- a/testing/fake-llm-server/package.json
+++ b/testing/fake-llm-server/package.json
@@ -15,11 +15,13 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
+    "multer": "^2.0.2",
     "stream": "0.0.2"
   },
   "devDependencies": {
     "@types/cors": "^2.8.18",
     "@types/express": "^4.17.21",
+    "@types/multer": "^2.0.0",
     "@types/node": "^20.17.46",
     "git-http-mock-server": "^2.0.0",
     "ts-node": "^10.9.2",


### PR DESCRIPTION
**Description**
This PR introduces an initial **voice-to-text (STT)** flow powered by OpenAI:

* Allows users to record/upload audio and get a transcribed text result.
* Currently **relies on the user providing their own OpenAI API key** (same pattern we use today).
* Marked as **work in progress**  final implementation will change.

**Next steps / Planned work**

* Implement a backend-driven approach similar to the existing chatbot (no need for individual user keys).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds voice-to-text input to Chat and Home chat. Transcription runs via Dyad Engine (Whisper-1), and the text is auto-inserted into the message; requires Dyad Pro enabled.

- **New Features**
  - Mic button with recording/transcribing states and a live waveform.
  - Integrated in ChatInput and HomeChatInput; waveform while recording, text appended on stop.
  - New hooks (useAudioRecorder, useVoiceInput) for capture, visualization, and IPC transcription.
  - IPC route chat:transcribe with a main-process handler calling Dyad Engine; Pro-gated with tooltip when unavailable.

- **Migration**
  - Add your Dyad Pro API key in Settings → Providers → Dyad Pro.
  - Enable Dyad Pro in Settings to use voice input.

<sup>Written for commit a8fdd11dd6610663cd290985bef8ee42af7bb753. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces voice-to-text input gated by Dyad Pro with recording, visualization, and backend transcription.
> 
> - New `VoiceInputButton` (record/stop/transcribing states) and `VoiceWaveform` visualization; integrated into `ChatInput` and `HomeChatInput` to append transcript into `LexicalChatInput`
> - Hooks: `useAudioRecorder` (MediaRecorder + analyser) and `useVoiceInput` (IPC transcription + appendText)
> - IPC: adds `chat:transcribe` to renderer (`IpcClient.transcribeAudio`), preload allowlist, and main handler `registerTranscriptionHandlers` calling `transcribeWithDyadEngine`
> - Dyad Engine util: `transcribeWithDyadEngine` posts multipart to `/audio/transcriptions` (Whisper-compatible)
> - E2E: `voice_transcription.spec.ts` validates record → waveform → transcribe → input append and Pro-only disabled state
> - Test server: adds `/engine/v1/audio/transcriptions` endpoint and `multer` dependency
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8fdd11dd6610663cd290985bef8ee42af7bb753. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->