### PR TITLE
e2e test: break

### DIFF
--- a/e2e-tests/chat_input.spec.ts
+++ b/e2e-tests/chat_input.spec.ts
@@ -21,7 +21,7 @@ test("send button disabled during pending proposal", async ({ po }) => {
   await po.approveProposal();
 
   // Check send button is enabled again
-  await expect(sendButton).toBeEnabled();
+  await expect(sendButton).toBeDisabled();
 });
 
 test("send button disabled during pending proposal - reject", async ({


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates assertion in `e2e-tests/chat_input.spec.ts`:
> 
> - In `send button disabled during pending proposal`, after calling `approveProposal()`, change expectation from `toBeEnabled()` to `toBeDisabled()` to reflect current post-approval state of the "Send message" button.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1f3bbab072fb95cbab61ae00439e29944aa9d31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Intentionally flip the chat_input e2e assertion to expect the Send button to be disabled after approving a proposal. This should break the test to validate the test-run pipeline.

<sup>Written for commit f1f3bbab072fb95cbab61ae00439e29944aa9d31. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Changed the test assertion on line 24 from `toBeEnabled()` to `toBeDisabled()`, which inverts the expected behavior after approving a proposal.

- The test now expects the send button to remain disabled after approving a proposal, which contradicts both the comment "Check send button is enabled again" and the test's intended purpose
- This change will cause the test to fail since the actual application behavior is for the send button to become enabled after proposal approval
- The second test in the file (`send button disabled during pending proposal - reject`) correctly expects `toBeEnabled()` after rejection, making this change inconsistent with the test suite logic

<h3>Confidence Score: 0/5</h3>


- This PR introduces a critical test failure that will break CI
- The inverted assertion creates a logic error that will cause the test to fail, blocking any CI/CD pipeline that runs e2e tests
- e2e-tests/chat_input.spec.ts requires immediate attention - line 24 has incorrect assertion

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| e2e-tests/chat_input.spec.ts | Test assertion inverted on line 24, causing test to fail - expects disabled button when it should be enabled |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as E2E Test
    participant UI as Chat UI
    participant Button as Send Button
    participant Proposal as Proposal System

    Test->>UI: sendPrompt("Create a simple React component")
    UI->>Proposal: Generate proposal
    Proposal-->>UI: Display proposal with approve/reject buttons
    Test->>UI: Check proposal button visible
    UI-->>Test: Approve button visible
    Test->>UI: Fill chat input with "test message"
    Test->>Button: Check button state
    Button-->>Test: Disabled (pending proposal)
    Test->>Proposal: approveProposal()
    Proposal->>UI: Apply changes
    UI->>Button: Enable button
    Test->>Button: Check button state (BROKEN)
    Note over Test,Button: Test expects disabled but button is enabled
    Button-->>Test: Enabled (actual state)
    Test->>Test: Test fails ❌
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->