### PR TITLE
Use direct username filtering for Claude PR workflow

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -7,24 +7,15 @@ on:
     types: [opened, synchronize, ready_for_review, reopened]
 
 jobs:
-  debug-author:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Debug author association
-        run: |
-          echo "Author: ${{ github.event.pull_request.user.login }}"
-          echo "Author association: ${{ github.event.pull_request.author_association }}"
-          echo "Event name: ${{ github.event_name }}"
-          echo "Action: ${{ github.event.action }}"
-
   claude-review:
     # Has Anthropic API key, etc.
     environment: ai-bots
     # Only review code from regular contributors since claude code has non-trivial costs
     # https://github.com/anthropics/claude-code-action/blob/main/examples/pr-review-filtered-authors.yml
     if: |
-      github.event.pull_request.author_association == 'OWNER' ||
-      github.event.pull_request.author_association == 'MEMBER'
+      github.event.pull_request.user.login == 'wwwillchen' ||
+      github.event.pull_request.user.login == 'azizmejri1' ||
+      github.event.pull_request.user.login == 'princeaden1'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Narrows when the Claude review runs and cleans up the workflow.
> 
> - Replaces `author_association` filter with explicit `github.event.pull_request.user.login` checks for `wwwillchen`, `azizmejri1`, and `princeaden1` in `claude-pr-review.yml`
> - Removes the `debug-author` job from the workflow
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42d84531e99ac84b5576f6c490a36813706d8c25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use direct username filtering in the Claude PR review workflow so reviews only run for selected contributors and we keep costs down. Removed the debug-author job and added checks for wwwillchen, azizmejri1, and princeaden1.

<sup>Written for commit 42d84531e99ac84b5576f6c490a36813706d8c25. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

