### PR TITLE
Windows signing hook: only sign dyad.exe

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -7,6 +7,19 @@ import { VitePlugin } from "@electron-forge/plugin-vite";
 import { FusesPlugin } from "@electron-forge/plugin-fuses";
 import { FuseV1Options, FuseVersion } from "@electron/fuses";
 import { AutoUnpackNativesPlugin } from "@electron-forge/plugin-auto-unpack-natives";
+import { execSync } from "child_process";
+import path from "path";
+
+// Path to signtool.exe bundled with electron-winstaller
+// On GitHub Actions, this is the full path:
+// D:\a\dyad\dyad\node_modules\electron-winstaller\vendor\signtool.exe
+const SIGNTOOL_PATH = path.join(
+  __dirname,
+  "node_modules",
+  "electron-winstaller",
+  "vendor",
+  "signtool.exe",
+);
 
 // Based on https://github.com/electron/forge/blob/6b2d547a7216c30fde1e1fddd1118eee5d872945/packages/plugin/vite/src/VitePlugin.ts#L124
 const ignore = (file: string) => {
@@ -86,7 +99,19 @@ const config: ForgeConfig = {
   },
   makers: [
     new MakerSquirrel({
-      signWithParams: `/sha1 ${process.env.SM_CODE_SIGNING_CERT_SHA1_HASH} /tr http://timestamp.digicert.com /td SHA256 /fd SHA256`,
+      windowsSign: {
+        hookFunction: (filePath: string) => {
+          const fileName = path.basename(filePath).toLowerCase();
+          // Only sign dyad.exe, skip all other files
+          if (fileName !== "dyad.exe") {
+            return;
+          }
+          const signParams = `/sha1 ${process.env.SM_CODE_SIGNING_CERT_SHA1_HASH} /tr http://timestamp.digicert.com /td SHA256 /fd SHA256`;
+          execSync(`"${SIGNTOOL_PATH}" sign ${signParams} "${filePath}"`, {
+            stdio: "inherit",
+          });
+        },
+      },
     }),
     new MakerZIP({}, ["darwin"]),
     new MakerRpm({}),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches Windows packaging to a custom signing hook that signs only `dyad.exe` using `signtool.exe` bundled with `electron-winstaller`.
> 
> - Replaces `signWithParams` with `windowsSign.hookFunction` in `forge.config.ts` to run `signtool` via `execSync`
> - Adds `SIGNTOOL_PATH` resolution and imports for `child_process` and `path`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5fa37cca92fecb9bac678b0a1f0f143d4ee7cecb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Only sign dyad.exe during the Windows build to avoid signing other files and prevent CI signing errors. Replaced MakerSquirrel signWithParams with a windowsSign hook that runs the bundled signtool.exe using the same cert and timestamp settings.

<sup>Written for commit 5fa37cca92fecb9bac678b0a1f0f143d4ee7cecb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

