### PR TITLE
feat: add bulk mode

### DIFF
--- a/src/components/AppList.tsx
+++ b/src/components/AppList.tsx
@@ -221,13 +221,19 @@ export function AppList({ show }: { show?: boolean }) {
                   const results = await Promise.allSettled(
                     ids.map((id) => ipc.deleteApp(id)),
                   );
-                  const failed = results.filter((r) => r.status === "rejected");
-                  if (failed.length > 0) {
-                    showError(`some `);
+                  const failedIds = results.flatMap((r, i) =>
+                    r.status === "rejected" ? [ids[i]] : [],
+                  );
+                  if (failedIds.length > 0) {
+                    showError(
+                      `Failed to delete ${failedIds.length} of ${ids.length} app(s).`,
+                    );
+                    setSelectedIds(new Set(failedIds));
+                  } else {
+                    setSelectedIds(new Set());
+                    showSuccess(`Deleted ${ids.length} app(s).`);
                   }
-                  setSelectedIds(new Set());
                   setIsBulkConfirmDialogOpen(false);
-                  showSuccess("success");
                 } catch (e) {
                   showError(e);
                 } finally {

--- a/src/components/appItem.tsx
+++ b/src/components/appItem.tsx
@@ -3,6 +3,7 @@ import { Star } from "lucide-react";
 import { SidebarMenuItem } from "@/components/ui/sidebar";
 import { Button } from "@/components/ui/button";
 import { App } from "@/ipc/ipc_types";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Tooltip,
   TooltipContent,
@@ -16,6 +17,9 @@ type AppItemProps = {
   selectedAppId: number | null;
   handleToggleFavorite: (appId: number, e: React.MouseEvent) => void;
   isFavoriteLoading: boolean;
+  bulkMode?: boolean;
+  checked?: boolean;
+  onToggleSelect?: (id: number) => void;
 };
 
 export function AppItem({
@@ -24,6 +28,9 @@ export function AppItem({
   selectedAppId,
   handleToggleFavorite,
   isFavoriteLoading,
+  bulkMode = false,
+  checked = false,
+  onToggleSelect,
 }: AppItemProps) {
   return (
     <SidebarMenuItem className="mb-1 relative ">
@@ -31,6 +38,13 @@ export function AppItem({
         <Tooltip>
           <TooltipTrigger asChild>
             <div className="flex w-[190px] items-center">
+              {bulkMode && (
+                <Checkbox
+                  checked={!!checked}
+                  onCheckedChange={() => onToggleSelect?.(app.id)}
+                  className="mr-2"
+                />
+              )}
               <Button
                 variant="ghost"
                 onClick={() => handleAppClick(app.id)}


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add bulk mode to the app list so users can select multiple apps and delete them at once with a confirmation dialog. This makes app management faster and reduces accidental deletes.

- **New Features**
  - Toggle Bulk Mode from the sidebar; select apps via checkboxes or item clicks.
  - Show a Bulk Delete button with a confirm dialog that warns deletion is irreversible.
  - Delete selected apps in parallel via IPC, show progress, and surface success/error toasts.
  - Update AppItem to render a checkbox and support selection in bulk mode.

<sup>Written for commit 337f1e6c62ff1027423ca60f8f7ef2e016e80468. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<img width="2560" height="1400" alt="image" src="https://github.com/user-attachments/assets/ec42fe7c-e9b9-45e9-9eec-af1ebb5cb804" />

<img width="2560" height="1400" alt="image" src="https://github.com/user-attachments/assets/bd2d12ce-3a97-4462-929b-5d2779525e3d" />


