### PR TITLE
fix test naming

### DIFF
--- a/e2e-tests/undo.spec.ts
+++ b/e2e-tests/undo.spec.ts
@@ -1,8 +1,8 @@
 import { PageObject, testSkipIfWindows, Timeout } from "./helpers/test_helper";
 import { expect } from "@playwright/test";
 
-const runUndoTest = async (po: PageObject, disableNativeGit: boolean) => {
-  await po.setUp({ autoApprove: true, disableNativeGit });
+const runUndoTest = async (po: PageObject, nativeGit: boolean) => {
+  await po.setUp({ autoApprove: true, disableNativeGit: !nativeGit });
   await po.sendPrompt("tc=write-index");
   await po.sendPrompt("tc=write-index-2");
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Simplifies flag semantics in the undo e2e test.
> 
> - Renames `runUndoTest` param from `disableNativeGit` to `nativeGit` and updates `setUp` call to pass `disableNativeGit: !nativeGit`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2045f4029fc01b7555548f691fddc40959d485d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the undo E2E test to use a positive nativeGit flag instead of disableNativeGit. Inverted the setup option to disableNativeGit: !nativeGit for clearer naming and less confusion in test configuration.

<sup>Written for commit a2045f4029fc01b7555548f691fddc40959d485d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

