### PR TITLE
Bump to 0.29 stable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
             { name: "windows", image: "windows-latest" },
             # See https://github.com/dyad-sh/dyad/issues/96
             { name: "linux", image: "ubuntu-22.04" },
-            { name: "macos-intel", image: "macos-13" },
+            { name: "macos-intel", image: "macos-15-intel" },
             { name: "macos", image: "macos-latest" },
           ]
     runs-on: ${{ matrix.os.image }}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dyad",
   "productName": "dyad",
-  "version": "0.29.0-beta.1",
+  "version": "0.29.0",
   "description": "Free, local, open-source AI app builder",
   "main": ".vite/build/main.js",
   "repository": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Promotes to 0.29.0 stable and updates the CI macOS-Intel runner to macos-15-intel.
> 
> - **Release**:
>   - Bump `package.json` version from `0.29.0-beta.1` to `0.29.0`.
> - **CI/CD**:
>   - Update `macos-intel` matrix image in `.github/workflows/release.yml` from `macos-13` to `macos-15-intel`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1711153caa716f3a95bc396b86bde670fb1da946. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes Dyad to the 0.29.0 stable release by updating package.json from 0.29.0-beta.1 to 0.29.0. Also updates the release workflow to use macos-15-intel for the macOS Intel runner.

<sup>Written for commit 1711153caa716f3a95bc396b86bde670fb1da946. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



