### PR TITLE
feat(chat input): recall previous messages using Up Arrow

### DIFF
--- a/e2e-tests/chat_input.spec.ts
+++ b/e2e-tests/chat_input.spec.ts
@@ -48,3 +48,126 @@ test("send button disabled during pending proposal - reject", async ({
   // Check send button is enabled again
   await expect(sendButton).toBeEnabled();
 });
+
+test("chat input history navigation - up arrow recalls previous prompts", async ({
+  po,
+}) => {
+  await po.setUp({ autoApprove: true });
+
+  const chatInput = po.getChatInput();
+
+  // Send multiple prompts to create history
+  await po.sendPrompt("First message");
+  await po.sendPrompt("Second message");
+  await po.sendPrompt("Third message");
+
+  // Clear the input (should be empty after sending)
+  await chatInput.click();
+  await chatInput.fill("");
+  await po.page.waitForTimeout(100); // Wait for input to clear
+
+  // Press Up arrow to get the most recent message (Third message)
+  await chatInput.press("ArrowUp");
+  await po.page.waitForTimeout(100);
+  expect(await chatInput.textContent()).toBe("Third message");
+
+  // Press Up arrow again to get the second message
+  await chatInput.press("ArrowUp");
+  await po.page.waitForTimeout(100);
+  expect(await chatInput.textContent()).toBe("Second message");
+
+  // Press Up arrow again to get the first message
+  await chatInput.press("ArrowUp");
+  await po.page.waitForTimeout(100);
+  expect(await chatInput.textContent()).toBe("First message");
+
+  // Press Down arrow to go back to second message
+  await chatInput.press("ArrowDown");
+  await po.page.waitForTimeout(100);
+  expect(await chatInput.textContent()).toBe("Second message");
+
+  // Press Down arrow again to go back to third message
+  await chatInput.press("ArrowDown");
+  await po.page.waitForTimeout(100);
+  expect(await chatInput.textContent()).toBe("Third message");
+
+  // Press Down arrow again to go back to empty (draft)
+  await chatInput.press("ArrowDown");
+  await po.page.waitForTimeout(100);
+  expect(await chatInput.textContent()).toBe("");
+});
+
+test("chat input history navigation - only works when input is empty", async ({
+  po,
+}) => {
+  await po.setUp({ autoApprove: true });
+
+  const chatInput = po.getChatInput();
+
+  // Send a message to create history
+  await po.sendPrompt("Previous message");
+
+  // Type something in the input (not empty)
+  await chatInput.click();
+  await chatInput.fill("Currently typing");
+  await po.page.waitForTimeout(100);
+
+  // Press Up arrow - should NOT navigate (input is not empty)
+  await chatInput.press("ArrowUp");
+  await po.page.waitForTimeout(100);
+  expect(await chatInput.textContent()).toBe("Currently typing");
+
+  // Clear input and try again
+  await chatInput.fill("");
+  await po.page.waitForTimeout(100);
+  await chatInput.press("ArrowUp");
+  await po.page.waitForTimeout(100);
+  // Now it should work since input is empty
+  expect(await chatInput.textContent()).toBe("Previous message");
+});
+
+test("chat input history navigation - works with multiple messages", async ({
+  po,
+}) => {
+  await po.setUp({ autoApprove: true });
+
+  const chatInput = po.getChatInput();
+
+  // Send 5 messages
+  await po.sendPrompt("Message 1");
+  await po.sendPrompt("Message 2");
+  await po.sendPrompt("Message 3");
+  await po.sendPrompt("Message 4");
+  await po.sendPrompt("Message 5");
+
+  // Clear input and navigate through all messages
+  await chatInput.click();
+  await chatInput.fill("");
+  await po.page.waitForTimeout(100);
+
+  // Navigate backwards through all messages
+  await chatInput.press("ArrowUp"); // Message 5
+  await po.page.waitForTimeout(100);
+  expect(await chatInput.textContent()).toBe("Message 5");
+
+  await chatInput.press("ArrowUp"); // Message 4
+  await po.page.waitForTimeout(100);
+  expect(await chatInput.textContent()).toBe("Message 4");
+
+  await chatInput.press("ArrowUp"); // Message 3
+  await po.page.waitForTimeout(100);
+  expect(await chatInput.textContent()).toBe("Message 3");
+
+  await chatInput.press("ArrowUp"); // Message 2
+  await po.page.waitForTimeout(100);
+  expect(await chatInput.textContent()).toBe("Message 2");
+
+  await chatInput.press("ArrowUp"); // Message 1
+  await po.page.waitForTimeout(100);
+  expect(await chatInput.textContent()).toBe("Message 1");
+
+  // Can't go further back
+  await chatInput.press("ArrowUp");
+  await po.page.waitForTimeout(100);
+  expect(await chatInput.textContent()).toBe("Message 1");
+});

--- a/e2e-tests/chat_input.spec.ts
+++ b/e2e-tests/chat_input.spec.ts
@@ -64,12 +64,11 @@ test("chat input history navigation - up arrow recalls previous prompts", async 
   // Clear the input (should be empty after sending)
   await chatInput.click();
   await chatInput.fill("");
-  await po.page.waitForTimeout(100); // Wait for input to clear
+  await expect(chatInput).toBeEmpty(); // Wait for input to clear
 
   // Press Up arrow to get the most recent message (Third message)
   await chatInput.press("ArrowUp");
-  await po.page.waitForTimeout(100);
-  expect(await chatInput.textContent()).toBe("Third message");
+  await expect(chatInput).toHaveText("Third message");
 
   // Press Up arrow again to get the second message
   await chatInput.press("ArrowUp");

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -19,7 +19,7 @@ import {
   Lock,
 } from "lucide-react";
 import type React from "react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, useMemo } from "react";
 
 import { useSettings } from "@/hooks/useSettings";
 import { IpcClient } from "@/ipc/ipc_client";
@@ -155,6 +155,16 @@ export function ChatInput({ chatId }: { chatId?: number }) {
     !!proposal &&
     proposal.type === "code-proposal" &&
     messageId === lastMessage.id;
+
+  // Extract user message history for terminal-style navigation
+  const userMessageHistory = useMemo(() => {
+    if (!chatId) return [];
+    const messages = messagesById.get(chatId) ?? [];
+    return messages
+      .filter((msg) => msg.role === "user")
+      .map((msg) => msg.content)
+      .reverse(); // Most recent first
+  }, [chatId, messagesById]);
 
   const { userBudget } = useUserBudgetInfo();
 
@@ -446,6 +456,7 @@ export function ChatInput({ chatId }: { chatId?: number }) {
               placeholder="Ask Dyad to build..."
               excludeCurrentApp={true}
               disableSendButton={disableSendButton}
+              messageHistory={userMessageHistory}
             />
 
             {isStreaming ? (

--- a/src/components/chat/HistoryNavigation.tsx
+++ b/src/components/chat/HistoryNavigation.tsx
@@ -1,0 +1,161 @@
+import React, { useCallback, useEffect } from "react";
+import { $getRoot, $createParagraphNode, $createTextNode } from "lexical";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import {
+  KEY_ARROW_UP_COMMAND,
+  KEY_ARROW_DOWN_COMMAND,
+  COMMAND_PRIORITY_HIGH,
+} from "lexical";
+
+interface HistoryNavigationProps {
+  messageHistory: string[];
+  onChange: (value: string) => void;
+}
+
+export function HistoryNavigation({
+  messageHistory,
+  onChange,
+}: HistoryNavigationProps) {
+  const [editor] = useLexicalComposerContext();
+  const historyIndexRef = React.useRef<number>(-1);
+  const draftRef = React.useRef<string>("");
+
+  useEffect(() => {
+    // Reset history index when history changes (e.g., new message sent)
+    historyIndexRef.current = -1;
+    draftRef.current = "";
+  }, [messageHistory]);
+
+  const handleArrowUp = useCallback(
+    (event: KeyboardEvent) => {
+      // Check if mentions menu is open
+      const mentionsMenu = document.querySelector(
+        '[data-mentions-menu="true"]',
+      );
+      const hasVisibleItems = mentionsMenu && mentionsMenu.children.length > 0;
+
+      if (hasVisibleItems) {
+        return false;
+      }
+
+      if (messageHistory.length === 0) {
+        return false;
+      }
+
+      // Check if input is empty (only start navigation when input is empty)
+      let isEmpty = false;
+      let currentText = "";
+      editor.getEditorState().read(() => {
+        const root = $getRoot();
+        currentText = root.getTextContent();
+        isEmpty = currentText.length === 0;
+      });
+
+      // Only start navigation if input is empty OR we're already navigating
+      if (historyIndexRef.current === -1 && !isEmpty) {
+        return false;
+      }
+
+      // Save current draft when starting navigation
+      if (historyIndexRef.current === -1) {
+        draftRef.current = currentText;
+      }
+
+      event.preventDefault();
+
+      // Move to previous history item
+      if (historyIndexRef.current < messageHistory.length - 1) {
+        historyIndexRef.current += 1;
+        const historyItem = messageHistory[historyIndexRef.current];
+        editor.update(() => {
+          const root = $getRoot();
+          root.clear();
+          const paragraph = $createParagraphNode();
+          paragraph.append($createTextNode(historyItem));
+          root.append(paragraph);
+          paragraph.selectEnd();
+        });
+        onChange(historyItem);
+        return true;
+      }
+
+      return false;
+    },
+    [editor, messageHistory, onChange],
+  );
+
+  const handleArrowDown = useCallback(
+    (event: KeyboardEvent) => {
+      // Check if mentions menu is open
+      const mentionsMenu = document.querySelector(
+        '[data-mentions-menu="true"]',
+      );
+      const hasVisibleItems = mentionsMenu && mentionsMenu.children.length > 0;
+
+      if (hasVisibleItems) {
+        return false;
+      }
+
+      // Only handle if we're currently navigating history
+      if (historyIndexRef.current === -1) {
+        return false;
+      }
+
+      event.preventDefault();
+
+      // Move to next history item (or back to draft)
+      if (historyIndexRef.current > 0) {
+        historyIndexRef.current -= 1;
+        const historyItem = messageHistory[historyIndexRef.current];
+        editor.update(() => {
+          const root = $getRoot();
+          root.clear();
+          const paragraph = $createParagraphNode();
+          paragraph.append($createTextNode(historyItem));
+          root.append(paragraph);
+          paragraph.selectEnd();
+        });
+        onChange(historyItem);
+        return true;
+      } else {
+        // Go back to draft (empty or saved draft)
+        historyIndexRef.current = -1;
+        const draft = draftRef.current;
+        draftRef.current = "";
+        editor.update(() => {
+          const root = $getRoot();
+          root.clear();
+          const paragraph = $createParagraphNode();
+          if (draft) {
+            paragraph.append($createTextNode(draft));
+          }
+          root.append(paragraph);
+          paragraph.selectEnd();
+        });
+        onChange(draft);
+        return true;
+      }
+    },
+    [editor, messageHistory, onChange],
+  );
+
+  useEffect(() => {
+    const unregisterUp = editor.registerCommand(
+      KEY_ARROW_UP_COMMAND,
+      handleArrowUp,
+      COMMAND_PRIORITY_HIGH,
+    );
+    const unregisterDown = editor.registerCommand(
+      KEY_ARROW_DOWN_COMMAND,
+      handleArrowDown,
+      COMMAND_PRIORITY_HIGH,
+    );
+
+    return () => {
+      unregisterUp();
+      unregisterDown();
+    };
+  }, [editor, handleArrowUp, handleArrowDown]);
+
+  return null;
+}

--- a/src/components/chat/LexicalChatInput.tsx
+++ b/src/components/chat/LexicalChatInput.tsx
@@ -27,6 +27,7 @@ import { useAtomValue } from "jotai";
 import { selectedAppIdAtom } from "@/atoms/appAtoms";
 import { MENTION_REGEX, parseAppMentions } from "@/shared/parse_mention_apps";
 import { useLoadApp } from "@/hooks/useLoadApp";
+import { HistoryNavigation } from "./HistoryNavigation";
 
 // Define the theme for mentions
 const beautifulMentionsTheme: BeautifulMentionsTheme = {
@@ -238,6 +239,7 @@ interface LexicalChatInputProps {
   disabled?: boolean;
   excludeCurrentApp: boolean;
   disableSendButton: boolean;
+  messageHistory?: string[];
 }
 
 function onError(error: Error) {
@@ -253,6 +255,7 @@ export function LexicalChatInput({
   placeholder = "Ask Dyad to build...",
   disabled = false,
   disableSendButton,
+  messageHistory = [],
 }: LexicalChatInputProps) {
   const { apps } = useLoadApps();
   const { prompts } = usePrompts();
@@ -423,6 +426,10 @@ export function LexicalChatInput({
         <ClearEditorPlugin
           shouldClear={shouldClear}
           onCleared={handleCleared}
+        />
+        <HistoryNavigation
+          messageHistory={messageHistory}
+          onChange={onChange}
         />
       </div>
     </LexicalComposer>


### PR DESCRIPTION
closes #1999

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recall previous prompts in the chat input with Up Arrow; Down Arrow moves forward and returns to your draft. Aligns with Linear #1999.

- **New Features**
  - Added a Lexical plugin (HistoryNavigation) to handle ArrowUp/ArrowDown and insert past user messages.
  - Activates only when the input is empty; saves/restores your draft when exiting history.
  - Skips navigation when the mentions menu is open.
  - ChatInput collects user message history (most recent first) and passes it to LexicalChatInput.
  - E2E tests cover backward/forward navigation, non-empty input behavior, and multiple messages.

<sup>Written for commit 57c8c281c2f0801ef6a839425f29c834b4f3523b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds terminal-style navigation for past user prompts in `LexicalChatInput` via a new `HistoryNavigation` Lexical plugin.
> 
> - New `HistoryNavigation` plugin handles `ArrowUp/Down` to recall earlier user messages; activates only when input is empty, preserves/restores draft, and ignores when mentions menu is open
> - `ChatInput` derives user `messageHistory` (most recent first) with `useMemo` and passes it to `LexicalChatInput`
> - Minor `ChatInput` import update to include `useMemo`
> - E2E tests cover backward/forward navigation, empty-input requirement, and multiple-message history
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57c8c281c2f0801ef6a839425f29c834b4f3523b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->