### PR TITLE
Pin capacitor to v7.4.4

### DIFF
--- a/src/ipc/handlers/app_upgrade_handlers.ts
+++ b/src/ipc/handlers/app_upgrade_handlers.ts
@@ -205,7 +205,7 @@ async function applyCapacitor({
   // Install Capacitor dependencies
   await simpleSpawn({
     command:
-      "pnpm add @capacitor/core @capacitor/cli @capacitor/ios @capacitor/android || npm install @capacitor/core @capacitor/cli @capacitor/ios @capacitor/android --legacy-peer-deps",
+      "pnpm add @capacitor/core@7.4.4 @capacitor/cli@7.4.4 @capacitor/ios@7.4.4 @capacitor/android@7.4.4 || npm install @capacitor/core@7.4.4 @capacitor/cli@7.4.4 @capacitor/ios@7.4.4 @capacitor/android@7.4.4 --legacy-peer-deps",
     cwd: appPath,
     successMessage: "Capacitor dependencies installed successfully",
     errorPrefix: "Failed to install Capacitor dependencies",


### PR DESCRIPTION
besides making our capacitor e2e test more deterministic, it also prevents silent upgrades given the various npm ecosystem compromises in the past.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pin Capacitor dependencies to version 7.4.4 in the app upgrade installer.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b54a82dc061b6595160d5c09a23a4c6bdd1cbeb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins @capacitor/core, @capacitor/cli, @capacitor/ios, and @capacitor/android to v7.4.4 in the app upgrade installer to ensure consistent installs and prevent silent upgrades. This stabilizes our Capacitor E2E tests and reduces supply chain risk from unexpected dependency changes.

<sup>Written for commit 6b54a82dc061b6595160d5c09a23a4c6bdd1cbeb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

