### PR TITLE
Slim binary: remove sourcemaps and extra Monaco resources

### DIFF
--- a/src/components/chat/monaco.ts
+++ b/src/components/chat/monaco.ts
@@ -1,8 +1,35 @@
-import { editor } from "monaco-editor";
-
 import { loader } from "@monaco-editor/react";
 
-import * as monaco from "monaco-editor";
+// Use the core editor API (no languages bundled by default)
+import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
+
+// Language services (IntelliSense, validation, etc.)
+import "monaco-editor/esm/vs/language/typescript/monaco.contribution";
+import "monaco-editor/esm/vs/language/json/monaco.contribution";
+import "monaco-editor/esm/vs/language/css/monaco.contribution";
+import "monaco-editor/esm/vs/language/html/monaco.contribution";
+
+// Basic language tokenizers (syntax highlighting)
+import "monaco-editor/esm/vs/basic-languages/typescript/typescript.contribution";
+import "monaco-editor/esm/vs/basic-languages/javascript/javascript.contribution";
+import "monaco-editor/esm/vs/basic-languages/css/css.contribution";
+import "monaco-editor/esm/vs/basic-languages/less/less.contribution";
+import "monaco-editor/esm/vs/basic-languages/scss/scss.contribution";
+import "monaco-editor/esm/vs/basic-languages/html/html.contribution";
+import "monaco-editor/esm/vs/basic-languages/markdown/markdown.contribution";
+import "monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution";
+import "monaco-editor/esm/vs/basic-languages/shell/shell.contribution";
+import "monaco-editor/esm/vs/basic-languages/python/python.contribution";
+import "monaco-editor/esm/vs/basic-languages/sql/sql.contribution";
+import "monaco-editor/esm/vs/basic-languages/xml/xml.contribution";
+import "monaco-editor/esm/vs/basic-languages/java/java.contribution";
+import "monaco-editor/esm/vs/basic-languages/kotlin/kotlin.contribution";
+import "monaco-editor/esm/vs/basic-languages/swift/swift.contribution";
+import "monaco-editor/esm/vs/basic-languages/dockerfile/dockerfile.contribution";
+import "monaco-editor/esm/vs/basic-languages/ruby/ruby.contribution";
+import "monaco-editor/esm/vs/basic-languages/php/php.contribution";
+
+const { editor } = monaco;
 // @ts-ignore
 import editorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
 // @ts-ignore
@@ -35,7 +62,7 @@ self.MonacoEnvironment = {
 loader.config({ monaco });
 
 // loader.init().then(/* ... */);
-export const customLight: editor.IStandaloneThemeData = {
+export const customLight: monaco.editor.IStandaloneThemeData = {
   base: "vs",
   inherit: false,
   rules: [
@@ -108,7 +135,7 @@ export const customLight: editor.IStandaloneThemeData = {
 
 editor.defineTheme("dyad-light", customLight);
 
-export const customDark: editor.IStandaloneThemeData = {
+export const customDark: monaco.editor.IStandaloneThemeData = {
   base: "vs-dark",
   inherit: false,
   rules: [

--- a/vite.main.config.mts
+++ b/vite.main.config.mts
@@ -11,9 +11,6 @@ export default defineConfig({
   build: {
     rollupOptions: {
       external: ["better-sqlite3"],
-      output: {
-        sourcemap: true,
-      },
     },
   },
   plugins: [

--- a/vite.renderer.config.mts
+++ b/vite.renderer.config.mts
@@ -1,11 +1,34 @@
 import path from "path";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
+import { defineConfig, Plugin } from "vite";
+
+/**
+ * Custom plugin to prevent the full Monaco editor bundle from being included.
+ * Redirects bare "monaco-editor" imports to the slim ESM entry point.
+ * Language contributions are explicitly imported in src/components/chat/monaco.ts
+ */
+function monacoEsmPlugin(): Plugin {
+  return {
+    name: "vite-plugin-monaco-esm",
+    enforce: "pre",
+    resolveId(source, importer) {
+      // Intercept bare "monaco-editor" imports and redirect to slim ESM API
+      if (source === "monaco-editor") {
+        return this.resolve(
+          "monaco-editor/esm/vs/editor/editor.api",
+          importer,
+          { skipSelf: true },
+        );
+      }
+      return null;
+    },
+  };
+}
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [monacoEsmPlugin(), react(), tailwindcss()],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Slims the app by using Monaco’s ESM core with explicit language contributions and a Vite plugin to avoid bundling the full editor, and removes sourcemaps in the main build.
> 
> - **Editor (Monaco)**:
>   - Switch to `monaco-editor/esm/vs/editor/editor.api` and explicitly import language services (`typescript/json/css/html`) and basic tokenizers for common languages.
>   - Update theme typings to `monaco.editor.IStandaloneThemeData`; keep worker setup and `loader.config({ monaco })`.
> - **Build/Config**:
>   - Add custom Vite plugin to redirect `monaco-editor` to the ESM API in the renderer.
>   - Remove Rollup sourcemap output from `vite.main.config.mts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db664e68551c8e36a0d3765a44b431d4c476dfe6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Slims the app binary by removing sourcemaps and trimming Monaco to the ESM core with selected language contributions. This reduces bundle size and speeds up startup while keeping IntelliSense for TS/JSON/CSS/HTML and syntax highlighting for common languages.

- **Refactors**
  - Switched to monaco-editor ESM core (editor.api), enforced via a Vite plugin that redirects bare "monaco-editor" imports, and imported only needed language services (TS/JSON/CSS/HTML) plus basic tokenizers.
  - Updated theme types to monaco.editor.IStandaloneThemeData and kept editor/ts/json/css/html workers.
  - Removed Rollup sourcemap output in vite.main.config.mts to cut build artifacts.

<sup>Written for commit db664e68551c8e36a0d3765a44b431d4c476dfe6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



