### PR TITLE
Add AppImage maker

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -3,6 +3,7 @@ import { MakerSquirrel } from "@electron-forge/maker-squirrel";
 import { MakerZIP } from "@electron-forge/maker-zip";
 import { MakerDeb } from "@electron-forge/maker-deb";
 import { MakerRpm } from "@electron-forge/maker-rpm";
+import { MakerAppImage } from "./makers/MakerAppImage";
 import { VitePlugin } from "@electron-forge/plugin-vite";
 import { FusesPlugin } from "@electron-forge/plugin-fuses";
 import { FuseV1Options, FuseVersion } from "@electron/fuses";
@@ -153,6 +154,7 @@ const config: ForgeConfig = {
         mimeType: ["x-scheme-handler/dyad"],
       },
     }),
+    new MakerAppImage({}),
   ],
   publishers: [
     {

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -154,7 +154,9 @@ const config: ForgeConfig = {
         mimeType: ["x-scheme-handler/dyad"],
       },
     }),
-    new MakerAppImage({}),
+    new MakerAppImage({
+      icon: "./assets/icon/logo.png",
+    }),
   ],
   publishers: [
     {

--- a/makers/MakerAppImage.ts
+++ b/makers/MakerAppImage.ts
@@ -1,0 +1,114 @@
+import { MakerBase, MakerOptions } from "@electron-forge/maker-base";
+import { execFileSync } from "child_process";
+import {
+  writeFile,
+  appendFile,
+  mkdtemp,
+  mkdir,
+  cp,
+  symlink,
+  chmod,
+  readFile,
+} from "fs/promises";
+import { tmpdir } from "os";
+import { resolve, relative } from "path";
+
+const RUNTIME_URL =
+  "https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-x86_64";
+
+/**
+ * Minimalist Forge maker for AppImages
+ */
+export class MakerAppImage extends MakerBase<{}> {
+  override defaultPlatforms = ["linux"];
+  override name = "AppImage";
+  override requiredExternalBinaries = ["mksquashfs"];
+
+  override isSupportedOnCurrentPlatform(): boolean {
+    return process.platform === "linux" && process.arch === "x64";
+  }
+
+  override async make({
+    appName,
+    dir,
+    makeDir,
+    packageJSON,
+    targetArch,
+  }: MakerOptions): Promise<string[]> {
+    const version = packageJSON["version"];
+
+    if (!version || typeof version !== "string")
+      throw new Error("Could not access version information");
+
+    const exeName = `${appName}_${version}_${targetArch}.AppImage`;
+    const outputDir = resolve(makeDir, "AppImage");
+    const outputFilePath = resolve(outputDir, exeName);
+
+    // Fetch AppImage runtime
+    const runtime = await fetch(RUNTIME_URL).then((res) => res.bytes());
+
+    // Create directory structure of AppDir.
+    // For conventions, see: https://docs.appimage.org/reference/appdir.html#conventions
+    const appDir = await mkdtemp(resolve(tmpdir(), exeName));
+    const binDir = resolve(appDir, "usr/bin");
+    const libDir = resolve(appDir, `usr/lib/${appName}`);
+
+    await mkdir(binDir, { recursive: true, mode: 0o755 });
+    await mkdir(libDir, { recursive: true, mode: 0o755 });
+
+    // Add the actual application code to the AppDir
+    await cp(dir, libDir, { recursive: true });
+
+    // Generate .desktop file
+    // See: https://docs.appimage.org/reference/desktop-integration.html#desktop-files
+    // Also: https://specifications.freedesktop.org/desktop-entry/latest/recognized-keys.html
+    const desktopFile = `
+      [Desktop Entry]
+      Type=Application
+      Version=1.5
+      Name=${appName}
+      Exec=AppRun %U
+      X-AppImage-Name=${appName}
+      X-AppImage-Version=${version}
+      X-AppImage-Arch=x86_64
+    `
+      .replaceAll(/\n[ \t]+|[ \t]+\n/g, "\n") // Remove excess ws; only necessary due to string formatting aesthetics
+      .trim();
+
+    await writeFile(resolve(appDir, `${appName}.desktop`), desktopFile);
+
+    // By convention, executables should be in /bin
+    await symlink(
+      relative(binDir, resolve(libDir, appName)),
+      resolve(binDir, appName),
+      "file",
+    );
+
+    // The entry point of an AppImage should be the AppRun file.
+    // See: https://docs.appimage.org/reference/appdir.html#general-description
+    await symlink(
+      relative(appDir, resolve(binDir, appName)),
+      resolve(appDir, "AppRun"),
+      "file",
+    );
+
+    // mksquashfs emits a file, so we create a temporary file
+    // inside a temporary directory to hold the output
+    const tempWorkDir = await mkdtemp(resolve(tmpdir(), "AppImageWorkDir"));
+    const tempSquashedFsPath = resolve(tempWorkDir, "temp");
+    execFileSync("mksquashfs", [appDir, tempSquashedFsPath]);
+
+    // Directory to hold final executable
+    await mkdir(outputDir, { recursive: true, mode: 0o755 });
+
+    // Per the documentation, AppImages should consist
+    // of the runtime prepended to the squashed fs.
+    // See: https://docs.appimage.org/reference/architecture.html
+    await writeFile(outputFilePath, runtime);
+    await appendFile(outputFilePath, await readFile(tempSquashedFsPath));
+
+    await chmod(outputFilePath, 0o755);
+
+    return [outputFilePath];
+  }
+}

--- a/makers/MakerAppImage.ts
+++ b/makers/MakerAppImage.ts
@@ -81,18 +81,16 @@ export class MakerAppImage extends MakerBase<{}> {
       // Generate .desktop file
       // See: https://docs.appimage.org/reference/desktop-integration.html#desktop-files
       // Also: https://specifications.freedesktop.org/desktop-entry/latest/recognized-keys.html
-      const desktopFile = `
-        [Desktop Entry]
-        Type=Application
-        Version=1.5
-        Name=${appName}
-        Exec=AppRun %U
-        X-AppImage-Name=${appName}
-        X-AppImage-Version=${version}
-        X-AppImage-Arch=x86_64
-      `
-        .replaceAll(/\n[ \t]+|[ \t]+\n/g, "\n") // Remove excess ws; only necessary due to string formatting aesthetics
-        .trim();
+      const desktopFile = [
+        "[Desktop Entry]",
+        "Type=Application",
+        "Version=1.5",
+        `Name=${appName}`,
+        "Exec=AppRun %U",
+        `X-AppImage-Name=${appName}`,
+        `X-AppImage-Version=${version}`,
+        "X-AppImage-Arch=x86_64",
+      ].join("\n");
 
       await writeFile(resolve(appDir, `${appName}.desktop`), desktopFile);
 

--- a/makers/MakerAppImage.ts
+++ b/makers/MakerAppImage.ts
@@ -70,7 +70,7 @@ export class MakerAppImage extends MakerBase<{ icon?: string }> {
         `Could not fetch AppImage runtime: ${res.status} ${res.statusText}`,
       );
 
-    const runtime = await res.bytes();
+    const runtime = Buffer.from(await res.arrayBuffer());
 
     // Verify SHA256 hash
     const hash = createHash("sha256").update(runtime).digest("hex");

--- a/makers/MakerAppImage.ts
+++ b/makers/MakerAppImage.ts
@@ -9,12 +9,17 @@ import {
   symlink,
   chmod,
   readFile,
+  rm,
 } from "fs/promises";
 import { tmpdir } from "os";
 import { resolve, relative } from "path";
 
 const RUNTIME_URL =
   "https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-x86_64";
+
+// For creating temporary work directories; largely arbitrary
+const APPDIR_PREFIX = "AppDir";
+const WORKDIR_PREFIX = "AppImageWorkDir";
 
 /**
  * Minimalist Forge maker for AppImages
@@ -54,68 +59,91 @@ export class MakerAppImage extends MakerBase<{}> {
 
     const runtime = await res.bytes();
 
-    // Create directory structure of AppDir.
-    // For conventions, see: https://docs.appimage.org/reference/appdir.html#conventions
-    const appDir = await mkdtemp(resolve(tmpdir(), exeName));
-    const binDir = resolve(appDir, "usr/bin");
-    const libDir = resolve(appDir, `usr/lib/${appName}`);
+    // Names of temporary directories to clean up later
+    let appDir: string | undefined;
+    let workDir: string | undefined;
 
-    await mkdir(binDir, { recursive: true, mode: 0o755 });
-    await mkdir(libDir, { recursive: true, mode: 0o755 });
+    try {
+      // Create directory structure of AppDir.
+      // For conventions, see: https://docs.appimage.org/reference/appdir.html#conventions
+      appDir = await mkdtemp(
+        resolve(tmpdir(), `${APPDIR_PREFIX}_${appName}_${version}_`),
+      );
+      const binDir = resolve(appDir, "usr/bin");
+      const libDir = resolve(appDir, `usr/lib/${appName}`);
 
-    // Add the actual application code to the AppDir
-    await cp(dir, libDir, { recursive: true });
+      await mkdir(binDir, { recursive: true, mode: 0o755 });
+      await mkdir(libDir, { recursive: true, mode: 0o755 });
 
-    // Generate .desktop file
-    // See: https://docs.appimage.org/reference/desktop-integration.html#desktop-files
-    // Also: https://specifications.freedesktop.org/desktop-entry/latest/recognized-keys.html
-    const desktopFile = `
-      [Desktop Entry]
-      Type=Application
-      Version=1.5
-      Name=${appName}
-      Exec=AppRun %U
-      X-AppImage-Name=${appName}
-      X-AppImage-Version=${version}
-      X-AppImage-Arch=x86_64
-    `
-      .replaceAll(/\n[ \t]+|[ \t]+\n/g, "\n") // Remove excess ws; only necessary due to string formatting aesthetics
-      .trim();
+      // Add the actual application code to the AppDir
+      await cp(dir, libDir, { recursive: true });
 
-    await writeFile(resolve(appDir, `${appName}.desktop`), desktopFile);
+      // Generate .desktop file
+      // See: https://docs.appimage.org/reference/desktop-integration.html#desktop-files
+      // Also: https://specifications.freedesktop.org/desktop-entry/latest/recognized-keys.html
+      const desktopFile = `
+        [Desktop Entry]
+        Type=Application
+        Version=1.5
+        Name=${appName}
+        Exec=AppRun %U
+        X-AppImage-Name=${appName}
+        X-AppImage-Version=${version}
+        X-AppImage-Arch=x86_64
+      `
+        .replaceAll(/\n[ \t]+|[ \t]+\n/g, "\n") // Remove excess ws; only necessary due to string formatting aesthetics
+        .trim();
 
-    // By convention, executables should be in /bin
-    await symlink(
-      relative(binDir, resolve(libDir, appName)),
-      resolve(binDir, appName),
-      "file",
-    );
+      await writeFile(resolve(appDir, `${appName}.desktop`), desktopFile);
 
-    // The entry point of an AppImage should be the AppRun file.
-    // See: https://docs.appimage.org/reference/appdir.html#general-description
-    await symlink(
-      relative(appDir, resolve(binDir, appName)),
-      resolve(appDir, "AppRun"),
-      "file",
-    );
+      // By convention, executables should be in /bin
+      await symlink(
+        relative(binDir, resolve(libDir, appName)),
+        resolve(binDir, appName),
+        "file",
+      );
 
-    // mksquashfs emits a file, so we create a temporary file
-    // inside a temporary directory to hold the output
-    const tempWorkDir = await mkdtemp(resolve(tmpdir(), "AppImageWorkDir"));
-    const tempSquashedFsPath = resolve(tempWorkDir, "temp");
-    execFileSync("mksquashfs", [appDir, tempSquashedFsPath]);
+      // The entry point of an AppImage should be the AppRun file.
+      // See: https://docs.appimage.org/reference/appdir.html#general-description
+      await symlink(
+        relative(appDir, resolve(binDir, appName)),
+        resolve(appDir, "AppRun"),
+        "file",
+      );
 
-    // Directory to hold final executable
-    await mkdir(outputDir, { recursive: true, mode: 0o755 });
+      // mksquashfs emits a file, so we create a temporary file
+      // inside a temporary directory to hold the output
+      workDir = await mkdtemp(
+        resolve(tmpdir(), `${WORKDIR_PREFIX}_${appName}_${version}_`),
+      );
+      const tempSquashedFsPath = resolve(workDir, "temp");
+      execFileSync("mksquashfs", [appDir, tempSquashedFsPath]);
 
-    // Per the documentation, AppImages should consist
-    // of the runtime prepended to the squashed fs.
-    // See: https://docs.appimage.org/reference/architecture.html
-    await writeFile(outputFilePath, runtime);
-    await appendFile(outputFilePath, await readFile(tempSquashedFsPath));
+      // Directory to hold final executable
+      await mkdir(outputDir, { recursive: true, mode: 0o755 });
 
-    await chmod(outputFilePath, 0o755);
+      // Per the documentation, AppImages should consist
+      // of the runtime prepended to the squashed fs.
+      // See: https://docs.appimage.org/reference/architecture.html
+      await writeFile(outputFilePath, runtime);
+      await appendFile(outputFilePath, await readFile(tempSquashedFsPath));
 
-    return [outputFilePath];
+      await chmod(outputFilePath, 0o755);
+
+      return [outputFilePath];
+    } finally {
+      // Clean up temporary directories
+      if (appDir)
+        await rm(appDir, {
+          recursive: true,
+          force: true,
+        });
+
+      if (workDir)
+        await rm(workDir, {
+          recursive: true,
+          force: true,
+        });
+    }
   }
 }

--- a/makers/MakerAppImage.ts
+++ b/makers/MakerAppImage.ts
@@ -49,7 +49,6 @@ export class MakerAppImage extends MakerBase<{ icon?: string }> {
     dir,
     makeDir,
     packageJSON,
-    targetArch,
   }: MakerOptions): Promise<string[]> {
     const version = packageJSON["version"];
 
@@ -58,7 +57,7 @@ export class MakerAppImage extends MakerBase<{ icon?: string }> {
 
     const { icon } = this.config;
 
-    const exeName = `${appName}_${version}_${targetArch}.AppImage`;
+    const exeName = `${appName}_${version}_x86_64.AppImage`;
     const outputDir = resolve(makeDir, "AppImage");
     const outputFilePath = resolve(outputDir, exeName);
 

--- a/makers/MakerAppImage.ts
+++ b/makers/MakerAppImage.ts
@@ -1,5 +1,5 @@
 import { MakerBase, MakerOptions } from "@electron-forge/maker-base";
-import { execFileSync } from "child_process";
+import { execFile } from "child_process";
 import {
   writeFile,
   appendFile,
@@ -12,6 +12,7 @@ import {
   rm,
 } from "fs/promises";
 import { tmpdir } from "os";
+import { promisify } from "util";
 import { resolve, relative } from "path";
 
 const RUNTIME_URL =
@@ -115,7 +116,9 @@ export class MakerAppImage extends MakerBase<{}> {
         resolve(tmpdir(), `${WORKDIR_PREFIX}_${appName}_${version}_`),
       );
       const tempSquashedFsPath = resolve(workDir, "temp");
-      execFileSync("mksquashfs", [appDir, tempSquashedFsPath]);
+
+      const execFileAsync = promisify(execFile);
+      await execFileAsync("mksquashfs", [appDir, tempSquashedFsPath]);
 
       // Directory to hold final executable
       await mkdir(outputDir, { recursive: true, mode: 0o755 });

--- a/makers/MakerAppImage.ts
+++ b/makers/MakerAppImage.ts
@@ -63,7 +63,9 @@ export class MakerAppImage extends MakerBase<{ icon?: string }> {
     const outputFilePath = resolve(outputDir, exeName);
 
     // Fetch AppImage runtime
-    const res = await fetch(RUNTIME_URL);
+    const res = await fetch(RUNTIME_URL, {
+      signal: AbortSignal.timeout(10000), // 10 second timeout
+    });
 
     if (!res.ok)
       throw new Error(

--- a/makers/MakerAppImage.ts
+++ b/makers/MakerAppImage.ts
@@ -136,7 +136,24 @@ export class MakerAppImage extends MakerBase<{ icon?: string }> {
       const tempSquashedFsPath = resolve(workDir, "temp");
 
       const execFileAsync = promisify(execFile);
-      await execFileAsync("mksquashfs", [appDir, tempSquashedFsPath]);
+
+      try {
+        await execFileAsync("mksquashfs", [appDir, tempSquashedFsPath]);
+      } catch (err: any) {
+        const stderr = err?.stderr?.toString?.() ?? "";
+        const stdout = err?.stdout?.toString?.() ?? "";
+
+        throw new Error(
+          [
+            "mksquashfs failed",
+            `exit code: ${err?.code ?? "unknown"}`,
+            stderr && `stderr:\n${stderr}`,
+            stdout && `stdout:\n${stdout}`,
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        );
+      }
 
       // Directory to hold final executable
       await mkdir(outputDir, { recursive: true, mode: 0o755 });

--- a/makers/MakerAppImage.ts
+++ b/makers/MakerAppImage.ts
@@ -45,7 +45,14 @@ export class MakerAppImage extends MakerBase<{}> {
     const outputFilePath = resolve(outputDir, exeName);
 
     // Fetch AppImage runtime
-    const runtime = await fetch(RUNTIME_URL).then((res) => res.bytes());
+    const res = await fetch(RUNTIME_URL);
+
+    if (!res.ok)
+      throw new Error(
+        `Could not fetch AppImage runtime: ${res.status} ${res.statusText}`,
+      );
+
+    const runtime = await res.bytes();
 
     // Create directory structure of AppDir.
     // For conventions, see: https://docs.appimage.org/reference/appdir.html#conventions

--- a/scripts/verify-release-assets.js
+++ b/scripts/verify-release-assets.js
@@ -87,6 +87,7 @@ async function verifyReleaseAssets() {
       `dyad-darwin-arm64-${version}.zip`,
       `dyad-darwin-x64-${version}.zip`,
       `dyad_${normalizeVersionForPlatform(version, "deb")}_amd64.deb`,
+      `dyad_${version}_x64.AppImage`,
       "RELEASES",
     ];
 

--- a/scripts/verify-release-assets.js
+++ b/scripts/verify-release-assets.js
@@ -87,7 +87,7 @@ async function verifyReleaseAssets() {
       `dyad-darwin-arm64-${version}.zip`,
       `dyad-darwin-x64-${version}.zip`,
       `dyad_${normalizeVersionForPlatform(version, "deb")}_amd64.deb`,
-      `dyad_${version}_x64.AppImage`,
+      `dyad_${version}_x86_64.AppImage`,
       "RELEASES",
     ];
 


### PR DESCRIPTION
Closes #817.

A while back, I had opened #960 for the same issue, and I thought I would give it a second try. Unlike my previous PR, this time I implemented the AppImage maker myself.

Given that security concerns came up last time, I feel obligated to mention the following:
1. This code does run `mksquashfs` (technically a third-party executable) in the same environment as the signing keys. However, it's widely used and is present on the GitHub runner by default.
2. My code also fetches the AppImage runtime during build, but this gets embedded in the AppImage and never runs on the server. As such, it would not be able to access the signing keys even if it theoretically had a vulnerability or was infected.

If we're including an AppImage in the releases going forward, I don't think that either of the above two points are easily avoidable. We _could_ handle the second point by storing our own static version of the AppImage runtime, but I don't think that's particularly elegant or desirable. 

Of course, please feel free to let me know if you'd like any changes. Thanks!

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an AppImage maker to Electron Forge and includes a Linux x86_64 AppImage in release assets.

- **New Features**
  - Implements MakerAppImage that builds the AppDir, generates the .desktop file, embeds the app icon, sets AppRun, and packs with mksquashfs.
  - Fetches the AppImage runtime at build time, verifies its SHA-256, and embeds it; it never executes on CI.
  - Integrates into forge.config and release asset checks. Output: dyad_{version}_x86_64.AppImage.

- **Dependencies**
  - Requires mksquashfs on the build host (available on GitHub runners).

<sup>Written for commit 8bdb3840b906cc74a852704be50acb1b4d08fc97. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces Linux AppImage packaging and aligns release checks.
> 
> - Adds `MakerAppImage` that assembles `AppDir`, generates `.desktop`, embeds icon, creates `AppRun` symlink, packs with `mksquashfs`, and prepends the fetched AppImage runtime after SHA-256 verification
> - Integrates maker in `forge.config.ts` (outputs `dyad_{version}_x86_64.AppImage`; linux x64; requires `mksquashfs`)
> - Updates `scripts/verify-release-assets.js` to include the AppImage in expected assets
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8bdb3840b906cc74a852704be50acb1b4d08fc97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->