### PR TITLE
Refactor useSupabase hook to be idiomatic

### DIFF
--- a/src/atoms/supabaseAtoms.ts
+++ b/src/atoms/supabaseAtoms.ts
@@ -1,25 +1,4 @@
 import { atom } from "jotai";
-import {
-  SupabaseBranch,
-  SupabaseOrganizationInfo,
-  SupabaseProject,
-} from "@/ipc/ipc_types";
-
-// Define atom for storing the list of connected Supabase organizations
-export const supabaseOrganizationsAtom = atom<SupabaseOrganizationInfo[]>([]);
-
-// Define atom for storing the list of Supabase projects
-export const supabaseProjectsAtom = atom<SupabaseProject[]>([]);
-export const supabaseBranchesAtom = atom<SupabaseBranch[]>([]);
-
-// Define atom for tracking loading state
-export const supabaseLoadingAtom = atom<boolean>(false);
-
-// Define atom for storing any error that occurs during loading
-export const supabaseErrorAtom = atom<Error | null>(null);
-
-// Define atom for storing the currently selected Supabase project
-export const selectedSupabaseProjectAtom = atom<string | null>(null);
 
 // Define atom for tracking the last log timestamp per project (for incremental log loading)
 export const lastLogTimestampAtom = atom<Record<string, number>>({});

--- a/src/components/SupabaseConnector.tsx
+++ b/src/components/SupabaseConnector.tsx
@@ -62,12 +62,15 @@ export function SupabaseConnector({ appId }: { appId: number }) {
   const {
     organizations,
     projects,
-    loading,
-    error,
+    branches,
+    isLoadingProjects,
+    isFetchingProjects,
+    projectsError,
+    isLoadingBranches,
+    isSettingAppProject,
     loadOrganizations,
     deleteOrganization,
     loadProjects,
-    branches,
     loadBranches,
     setAppProject,
     unsetAppProject,
@@ -242,7 +245,7 @@ export function SupabaseConnector({ appId }: { appId: number }) {
                     toast.error("Failed to set branch: " + error);
                   }
                 }}
-                disabled={loading}
+                disabled={isLoadingBranches || isSettingAppProject}
               >
                 <SelectTrigger
                   id="supabase-branch-select"
@@ -301,14 +304,14 @@ export function SupabaseConnector({ appId }: { appId: number }) {
           </CardDescription>
         </CardHeader>
         <CardContent>
-          {loading ? (
+          {isLoadingProjects || isFetchingProjects ? (
             <div className="space-y-2">
               <Skeleton className="h-4 w-full" />
               <Skeleton className="h-10 w-full" />
             </div>
-          ) : error ? (
+          ) : projectsError ? (
             <div className="text-red-500">
-              Error loading projects: {error.message}
+              Error loading projects: {projectsError.message}
               <Button
                 variant="outline"
                 className="mt-2"

--- a/src/components/SupabaseConnector.tsx
+++ b/src/components/SupabaseConnector.tsx
@@ -158,7 +158,6 @@ export function SupabaseConnector({ appId }: { appId: number }) {
     try {
       await deleteOrganization({ organizationSlug });
       toast.success("Organization disconnected successfully");
-      await refetchProjects();
     } catch (error) {
       toast.error("Failed to disconnect organization: " + error);
     }

--- a/src/components/SupabaseConnector.tsx
+++ b/src/components/SupabaseConnector.tsx
@@ -48,6 +48,9 @@ export function SupabaseConnector({ appId }: { appId: number }) {
   const { lastDeepLink, clearLastDeepLink } = useDeepLink();
   const { isDarkMode } = useTheme();
 
+  // Check if there are any connected organizations
+  const isConnected = isSupabaseConnected(settings);
+
   const branchesProjectId =
     app?.supabaseParentProjectId || app?.supabaseProjectId;
 
@@ -82,21 +85,6 @@ export function SupabaseConnector({ appId }: { appId: number }) {
     };
     handleDeepLink();
   }, [lastDeepLink?.timestamp]);
-
-  // Check if there are any connected organizations
-  const isConnected = isSupabaseConnected(settings);
-
-  useEffect(() => {
-    // Load organizations and projects when the component mounts
-    refetchOrganizations();
-  }, [refetchOrganizations]);
-
-  useEffect(() => {
-    // Load projects when organizations are available
-    if (isConnected) {
-      refetchProjects();
-    }
-  }, [isConnected, refetchProjects]);
 
   const handleProjectSelect = async (projectValue: string) => {
     try {

--- a/src/components/SupabaseIntegration.tsx
+++ b/src/components/SupabaseIntegration.tsx
@@ -12,13 +12,13 @@ import { isSupabaseConnected } from "@/lib/schemas";
 
 export function SupabaseIntegration() {
   const { settings, updateSettings } = useSettings();
-  const { organizations, loadOrganizations, deleteOrganization } =
+  const { organizations, refetchOrganizations, deleteOrganization } =
     useSupabase();
   const [isDisconnecting, setIsDisconnecting] = useState(false);
 
   useEffect(() => {
-    loadOrganizations();
-  }, [loadOrganizations]);
+    refetchOrganizations();
+  }, [refetchOrganizations]);
 
   const handleDisconnectAllFromSupabase = async () => {
     setIsDisconnecting(true);
@@ -31,7 +31,7 @@ export function SupabaseIntegration() {
       });
       if (result) {
         showSuccess("Successfully disconnected all Supabase organizations");
-        await loadOrganizations();
+        await refetchOrganizations();
       } else {
         showError("Failed to disconnect from Supabase");
       }

--- a/src/components/SupabaseIntegration.tsx
+++ b/src/components/SupabaseIntegration.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
@@ -12,13 +12,13 @@ import { isSupabaseConnected } from "@/lib/schemas";
 
 export function SupabaseIntegration() {
   const { settings, updateSettings } = useSettings();
-  const { organizations, refetchOrganizations, deleteOrganization } =
-    useSupabase();
   const [isDisconnecting, setIsDisconnecting] = useState(false);
 
-  useEffect(() => {
-    refetchOrganizations();
-  }, [refetchOrganizations]);
+  // Check if there are any connected organizations
+  const isConnected = isSupabaseConnected(settings);
+
+  const { organizations, refetchOrganizations, deleteOrganization } =
+    useSupabase();
 
   const handleDisconnectAllFromSupabase = async () => {
     setIsDisconnecting(true);
@@ -63,9 +63,6 @@ export function SupabaseIntegration() {
       showError(err.message || "Failed to update setting");
     }
   };
-
-  // Check if there are any connected organizations
-  const isConnected = isSupabaseConnected(settings);
 
   if (!isConnected) {
     return null;

--- a/src/components/preview_panel/PreviewPanel.tsx
+++ b/src/components/preview_panel/PreviewPanel.tsx
@@ -117,13 +117,13 @@ export function PreviewPanel() {
     if (!projectId) return;
 
     // Load logs immediately
-    loadEdgeLogs(projectId, organizationSlug).catch((error) => {
+    loadEdgeLogs({ projectId, organizationSlug }).catch((error) => {
       console.error("Failed to load edge logs:", error);
     });
 
     // Poll for new logs every 5 seconds
     const intervalId = setInterval(() => {
-      loadEdgeLogs(projectId, organizationSlug).catch((error) => {
+      loadEdgeLogs({ projectId, organizationSlug }).catch((error) => {
         console.error("Failed to load edge logs:", error);
       });
     }, 5000);

--- a/src/hooks/useSupabase.ts
+++ b/src/hooks/useSupabase.ts
@@ -101,7 +101,7 @@ export function useSupabase(options: UseSupabaseOptions = {}) {
 
   // Query: Load branches for a Supabase project
   const branchesQuery = useQuery<SupabaseBranch[], Error>({
-    queryKey: SUPABASE_QUERY_KEYS.branches(branchesProjectId ?? ""),
+    queryKey: [...SUPABASE_QUERY_KEYS.branches(branchesProjectId ?? ""), branchesOrganizationSlug ?? null],
     queryFn: async () => {
       const ipcClient = IpcClient.getInstance();
       const list = await ipcClient.listSupabaseBranches({

--- a/src/hooks/useSupabase.ts
+++ b/src/hooks/useSupabase.ts
@@ -101,7 +101,10 @@ export function useSupabase(options: UseSupabaseOptions = {}) {
 
   // Query: Load branches for a Supabase project
   const branchesQuery = useQuery<SupabaseBranch[], Error>({
-    queryKey: [...SUPABASE_QUERY_KEYS.branches(branchesProjectId ?? ""), branchesOrganizationSlug ?? null],
+    queryKey: [
+      ...SUPABASE_QUERY_KEYS.branches(branchesProjectId ?? ""),
+      branchesOrganizationSlug ?? null,
+    ],
     queryFn: async () => {
       const ipcClient = IpcClient.getInstance();
       const list = await ipcClient.listSupabaseBranches({


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Moves Supabase data fetching/mutations to React Query and aligns UI with new query states for clearer loading/errors and cache-driven updates.
> 
> - Removed most Supabase atoms; kept `lastLogTimestampAtom` only
> - New `useSupabase` exposes React Query queries (`organizations`, `projects`, `branches`) and mutations (delete org, set/unset app project, edge logs) with invalidate/refetch helpers
> - `SupabaseConnector` and `SupabaseIntegration` now use `refetch*`, granular `isLoading*/error` flags, and updated handlers; branch select disabled via `isLoadingBranches`/`isSettingAppProject`
> - `PreviewPanel` switches `loadEdgeLogs` to accept `{ projectId, organizationSlug }` and continues polling
> - OAuth return flow now calls `refetchOrganizations`/`refetchProjects` instead of manual load functions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 573df5298f323854d4a8aa1ce5903b99e4caba62. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->









<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored Supabase integration to use TanStack React Query for data fetching and mutations. This makes loading/error handling clearer, improves cache invalidation, and smooths the UI.

- **Refactors**
  - Replaced Jotai state with React Query for organizations, projects, and branches; removed related atoms.
  - Added mutations for delete organization, set/unset app project, and edge logs; invalidates org/project queries on deletion.
  - Exposed granular states for organizations, projects, and branches; removed selected project state.
  - Updated SupabaseConnector/SupabaseIntegration to use refetch* methods and new flags; PreviewPanel now calls loadEdgeLogs with params; disables branch select while loading or setting.

<sup>Written for commit 573df5298f323854d4a8aa1ce5903b99e4caba62. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









