### PR TITLE
Fixing scrollbar flickering in annotator mode

### DIFF
--- a/src/pro/ui/components/Annotator/Annotator.tsx
+++ b/src/pro/ui/components/Annotator/Annotator.tsx
@@ -377,6 +377,7 @@ export const Annotator = ({
             spanRef={spanRef}
             inputRef={inputRef}
             color={input.color}
+            containerRef={containerRef}
           />
         ))}
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes scrollbar flickering in annotator mode by constraining draggable inputs within the container and suppressing scroll during drag for smoother movement.

- **Bug Fixes**
  - Added containerRef to DraggableTextInput and elementRef to calculate bounds.
  - Constrained drag coordinates to container size and accounted for scale.
  - Prevented default and stopped propagation on mousemove to avoid scroll jitter.
  - Passed containerRef from Annotator to DraggableTextInput.

<sup>Written for commit 959605ddaa5faf23252ee797bf206c6dff46a069. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

