### PR TITLE
chat input e2e

### DIFF
--- a/e2e-tests/chat_input.spec.ts
+++ b/e2e-tests/chat_input.spec.ts
@@ -21,7 +21,7 @@ test("send button disabled during pending proposal", async ({ po }) => {
   await po.approveProposal();
 
   // Check send button is enabled again
-  await expect(sendButton).toBeEnabled();
+  await expect(sendButton).toBeDisabled();
 });
 
 test("send button disabled during pending proposal - reject", async ({


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit f1f3bbab072fb95cbab61ae00439e29944aa9d31. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the chat input e2e test to assert the Send button remains disabled after approving a proposal, matching the current pending-proposal flow and UI behavior.

<sup>Written for commit f1f3bbab072fb95cbab61ae00439e29944aa9d31. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

