### PR TITLE
remove stuff

### DIFF
--- a/e2e-tests/mcp.spec.ts
+++ b/e2e-tests/mcp.spec.ts
@@ -3,8 +3,6 @@ import { test } from "./helpers/test_helper";
 import { expect } from "@playwright/test";
 
 test("mcp - call calculator", async ({ po }) => {
-  await po.setUp();
-  await po.goToSettingsTab();
   await po.page.getByRole("button", { name: "Tools (MCP)" }).click();
 
   await po.page


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Streamlines MCP e2e flow**
> 
> - Removes `po.setUp()` and `po.goToSettingsTab()` from `e2e-tests/mcp.spec.ts`, starting the test by clicking `Tools (MCP)` directly
> - Keeps server configuration, env var addition, consent handling, approval, and dump steps unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d716ab281f2c0f60a9841de8bcfea68e2b35c6ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streamlined the MCP e2e test by removing redundant setup and settings navigation. The test now clicks Tools (MCP) directly, reducing runtime and potential flakiness.

<sup>Written for commit d716ab281f2c0f60a9841de8bcfea68e2b35c6ec. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

