### PR TITLE
Add GPT 5.2 and remove older OpenAI models

### DIFF
--- a/src/ipc/shared/language_model_constants.ts
+++ b/src/ipc/shared/language_model_constants.ts
@@ -22,6 +22,18 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
   openai: [
     // https://platform.openai.com/docs/models/gpt-5.1
     {
+      name: "gpt-5.2",
+      displayName: "GPT 5.2",
+      description: "OpenAI's latest model",
+      // Technically it's 128k but OpenAI errors if you set max_tokens instead of max_completion_tokens
+      maxOutputTokens: undefined,
+      contextWindow: 400_000,
+      // Requires temperature to be default value (1)
+      temperature: 1,
+      dollarSigns: 3,
+    },
+    // https://platform.openai.com/docs/models/gpt-5.1
+    {
       name: "gpt-5.1",
       displayName: "GPT 5.1",
       description:
@@ -92,31 +104,6 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
       contextWindow: 400_000,
       // Requires temperature to be default value (1)
       temperature: 1,
-      dollarSigns: 2,
-    },
-    // https://platform.openai.com/docs/models/gpt-5-nano
-    {
-      name: "gpt-5-nano",
-      displayName: "GPT 5 Nano",
-      description: "Fastest, most cost-efficient version of GPT-5",
-      // Technically it's 128k but OpenAI errors if you set max_tokens instead of max_completion_tokens
-      maxOutputTokens: undefined,
-      contextWindow: 400_000,
-      // Requires temperature to be default value (1)
-      temperature: 1,
-      dollarSigns: 1,
-    },
-    // https://platform.openai.com/docs/models/o4-mini
-    {
-      name: "o4-mini",
-      displayName: "o4 mini",
-      description: "Reasoning model",
-      // Technically the max output tokens is 100k, *however* if the user has a lot of input tokens,
-      // then setting a high max output token will cause the request to fail because
-      // the max output tokens is *included* in the context window limit.
-      maxOutputTokens: 32_000,
-      contextWindow: 200_000,
-      temperature: 0,
       dollarSigns: 2,
     },
   ],


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added GPT 5.2 to the OpenAI model options and removed older models to keep the list current and reduce API issues.

- **New Features**
  - Added GPT 5.2 with a 400k context window, maxOutputTokens unset, temperature fixed at 1, and cost indicator set to $$$.

- **Refactors**
  - Removed gpt-5-nano and o4-mini from available OpenAI models.

<sup>Written for commit 182da655a2702ddc5adbbca6279ae3931cc837ab. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

