### PR TITLE
Fix claude review env

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -7,7 +7,9 @@ on:
         types: [opened, synchronize, ready_for_review, reopened]
 
 jobs:
-    review-with-tracking:
+    claude-review:
+        # Has Anthropic API key, etc.
+        environment: ai-bots
         # Only review code from regular contributors since claude code has non-trivial costs
         # https://github.com/anthropics/claude-code-action/blob/main/examples/pr-review-filtered-authors.yml
         if: |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Configure Claude PR review workflow**
> 
> - Renames job to `claude-review` and binds to `environment: ai-bots`
> - Grants required permissions including `id-token: write`
> - Adds steps: repository checkout and `anthropics/claude-code-action@v1` with `track_progress: true`
> - Provides detailed custom review `prompt` and updates `claude_args` (model and allowed tools)
> - Retains contributor filter to limit reviews to specific authors
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb7f18b0899a50078fcd5aeaaf9b40dc6346fbe0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Attach the Claude PR review workflow to the ai-bots environment to provide required secrets and prevent review failures. Renamed the job to claude-review for clarity.

<sup>Written for commit eb7f18b0899a50078fcd5aeaaf9b40dc6346fbe0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

