### PR TITLE
Fix playwright comment & Claude PR workflows

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -3,7 +3,7 @@ name: Claude PR Review
 # https://github.com/anthropics/claude-code-action/blob/main/examples/pr-review-comprehensive.yml
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, ready_for_review, reopened]
 
 jobs:
@@ -13,27 +13,30 @@ jobs:
     # Only review code from regular contributors since claude code has non-trivial costs
     # https://github.com/anthropics/claude-code-action/blob/main/examples/pr-review-filtered-authors.yml
     if: |
-      github.event.pull_request.user.login == 'wwwillchen' ||
-      github.event.pull_request.user.login == 'azizmejri1' ||
-      github.event.pull_request.user.login == 'princeaden1'
+      github.event.pull_request.author_association == 'OWNER' ||
+      github.event.pull_request.author_association == 'MEMBER'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
-      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 1
 
-      - name: PR Review with Progress Tracking
+      - name: PR Review
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # See: https://github.com/anthropics/claude-code-action/blob/v1/docs/security.md
+          github_token: ${{ secrets.GITHUB_TOKEN }} # bypass OIDC
+          allowed_non_write_users: "princeaden1" # remember, we already filter above.
 
-          # Enable progress tracking
-          track_progress: true
+          # Disable progress tracking (try to save tokens)
+          track_progress: false
 
           # Your custom review instructions
           # Using Code Review prompt based on https://github.com/openai/codex/blob/main/codex-rs/core/review_prompt.md?plain=1
@@ -88,20 +91,14 @@ jobs:
 
               At the beginning of the finding title, tag the bug with priority level. For example "[P1] Un-padding slices along wrong tensor dimensions". [P0] – Drop everything to fix.  Blocking release, operations, or major usage. Only use for universal issues that do not depend on any assumptions about the inputs. · [P1] – Urgent. Should be addressed in the next cycle · [P2] – Normal. To be fixed eventually · [P3] – Low. Nice to have.
 
-              At the end of your findings, output an "overall correctness" verdict of whether or not the patch should be considered "correct".
+              If there are NO issue, be very concise and say there are no issues. If there are issues, BRIEFLY summarize the most critical issues.
               
               Correct implies that existing code and tests will not break, and the patch is free of bugs and other blocking issues.
               Ignore non-blocking issues such as style, formatting, typos, documentation, and other nits.
 
               FORMATTING GUIDELINES:
-              The finding description should be one paragraph.
+              The finding description should be 1-2 sentences. Keep it brief.
 
           # Tools for comprehensive PR review
           claude_args: |
             --model claude-opus-4-5-20251101 --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
-
-# When track_progress is enabled:
-# - Creates a tracking comment with progress checkboxes
-# - Includes all PR context (comments, attachments, images)
-# - Updates progress as the review proceeds
-# - Marks as completed when done

--- a/.github/workflows/playwright-comment.yml
+++ b/.github/workflows/playwright-comment.yml
@@ -21,18 +21,34 @@ jobs:
         with:
           script: |
             const { owner, repo } = context.repo;
-            const sha = context.payload.workflow_run.head_sha;
+            const workflowRun = context.payload.workflow_run;
+            const sha = workflowRun.head_sha;
+            const headBranch = workflowRun.head_branch;
+            const headRepoOwner = workflowRun.head_repository?.owner?.login;
 
-            core.info(`Looking up PR for sha=${sha}`);
+            core.info(`Looking up PR for sha=${sha}, branch=${headBranch}, headRepoOwner=${headRepoOwner}`);
 
-            // Lists PRs associated with this commit (reliable when workflow_run.pull_requests is empty)
+            // Method 1: Try listPullRequestsAssociatedWithCommit (works for same-repo PRs)
             const res = await github.rest.repos.listPullRequestsAssociatedWithCommit({
               owner,
               repo,
               commit_sha: sha,
             });
 
-            const pr = res.data?.[0];
+            let pr = res.data?.[0];
+
+            // Method 2: Fallback for fork PRs - search by head reference
+            if (!pr && headRepoOwner && headBranch) {
+              core.info(`Trying fallback: searching for PRs with head=${headRepoOwner}:${headBranch}`);
+              const pullsRes = await github.rest.pulls.list({
+                owner,
+                repo,
+                state: 'open',
+                head: `${headRepoOwner}:${headBranch}`,
+              });
+              pr = pullsRes.data?.[0];
+            }
+
             if (!pr) {
               core.info("No PR associated with this workflow_run. Likely a push/schedule run.");
               core.setOutput("number", "");


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Workflows**
> 
> - Updates `playwright-comment.yml` to reliably find the associated PR, including forks: extracts `head_branch`/`head_repository`, logs context, and falls back to `pulls.list` with `head: "owner:branch"` when commit association lookup returns no PR.
> - Revises `claude-pr-review.yml` to use `pull_request_target`, restricts execution via `author_association` (`OWNER`/`MEMBER`), and checks out the PR head repo/ref explicitly for fork safety.
> - Configures the Claude action with `github_token` (OIDC bypass), `allowed_non_write_users`, and disables `track_progress`; trims/clarifies review prompt guidelines.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8267093820bd968db57167a37b2d2570e94fe010. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Playwright comment workflow so it reliably finds the associated PR, including PRs from forks. Updates the Claude PR Review workflow to run safely on forked PRs and only for org members.

- **Bug Fixes**
  - Playwright: add fallback search by head owner:branch; better logging (SHA, branch, owner) to post to the right PR.
  - Claude PR Review: switch to pull_request_target with OWNER/MEMBER filter; checkout fork head; disable progress; drop id-token.

<sup>Written for commit 8267093820bd968db57167a37b2d2570e94fe010. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR restores the fallback mechanism for finding PR numbers from forked repositories. The previous commit (41a46a9) inadvertently removed the fork PR detection logic, breaking Playwright comment posting for external contributors. This fix re-introduces a two-method approach:

- **Method 1**: Uses `listPullRequestsAssociatedWithCommit` (works for same-repo PRs)
- **Method 2**: Falls back to `pulls.list` with `head: "owner:branch"` when Method 1 fails (handles fork PRs)

The change extracts additional context (`head_branch`, `head_repository.owner.login`) from the workflow run payload and adds improved logging for debugging PR lookups.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- The change restores critical functionality that was accidentally removed in the previous commit. The implementation is correct, well-commented, and follows GitHub Actions best practices. No logic errors, security issues, or breaking changes detected.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/playwright-comment.yml | Added fallback logic for fork PRs by searching head branch when commit lookup fails |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CI as CI Workflow
    participant WR as Workflow Run Event
    participant GH as GitHub API
    participant Script as PR Lookup Script
    
    CI->>WR: Completes (triggers workflow_run)
    WR->>Script: Provides head_sha, head_branch, head_repository
    Script->>Script: Extract sha, headBranch, headRepoOwner
    
    Script->>GH: listPullRequestsAssociatedWithCommit(sha)
    alt Commit found (same-repo PRs)
        GH-->>Script: Returns PR data
        Script->>Script: Set PR number output
    else No PR found
        Script->>Script: Check if headRepoOwner & headBranch exist
        alt Fork PR fallback
            Script->>GH: pulls.list(head: "owner:branch")
            GH-->>Script: Returns PR from fork
            Script->>Script: Set PR number output
        else Still no PR
            Script->>Script: Set empty output (skip commenting)
        end
    end
    
    Script->>WR: Output PR number or empty
    
    alt PR found
        WR->>Script: Download artifacts & generate comment
        Script->>GH: Post/update PR comment
    else No PR
        WR->>WR: Skip remaining steps
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->