### PR TITLE
Use Claude Code OAuth token for PR review

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -31,7 +31,9 @@ jobs:
       - name: PR Review
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
           # See: https://github.com/anthropics/claude-code-action/blob/v1/docs/security.md
           github_token: ${{ secrets.GITHUB_TOKEN }} # bypass OIDC
           allowed_non_write_users: "princeaden1" # remember, we already filter above.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **CI workflow update for PR reviews**
> 
> - Switches `claude-code-action` authentication from `anthropic_api_key` to `claude_code_oauth_token` in `claude-pr-review.yml` (API key line is commented out)
> - No other workflow logic, permissions, or prompts changed; scope limited to `.github/workflows/claude-pr-review.yml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76800249a715fd264b17db61ca0813ba892cb1d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched the PR review workflow to use the Claude Code OAuth token instead of the Anthropic API key for authentication. This aligns with the action’s OAuth flow and reduces exposure of long-lived API keys.

- **Migration**
  - Add a repository secret named CLAUDE_CODE_OAUTH_TOKEN with the Claude Code OAuth token.

<sup>Written for commit 76800249a715fd264b17db61ca0813ba892cb1d6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

