### PR TITLE
Update GLM 4.6 to 4.7

### DIFF
--- a/src/ipc/shared/language_model_constants.ts
+++ b/src/ipc/shared/language_model_constants.ts
@@ -442,12 +442,12 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
 
 export const TURBO_MODELS: LanguageModel[] = [
   {
-    apiName: "glm-4.6:turbo",
-    displayName: "GLM 4.6",
+    apiName: "glm-4.7:turbo",
+    displayName: "GLM 4.7",
     description: "Strong coding model (very fast)",
     maxOutputTokens: 32_000,
     contextWindow: 131_000,
-    temperature: 0,
+    temperature: 0.7,
     dollarSigns: 3,
     type: "cloud",
   },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates the turbo GLM entry to the newer version and tweaks its generation settings.
> 
> - Replace `glm-4.6:turbo` with `glm-4.7:turbo` in `TURBO_MODELS` and update `displayName`
> - Increase `temperature` for GLM turbo from `0` to `0.7`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6aabf935bebf642548d4583d1842f89a6214601. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replace GLM 4.6 turbo with GLM 4.7 turbo and raise the default temperature to 0.7. Token limits and context window are unchanged.

<sup>Written for commit c6aabf935bebf642548d4583d1842f89a6214601. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

