### PR TITLE
enable debug logging for windows sign

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,7 @@ jobs:
         # Publish (all platforms)
       - name: Publish app
         env:
+          DEBUG: "@electron/*"
           NODE_OPTIONS: "--max-old-space-size=4096"
           SM_CODE_SIGNING_CERT_SHA1_HASH: ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -88,6 +88,7 @@ const config: ForgeConfig = {
   makers: [
     new MakerSquirrel({
       windowsSign: {
+        debug: true,
         hookModulePath: path.join(__dirname, "scripts", "windows-sign-hook.js"),
       },
     }),

--- a/scripts/windows-sign-hook.js
+++ b/scripts/windows-sign-hook.js
@@ -24,9 +24,12 @@ module.exports = function (filePath) {
   }
 
   console.log(`[windows-sign-hook] Signing: ${fileName}`);
-  const signParams = `/sha1 ${process.env.SM_CODE_SIGNING_CERT_SHA1_HASH} /tr http://timestamp.digicert.com /td SHA256 /fd SHA256`;
+  const certHash = process.env.SM_CODE_SIGNING_CERT_SHA1_HASH;
+  const signParams = `/sha1 ${certHash} /tr http://timestamp.digicert.com /td SHA256 /fd SHA256`;
   const cmd = `"${SIGNTOOL_PATH}" sign ${signParams} "${filePath}"`;
-  console.log(`[windows-sign-hook] Command: ${cmd}`);
+  const redactedSignParams = `/sha1 ${certHash ? "[REDACTED]" : "[NOT SET]"} /tr http://timestamp.digicert.com /td SHA256 /fd SHA256`;
+  const redactedCmd = `"${SIGNTOOL_PATH}" sign ${redactedSignParams} "${filePath}"`;
+  console.log(`[windows-sign-hook] Command: ${redactedCmd}`);
 
   try {
     execSync(cmd, { stdio: "inherit" });

--- a/scripts/windows-sign-hook.js
+++ b/scripts/windows-sign-hook.js
@@ -1,9 +1,6 @@
 const { execSync } = require("child_process");
 const path = require("path");
 
-// Path to signtool.exe bundled with electron-winstaller
-// On GitHub Actions, this is the full path:
-// D:\a\dyad\dyad\node_modules\electron-winstaller\vendor\signtool.exe
 const SIGNTOOL_PATH = path.join(
   __dirname,
   "..",
@@ -13,19 +10,29 @@ const SIGNTOOL_PATH = path.join(
   "signtool.exe",
 );
 
-/**
- * Custom hook function for Windows code signing.
- * Only signs dyad.exe, skips all other files.
- * @param {string} filePath - Path to the file to sign
- */
 module.exports = function (filePath) {
+  console.log(`[windows-sign-hook] Called with: ${filePath}`);
+  console.log(`[windows-sign-hook] SIGNTOOL_PATH: ${SIGNTOOL_PATH}`);
+  console.log(
+    `[windows-sign-hook] SM_CODE_SIGNING_CERT_SHA1_HASH: ${process.env.SM_CODE_SIGNING_CERT_SHA1_HASH ? "SET" : "NOT SET"}`,
+  );
+
   const fileName = path.basename(filePath).toLowerCase();
-  // Only sign dyad.exe, skip all other files
   if (fileName !== "dyad.exe") {
+    console.log(`[windows-sign-hook] Skipping: ${fileName}`);
     return;
   }
+
+  console.log(`[windows-sign-hook] Signing: ${fileName}`);
   const signParams = `/sha1 ${process.env.SM_CODE_SIGNING_CERT_SHA1_HASH} /tr http://timestamp.digicert.com /td SHA256 /fd SHA256`;
-  execSync(`"${SIGNTOOL_PATH}" sign ${signParams} "${filePath}"`, {
-    stdio: "inherit",
-  });
+  const cmd = `"${SIGNTOOL_PATH}" sign ${signParams} "${filePath}"`;
+  console.log(`[windows-sign-hook] Command: ${cmd}`);
+
+  try {
+    execSync(cmd, { stdio: "inherit" });
+    console.log(`[windows-sign-hook] Signing successful`);
+  } catch (error) {
+    console.error(`[windows-sign-hook] Signing failed:`, error);
+    throw error;
+  }
 };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves observability of Windows signing during releases.
> 
> - Enable Electron Forge debug output in the workflow by setting `DEBUG="@electron/*"` during `Publish app`
> - Turn on `windowsSign.debug` in `forge.config.ts`
> - Add detailed, redacted logging and error handling to `scripts/windows-sign-hook.js` (logs inputs, command, success/failure; still only signs `dyad.exe`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bfdbc12a7a0e5a5eb0810a3303e732c6ad0a4eef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable verbose debugging for Windows code signing to make CI signing issues easier to diagnose. Adds detailed logs in the signing hook and enables Electron Forge debug output during release.

- **New Features**
  - Set DEBUG="@electron/*" in the release workflow to capture Forge/Squirrel logs.
  - Enable windowsSign.debug in forge.config.
  - Add verbose logging and error handling in windows-sign-hook (inputs, command, success/failure).

<sup>Written for commit bfdbc12a7a0e5a5eb0810a3303e732c6ad0a4eef. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



