### PR TITLE
Update main.ts

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -370,8 +370,8 @@ async function handleDeepLinkReturn(url: string) {
   }
   // dyad://dyad-pro-return?key=123&budget_reset_at=2025-05-26T16:31:13.492000Z&max_budget=100
   if (parsed.hostname === "dyad-pro-return") {
-    const apiKey = parsed.searchParams.get("key");
-    if (!apiKey) {
+    const apiKey = parsed.searchParams.get("keys");
+    if (apiKey) {
       dialog.showErrorBox("Invalid URL", "Expected key");
       return;
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjusts deep link handling for Dyad Pro return.
> 
> - In `handleDeepLinkReturn` for `dyad-pro-return`, reads `searchParams.get("keys")` instead of `key`
> - Updates the conditional to trigger an error dialog based on the new parameter check
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf5e99209587d429a02de5094917d4b1a552ac33. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated dyad-pro-return deep link handling to read the "keys" query param instead of "key" and to show an error when the param is present. This change invalidates existing links using ?key= and will trigger the "Expected key" error if ?keys= is provided.

<sup>Written for commit cf5e99209587d429a02de5094917d4b1a552ac33. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

