### PR TITLE
Single build task for each OS for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,29 +148,6 @@ jobs:
         # do not run this on windows (it's redundant)
         if: contains(matrix.os.name, 'macos')
         run: npm run test
-      - name: Setup pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-        with:
-          version: latest
-      - name: Clone nextjs-template
-        run: git clone --depth 1 https://github.com/dyad-sh/nextjs-template.git nextjs-template
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-      - name: Setup pnpm cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ matrix.os.name }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ matrix.os.name }}-pnpm-store-
-      # Not strictly needed but makes the e2e tests faster (and less flaky)
-      - name: Install scaffold dependencies
-        run: cd scaffold && pnpm install
-      - name: Install nextjs-template dependencies
-        run: cd nextjs-template && pnpm install
       - name: Build
         env:
           NODE_OPTIONS: "--max-old-space-size=4096"
@@ -212,10 +189,36 @@ jobs:
           cache-dependency-path: package-lock.json
       - name: Install node modules
         run: npm ci --no-audit --no-fund --progress=false
+      - name: Setup pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+        with:
+          version: latest
+      - name: Clone nextjs-template
+        run: git clone --depth 1 https://github.com/dyad-sh/nextjs-template.git nextjs-template
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ matrix.os.name }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ matrix.os.name }}-pnpm-store-
+      # Not strictly needed but makes the e2e tests faster (and less flaky)
+      - name: Install scaffold dependencies
+        run: cd scaffold && pnpm install
+      - name: Install nextjs-template dependencies
+        run: cd nextjs-template && pnpm install
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
           name: build-${{ matrix.os.name }}
+      - name: Restore executable permissions (macOS)
+        if: contains(matrix.os.name, 'macos')
+        run: chmod +x out/dyad-darwin-arm64/dyad.app/Contents/MacOS/dyad
       - name: Install Chromium browser for Playwright
         run: npx playwright install chromium --with-deps
       - name: E2E tests (Shard ${{ matrix.shard }}/4)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,9 @@ jobs:
       - name: Restore executable permissions (macOS)
         if: contains(matrix.os.name, 'macos')
         run: chmod +x out/dyad-darwin-arm64/dyad.app/Contents/MacOS/dyad
+      - name: Clear macOS quarantine (if present)
+        if: contains(matrix.os.name, 'macos')
+        run: xattr -cr out/dyad-darwin-arm64/dyad.app || true
       - name: Install Chromium browser for Playwright
         run: npx playwright install chromium --with-deps
       - name: E2E tests (Shard ${{ matrix.shard }}/4)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
             echo "$NON_CLAUDE_FILES"
           fi
 
-  test:
+  build:
     needs: [check-changes]
     if: needs.check-changes.outputs.should_run_tests == 'true'
     # Why Mac and Windows?
@@ -118,10 +118,6 @@ jobs:
             { name: "windows", image: "windows-latest" },
             { name: "macos", image: "macos-latest" },
           ]
-        # If you update this, you need to update
-        # scripts/generate-playwright-summary.js
-        shard: [1, 2, 3, 4]
-        shardTotal: [4]
     runs-on: ${{ matrix.os.image }}
     steps:
       - name: Checkout code
@@ -142,18 +138,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Presubmit check (e.g. lint, format)
         # do not run this on Windows (it fails and not necessary)
-        # Only run on shard 1 to avoid redundant execution
-        if: contains(matrix.os.name, 'macos') && matrix.shard == 1
+        if: contains(matrix.os.name, 'macos')
         run: npm run presubmit
       - name: Type-checking
-        # do not run this on windows (it's redunant)
-        # Only run on shard 1 to avoid redundant execution
-        if: contains(matrix.os.name, 'macos') && matrix.shard == 1
+        # do not run this on windows (it's redundant)
+        if: contains(matrix.os.name, 'macos')
         run: npm run ts
       - name: Unit tests
-        # do not run this on windows (it's redunant)
-        # Only run on shard 1 to avoid redundant execution
-        if: contains(matrix.os.name, 'macos') && matrix.shard == 1
+        # do not run this on windows (it's redundant)
+        if: contains(matrix.os.name, 'macos')
         run: npm run test
       - name: Setup pnpm
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
@@ -178,14 +171,53 @@ jobs:
         run: cd scaffold && pnpm install
       - name: Install nextjs-template dependencies
         run: cd nextjs-template && pnpm install
-      - name: Install Chromium browser for Playwright
-        run: npx playwright install chromium --with-deps
       - name: Build
         env:
           NODE_OPTIONS: "--max-old-space-size=4096"
         run: npm run pre:e2e
       - name: Prep test server
         run: cd testing/fake-llm-server && npm install && npm run build && cd -
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: build-${{ matrix.os.name }}
+          path: |
+            out/
+            scaffold/
+            nextjs-template/
+            testing/fake-llm-server/
+          retention-days: 1
+
+  e2e-tests:
+    needs: [build]
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          [
+            { name: "windows", image: "windows-latest" },
+            { name: "macos", image: "macos-latest" },
+          ]
+        shard: [1, 2, 3, 4]
+        shardTotal: [4]
+    runs-on: ${{ matrix.os.image }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Initialize environment
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - name: Install node modules
+        run: npm ci --no-audit --no-fund --progress=false
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-${{ matrix.os.name }}
+      - name: Install Chromium browser for Playwright
+        run: npx playwright install chromium --with-deps
       - name: E2E tests (Shard ${{ matrix.shard }}/4)
         # You can add debug logging to make it easier to see what's failing
         # by adding "DEBUG=pw:browser" in front.
@@ -203,7 +235,7 @@ jobs:
     # Merge reports after playwright-tests, even if some shards have failed
     # Skip if tests were skipped (only .claude files changed)
     if: ${{ !cancelled() && needs.check-changes.outputs.should_run_tests == 'true' }}
-    needs: [check-changes, test]
+    needs: [check-changes, e2e-tests]
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,14 +154,29 @@ jobs:
         run: npm run pre:e2e
       - name: Prep test server
         run: cd testing/fake-llm-server && npm install && npm run build && cd -
-      - name: Upload build artifacts
+      # macOS: Archive app bundle with tar to preserve metadata (code signatures, extended attributes)
+      # This is necessary because GitHub artifact upload/download loses these attributes
+      - name: Archive macOS app bundle
+        if: contains(matrix.os.name, 'macos')
+        run: tar -cvf out-macos.tar out/
+      - name: Upload build artifacts (macOS)
+        if: contains(matrix.os.name, 'macos')
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: build-${{ matrix.os.name }}
+          path: |
+            out-macos.tar
+            scaffold/
+            testing/fake-llm-server/
+          retention-days: 1
+      - name: Upload build artifacts (Windows)
+        if: contains(matrix.os.name, 'windows')
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: build-${{ matrix.os.name }}
           path: |
             out/
             scaffold/
-            nextjs-template/
             testing/fake-llm-server/
           retention-days: 1
 
@@ -189,6 +204,9 @@ jobs:
           cache-dependency-path: package-lock.json
       - name: Install node modules
         run: npm ci --no-audit --no-fund --progress=false
+        env:
+          # Required for @vscode/ripgrep to download binaries without hitting GitHub API rate limits
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup pnpm
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
         with:
@@ -216,12 +234,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: build-${{ matrix.os.name }}
-      - name: Restore executable permissions (macOS)
+      # macOS: Extract tar archive to restore app bundle with preserved metadata
+      - name: Extract macOS app bundle
         if: contains(matrix.os.name, 'macos')
-        run: chmod +x out/dyad-darwin-arm64/dyad.app/Contents/MacOS/dyad
-      - name: Clear macOS quarantine (if present)
-        if: contains(matrix.os.name, 'macos')
-        run: xattr -cr out/dyad-darwin-arm64/dyad.app || true
+        run: tar -xvf out-macos.tar
       - name: Install Chromium browser for Playwright
         run: npx playwright install chromium --with-deps
       - name: E2E tests (Shard ${{ matrix.shard }}/4)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes CI execution order and artifact handling across macOS/Windows, which could cause failures or masking of build/test issues if artifacts are incomplete or OS-specific metadata isn’t preserved.
> 
> **Overview**
> Refactors the CI workflow to run a single per-OS `build` job (including `pre:e2e` and fake server build) and then execute Playwright `e2e-tests` in 4 shards that **download the built artifacts** instead of rebuilding per shard.
> 
> Adds OS-specific artifact packaging: macOS bundles are tarred (`out-macos.tar`) to preserve app metadata, while Windows uploads `out/` directly; `merge-reports` is updated to depend on `e2e-tests` rather than the old `test` job.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f42db63302827878905a8225fd47fc7b6cf1972. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2026">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
