### PR TITLE
Voice to Text with Vosk Model

### DIFF
--- a/e2e-tests/voice-input.spec.ts
+++ b/e2e-tests/voice-input.spec.ts
@@ -1,0 +1,30 @@
+import { expect } from "@playwright/test";
+import { test, Timeout } from "./helpers/test_helper";
+
+test("voice toggle injects text into chat input (mocked)", async ({
+  electronApp,
+}) => {
+  const page = await electronApp.firstWindow();
+
+  await page.evaluate(() => {
+    (window as any).__DYAD_TEST_VOICE__ = true;
+  });
+
+  const voiceToggle = page.getByTestId("voice-toggle");
+  await voiceToggle.waitFor({ timeout: Timeout.MEDIUM });
+
+  await voiceToggle.click();
+
+  await page.evaluate(() => {
+    window.dispatchEvent(
+      new CustomEvent("dyad-test-voice", {
+        detail: { text: "hello voice world", final: true },
+      }),
+    );
+  });
+
+  const input = page.getByTestId("lexical-chat-input");
+  await expect(input).toHaveText(/hello voice world/i, {
+    timeout: Timeout.MEDIUM,
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dyad",
-  "version": "0.30.0-beta.1",
+  "version": "0.31.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dyad",
-      "version": "0.30.0-beta.1",
+      "version": "0.31.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/amazon-bedrock": "^3.0.15",
@@ -99,6 +99,7 @@
         "tw-animate-css": "^1.2.5",
         "update-electron-app": "^3.1.1",
         "uuid": "^11.1.0",
+        "vosk-browser": "^0.0.8",
         "zod": "^3.25.76"
       },
       "devDependencies": {
@@ -21753,6 +21754,24 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vosk-browser": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/vosk-browser/-/vosk-browser-0.0.8.tgz",
+      "integrity": "sha512-df9MuChirUGKxP/+4k8tBV6hJOic8IRdJXv64+ET0Ue5CddOzLZINiHOWCka765gBzHJWNtQKgaYakS0FXZIJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "uuid": "9.0.0"
+      }
+    },
+    "node_modules/vosk-browser/node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/wcwidth": {

--- a/package.json
+++ b/package.json
@@ -175,6 +175,7 @@
     "tw-animate-css": "^1.2.5",
     "update-electron-app": "^3.1.1",
     "uuid": "^11.1.0",
+    "vosk-browser": "^0.0.8",
     "zod": "^3.25.76"
   },
   "lint-staged": {

--- a/src/components/chat/LexicalChatInput.tsx
+++ b/src/components/chat/LexicalChatInput.tsx
@@ -389,6 +389,7 @@ export function LexicalChatInput({
           contentEditable={
             <ContentEditable
               className="flex-1 p-2 focus:outline-none overflow-y-auto min-h-[40px] max-h-[200px] resize-none"
+              data-testid="lexical-chat-input"
               aria-placeholder={placeholder}
               placeholder={
                 <div className="absolute top-2 left-2 text-muted-foreground pointer-events-none select-none">

--- a/src/hooks/useVoskVoiceToText.ts
+++ b/src/hooks/useVoskVoiceToText.ts
@@ -1,0 +1,267 @@
+/// <reference types="vite/client" />
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const SAMPLE_RATE = 16000;
+const DEFAULT_MODEL_URL =
+  import.meta.env.VITE_VOSK_MODEL_URL ??
+  "/models/vosk-model-small-en-us-0.15.tar.gz";
+
+type VoskModel = {
+  KaldiRecognizer: new (sampleRate?: number) => VoskRecognizer;
+  ready?: boolean;
+  on?: (event: string, handler: (message: any) => void) => void;
+  terminate?: () => void;
+  setLogLevel?: (level: number) => void;
+};
+
+type VoskRecognizer = {
+  acceptWaveform: (buffer: AudioBuffer) => void;
+  setWords?: (words: boolean) => void;
+  remove?: () => void;
+  on?: (event: string, handler: (message: any) => void) => void;
+};
+
+type UseVoskVoiceToTextOptions = {
+  onFinalResult?: (text: string) => void;
+  onPartialResult?: (text: string) => void;
+  modelUrl?: string;
+};
+
+export function useVoskVoiceToText({
+  onFinalResult,
+  onPartialResult,
+  modelUrl = DEFAULT_MODEL_URL,
+}: UseVoskVoiceToTextOptions) {
+  const [isInitializing, setIsInitializing] = useState(false);
+  const [isRecording, setIsRecording] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [partialText, setPartialText] = useState("");
+  const latestPartialRef = useRef("");
+  const testEventHandlerRef = useRef<((event: Event) => void) | null>(null);
+
+  const modelRef = useRef<VoskModel | null>(null);
+  const recognizerRef = useRef<VoskRecognizer | null>(null);
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const processorRef = useRef<ScriptProcessorNode | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const isTestMode =
+    typeof window !== "undefined" &&
+    Boolean((window as any).__DYAD_TEST_VOICE__ === true);
+
+  const resetError = useCallback(() => setError(null), []);
+
+  const cleanupAudio = useCallback(() => {
+    processorRef.current?.disconnect();
+    processorRef.current = null;
+
+    audioContextRef.current?.close().catch(() => {
+      /* noop */
+    });
+    audioContextRef.current = null;
+
+    if (streamRef.current) {
+      for (const track of streamRef.current.getTracks()) {
+        track.stop();
+      }
+      streamRef.current = null;
+    }
+  }, []);
+
+  const cleanupRecognizer = useCallback(() => {
+    recognizerRef.current?.remove?.();
+    recognizerRef.current = null;
+  }, []);
+
+  const cleanupAll = useCallback(() => {
+    cleanupAudio();
+    cleanupRecognizer();
+    setIsRecording(false);
+    setPartialText("");
+    latestPartialRef.current = "";
+  }, [cleanupAudio, cleanupRecognizer]);
+
+  const ensureModel = useCallback(async () => {
+    if (modelRef.current) return modelRef.current;
+
+    setIsInitializing(true);
+    setError(null);
+    try {
+      const vosk = (await import("vosk-browser")) as any;
+      const model: VoskModel =
+        (vosk.createModel && (await vosk.createModel(modelUrl))) ||
+        new vosk.Model(modelUrl);
+
+      // Wait for model to finish loading if it exposes events
+      if (!model.ready && model.on) {
+        await new Promise<void>((resolve, reject) => {
+          const handleLoad = (message: any) => {
+            if (message?.result === false) {
+              reject(
+                new Error("Failed to load Vosk model. Check the modelUrl."),
+              );
+              return;
+            }
+            resolve();
+          };
+          const handleError = (message: any) => {
+            reject(
+              new Error(
+                message?.error ||
+                  "Unable to load Vosk model. See console for details.",
+              ),
+            );
+          };
+
+          model.on?.("load", handleLoad);
+          model.on?.("error", handleError);
+        });
+      }
+
+      model.setLogLevel?.(-1);
+      modelRef.current = model;
+      return model;
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Unable to initialize Vosk.";
+      setError(message);
+      throw err;
+    } finally {
+      setIsInitializing(false);
+    }
+  }, [modelUrl]);
+
+  const stopRecording = useCallback(() => {
+    if (testEventHandlerRef.current) {
+      window.removeEventListener("dyad-test-voice", testEventHandlerRef.current);
+      testEventHandlerRef.current = null;
+    }
+    if (latestPartialRef.current) {
+      onFinalResult?.(latestPartialRef.current);
+      latestPartialRef.current = "";
+    }
+    cleanupAll();
+  }, [cleanupAll, onFinalResult]);
+
+  const startRecording = useCallback(async () => {
+    if (isRecording) return;
+
+    try {
+      if (isTestMode) {
+        setIsRecording(true);
+        const handler = (event: Event) => {
+          const detail = (event as CustomEvent).detail || {};
+          const text: string = detail.text ?? "";
+          const isFinal = Boolean(detail.final);
+          if (text) {
+            if (isFinal) {
+              latestPartialRef.current = "";
+              onFinalResult?.(text);
+            } else {
+              latestPartialRef.current = text;
+              setPartialText(text);
+              onPartialResult?.(text);
+            }
+          }
+        };
+        window.addEventListener("dyad-test-voice", handler as EventListener);
+        testEventHandlerRef.current = handler as EventListener;
+        return;
+      }
+
+      const model = await ensureModel();
+      const recognizer = new model.KaldiRecognizer(SAMPLE_RATE);
+      recognizerRef.current = recognizer;
+
+      recognizer.setWords?.(true);
+      recognizer.on?.("result", (message: any) => {
+        const text = message?.result?.text?.trim();
+        if (text) {
+          setPartialText("");
+          latestPartialRef.current = "";
+          onFinalResult?.(text);
+        }
+      });
+      recognizer.on?.("partialresult", (message: any) => {
+        const text = message?.result?.partial ?? "";
+        setPartialText(text);
+        latestPartialRef.current = text;
+        onPartialResult?.(text);
+      });
+
+      const mediaStream = await navigator.mediaDevices.getUserMedia({
+        video: false,
+        audio: {
+          echoCancellation: true,
+          noiseSuppression: true,
+          channelCount: 1,
+          sampleRate: SAMPLE_RATE,
+        },
+      });
+      streamRef.current = mediaStream;
+
+      const audioContext = new AudioContext({ sampleRate: SAMPLE_RATE });
+      audioContextRef.current = audioContext;
+
+      const recognizerNode = audioContext.createScriptProcessor(4096, 1, 1);
+      processorRef.current = recognizerNode;
+      recognizerNode.onaudioprocess = (event) => {
+        try {
+          recognizer.acceptWaveform(event.inputBuffer);
+        } catch (err) {
+          console.error("acceptWaveform failed", err);
+          setError(
+            err instanceof Error
+              ? err.message
+              : "Unable to process microphone audio.",
+          );
+          stopRecording();
+        }
+      };
+
+      const source = audioContext.createMediaStreamSource(mediaStream);
+      source.connect(recognizerNode);
+      recognizerNode.connect(audioContext.destination);
+
+      setIsRecording(true);
+    } catch (err) {
+      console.error("Failed to start voice capture", err);
+      const message =
+        err instanceof Error
+          ? err.message
+          : "Unable to access microphone or model.";
+      setError(message);
+      cleanupAll();
+    }
+  }, [
+    cleanupAll,
+    ensureModel,
+    isRecording,
+    onFinalResult,
+    onPartialResult,
+    stopRecording,
+  ]);
+
+  useEffect(() => {
+    return () => {
+      if (testEventHandlerRef.current) {
+        window.removeEventListener(
+          "dyad-test-voice",
+          testEventHandlerRef.current,
+        );
+      }
+      cleanupAll();
+      modelRef.current?.terminate?.();
+      modelRef.current = null;
+    };
+  }, [cleanupAll]);
+
+  return {
+    startRecording,
+    stopRecording,
+    isRecording,
+    isInitializing,
+    partialText,
+    error,
+    resetError,
+  };
+}

--- a/src/types/vosk-browser.d.ts
+++ b/src/types/vosk-browser.d.ts
@@ -1,0 +1,19 @@
+declare module "vosk-browser" {
+  export const createModel: (modelUrl: string) => Promise<any>;
+
+  export class Model {
+    constructor(modelUrl: string);
+    KaldiRecognizer: new (sampleRate?: number) => any;
+    ready?: boolean;
+    on?: (event: string, handler: (message: any) => void) => void;
+    setLogLevel?: (level: number) => void;
+    terminate?: () => void;
+  }
+
+  const Vosk: {
+    createModel: typeof createModel;
+    Model: typeof Model;
+  };
+
+  export default Vosk;
+}


### PR DESCRIPTION
What needs to be done:
At the moment the model is bundled as an assets, we can make the model downloadable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds voice-to-text to chat using the Vosk browser model so users can record speech, see live partial text, and have final transcriptions placed in the input.

- **New Features**
  - Mic toggle in ChatInput with loading and stop states; recording auto-stops when generation starts.
  - Vosk-based hook that streams mic audio and emits partial and final results, with inline error and partial preview.
  - E2E test using a mocked voice event; added test id to the Lexical input.
  - Loads the small en-US model from /public/models; modelUrl is configurable.

- **Dependencies**
  - Added vosk-browser ^0.0.8 and included the small en-US model tarball in public/models.

<sup>Written for commit ff77c2189eb2e9407d1ea34a4a3e734fd07d4be2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

