### PR TITLE
Update macos-intel to use macos-15

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
             { name: "windows", image: "windows-latest" },
             # See https://github.com/dyad-sh/dyad/issues/96
             { name: "linux", image: "ubuntu-22.04" },
-            { name: "macos-intel", image: "macos-13" },
+            { name: "macos-intel", image: "macos-15-intel" },
             { name: "macos", image: "macos-latest" },
           ]
     runs-on: ${{ matrix.os.image }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates the release workflow matrix to use the `macos-15-intel` runner for `macos-intel` builds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37416cf576675ea399dd84cf1e50a2511b768de8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the macos-intel release job to the macos-15-intel GitHub Actions runner. This updates CI to the macOS 15 Intel image and keeps our matrix consistent with current supported runners.

<sup>Written for commit 37416cf576675ea399dd84cf1e50a2511b768de8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

