### PR TITLE
web crawl/clone

### DIFF
--- a/e2e-tests/snapshots/local_agent_basic.spec.ts_local-agent---dump-request-1.txt
+++ b/e2e-tests/snapshots/local_agent_basic.spec.ts_local-agent---dump-request-1.txt
@@ -303,6 +303,27 @@
             "$schema": "http://json-schema.org/draft-07/schema#"
           }
         }
+      },
+      {
+        "type": "function",
+        "function": {
+          "name": "web_crawl",
+          "description": "\nYou can crawl a website so you can clone it.\n\n### When You MUST Trigger a Crawl\nTrigger a crawl ONLY if BOTH conditions are true:\n\n1. The user's message shows intent to CLONE / COPY / REPLICATE / RECREATE / DUPLICATE / MIMIC a website.\n   - Keywords include: clone, copy, replicate, recreate, duplicate, mimic, build the same, make the same.\n\n2. The user's message contains a URL or something that appears to be a domain name.\n   - e.g. \"example.com\", \"https://example.com\"\n   - Do not require 'http://' or 'https://'.\n",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "url": {
+                "type": "string",
+                "description": "URL to crawl"
+              }
+            },
+            "required": [
+              "url"
+            ],
+            "additionalProperties": false,
+            "$schema": "http://json-schema.org/draft-07/schema#"
+          }
+        }
       }
     ],
     "tool_choice": "auto",

--- a/src/pro/main/ipc/handlers/local_agent/tool_definitions.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tool_definitions.ts
@@ -21,7 +21,7 @@ import { readLogsTool } from "./tools/read_logs";
 import { editFileTool } from "./tools/edit_file";
 import { webSearchTool } from "./tools/web_search";
 import { webCrawlTool } from "./tools/web_crawl";
-import type { LanguageModelV2ToolResultOutput } from "@ai-sdk/provider";
+import type { LanguageModelV3ToolResultOutput } from "@ai-sdk/provider";
 import {
   escapeXmlAttr,
   escapeXmlContent,
@@ -236,25 +236,18 @@ async function processArgPlaceholders<T extends Record<string, any>>(
  */
 function convertToolResultForAiSdk(
   result: ToolResult,
-): LanguageModelV2ToolResultOutput {
+): LanguageModelV3ToolResultOutput {
   if (typeof result === "string") {
     return { type: "text", value: result };
   }
 
-  // Convert our content parts to AI SDK format
+  // Convert our content parts to AI SDK V3 format (text only for tool results)
   return {
     type: "content",
-    value: result.content.map((part) => {
-      if (part.type === "text") {
-        return { type: "text" as const, text: part.text };
-      }
-      // part.type === "media"
-      return {
-        type: "media" as const,
-        data: part.data,
-        mediaType: part.mediaType,
-      };
-    }),
+    value: result.content.map((part) => ({
+      type: "text" as const,
+      text: part.text,
+    })),
   };
 }
 

--- a/src/pro/main/ipc/handlers/local_agent/tool_definitions.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tool_definitions.ts
@@ -232,7 +232,7 @@ async function processArgPlaceholders<T extends Record<string, any>>(
 }
 
 /**
- * Convert our ToolResult to AI SDK's LanguageModelV2ToolResultOutput format
+ * Convert our ToolResult to AI SDK format
  */
 function convertToolResultForAiSdk(
   result: ToolResult,
@@ -240,15 +240,7 @@ function convertToolResultForAiSdk(
   if (typeof result === "string") {
     return { type: "text", value: result };
   }
-
-  // Convert our content parts to AI SDK V3 format (text only for tool results)
-  return {
-    type: "content",
-    value: result.content.map((part) => ({
-      type: "text" as const,
-      text: part.text,
-    })),
-  };
+  throw new Error(`Unsupported tool result type: ${typeof result}`);
 }
 
 /**

--- a/src/pro/main/ipc/handlers/local_agent/tools/types.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/types.ts
@@ -74,6 +74,23 @@ export function parsePartialJson<T extends Record<string, unknown>>(
 }
 
 // ============================================================================
+// Tool Result Types
+// ============================================================================
+
+/**
+ * Content part types for multi-modal tool results
+ * Note: AI SDK's LanguageModelV2ToolResultOutput only supports text and media (base64)
+ */
+export type ToolResultContentPart =
+  | { type: "text"; text: string }
+  | { type: "media"; data: string; mediaType: string };
+
+/**
+ * Tool result can be a simple string or a structured result with content parts
+ */
+export type ToolResult = string | { content: ToolResultContentPart[] };
+
+// ============================================================================
 // Tool Definition Interface
 // ============================================================================
 
@@ -82,7 +99,7 @@ export interface ToolDefinition<T = any> {
   readonly description: string;
   readonly inputSchema: z.ZodType<T>;
   readonly defaultConsent: AgentToolConsent;
-  execute: (args: T, ctx: AgentContext) => Promise<string>;
+  execute: (args: T, ctx: AgentContext) => Promise<ToolResult>;
 
   /**
    * If defined, returns whether the tool should be available in the current context.

--- a/src/pro/main/ipc/handlers/local_agent/tools/types.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/types.ts
@@ -47,6 +47,12 @@ export interface AgentContext {
     toolDescription?: string | null;
     inputPreview?: string | null;
   }) => Promise<boolean>;
+  /**
+   * Append a user message to be sent after the tool result.
+   * Use this when the tool needs to provide non-text content (like images)
+   * that models don't support in tool result messages.
+   */
+  appendUserMessage: (content: UserMessageContentPart[]) => void;
 }
 
 // ============================================================================
@@ -78,12 +84,17 @@ export function parsePartialJson<T extends Record<string, unknown>>(
 // ============================================================================
 
 /**
- * Content part types for multi-modal tool results
- * Note: AI SDK's LanguageModelV2ToolResultOutput only supports text and media (base64)
+ * Content part types for tool results (text only for model compatibility)
  */
-export type ToolResultContentPart =
+export type ToolResultContentPart = { type: "text"; text: string };
+
+/**
+ * Content part types for user messages (supports images)
+ * These can be appended as follow-up user messages after tool results
+ */
+export type UserMessageContentPart =
   | { type: "text"; text: string }
-  | { type: "media"; data: string; mediaType: string };
+  | { type: "image-url"; url: string };
 
 /**
  * Tool result can be a simple string or a structured result with content parts

--- a/src/pro/main/ipc/handlers/local_agent/tools/types.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/types.ts
@@ -84,11 +84,6 @@ export function parsePartialJson<T extends Record<string, unknown>>(
 // ============================================================================
 
 /**
- * Content part types for tool results (text only for model compatibility)
- */
-export type ToolResultContentPart = { type: "text"; text: string };
-
-/**
  * Content part types for user messages (supports images)
  * These can be appended as follow-up user messages after tool results
  */
@@ -99,7 +94,7 @@ export type UserMessageContentPart =
 /**
  * Tool result can be a simple string or a structured result with content parts
  */
-export type ToolResult = string | { content: ToolResultContentPart[] };
+export type ToolResult = string;
 
 // ============================================================================
 // Tool Definition Interface

--- a/src/pro/main/ipc/handlers/local_agent/tools/web_crawl.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/web_crawl.ts
@@ -1,0 +1,193 @@
+import { z } from "zod";
+import log from "electron-log";
+import {
+  ToolDefinition,
+  escapeXmlContent,
+  ToolResultContentPart,
+} from "./types";
+import { readSettings } from "@/main/settings";
+
+const logger = log.scope("web_crawl");
+
+const DYAD_ENGINE_URL =
+  process.env.DYAD_ENGINE_URL ?? "https://engine.dyad.sh/v1";
+
+const webCrawlSchema = z.object({
+  url: z.string().describe("URL to crawl"),
+});
+
+const webCrawlResponseSchema = z.object({
+  rootUrl: z.string(),
+  html: z.string().optional(),
+  markdown: z.string().optional(),
+  screenshot: z.string().optional(),
+  pages: z.array(
+    z.object({
+      url: z.string(),
+      markdown: z.string().optional(),
+      html: z.string().optional(),
+      screenshot: z.string().optional(),
+      metadata: z.record(z.unknown()).optional(),
+    }),
+  ),
+});
+
+const DESCRIPTION = `
+You can crawl a website so you can clone it.
+
+### When You MUST Trigger a Crawl
+Trigger a crawl ONLY if BOTH conditions are true:
+
+1. The user's message shows intent to CLONE / COPY / REPLICATE / RECREATE / DUPLICATE / MIMIC a website.
+   - Keywords include: clone, copy, replicate, recreate, duplicate, mimic, build the same, make the same.
+
+2. The user's message contains a URL or something that appears to be a domain name.
+   - e.g. "example.com", "https://example.com"
+   - Do not require 'http://' or 'https://'.
+`;
+
+const IMAGE_PLACEHOLDER_INSTRUCTIONS = `
+
+---
+
+## Instructions for Replicating the Website
+
+You are replicating the website from the provided HTML, markdown, and screenshot.
+
+**Use the screenshot as your primary visual reference** to understand the layout, colors, typography, and overall design of the website. The screenshot shows exactly how the page should look.
+
+**IMPORTANT: Image Handling**
+- Do NOT use or reference real external image URLs.
+- Instead, create a file named "placeholder.svg" at "/public/assets/placeholder.svg".
+- The file must be included in the output as its own code block.
+- The SVG should be a simple neutral gray rectangle, like:
+  \`\`\`svg
+  <svg width="400" height="300" xmlns="http://www.w3.org/2000/svg">
+    <rect width="100%" height="100%" fill="#e2e2e2"/>
+  </svg>
+  \`\`\`
+
+**When generating code:**
+- Replace all \`<img src="...">\` with: \`<img src="/assets/placeholder.svg" alt="placeholder" />\`
+- If using Next.js Image component: \`<Image src="/assets/placeholder.svg" alt="placeholder" width={400} height={300} />\`
+
+Always include the placeholder.svg file in your output file tree.
+`;
+
+async function callWebCrawl(
+  url: string,
+): Promise<z.infer<typeof webCrawlResponseSchema>> {
+  const settings = readSettings();
+  const apiKey = settings.providerSettings?.auto?.apiKey?.value;
+
+  if (!apiKey) {
+    throw new Error("Dyad Pro API key is required for web_crawl tool");
+  }
+
+  const response = await fetch(`${DYAD_ENGINE_URL}/tools/web-crawl`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({ url }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(
+      `Web crawl failed: ${response.status} ${response.statusText} - ${errorText}`,
+    );
+  }
+
+  const data = webCrawlResponseSchema.parse(await response.json());
+  return data;
+}
+
+export const webCrawlTool: ToolDefinition<z.infer<typeof webCrawlSchema>> = {
+  name: "web_crawl",
+  description: DESCRIPTION,
+  inputSchema: webCrawlSchema,
+  defaultConsent: "ask",
+
+  getConsentPreview: (args) => `Crawl URL: "${args.url}"`,
+
+  buildXml: (args, isComplete) => {
+    if (!args.url) return undefined;
+
+    let xml = `<dyad-web-crawl>${escapeXmlContent(args.url)}`;
+    if (isComplete) {
+      xml += "</dyad-web-crawl>";
+    }
+    return xml;
+  },
+
+  execute: async (args) => {
+    logger.log(`Executing web crawl: ${args.url}`);
+
+    const result = await callWebCrawl(args.url);
+
+    if (!result) {
+      throw new Error("Web crawl returned no results");
+    }
+
+    // Build markdown content from the crawl result
+    let content = "";
+
+    // Add root page content if available
+    if (result.markdown) {
+      content += result.markdown;
+    }
+
+    // Add content from additional pages
+    if (result.pages && result.pages.length > 0) {
+      for (const page of result.pages) {
+        if (page.markdown) {
+          content += `\n\n---\n\n## ${page.url}\n\n${page.markdown}`;
+        }
+      }
+    }
+
+    if (!content) {
+      content = "No content extracted from the URL.";
+    }
+
+    logger.log(`Web crawl completed for URL: ${args.url}`);
+
+    // Build multi-part result with text and screenshot
+    const contentParts: ToolResultContentPart[] = [];
+
+    // Add text content with instructions
+    contentParts.push({
+      type: "text",
+      text: content + IMAGE_PLACEHOLDER_INSTRUCTIONS,
+    });
+
+    // Include screenshot as a proper image content part if available
+    if (result.screenshot) {
+      try {
+        // Fetch the screenshot URL and convert to base64
+        const imageResponse = await fetch(result.screenshot);
+        if (imageResponse.ok) {
+          const arrayBuffer = await imageResponse.arrayBuffer();
+          const base64Data = Buffer.from(arrayBuffer).toString("base64");
+          const contentType =
+            imageResponse.headers.get("content-type") || "image/png";
+          contentParts.push({
+            type: "media",
+            data: base64Data,
+            mediaType: contentType,
+          });
+        } else {
+          logger.warn(
+            `Failed to fetch screenshot: ${imageResponse.status} ${imageResponse.statusText}`,
+          );
+        }
+      } catch (error) {
+        logger.warn(`Error fetching screenshot: ${error}`);
+      }
+    }
+
+    return { content: contentParts };
+  },
+};


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces website crawling for cloning workflows and enables multimodal follow-ups after tool calls.
> 
> - Adds `web_crawl` tool with consent preview, XML marker (`buildXml`), and Dyad Engine `/tools/web-crawl` call; requires Dyad Pro API key
> - Injects screenshot and content snapshots by appending user messages via new `appendUserMessage` in `AgentContext` and `prepareStep` hook
> - Defines `UserMessageContentPart` and `ToolResult` types; converts tool results to AI SDK format with `convertToolResultForAiSdk`
> - Registers `web_crawl` in `TOOL_DEFINITIONS`; updates e2e snapshot to expose the new tool
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 877a2e872b4a6e0c4e293ef234d623f9e6ff07d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a web_crawl agent tool to crawl a URL and return page content and a screenshot for cloning. Tool results are text-only, and the screenshot and content are appended as follow-up user messages for multimodal models.

- **New Features**
  - Added web_crawl tool with consent preview and XML marker; calls Dyad Engine /tools/web-crawl.
  - Returns markdown and HTML plus a screenshot URL, with placeholder.svg instructions for replication.
  - Introduced ToolResult (text-only) and convertToolResultForAiSdk; tool execute now returns ToolResult.
  - Added appendUserMessage and prepareStep injection to include images/content after tool results.
  - Registered the tool in TOOL_DEFINITIONS with default consent set to ask; requires a Dyad Pro API key in settings.

<sup>Written for commit 877a2e872b4a6e0c4e293ef234d623f9e6ff07d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

