### PR TITLE
Subtle error

### DIFF
--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -66,7 +66,7 @@ const posthogClient = posthog.init(
     capture_exceptions: true,
     capture_pageview: false,
     before_send: (event) => {
-      if (!isTelemetryOptedIn()) {
+      if (isTelemetryOptedIn()) {
         console.debug("Telemetry not opted in, skipping event");
         return null;
       }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjusts telemetry gating in PostHog initialization.
> 
> - In `renderer.tsx`, `before_send` now checks `isTelemetryOptedIn()` (instead of negation) and returns `null` to skip sending events when that condition is true; existing user identification and `$ip` nulling remain unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c52f0dac014c63ade86570a2c6436d04287c4c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reversed the telemetry opt‑in check in PostHog’s before_send, so events are skipped when telemetry is opted in. This suppresses analytics for users who opted in.

<sup>Written for commit 1c52f0dac014c63ade86570a2c6436d04287c4c6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

