### PR TITLE
gemini 3 flash

### DIFF
--- a/src/ipc/shared/language_model_constants.ts
+++ b/src/ipc/shared/language_model_constants.ts
@@ -152,8 +152,22 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
       maxOutputTokens: 65_536 - 1,
       // Gemini context window = input token + output token
       contextWindow: 1_048_576,
+      // Recommended by Google: https://ai.google.dev/gemini-api/docs/gemini-3?thinking=high#temperature
       temperature: 1.0,
       dollarSigns: 4,
+    },
+    // https://ai.google.dev/gemini-api/docs/models#gemini-3-pro
+    {
+      name: "gemini-3-flash-preview",
+      displayName: "Gemini 3 Flash (Preview)",
+      description: "Powerful coding model at a good price",
+      // See Flash 2.5 comment below (go 1 below just to be safe, even though it seems OK now).
+      maxOutputTokens: 65_536 - 1,
+      // Gemini context window = input token + output token
+      contextWindow: 1_048_576,
+      // Recommended by Google: https://ai.google.dev/gemini-api/docs/gemini-3?thinking=high#temperature
+      temperature: 1.0,
+      dollarSigns: 2,
     },
     // https://ai.google.dev/gemini-api/docs/models#gemini-2.5-pro-preview-03-25
     {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds Google Gemini 3 Flash (Preview) model and documents recommended temperature for Gemini 3 Pro.
> 
> - **Models (Google)**:
>   - **Add** `gemini-3-flash-preview` with `maxOutputTokens: 65_535`, `contextWindow: 1_048_576`, `temperature: 1.0`, `dollarSigns: 2`.
>   - **Update metadata** for `gemini-3-pro-preview`: include recommended temperature guidance comment (`temperature: 1.0`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 015da81bdee067873de66007016e46b15d3b4ff0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Gemini 3 Flash (Preview) to the available models so users can choose a faster, lower-cost coding option. Uses safe defaults aligned with Google’s guidance.

- **New Features**
  - New model: gemini-3-flash-preview (display: Gemini 3 Flash (Preview))
  - Defaults: context window 1,048,576; max output 65,535; temperature 1.0; cost tier: $$

<sup>Written for commit 015da81bdee067873de66007016e46b15d3b4ff0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

