### PR TITLE
feat: Edit & Copy Chat Prompt

### DIFF
--- a/e2e-tests/prompt_edit.spec.ts
+++ b/e2e-tests/prompt_edit.spec.ts
@@ -30,6 +30,7 @@ test("editing a later prompt copies only previous history into the new chat", as
 
   await po.sendPrompt("tc=chat1");
   await po.sendPrompt("tc=chat2");
+  await po.sendPrompt("tc=chat3");
   await po.page.locator("button:has(.lucide-pencil)").nth(2).click();
   // Wait for the textarea to be visible before trying to fill it
   const editTextarea = po.page.getByTestId("chat-message-edit-textarea");

--- a/e2e-tests/prompt_edit.spec.ts
+++ b/e2e-tests/prompt_edit.spec.ts
@@ -37,10 +37,11 @@ test("editing a later prompt copies only previous history into the new chat", as
   await po.page.getByRole("button", { name: "Save" }).click();
 
   await po.waitForChatCompletion();
-  // Check that the new chat has both previous prompts copied (tc=chat1 and tc=chat2)
+  // Check that only messages before the edited one are copied (tc=chat1)
   await expect(po.page.getByText("tc=chat1")).toHaveCount(1);
+  // Check that the edited message (tc=chat2) is replaced with the new content
   await expect(po.page.getByText("tc=chat2")).toHaveCount(0);
-  // Check that tc=chat3 was replaced with the edited prompt
+  // Check that messages after the edited one (tc=chat3) are not copied
   await expect(po.page.getByText("tc=chat3")).toHaveCount(0);
   await expect(po.page.getByText("Update your prompt...")).toBeVisible();
 });

--- a/e2e-tests/prompt_edit.spec.ts
+++ b/e2e-tests/prompt_edit.spec.ts
@@ -1,0 +1,45 @@
+import { test } from "./helpers/test_helper";
+import { expect } from "@playwright/test";
+
+test("edit first prompt creates a new chat with edited content only", async ({
+  po,
+}) => {
+  await po.setUp({ autoApprove: true });
+  await po.importApp("minimal");
+
+  await po.sendPrompt("tc=chat1");
+
+  await po.page.locator("button:has(.lucide-pencil)").first().click();
+  // Wait for the textarea to be visible before trying to fill it
+  const editTextarea = po.page.getByTestId("chat-message-edit-textarea");
+  await editTextarea.waitFor({ state: "visible" });
+  await editTextarea.fill("Update your prompt...");
+  await po.page.getByRole("button", { name: "Save" }).click();
+
+  await po.waitForChatCompletion();
+
+  await expect(po.page.getByText("tc=chat1")).toHaveCount(0);
+  await expect(po.page.getByText("Update your prompt...")).toBeVisible();
+});
+
+test("editing a later prompt copies only previous history into the new chat", async ({
+  po,
+}) => {
+  await po.setUp({ autoApprove: true });
+  await po.importApp("minimal");
+
+  await po.sendPrompt("tc=chat1");
+  await po.sendPrompt("tc=chat2");
+  await po.page.locator("button:has(.lucide-pencil)").nth(2).click();
+  // Wait for the textarea to be visible before trying to fill it
+  const editTextarea = po.page.getByTestId("chat-message-edit-textarea");
+  await editTextarea.waitFor({ state: "visible" });
+  await editTextarea.fill("Update your prompt...");
+  await po.page.getByRole("button", { name: "Save" }).click();
+
+  await po.waitForChatCompletion();
+  // Check that the new chat has only the first prompt's content
+  await expect(po.page.getByText("tc=chat1")).toHaveCount(1);
+  await expect(po.page.getByText("tc=chat2")).toHaveCount(0);
+  await expect(po.page.getByText("Update your prompt...")).toBeVisible();
+});

--- a/e2e-tests/prompt_edit.spec.ts
+++ b/e2e-tests/prompt_edit.spec.ts
@@ -5,7 +5,6 @@ test("edit first prompt creates a new chat with edited content only", async ({
   po,
 }) => {
   await po.setUp({ autoApprove: true });
-  await po.importApp("minimal");
 
   await po.sendPrompt("tc=chat1");
 
@@ -26,12 +25,11 @@ test("editing a later prompt copies only previous history into the new chat", as
   po,
 }) => {
   await po.setUp({ autoApprove: true });
-  await po.importApp("minimal");
 
   await po.sendPrompt("tc=chat1");
   await po.sendPrompt("tc=chat2");
   await po.sendPrompt("tc=chat3");
-  await po.page.locator("button:has(.lucide-pencil)").nth(2).click();
+  await po.page.locator("button:has(.lucide-pencil)").nth(1).click();
   // Wait for the textarea to be visible before trying to fill it
   const editTextarea = po.page.getByTestId("chat-message-edit-textarea");
   await editTextarea.waitFor({ state: "visible" });
@@ -39,8 +37,10 @@ test("editing a later prompt copies only previous history into the new chat", as
   await po.page.getByRole("button", { name: "Save" }).click();
 
   await po.waitForChatCompletion();
-  // Check that the new chat has only the first prompt's content
+  // Check that the new chat has both previous prompts copied (tc=chat1 and tc=chat2)
   await expect(po.page.getByText("tc=chat1")).toHaveCount(1);
   await expect(po.page.getByText("tc=chat2")).toHaveCount(0);
+  // Check that tc=chat3 was replaced with the edited prompt
+  await expect(po.page.getByText("tc=chat3")).toHaveCount(0);
   await expect(po.page.getByText("Update your prompt...")).toBeVisible();
 });

--- a/e2e-tests/snapshots/prompt_edit.spec.ts_edit-first-prompt-creates-a-new-chat-with-edited-content-only-1.aria.yml
+++ b/e2e-tests/snapshots/prompt_edit.spec.ts_edit-first-prompt-creates-a-new-chat-with-edited-content-only-1.aria.yml
@@ -1,0 +1,24 @@
+- paragraph: Update your prompt...
+- button:
+  - img
+- button:
+  - img
+- img
+- text: file1.txt
+- button "Edit":
+  - img
+- img
+- text: file1.txt
+- paragraph: More EOM
+- button:
+  - img
+- img
+- text: Approved
+- img
+- text: less than a minute ago
+- img
+- text: wrote 1 file(s)
+- button "Undo":
+  - img
+- button "Retry":
+  - img

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -80,8 +80,7 @@ const ChatMessage = ({ message, isLastMessage }: ChatMessageProps) => {
       });
       setIsEditing(false);
     } catch (error) {
-      showError;
-      "Failed to save edit: " + (error as Error).message;
+      showError("Failed to save edit: " + (error as Error).message);
     } finally {
       setIsSaving(false);
     }

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -56,6 +56,7 @@ const ChatMessage = ({ message, isLastMessage }: ChatMessageProps) => {
       !selectedChatId ||
       !appId ||
       !message.id ||
+      !editContent.trim() ||
       editContent.trim() === message.content.trim()
     ) {
       setIsEditing(false);

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -52,6 +52,9 @@ const ChatMessage = ({ message, isLastMessage }: ChatMessageProps) => {
   const selectedChatId = message.chatId;
   const navigate = useNavigate();
   const handleSaveEdit = async () => {
+    if (isSaving) {
+      return;
+    }
     if (
       !selectedChatId ||
       !appId ||
@@ -157,12 +160,16 @@ const ChatMessage = ({ message, isLastMessage }: ChatMessageProps) => {
                 onKeyDown={(e) => {
                   if (e.key === "Escape") {
                     e.preventDefault();
-                    setEditContent(message.content.trim());
-                    setIsEditing(false);
+                    if (!isSaving) {
+                      setEditContent(message.content.trim());
+                      setIsEditing(false);
+                    }
                   }
                   if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
                     e.preventDefault();
-                    handleSaveEdit();
+                    if (!isSaving) {
+                      handleSaveEdit();
+                    }
                   }
                 }}
               />

--- a/src/ipc/ipc_client.ts
+++ b/src/ipc/ipc_client.ts
@@ -54,7 +54,6 @@ import type {
   VercelProject,
   UpdateChatParams,
   CreateChatFromPromptEditParams,
-  CreateChatFromPromptEditResult,
   FileAttachment,
   CreateNeonProjectParams,
   NeonProject,
@@ -530,7 +529,7 @@ export class IpcClient {
 
   public async createChatFromPromptEdit(
     params: CreateChatFromPromptEditParams,
-  ): Promise<CreateChatFromPromptEditResult> {
+  ): Promise<{ chatId: number }> {
     return this.ipcRenderer.invoke("chat:create-from-prompt-edit", params);
   }
 

--- a/src/ipc/ipc_client.ts
+++ b/src/ipc/ipc_client.ts
@@ -53,6 +53,8 @@ import type {
   SaveVercelAccessTokenParams,
   VercelProject,
   UpdateChatParams,
+  CreateChatFromPromptEditParams,
+  CreateChatFromPromptEditResult,
   FileAttachment,
   CreateNeonProjectParams,
   NeonProject,
@@ -524,6 +526,12 @@ export class IpcClient {
   // Create a new chat for an app
   public async createChat(appId: number): Promise<number> {
     return this.ipcRenderer.invoke("create-chat", appId);
+  }
+
+  public async createChatFromPromptEdit(
+    params: CreateChatFromPromptEditParams,
+  ): Promise<CreateChatFromPromptEditResult> {
+    return this.ipcRenderer.invoke("chat:create-from-prompt-edit", params);
   }
 
   public async updateChat(params: UpdateChatParams): Promise<void> {

--- a/src/ipc/ipc_types.ts
+++ b/src/ipc/ipc_types.ts
@@ -86,6 +86,7 @@ export interface Message {
   requestId?: string | null;
   totalTokens?: number | null;
   model?: string | null;
+  chatId?: number;
 }
 
 export interface Chat {
@@ -94,6 +95,17 @@ export interface Chat {
   messages: Message[];
   initialCommitHash?: string | null;
   dbTimestamp?: string | null;
+}
+
+export interface CreateChatFromPromptEditParams {
+  appId: number;
+  chatId: number;
+  messageId: number;
+}
+
+export interface CreateChatFromPromptEditResult {
+  chatId: number;
+  copiedMessagesCount: number;
 }
 
 export interface App {

--- a/src/ipc/ipc_types.ts
+++ b/src/ipc/ipc_types.ts
@@ -103,11 +103,6 @@ export interface CreateChatFromPromptEditParams {
   messageId: number;
 }
 
-export interface CreateChatFromPromptEditResult {
-  chatId: number;
-  copiedMessagesCount: number;
-}
-
 export interface App {
   id: number;
   name: string;

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -21,6 +21,7 @@ const validInvokeChannels = [
   "chat:cancel",
   "chat:stream",
   "chat:count-tokens",
+  "chat:create-from-prompt-edit",
   "create-chat",
   "create-app",
   "copy-app",


### PR DESCRIPTION
Simple Prompt and Copy Prompt
Closes #1231 #1636











<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Edit and Copy actions for user chat prompts. Editing a prompt starts a new chat that includes only history up to that point and streams the edited content. Closes #1231 and #1636.

- **New Features**
  - Inline edit for user prompts with Save/Cancel and Esc / Cmd/Ctrl+Enter.
  - New IPC flow to create a chat from a prompt edit, copying earlier messages only.
  - Auto-navigate to the new chat and continue with the edited prompt.
  - One-click copy for prompt content with tooltip feedback.
  - E2E tests covering editing the first prompt and a later prompt.

<sup>Written for commit 0c9f55cf742344309a5286244081808c83b61896. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->











<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces prompt editing that forks conversation context and continues with the edited input.
> 
> - **UI**: Inline edit in `ChatMessage` with `Textarea`, Save/Cancel, Esc or Cmd/Ctrl+Enter; disables during streaming; adds prompt copy button with tooltip
> - **IPC**: New `chat:create-from-prompt-edit` handler to create a chat from an edited prompt; adds `IpcClient.createChatFromPromptEdit`, `CreateChatFromPromptEditParams`, and exposes channel in `preload`
> - **Data**: Extends `Message` type with optional `chatId`
> - **Behavior**: On save, navigates to the new chat and calls `streamMessage`; only messages before the edited one are copied into the new chat
> - **Tests**: Playwright E2E tests for editing the first prompt and a later prompt; adds snapshot
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a421c3a2ca7e0953a1857c4e9fba97b6843e3cf9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->