### PR TITLE
mcp test update

### DIFF
--- a/e2e-tests/mcp.spec.ts
+++ b/e2e-tests/mcp.spec.ts
@@ -3,7 +3,6 @@ import { test } from "./helpers/test_helper";
 import { expect } from "@playwright/test";
 
 test("mcp - call calculator", async ({ po }) => {
-  await po.setUp();
   await po.goToSettingsTab();
   await po.page.getByRole("button", { name: "Tools (MCP)" }).click();
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates the MCP end-to-end test to start directly in Settings without an initial setup step.
> 
> - Removes `po.setUp()` from `e2e-tests/mcp.spec.ts`, keeping the flow that configures the MCP server, adds an env var, handles consent, and verifies tool execution
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c3039c2662efd01cf6bade2beed5710f14d6283. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the redundant po.setUp() call in the MCP “call calculator” e2e test. Setup now happens via the test helper, reducing flakiness and avoiding duplicate init.

<sup>Written for commit 9c3039c2662efd01cf6bade2beed5710f14d6283. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

