### PR TITLE
Telemetry for search & replace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dyad",
-  "version": "0.30.0-beta.1",
+  "version": "0.31.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dyad",
-      "version": "0.30.0-beta.1",
+      "version": "0.31.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/amazon-bedrock": "^3.0.15",

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -39,6 +39,7 @@ import { streamTestResponse } from "./testing_chat_handlers";
 import { getTestResponse } from "./testing_chat_handlers";
 import { getModelClient, ModelClient } from "../utils/get_model_client";
 import log from "electron-log";
+import { sendTelemetryEvent } from "../utils/telemetry";
 import {
   getSupabaseContext,
   getSupabaseClientCode,
@@ -1071,6 +1072,15 @@ This conversation includes one or more image attachments. When the user uploads 
               fullResponse,
               appPath: getDyadAppPath(updatedChat.app.path),
             });
+            sendTelemetryEvent("search_replace:fix", {
+              attemptNumber: 0,
+              success: issues.length === 0,
+              issueCount: issues.length,
+              errors: issues.map((i) => ({
+                filePath: i.filePath,
+                error: i.error,
+              })),
+            });
 
             let searchReplaceFixAttempts = 0;
             const originalFullResponse = fullResponse;
@@ -1140,6 +1150,16 @@ ${formattedSearchReplaceIssues}`,
               issues = await dryRunSearchReplace({
                 fullResponse: result.incrementalResponse,
                 appPath: getDyadAppPath(updatedChat.app.path),
+              });
+
+              sendTelemetryEvent("search_replace:fix", {
+                attemptNumber: searchReplaceFixAttempts,
+                success: issues.length === 0,
+                issueCount: issues.length,
+                errors: issues.map((i) => ({
+                  filePath: i.filePath,
+                  error: i.error,
+                })),
               });
             }
           }

--- a/src/ipc/ipc_client.ts
+++ b/src/ipc/ipc_client.ts
@@ -76,6 +76,7 @@ import type {
   SetAgentToolConsentParams,
   AgentToolConsentRequestPayload,
   AgentToolConsentResponseParams,
+  TelemetryEventPayload,
 } from "./ipc_types";
 import type { Template } from "../shared/templates";
 import type {
@@ -131,12 +132,7 @@ export class IpcClient {
   >;
   private mcpConsentHandlers: Map<string, (payload: any) => void>;
   private agentConsentHandlers: Map<string, (payload: any) => void>;
-  private telemetryEventHandlers: Set<
-    (payload: {
-      eventName: string;
-      properties?: Record<string, unknown>;
-    }) => void
-  >;
+  private telemetryEventHandlers: Set<(payload: TelemetryEventPayload) => void>;
   // Global handlers called for any chat stream completion (used for cleanup)
   private globalChatStreamEndHandlers: Set<(chatId: number) => void>;
   private constructor() {
@@ -299,12 +295,7 @@ export class IpcClient {
     this.ipcRenderer.on("telemetry:event", (payload) => {
       if (payload && typeof payload === "object" && "eventName" in payload) {
         for (const handler of this.telemetryEventHandlers) {
-          handler(
-            payload as {
-              eventName: string;
-              properties?: Record<string, unknown>;
-            },
-          );
+          handler(payload as TelemetryEventPayload);
         }
       }
     });
@@ -996,10 +987,7 @@ export class IpcClient {
    * @returns Unsubscribe function
    */
   public onTelemetryEvent(
-    handler: (payload: {
-      eventName: string;
-      properties?: Record<string, unknown>;
-    }) => void,
+    handler: (payload: TelemetryEventPayload) => void,
   ): () => void {
     this.telemetryEventHandlers.add(handler);
     return () => {

--- a/src/ipc/ipc_types.ts
+++ b/src/ipc/ipc_types.ts
@@ -619,3 +619,8 @@ export interface AgentToolConsentResponseParams {
 // ============================================================================
 
 export type AgentToolConsent = "ask" | "always";
+
+export interface TelemetryEventPayload {
+  eventName: string;
+  properties?: Record<string, unknown>;
+}

--- a/src/ipc/processors/response_processor.ts
+++ b/src/ipc/processors/response_processor.ts
@@ -79,6 +79,9 @@ export async function dryRunSearchReplace({
           error:
             "Unable to apply search-replace to file because: " + result.error,
         });
+        logger.warn(
+          `Unable to apply search-replace to file ${filePath} because: ${result.error}. Original content:\n${original}\n Diff content:\n${tag.content}`,
+        );
         continue;
       }
     } catch (error) {

--- a/src/ipc/processors/response_processor.ts
+++ b/src/ipc/processors/response_processor.ts
@@ -39,6 +39,7 @@ import {
 } from "../utils/dyad_tag_parser";
 import { applySearchReplace } from "../../pro/main/ipc/processors/search_replace_processor";
 import { storeDbTimestampAtCurrentVersion } from "../utils/neon_timestamp_utils";
+import { sendTelemetryEvent } from "../utils/telemetry";
 
 import { FileUploadsState } from "../utils/file_uploads_state";
 
@@ -73,6 +74,10 @@ export async function dryRunSearchReplace({
 
       const original = await readFile(fullFilePath, "utf8");
       const result = applySearchReplace(original, tag.content);
+      sendTelemetryEvent("search-replace:result", {
+        success: result.success,
+        error: result.success ? undefined : result.error,
+      });
       if (!result.success || typeof result.content !== "string") {
         issues.push({
           filePath,

--- a/src/ipc/processors/response_processor.ts
+++ b/src/ipc/processors/response_processor.ts
@@ -39,7 +39,6 @@ import {
 } from "../utils/dyad_tag_parser";
 import { applySearchReplace } from "../../pro/main/ipc/processors/search_replace_processor";
 import { storeDbTimestampAtCurrentVersion } from "../utils/neon_timestamp_utils";
-import { sendTelemetryEvent } from "../utils/telemetry";
 
 import { FileUploadsState } from "../utils/file_uploads_state";
 
@@ -74,10 +73,6 @@ export async function dryRunSearchReplace({
 
       const original = await readFile(fullFilePath, "utf8");
       const result = applySearchReplace(original, tag.content);
-      sendTelemetryEvent("search-replace:result", {
-        success: result.success,
-        error: result.success ? undefined : result.error,
-      });
       if (!result.success || typeof result.content !== "string") {
         issues.push({
           filePath,

--- a/src/ipc/utils/telemetry.ts
+++ b/src/ipc/utils/telemetry.ts
@@ -1,0 +1,23 @@
+import { BrowserWindow } from "electron";
+
+export interface TelemetryEventPayload {
+  eventName: string;
+  properties?: Record<string, unknown>;
+}
+
+/**
+ * Sends a telemetry event from the main process to the renderer,
+ * where PostHog can capture it.
+ */
+export function sendTelemetryEvent(
+  eventName: string,
+  properties?: Record<string, unknown>,
+): void {
+  const windows = BrowserWindow.getAllWindows();
+  if (windows.length > 0) {
+    windows[0].webContents.send("telemetry:event", {
+      eventName,
+      properties,
+    } satisfies TelemetryEventPayload);
+  }
+}

--- a/src/ipc/utils/telemetry.ts
+++ b/src/ipc/utils/telemetry.ts
@@ -1,4 +1,7 @@
 import { BrowserWindow } from "electron";
+import log from "electron-log";
+
+const logger = log.scope("telemetry");
 
 export interface TelemetryEventPayload {
   eventName: string;
@@ -13,11 +16,15 @@ export function sendTelemetryEvent(
   eventName: string,
   properties?: Record<string, unknown>,
 ): void {
-  const windows = BrowserWindow.getAllWindows();
-  if (windows.length > 0) {
-    windows[0].webContents.send("telemetry:event", {
-      eventName,
-      properties,
-    } satisfies TelemetryEventPayload);
+  try {
+    const windows = BrowserWindow.getAllWindows();
+    if (windows.length > 0) {
+      windows[0].webContents.send("telemetry:event", {
+        eventName,
+        properties,
+      } satisfies TelemetryEventPayload);
+    }
+  } catch (error) {
+    logger.warn("Error sending telemetry event:", error);
   }
 }

--- a/src/ipc/utils/telemetry.ts
+++ b/src/ipc/utils/telemetry.ts
@@ -1,12 +1,8 @@
 import { BrowserWindow } from "electron";
 import log from "electron-log";
+import { TelemetryEventPayload } from "../ipc_types";
 
 const logger = log.scope("telemetry");
-
-export interface TelemetryEventPayload {
-  eventName: string;
-  properties?: Record<string, unknown>;
-}
 
 /**
  * Sends a telemetry event from the main process to the renderer,

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -167,6 +167,8 @@ const validReceiveChannels = [
   "mcp:tool-consent-request",
   // Agent tool consent request from main to renderer
   "agent-tool:consent-request",
+  // Telemetry events from main to renderer
+  "telemetry:event",
 ] as const;
 
 type ValidInvokeChannel = (typeof validInvokeChannels)[number];

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -157,6 +157,15 @@ function App() {
     return () => unsubscribe();
   }, [setPendingAgentConsents]);
 
+  // Forward telemetry events from main process to PostHog
+  useEffect(() => {
+    const ipc = IpcClient.getInstance();
+    const unsubscribe = ipc.onTelemetryEvent(({ eventName, properties }) => {
+      posthog.capture(eventName, properties);
+    });
+    return () => unsubscribe();
+  }, []);
+
   return <RouterProvider router={router} />;
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds end-to-end telemetry for Turbo Edits search & replace and wiring to PostHog.
> 
> - Track `search_replace:fix` on initial dry run and each retry with `attemptNumber`, `success`, `issueCount`, and per-file `errors` (emitted from `chat_stream_handlers.ts`)
> - New main helper `sendTelemetryEvent` and IPC channel `telemetry:event` (whitelisted in `preload.ts`); renderer subscribes via `IpcClient.onTelemetryEvent` and forwards with `posthog.capture`
> - Improves diagnostics: warns with original and diff when `applySearchReplace` fails in `response_processor.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56bc3a352a2ab3b1e0100923cb395759229ee645. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added telemetry for Turbo Edits search & replace, forwarding events from main to renderer and capturing them in PostHog. Tracks success/failure and errors for each fix attempt.

- **New Features**
  - Emit "search_replace:fix" with attemptNumber, success, issueCount, and per-file errors on initial attempt and retries.
  - Add a sendTelemetryEvent helper in main and a "telemetry:event" IPC channel (whitelisted in preload).
  - Expose IpcClient.onTelemetryEvent; renderer forwards to PostHog via posthog.capture.

<sup>Written for commit 56bc3a352a2ab3b1e0100923cb395759229ee645. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







