### PR TITLE
Add debug logging to Claude PR review workflow

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -7,6 +7,16 @@ on:
     types: [opened, synchronize, ready_for_review, reopened]
 
 jobs:
+  debug-author:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Debug author association
+        run: |
+          echo "Author: ${{ github.event.pull_request.user.login }}"
+          echo "Author association: ${{ github.event.pull_request.author_association }}"
+          echo "Event name: ${{ github.event_name }}"
+          echo "Action: ${{ github.event.action }}"
+
   claude-review:
     # Has Anthropic API key, etc.
     environment: ai-bots

--- a/e2e-tests/chat_input.spec.ts
+++ b/e2e-tests/chat_input.spec.ts
@@ -21,7 +21,7 @@ test("send button disabled during pending proposal", async ({ po }) => {
   await po.approveProposal();
 
   // Check send button is enabled again
-  await expect(sendButton).toBeEnabled();
+  await expect(sendButton).toBeDisabled();
 });
 
 test("send button disabled during pending proposal - reject", async ({

--- a/e2e-tests/chat_input.spec.ts
+++ b/e2e-tests/chat_input.spec.ts
@@ -21,7 +21,7 @@ test("send button disabled during pending proposal", async ({ po }) => {
   await po.approveProposal();
 
   // Check send button is enabled again
-  await expect(sendButton).toBeDisabled();
+  await expect(sendButton).toBeEnabled();
 });
 
 test("send button disabled during pending proposal - reject", async ({


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a debug job to the Claude PR review workflow for easier CI troubleshooting.
> 
> - New `debug-author` job prints `user.login`, `author_association`, `event_name`, and `action` on `pull_request_target` events
> - No app code changes; only CI workflow updates
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34e5e4b30a370701a608281e2368ce5428ba6897. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a debug job to the Claude PR review workflow to print PR author, author_association, and event details for easier CI troubleshooting. Updated the chat input e2e test to expect the send button remains disabled after approving a proposal.

<sup>Written for commit 34e5e4b30a370701a608281e2368ce5428ba6897. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



