### PR TITLE
Get electron forge logs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,14 +65,16 @@ jobs:
         # Publish (all platforms)
       - name: Publish app
         env:
-          DEBUG: "@electron/*"
+          DEBUG: "@electron/*,electron-forge:*,electron-windows-installer:main"
           NODE_OPTIONS: "--max-old-space-size=4096"
           SM_CODE_SIGNING_CERT_SHA1_HASH: ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-        run: npm run publish
+        # Don't use npm run because we don't get logs
+        # https://github.com/electron/forge/blob/main/SUPPORT.md
+        run: electron-forge publish
 
   verify-assets:
     name: Verify Release Assets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
         # Don't use npm run because we don't get logs
         # https://github.com/electron/forge/blob/main/SUPPORT.md
-        run: electron-forge publish
+        run: ./node_modules/.bin/electron-forge publish
 
   verify-assets:
     name: Verify Release Assets


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves release workflow logging and visibility during publishing.
> 
> - Run `electron-forge publish` directly instead of `npm run publish` to surface full logs
> - Expand `DEBUG` to `"@electron/*,electron-forge:*,electron-windows-installer:main"` for granular Electron Forge and Windows installer output in `release.yml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 498d93aff656dc635bc60880a3887d3d67ddf291. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose detailed Electron Forge logs in the release workflow by running electron-forge publish directly (instead of npm) and setting DEBUG to "@electron/*,electron-forge:*,electron-windows-installer:main". This improves visibility and makes publish failures easier to debug.

<sup>Written for commit 498d93aff656dc635bc60880a3887d3d67ddf291. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR improves debugging capabilities for the release workflow by enhancing electron-forge logging. It adds more granular DEBUG flags (`electron-forge:*` and `electron-windows-installer:main`) and switches from `npm run publish` to direct `electron-forge publish` execution to prevent npm from suppressing logs, following electron-forge's official support documentation.

- Added more comprehensive DEBUG environment variables for better visibility into the build process
- Changed to direct `electron-forge publish` command to ensure logs are properly captured
- Removed implicit `npm run clean` step (redundant in CI environment with fresh checkout)

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- The changes are minimal and focused on improving debugging visibility. Switching from `npm run publish` to `electron-forge publish` only removes the redundant clean step, which is unnecessary in CI environments that start from fresh checkouts. The additional DEBUG flags provide better logging without changing any build logic.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Enhanced debug logging and switched to direct `electron-forge publish` for better log visibility |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GHA as GitHub Actions
    participant WF as Release Workflow
    participant NPM as npm
    participant EF as electron-forge
    participant Logger as Debug Logger

    Note over GHA,Logger: Previous Flow (npm run publish)
    GHA->>WF: Trigger release workflow
    WF->>NPM: npm run publish
    NPM->>NPM: Execute clean script
    NPM->>EF: electron-forge publish
    EF->>Logger: Log output (suppressed by npm)
    Logger-->>NPM: Limited logs
    NPM-->>WF: Exit code only

    Note over GHA,Logger: New Flow (direct electron-forge)
    GHA->>WF: Trigger release workflow
    WF->>EF: electron-forge publish (direct)
    activate Logger
    Note over Logger: DEBUG=@electron/*,<br/>electron-forge:*,<br/>electron-windows-installer:main
    EF->>Logger: Full debug logs
    Logger-->>WF: Complete logs visible
    deactivate Logger
    EF-->>WF: Exit code + logs
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->