### PR TITLE
Claude settings

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,5 @@
+{
+  "permissions": {
+    "allow": ["Bash(gh pr:*)"]
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a local Claude config to permit GitHub CLI PR commands.
> 
> - Introduces `.claude/settings.local.json` granting `permissions.allow` for `Bash(gh pr:*)`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2f6f6fbd0cb8880f3c71812278a4f3d3bd0bfdb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Configured local Claude permissions to allow Bash(gh pr:*) commands, enabling PR actions via the GitHub CLI.

Adds .claude/settings.local.json with an allow list for Bash(gh pr:*).

<sup>Written for commit b2f6f6fbd0cb8880f3c71812278a4f3d3bd0bfdb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

