### PR TITLE
Add DeepSeek v3.2

### DIFF
--- a/src/ipc/shared/language_model_constants.ts
+++ b/src/ipc/shared/language_model_constants.ts
@@ -263,6 +263,15 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
       dollarSigns: 0,
     },
     {
+      name: "deepseek/deepseek-v3.2",
+      displayName: "DeepSeek v3.2",
+      description: "DeepSeek's latest model",
+      maxOutputTokens: 32_000,
+      contextWindow: 128_000,
+      temperature: 1,
+      dollarSigns: 2,
+    },
+    {
       name: "z-ai/glm-4.6",
       displayName: "GLM 4.6",
       description: "Z-AI's best coding model",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 42cf267c18561da515a7b74c477a61523a311360. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added DeepSeek v3.2 to the model catalog, enabling selection of DeepSeek’s latest model with a 128k context window and up to 32k output tokens.

<sup>Written for commit 42cf267c18561da515a7b74c477a61523a311360. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

