### PR TITLE
feat: Support for Dyad Extension/Plugin installation + Cloudflare deployment

### DIFF
--- a/drizzle/0021_lumpy_rick_jones.sql
+++ b/drizzle/0021_lumpy_rick_jones.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `extension_data` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`app_id` integer NOT NULL,
+	`extension_id` text NOT NULL,
+	`key` text NOT NULL,
+	`value` text,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`updated_at` integer DEFAULT (unixepoch()) NOT NULL,
+	FOREIGN KEY (`app_id`) REFERENCES `apps`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `extension_data_app_id_extension_id_key_unique` ON `extension_data` (`app_id`,`extension_id`,`key`);

--- a/drizzle/meta/0021_snapshot.json
+++ b/drizzle/meta/0021_snapshot.json
@@ -1,0 +1,873 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "e957e9fe-bb4d-4c19-8bb7-17ebf14c1059",
+  "prevId": "6572da73-71b6-44ff-b997-05094c580dff",
+  "tables": {
+    "apps": {
+      "name": "apps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "github_org": {
+          "name": "github_org",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_repo": {
+          "name": "github_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_branch": {
+          "name": "github_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supabase_project_id": {
+          "name": "supabase_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supabase_parent_project_id": {
+          "name": "supabase_parent_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supabase_organization_slug": {
+          "name": "supabase_organization_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_project_id": {
+          "name": "neon_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_development_branch_id": {
+          "name": "neon_development_branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_preview_branch_id": {
+          "name": "neon_preview_branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vercel_project_id": {
+          "name": "vercel_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vercel_project_name": {
+          "name": "vercel_project_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vercel_team_id": {
+          "name": "vercel_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vercel_deployment_url": {
+          "name": "vercel_deployment_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "install_command": {
+          "name": "install_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_command": {
+          "name": "start_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chat_context": {
+          "name": "chat_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chats": {
+      "name": "chats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "initial_commit_hash": {
+          "name": "initial_commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chats_app_id_apps_id_fk": {
+          "name": "chats_app_id_apps_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "extension_data": {
+      "name": "extension_data",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "extension_id": {
+          "name": "extension_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "extension_data_app_id_extension_id_key_unique": {
+          "name": "extension_data_app_id_extension_id_key_unique",
+          "columns": [
+            "app_id",
+            "extension_id",
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "extension_data_app_id_apps_id_fk": {
+          "name": "extension_data_app_id_apps_id_fk",
+          "tableFrom": "extension_data",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "language_model_providers": {
+      "name": "language_model_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_base_url": {
+          "name": "api_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "env_var_name": {
+          "name": "env_var_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "language_models": {
+      "name": "language_models",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_name": {
+          "name": "api_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "builtin_provider_id": {
+          "name": "builtin_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "custom_provider_id": {
+          "name": "custom_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_output_tokens": {
+          "name": "max_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "language_models_custom_provider_id_language_model_providers_id_fk": {
+          "name": "language_models_custom_provider_id_language_model_providers_id_fk",
+          "tableFrom": "language_models",
+          "tableTo": "language_model_providers",
+          "columnsFrom": [
+            "custom_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "env_json": {
+          "name": "env_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_tool_consents": {
+      "name": "mcp_tool_consents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consent": {
+          "name": "consent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ask'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "uniq_mcp_consent": {
+          "name": "uniq_mcp_consent",
+          "columns": [
+            "server_id",
+            "tool_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "mcp_tool_consents_server_id_mcp_servers_id_fk": {
+          "name": "mcp_tool_consents_server_id_mcp_servers_id_fk",
+          "tableFrom": "mcp_tool_consents",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "approval_state": {
+          "name": "approval_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_commit_hash": {
+          "name": "source_commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "commit_hash": {
+          "name": "commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_tokens_used": {
+          "name": "max_tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ai_messages_json": {
+          "name": "ai_messages_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_chat_id_chats_id_fk": {
+          "name": "messages_chat_id_chats_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompts": {
+      "name": "prompts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "versions": {
+      "name": "versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "commit_hash": {
+          "name": "commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "neon_db_timestamp": {
+          "name": "neon_db_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "versions_app_commit_unique": {
+          "name": "versions_app_commit_unique",
+          "columns": [
+            "app_id",
+            "commit_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "versions_app_id_apps_id_fk": {
+          "name": "versions_app_id_apps_id_fk",
+          "tableFrom": "versions",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1766619976318,
       "tag": "0020_nebulous_patch",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "6",
+      "when": 1767460858939,
+      "tag": "0021_lumpy_rick_jones",
+      "breakpoints": true
     }
   ]
 }

--- a/src/__tests__/extension_data.test.ts
+++ b/src/__tests__/extension_data.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  setExtensionData,
+  getExtensionData,
+  getAllExtensionData,
+  deleteExtensionData,
+} from "../extensions/core/extension_data";
+
+const dbMocks = vi.hoisted(() => {
+  const where = vi.fn();
+  const set = vi.fn(() => ({ where }));
+  const update = vi.fn(() => ({ set }));
+  const insert = vi.fn(() => ({
+    values: vi.fn().mockResolvedValue(undefined),
+  }));
+  const select = vi.fn(() => ({
+    from: vi.fn(() => ({ where, limit: vi.fn(() => Promise.resolve([])) })),
+  }));
+  const delete_ = vi.fn(() => ({ where }));
+
+  return { update, set, where, insert, select, delete: delete_ };
+});
+
+const schemaMocks = vi.hoisted(() => {
+  return {
+    extensionData: {
+      appId: "extension_data.app_id",
+      extensionId: "extension_data.extension_id",
+      key: "extension_data.key",
+    },
+  };
+});
+
+const drizzleMocks = vi.hoisted(() => {
+  return {
+    eq: vi.fn((column: unknown, value: unknown) => `EQ(${column}, ${value})`),
+    and: vi.fn((...args: unknown[]) => `AND(${args.join(", ")})`),
+  };
+});
+
+vi.mock("@/db", () => ({
+  getDb: vi.fn(() => dbMocks),
+}));
+
+vi.mock("@/db/schema", () => ({
+  extensionData: schemaMocks.extensionData,
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: drizzleMocks.eq,
+  and: drizzleMocks.and,
+}));
+
+vi.mock("electron-log", () => ({
+  default: {
+    scope: vi.fn(() => ({
+      error: vi.fn(),
+      log: vi.fn(),
+      warn: vi.fn(),
+    })),
+  },
+}));
+
+describe("Extension Data Helpers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("setExtensionData", () => {
+    it("should insert new data when record does not exist", async () => {
+      // Mock select to return empty array (no existing record)
+      dbMocks.select.mockReturnValue({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({
+            limit: vi.fn(() => Promise.resolve([])),
+          })),
+        })),
+      });
+
+      await setExtensionData("test-ext", 1, "projectId", "proj_123");
+
+      expect(dbMocks.insert).toHaveBeenCalled();
+      expect(dbMocks.update).not.toHaveBeenCalled();
+    });
+
+    it("should update existing data when record exists", async () => {
+      // Mock select to return existing record
+      dbMocks.select.mockReturnValue({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({
+            limit: vi.fn(() =>
+              Promise.resolve([{ id: 1, value: '{"old":"data"}' }]),
+            ),
+          })),
+        })),
+      });
+
+      // Mock update chain
+      const updateWhere = vi.fn().mockResolvedValue(undefined);
+      dbMocks.where.mockReturnValue(updateWhere);
+      dbMocks.set.mockReturnValue({ where: updateWhere });
+
+      await setExtensionData("test-ext", 1, "projectId", "proj_123");
+
+      expect(dbMocks.update).toHaveBeenCalled();
+      expect(dbMocks.set).toHaveBeenCalledWith(
+        expect.objectContaining({
+          value: JSON.stringify("proj_123"),
+        }),
+      );
+    });
+  });
+
+  describe("getExtensionData", () => {
+    it("should return parsed JSON value when data exists", async () => {
+      const mockValue = { projectId: "proj_123", name: "My Project" };
+      dbMocks.select.mockReturnValue({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({
+            limit: vi.fn(() =>
+              Promise.resolve([{ id: 1, value: JSON.stringify(mockValue) }]),
+            ),
+          })),
+        })),
+      });
+
+      const result = await getExtensionData("test-ext", 1, "projectId");
+
+      expect(result).toEqual(mockValue);
+    });
+
+    it("should return null when data does not exist", async () => {
+      dbMocks.select.mockReturnValue({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({
+            limit: vi.fn(() => Promise.resolve([])),
+          })),
+        })),
+      });
+
+      const result = await getExtensionData("test-ext", 1, "projectId");
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null when value is null", async () => {
+      dbMocks.select.mockReturnValue({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({
+            limit: vi.fn(() => Promise.resolve([{ id: 1, value: null }])),
+          })),
+        })),
+      });
+
+      const result = await getExtensionData("test-ext", 1, "projectId");
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("getAllExtensionData", () => {
+    it("should return all extension data as a record", async () => {
+      const mockData = [
+        { key: "projectId", value: JSON.stringify("proj_123") },
+        { key: "deploymentUrl", value: JSON.stringify("https://example.com") },
+        { key: "invalid", value: "invalid json" }, // Should be skipped
+      ];
+
+      dbMocks.select.mockReturnValue({
+        from: vi.fn(() => ({
+          where: vi.fn(() => Promise.resolve(mockData)),
+        })),
+      });
+
+      const result = await getAllExtensionData("test-ext", 1);
+
+      expect(result).toEqual({
+        projectId: "proj_123",
+        deploymentUrl: "https://example.com",
+      });
+    });
+
+    it("should return empty object when no data exists", async () => {
+      dbMocks.select.mockReturnValue({
+        from: vi.fn(() => ({
+          where: vi.fn(() => Promise.resolve([])),
+        })),
+      });
+
+      const result = await getAllExtensionData("test-ext", 1);
+
+      expect(result).toEqual({});
+    });
+  });
+
+  describe("deleteExtensionData", () => {
+    it("should delete specific key when key is provided", async () => {
+      const deleteWhere = vi.fn().mockResolvedValue(undefined);
+      dbMocks.where.mockReturnValue(deleteWhere);
+      dbMocks.delete.mockReturnValue({ where: deleteWhere });
+
+      await deleteExtensionData("test-ext", 1, "projectId");
+
+      expect(dbMocks.delete).toHaveBeenCalled();
+      expect(drizzleMocks.and).toHaveBeenCalled();
+    });
+
+    it("should delete all extension data when key is not provided", async () => {
+      const deleteWhere = vi.fn().mockResolvedValue(undefined);
+      dbMocks.where.mockReturnValue(deleteWhere);
+      dbMocks.delete.mockReturnValue({ where: deleteWhere });
+
+      await deleteExtensionData("test-ext", 1);
+
+      expect(dbMocks.delete).toHaveBeenCalled();
+      expect(drizzleMocks.and).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/__tests__/extension_registry.test.ts
+++ b/src/__tests__/extension_registry.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { extensionRegistry } from "../extensions/core/extension_registry";
+import type { LoadedExtension } from "../extensions/core/extension_types";
+
+describe("ExtensionRegistry", () => {
+  beforeEach(() => {
+    // Clear registry before each test
+    extensionRegistry.clear();
+  });
+
+  function createMockExtension(id: string): LoadedExtension {
+    return {
+      manifest: {
+        id,
+        name: `Extension ${id}`,
+        version: "1.0.0",
+        description: `Test extension ${id}`,
+        capabilities: {
+          hasMainProcess: false,
+          hasRendererProcess: false,
+          hasDatabaseSchema: false,
+          hasSettingsSchema: false,
+        },
+      },
+      directory: `/extensions/${id}`,
+      registeredChannels: [],
+    };
+  }
+
+  describe("register", () => {
+    it("should register an extension successfully", () => {
+      const extension = createMockExtension("test-ext");
+      extensionRegistry.register(extension);
+
+      expect(extensionRegistry.has("test-ext")).toBe(true);
+      expect(extensionRegistry.get("test-ext")).toBe(extension);
+    });
+
+    it("should throw error when registering duplicate extension", () => {
+      const extension1 = createMockExtension("duplicate");
+      const extension2 = createMockExtension("duplicate");
+
+      extensionRegistry.register(extension1);
+
+      expect(() => extensionRegistry.register(extension2)).toThrow(
+        'Extension with id "duplicate" is already registered',
+      );
+    });
+  });
+
+  describe("get", () => {
+    it("should return extension when it exists", () => {
+      const extension = createMockExtension("existing");
+      extensionRegistry.register(extension);
+
+      const result = extensionRegistry.get("existing");
+      expect(result).toBe(extension);
+    });
+
+    it("should return undefined when extension does not exist", () => {
+      const result = extensionRegistry.get("non-existent");
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("getAll", () => {
+    it("should return empty array when no extensions registered", () => {
+      const result = extensionRegistry.getAll();
+      expect(result).toEqual([]);
+    });
+
+    it("should return all registered extensions", () => {
+      const ext1 = createMockExtension("ext1");
+      const ext2 = createMockExtension("ext2");
+      const ext3 = createMockExtension("ext3");
+
+      extensionRegistry.register(ext1);
+      extensionRegistry.register(ext2);
+      extensionRegistry.register(ext3);
+
+      const result = extensionRegistry.getAll();
+      expect(result).toHaveLength(3);
+      expect(result).toContain(ext1);
+      expect(result).toContain(ext2);
+      expect(result).toContain(ext3);
+    });
+  });
+
+  describe("has", () => {
+    it("should return true when extension exists", () => {
+      const extension = createMockExtension("exists");
+      extensionRegistry.register(extension);
+
+      expect(extensionRegistry.has("exists")).toBe(true);
+    });
+
+    it("should return false when extension does not exist", () => {
+      expect(extensionRegistry.has("does-not-exist")).toBe(false);
+    });
+  });
+
+  describe("unregister", () => {
+    it("should unregister extension successfully", () => {
+      const extension = createMockExtension("to-remove");
+      extensionRegistry.register(extension);
+
+      const result = extensionRegistry.unregister("to-remove");
+      expect(result).toBe(true);
+      expect(extensionRegistry.has("to-remove")).toBe(false);
+    });
+
+    it("should return false when unregistering non-existent extension", () => {
+      const result = extensionRegistry.unregister("non-existent");
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("clear", () => {
+    it("should clear all extensions", () => {
+      extensionRegistry.register(createMockExtension("ext1"));
+      extensionRegistry.register(createMockExtension("ext2"));
+      extensionRegistry.register(createMockExtension("ext3"));
+
+      extensionRegistry.clear();
+
+      expect(extensionRegistry.getAll()).toHaveLength(0);
+      expect(extensionRegistry.has("ext1")).toBe(false);
+      expect(extensionRegistry.has("ext2")).toBe(false);
+      expect(extensionRegistry.has("ext3")).toBe(false);
+    });
+  });
+});

--- a/src/components/ExtensionConnector.tsx
+++ b/src/components/ExtensionConnector.tsx
@@ -1,0 +1,33 @@
+import { rendererExtensionManager } from "@/extensions/core/renderer_extension_manager";
+import type { ExtensionMetadata } from "@/hooks/useExtensions";
+
+interface ExtensionConnectorProps {
+  extension: ExtensionMetadata;
+  appId: number;
+  folderName: string;
+}
+
+/**
+ * Component to render extension app connector integration
+ */
+export function ExtensionConnector({
+  extension,
+  appId,
+  folderName,
+}: ExtensionConnectorProps) {
+  if (!extension.ui?.appConnector) {
+    return null;
+  }
+
+  const Component = rendererExtensionManager.getComponent(
+    extension.id,
+    extension.ui.appConnector.component,
+  );
+
+  if (!Component) {
+    return null;
+  }
+
+  // Pass standard props that connectors typically need
+  return <Component appId={appId} folderName={folderName} />;
+}

--- a/src/components/ExtensionIntegration.tsx
+++ b/src/components/ExtensionIntegration.tsx
@@ -1,0 +1,26 @@
+import { rendererExtensionManager } from "@/extensions/core/renderer_extension_manager";
+import type { ExtensionMetadata } from "@/hooks/useExtensions";
+
+interface ExtensionIntegrationProps {
+  extension: ExtensionMetadata;
+}
+
+/**
+ * Component to render extension settings page integration
+ */
+export function ExtensionIntegration({ extension }: ExtensionIntegrationProps) {
+  if (!extension.ui?.settingsPage) {
+    return null;
+  }
+
+  const Component = rendererExtensionManager.getComponent(
+    extension.id,
+    extension.ui.settingsPage.component,
+  );
+
+  if (!Component) {
+    return null;
+  }
+
+  return <Component />;
+}

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -5,6 +5,7 @@ import {
   HelpCircle,
   Store,
   BookOpen,
+  Blocks,
 } from "lucide-react";
 import { Link, useRouterState } from "@tanstack/react-router";
 import { useSidebar } from "@/components/ui/sidebar"; // import useSidebar hook
@@ -42,6 +43,11 @@ const items = [
     icon: Inbox,
   },
   {
+    title: "Plugins",
+    to: "/extensions",
+    icon: Blocks,
+  },
+  {
     title: "Settings",
     to: "/settings",
     icon: Settings,
@@ -62,6 +68,7 @@ const items = [
 type HoverState =
   | "start-hover:app"
   | "start-hover:chat"
+  | "start-hover:extensions"
   | "start-hover:settings"
   | "start-hover:library"
   | "clear-hover"
@@ -96,6 +103,8 @@ export function AppSidebar() {
     routerState.location.pathname === "/" ||
     routerState.location.pathname.startsWith("/app-details");
   const isChatRoute = routerState.location.pathname === "/chat";
+  const isExtensionsRoute =
+    routerState.location.pathname.startsWith("/extensions");
   const isSettingsRoute = routerState.location.pathname.startsWith("/settings");
 
   let selectedItem: string | null = null;
@@ -103,6 +112,8 @@ export function AppSidebar() {
     selectedItem = "Apps";
   } else if (hoverState === "start-hover:chat") {
     selectedItem = "Chat";
+  } else if (hoverState === "start-hover:extensions") {
+    selectedItem = "Extensions";
   } else if (hoverState === "start-hover:settings") {
     selectedItem = "Settings";
   } else if (hoverState === "start-hover:library") {
@@ -112,6 +123,8 @@ export function AppSidebar() {
       selectedItem = "Apps";
     } else if (isChatRoute) {
       selectedItem = "Chat";
+    } else if (isExtensionsRoute) {
+      selectedItem = "Extensions";
     } else if (isSettingsRoute) {
       selectedItem = "Settings";
     }
@@ -208,6 +221,8 @@ function AppIcons({
                         onHoverChange("start-hover:app");
                       } else if (item.title === "Chat") {
                         onHoverChange("start-hover:chat");
+                      } else if (item.title === "Plugins") {
+                        onHoverChange("start-hover:extensions");
                       } else if (item.title === "Settings") {
                         onHoverChange("start-hover:settings");
                       } else if (item.title === "Library") {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -60,6 +60,32 @@ export const apps = sqliteTable("apps", {
     .default(sql`0`),
 });
 
+export const extensionData = sqliteTable(
+  "extension_data",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    appId: integer("app_id")
+      .notNull()
+      .references(() => apps.id, { onDelete: "cascade" }),
+    extensionId: text("extension_id").notNull(),
+    key: text("key").notNull(),
+    value: text("value"), // JSON string
+    createdAt: integer("created_at", { mode: "timestamp" })
+      .notNull()
+      .default(sql`(unixepoch())`),
+    updatedAt: integer("updated_at", { mode: "timestamp" })
+      .notNull()
+      .default(sql`(unixepoch())`),
+  },
+  (table) => ({
+    uniqueAppExtensionKey: unique().on(
+      table.appId,
+      table.extensionId,
+      table.key,
+    ),
+  }),
+);
+
 export const chats = sqliteTable("chats", {
   id: integer("id").primaryKey({ autoIncrement: true }),
   appId: integer("app_id")

--- a/src/extensions/README.md
+++ b/src/extensions/README.md
@@ -1,0 +1,189 @@
+# Extension System
+
+This directory contains the extension system infrastructure for Dyad.
+
+## Architecture
+
+The extension system allows third-party developers to create extensions that integrate with Dyad's IPC system, database, and UI.
+
+## Core Components
+
+### `core/extension_types.ts`
+
+TypeScript type definitions for extensions, including:
+
+- `ExtensionManifest`: Extension metadata structure
+- `ExtensionContext`: Context provided to extensions in main process
+- `ExtensionMain`: Main process entry point function type
+- `ExtensionRenderer`: Renderer process entry point function type
+
+### `core/extension_registry.ts`
+
+Singleton registry that stores all loaded extensions.
+
+### `core/extension_manager.ts`
+
+Manages the loading and lifecycle of extensions:
+
+- Discovers extensions from the extensions directory
+- Validates extension manifests
+- Loads and initializes extension main process code
+- Provides extension context with IPC handler registration, database access, etc.
+
+### `core/extension_data.ts`
+
+Helper functions for extensions to store and retrieve data:
+
+- `setExtensionData()`: Store extension-specific data for an app
+- `getExtensionData()`: Retrieve extension-specific data for an app
+- `getAllExtensionData()`: Get all data for an extension and app
+- `deleteExtensionData()`: Delete extension data
+
+## Extension Structure
+
+Extensions should be placed in the `extensions/plugins/` directory (relative to dyad-apps directory).
+
+### Extension Directory Structure
+
+```
+extensions/plugins/{extension-id}/
+  manifest.json       # Extension metadata
+  main.ts            # Main process entry point (if hasMainProcess: true)
+  renderer.tsx       # Renderer process entry point (optional)
+  ...                # Other extension files
+```
+
+### Manifest Format
+
+```json
+{
+  "id": "extension-id",
+  "name": "Extension Name",
+  "version": "1.0.0",
+  "description": "Extension description",
+  "author": "Author Name",
+  "capabilities": {
+    "hasMainProcess": true,
+    "hasRendererProcess": false,
+    "hasDatabaseSchema": false,
+    "hasSettingsSchema": false,
+    "ipcChannels": ["channel1", "channel2"]
+  },
+  "main": "main.js",
+  "renderer": "renderer.js",
+  "ui": {
+    "settingsPage": {
+      "component": "SettingsComponent",
+      "title": "Extension Settings"
+    },
+    "appConnector": {
+      "component": "ConnectorComponent",
+      "title": "Extension Connector"
+    }
+  }
+}
+```
+
+## IPC Channel Namespacing
+
+All extension IPC channels must be namespaced with the pattern:
+
+```
+extension:{extension-id}:{channel-name}
+```
+
+For example, an extension with ID "cloudflare" registering a channel "deploy" would use:
+
+```
+extension:cloudflare:deploy
+```
+
+## Extension Context API
+
+Extensions receive a context object with the following methods:
+
+### IPC Registration
+
+```typescript
+context.registerIpcHandler(
+  "extension:myext:my-channel",
+  async (event, args) => {
+    // Handler implementation
+  },
+);
+```
+
+### Database Access
+
+```typescript
+const db = context.getDb();
+// Use drizzle ORM to query database
+```
+
+### Settings Access
+
+```typescript
+const settings = context.readSettings();
+context.writeSettings({ ...settings, newField: value });
+```
+
+### App Data Access
+
+```typescript
+const app = await context.getApp(appId);
+await context.updateApp(appId, { name: "New Name" });
+```
+
+### Extension Data Storage
+
+```typescript
+await context.setExtensionData(appId, "projectId", "proj_123");
+const projectId = await context.getExtensionData(appId, "projectId");
+const allData = await context.getAllExtensionData(appId);
+```
+
+## Database Schema
+
+Extensions can store data using the `extension_data` table:
+
+```sql
+CREATE TABLE extension_data (
+  id INTEGER PRIMARY KEY,
+  app_id INTEGER NOT NULL,
+  extension_id TEXT NOT NULL,
+  key TEXT NOT NULL,
+  value TEXT,  -- JSON string
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE(app_id, extension_id, key),
+  FOREIGN KEY (app_id) REFERENCES apps(id) ON DELETE CASCADE
+);
+```
+
+## Settings Schema
+
+Extension settings are stored in `UserSettings.extensionSettings`:
+
+```typescript
+extensionSettings?: {
+  [extensionId: string]: {
+    [key: string]: any;
+  };
+};
+```
+
+## Security Considerations
+
+- All IPC channels are validated and must follow the namespacing pattern
+- Extensions run in the main process with full Node.js access (security considerations apply)
+- Extension code is not sandboxed (extensions have the same privileges as the main process)
+- Extension manifests are validated before loading
+
+## Future Enhancements
+
+- Renderer process extension loading
+- Extension sandboxing/isolation
+- Extension permissions system
+- Extension marketplace
+- Extension code signing
+- Hot-reloading for development

--- a/src/extensions/core/extension_data.ts
+++ b/src/extensions/core/extension_data.ts
@@ -1,0 +1,194 @@
+import { getDb } from "@/db";
+import { extensionData } from "@/db/schema";
+import { eq, and } from "drizzle-orm";
+import log from "electron-log";
+
+const logger = log.scope("extension-data");
+
+/**
+ * Set extension-specific data for an app
+ */
+export async function setExtensionData(
+  extensionId: string,
+  appId: number,
+  key: string,
+  value: any,
+): Promise<void> {
+  const db = getDb();
+
+  try {
+    // Check if record exists
+    const existing = await db
+      .select()
+      .from(extensionData)
+      .where(
+        and(
+          eq(extensionData.appId, appId),
+          eq(extensionData.extensionId, extensionId),
+          eq(extensionData.key, key),
+        ),
+      )
+      .limit(1);
+
+    const now = Math.floor(Date.now() / 1000);
+
+    if (existing.length > 0) {
+      // Update existing record
+      await db
+        .update(extensionData)
+        .set({
+          value: JSON.stringify(value),
+          updatedAt: new Date(now * 1000),
+        })
+        .where(
+          and(
+            eq(extensionData.appId, appId),
+            eq(extensionData.extensionId, extensionId),
+            eq(extensionData.key, key),
+          ),
+        );
+    } else {
+      // Insert new record
+      await db.insert(extensionData).values({
+        appId,
+        extensionId,
+        key,
+        value: JSON.stringify(value),
+        createdAt: new Date(now * 1000),
+        updatedAt: new Date(now * 1000),
+      });
+    }
+  } catch (error) {
+    logger.error(`Error setting extension data for ${extensionId}:`, error);
+    throw error;
+  }
+}
+
+/**
+ * Get extension-specific data for an app
+ */
+export async function getExtensionData(
+  extensionId: string,
+  appId: number,
+  key: string,
+): Promise<any> {
+  const db = getDb();
+
+  try {
+    const result = await db
+      .select()
+      .from(extensionData)
+      .where(
+        and(
+          eq(extensionData.appId, appId),
+          eq(extensionData.extensionId, extensionId),
+          eq(extensionData.key, key),
+        ),
+      )
+      .limit(1);
+
+    if (result.length === 0) {
+      return null;
+    }
+
+    const record = result[0];
+    if (!record.value) {
+      return null;
+    }
+
+    try {
+      return JSON.parse(record.value);
+    } catch (parseError) {
+      // Handle invalid JSON gracefully (consistent with getAllExtensionData)
+      logger.warn(
+        `Invalid JSON in extension data for ${extensionId}, app ${appId}, key "${key}":`,
+        parseError,
+      );
+      return null;
+    }
+  } catch (error) {
+    logger.error(`Error getting extension data for ${extensionId}:`, error);
+    throw error;
+  }
+}
+
+/**
+ * Get all extension data for an app
+ */
+export async function getAllExtensionData(
+  extensionId: string,
+  appId: number,
+): Promise<Record<string, any>> {
+  const db = getDb();
+
+  try {
+    const results = await db
+      .select()
+      .from(extensionData)
+      .where(
+        and(
+          eq(extensionData.appId, appId),
+          eq(extensionData.extensionId, extensionId),
+        ),
+      );
+
+    const data: Record<string, any> = {};
+    for (const record of results) {
+      if (record.value) {
+        try {
+          data[record.key] = JSON.parse(record.value);
+        } catch (parseError) {
+          // Skip invalid JSON (consistent with getExtensionData)
+          logger.warn(
+            `Invalid JSON in extension data for ${extensionId}, app ${appId}, key "${record.key}":`,
+            parseError,
+          );
+        }
+      }
+    }
+
+    return data;
+  } catch (error) {
+    logger.error(`Error getting all extension data for ${extensionId}:`, error);
+    throw error;
+  }
+}
+
+/**
+ * Delete extension data for an app
+ */
+export async function deleteExtensionData(
+  extensionId: string,
+  appId: number,
+  key?: string,
+): Promise<void> {
+  const db = getDb();
+
+  try {
+    if (key) {
+      // Delete specific key
+      await db
+        .delete(extensionData)
+        .where(
+          and(
+            eq(extensionData.appId, appId),
+            eq(extensionData.extensionId, extensionId),
+            eq(extensionData.key, key),
+          ),
+        );
+    } else {
+      // Delete all data for this extension and app
+      await db
+        .delete(extensionData)
+        .where(
+          and(
+            eq(extensionData.appId, appId),
+            eq(extensionData.extensionId, extensionId),
+          ),
+        );
+    }
+  } catch (error) {
+    logger.error(`Error deleting extension data for ${extensionId}:`, error);
+    throw error;
+  }
+}

--- a/src/extensions/core/extension_manager.ts
+++ b/src/extensions/core/extension_manager.ts
@@ -1,0 +1,361 @@
+import * as path from "node:path";
+import * as fs from "node:fs/promises";
+import { ipcMain, type IpcMainInvokeEvent } from "electron";
+import log from "electron-log";
+import type {
+  ExtensionManifest,
+  ExtensionContext,
+  ExtensionMain,
+  LoadedExtension,
+  App,
+} from "./extension_types";
+import { extensionRegistry } from "./extension_registry";
+import { getDb } from "@/db";
+import { apps } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import { readSettings, writeSettings } from "@/main/settings";
+import {
+  setExtensionData,
+  getExtensionData,
+  getAllExtensionData,
+} from "./extension_data";
+import { getFilesRecursively } from "@/ipc/utils/file_utils";
+import { getDyadAppPath } from "@/paths/paths";
+import { normalizePath } from "../../../shared/normalizePath";
+
+const logger = log.scope("extension-manager");
+
+/**
+ * Validates an extension manifest
+ */
+function validateManifest(manifest: any): manifest is ExtensionManifest {
+  if (!manifest || typeof manifest !== "object") {
+    throw new Error("Manifest must be an object");
+  }
+
+  if (!manifest.id || typeof manifest.id !== "string") {
+    throw new Error("Manifest must have a string 'id' field");
+  }
+
+  if (!manifest.name || typeof manifest.name !== "string") {
+    throw new Error("Manifest must have a string 'name' field");
+  }
+
+  if (!manifest.version || typeof manifest.version !== "string") {
+    throw new Error("Manifest must have a string 'version' field");
+  }
+
+  if (!manifest.capabilities || typeof manifest.capabilities !== "object") {
+    throw new Error("Manifest must have a 'capabilities' object");
+  }
+
+  // Validate IPC channel names if provided
+  if (manifest.capabilities.ipcChannels) {
+    if (!Array.isArray(manifest.capabilities.ipcChannels)) {
+      throw new Error("ipcChannels must be an array");
+    }
+    for (const channel of manifest.capabilities.ipcChannels) {
+      if (typeof channel !== "string" || !/^[a-z0-9-:]+$/.test(channel)) {
+        throw new Error(
+          `Invalid IPC channel name: "${channel}". Must be lowercase alphanumeric with hyphens and colons only.`,
+        );
+      }
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Validates IPC channel name to ensure it's properly namespaced
+ */
+function validateChannelName(extensionId: string, channel: string): void {
+  const expectedPrefix = `extension:${extensionId}:`;
+  if (!channel.startsWith(expectedPrefix)) {
+    throw new Error(
+      `IPC channel "${channel}" must start with "${expectedPrefix}"`,
+    );
+  }
+  if (!/^[a-z0-9-:]+$/.test(channel)) {
+    throw new Error(
+      `Invalid IPC channel name: "${channel}". Must be lowercase alphanumeric with hyphens and colons only.`,
+    );
+  }
+}
+
+/**
+ * Helper function to get app data (simplified version of the handler)
+ */
+async function getAppData(appId: number): Promise<App> {
+  const db = getDb();
+  const app = await db.query.apps.findFirst({
+    where: eq(apps.id, appId),
+  });
+
+  if (!app) {
+    throw new Error(`App with id ${appId} not found`);
+  }
+
+  // Get app files
+  const appPath = getDyadAppPath(app.path);
+  let files: string[] = [];
+
+  try {
+    files = getFilesRecursively(appPath, appPath);
+    files = files.map((filePath) => normalizePath(filePath));
+  } catch (error) {
+    logger.error(`Error reading files for app ${appId}:`, error);
+    // Continue without files
+  }
+
+  // Simplified app data - extensions can get full data via IPC if needed
+  return {
+    id: app.id,
+    name: app.name,
+    path: app.path,
+    files,
+    createdAt: app.createdAt,
+    updatedAt: app.updatedAt,
+    githubOrg: app.githubOrg,
+    githubRepo: app.githubRepo,
+    githubBranch: app.githubBranch,
+    supabaseProjectId: app.supabaseProjectId,
+    supabaseParentProjectId: app.supabaseParentProjectId,
+    supabaseProjectName: null,
+    supabaseOrganizationSlug: app.supabaseOrganizationSlug,
+    neonProjectId: app.neonProjectId,
+    neonDevelopmentBranchId: app.neonDevelopmentBranchId,
+    neonPreviewBranchId: app.neonPreviewBranchId,
+    vercelProjectId: app.vercelProjectId,
+    vercelProjectName: app.vercelProjectName,
+    vercelTeamSlug: null,
+    vercelDeploymentUrl: app.vercelDeploymentUrl,
+    installCommand: app.installCommand,
+    startCommand: app.startCommand,
+    isFavorite: app.isFavorite,
+  };
+}
+
+/**
+ * Creates extension context for an extension
+ */
+export function createExtensionContext(
+  manifest: ExtensionManifest,
+  _directory: string,
+): ExtensionContext & { registeredChannels: string[] } {
+  const extensionLogger = log.scope(`extension:${manifest.id}`);
+  const registeredChannels: string[] = [];
+
+  const context: ExtensionContext & { registeredChannels: string[] } = {
+    extensionId: manifest.id,
+    manifest,
+    logger: extensionLogger,
+    registeredChannels,
+    registerIpcHandler: (channel: string, handler: Function) => {
+      // Validate channel name
+      validateChannelName(manifest.id, channel);
+
+      // Check if channel was declared in manifest
+      if (
+        manifest.capabilities.ipcChannels &&
+        !manifest.capabilities.ipcChannels.some((declared) =>
+          channel.endsWith(`:${declared}`),
+        )
+      ) {
+        extensionLogger.warn(
+          `Channel "${channel}" was not declared in manifest ipcChannels`,
+        );
+      }
+
+      // Register handler with logging
+      ipcMain.handle(
+        channel,
+        async (event: IpcMainInvokeEvent, ...args: any[]) => {
+          extensionLogger.log(`IPC: ${channel} called`);
+          try {
+            const result = await handler(event, ...args);
+            extensionLogger.log(`IPC: ${channel} completed`);
+            return result;
+          } catch (error) {
+            extensionLogger.error(`IPC: ${channel} error:`, error);
+            throw error;
+          }
+        },
+      );
+
+      registeredChannels.push(channel);
+      extensionLogger.log(`Registered IPC channel: ${channel}`);
+    },
+    getDb: () => getDb(),
+    readSettings,
+    writeSettings,
+    getApp: async (appId: number) => {
+      return getAppData(appId);
+    },
+    updateApp: async (appId: number, data: Partial<App>) => {
+      const db = getDb();
+      await db.update(apps).set(data).where(eq(apps.id, appId));
+    },
+    setExtensionData: async (appId: number, key: string, value: any) => {
+      return setExtensionData(manifest.id, appId, key, value);
+    },
+    getExtensionData: async (appId: number, key: string) => {
+      return getExtensionData(manifest.id, appId, key);
+    },
+    getAllExtensionData: async (appId: number) => {
+      return getAllExtensionData(manifest.id, appId);
+    },
+  };
+
+  return context;
+}
+
+/**
+ * Loads a single extension from a directory
+ */
+async function loadExtension(
+  extensionDir: string,
+): Promise<LoadedExtension | null> {
+  const extensionId = path.basename(extensionDir);
+  const manifestPath = path.join(extensionDir, "manifest.json");
+
+  try {
+    // Read and validate manifest
+    const manifestContent = await fs.readFile(manifestPath, "utf-8");
+    const manifestJson = JSON.parse(manifestContent);
+    validateManifest(manifestJson);
+    const manifest = manifestJson as ExtensionManifest;
+
+    // Validate extension ID matches directory name
+    if (manifest.id !== extensionId) {
+      throw new Error(
+        `Extension ID "${manifest.id}" does not match directory name "${extensionId}"`,
+      );
+    }
+
+    logger.log(`Loading extension: ${manifest.id} v${manifest.version}`);
+
+    const loadedExtension: LoadedExtension = {
+      manifest,
+      directory: extensionDir,
+      registeredChannels: [],
+    };
+
+    // Load main process code if specified
+    if (manifest.capabilities.hasMainProcess && manifest.main) {
+      const mainPath = path.join(extensionDir, manifest.main);
+
+      // Check if file exists
+      try {
+        await fs.access(mainPath);
+      } catch {
+        throw new Error(`Main entry point not found: ${mainPath}`);
+      }
+
+      // Dynamic import of extension main code
+      // Note: In production, extensions would need to be in a format that can be imported
+      // For development, we assume extensions are TypeScript/JavaScript files
+      try {
+        // Use require for now (extensions will need to be compiled or use .js extension)
+        // In production, you'd want to load from a compiled location
+        const mainModule = await import(
+          /* @vite-ignore */ mainPath.replace(/\\/g, "/")
+        );
+        if (!mainModule.main || typeof mainModule.main !== "function") {
+          throw new Error(`Extension main entry must export a 'main' function`);
+        }
+        loadedExtension.mainEntry = mainModule.main as ExtensionMain;
+
+        // Create context and initialize extension
+        const context = createExtensionContext(manifest, extensionDir);
+        await loadedExtension.mainEntry(context);
+        loadedExtension.registeredChannels = context.registeredChannels || [];
+
+        logger.log(
+          `Extension ${manifest.id} main process initialized with ${loadedExtension.registeredChannels.length} IPC channels`,
+        );
+      } catch (error: any) {
+        throw new Error(
+          `Failed to load extension main process: ${error.message}`,
+        );
+      }
+    }
+
+    // Renderer process code is loaded separately by renderer extension manager
+    // We just store the path for now
+
+    return loadedExtension;
+  } catch (error: any) {
+    logger.error(`Failed to load extension from ${extensionDir}:`, error);
+    return null;
+  }
+}
+
+/**
+ * Extension Manager
+ * Manages loading and lifecycle of extensions
+ */
+export class ExtensionManager {
+  private extensionsDirectory: string;
+
+  constructor(extensionsDirectory: string) {
+    this.extensionsDirectory = extensionsDirectory;
+  }
+
+  /**
+   * Discover and load all extensions
+   */
+  async loadExtensions(): Promise<void> {
+    logger.log(`Loading extensions from: ${this.extensionsDirectory}`);
+
+    try {
+      // Ensure extensions directory exists
+      await fs.mkdir(this.extensionsDirectory, { recursive: true });
+
+      // Read extension directories
+      const entries = await fs.readdir(this.extensionsDirectory, {
+        withFileTypes: true,
+      });
+
+      const extensionDirs = entries
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => path.join(this.extensionsDirectory, entry.name));
+
+      logger.log(`Found ${extensionDirs.length} extension directories`);
+
+      // Load each extension
+      const loadPromises = extensionDirs.map((dir) => loadExtension(dir));
+      const loadedExtensions = await Promise.all(loadPromises);
+
+      // Register successfully loaded extensions
+      let successCount = 0;
+      for (const extension of loadedExtensions) {
+        if (extension) {
+          extensionRegistry.register(extension);
+          successCount++;
+        }
+      }
+
+      logger.log(
+        `Successfully loaded ${successCount}/${extensionDirs.length} extensions`,
+      );
+    } catch (error) {
+      logger.error("Error loading extensions:", error);
+      throw error;
+    }
+  }
+
+  /**
+   * Get all loaded extensions
+   */
+  getExtensions(): LoadedExtension[] {
+    return extensionRegistry.getAll();
+  }
+
+  /**
+   * Get extension by ID
+   */
+  getExtension(id: string): LoadedExtension | undefined {
+    return extensionRegistry.get(id);
+  }
+}

--- a/src/extensions/core/extension_registry.ts
+++ b/src/extensions/core/extension_registry.ts
@@ -1,0 +1,59 @@
+import type { LoadedExtension } from "./extension_types";
+
+/**
+ * Global extension registry
+ * Stores all loaded extensions
+ */
+class ExtensionRegistry {
+  private extensions: Map<string, LoadedExtension> = new Map();
+
+  /**
+   * Register a loaded extension
+   */
+  register(extension: LoadedExtension): void {
+    if (this.extensions.has(extension.manifest.id)) {
+      throw new Error(
+        `Extension with id "${extension.manifest.id}" is already registered`,
+      );
+    }
+    this.extensions.set(extension.manifest.id, extension);
+  }
+
+  /**
+   * Get extension by ID
+   */
+  get(id: string): LoadedExtension | undefined {
+    return this.extensions.get(id);
+  }
+
+  /**
+   * Get all registered extensions
+   */
+  getAll(): LoadedExtension[] {
+    return Array.from(this.extensions.values());
+  }
+
+  /**
+   * Check if extension is registered
+   */
+  has(id: string): boolean {
+    return this.extensions.has(id);
+  }
+
+  /**
+   * Unregister an extension
+   */
+  unregister(id: string): boolean {
+    return this.extensions.delete(id);
+  }
+
+  /**
+   * Clear all extensions
+   */
+  clear(): void {
+    this.extensions.clear();
+  }
+}
+
+// Singleton instance
+export const extensionRegistry = new ExtensionRegistry();

--- a/src/extensions/core/extension_types.ts
+++ b/src/extensions/core/extension_types.ts
@@ -1,0 +1,143 @@
+import type { IpcMainInvokeEvent } from "electron";
+import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
+import type * as schema from "@/db/schema";
+import type { UserSettings, App } from "@/ipc/ipc_types";
+import type log from "electron-log";
+
+/**
+ * Extension capabilities declaration
+ */
+export interface ExtensionCapabilities {
+  /** Extension has main process code */
+  hasMainProcess: boolean;
+  /** Extension has renderer process code */
+  hasRendererProcess: boolean;
+  /** Extension requires database schema changes */
+  hasDatabaseSchema: boolean;
+  /** Extension requires settings schema changes */
+  hasSettingsSchema: boolean;
+  /** IPC channels this extension will register (for validation) */
+  ipcChannels?: string[];
+}
+
+/**
+ * UI integration points for extensions
+ */
+export interface ExtensionUI {
+  /** Settings page integration */
+  settingsPage?: {
+    /** Component name to render in settings */
+    component: string;
+    /** Title to display */
+    title: string;
+    /** Optional icon identifier */
+    icon?: string;
+  };
+  /** App connector integration (shows in app detail view) */
+  appConnector?: {
+    /** Component name to render */
+    component: string;
+    /** Title to display */
+    title: string;
+  };
+}
+
+/**
+ * Extension manifest (extension metadata)
+ */
+export interface ExtensionManifest {
+  /** Unique extension identifier (must match directory name) */
+  id: string;
+  /** Human-readable extension name */
+  name: string;
+  /** Extension version (semver) */
+  version: string;
+  /** Extension description */
+  description: string;
+  /** Extension author (optional) */
+  author?: string;
+  /** Minimum required Dyad version (optional) */
+  dyadVersion?: string;
+  /** Extension capabilities */
+  capabilities: ExtensionCapabilities;
+  /** Main process entry point (relative to extension root) */
+  main?: string;
+  /** Renderer process entry point (relative to extension root, optional) */
+  renderer?: string;
+  /** UI integration configuration */
+  ui?: ExtensionUI;
+}
+
+/**
+ * Database type helper
+ */
+export type Database = BetterSQLite3Database<typeof schema>;
+
+/**
+ * Extension context provided to main process extensions
+ */
+export interface ExtensionContext {
+  /** Extension identifier */
+  extensionId: string;
+  /** Extension manifest */
+  manifest: ExtensionManifest;
+  /** Logger scoped to this extension */
+  logger: log.LogFunctions;
+  /** Register an IPC handler (automatically namespaced) */
+  registerIpcHandler: (
+    channel: string,
+    handler: (event: IpcMainInvokeEvent, ...args: any[]) => Promise<any> | any,
+  ) => void;
+  /** Get database instance */
+  getDb: () => Database;
+  /** Read user settings */
+  readSettings: () => UserSettings;
+  /** Write user settings */
+  writeSettings: (settings: Partial<UserSettings>) => void;
+  /** Get app by ID */
+  getApp: (appId: number) => Promise<App>;
+  /** Update app data */
+  updateApp: (appId: number, data: Partial<App>) => Promise<void>;
+  /** Set extension-specific data for an app */
+  setExtensionData: (appId: number, key: string, value: any) => Promise<void>;
+  /** Get extension-specific data for an app */
+  getExtensionData: (appId: number, key: string) => Promise<any>;
+  /** Get all extension data for an app */
+  getAllExtensionData: (appId: number) => Promise<Record<string, any>>;
+}
+
+/**
+ * Extension renderer context (for future use)
+ */
+export interface ExtensionRendererContext {
+  extensionId: string;
+  manifest: ExtensionManifest;
+}
+
+/**
+ * Main process extension entry point function
+ */
+export type ExtensionMain = (context: ExtensionContext) => void | Promise<void>;
+
+/**
+ * Renderer process extension entry point function
+ */
+export type ExtensionRenderer = (
+  context: ExtensionRendererContext,
+) => void | Promise<void>;
+
+/**
+ * Loaded extension metadata
+ */
+export interface LoadedExtension {
+  /** Extension manifest */
+  manifest: ExtensionManifest;
+  /** Extension directory path */
+  directory: string;
+  /** Main process entry point (if loaded) */
+  mainEntry?: ExtensionMain;
+  /** Renderer process entry point (if loaded) */
+  rendererEntry?: ExtensionRenderer;
+  /** Registered IPC channels */
+  registeredChannels: string[];
+}

--- a/src/extensions/core/load_development_extension.ts
+++ b/src/extensions/core/load_development_extension.ts
@@ -1,0 +1,61 @@
+import type {
+  ExtensionManifest,
+  ExtensionMain,
+  LoadedExtension,
+} from "./extension_types";
+import { extensionRegistry } from "./extension_registry";
+import { createExtensionContext } from "./extension_manager";
+import log from "electron-log";
+
+const logger = log.scope("load-development-extension");
+
+/**
+ * Load an extension from source code in development mode
+ * This allows extensions to be imported statically (as part of the bundle)
+ */
+export async function loadDevelopmentExtension(
+  manifest: ExtensionManifest,
+  mainEntry: ExtensionMain | undefined,
+  extensionDir: string,
+): Promise<void> {
+  try {
+    // Check if extension is already registered
+    if (extensionRegistry.has(manifest.id)) {
+      logger.log(`Extension ${manifest.id} is already registered, skipping`);
+      return;
+    }
+
+    const loadedExtension: LoadedExtension = {
+      manifest,
+      directory: extensionDir,
+      mainEntry: undefined,
+      registeredChannels: [],
+    };
+
+    // Initialize main process code if provided
+    if (mainEntry && manifest.capabilities.hasMainProcess) {
+      try {
+        // Create context and initialize extension
+        const context = createExtensionContext(manifest, extensionDir);
+        await mainEntry(context);
+        loadedExtension.mainEntry = mainEntry;
+        loadedExtension.registeredChannels = context.registeredChannels || [];
+
+        logger.log(
+          `Extension ${manifest.id} main process initialized with ${loadedExtension.registeredChannels.length} IPC channels`,
+        );
+      } catch (error: any) {
+        throw new Error(
+          `Failed to initialize extension main process: ${error.message}`,
+        );
+      }
+    }
+
+    // Register the extension
+    extensionRegistry.register(loadedExtension);
+    logger.log(`Successfully loaded development extension: ${manifest.id}`);
+  } catch (error: any) {
+    logger.error(`Failed to load development extension ${manifest.id}:`, error);
+    throw error;
+  }
+}

--- a/src/extensions/core/load_development_extensions.ts
+++ b/src/extensions/core/load_development_extensions.ts
@@ -1,0 +1,78 @@
+import { loadDevelopmentExtension } from "./load_development_extension";
+import type { ExtensionManifest } from "./extension_types";
+import { app } from "electron";
+import * as path from "node:path";
+import log from "electron-log";
+
+const logger = log.scope("load-development-extensions");
+
+/**
+ * Load development extensions from source code
+ * This is called in development mode to load extensions statically
+ */
+export async function loadDevelopmentExtensions(): Promise<void> {
+  try {
+    // Import Cloudflare extension
+    const cloudflareManifest: ExtensionManifest = {
+      id: "cloudflare",
+      name: "Cloudflare Pages",
+      version: "1.0.0",
+      description: "Deploy your projects to Cloudflare Pages",
+      author: "Dyad",
+      capabilities: {
+        hasMainProcess: true,
+        hasRendererProcess: true,
+        hasDatabaseSchema: false,
+        hasSettingsSchema: false,
+        ipcChannels: [
+          "save-token",
+          "list-projects",
+          "create-project",
+          "connect-existing-project",
+          "deploy",
+          "list-deployments",
+          "disconnect",
+        ],
+      },
+      main: "main.ts",
+      renderer: "renderer.ts",
+      ui: {
+        settingsPage: {
+          component: "CloudflareSettings",
+          title: "Cloudflare Pages",
+          icon: "Cloud",
+        },
+        appConnector: {
+          component: "CloudflareConnector",
+          title: "Cloudflare Pages",
+        },
+      },
+    };
+
+    // Import the main entry point
+    const cloudflareMainModule = await import("../plugins/cloudflare/main");
+    const cloudflareMain = cloudflareMainModule.main;
+
+    // Get the extension directory path (for context)
+    // In development, app.getAppPath() is the project root
+    const cloudflareExtensionDir = path.join(
+      app.getAppPath(),
+      "src",
+      "extensions",
+      "plugins",
+      "cloudflare",
+    );
+
+    await loadDevelopmentExtension(
+      cloudflareManifest,
+      cloudflareMain,
+      cloudflareExtensionDir,
+    );
+
+    logger.log("Development extensions loaded successfully");
+  } catch (error: unknown) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    logger.error("Error loading development extensions:", errorMessage);
+    throw error;
+  }
+}

--- a/src/extensions/core/renderer_extension_manager.ts
+++ b/src/extensions/core/renderer_extension_manager.ts
@@ -1,0 +1,57 @@
+/**
+ * Renderer Extension Manager
+ *
+ * Note: In a real implementation, this would need to:
+ * 1. Receive extension metadata from main process (via IPC)
+ * 2. Dynamically import extension renderer code
+ * 3. Register components with the registry
+ *
+ * For now, extensions manually register their components via the registry.
+ * This is a placeholder for future dynamic loading support.
+ */
+
+import type { ComponentType } from "react";
+import { rendererExtensionRegistry } from "./renderer_extension_registry";
+
+/**
+ * Renderer Extension Manager
+ * Manages loading and registration of renderer-side extension code
+ */
+export class RendererExtensionManager {
+  private loadedExtensions: Set<string> = new Set();
+
+  /**
+   * Register components from an extension
+   * This is called by extension renderer code
+   */
+  registerExtensionComponents(
+    extensionId: string,
+    components: Record<string, ComponentType<any>>,
+  ): void {
+    for (const [componentName, component] of Object.entries(components)) {
+      const key = `${extensionId}:${componentName}`;
+      rendererExtensionRegistry.register(key, component);
+    }
+    this.loadedExtensions.add(extensionId);
+  }
+
+  /**
+   * Check if an extension is loaded in renderer
+   */
+  isExtensionLoaded(extensionId: string): boolean {
+    return this.loadedExtensions.has(extensionId);
+  }
+
+  /**
+   * Get a component by extension ID and component name
+   */
+  getComponent(
+    extensionId: string,
+    componentName: string,
+  ): ComponentType<any> | undefined {
+    return rendererExtensionRegistry.getComponent(extensionId, componentName);
+  }
+}
+
+// Singleton instance
+export const rendererExtensionManager = new RendererExtensionManager();

--- a/src/extensions/core/renderer_extension_registry.ts
+++ b/src/extensions/core/renderer_extension_registry.ts
@@ -1,0 +1,70 @@
+import type { ComponentType } from "react";
+
+/**
+ * Extension component registry for renderer process
+ * Stores React components registered by extensions
+ */
+class RendererExtensionRegistry {
+  private components: Map<string, ComponentType<any>> = new Map();
+
+  /**
+   * Register a component with a unique key
+   * Key format: {extensionId}:{componentName}
+   */
+  register(key: string, component: ComponentType<any>): void {
+    if (this.components.has(key)) {
+      console.warn(
+        `Component with key "${key}" is already registered, overwriting`,
+      );
+    }
+    this.components.set(key, component);
+  }
+
+  /**
+   * Get a component by key
+   */
+  get(key: string): ComponentType<any> | undefined {
+    return this.components.get(key);
+  }
+
+  /**
+   * Get a component by extension ID and component name
+   */
+  getComponent(
+    extensionId: string,
+    componentName: string,
+  ): ComponentType<any> | undefined {
+    return this.get(`${extensionId}:${componentName}`);
+  }
+
+  /**
+   * Check if a component is registered
+   */
+  has(key: string): boolean {
+    return this.components.has(key);
+  }
+
+  /**
+   * Unregister a component
+   */
+  unregister(key: string): boolean {
+    return this.components.delete(key);
+  }
+
+  /**
+   * Clear all components
+   */
+  clear(): void {
+    this.components.clear();
+  }
+
+  /**
+   * Get all registered component keys
+   */
+  getAllKeys(): string[] {
+    return Array.from(this.components.keys());
+  }
+}
+
+// Singleton instance
+export const rendererExtensionRegistry = new RendererExtensionRegistry();

--- a/src/extensions/core/renderer_loader.ts
+++ b/src/extensions/core/renderer_loader.ts
@@ -1,0 +1,42 @@
+/**
+ * Renderer Extension Loader
+ *
+ * This module provides utilities to load extension renderer code.
+ * Extensions register their components by importing and calling the loader.
+ *
+ * In the future, this could be enhanced to dynamically load extension code
+ * based on metadata from the main process.
+ */
+
+import type { ComponentType } from "react";
+import { rendererExtensionManager } from "./renderer_extension_manager";
+
+/**
+ * Load extension renderer code
+ * This should be called by extension renderer entry points
+ */
+export async function loadExtensionRenderer(
+  extensionId: string,
+  rendererModule: { renderer?: (context: any) => void | Promise<void> },
+): Promise<void> {
+  if (
+    rendererModule.renderer &&
+    typeof rendererModule.renderer === "function"
+  ) {
+    await rendererModule.renderer({
+      extensionId,
+      // Additional context can be added here
+    });
+  }
+}
+
+/**
+ * Manual registration helper for extensions
+ * Extensions can use this to register components directly
+ */
+export function registerExtensionComponents(
+  extensionId: string,
+  components: Record<string, ComponentType<any>>,
+): void {
+  rendererExtensionManager.registerExtensionComponents(extensionId, components);
+}

--- a/src/extensions/plugins/cloudflare/EXTENSION_STATUS.md
+++ b/src/extensions/plugins/cloudflare/EXTENSION_STATUS.md
@@ -1,0 +1,84 @@
+# Cloudflare Pages Extension - Status
+
+## ✅ Completed
+
+### Core Extension Files
+
+- ✅ `manifest.json` - Extension metadata and configuration
+- ✅ `main.ts` - Main process entry point
+- ✅ `handlers.ts` - IPC handlers for Cloudflare Pages API
+- ✅ `types.ts` - TypeScript type definitions
+- ✅ `hooks.ts` - React hooks for data fetching (ready for use)
+- ✅ `README.md` - Documentation
+
+### Features Implemented
+
+- ✅ Save Cloudflare API token
+- ✅ List Cloudflare Pages projects
+- ✅ Create new Cloudflare Pages projects
+- ✅ Connect to existing projects
+- ✅ List deployments
+- ✅ Disconnect projects
+- ✅ Auto-detect build output directories
+- ✅ Store project data in extension_data table
+
+## ⚠️ Pending (Requires Phase 2: Renderer Extension Manager)
+
+### React Components
+
+- ⏳ `CloudflareConnector.tsx` - Main connector component for app view
+- ⏳ `CloudflareSettings.tsx` - Settings page component
+- ⏳ `renderer.ts` - Renderer process entry point (for component registration)
+
+These components are ready to be created but require the Renderer Extension Manager system to be implemented first. The components will need to:
+
+1. Be registered in a renderer extension registry
+2. Be dynamically loaded and rendered in the UI
+3. Use the hooks defined in `hooks.ts`
+
+## Current Status
+
+The extension's **main process code is complete and functional**. The IPC handlers are registered and ready to use. However, the **React UI components** cannot be automatically loaded yet because the renderer extension system (Phase 2) hasn't been implemented.
+
+## Next Steps
+
+To complete the extension:
+
+1. **Implement Renderer Extension Manager** (Phase 2)
+
+   - Create renderer extension registry
+   - Add component loading system
+   - Integrate into settings and app views
+
+2. **Create React Components**
+
+   - `CloudflareConnector.tsx` - Similar to `VercelConnector.tsx`
+   - `CloudflareSettings.tsx` - Similar to `VercelIntegration.tsx`
+
+3. **Test the Extension**
+   - Test IPC handlers
+   - Test component integration
+   - Test deployment workflow
+
+## Manual Integration (Temporary Workaround)
+
+Until the renderer extension system is implemented, the extension handlers can be tested manually by:
+
+1. Calling the IPC channels directly from the renderer process
+2. Using the hooks defined in `hooks.ts` in temporary components
+3. Manually integrating components into the app (not recommended for production)
+
+## API Usage Example
+
+```typescript
+// In renderer process (temporary)
+const ipcClient = IpcClient.getInstance() as any;
+const token = await ipcClient.ipcRenderer.invoke(
+  "extension:cloudflare:save-token",
+  { token: "your-token-here" },
+);
+
+const projects = await ipcClient.ipcRenderer.invoke(
+  "extension:cloudflare:list-projects",
+);
+```

--- a/src/extensions/plugins/cloudflare/README.md
+++ b/src/extensions/plugins/cloudflare/README.md
@@ -1,0 +1,85 @@
+# Cloudflare Pages Extension
+
+This extension allows users to deploy their Dyad applications to Cloudflare Pages.
+
+## Features
+
+- **Authenticate with Cloudflare**: Securely store Cloudflare API tokens
+- **Create Projects**: Create new Cloudflare Pages projects
+- **Connect Existing Projects**: Link to existing Cloudflare Pages projects
+- **View Deployments**: List and view deployment history
+- **Disconnect Projects**: Remove project connections
+
+## Setup
+
+### 1. Get Cloudflare API Token
+
+1. Go to [Cloudflare Dashboard](https://dash.cloudflare.com/profile/api-tokens)
+2. Click "Create Token"
+3. Use the "Edit Cloudflare Workers" template or create a custom token with:
+   - Account: `Cloudflare Pages:Edit` permission
+   - Zone Resources: Include all zones (or specific zones)
+4. Copy the generated token
+
+### 2. Configure Extension
+
+1. Open Dyad Settings
+2. Navigate to the Cloudflare Pages section
+3. Enter your API token
+4. Click "Save Access Token"
+
+### 3. Connect a Project
+
+1. Open your app in Dyad
+2. Navigate to the Cloudflare Pages connector
+3. Choose to either:
+   - **Create a new project**: Enter a project name
+   - **Connect to existing project**: Select from your existing projects
+4. Click the appropriate button to connect
+
+## API Reference
+
+### IPC Channels
+
+All channels are namespaced with `extension:cloudflare:`:
+
+- `extension:cloudflare:save-token` - Save Cloudflare API token
+- `extension:cloudflare:list-projects` - List all Cloudflare Pages projects
+- `extension:cloudflare:create-project` - Create a new Cloudflare Pages project
+- `extension:cloudflare:connect-existing-project` - Connect to an existing project
+- `extension:cloudflare:list-deployments` - Get deployments for a project
+- `extension:cloudflare:disconnect` - Disconnect a project
+
+### Extension Data Storage
+
+The extension stores the following data per app:
+
+- `projectId` - Cloudflare Pages project ID
+- `projectName` - Project name
+- `accountId` - Cloudflare account ID
+- `deploymentUrl` - Primary deployment URL
+
+## Development
+
+### File Structure
+
+```
+cloudflare/
+  ├── manifest.json      # Extension manifest
+  ├── main.ts           # Main process entry point
+  ├── handlers.ts       # IPC handlers
+  ├── types.ts          # TypeScript types
+  ├── hooks.ts          # React hooks (for renderer)
+  └── README.md         # This file
+```
+
+### Building
+
+Extensions are loaded from the `extensions/plugins/` directory. The extension manager will automatically discover and load this extension on app startup.
+
+## Notes
+
+- The extension requires a valid Cloudflare API token with appropriate permissions
+- Projects are stored per-app in the extension_data table
+- Deployment URLs are automatically detected from the project's primary domain
+- Build output directories are auto-detected (dist, build, .next, out, public)

--- a/src/extensions/plugins/cloudflare/components.tsx
+++ b/src/extensions/plugins/cloudflare/components.tsx
@@ -1,0 +1,591 @@
+import { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { IpcClient } from "@/ipc/ipc_client";
+import { useSettings } from "@/hooks/useSettings";
+import { useLoadApp } from "@/hooks/useLoadApp";
+import { useAllExtensionData } from "@/hooks/useExtensionData";
+import { useCloudflareDeployments } from "../cloudflare/hooks";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { CloudflareProject } from "./types";
+import { showSuccess, showError } from "@/lib/toast";
+
+// Helper to invoke extension IPC channels
+function invokeExtensionChannel(channel: string, ...args: any[]): Promise<any> {
+  const ipcClient = IpcClient.getInstance() as any;
+  return ipcClient.ipcRenderer.invoke(channel, ...args);
+}
+
+interface CloudflareConnectorProps {
+  appId: number;
+  folderName: string;
+}
+
+interface ConnectedCloudflareConnectorProps {
+  appId: number;
+  refreshApp: () => void;
+}
+
+interface UnconnectedCloudflareConnectorProps {
+  appId: number | null;
+  folderName: string;
+  settings: any;
+  refreshSettings: () => void;
+  refreshApp: () => void;
+}
+
+function ConnectedCloudflareConnector({
+  appId,
+  refreshApp,
+}: ConnectedCloudflareConnectorProps) {
+  const {
+    deployments,
+    isLoading: isLoadingDeployments,
+    error: deploymentsError,
+    getDeployments,
+    disconnectProject,
+    isDisconnecting,
+    disconnectError,
+  } = useCloudflareDeployments(appId);
+
+  // Get project data from extension data
+  const { data: extensionData } = useAllExtensionData("cloudflare", appId);
+  const projectName = extensionData?.projectName || null;
+  const deploymentUrl = extensionData?.deploymentUrl || null;
+
+  const handleDisconnectProject = async () => {
+    await disconnectProject();
+    refreshApp();
+  };
+
+  return (
+    <div className="mt-4 w-full rounded-md">
+      <p className="text-sm text-gray-600 dark:text-gray-300">
+        Connected to Cloudflare Pages Project:
+      </p>
+      {projectName && (
+        <a
+          onClick={(e) => {
+            e.preventDefault();
+            IpcClient.getInstance().openExternalUrl(
+              `https://dash.cloudflare.com/pages`,
+            );
+          }}
+          className="cursor-pointer text-blue-600 hover:underline dark:text-blue-400"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {projectName}
+        </a>
+      )}
+      {deploymentUrl && (
+        <div className="mt-2">
+          <p className="text-sm text-gray-600 dark:text-gray-300">
+            Live URL:{" "}
+            <a
+              onClick={(e) => {
+                e.preventDefault();
+                IpcClient.getInstance().openExternalUrl(deploymentUrl);
+              }}
+              className="cursor-pointer text-blue-600 hover:underline dark:text-blue-400 font-mono"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {deploymentUrl}
+            </a>
+          </p>
+        </div>
+      )}
+      <div className="mt-2 flex gap-2">
+        <Button onClick={getDeployments} disabled={isLoadingDeployments}>
+          {isLoadingDeployments ? "Loading..." : "Refresh Deployments"}
+        </Button>
+        <Button
+          onClick={handleDisconnectProject}
+          disabled={isDisconnecting}
+          variant="outline"
+        >
+          {isDisconnecting ? "Disconnecting..." : "Disconnect"}
+        </Button>
+      </div>
+      {deploymentsError && (
+        <div className="mt-2">
+          <p className="text-red-600 text-sm">{deploymentsError}</p>
+        </div>
+      )}
+      {disconnectError && (
+        <div className="mt-2">
+          <p className="text-red-600 text-sm">{disconnectError}</p>
+        </div>
+      )}
+      {deployments.length > 0 && (
+        <div className="mt-4">
+          <h4 className="font-medium mb-2 text-sm">Recent Deployments:</h4>
+          <div className="space-y-2">
+            {deployments.slice(0, 5).map((deployment) => (
+              <div
+                key={deployment.id}
+                className="bg-gray-50 dark:bg-gray-800 rounded-md p-3"
+              >
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <span
+                      className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-medium ${
+                        deployment.latest_stage?.status === "success"
+                          ? "bg-green-100 text-green-800 dark:bg-green-900/20 dark:text-green-300"
+                          : deployment.latest_stage?.status === "active"
+                            ? "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/20 dark:text-yellow-300"
+                            : "bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300"
+                      }`}
+                    >
+                      {deployment.latest_stage?.status || "unknown"}
+                    </span>
+                    <span className="text-sm text-gray-600 dark:text-gray-300">
+                      {new Date(deployment.created_on).toLocaleString()}
+                    </span>
+                  </div>
+                  <a
+                    onClick={(e) => {
+                      e.preventDefault();
+                      IpcClient.getInstance().openExternalUrl(deployment.url);
+                    }}
+                    className="cursor-pointer text-blue-600 hover:underline dark:text-blue-400 text-sm"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    View
+                  </a>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function UnconnectedCloudflareConnector({
+  appId,
+  folderName,
+  settings,
+  refreshSettings,
+  refreshApp,
+}: UnconnectedCloudflareConnectorProps) {
+  const [accessToken, setAccessToken] = useState("");
+  const [isSavingToken, setIsSavingToken] = useState(false);
+  const [tokenError, setTokenError] = useState<string | null>(null);
+  const [tokenSuccess, setTokenSuccess] = useState(false);
+  const [projectSetupMode, setProjectSetupMode] = useState<
+    "create" | "existing"
+  >("create");
+  const [availableProjects, setAvailableProjects] = useState<
+    CloudflareProject[]
+  >([]);
+  const [isLoadingProjects, setIsLoadingProjects] = useState(false);
+  const [selectedProject, setSelectedProject] = useState<string>("");
+  const [projectName, setProjectName] = useState(folderName);
+  const [isCreatingProject, setIsCreatingProject] = useState(false);
+  const [createProjectError, setCreateProjectError] = useState<string | null>(
+    null,
+  );
+  const [createProjectSuccess, setCreateProjectSuccess] = useState(false);
+
+  const cloudflareToken = settings?.extensionSettings?.cloudflare?.accessToken;
+
+  const isConnected = !!cloudflareToken;
+
+  useEffect(() => {
+    if (isConnected && projectSetupMode === "existing") {
+      loadAvailableProjects();
+    }
+  }, [isConnected, projectSetupMode]);
+
+  const loadAvailableProjects = async () => {
+    setIsLoadingProjects(true);
+    try {
+      const projects = await invokeExtensionChannel(
+        "extension:cloudflare:list-projects",
+      );
+      setAvailableProjects(projects || []);
+    } catch (error: any) {
+      console.error("Failed to load Cloudflare projects:", error);
+    } finally {
+      setIsLoadingProjects(false);
+    }
+  };
+
+  const handleSaveAccessToken = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!accessToken.trim()) return;
+
+    setIsSavingToken(true);
+    setTokenError(null);
+    setTokenSuccess(false);
+
+    try {
+      await invokeExtensionChannel("extension:cloudflare:save-token", {
+        token: accessToken.trim(),
+      });
+      setTokenSuccess(true);
+      setAccessToken("");
+      refreshSettings();
+      showSuccess("Successfully connected to Cloudflare Pages");
+    } catch (err: any) {
+      setTokenError(err.message || "Failed to save access token.");
+    } finally {
+      setIsSavingToken(false);
+    }
+  };
+
+  const handleSetupProject = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!appId) return;
+
+    setIsCreatingProject(true);
+    setCreateProjectError(null);
+    setCreateProjectSuccess(false);
+
+    try {
+      if (projectSetupMode === "create") {
+        await invokeExtensionChannel("extension:cloudflare:create-project", {
+          appId,
+          name: projectName,
+        });
+      } else {
+        await invokeExtensionChannel(
+          "extension:cloudflare:connect-existing-project",
+          {
+            appId,
+            projectId: selectedProject,
+          },
+        );
+      }
+      setCreateProjectSuccess(true);
+      refreshApp();
+      showSuccess(
+        projectSetupMode === "create"
+          ? "Project created and linked successfully!"
+          : "Connected to project successfully!",
+      );
+    } catch (err: any) {
+      setCreateProjectError(err.message || "Failed to setup project.");
+    } finally {
+      setIsCreatingProject(false);
+    }
+  };
+
+  if (!isConnected) {
+    return (
+      <div className="mt-4 w-full rounded-md">
+        <div className="font-medium mb-2">Cloudflare Pages</div>
+        <div className="space-y-4">
+          <div>
+            <p className="text-sm text-gray-600 dark:text-gray-400 mb-3">
+              Connect your Cloudflare account to deploy your projects to
+              Cloudflare Pages.
+            </p>
+            <form onSubmit={handleSaveAccessToken} className="space-y-3">
+              <div>
+                <Label className="block text-sm font-medium mb-1">
+                  Cloudflare API Token
+                </Label>
+                <Input
+                  type="password"
+                  placeholder="Enter your Cloudflare API token"
+                  value={accessToken}
+                  onChange={(e) => setAccessToken(e.target.value)}
+                  disabled={isSavingToken}
+                  className="w-full"
+                />
+              </div>
+              <Button
+                type="submit"
+                disabled={!accessToken.trim() || isSavingToken}
+                className="w-full"
+              >
+                {isSavingToken ? "Saving Token..." : "Save Access Token"}
+              </Button>
+            </form>
+            {tokenError && (
+              <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md p-3 mt-3">
+                <p className="text-sm text-red-800 dark:text-red-200">
+                  {tokenError}
+                </p>
+              </div>
+            )}
+            {tokenSuccess && (
+              <div className="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-md p-3 mt-3">
+                <p className="text-sm text-green-800 dark:text-green-200">
+                  Successfully connected to Cloudflare! You can now set up your
+                  project below.
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-4 w-full rounded-md">
+      <div className="font-medium mb-2">
+        Set up your Cloudflare Pages project
+      </div>
+      <div className="pt-0 space-y-4">
+        <div>
+          <div className="flex rounded-md border border-gray-200 dark:border-gray-700">
+            <Button
+              type="button"
+              variant={projectSetupMode === "create" ? "default" : "ghost"}
+              className={`flex-1 rounded-none rounded-l-md border-0 ${
+                projectSetupMode === "create"
+                  ? "bg-primary text-primary-foreground"
+                  : "hover:bg-gray-50 dark:hover:bg-gray-800"
+              }`}
+              onClick={() => {
+                setProjectSetupMode("create");
+                setCreateProjectError(null);
+                setCreateProjectSuccess(false);
+              }}
+            >
+              Create new project
+            </Button>
+            <Button
+              type="button"
+              variant={projectSetupMode === "existing" ? "default" : "ghost"}
+              className={`flex-1 rounded-none rounded-r-md border-0 border-l border-gray-200 dark:border-gray-700 ${
+                projectSetupMode === "existing"
+                  ? "bg-primary text-primary-foreground"
+                  : "hover:bg-gray-50 dark:hover:bg-gray-800"
+              }`}
+              onClick={() => {
+                setProjectSetupMode("existing");
+                setCreateProjectError(null);
+                setCreateProjectSuccess(false);
+              }}
+            >
+              Connect to existing project
+            </Button>
+          </div>
+        </div>
+
+        <form className="space-y-4" onSubmit={handleSetupProject}>
+          {projectSetupMode === "create" ? (
+            <div>
+              <Label className="block text-sm font-medium">Project Name</Label>
+              <Input
+                className="w-full mt-1"
+                value={projectName}
+                onChange={(e) => setProjectName(e.target.value)}
+                disabled={isCreatingProject}
+              />
+            </div>
+          ) : (
+            <div>
+              <Label className="block text-sm font-medium">
+                Select Project
+              </Label>
+              <Select
+                value={selectedProject}
+                onValueChange={setSelectedProject}
+                disabled={isLoadingProjects}
+              >
+                <SelectTrigger className="w-full mt-1">
+                  <SelectValue
+                    placeholder={
+                      isLoadingProjects
+                        ? "Loading projects..."
+                        : "Select a project"
+                    }
+                  />
+                </SelectTrigger>
+                <SelectContent>
+                  {availableProjects.map((project) => (
+                    <SelectItem key={project.id} value={project.id}>
+                      {project.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          <Button
+            type="submit"
+            disabled={
+              isCreatingProject ||
+              (projectSetupMode === "create" && !projectName) ||
+              (projectSetupMode === "existing" && !selectedProject)
+            }
+          >
+            {isCreatingProject
+              ? projectSetupMode === "create"
+                ? "Creating..."
+                : "Connecting..."
+              : projectSetupMode === "create"
+                ? "Create Project"
+                : "Connect to Project"}
+          </Button>
+        </form>
+
+        {createProjectError && (
+          <p className="text-red-600 mt-2 text-sm">{createProjectError}</p>
+        )}
+        {createProjectSuccess && (
+          <p className="text-green-600 mt-2 text-sm">
+            {projectSetupMode === "create"
+              ? "Project created and linked!"
+              : "Connected to project!"}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function CloudflareConnector({
+  appId,
+  folderName,
+}: CloudflareConnectorProps) {
+  const { app, refreshApp } = useLoadApp(appId);
+  const { settings, refreshSettings } = useSettings();
+  const { data: extensionData } = useAllExtensionData("cloudflare", appId);
+
+  // Check if project is connected
+  const isConnected = !!extensionData?.projectId;
+
+  if (isConnected && appId && app) {
+    return (
+      <ConnectedCloudflareConnector appId={appId} refreshApp={refreshApp} />
+    );
+  } else {
+    return (
+      <UnconnectedCloudflareConnector
+        appId={appId}
+        folderName={folderName}
+        settings={settings}
+        refreshSettings={refreshSettings}
+        refreshApp={refreshApp}
+      />
+    );
+  }
+}
+
+export function CloudflareSettings() {
+  const { settings, updateSettings } = useSettings();
+  const [accessToken, setAccessToken] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+  const [isDisconnecting, setIsDisconnecting] = useState(false);
+
+  const cloudflareToken = settings?.extensionSettings?.cloudflare?.accessToken;
+  const isConnected = !!cloudflareToken;
+
+  const handleSaveToken = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!accessToken.trim()) return;
+
+    setIsSaving(true);
+    setError(null);
+    setSuccess(false);
+
+    try {
+      await invokeExtensionChannel("extension:cloudflare:save-token", {
+        token: accessToken.trim(),
+      });
+      setSuccess(true);
+      setAccessToken("");
+      // Refresh settings to get the updated token
+      const result = await updateSettings({});
+      if (result) {
+        showSuccess("Successfully connected to Cloudflare Pages");
+      }
+    } catch (err: any) {
+      setError(err.message || "Failed to save token");
+      showError(err.message || "Failed to save token");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleDisconnect = async () => {
+    setIsDisconnecting(true);
+    setError(null);
+    try {
+      const result = await updateSettings({
+        extensionSettings: {
+          ...settings?.extensionSettings,
+          cloudflare: {
+            ...settings?.extensionSettings?.cloudflare,
+            accessToken: undefined,
+          },
+        },
+      });
+      if (result) {
+        showSuccess("Successfully disconnected from Cloudflare Pages");
+      } else {
+        showError("Failed to disconnect from Cloudflare Pages");
+      }
+    } catch (err: any) {
+      setError(err.message || "Failed to disconnect");
+      showError(err.message || "Failed to disconnect");
+    } finally {
+      setIsDisconnecting(false);
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-between p-4 bg-gray-50 dark:bg-gray-900 rounded-lg border">
+      <div>
+        <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300">
+          Cloudflare Pages
+        </h3>
+        <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+          {isConnected
+            ? "Your account is connected to Cloudflare Pages."
+            : "Connect your Cloudflare account to deploy projects."}
+        </p>
+      </div>
+      {isConnected ? (
+        <Button
+          onClick={handleDisconnect}
+          variant="destructive"
+          size="sm"
+          disabled={isDisconnecting}
+        >
+          {isDisconnecting ? "Disconnecting..." : "Disconnect"}
+        </Button>
+      ) : (
+        <form onSubmit={handleSaveToken} className="flex gap-2">
+          <Input
+            type="password"
+            placeholder="API Token"
+            value={accessToken}
+            onChange={(e) => setAccessToken(e.target.value)}
+            disabled={isSaving}
+            className="w-48"
+          />
+          <Button
+            type="submit"
+            disabled={!accessToken.trim() || isSaving}
+            size="sm"
+          >
+            {isSaving ? "Saving..." : "Connect"}
+          </Button>
+        </form>
+      )}
+      {error && <p className="text-red-600 text-xs mt-1">{error}</p>}
+      {success && <p className="text-green-600 text-xs mt-1">Connected!</p>}
+    </div>
+  );
+}

--- a/src/extensions/plugins/cloudflare/handlers.ts
+++ b/src/extensions/plugins/cloudflare/handlers.ts
@@ -1,0 +1,386 @@
+import type { IpcMainInvokeEvent } from "electron";
+import type { ExtensionContext } from "../../core/extension_types";
+import type {
+  CloudflareProject,
+  CloudflareDeployment,
+  CreateCloudflareProjectParamsWithAppId,
+  ConnectToExistingCloudflareProjectParams,
+  SaveCloudflareTokenParams,
+  GetCloudflareDeploymentsParams,
+  DisconnectCloudflareProjectParams,
+} from "./types";
+import * as path from "node:path";
+import * as fs from "node:fs/promises";
+import { getDyadAppPath } from "@/paths/paths";
+
+const CLOUDFLARE_API_BASE = "https://api.cloudflare.com/client/v4";
+
+/**
+ * Get Cloudflare API token from settings
+ */
+function getCloudflareToken(context: ExtensionContext): string {
+  const settings = context.readSettings();
+  const token =
+    settings.extensionSettings?.cloudflare?.accessToken?.value ||
+    settings.extensionSettings?.cloudflare?.accessToken;
+
+  if (!token || typeof token !== "string") {
+    throw new Error(
+      "Not authenticated with Cloudflare. Please add your API token in settings.",
+    );
+  }
+
+  return token;
+}
+
+/**
+ * Make authenticated request to Cloudflare API
+ */
+async function cloudflareApiRequest<T>(
+  token: string,
+  endpoint: string,
+  options: RequestInit = {},
+): Promise<T> {
+  const url = `${CLOUDFLARE_API_BASE}${endpoint}`;
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      ...options.headers,
+    },
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    let errorMessage = `Cloudflare API error: ${response.status} ${response.statusText}`;
+    try {
+      const errorJson = JSON.parse(errorText);
+      if (errorJson.errors && errorJson.errors.length > 0) {
+        errorMessage = errorJson.errors[0].message || errorMessage;
+      }
+    } catch {
+      // Use default error message
+    }
+    throw new Error(errorMessage);
+  }
+
+  const data = await response.json();
+  return data.result as T;
+}
+
+/**
+ * Validate Cloudflare API token
+ */
+async function validateCloudflareToken(token: string): Promise<boolean> {
+  try {
+    await cloudflareApiRequest<{ id: string; email: string }>(
+      token,
+      "/user/tokens/verify",
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Get Cloudflare account ID (first account)
+ */
+async function getCloudflareAccountId(token: string): Promise<string> {
+  try {
+    const accounts = await cloudflareApiRequest<
+      Array<{ id: string; name: string }>
+    >(token, "/accounts");
+
+    if (!Array.isArray(accounts) || accounts.length === 0) {
+      throw new Error("No Cloudflare accounts found");
+    }
+
+    return accounts[0].id;
+  } catch (error: any) {
+    throw new Error(`Failed to get Cloudflare account: ${error.message}`);
+  }
+}
+
+/**
+ * Detect build output directory from common frameworks
+ */
+async function detectBuildOutputDir(
+  appPath: string,
+): Promise<string | undefined> {
+  const commonDirs = [
+    { dir: "dist", checkFiles: ["index.html"] },
+    { dir: "build", checkFiles: ["index.html"] },
+    { dir: ".next", checkFiles: [] },
+    { dir: "out", checkFiles: ["index.html"] },
+    { dir: "public", checkFiles: ["index.html"] },
+  ];
+
+  for (const { dir, checkFiles } of commonDirs) {
+    const dirPath = path.join(appPath, dir);
+    try {
+      const stats = await fs.stat(dirPath);
+      if (stats.isDirectory()) {
+        if (checkFiles.length === 0) {
+          return dir;
+        }
+        // Check if required files exist
+        const hasAllFiles = await Promise.all(
+          checkFiles.map((file) =>
+            fs
+              .access(path.join(dirPath, file))
+              .then(() => true)
+              .catch(() => false),
+          ),
+        ).then((results) => results.every((r) => r));
+
+        if (hasAllFiles) {
+          return dir;
+        }
+      }
+    } catch {
+      // Directory doesn't exist, continue
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Register Cloudflare Pages IPC handlers
+ */
+export function registerCloudflareHandlers(context: ExtensionContext): void {
+  const { logger, registerIpcHandler } = context;
+
+  // Save Cloudflare API token
+  registerIpcHandler(
+    "extension:cloudflare:save-token",
+    async (_event: IpcMainInvokeEvent, params: SaveCloudflareTokenParams) => {
+      logger.log("Saving Cloudflare access token");
+
+      if (!params.token || params.token.trim() === "") {
+        throw new Error("Access token is required.");
+      }
+
+      try {
+        const isValid = await validateCloudflareToken(params.token.trim());
+        if (!isValid) {
+          throw new Error(
+            "Invalid access token. Please check your token and try again.",
+          );
+        }
+
+        const settings = context.readSettings();
+        context.writeSettings({
+          extensionSettings: {
+            ...settings.extensionSettings,
+            cloudflare: {
+              ...settings.extensionSettings?.cloudflare,
+              accessToken: params.token.trim(),
+            },
+          },
+        });
+
+        logger.log("Successfully saved Cloudflare access token.");
+      } catch (error: any) {
+        logger.error("Error saving Cloudflare token:", error);
+        throw new Error(`Failed to save access token: ${error.message}`);
+      }
+    },
+  );
+
+  // List Cloudflare Pages projects
+  registerIpcHandler(
+    "extension:cloudflare:list-projects",
+    async (_event: IpcMainInvokeEvent): Promise<CloudflareProject[]> => {
+      const token = getCloudflareToken(context);
+      const accountId = await getCloudflareAccountId(token);
+
+      try {
+        const projects = await cloudflareApiRequest<CloudflareProject[]>(
+          token,
+          `/accounts/${accountId}/pages/projects`,
+        );
+
+        return Array.isArray(projects) ? projects : [];
+      } catch (error: any) {
+        logger.error("Error listing Cloudflare projects:", error);
+        throw new Error(`Failed to list projects: ${error.message}`);
+      }
+    },
+  );
+
+  // Create Cloudflare Pages project
+  registerIpcHandler(
+    "extension:cloudflare:create-project",
+    async (
+      _event: IpcMainInvokeEvent,
+      params: CreateCloudflareProjectParamsWithAppId,
+    ): Promise<void> => {
+      const token = getCloudflareToken(context);
+      const accountId = await getCloudflareAccountId(token);
+
+      try {
+        const app = await context.getApp(params.appId);
+        const appPath = getDyadAppPath(app.path);
+
+        // Detect build output directory if not provided
+        const buildOutputDir =
+          params.build_output_dir || (await detectBuildOutputDir(appPath));
+
+        const projectData = await cloudflareApiRequest<CloudflareProject>(
+          token,
+          `/accounts/${accountId}/pages/projects`,
+          {
+            method: "POST",
+            body: JSON.stringify({
+              name: params.name,
+              production_branch: params.production_branch || "main",
+              build_command: params.build_command,
+              build_output_dir: buildOutputDir || "dist",
+            }),
+          },
+        );
+
+        // Store project info in extension data
+        await context.setExtensionData(
+          params.appId,
+          "projectId",
+          projectData.id,
+        );
+        await context.setExtensionData(
+          params.appId,
+          "projectName",
+          projectData.name,
+        );
+        await context.setExtensionData(params.appId, "accountId", accountId);
+
+        // Get deployment URL (primary domain)
+        if (projectData.domains && projectData.domains.length > 0) {
+          await context.setExtensionData(
+            params.appId,
+            "deploymentUrl",
+            `https://${projectData.domains[0]}`,
+          );
+        }
+
+        logger.log(
+          `Successfully created Cloudflare Pages project: ${projectData.name} (${projectData.id})`,
+        );
+      } catch (error: any) {
+        logger.error("Error creating Cloudflare project:", error);
+        throw new Error(`Failed to create project: ${error.message}`);
+      }
+    },
+  );
+
+  // Connect to existing Cloudflare Pages project
+  registerIpcHandler(
+    "extension:cloudflare:connect-existing-project",
+    async (
+      _event: IpcMainInvokeEvent,
+      params: ConnectToExistingCloudflareProjectParams,
+    ): Promise<void> => {
+      const token = getCloudflareToken(context);
+      const accountId = await getCloudflareAccountId(token);
+
+      try {
+        // Verify the project exists and get its details
+        const projectData = await cloudflareApiRequest<CloudflareProject>(
+          token,
+          `/accounts/${accountId}/pages/projects/${params.projectId}`,
+        );
+
+        // Store project info in extension data
+        await context.setExtensionData(
+          params.appId,
+          "projectId",
+          projectData.id,
+        );
+        await context.setExtensionData(
+          params.appId,
+          "projectName",
+          projectData.name,
+        );
+        await context.setExtensionData(params.appId, "accountId", accountId);
+
+        // Get deployment URL (primary domain)
+        if (projectData.domains && projectData.domains.length > 0) {
+          await context.setExtensionData(
+            params.appId,
+            "deploymentUrl",
+            `https://${projectData.domains[0]}`,
+          );
+        }
+
+        logger.log(
+          `Successfully connected to Cloudflare Pages project: ${projectData.name} (${projectData.id})`,
+        );
+      } catch (error: any) {
+        logger.error("Error connecting to Cloudflare project:", error);
+        throw new Error(`Failed to connect to project: ${error.message}`);
+      }
+    },
+  );
+
+  // Get deployments for a project
+  registerIpcHandler(
+    "extension:cloudflare:list-deployments",
+    async (
+      _event: IpcMainInvokeEvent,
+      params: GetCloudflareDeploymentsParams,
+    ): Promise<CloudflareDeployment[]> => {
+      const token = getCloudflareToken(context);
+      const projectId = await context.getExtensionData(
+        params.appId,
+        "projectId",
+      );
+
+      if (!projectId) {
+        throw new Error(
+          "Project not connected. Please connect a project first.",
+        );
+      }
+
+      try {
+        const accountId = await context.getExtensionData(
+          params.appId,
+          "accountId",
+        );
+
+        const deployments = await cloudflareApiRequest<CloudflareDeployment[]>(
+          token,
+          `/accounts/${accountId}/pages/projects/${projectId}/deployments`,
+        );
+
+        return Array.isArray(deployments) ? deployments : [];
+      } catch (error: any) {
+        logger.error("Error listing Cloudflare deployments:", error);
+        throw new Error(`Failed to list deployments: ${error.message}`);
+      }
+    },
+  );
+
+  // Disconnect Cloudflare project
+  registerIpcHandler(
+    "extension:cloudflare:disconnect",
+    async (
+      _event: IpcMainInvokeEvent,
+      params: DisconnectCloudflareProjectParams,
+    ): Promise<void> => {
+      try {
+        // Delete all extension data for this app using the deleteExtensionData helper
+        const { deleteExtensionData } = await import(
+          "../../core/extension_data"
+        );
+        await deleteExtensionData(context.extensionId, params.appId);
+
+        logger.log(`Disconnected Cloudflare project for app ${params.appId}`);
+      } catch (error: any) {
+        logger.error("Error disconnecting Cloudflare project:", error);
+        throw new Error(`Failed to disconnect project: ${error.message}`);
+      }
+    },
+  );
+}

--- a/src/extensions/plugins/cloudflare/hooks.ts
+++ b/src/extensions/plugins/cloudflare/hooks.ts
@@ -1,0 +1,65 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { IpcClient } from "@/ipc/ipc_client";
+import type { CloudflareDeployment } from "./types";
+
+// Helper to invoke extension IPC channels
+// Note: This is a workaround until we have proper extension IPC client methods
+function invokeExtensionChannel(channel: string, ...args: any[]): Promise<any> {
+  // Access the private ipcRenderer through a type cast
+  // In a real implementation, we'd add these methods to IpcClient
+  const ipcClient = IpcClient.getInstance() as any;
+  return ipcClient.ipcRenderer.invoke(channel, ...args);
+}
+
+/**
+ * Hook for managing Cloudflare Pages deployments
+ */
+export function useCloudflareDeployments(appId: number) {
+  const queryClient = useQueryClient();
+
+  const {
+    data: deployments = [],
+    isLoading,
+    error,
+    refetch,
+  } = useQuery<CloudflareDeployment[], Error>({
+    queryKey: ["cloudflare-deployments", appId],
+    queryFn: async () => {
+      return invokeExtensionChannel("extension:cloudflare:list-deployments", {
+        appId,
+      });
+    },
+    enabled: false, // Don't auto-fetch, only fetch when explicitly requested
+  });
+
+  const disconnectProjectMutation = useMutation<void, Error, void>({
+    mutationFn: async () => {
+      return invokeExtensionChannel("extension:cloudflare:disconnect", {
+        appId,
+      });
+    },
+    onSuccess: () => {
+      queryClient.removeQueries({
+        queryKey: ["cloudflare-deployments", appId],
+      });
+    },
+  });
+
+  const getDeployments = async () => {
+    return refetch();
+  };
+
+  const disconnectProject = async () => {
+    return disconnectProjectMutation.mutateAsync();
+  };
+
+  return {
+    deployments,
+    isLoading,
+    error: error?.message || null,
+    getDeployments,
+    disconnectProject,
+    isDisconnecting: disconnectProjectMutation.isPending,
+    disconnectError: disconnectProjectMutation.error?.message || null,
+  };
+}

--- a/src/extensions/plugins/cloudflare/main.ts
+++ b/src/extensions/plugins/cloudflare/main.ts
@@ -1,0 +1,10 @@
+import type { ExtensionMain } from "../../core/extension_types";
+import { registerCloudflareHandlers } from "./handlers";
+
+/**
+ * Cloudflare Pages extension main process entry point
+ */
+export const main: ExtensionMain = (context) => {
+  registerCloudflareHandlers(context);
+  context.logger.info("Cloudflare Pages extension loaded");
+};

--- a/src/extensions/plugins/cloudflare/manifest.json
+++ b/src/extensions/plugins/cloudflare/manifest.json
@@ -1,0 +1,35 @@
+{
+  "id": "cloudflare",
+  "name": "Cloudflare Pages",
+  "version": "1.0.0",
+  "description": "Deploy your projects to Cloudflare Pages",
+  "author": "Dyad",
+  "capabilities": {
+    "hasMainProcess": true,
+    "hasRendererProcess": true,
+    "hasDatabaseSchema": false,
+    "hasSettingsSchema": false,
+    "ipcChannels": [
+      "save-token",
+      "list-projects",
+      "create-project",
+      "connect-existing-project",
+      "deploy",
+      "list-deployments",
+      "disconnect"
+    ]
+  },
+  "main": "main.ts",
+  "renderer": "renderer.ts",
+  "ui": {
+    "settingsPage": {
+      "component": "CloudflareSettings",
+      "title": "Cloudflare Pages",
+      "icon": "Cloud"
+    },
+    "appConnector": {
+      "component": "CloudflareConnector",
+      "title": "Cloudflare Pages"
+    }
+  }
+}

--- a/src/extensions/plugins/cloudflare/renderer.ts
+++ b/src/extensions/plugins/cloudflare/renderer.ts
@@ -1,0 +1,14 @@
+import type { ExtensionRenderer } from "../../core/extension_types";
+import { rendererExtensionManager } from "../../core/renderer_extension_manager";
+import { CloudflareConnector, CloudflareSettings } from "./components";
+
+/**
+ * Cloudflare Pages extension renderer process entry point
+ */
+export const renderer: ExtensionRenderer = (context) => {
+  // Register components with the renderer extension manager
+  rendererExtensionManager.registerExtensionComponents(context.extensionId, {
+    CloudflareConnector,
+    CloudflareSettings,
+  });
+};

--- a/src/extensions/plugins/cloudflare/types.ts
+++ b/src/extensions/plugins/cloudflare/types.ts
@@ -1,0 +1,71 @@
+/**
+ * Cloudflare Pages extension types
+ */
+
+export interface CloudflareProject {
+  id: string;
+  name: string;
+  production_branch?: string;
+  domains?: string[];
+  created_on?: string;
+}
+
+export interface CloudflareDeployment {
+  id: string;
+  short_id: string;
+  project_id: string;
+  project_name: string;
+  environment: string;
+  url: string;
+  created_on: string;
+  modified_on: string;
+  latest_stage?: {
+    name: string;
+    started_on: string | null;
+    ended_on: string | null;
+    status: string;
+  };
+  deployment_trigger?: {
+    type: string;
+    metadata?: {
+      branch?: string;
+      commit_hash?: string;
+      commit_message?: string;
+    };
+  };
+  stages?: Array<{
+    name: string;
+    started_on: string | null;
+    ended_on: string | null;
+    status: string;
+  }>;
+}
+
+export interface CreateCloudflareProjectParams {
+  name: string;
+  production_branch?: string;
+  build_command?: string;
+  build_output_dir?: string;
+}
+
+export interface ConnectToExistingCloudflareProjectParams {
+  projectId: string;
+  appId: number;
+}
+
+export interface CreateCloudflareProjectParamsWithAppId
+  extends CreateCloudflareProjectParams {
+  appId: number;
+}
+
+export interface SaveCloudflareTokenParams {
+  token: string;
+}
+
+export interface GetCloudflareDeploymentsParams {
+  appId: number;
+}
+
+export interface DisconnectCloudflareProjectParams {
+  appId: number;
+}

--- a/src/hooks/useExtensionData.ts
+++ b/src/hooks/useExtensionData.ts
@@ -1,0 +1,47 @@
+import { useQuery } from "@tanstack/react-query";
+import { IpcClient } from "@/ipc/ipc_client";
+
+/**
+ * Hook to get extension data for an app
+ */
+export function useExtensionData(
+  extensionId: string,
+  appId: number | null,
+  key: string,
+) {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["extension-data", extensionId, appId, key],
+    queryFn: async () => {
+      if (!appId) return null;
+      const ipcClient = IpcClient.getInstance() as any;
+      return await ipcClient.ipcRenderer.invoke("extension:get-data", {
+        extensionId,
+        appId,
+        key,
+      });
+    },
+    enabled: !!appId,
+  });
+
+  return { data, isLoading, error };
+}
+
+/**
+ * Hook to get all extension data for an app
+ */
+export function useAllExtensionData(extensionId: string, appId: number | null) {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["extension-data-all", extensionId, appId],
+    queryFn: async () => {
+      if (!appId) return {};
+      const ipcClient = IpcClient.getInstance() as any;
+      return await ipcClient.ipcRenderer.invoke("extension:get-all-data", {
+        extensionId,
+        appId,
+      });
+    },
+    enabled: !!appId,
+  });
+
+  return { data: data || {}, isLoading, error };
+}

--- a/src/hooks/useExtensions.ts
+++ b/src/hooks/useExtensions.ts
@@ -1,0 +1,55 @@
+import { useQuery } from "@tanstack/react-query";
+import { IpcClient } from "@/ipc/ipc_client";
+
+/**
+ * Extension metadata from main process
+ */
+export interface ExtensionMetadata {
+  id: string;
+  name: string;
+  version: string;
+  description: string;
+  ui?: {
+    settingsPage?: {
+      component: string;
+      title: string;
+      icon?: string;
+    };
+    appConnector?: {
+      component: string;
+      title: string;
+    };
+  };
+}
+
+/**
+ * Hook to get list of loaded extensions
+ * Note: This requires an IPC handler to be implemented in the main process
+ */
+export function useExtensions() {
+  const {
+    data: extensions = [],
+    isLoading,
+    error,
+  } = useQuery<ExtensionMetadata[]>({
+    queryKey: ["extensions"],
+    queryFn: async () => {
+      // For now, return empty array until IPC handler is implemented
+      // TODO: Implement "extension:list" IPC handler in main process
+      try {
+        const ipcClient = IpcClient.getInstance() as any;
+        return (await ipcClient.ipcRenderer.invoke("extension:list")) || [];
+      } catch {
+        // Handler not implemented yet, return empty array
+        return [];
+      }
+    },
+    staleTime: 5 * 60 * 1000, // Cache for 5 minutes
+  });
+
+  return {
+    extensions,
+    isLoading,
+    error,
+  };
+}

--- a/src/ipc/handlers/extension_data_handlers.ts
+++ b/src/ipc/handlers/extension_data_handlers.ts
@@ -1,0 +1,34 @@
+import { createLoggedHandler } from "./safe_handle";
+import log from "electron-log";
+import {
+  getExtensionData,
+  getAllExtensionData,
+} from "@/extensions/core/extension_data";
+
+const logger = log.scope("extension_data_handlers");
+const handle = createLoggedHandler(logger);
+
+/**
+ * Get extension data for an app
+ */
+async function handleGetExtensionData(
+  _event: any,
+  params: { extensionId: string; appId: number; key: string },
+) {
+  return getExtensionData(params.extensionId, params.appId, params.key);
+}
+
+/**
+ * Get all extension data for an app
+ */
+async function handleGetAllExtensionData(
+  _event: any,
+  params: { extensionId: string; appId: number },
+) {
+  return getAllExtensionData(params.extensionId, params.appId);
+}
+
+export function registerExtensionDataHandlers() {
+  handle("extension:get-data", handleGetExtensionData);
+  handle("extension:get-all-data", handleGetAllExtensionData);
+}

--- a/src/ipc/handlers/extension_handlers.ts
+++ b/src/ipc/handlers/extension_handlers.ts
@@ -1,0 +1,25 @@
+import { createLoggedHandler } from "./safe_handle";
+import log from "electron-log";
+import { extensionRegistry } from "@/extensions/core/extension_registry";
+
+const logger = log.scope("extension_handlers");
+const handle = createLoggedHandler(logger);
+
+/**
+ * IPC handler to list all loaded extensions
+ */
+async function handleListExtensions() {
+  const extensions = extensionRegistry.getAll();
+
+  return extensions.map((ext) => ({
+    id: ext.manifest.id,
+    name: ext.manifest.name,
+    version: ext.manifest.version,
+    description: ext.manifest.description,
+    ui: ext.manifest.ui,
+  }));
+}
+
+export function registerExtensionHandlers() {
+  handle("extension:list", handleListExtensions);
+}

--- a/src/ipc/ipc_host.ts
+++ b/src/ipc/ipc_host.ts
@@ -34,6 +34,8 @@ import { registerMcpHandlers } from "./handlers/mcp_handlers";
 import { registerSecurityHandlers } from "./handlers/security_handlers";
 import { registerVisualEditingHandlers } from "../pro/main/ipc/handlers/visual_editing_handlers";
 import { registerAgentToolHandlers } from "../pro/main/ipc/handlers/local_agent/agent_tool_handlers";
+import { registerExtensionHandlers } from "./handlers/extension_handlers";
+import { registerExtensionDataHandlers } from "./handlers/extension_data_handlers";
 
 export function registerIpcHandlers() {
   // Register all IPC handlers by category
@@ -73,4 +75,6 @@ export function registerIpcHandlers() {
   registerSecurityHandlers();
   registerVisualEditingHandlers();
   registerAgentToolHandlers();
+  registerExtensionHandlers();
+  registerExtensionDataHandlers();
 }

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -295,6 +295,10 @@ export const UserSettingsSchema = z.object({
     })
     .optional(),
 
+  extensionSettings: z
+    .record(z.string(), z.record(z.string(), z.any()))
+    .optional(),
+
   ////////////////////////////////
   // E2E TESTING ONLY.
   ////////////////////////////////

--- a/src/pages/app-details.tsx
+++ b/src/pages/app-details.tsx
@@ -41,6 +41,41 @@ import { useDebounce } from "@/hooks/useDebounce";
 import { useCheckName } from "@/hooks/useCheckName";
 import { AppUpgrades } from "@/components/AppUpgrades";
 import { CapacitorControls } from "@/components/CapacitorControls";
+import { useExtensions } from "@/hooks/useExtensions";
+import { ExtensionConnector } from "@/components/ExtensionConnector";
+
+function ExtensionConnectorsList({
+  appId,
+  folderName,
+}: {
+  appId: number;
+  folderName: string;
+}) {
+  const { extensions } = useExtensions();
+
+  if (extensions.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      {extensions
+        .filter((ext) => ext.ui?.appConnector)
+        .map((extension) => (
+          <div
+            key={extension.id}
+            className="border border-gray-200 rounded-md p-4"
+          >
+            <ExtensionConnector
+              extension={extension}
+              appId={appId}
+              folderName={folderName}
+            />
+          </div>
+        ))}
+    </>
+  );
+}
 
 export default function AppDetailsPage() {
   const navigate = useNavigate();
@@ -345,6 +380,13 @@ export default function AppDetailsPage() {
           {appId && <SupabaseConnector appId={appId} />}
           {appId && <CapacitorControls appId={appId} />}
           <AppUpgrades appId={appId} />
+          {/* Extension connectors */}
+          {appId && (
+            <ExtensionConnectorsList
+              appId={appId}
+              folderName={selectedApp.path}
+            />
+          )}
         </div>
 
         {/* Rename Dialog */}

--- a/src/pages/extensions.tsx
+++ b/src/pages/extensions.tsx
@@ -1,0 +1,206 @@
+import { useState } from "react";
+import { useExtensions } from "@/hooks/useExtensions";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { IpcClient } from "@/ipc/ipc_client";
+import { showError, showSuccess } from "@/lib/toast";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Loader2, Trash2, Package } from "lucide-react";
+
+export function ExtensionsPage() {
+  const { extensions, isLoading } = useExtensions();
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [extensionToDelete, setExtensionToDelete] = useState<string | null>(
+    null,
+  );
+  const queryClient = useQueryClient();
+
+  const deleteExtensionMutation = useMutation<
+    void,
+    Error,
+    { extensionId: string }
+  >({
+    mutationFn: async ({ extensionId }) => {
+      const ipcClient = IpcClient.getInstance() as any;
+      await ipcClient.ipcRenderer.invoke("extension:delete", { extensionId });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["extensions"] });
+      showSuccess("Extension deleted successfully");
+      setDeleteDialogOpen(false);
+      setExtensionToDelete(null);
+    },
+    onError: (error) => {
+      showError(error.message || "Failed to delete extension");
+    },
+  });
+
+  const handleDeleteClick = (extensionId: string) => {
+    setExtensionToDelete(extensionId);
+    setDeleteDialogOpen(true);
+  };
+
+  const handleDeleteConfirm = () => {
+    if (extensionToDelete) {
+      deleteExtensionMutation.mutate({ extensionId: extensionToDelete });
+    }
+  };
+
+  const extensionToDeleteInfo = extensionToDelete
+    ? extensions.find((ext) => ext.id === extensionToDelete)
+    : null;
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-screen">
+        <Loader2 className="h-8 w-8 animate-spin text-gray-400" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto py-8 px-4 max-w-6xl">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">
+          Extensions
+        </h1>
+        <p className="text-gray-600 dark:text-gray-400">
+          Manage your installed extensions
+        </p>
+      </div>
+
+      {extensions.length === 0 ? (
+        <Card>
+          <CardContent className="flex flex-col items-center justify-center py-16">
+            <Package className="h-16 w-16 text-gray-300 dark:text-gray-600 mb-4" />
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+              No extensions installed
+            </h3>
+            <p className="text-gray-500 dark:text-gray-400 text-center max-w-md">
+              Extensions will appear here once installed. Install extensions by
+              placing them in the extensions directory.
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {extensions.map((extension) => (
+            <Card key={extension.id} className="flex flex-col">
+              <CardHeader>
+                <div className="flex items-start justify-between">
+                  <div className="flex-1">
+                    <CardTitle className="text-lg mb-1">
+                      {extension.name}
+                    </CardTitle>
+                    <CardDescription className="text-sm">
+                      {extension.description}
+                    </CardDescription>
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent className="flex-1 flex flex-col justify-between">
+                <div className="space-y-3">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <Badge variant="secondary" className="text-xs">
+                      v{extension.version}
+                    </Badge>
+                    <Badge variant="outline" className="text-xs">
+                      {extension.id}
+                    </Badge>
+                  </div>
+
+                  {extension.ui && (
+                    <div className="text-sm text-gray-600 dark:text-gray-400">
+                      {extension.ui.settingsPage && (
+                        <div className="mb-1">
+                          <span className="font-medium">Settings:</span>{" "}
+                          {extension.ui.settingsPage.title}
+                        </div>
+                      )}
+                      {extension.ui.appConnector && (
+                        <div>
+                          <span className="font-medium">Connector:</span>{" "}
+                          {extension.ui.appConnector.title}
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+
+                <div className="mt-4 pt-4 border-t border-gray-200 dark:border-gray-700">
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    className="w-full"
+                    onClick={() => handleDeleteClick(extension.id)}
+                    disabled={deleteExtensionMutation.isPending}
+                  >
+                    <Trash2 className="h-4 w-4 mr-2" />
+                    Delete
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      <Dialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete Extension</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to delete{" "}
+              <span className="font-semibold">
+                {extensionToDeleteInfo?.name}
+              </span>
+              ? This action cannot be undone and will permanently remove the
+              extension from your system.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setDeleteDialogOpen(false);
+                setExtensionToDelete(null);
+              }}
+              disabled={deleteExtensionMutation.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleDeleteConfirm}
+              disabled={deleteExtensionMutation.isPending}
+            >
+              {deleteExtensionMutation.isPending ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Deleting...
+                </>
+              ) : (
+                "Delete"
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -16,6 +16,8 @@ import { useRouter } from "@tanstack/react-router";
 import { GitHubIntegration } from "@/components/GitHubIntegration";
 import { VercelIntegration } from "@/components/VercelIntegration";
 import { SupabaseIntegration } from "@/components/SupabaseIntegration";
+import { useExtensions } from "@/hooks/useExtensions";
+import { ExtensionIntegration } from "@/components/ExtensionIntegration";
 
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
@@ -30,6 +32,24 @@ import { AgentToolsSettings } from "@/components/settings/AgentToolsSettings";
 import { ZoomSelector } from "@/components/ZoomSelector";
 import { useSetAtom } from "jotai";
 import { activeSettingsSectionAtom } from "@/atoms/viewAtoms";
+
+function ExtensionIntegrationsList() {
+  const { extensions } = useExtensions();
+
+  if (extensions.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      {extensions
+        .filter((ext) => ext.ui?.settingsPage)
+        .map((extension) => (
+          <ExtensionIntegration key={extension.id} extension={extension} />
+        ))}
+    </>
+  );
+}
 
 export default function SettingsPage() {
   const [isResetDialogOpen, setIsResetDialogOpen] = useState(false);
@@ -127,6 +147,7 @@ export default function SettingsPage() {
               <VercelIntegration />
               <SupabaseIntegration />
               <NeonIntegration />
+              <ExtensionIntegrationsList />
             </div>
           </div>
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -144,6 +144,9 @@ const validInvokeChannels = [
   "add-to-favorite",
   "github:clone-repo-from-url",
   "get-latest-security-review",
+  // Extensions
+  "extension:list",
+  "extension:delete",
   // Test-only channels
   // These should ALWAYS be guarded with IS_TEST_BUILD in the main process.
   // We can't detect with IS_TEST_BUILD in the preload script because
@@ -183,6 +186,10 @@ contextBridge.exposeInMainWorld("electron", {
   ipcRenderer: {
     invoke: (channel: ValidInvokeChannel, ...args: unknown[]) => {
       if (validInvokeChannels.includes(channel)) {
+        return ipcRenderer.invoke(channel, ...args);
+      }
+      // Allow extension IPC channels (format: extension:{extensionId}:{channelName})
+      if (typeof channel === "string" && channel.startsWith("extension:")) {
         return ipcRenderer.invoke(channel, ...args);
       }
       throw new Error(`Invalid channel: ${channel}`);

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -170,6 +170,39 @@ function App() {
   return <RouterProvider router={router} />;
 }
 
+// Load extension renderer code
+// Note: In production, this would dynamically load based on extension metadata
+// For now, extensions manually import and register their components
+try {
+  // Cloudflare extension
+  import("./extensions/plugins/cloudflare/renderer")
+    .then((module) => {
+      if (module.renderer) {
+        module.renderer({
+          extensionId: "cloudflare",
+          manifest: {
+            id: "cloudflare",
+            name: "Cloudflare Pages",
+            version: "1.0.0",
+            description: "Deploy your projects to Cloudflare Pages",
+            capabilities: {
+              hasMainProcess: true,
+              hasRendererProcess: true,
+              hasDatabaseSchema: false,
+              hasSettingsSchema: false,
+              ipcChannels: [],
+            },
+          },
+        });
+      }
+    })
+    .catch((error) => {
+      console.warn("Failed to load Cloudflare extension renderer:", error);
+    });
+} catch (error) {
+  console.warn("Error loading extensions:", error);
+}
+
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>

--- a/src/router.ts
+++ b/src/router.ts
@@ -7,12 +7,14 @@ import { providerSettingsRoute } from "./routes/settings/providers/$provider";
 import { appDetailsRoute } from "./routes/app-details";
 import { hubRoute } from "./routes/hub";
 import { libraryRoute } from "./routes/library";
+import { extensionsRoute } from "./routes/extensions";
 
 const routeTree = rootRoute.addChildren([
   homeRoute,
   hubRoute,
   libraryRoute,
   chatRoute,
+  extensionsRoute,
   appDetailsRoute,
   settingsRoute.addChildren([providerSettingsRoute]),
 ]);

--- a/src/routes/extensions.tsx
+++ b/src/routes/extensions.tsx
@@ -1,0 +1,9 @@
+import { createRoute } from "@tanstack/react-router";
+import { rootRoute } from "./root";
+import { ExtensionsPage } from "@/pages/extensions";
+
+export const extensionsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/extensions",
+  component: ExtensionsPage,
+});


### PR DESCRIPTION
This is a draft, this PR will later be split into two: 1 for the extension feature and 2. FOr the inbuilt Cloudflare deployment extension. 

What needs to be done.
1. UI/UX improvement for the Extension installation
2. tests


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a first-class extension system and ships a built-in Cloudflare Pages plugin to let users deploy apps directly from Dyad.

- **New Features**
  - Extension core: manifest validation, global registry, main/renderer managers, and IPC hooks.
  - Persistent extension data via a new extension_data table with typed helpers and IPC handlers.
  - Renderer integration: component registry plus ExtensionConnector and ExtensionIntegration components.
  - Cloudflare Pages plugin: save token, list/create/connect projects, list deployments, deploy, disconnect.
  - New Plugins page, sidebar entry, and route; settings and app details now surface extension UIs.
  - Hooks: useExtensions, useExtensionData, useAllExtensionData, useCloudflareDeployments.
  - IPC: extension:list, extension:get-data, extension:get-all-data, and namespaced extension channels in preload.
  - Development loading for extensions in main/renderer; initial Cloudflare components registered.
  - Tests for extension registry and extension data.

- **Migration**
  - Run the new Drizzle migration to create the extension_data table.

<sup>Written for commit fdaa136f3021e8a2c46872e5d5f4ba17f41e0ea3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

