### PR TITLE
disable sourcemap

### DIFF
--- a/vite.main.config.mts
+++ b/vite.main.config.mts
@@ -11,9 +11,6 @@ export default defineConfig({
   build: {
     rollupOptions: {
       external: ["better-sqlite3"],
-      output: {
-        sourcemap: true,
-      },
     },
   },
   plugins: [


### PR DESCRIPTION
The sourcemap is almost 20mb (and we still don't get proper stacktraces for errors in the main/node.js thread)

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 267749b95f6416b3f88c8caa9a72e21438fc1ee8. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->