### PR TITLE
Use hook module path

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -7,19 +7,7 @@ import { VitePlugin } from "@electron-forge/plugin-vite";
 import { FusesPlugin } from "@electron-forge/plugin-fuses";
 import { FuseV1Options, FuseVersion } from "@electron/fuses";
 import { AutoUnpackNativesPlugin } from "@electron-forge/plugin-auto-unpack-natives";
-import { execSync } from "child_process";
 import path from "path";
-
-// Path to signtool.exe bundled with electron-winstaller
-// On GitHub Actions, this is the full path:
-// D:\a\dyad\dyad\node_modules\electron-winstaller\vendor\signtool.exe
-const SIGNTOOL_PATH = path.join(
-  __dirname,
-  "node_modules",
-  "electron-winstaller",
-  "vendor",
-  "signtool.exe",
-);
 
 // Based on https://github.com/electron/forge/blob/6b2d547a7216c30fde1e1fddd1118eee5d872945/packages/plugin/vite/src/VitePlugin.ts#L124
 const ignore = (file: string) => {
@@ -100,17 +88,7 @@ const config: ForgeConfig = {
   makers: [
     new MakerSquirrel({
       windowsSign: {
-        hookFunction: (filePath: string) => {
-          const fileName = path.basename(filePath).toLowerCase();
-          // Only sign dyad.exe, skip all other files
-          if (fileName !== "dyad.exe") {
-            return;
-          }
-          const signParams = `/sha1 ${process.env.SM_CODE_SIGNING_CERT_SHA1_HASH} /tr http://timestamp.digicert.com /td SHA256 /fd SHA256`;
-          execSync(`"${SIGNTOOL_PATH}" sign ${signParams} "${filePath}"`, {
-            stdio: "inherit",
-          });
-        },
+        hookModulePath: path.join(__dirname, "scripts", "windows-sign-hook.js"),
       },
     }),
     new MakerZIP({}, ["darwin"]),

--- a/scripts/windows-sign-hook.js
+++ b/scripts/windows-sign-hook.js
@@ -1,0 +1,31 @@
+const { execSync } = require("child_process");
+const path = require("path");
+
+// Path to signtool.exe bundled with electron-winstaller
+// On GitHub Actions, this is the full path:
+// D:\a\dyad\dyad\node_modules\electron-winstaller\vendor\signtool.exe
+const SIGNTOOL_PATH = path.join(
+  __dirname,
+  "..",
+  "node_modules",
+  "electron-winstaller",
+  "vendor",
+  "signtool.exe",
+);
+
+/**
+ * Custom hook function for Windows code signing.
+ * Only signs dyad.exe, skips all other files.
+ * @param {string} filePath - Path to the file to sign
+ */
+module.exports = function (filePath) {
+  const fileName = path.basename(filePath).toLowerCase();
+  // Only sign dyad.exe, skip all other files
+  if (fileName !== "dyad.exe") {
+    return;
+  }
+  const signParams = `/sha1 ${process.env.SM_CODE_SIGNING_CERT_SHA1_HASH} /tr http://timestamp.digicert.com /td SHA256 /fd SHA256`;
+  execSync(`"${SIGNTOOL_PATH}" sign ${signParams} "${filePath}"`, {
+    stdio: "inherit",
+  });
+};


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Externalizes Windows code signing logic and points Forge to a hook module.
> 
> - Replace inline `windowsSign.hookFunction` in `forge.config.ts` with `hookModulePath` to `scripts/windows-sign-hook.js`
> - Add `scripts/windows-sign-hook.js` implementing the signing logic (only signs `dyad.exe` via bundled `signtool.exe`)
> - Remove in-file `signtool` path and related imports from `forge.config.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f54920421cc7c47882465f0dd0ca371a5620454. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Moved Windows code signing to an external hook (scripts/windows-sign-hook.js) via MakerSquirrel’s hookModulePath, replacing the inline hookFunction. This simplifies forge.config, signs only dyad.exe, and correctly resolves signtool.exe from electron-winstaller for CI builds.

<sup>Written for commit 9f54920421cc7c47882465f0dd0ca371a5620454. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

