### PR TITLE
Fix Dyad Pro error messaging

### DIFF
--- a/src/components/chat/ChatErrorBox.tsx
+++ b/src/components/chat/ChatErrorBox.tsx
@@ -36,10 +36,15 @@ export function ChatErrorBox({
 
   // Important, this needs to come after the "free quota tier" check
   // because it also includes this URL in the error message
+  //
+  // Sometimes Dyad Pro can return rate limit errors and we do not want to
+  // show the upgrade to Dyad Pro link in that case because they are
+  // already on the Dyad Pro plan.
   if (
-    error.includes("Resource has been exhausted") ||
-    error.includes("https://ai.google.dev/gemini-api/docs/rate-limits") ||
-    error.includes("Provider returned error")
+    !isDyadProEnabled &&
+    (error.includes("Resource has been exhausted") ||
+      error.includes("https://ai.google.dev/gemini-api/docs/rate-limits") ||
+      error.includes("Provider returned error"))
   ) {
     return (
       <ChatErrorContainer onDismiss={onDismiss}>
@@ -93,8 +98,13 @@ export function ChatErrorBox({
     );
   }
   // This is a very long list of model fallbacks that clutters the error message.
-  if (error.includes("Fallbacks=")) {
-    error = error.split("Fallbacks=")[0];
+  //
+  // We are matching "Fallbacks=[{" and not just "Fallbacks=" because the fallback
+  // model itself can error and we want to include the fallback model error in the error message.
+  // Example: https://github.com/dyad-sh/dyad/issues/1849#issuecomment-3590685911
+  const fallbackPrefix = "Fallbacks=[{";
+  if (error.includes(fallbackPrefix)) {
+    error = error.split(fallbackPrefix)[0];
   }
   return (
     <ChatErrorContainer onDismiss={onDismiss}>


### PR DESCRIPTION
Addresses issue in https://github.com/dyad-sh/dyad/issues/1849

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Pro users seeing an “Upgrade to Dyad Pro” prompt on provider rate-limit errors and cleans up noisy fallback details in error messages. Pro users now get the correct message, and errors are shorter and clearer.

- **Bug Fixes**
  - Show the upgrade link only when not on Pro for rate-limit errors (Gemini and generic provider errors).
  - Trim verbose fallback lists by splitting on "Fallbacks=[{" to keep the fallback model’s error while removing the rest.

<sup>Written for commit e0f69dcda4b4aa0f1be2af3b1af163d84e995fe7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Avoids Pro upsell for Pro users on rate-limit errors and trims fallback details more precisely in error messages.
> 
> - **Chat error handling (`src/components/chat/ChatErrorBox.tsx`)**:
>   - **Rate-limit messaging**: Show Dyad Pro upgrade link only when `!isDyadProEnabled` (prevents upsell for existing Pro users).
>   - **Fallback error trimming**: Truncate error text at `"Fallbacks=[{"` instead of `"Fallbacks="` to retain fallback model error context.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0f69dcda4b4aa0f1be2af3b1af163d84e995fe7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->