### PR TITLE
setup flow e2e test

### DIFF
--- a/e2e-tests/helpers/test_helper.ts
+++ b/e2e-tests/helpers/test_helper.ts
@@ -1071,6 +1071,16 @@ export class PageObject {
     await this.page.getByRole("button", { name: "Add Model" }).click();
   }
 
+  async setUpTestProviderApiKey() {
+    // Fill in a test API key for the custom provider
+    await this.page
+      .getByPlaceholder(/Enter new.*API Key here/)
+      .fill("test-api-key-12345");
+    await this.page.getByRole("button", { name: "Save Key" }).click();
+    // Wait for the key to be saved
+    await expect(this.page.getByText("test-api-key-12345")).toBeVisible();
+  }
+
   async goToSettingsTab() {
     await this.page.getByRole("link", { name: "Settings" }).click();
   }

--- a/e2e-tests/helpers/test_helper.ts
+++ b/e2e-tests/helpers/test_helper.ts
@@ -1423,6 +1423,22 @@ export class PageObject {
   async clickAgentConsentDecline() {
     await this.page.getByRole("button", { name: "Decline" }).click();
   }
+
+  ////////////////////////////////
+  // Test-only: Node.js Mock Control
+  ////////////////////////////////
+
+  /**
+   * Set the mock state for Node.js installation status.
+   * @param installed - true = mock as installed, false = mock as not installed, null = use real check
+   */
+  async setNodeMock(installed: boolean | null) {
+    await this.page.evaluate(async (installed) => {
+      await (window as any).electron.ipcRenderer.invoke("test:set-node-mock", {
+        installed,
+      });
+    }, installed);
+  }
 }
 
 interface ElectronConfig {

--- a/e2e-tests/setup_flow.spec.ts
+++ b/e2e-tests/setup_flow.spec.ts
@@ -10,7 +10,9 @@ testSetup.describe("Setup Flow", () => {
     "setup banner shows correct state when node.js is installed",
     async ({ po }) => {
       // Verify the "Setup Dyad" heading is visible
-      await expect(po.page.getByText("Setup Dyad")).toBeVisible();
+      await expect(
+        po.page.getByText("Setup Dyad", { exact: true }),
+      ).toBeVisible();
 
       // Verify both accordion sections are visible
       await expect(
@@ -26,10 +28,10 @@ testSetup.describe("Setup Flow", () => {
 
       // AI provider section should show warning state (needs action)
       await expect(
-        po.page.getByRole("button", { name: "Setup Google Gemini API Key" }),
+        po.page.getByRole("button", { name: /Setup Google Gemini API Key/ }),
       ).toBeVisible();
       await expect(
-        po.page.getByRole("button", { name: "Setup OpenRouter API Key" }),
+        po.page.getByRole("button", { name: /Setup OpenRouter API Key/ }),
       ).toBeVisible();
     },
   );
@@ -40,7 +42,9 @@ testSetup.describe("Setup Flow", () => {
     await po.page.reload();
 
     // Verify setup banner and install button are visible
-    await expect(po.page.getByText("Setup Dyad")).toBeVisible();
+    await expect(
+      po.page.getByText("Setup Dyad", { exact: true }),
+    ).toBeVisible();
     await expect(
       po.page.getByRole("button", { name: "Install Node.js Runtime" }),
     ).toBeVisible();
@@ -79,12 +83,20 @@ testSetup.describe("Setup Flow", () => {
 
   testSetup("ai provider setup flow", async ({ po }) => {
     // Verify setup banner is visible
-    await expect(po.page.getByText("Setup Dyad")).toBeVisible();
+    await expect(
+      po.page.getByText("Setup Dyad", { exact: true }),
+    ).toBeVisible();
+
+    // Dismiss telemetry consent if present
+    const laterButton = po.page.getByRole("button", { name: "Later" });
+    if (await laterButton.isVisible({ timeout: 1000 }).catch(() => false)) {
+      await laterButton.click();
+    }
 
     // Test Google Gemini navigation
     await po.page
-      .getByRole("button", { name: "Setup Google Gemini API Key" })
-      .click();
+      .getByRole("heading", { name: "Setup Google Gemini API Key" })
+      .click({ force: true });
     await expect(
       po.page.getByRole("heading", { name: "Configure Google" }),
     ).toBeVisible();
@@ -92,7 +104,7 @@ testSetup.describe("Setup Flow", () => {
 
     // Test OpenRouter navigation
     await po.page
-      .getByRole("button", { name: "Setup OpenRouter API Key" })
+      .getByRole("heading", { name: "Setup OpenRouter API Key" })
       .click();
     await expect(
       po.page.getByRole("heading", { name: "Configure OpenRouter" }),
@@ -101,19 +113,24 @@ testSetup.describe("Setup Flow", () => {
 
     // Test other providers navigation
     await po.page
-      .getByRole("button", { name: "Setup other AI providers" })
+      .getByRole("heading", { name: "Setup other AI providers" })
       .click();
     await expect(po.page.getByRole("link", { name: "Settings" })).toBeVisible();
 
     // Now configure the test provider
     await po.setUpTestProvider();
+    // Set up API key so provider is considered configured
+    await po.page.getByRole("heading", { name: "test-provider" }).click();
+    await po.setUpTestProviderApiKey();
     await po.setUpTestModel();
 
     // Go back to apps tab
     await po.goToAppsTab();
 
     // After configuring a provider, the setup banner should be gone
-    await expect(po.page.getByText("Setup Dyad")).not.toBeVisible();
-    await expect(po.page.getByText("Build your dream app")).toBeVisible();
+    await expect(
+      po.page.getByText("Setup Dyad", { exact: true }),
+    ).not.toBeVisible();
+    await expect(po.page.getByText("Build a new app")).toBeVisible();
   });
 });

--- a/e2e-tests/setup_flow.spec.ts
+++ b/e2e-tests/setup_flow.spec.ts
@@ -1,0 +1,119 @@
+import { testWithConfig } from "./helpers/test_helper";
+import { expect } from "@playwright/test";
+
+const testSetup = testWithConfig({
+  showSetupScreen: true,
+});
+
+testSetup.describe("Setup Flow", () => {
+  testSetup(
+    "setup banner shows correct state when node.js is installed",
+    async ({ po }) => {
+      // Verify the "Setup Dyad" heading is visible
+      await expect(po.page.getByText("Setup Dyad")).toBeVisible();
+
+      // Verify both accordion sections are visible
+      await expect(
+        po.page.getByText("1. Install Node.js (App Runtime)"),
+      ).toBeVisible();
+      await expect(po.page.getByText("2. Setup AI Access")).toBeVisible();
+
+      // Expand Node.js section and verify completed state
+      await po.page.getByText("1. Install Node.js (App Runtime)").click();
+      await expect(
+        po.page.getByText(/Node\.js \(v[\d.]+\) installed/),
+      ).toBeVisible();
+
+      // AI provider section should show warning state (needs action)
+      await expect(
+        po.page.getByRole("button", { name: "Setup Google Gemini API Key" }),
+      ).toBeVisible();
+      await expect(
+        po.page.getByRole("button", { name: "Setup OpenRouter API Key" }),
+      ).toBeVisible();
+    },
+  );
+
+  testSetup("node.js install flow", async ({ po }) => {
+    // Start with Node.js not installed
+    await po.setNodeMock(false);
+    await po.page.reload();
+
+    // Verify setup banner and install button are visible
+    await expect(po.page.getByText("Setup Dyad")).toBeVisible();
+    await expect(
+      po.page.getByRole("button", { name: "Install Node.js Runtime" }),
+    ).toBeVisible();
+
+    // Manual configuration link should be visible
+    await expect(
+      po.page.getByText("Node.js already installed? Configure path manually"),
+    ).toBeVisible();
+
+    // Click the install button (opens external URL)
+    await po.page
+      .getByRole("button", { name: "Install Node.js Runtime" })
+      .click();
+
+    // After clicking install, the "Continue" button should appear
+    await expect(
+      po.page.getByRole("button", { name: /Continue.*I installed Node\.js/ }),
+    ).toBeVisible();
+
+    // Simulate user having installed Node.js
+    await po.setNodeMock(true);
+
+    // Click the continue button
+    await po.page
+      .getByRole("button", { name: /Continue.*I installed Node\.js/ })
+      .click();
+
+    // Node.js should now show as installed
+    await expect(
+      po.page.getByText(/Node\.js \(v[\d.]+\) installed/),
+    ).toBeVisible();
+
+    // Reset mock
+    await po.setNodeMock(null);
+  });
+
+  testSetup("ai provider setup flow", async ({ po }) => {
+    // Verify setup banner is visible
+    await expect(po.page.getByText("Setup Dyad")).toBeVisible();
+
+    // Test Google Gemini navigation
+    await po.page
+      .getByRole("button", { name: "Setup Google Gemini API Key" })
+      .click();
+    await expect(
+      po.page.getByRole("heading", { name: "Configure Google" }),
+    ).toBeVisible();
+    await po.page.getByRole("button", { name: "Go Back" }).click();
+
+    // Test OpenRouter navigation
+    await po.page
+      .getByRole("button", { name: "Setup OpenRouter API Key" })
+      .click();
+    await expect(
+      po.page.getByRole("heading", { name: "Configure OpenRouter" }),
+    ).toBeVisible();
+    await po.page.getByRole("button", { name: "Go Back" }).click();
+
+    // Test other providers navigation
+    await po.page
+      .getByRole("button", { name: "Setup other AI providers" })
+      .click();
+    await expect(po.page.getByRole("link", { name: "Settings" })).toBeVisible();
+
+    // Now configure the test provider
+    await po.setUpTestProvider();
+    await po.setUpTestModel();
+
+    // Go back to apps tab
+    await po.goToAppsTab();
+
+    // After configuring a provider, the setup banner should be gone
+    await expect(po.page.getByText("Setup Dyad")).not.toBeVisible();
+    await expect(po.page.getByText("Build your dream app")).toBeVisible();
+  });
+});

--- a/src/ipc/preload/channels.ts
+++ b/src/ipc/preload/channels.ts
@@ -47,7 +47,10 @@ const CHAT_STREAM_CHANNELS = getStreamChannels(chatStreamContract);
 const HELP_STREAM_CHANNELS = getStreamChannels(helpStreamContract);
 
 // Test-only channels (handler only registered in E2E test builds, but channel always allowed)
-const TEST_INVOKE_CHANNELS = ["test:simulateQuotaTimeElapsed"] as const;
+const TEST_INVOKE_CHANNELS = [
+  "test:simulateQuotaTimeElapsed",
+  "test:set-node-mock",
+] as const;
 
 /**
  * All valid invoke channels derived from contracts.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new IPC entrypoint and changes Node.js status resolution logic (even though gated to `E2E_TEST_BUILD`), which could affect runtime behavior if the flag/channel is misused. The rest is E2E-only test additions/refactors.
> 
> **Overview**
> Adds Playwright E2E coverage for the initial *Setup Dyad* flow, including Node.js install UX states, provider setup navigation, and verifying the setup banner disappears after configuring an AI provider.
> 
> Introduces a **test-only IPC** (`test:set-node-mock`) to deterministically mock Node.js installed/not-installed status in E2E builds, with a new `PageObject.setNodeMock()` helper and preload allowlisting. Refactors Node.js status handling to centralize Node download URL selection via `getNodeDownloadUrl()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5dd01b9e95375ff4a39d00b9ec9ecb40685d89a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Playwright E2E coverage for the setup flow and a test-only IPC to mock Node.js install status, making the flow fully testable and deterministic. Also refactors Node download URL selection for clarity.

- **New Features**
  - Added setup_flow.spec.ts to verify:
    - Banner states when Node is installed.
    - Node install flow with “Continue… I installed Node.js”.
    - AI provider navigation and banner dismissal after configuration.
  - Introduced test-only IPC channel test:set-node-mock (allowlisted in preload) gated by E2E_TEST_BUILD=true; added PageObject.setNodeMock() helper.
  - Refactored node_handlers to use getNodeDownloadUrl() and return mocked versions when enabled.

- **Migration**
  - Run E2E with E2E_TEST_BUILD=true to enable the mock IPC.

<sup>Written for commit 5dd01b9e95375ff4a39d00b9ec9ecb40685d89a0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2028">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
