### PR TITLE
Fix MCP e2e test

### DIFF
--- a/e2e-tests/helpers/test_helper.ts
+++ b/e2e-tests/helpers/test_helper.ts
@@ -341,7 +341,11 @@ export class PageObject {
 
   async selectChatMode(mode: "build" | "ask" | "agent") {
     await this.page.getByTestId("chat-mode-selector").click();
-    await this.page.getByRole("option", { name: mode }).click();
+    await this.page
+      .getByRole("option", {
+        name: mode === "agent" ? "Build with MCP (experimental)" : mode,
+      })
+      .click();
   }
 
   async openContextFilesPicker() {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates e2e chat mode selection to click "Build with MCP (experimental)" when mode is "agent".
> 
> - **e2e tests**:
>   - **Chat mode selection**: In `e2e-tests/helpers/test_helper.ts`, `selectChatMode` now clicks `Build with MCP (experimental)` when `mode === "agent"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8f494513ae9b2fedda833aeda41ed660b584f16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the MCP e2e test by aligning chat mode selection with the new UI label. When mode is "agent", the helper now clicks the "Build with MCP (experimental)" option instead of "agent".

<sup>Written for commit c8f494513ae9b2fedda833aeda41ed660b584f16. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

