### PR TITLE
Make undo more robust by using sourceCommitHash

### DIFF
--- a/e2e-tests/fixtures/no-code-response.md
+++ b/e2e-tests/fixtures/no-code-response.md
@@ -1,0 +1,2 @@
+I understand your request. This is a response without any code changes.
+

--- a/e2e-tests/undo.spec.ts
+++ b/e2e-tests/undo.spec.ts
@@ -40,3 +40,29 @@ testSkipIfWindows("undo", async ({ po }) => {
 testSkipIfWindows("undo with native git", async ({ po }) => {
   await runUndoTest(po, true);
 });
+
+testSkipIfWindows("undo after assistant with no code", async ({ po }) => {
+  await po.setUp({ autoApprove: true, nativeGit: false });
+
+  // First prompt - no code generated
+  await po.sendPrompt("tc=no-code-response");
+
+  // Second prompt - generates code
+  await po.sendPrompt("tc=write-index");
+
+  const iframe = po.getPreviewIframeElement();
+  await expect(
+    iframe.contentFrame().getByText("Testing:write-index!"),
+  ).toBeVisible({
+    timeout: Timeout.LONG,
+  });
+
+  // Undo should work even though first assistant had no commit
+  await po.clickUndo();
+
+  await expect(
+    iframe.contentFrame().getByText("Welcome to Your Blank App"),
+  ).toBeVisible({
+    timeout: Timeout.LONG,
+  });
+});

--- a/src/components/chat/MessagesList.tsx
+++ b/src/components/chat/MessagesList.tsx
@@ -88,8 +88,7 @@ function FooterComponent({ context }: { context?: FooterContext }) {
       {!isStreaming && (
         <div className="flex max-w-3xl mx-auto gap-2">
           {!!messages.length &&
-            messages[messages.length - 1].role === "assistant" &&
-            messages[messages.length - 1].commitHash && (
+            messages[messages.length - 1].role === "assistant" && (
               <Button
                 variant="outline"
                 size="sm"
@@ -103,6 +102,8 @@ function FooterComponent({ context }: { context?: FooterContext }) {
                   setIsUndoLoading(true);
                   try {
                     const currentMessage = messages[messages.length - 1];
+                    // The user message that triggered this assistant response
+                    const userMessage = messages[messages.length - 2];
                     if (currentMessage?.sourceCommitHash) {
                       console.debug(
                         "Reverting to source commit hash",
@@ -110,6 +111,12 @@ function FooterComponent({ context }: { context?: FooterContext }) {
                       );
                       await revertVersion({
                         versionId: currentMessage.sourceCommitHash,
+                        currentChatMessageId: userMessage
+                          ? {
+                              chatId: selectedChatId,
+                              messageId: userMessage.id,
+                            }
+                          : undefined,
                       });
                       const chat =
                         await IpcClient.getInstance().getChat(selectedChatId);

--- a/src/hooks/useVersions.ts
+++ b/src/hooks/useVersions.ts
@@ -42,9 +42,18 @@ export function useVersions(appId: number | null) {
   const revertVersionMutation = useMutation<
     RevertVersionResponse,
     Error,
-    { versionId: string }
+    {
+      versionId: string;
+      currentChatMessageId?: { chatId: number; messageId: number };
+    }
   >({
-    mutationFn: async ({ versionId }: { versionId: string }) => {
+    mutationFn: async ({
+      versionId,
+      currentChatMessageId,
+    }: {
+      versionId: string;
+      currentChatMessageId?: { chatId: number; messageId: number };
+    }) => {
       const currentAppId = appId;
       if (currentAppId === null) {
         throw new Error("App ID is null");
@@ -53,6 +62,7 @@ export function useVersions(appId: number | null) {
       return ipcClient.revertVersion({
         appId: currentAppId,
         previousVersionId: versionId,
+        currentChatMessageId,
       });
     },
     onSuccess: async (result) => {

--- a/src/ipc/handlers/version_handlers.ts
+++ b/src/ipc/handlers/version_handlers.ts
@@ -1,6 +1,6 @@
 import { db } from "../../db";
 import { apps, messages, versions } from "../../db/schema";
-import { desc, eq, and, gt } from "drizzle-orm";
+import { desc, eq, and, gt, gte } from "drizzle-orm";
 import type {
   Version,
   BranchResult,
@@ -156,7 +156,7 @@ export function registerVersionHandlers() {
     "revert-version",
     async (
       _,
-      { appId, previousVersionId }: RevertVersionParams,
+      { appId, previousVersionId, currentChatMessageId }: RevertVersionParams,
     ): Promise<RevertVersionResponse> => {
       return withLock(appId, async () => {
         let successMessage = "Restored version";
@@ -199,41 +199,67 @@ export function registerVersionHandlers() {
           message: `Reverted all changes back to version ${previousVersionId}`,
         });
 
-        // Find the chat and message associated with the commit hash
-        const messageWithCommit = await db.query.messages.findFirst({
-          where: eq(messages.commitHash, previousVersionId),
-          with: {
-            chat: true,
-          },
-        });
+        // Delete messages based on currentChatMessageId if provided, otherwise use commit hash lookup
+        if (currentChatMessageId) {
+          // Delete all messages including and after the specified message
+          const { chatId, messageId } = currentChatMessageId;
 
-        // If we found a message with this commit hash, delete all subsequent messages (but keep this message)
-        if (messageWithCommit) {
-          const chatId = messageWithCommit.chatId;
-
-          // Find all messages in this chat with IDs > the one with our commit hash
           const messagesToDelete = await db.query.messages.findMany({
             where: and(
               eq(messages.chatId, chatId),
-              gt(messages.id, messageWithCommit.id),
+              gte(messages.id, messageId),
             ),
             orderBy: desc(messages.id),
           });
 
           logger.log(
-            `Deleting ${messagesToDelete.length} messages after commit ${previousVersionId} from chat ${chatId}`,
+            `Deleting ${messagesToDelete.length} messages (id >= ${messageId}) from chat ${chatId}`,
           );
 
-          // Delete the messages
           if (messagesToDelete.length > 0) {
             await db
               .delete(messages)
               .where(
-                and(
-                  eq(messages.chatId, chatId),
-                  gt(messages.id, messageWithCommit.id),
-                ),
+                and(eq(messages.chatId, chatId), gte(messages.id, messageId)),
               );
+          }
+        } else {
+          // Find the chat and message associated with the commit hash
+          const messageWithCommit = await db.query.messages.findFirst({
+            where: eq(messages.commitHash, previousVersionId),
+            with: {
+              chat: true,
+            },
+          });
+
+          // If we found a message with this commit hash, delete all subsequent messages (but keep this message)
+          if (messageWithCommit) {
+            const chatId = messageWithCommit.chatId;
+
+            // Find all messages in this chat with IDs > the one with our commit hash
+            const messagesToDelete = await db.query.messages.findMany({
+              where: and(
+                eq(messages.chatId, chatId),
+                gt(messages.id, messageWithCommit.id),
+              ),
+              orderBy: desc(messages.id),
+            });
+
+            logger.log(
+              `Deleting ${messagesToDelete.length} messages after commit ${previousVersionId} from chat ${chatId}`,
+            );
+
+            // Delete the messages
+            if (messagesToDelete.length > 0) {
+              await db
+                .delete(messages)
+                .where(
+                  and(
+                    eq(messages.chatId, chatId),
+                    gt(messages.id, messageWithCommit.id),
+                  ),
+                );
+            }
           }
         }
 

--- a/src/ipc/handlers/version_handlers.ts
+++ b/src/ipc/handlers/version_handlers.ts
@@ -194,8 +194,8 @@ export function registerVersionHandlers() {
           path: appPath,
           targetOid: previousVersionId,
         });
-        const hasChanges = await isGitStatusClean({ path: appPath });
-        if (hasChanges) {
+        const isClean = await isGitStatusClean({ path: appPath });
+        if (!isClean) {
           await gitCommit({
             path: appPath,
             message: `Reverted all changes back to version ${previousVersionId}`,

--- a/src/ipc/handlers/version_handlers.ts
+++ b/src/ipc/handlers/version_handlers.ts
@@ -23,6 +23,7 @@ import {
   getCurrentCommitHash,
   gitCurrentBranch,
   gitLog,
+  isGitStatusClean,
 } from "../utils/git_utils";
 
 import {
@@ -193,11 +194,13 @@ export function registerVersionHandlers() {
           path: appPath,
           targetOid: previousVersionId,
         });
-
-        await gitCommit({
-          path: appPath,
-          message: `Reverted all changes back to version ${previousVersionId}`,
-        });
+        const hasChanges = await isGitStatusClean({ path: appPath });
+        if (hasChanges) {
+          await gitCommit({
+            path: appPath,
+            message: `Reverted all changes back to version ${previousVersionId}`,
+          });
+        }
 
         // Delete messages based on currentChatMessageId if provided, otherwise use commit hash lookup
         if (currentChatMessageId) {

--- a/src/ipc/ipc_types.ts
+++ b/src/ipc/ipc_types.ts
@@ -442,6 +442,10 @@ export interface GetNeonProjectResponse {
 export interface RevertVersionParams {
   appId: number;
   previousVersionId: string;
+  currentChatMessageId?: {
+    chatId: number;
+    messageId: number;
+  };
 }
 
 export type RevertVersionResponse =

--- a/src/ipc/ipc_types.ts
+++ b/src/ipc/ipc_types.ts
@@ -80,6 +80,7 @@ export interface Message {
   content: string;
   approvalState?: "approved" | "rejected" | null;
   commitHash?: string | null;
+  sourceCommitHash?: string | null;
   dbTimestamp?: string | null;
   createdAt?: Date | string;
   requestId?: string | null;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Strengthens undo to work even when an assistant message produced no code.
> 
> - Use the last assistant message’s `sourceCommitHash` for `revertVersion` and pass `currentChatMessageId` to prune messages at/after the triggering user message; refresh chat state
> - Backend `revert-version` now conditionally commits only if there are staged changes and supports message deletion via `gte` with `currentChatMessageId`, falling back to commit-hash-based pruning
> - Extend IPC types: add `Message.sourceCommitHash` and `RevertVersionParams.currentChatMessageId`
> - Add e2e test and fixture for undo after a no-code assistant response
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a97e153d3cb703461b66bb7eaec28b4c7ae32cc4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make undo reliable by reverting to the message’s source commit instead of relying on a previous assistant message or the chat’s initial state. This fixes undo when an assistant reply contains no code.

- **Bug Fixes**
  - Use current message’s sourceCommitHash for revertVersion and pass currentChatMessageId to prune messages at/after the triggering user message; then refresh chat.
  - Extend Message type with sourceCommitHash and show a warning if it’s missing.
  - Add e2e test for undo after a no-code assistant response with a new fixture.

<sup>Written for commit a97e153d3cb703461b66bb7eaec28b4c7ae32cc4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







