### PR TITLE
Do not hardcode 32100 port

### DIFF
--- a/shared/ports.ts
+++ b/shared/ports.ts
@@ -1,0 +1,7 @@
+/**
+ * Calculate the port for a given app based on its ID.
+ * Uses a base port of 32100 and offsets by appId % 10_000.
+ */
+export function getAppPort(appId: number): number {
+  return 32100 + (appId % 10_000);
+}

--- a/src/client_logic/template_hook.ts
+++ b/src/client_logic/template_hook.ts
@@ -1,4 +1,5 @@
 import { IpcClient } from "@/ipc/ipc_client";
+import { getAppPort } from "../../shared/ports";
 
 import { v4 as uuidv4 } from "uuid";
 
@@ -29,7 +30,7 @@ export async function neonTemplateHook({
       },
       {
         key: "NEXT_PUBLIC_SERVER_URL",
-        value: "http://localhost:32100",
+        value: `http://localhost:${getAppPort(appId)}`,
       },
       {
         key: "GMAIL_USER",


### PR DESCRIPTION
Fixes #1949 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 46ac310c762fd4044c35bc59264122234ed19bbf. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make app ports dynamic instead of hardcoded 32100 to prevent conflicts and keep local runs, Docker, and env URLs in sync. Ports now derive from appId using a base of 32100.

- **Bug Fixes**
  - Added getAppPort(appId) = 32100 + (appId % 10_000).
  - Used the dynamic port in NEXT_PUBLIC_SERVER_URL, start commands, Docker -p mapping, and cleanUpPort.
  - Updated getCommand to accept appId and generate a per-app default start command.

<sup>Written for commit 46ac310c762fd4044c35bc59264122234ed19bbf. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

