### PR TITLE
Support shared modules for supabase edge functions

### DIFF
--- a/src/__tests__/supabase_utils.test.ts
+++ b/src/__tests__/supabase_utils.test.ts
@@ -6,7 +6,6 @@ import {
 } from "@/supabase_admin/supabase_utils";
 import {
   toPosixPath,
-  findFunctionDirectory,
   stripSupabaseFunctionsPrefix,
   buildSignature,
   type FileStatEntry,
@@ -193,66 +192,6 @@ describe("toPosixPath", () => {
   // This test is for documentation - actual behavior depends on platform
   it("should handle path with no separators", () => {
     expect(toPosixPath("filename")).toBe("filename");
-  });
-});
-
-describe("findFunctionDirectory", () => {
-  describe("finds function directory from file paths", () => {
-    it("should find directory from index.ts path", () => {
-      const result = findFunctionDirectory(
-        "/app/supabase/functions/hello/index.ts",
-        "hello",
-      );
-      expect(result).toBe("/app/supabase/functions/hello");
-    });
-
-    it("should find directory from nested file path", () => {
-      const result = findFunctionDirectory(
-        "/app/supabase/functions/hello/lib/utils.ts",
-        "hello",
-      );
-      expect(result).toBe("/app/supabase/functions/hello");
-    });
-
-    it("should find directory from deeply nested path", () => {
-      const result = findFunctionDirectory(
-        "/app/supabase/functions/hello/src/helpers/format.ts",
-        "hello",
-      );
-      expect(result).toBe("/app/supabase/functions/hello");
-    });
-  });
-
-  describe("returns null for invalid paths", () => {
-    it("should return null when function name doesn't match", () => {
-      const result = findFunctionDirectory(
-        "/app/supabase/functions/hello/index.ts",
-        "world",
-      );
-      expect(result).toBe(null);
-    });
-
-    it("should return null for non-functions path", () => {
-      const result = findFunctionDirectory("/app/src/utils.ts", "hello");
-      expect(result).toBe(null);
-    });
-
-    it("should return null for _shared paths", () => {
-      const result = findFunctionDirectory(
-        "/app/supabase/functions/_shared/utils.ts",
-        "_shared",
-      );
-      // _shared doesn't match the pattern /supabase/functions/functionName
-      expect(result).toBe("/app/supabase/functions/_shared");
-    });
-
-    it("should return null for paths outside supabase", () => {
-      const result = findFunctionDirectory(
-        "/app/node_modules/something/index.ts",
-        "hello",
-      );
-      expect(result).toBe(null);
-    });
   });
 });
 

--- a/src/__tests__/supabase_utils.test.ts
+++ b/src/__tests__/supabase_utils.test.ts
@@ -1,0 +1,328 @@
+import { describe, it, expect } from "vitest";
+import {
+  isServerFunction,
+  isSharedServerModule,
+} from "@/supabase_admin/supabase_utils";
+import {
+  toPosixPath,
+  findFunctionDirectory,
+  stripSupabaseFunctionsPrefix,
+  buildSignature,
+  type FileStatEntry,
+} from "@/supabase_admin/supabase_management_client";
+
+describe("isServerFunction", () => {
+  describe("returns true for valid function paths", () => {
+    it("should return true for function index.ts", () => {
+      expect(isServerFunction("supabase/functions/hello/index.ts")).toBe(true);
+    });
+
+    it("should return true for nested function files", () => {
+      expect(isServerFunction("supabase/functions/hello/lib/utils.ts")).toBe(
+        true,
+      );
+    });
+
+    it("should return true for function with complex name", () => {
+      expect(isServerFunction("supabase/functions/send-email/index.ts")).toBe(
+        true,
+      );
+    });
+  });
+
+  describe("returns false for non-function paths", () => {
+    it("should return false for shared modules", () => {
+      expect(isServerFunction("supabase/functions/_shared/utils.ts")).toBe(
+        false,
+      );
+    });
+
+    it("should return false for regular source files", () => {
+      expect(isServerFunction("src/components/Button.tsx")).toBe(false);
+    });
+
+    it("should return false for root supabase files", () => {
+      expect(isServerFunction("supabase/config.toml")).toBe(false);
+    });
+
+    it("should return false for non-supabase paths", () => {
+      expect(isServerFunction("package.json")).toBe(false);
+    });
+  });
+});
+
+describe("isSharedServerModule", () => {
+  describe("returns true for _shared paths", () => {
+    it("should return true for files in _shared", () => {
+      expect(isSharedServerModule("supabase/functions/_shared/utils.ts")).toBe(
+        true,
+      );
+    });
+
+    it("should return true for nested _shared files", () => {
+      expect(
+        isSharedServerModule("supabase/functions/_shared/lib/helpers.ts"),
+      ).toBe(true);
+    });
+
+    it("should return true for _shared directory itself", () => {
+      expect(isSharedServerModule("supabase/functions/_shared/")).toBe(true);
+    });
+  });
+
+  describe("returns false for non-_shared paths", () => {
+    it("should return false for regular functions", () => {
+      expect(isSharedServerModule("supabase/functions/hello/index.ts")).toBe(
+        false,
+      );
+    });
+
+    it("should return false for similar but different paths", () => {
+      expect(isSharedServerModule("supabase/functions/shared/utils.ts")).toBe(
+        false,
+      );
+    });
+
+    it("should return false for _shared in wrong location", () => {
+      expect(isSharedServerModule("src/_shared/utils.ts")).toBe(false);
+    });
+  });
+});
+
+describe("toPosixPath", () => {
+  it("should keep forward slashes unchanged", () => {
+    expect(toPosixPath("supabase/functions/hello/index.ts")).toBe(
+      "supabase/functions/hello/index.ts",
+    );
+  });
+
+  it("should handle empty string", () => {
+    expect(toPosixPath("")).toBe("");
+  });
+
+  it("should handle single filename", () => {
+    expect(toPosixPath("index.ts")).toBe("index.ts");
+  });
+
+  // Note: On Unix, path.sep is "/", so backslashes won't be converted
+  // This test is for documentation - actual behavior depends on platform
+  it("should handle path with no separators", () => {
+    expect(toPosixPath("filename")).toBe("filename");
+  });
+});
+
+describe("findFunctionDirectory", () => {
+  describe("finds function directory from file paths", () => {
+    it("should find directory from index.ts path", () => {
+      const result = findFunctionDirectory(
+        "/app/supabase/functions/hello/index.ts",
+        "hello",
+      );
+      expect(result).toBe("/app/supabase/functions/hello");
+    });
+
+    it("should find directory from nested file path", () => {
+      const result = findFunctionDirectory(
+        "/app/supabase/functions/hello/lib/utils.ts",
+        "hello",
+      );
+      expect(result).toBe("/app/supabase/functions/hello");
+    });
+
+    it("should find directory from deeply nested path", () => {
+      const result = findFunctionDirectory(
+        "/app/supabase/functions/hello/src/helpers/format.ts",
+        "hello",
+      );
+      expect(result).toBe("/app/supabase/functions/hello");
+    });
+  });
+
+  describe("returns null for invalid paths", () => {
+    it("should return null when function name doesn't match", () => {
+      const result = findFunctionDirectory(
+        "/app/supabase/functions/hello/index.ts",
+        "world",
+      );
+      expect(result).toBe(null);
+    });
+
+    it("should return null for non-functions path", () => {
+      const result = findFunctionDirectory("/app/src/utils.ts", "hello");
+      expect(result).toBe(null);
+    });
+
+    it("should return null for _shared paths", () => {
+      const result = findFunctionDirectory(
+        "/app/supabase/functions/_shared/utils.ts",
+        "_shared",
+      );
+      // _shared doesn't match the pattern /supabase/functions/functionName
+      expect(result).toBe("/app/supabase/functions/_shared");
+    });
+
+    it("should return null for paths outside supabase", () => {
+      const result = findFunctionDirectory(
+        "/app/node_modules/something/index.ts",
+        "hello",
+      );
+      expect(result).toBe(null);
+    });
+  });
+});
+
+describe("stripSupabaseFunctionsPrefix", () => {
+  describe("strips prefix correctly", () => {
+    it("should strip full prefix from index.ts", () => {
+      expect(
+        stripSupabaseFunctionsPrefix(
+          "supabase/functions/hello/index.ts",
+          "hello",
+        ),
+      ).toBe("index.ts");
+    });
+
+    it("should strip prefix from nested file", () => {
+      expect(
+        stripSupabaseFunctionsPrefix(
+          "supabase/functions/hello/lib/utils.ts",
+          "hello",
+        ),
+      ).toBe("lib/utils.ts");
+    });
+
+    it("should handle leading slash", () => {
+      expect(
+        stripSupabaseFunctionsPrefix(
+          "/supabase/functions/hello/index.ts",
+          "hello",
+        ),
+      ).toBe("index.ts");
+    });
+  });
+
+  describe("handles edge cases", () => {
+    it("should return filename when no prefix match", () => {
+      const result = stripSupabaseFunctionsPrefix("just-a-file.ts", "hello");
+      expect(result).toBe("just-a-file.ts");
+    });
+
+    it("should handle paths without function name", () => {
+      const result = stripSupabaseFunctionsPrefix(
+        "supabase/functions/other/index.ts",
+        "hello",
+      );
+      // Should strip base prefix and return the rest
+      expect(result).toBe("other/index.ts");
+    });
+
+    it("should handle empty relative path after prefix", () => {
+      // When the path is exactly the function directory
+      const result = stripSupabaseFunctionsPrefix(
+        "supabase/functions/hello",
+        "hello",
+      );
+      expect(result).toBe("hello");
+    });
+  });
+});
+
+describe("buildSignature", () => {
+  it("should build signature from single entry", () => {
+    const entries: FileStatEntry[] = [
+      {
+        absolutePath: "/app/file.ts",
+        relativePath: "file.ts",
+        mtimeMs: 1000,
+        size: 100,
+      },
+    ];
+    const result = buildSignature(entries);
+    expect(result).toBe("file.ts:3e8:64");
+  });
+
+  it("should build signature from multiple entries sorted by relativePath", () => {
+    const entries: FileStatEntry[] = [
+      {
+        absolutePath: "/app/b.ts",
+        relativePath: "b.ts",
+        mtimeMs: 2000,
+        size: 200,
+      },
+      {
+        absolutePath: "/app/a.ts",
+        relativePath: "a.ts",
+        mtimeMs: 1000,
+        size: 100,
+      },
+    ];
+    const result = buildSignature(entries);
+    // Should be sorted by relativePath
+    expect(result).toBe("a.ts:3e8:64|b.ts:7d0:c8");
+  });
+
+  it("should return empty string for empty array", () => {
+    const result = buildSignature([]);
+    expect(result).toBe("");
+  });
+
+  it("should produce different signatures for different mtimes", () => {
+    const entries1: FileStatEntry[] = [
+      {
+        absolutePath: "/app/file.ts",
+        relativePath: "file.ts",
+        mtimeMs: 1000,
+        size: 100,
+      },
+    ];
+    const entries2: FileStatEntry[] = [
+      {
+        absolutePath: "/app/file.ts",
+        relativePath: "file.ts",
+        mtimeMs: 2000,
+        size: 100,
+      },
+    ];
+    expect(buildSignature(entries1)).not.toBe(buildSignature(entries2));
+  });
+
+  it("should produce different signatures for different sizes", () => {
+    const entries1: FileStatEntry[] = [
+      {
+        absolutePath: "/app/file.ts",
+        relativePath: "file.ts",
+        mtimeMs: 1000,
+        size: 100,
+      },
+    ];
+    const entries2: FileStatEntry[] = [
+      {
+        absolutePath: "/app/file.ts",
+        relativePath: "file.ts",
+        mtimeMs: 1000,
+        size: 200,
+      },
+    ];
+    expect(buildSignature(entries1)).not.toBe(buildSignature(entries2));
+  });
+
+  it("should include path in signature for cache invalidation", () => {
+    const entries1: FileStatEntry[] = [
+      {
+        absolutePath: "/app/a.ts",
+        relativePath: "a.ts",
+        mtimeMs: 1000,
+        size: 100,
+      },
+    ];
+    const entries2: FileStatEntry[] = [
+      {
+        absolutePath: "/app/b.ts",
+        relativePath: "b.ts",
+        mtimeMs: 1000,
+        size: 100,
+      },
+    ];
+    expect(buildSignature(entries1)).not.toBe(buildSignature(entries2));
+  });
+});

--- a/src/ipc/handlers/app_handlers.ts
+++ b/src/ipc/handlers/app_handlers.ts
@@ -35,7 +35,7 @@ import killPort from "kill-port";
 import util from "util";
 import log from "electron-log";
 import {
-  deploySupabaseFunctions,
+  deploySupabaseFunction,
   getSupabaseProjectName,
 } from "../../supabase_admin/supabase_management_client";
 import { createLoggedHandler } from "./safe_handle";
@@ -1002,6 +1002,8 @@ export function registerAppHandlers() {
         content,
       }: { appId: number; filePath: string; content: string },
     ): Promise<EditAppFileReturnType> => {
+      // It should already be normalized, but just in case.
+      filePath = normalizePath(filePath);
       const app = await db.query.apps.findFirst({
         where: eq(apps.id, appId),
       });
@@ -1085,7 +1087,7 @@ export function registerAppHandlers() {
           // Regular function file - deploy just this function
           try {
             const functionName = extractFunctionNameFromPath(filePath);
-            await deploySupabaseFunctions({
+            await deploySupabaseFunction({
               supabaseProjectId: app.supabaseProjectId,
               functionName,
               appPath,

--- a/src/ipc/handlers/app_handlers.ts
+++ b/src/ipc/handlers/app_handlers.ts
@@ -1085,17 +1085,10 @@ export function registerAppHandlers() {
           // Regular function file - deploy just this function
           try {
             const functionName = extractFunctionNameFromPath(filePath);
-            const functionPath = path.join(
-              appPath,
-              "supabase",
-              "functions",
-              functionName,
-            );
             await deploySupabaseFunctions({
               supabaseProjectId: app.supabaseProjectId,
               functionName,
               appPath,
-              functionPath,
             });
           } catch (error) {
             logger.error(

--- a/src/ipc/handlers/app_handlers.ts
+++ b/src/ipc/handlers/app_handlers.ts
@@ -56,6 +56,7 @@ import {
   isServerFunction,
   isSharedServerModule,
   deployAllSupabaseFunctions,
+  extractFunctionNameFromPath,
 } from "@/supabase_admin/supabase_utils";
 import { getVercelTeamSlug } from "../utils/vercel_utils";
 import { storeDbTimestampAtCurrentVersion } from "../utils/neon_timestamp_utils";
@@ -1083,7 +1084,7 @@ export function registerAppHandlers() {
         } else if (isServerFunction(filePath)) {
           // Regular function file - deploy just this function
           try {
-            const functionName = path.basename(path.dirname(filePath));
+            const functionName = extractFunctionNameFromPath(filePath);
             const functionPath = path.join(
               appPath,
               "supabase",

--- a/src/ipc/processors/response_processor.ts
+++ b/src/ipc/processors/response_processor.ts
@@ -10,7 +10,7 @@ import log from "electron-log";
 import { executeAddDependency } from "./executeAddDependency";
 import {
   deleteSupabaseFunction,
-  deploySupabaseFunctions,
+  deploySupabaseFunction,
   executeSupabaseSql,
 } from "../../supabase_admin/supabase_management_client";
 import {
@@ -342,7 +342,7 @@ export async function processFullResponseActions(
       // Deploy renamed function (skip if shared modules changed - will be handled later)
       if (isServerFunction(tag.to) && !sharedModulesChanged) {
         try {
-          await deploySupabaseFunctions({
+          await deploySupabaseFunction({
             supabaseProjectId: chatWithApp.app.supabaseProjectId!,
             functionName: extractFunctionNameFromPath(tag.to),
             appPath,
@@ -389,7 +389,7 @@ export async function processFullResponseActions(
         // If server function (not shared), redeploy (skip if shared modules changed)
         if (isServerFunction(filePath) && !sharedModulesChanged) {
           try {
-            await deploySupabaseFunctions({
+            await deploySupabaseFunction({
               supabaseProjectId: chatWithApp.app.supabaseProjectId!,
               functionName: extractFunctionNameFromPath(filePath),
               appPath,
@@ -459,7 +459,7 @@ export async function processFullResponseActions(
         !sharedModulesChanged
       ) {
         try {
-          await deploySupabaseFunctions({
+          await deploySupabaseFunction({
             supabaseProjectId: chatWithApp.app.supabaseProjectId!,
             functionName: extractFunctionNameFromPath(filePath),
             appPath,

--- a/src/ipc/processors/response_processor.ts
+++ b/src/ipc/processors/response_processor.ts
@@ -50,12 +50,6 @@ interface Output {
   error: unknown;
 }
 
-function getFunctionPath(appPath: string, filePath: string): string {
-  // Get the function directory from a file path like "supabase/functions/hello/index.ts"
-  const functionName = extractFunctionNameFromPath(filePath);
-  return path.join(appPath, "supabase", "functions", functionName);
-}
-
 export async function dryRunSearchReplace({
   fullResponse,
   appPath,
@@ -352,7 +346,6 @@ export async function processFullResponseActions(
             supabaseProjectId: chatWithApp.app.supabaseProjectId!,
             functionName: extractFunctionNameFromPath(tag.to),
             appPath,
-            functionPath: getFunctionPath(appPath, tag.to),
           });
         } catch (error) {
           errors.push({
@@ -398,9 +391,8 @@ export async function processFullResponseActions(
           try {
             await deploySupabaseFunctions({
               supabaseProjectId: chatWithApp.app.supabaseProjectId!,
-              functionName: path.basename(path.dirname(filePath)),
+              functionName: extractFunctionNameFromPath(filePath),
               appPath,
-              functionPath: getFunctionPath(appPath, filePath),
             });
           } catch (error) {
             errors.push({
@@ -469,9 +461,8 @@ export async function processFullResponseActions(
         try {
           await deploySupabaseFunctions({
             supabaseProjectId: chatWithApp.app.supabaseProjectId!,
-            functionName: path.basename(path.dirname(filePath)),
+            functionName: extractFunctionNameFromPath(filePath),
             appPath,
-            functionPath: getFunctionPath(appPath, filePath),
           });
         } catch (error) {
           errors.push({

--- a/src/ipc/processors/response_processor.ts
+++ b/src/ipc/processors/response_processor.ts
@@ -17,6 +17,7 @@ import {
   isServerFunction,
   isSharedServerModule,
   deployAllSupabaseFunctions,
+  extractFunctionNameFromPath,
 } from "../../supabase_admin/supabase_utils";
 import { UserSettings } from "../../lib/schemas";
 import {
@@ -49,13 +50,9 @@ interface Output {
   error: unknown;
 }
 
-function getFunctionNameFromPath(input: string): string {
-  return path.basename(path.extname(input) ? path.dirname(input) : input);
-}
-
 function getFunctionPath(appPath: string, filePath: string): string {
   // Get the function directory from a file path like "supabase/functions/hello/index.ts"
-  const functionName = getFunctionNameFromPath(filePath);
+  const functionName = extractFunctionNameFromPath(filePath);
   return path.join(appPath, "supabase", "functions", functionName);
 }
 
@@ -292,7 +289,7 @@ export async function processFullResponseActions(
         try {
           await deleteSupabaseFunction({
             supabaseProjectId: chatWithApp.app.supabaseProjectId!,
-            functionName: getFunctionNameFromPath(filePath),
+            functionName: extractFunctionNameFromPath(filePath),
           });
         } catch (error) {
           errors.push({
@@ -339,7 +336,7 @@ export async function processFullResponseActions(
         try {
           await deleteSupabaseFunction({
             supabaseProjectId: chatWithApp.app.supabaseProjectId!,
-            functionName: getFunctionNameFromPath(tag.from),
+            functionName: extractFunctionNameFromPath(tag.from),
           });
         } catch (error) {
           warnings.push({
@@ -353,7 +350,7 @@ export async function processFullResponseActions(
         try {
           await deploySupabaseFunctions({
             supabaseProjectId: chatWithApp.app.supabaseProjectId!,
-            functionName: getFunctionNameFromPath(tag.to),
+            functionName: extractFunctionNameFromPath(tag.to),
             appPath,
             functionPath: getFunctionPath(appPath, tag.to),
           });

--- a/src/prompts/supabase_prompt.ts
+++ b/src/prompts/supabase_prompt.ts
@@ -287,6 +287,7 @@ CREATE TRIGGER on_auth_user_created
 1. Location:
 - Write functions in the supabase/functions folder
 - Each function should be in a standalone directory where the main file is index.ts (e.g., supabase/functions/hello/index.ts)
+- Reusable utilities belong in the supabase/functions/_shared folder. Import them in your edge functions with relative paths like ../_shared/logger.ts.
 - Make sure you use <dyad-write> tags to make changes to edge functions. 
 - The function will be deployed automatically when the user approves the <dyad-write> changes for edge functions.
 - Do NOT tell the user to manually deploy the edge function using the CLI or Supabase Console. It's unhelpful and not needed.

--- a/src/supabase_admin/supabase_management_client.ts
+++ b/src/supabase_admin/supabase_management_client.ts
@@ -353,8 +353,6 @@ export async function deploySupabaseFunctions({
   );
 
   if (response.status !== 201) {
-    const text = await response.text();
-    logger.error(`Supabase response: ${response.status} ${text}`);
     throw await createResponseError(response, "create function");
   }
 

--- a/src/supabase_admin/supabase_management_client.ts
+++ b/src/supabase_admin/supabase_management_client.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import path from "node:path";
 import { withLock } from "../ipc/utils/lock_utils";
 import { readSettings, writeSettings } from "../main/settings";
 import {
@@ -7,7 +9,41 @@ import {
 import log from "electron-log";
 import { IS_TEST_BUILD } from "../ipc/utils/test_utils";
 
+const fsPromises = fs.promises;
+
 const logger = log.scope("supabase_management_client");
+
+// ─────────────────────────────────────────────────────────────────────
+// Interfaces for file collection and caching
+// ─────────────────────────────────────────────────────────────────────
+
+export interface ZipFileEntry {
+  relativePath: string;
+  content: Buffer;
+  date: Date;
+}
+
+export interface FileStatEntry {
+  absolutePath: string;
+  relativePath: string;
+  mtimeMs: number;
+  size: number;
+}
+
+interface CachedSharedFiles {
+  signature: string;
+  files: ZipFileEntry[];
+}
+
+interface FunctionFilesResult {
+  files: ZipFileEntry[];
+  signature: string;
+  entrypointPath: string;
+  cacheKey: string;
+}
+
+// Caches for shared files to avoid re-reading unchanged files
+const sharedFilesCache = new Map<string, CachedSharedFiles>();
 
 /**
  * Checks if the Supabase access token is expired or about to expire
@@ -223,33 +259,84 @@ export async function listSupabaseBranches({
   return jsonResponse;
 }
 
+// ─────────────────────────────────────────────────────────────────────
+// Deploy Supabase Functions with shared module support
+// ─────────────────────────────────────────────────────────────────────
+
 export async function deploySupabaseFunctions({
   supabaseProjectId,
   functionName,
-  content,
+  appPath,
+  functionPath,
 }: {
   supabaseProjectId: string;
   functionName: string;
-  content: string;
+  appPath: string;
+  functionPath: string;
 }): Promise<void> {
   logger.info(
     `Deploying Supabase function: ${functionName} to project: ${supabaseProjectId}`,
   );
+
+  // 1) Collect function files
+  const functionFiles = await collectFunctionFiles({
+    appPath,
+    functionPath,
+    functionName,
+  });
+
+  // 2) Collect shared files (from supabase/functions/_shared/)
+  const sharedFiles = await getSharedFiles(appPath);
+
+  // 3) Combine all files
+  const filesToUpload = [...functionFiles.files, ...sharedFiles.files];
+
+  // 4) Create an import map next to the function entrypoint
+  const entrypointPath = functionFiles.entrypointPath;
+  const entryDir = path.posix.dirname(entrypointPath);
+  const importMapRelPath = path.posix.join(entryDir, "import_map.json");
+
+  const importMapObject = {
+    imports: {
+      // This resolves "_shared/" imports to the _shared directory
+      "_shared/": "../_shared/",
+    },
+  };
+
+  // Add the import map file into the upload list
+  filesToUpload.push({
+    relativePath: importMapRelPath,
+    content: Buffer.from(JSON.stringify(importMapObject, null, 2)),
+    date: new Date(),
+  });
+
+  // 5) Prepare multipart form-data
   const supabase = await getSupabaseClient();
   const formData = new FormData();
-  formData.append(
-    "metadata",
-    JSON.stringify({
-      entrypoint_path: "index.ts",
-      name: functionName,
-      // See: https://github.com/dyad-sh/dyad/issues/1010
-      verify_jwt: false,
-    }),
-  );
-  formData.append("file", new Blob([content]), "index.ts");
 
+  // Metadata: instruct Supabase to use our import map
+  const metadata = {
+    entrypoint_path: entrypointPath,
+    name: functionName,
+    verify_jwt: false,
+    import_map: importMapRelPath,
+  };
+
+  formData.append("metadata", JSON.stringify(metadata));
+
+  // Add all files to form data
+  for (const f of filesToUpload) {
+    const buf: Buffer = f.content;
+    const mime = guessMimeType(f.relativePath);
+    const blob = new Blob([new Uint8Array(buf)], { type: mime });
+    formData.append("file", blob, f.relativePath);
+  }
+
+  // 6) Perform the deploy request
   const response = await fetch(
-    `https://api.supabase.com/v1/projects/${supabaseProjectId}/functions/deploy?slug=${functionName}`,
+    `https://api.supabase.com/v1/projects/${encodeURIComponent(
+      supabaseProjectId,
+    )}/functions/deploy?slug=${encodeURIComponent(functionName)}`,
     {
       method: "POST",
       headers: {
@@ -260,14 +347,279 @@ export async function deploySupabaseFunctions({
   );
 
   if (response.status !== 201) {
+    const text = await response.text();
+    logger.error(`Supabase response: ${response.status} ${text}`);
     throw await createResponseError(response, "create function");
   }
 
   logger.info(
     `Deployed Supabase function: ${functionName} to project: ${supabaseProjectId}`,
   );
-  return response.json();
+
+  await response.json();
 }
+
+// ─────────────────────────────────────────────────────────────────────
+// File collection helpers
+// ─────────────────────────────────────────────────────────────────────
+
+async function collectFunctionFiles({
+  appPath,
+  functionPath,
+  functionName,
+}: {
+  appPath: string;
+  functionPath: string;
+  functionName: string;
+}): Promise<FunctionFilesResult> {
+  const normalizedFunctionPath = path.resolve(functionPath);
+  const stats = await fsPromises.stat(normalizedFunctionPath);
+
+  let functionDirectory: string | null = null;
+
+  if (stats.isDirectory()) {
+    functionDirectory = normalizedFunctionPath;
+  } else {
+    functionDirectory = findFunctionDirectory(
+      normalizedFunctionPath,
+      functionName,
+    );
+
+    if (!functionDirectory) {
+      // Single file case - just return the file
+      const relativeFilePath = toPosixPath(
+        path.relative(appPath, normalizedFunctionPath),
+      );
+      const zipRelativePath = stripSupabaseFunctionsPrefix(
+        relativeFilePath,
+        functionName,
+      );
+      const content = await fsPromises.readFile(normalizedFunctionPath);
+      return {
+        files: [
+          {
+            relativePath: zipRelativePath,
+            content,
+            date: stats.mtime,
+          },
+        ],
+        signature: buildSignature([
+          {
+            absolutePath: normalizedFunctionPath,
+            relativePath: zipRelativePath,
+            mtimeMs: stats.mtimeMs,
+            size: stats.size,
+          },
+        ]),
+        entrypointPath: zipRelativePath,
+        cacheKey: normalizedFunctionPath,
+      };
+    }
+  }
+
+  if (!functionDirectory) {
+    throw new Error(
+      `Unable to locate directory for Supabase function ${functionName}`,
+    );
+  }
+
+  const indexPath = path.join(functionDirectory, "index.ts");
+
+  try {
+    await fsPromises.access(indexPath);
+  } catch {
+    throw new Error(
+      `Supabase function ${functionName} is missing an index.ts entrypoint`,
+    );
+  }
+
+  const statEntries = await listFilesWithStats(functionDirectory, "");
+  const signature = buildSignature(statEntries);
+  const files = await loadZipEntries(statEntries);
+
+  return {
+    files,
+    signature,
+    entrypointPath: toPosixPath(path.relative(functionDirectory, indexPath)),
+    cacheKey: functionDirectory,
+  };
+}
+
+async function getSharedFiles(appPath: string): Promise<CachedSharedFiles> {
+  const sharedDirectory = path.join(
+    appPath,
+    "supabase",
+    "functions",
+    "_shared",
+  );
+
+  try {
+    const sharedStats = await fsPromises.stat(sharedDirectory);
+    if (!sharedStats.isDirectory()) {
+      return { signature: "", files: [] };
+    }
+  } catch (error: any) {
+    if (error && error.code === "ENOENT") {
+      return { signature: "", files: [] };
+    }
+    throw error;
+  }
+
+  const statEntries = await listFilesWithStats(sharedDirectory, "_shared");
+  const signature = buildSignature(statEntries);
+
+  const cached = sharedFilesCache.get(sharedDirectory);
+  if (cached && cached.signature === signature) {
+    return cached;
+  }
+
+  const files = await loadZipEntries(statEntries);
+  const result = { signature, files };
+  sharedFilesCache.set(sharedDirectory, result);
+  return result;
+}
+
+export async function listFilesWithStats(
+  directory: string,
+  prefix: string,
+): Promise<FileStatEntry[]> {
+  const dirents = await fsPromises.readdir(directory, { withFileTypes: true });
+  dirents.sort((a, b) => a.name.localeCompare(b.name));
+  const entries: FileStatEntry[] = [];
+
+  for (const dirent of dirents) {
+    const absolutePath = path.join(directory, dirent.name);
+    const relativePath = path.posix.join(prefix, dirent.name);
+
+    if (dirent.isDirectory()) {
+      const nestedEntries = await listFilesWithStats(
+        absolutePath,
+        relativePath,
+      );
+      entries.push(...nestedEntries);
+    } else if (dirent.isFile() || dirent.isSymbolicLink()) {
+      const stat = await fsPromises.stat(absolutePath);
+      entries.push({
+        absolutePath,
+        relativePath,
+        mtimeMs: stat.mtimeMs,
+        size: stat.size,
+      });
+    }
+  }
+
+  return entries;
+}
+
+export function buildSignature(entries: FileStatEntry[]): string {
+  return entries
+    .map(
+      (entry) =>
+        `${entry.relativePath}:${entry.mtimeMs.toString(16)}:${entry.size.toString(16)}`,
+    )
+    .sort()
+    .join("|");
+}
+
+async function loadZipEntries(
+  entries: FileStatEntry[],
+): Promise<ZipFileEntry[]> {
+  const files: ZipFileEntry[] = [];
+
+  for (const entry of entries) {
+    const content = await fsPromises.readFile(entry.absolutePath);
+    files.push({
+      relativePath: toPosixPath(entry.relativePath),
+      content,
+      date: new Date(entry.mtimeMs),
+    });
+  }
+
+  return files;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Path helpers (exported for testing)
+// ─────────────────────────────────────────────────────────────────────
+
+export function toPosixPath(filePath: string): string {
+  return filePath.split(path.sep).join(path.posix.sep);
+}
+
+export function findFunctionDirectory(
+  filePath: string,
+  functionName: string,
+): string | null {
+  let currentDir = path.dirname(filePath);
+
+  while (true) {
+    const parentDir = path.dirname(currentDir);
+    const normalized = toPosixPath(currentDir);
+
+    if (normalized.endsWith(`/supabase/functions/${functionName}`)) {
+      return currentDir;
+    }
+
+    if (!normalized.includes("/supabase/functions/")) {
+      break;
+    }
+
+    if (currentDir === parentDir) {
+      break;
+    }
+
+    currentDir = parentDir;
+  }
+
+  return null;
+}
+
+export function stripSupabaseFunctionsPrefix(
+  relativePath: string,
+  functionName: string,
+): string {
+  const normalized = toPosixPath(relativePath).replace(/^\//, "");
+  const slugPrefix = `supabase/functions/${functionName}/`;
+
+  if (normalized.startsWith(slugPrefix)) {
+    const remainder = normalized.slice(slugPrefix.length);
+    return remainder || "index.ts";
+  }
+
+  const slugFilePrefix = `supabase/functions/${functionName}`;
+
+  if (normalized.startsWith(slugFilePrefix)) {
+    const remainder = normalized.slice(slugFilePrefix.length);
+    if (remainder.startsWith("/")) {
+      const trimmed = remainder.slice(1);
+      return trimmed || "index.ts";
+    }
+    const combined = `${functionName}${remainder}`;
+    return combined || "index.ts";
+  }
+
+  const basePrefix = "supabase/functions/";
+  if (normalized.startsWith(basePrefix)) {
+    const withoutBase = normalized.slice(basePrefix.length);
+    return withoutBase || path.posix.basename(normalized);
+  }
+
+  return normalized || path.posix.basename(relativePath);
+}
+
+function guessMimeType(filePath: string): string {
+  if (filePath.endsWith(".json")) return "application/json";
+  if (filePath.endsWith(".ts")) return "application/typescript";
+  if (filePath.endsWith(".mjs")) return "application/javascript";
+  if (filePath.endsWith(".js")) return "application/javascript";
+  if (filePath.endsWith(".wasm")) return "application/wasm";
+  if (filePath.endsWith(".map")) return "application/json";
+  return "application/octet-stream";
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Error handling helpers
+// ─────────────────────────────────────────────────────────────────────
 
 async function createResponseError(response: Response, action: string) {
   const errorBody = await safeParseErrorResponseBody(response);

--- a/src/supabase_admin/supabase_management_client.ts
+++ b/src/supabase_admin/supabase_management_client.ts
@@ -267,15 +267,20 @@ export async function deploySupabaseFunctions({
   supabaseProjectId,
   functionName,
   appPath,
-  functionPath,
 }: {
   supabaseProjectId: string;
   functionName: string;
   appPath: string;
-  functionPath: string;
 }): Promise<void> {
   logger.info(
     `Deploying Supabase function: ${functionName} to project: ${supabaseProjectId}`,
+  );
+
+  const functionPath = path.join(
+    appPath,
+    "supabase",
+    "functions",
+    functionName,
   );
 
   // 1) Collect function files

--- a/src/supabase_admin/supabase_management_client.ts
+++ b/src/supabase_admin/supabase_management_client.ts
@@ -285,7 +285,6 @@ export async function deploySupabaseFunction({
 
   // 1) Collect function files
   const functionFiles = await collectFunctionFiles({
-    appPath,
     functionPath,
     functionName,
   });

--- a/src/supabase_admin/supabase_utils.ts
+++ b/src/supabase_admin/supabase_utils.ts
@@ -117,7 +117,6 @@ export async function deployAllSupabaseFunctions({
           supabaseProjectId,
           functionName,
           appPath,
-          functionPath,
         });
 
         logger.info(`Successfully deployed function: ${functionName}`);

--- a/src/supabase_admin/supabase_utils.ts
+++ b/src/supabase_admin/supabase_utils.ts
@@ -24,6 +24,40 @@ export function isSharedServerModule(filePath: string): boolean {
 }
 
 /**
+ * Extracts the function name from a Supabase function file path.
+ * Handles nested paths like "supabase/functions/hello/lib/utils.ts" → "hello"
+ *
+ * @param filePath - A path like "supabase/functions/{functionName}/..."
+ * @returns The function name
+ * @throws Error if the path is not a valid function path
+ */
+export function extractFunctionNameFromPath(filePath: string): string {
+  // Normalize path separators to forward slashes
+  const normalized = filePath.replace(/\\/g, "/");
+
+  // Match the pattern: supabase/functions/{functionName}/...
+  // The function name is the segment immediately after "supabase/functions/"
+  const match = normalized.match(/^supabase\/functions\/([^/]+)/);
+
+  if (!match) {
+    throw new Error(
+      `Invalid Supabase function path: ${filePath}. Expected format: supabase/functions/{functionName}/...`,
+    );
+  }
+
+  const functionName = match[1];
+
+  // Exclude _shared and other special directories
+  if (functionName.startsWith("_")) {
+    throw new Error(
+      `Invalid Supabase function path: ${filePath}. Function names starting with "_" are reserved for special directories.`,
+    );
+  }
+
+  return functionName;
+}
+
+/**
  * Deploys all Supabase edge functions found in the app's supabase/functions directory
  * @param appPath - The absolute path to the app directory
  * @param supabaseProjectId - The Supabase project ID

--- a/src/supabase_admin/supabase_utils.ts
+++ b/src/supabase_admin/supabase_utils.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import log from "electron-log";
-import { deploySupabaseFunctions } from "./supabase_management_client";
+import { deploySupabaseFunction } from "./supabase_management_client";
 
 const logger = log.scope("supabase_utils");
 
@@ -113,7 +113,7 @@ export async function deployAllSupabaseFunctions({
       try {
         logger.info(`Deploying function: ${functionName}`);
 
-        await deploySupabaseFunctions({
+        await deploySupabaseFunction({
           supabaseProjectId,
           functionName,
           appPath,


### PR DESCRIPTION
Credit: thanks @SlayTheDragons whose PR https://github.com/dyad-sh/dyad/pull/1665 paved the way for this implementation.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds _shared module support for Supabase edge functions with import-map packaging and automatic redeploys; updates deployment to include full function directories plus shared files, and adds path utilities and tests.
> 
> - **Supabase Edge Functions**
>   - **Shared Modules Support**: Detect `_shared` changes and redeploy all functions; regular function changes deploy only that function.
>   - **Deployment Overhaul**: `deploySupabaseFunctions` now uploads full function directories plus `_shared` files via multipart form-data, sets `entrypoint_path`, and writes `import_map.json` (`_shared/` → `../_shared/`).
>   - **Function Discovery & Packaging**: Add file collection helpers (`listFilesWithStats`, `loadZipEntries`) and path utilities (`toPosixPath`, `findFunctionDirectory`, `stripSupabaseFunctionsPrefix`) with signature-based caching for `_shared`.
>   - **APIs & Utils**: Introduce `isSharedServerModule`, refine `isServerFunction` (excludes `_shared`), add `extractFunctionNameFromPath`, and `buildSignature`.
> - **IPC Changes**
>   - Update file edit/rename/delete flows to track shared module edits and trigger full redeploys; otherwise deploy per-function using extracted name and `appPath`.
> - **Prompts**
>   - Document `_shared` usage and import pattern in Supabase prompt.
> - **Tests**
>   - Add tests for function/shared detection, name extraction, path handling, and signature building.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f35599ec0e708e2ef6b7e78ae7901b29953a6dff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->









<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for shared modules for Supabase edge functions. Shared code in supabase/functions/_shared is now bundled via an import map and triggers redeploys across all functions when changed.

- **New Features**
  - Detects shared modules in supabase/functions/_shared and redeploys all functions when they change.
  - Deploys full function directories plus shared files, and writes an import_map.json that resolves "_shared/" imports.
  - Auto-deploys only the affected function on file changes; switches to redeploy-all when a shared module is touched.

- **Refactors**
  - deploySupabaseFunction now uploads multiple files (function + shared) using multipart form-data and sets entrypoint/import map.
  - Added file collection, path utilities, and shared-file caching via content signatures to reduce redundant reads.
  - Updated deployAllSupabaseFunctions to skip non-function dirs (e.g., _shared) and use functionPath.
  - Added tests for function/shared detection, path handling, and signature building.

<sup>Written for commit 302d84625d9e61477db9ada052a027b29ff18cef. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









