### PR TITLE
Use user info proxy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12898,37 +12898,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/html-dom-parser": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.1.1.tgz",
-      "integrity": "sha512-+o4Y4Z0CLuyemeccvGN4bAO20aauB2N9tFEAep5x4OW34kV4PTarBHm6RL02afYt2BMKcr0D2Agep8S3nJPIBg==",
-      "license": "MIT",
-      "dependencies": {
-        "domhandler": "5.0.3",
-        "htmlparser2": "10.0.0"
-      }
-    },
-    "node_modules/html-react-parser": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-5.2.6.tgz",
-      "integrity": "sha512-qcpPWLaSvqXi+TndiHbCa+z8qt0tVzjMwFGFBAa41ggC+ZA5BHaMIeMJla9g3VSp4SmiZb9qyQbmbpHYpIfPOg==",
-      "license": "MIT",
-      "dependencies": {
-        "domhandler": "5.0.3",
-        "html-dom-parser": "5.1.1",
-        "react-property": "2.0.2",
-        "style-to-js": "1.1.17"
-      },
-      "peerDependencies": {
-        "@types/react": "0.14 || 15 || 16 || 17 || 18 || 19",
-        "react": "0.14 || 15 || 16 || 17 || 18 || 19"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/html-to-image": {
       "version": "1.11.13",
       "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
@@ -17951,12 +17920,6 @@
         "@types/react": ">=18",
         "react": ">=18"
       }
-    },
-    "node_modules/react-property": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.2.tgz",
-      "integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==",
-      "license": "MIT"
     },
     "node_modules/react-reconciler": {
       "version": "0.33.0",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches budget fetch to `https://api.dyad.sh/v1/user/info` and validates/consumes `usedCredits`, `totalCredits`, and `budgetResetDate` directly via Zod.
> 
> - **IPC/Pro handlers (`src/ipc/handlers/pro_handlers.ts`)**:
>   - **Endpoint**: Update user info URL to `https://api.dyad.sh/v1/user/info`.
>   - **Validation**: Add `zod` schema `UserInfoResponseSchema` to validate API response.
>   - **Data mapping**: Use `usedCredits`, `totalCredits`, `budgetResetDate`, and `userId` from response directly; remove conversion logic and old nested `user_info` parsing.
>   - **Redaction**: Compute `redactedUserId` from `userId` and return parsed `UserBudgetInfo`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da1f192c2cabb2154bd10b69555c27d62fbb6368. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched user budget fetch to the new user info proxy and added schema validation. Uses API-provided credits directly and removes the old conversion logic.

- **Refactors**
  - Use https://api.dyad.sh/v1/user/info instead of llm-gateway.
  - Validate response with a Zod schema (usedCredits, totalCredits, budgetResetDate, userId).
  - Map fields directly to UserBudgetInfo and remove CONVERSION_RATIO.
  - Keep redacted user ID format (****1234).

- **Dependencies**
  - Removed unused html-dom-parser, html-react-parser, and react-property from the lockfile.

<sup>Written for commit da1f192c2cabb2154bd10b69555c27d62fbb6368. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

