### PR TITLE
fix: Show Token Usage Requires Double Open (#1947)

### DIFF
--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -94,6 +94,10 @@ export function ChatInput({ chatId }: { chatId?: number }) {
   const setMessagesById = useSetAtom(chatMessagesByIdAtom);
   const setIsPreviewOpen = useSetAtom(isPreviewOpenAtom);
   const [showTokenBar, setShowTokenBar] = useAtom(showTokenBarAtom);
+  const toggleShowTokenBar = useCallback(
+    () => setShowTokenBar((prev) => !prev),
+    [setShowTokenBar],
+  );
   const [selectedComponents, setSelectedComponents] = useAtom(
     selectedComponentsPreviewAtom,
   );
@@ -433,7 +437,7 @@ export function ChatInput({ chatId }: { chatId?: number }) {
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Button
-                    onClick={() => setShowTokenBar(!showTokenBar)}
+                    onClick={toggleShowTokenBar}
                     variant="ghost"
                     className={`has-[>svg]:px-2 ${
                       showTokenBar ? "text-purple-500 bg-purple-100" : ""


### PR DESCRIPTION
Closes #1947

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the Show Token Usage button so it toggles on a single click. Switched to a functional state updater to prevent stale state and double toggles.

- **Bug Fixes**
  - Replace setShowTokenBar(!showTokenBar) with a memoized toggle using setShowTokenBar(prev => !prev) to ensure reliable toggle and immediate active styling.

<sup>Written for commit e1351b9044a447515d4dc817cdff83fff50a57f4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

