### PR TITLE
Introduce CLA and PR check

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -28,8 +28,8 @@ jobs:
                   path-to-signatures: "signatures/version1/cla.json"
                   path-to-document: "https://github.com/dyad-sh/dyad/blob/main/CLA.md"
                   # branch should not be protected
-                  branch: "main"
-                  allowlist: user1,bot*
+                  branch: "cla"
+                  #   allowlist: user1,bot*
 
                   # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
                   #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,43 @@
+name: "CLA Assistant"
+on:
+    issue_comment:
+        types: [created]
+    pull_request_target:
+        types: [opened, closed, synchronize]
+
+# explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
+permissions:
+    actions: write
+    contents: write # this can be 'read' if the signatures are in remote repository
+    pull-requests: write
+    statuses: write
+
+jobs:
+    CLAAssistant:
+        runs-on: ubuntu-latest
+        steps:
+            - name: "CLA Assistant"
+              if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+              uses: contributor-assistant/github-action@v2.6.1
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  # the below token should have repo scope and must be manually added by you in the repository's secret
+                  # This token is required only if you have configured to store the signatures in a remote repository/organization
+                  # PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+              with:
+                  path-to-signatures: "signatures/version1/cla.json"
+                  path-to-document: "https://github.com/dyad-sh/dyad/blob/main/CLA.md"
+                  # branch should not be protected
+                  branch: "main"
+                  allowlist: user1,bot*
+
+                  # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
+                  #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)
+                  #remote-repository-name: enter the  remote repository name where the signatures should be stored (Default is storing the signatures in the same repository)
+                  #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
+                  #signed-commit-message: 'For example: $contributorName has signed the CLA in $owner/$repo#$pullRequestNo'
+                  #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'
+                  #custom-pr-sign-comment: 'The signature to be committed in order to sign the CLA'
+                  #custom-allsigned-prcomment: 'pull request comment when all contributors has signed, defaults to **CLA Assistant Lite bot** All Contributors have signed the CLA.'
+                  #lock-pullrequest-aftermerge: false - if you don't want this bot to automatically lock the pull request after merging (default - true)
+                  #use-dco-flag: true - If you are using DCO instead of CLA

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,74 @@
+# Contributor License Agreement (Individual)
+
+Thank you for your interest in contributing to this project.
+
+This Contributor License Agreement (“Agreement”) clarifies the intellectual property license granted by you to the project owner for your contributions.
+
+---
+
+## 1. Definitions
+
+**“You”** (or **“Your”**) means the individual who submits a Contribution to the project.
+
+**“Contribution”** means any original work of authorship, including code, documentation, or other material, that you intentionally submit for inclusion in the project.
+
+**“Project”** means the software project to which the Contribution is submitted.
+
+---
+
+## 2. Grant of Copyright License
+
+Subject to the terms of this Agreement, You hereby grant the Project and its maintainers a **perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license** to:
+
+- use,
+- reproduce,
+- modify,
+- prepare derivative works of,
+- publicly display,
+- publicly perform,
+- sublicense, and
+- distribute
+
+Your Contributions and such derivative works.
+
+You retain ownership of the copyright in Your Contributions.
+
+---
+
+## 3. Grant of Patent License
+
+Subject to the terms of this Agreement, You hereby grant the Project and its maintainers a **perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable patent license** to make, have made, use, offer to sell, sell, import, and otherwise transfer the Contribution, where such license applies only to those patent claims licensable by You that are necessarily infringed by Your Contribution alone or by combination with the Project.
+
+If You initiate patent litigation claiming that the Contribution or the Project infringes a patent, then any patent licenses granted under this Agreement shall terminate as of the date such litigation is filed.
+
+---
+
+## 4. Representation
+
+You represent that:
+
+- You are legally entitled to grant the licenses above.
+- Each Contribution is Your original creation, or You have the right to submit it.
+- Your Contribution does not knowingly include third-party code that is incompatible with the Project’s license.
+
+---
+
+## 5. No Warranty
+
+You provide the Contribution **“AS IS”**, without warranties or conditions of any kind, express or implied.
+
+---
+
+## 6. No Obligation
+
+You are not obligated to provide support, updates, or future Contributions.
+
+---
+
+## 7. Acceptance
+
+This Agreement applies to all Contributions You submit now or in the future, unless You explicitly state otherwise in writing at the time of submission.
+
+By submitting a Contribution, You agree to the terms of this Agreement.
+
+---

--- a/CLA.md
+++ b/CLA.md
@@ -1,8 +1,8 @@
 # Contributor License Agreement (Individual)
 
-Thank you for your interest in contributing to this project.
+Thank you for your interest in contributing to Dyad.
 
-This Contributor License Agreement (“Agreement”) clarifies the intellectual property license granted by you to the project owner for your contributions.
+This Contributor License Agreement (“Agreement”) clarifies the intellectual property license granted by you to the project owner, **Dyad Tech, Inc.**, for your contributions.
 
 ---
 
@@ -12,13 +12,13 @@ This Contributor License Agreement (“Agreement”) clarifies the intellectual 
 
 **“Contribution”** means any original work of authorship, including code, documentation, or other material, that you intentionally submit for inclusion in the project.
 
-**“Project”** means the software project to which the Contribution is submitted.
+**“Project”** means the Dyad open-source software project to which the Contribution is submitted.
 
 ---
 
 ## 2. Grant of Copyright License
 
-Subject to the terms of this Agreement, You hereby grant the Project and its maintainers a **perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license** to:
+Subject to the terms of this Agreement, You hereby grant the Project and **Dyad Tech, Inc.** a **perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license** to:
 
 - use,
 - reproduce,
@@ -37,7 +37,7 @@ You retain ownership of the copyright in Your Contributions.
 
 ## 3. Grant of Patent License
 
-Subject to the terms of this Agreement, You hereby grant the Project and its maintainers a **perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable patent license** to make, have made, use, offer to sell, sell, import, and otherwise transfer the Contribution, where such license applies only to those patent claims licensable by You that are necessarily infringed by Your Contribution alone or by combination with the Project.
+Subject to the terms of this Agreement, You hereby grant the Project and **Dyad Tech, Inc.** a **perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable patent license** to make, have made, use, offer to sell, sell, import, and otherwise transfer the Contribution, where such license applies only to those patent claims licensable by You that are necessarily infringed by Your Contribution alone or by combination with the Project.
 
 If You initiate patent litigation claiming that the Contribution or the Project infringes a patent, then any patent licenses granted under this Agreement shall terminate as of the date such litigation is filed.
 
@@ -70,5 +70,3 @@ You are not obligated to provide support, updates, or future Contributions.
 This Agreement applies to all Contributions You submit now or in the future, unless You explicitly state otherwise in writing at the time of submission.
 
 By submitting a Contribution, You agree to the terms of this Agreement.
-
----

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,8 @@ Before opening a pull request, please open an issue and discuss whether the chan
 - For a high-level overview of how Dyad works, please see the [Architecture Guide](./docs/architecture.md). Understanding the architecture will help ensure your contributions align with the overall design of the project.
 - For a detailed architecture on how the new local agent mode (aka Agent v2) works, please read the [Agent Architecture Guide](./docs/agent_architecture.md)
 
+> **Note:** By submitting a contribution within `src/pro`, you agree that such contribution is licensed under the Fair Source License (FSL) used by that directory.
+
 ## More than code contributions
 
 Something that I really appreciate are all the non-code contributions, such as reporting bugs, writing feature requests and participating on [Dyad's sub-reddit](https://www.reddit.com/r/dyadbuilders).

--- a/src/pro/CONTRIBUTING.md
+++ b/src/pro/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+By submitting a contribution to this directory, you agree that such contribution is licensed under the Fair Source License (FSL) used by this directory.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces contributor licensing and automated CLA enforcement.
> 
> - Adds `CLA.md` (individual agreement) and documents FSL licensing for `src/pro` (`CONTRIBUTING.md`, `src/pro/CONTRIBUTING.md`)
> - New GitHub Actions workflow `/.github/workflows/cla.yml` using `contributor-assistant/github-action@v2.6.1` on `pull_request_target` and `issue_comment`
> - Stores signatures at `signatures/version1/cla.json` on branch `cla` and updates PR status; supports signing via comment or `recheck`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5706a5ace13aabd8e8e83fdd071d65f7fc40500f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Contributor License Agreement and a GitHub Action that blocks PRs until all authors sign the CLA. Also clarifies that contributions in src/pro are licensed under FSL.

- **New Features**
  - Added CLA.md for individual contributors.
  - Enabled CLA Assistant on pull_request_target and issue_comment events.
  - Stores signatures at signatures/version1/cla.json on the cla branch and updates PR status.
  - Supports “recheck” and signing via comment.
  - Documented FSL licensing for src/pro contributions.

- **Migration**
  - Ensure the cla branch is not protected, or change the action’s target branch.
  - Optionally configure an allowlist to fit your org.
  - If storing signatures remotely, add the PERSONAL_ACCESS_TOKEN secret.
  - Contributors sign by commenting: “I have read the CLA Document and I hereby sign the CLA”.

<sup>Written for commit 5706a5ace13aabd8e8e83fdd071d65f7fc40500f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

