### PR TITLE
Setup CLA bot for GitHub PRs

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,40 @@
+name: CLA Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    steps:
+      - name: CLA Assistant
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The below token should have repo scope and must be manually added by you in the repository's secrets setting
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/version1/cla.json'
+          path-to-document: 'https://github.com/${{ github.repository }}/blob/main/CLA.md'
+          # Branch where signatures are stored
+          branch: 'main'
+          # Allowlist for users/bots that don't need to sign (e.g., dependabot, automated bots)
+          allowlist: bot*,*[bot],*-bot,github-actions[bot]
+          # Custom message when all contributors have signed
+          custom-notsigned-prcomment: 'Thank you for your contribution! Before we can merge this PR, we need you to sign our Contributor License Agreement (CLA).<br/><br/>Please read our [CLA Document](https://github.com/${{ github.repository }}/blob/main/CLA.md) and comment on this PR with the following to sign:<br/><br/>**I have read the CLA Document and I hereby sign the CLA**'
+          custom-allsigned-prcomment: 'All contributors have signed the CLA. ✅'
+          # Lock PR after merge to prevent signature tampering
+          lock-pullrequest-aftermerge: true
+          # Use remote repo for storing signatures (optional - only needed if you want centralized signature storage)
+          # remote-organization-name: ''
+          # remote-repository-name: ''

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,81 @@
+# Contributor License Agreement
+
+Thank you for your interest in contributing to Dyad ("We" or "Us").
+
+This contributor agreement ("Agreement") documents the rights granted by contributors to Us. To make this document effective, please sign it by commenting on your pull request with the following statement:
+
+```
+I have read the CLA Document and I hereby sign the CLA
+```
+
+## 1. Definitions
+
+**"You"** means the individual who submits a Contribution to Us.
+
+**"Contribution"** means any work of authorship that is submitted by You to Us in which You own or assert ownership of the Copyright.
+
+**"Copyright"** means all rights protecting works of authorship owned or controlled by You, including copyright, moral and neighboring rights, as appropriate, for the full term of their existence including any extensions by You.
+
+**"Material"** means the work of authorship which is made available by Us to third parties.
+
+**"Submit"** means any form of electronic, verbal, or written communication sent to Us or our representatives, including but not limited to electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, Us for the purpose of discussing and improving the Material, but excluding communication that is conspicuously marked or otherwise designated in writing by You as "Not a Contribution."
+
+## 2. Grant of Rights
+
+### 2.1 Copyright License
+
+(a) You retain ownership of the Copyright in Your Contribution and have the same rights to use or license the Contribution which You would have had without entering into the Agreement.
+
+(b) To the maximum extent permitted by the relevant law, You grant to Us a perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable license under the Copyright covering the Contribution, with the right to sublicense such rights through multiple tiers of sublicensees, to reproduce, modify, display, perform and distribute the Contribution as part of the Material; provided that this license is conditioned upon compliance with Section 2.3.
+
+### 2.2 Patent License
+
+For patent claims including, without limitation, method, process, and apparatus claims which You own, control or have the right to grant, now or in the future, You grant to Us a perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable patent license, with the right to sublicense these rights to multiple tiers of sublicensees, to make, have made, use, sell, offer for sale, import and otherwise transfer the Contribution and the Contribution in combination with the Material (and portions of such combination). This license is granted only to the extent that the exercise of the licensed rights infringes such patent claims; and provided that this license is conditioned upon compliance with Section 2.3.
+
+### 2.3 Outbound License
+
+As a condition on the grant of rights in Sections 2.1 and 2.2, We agree to license the Contribution only under the terms of the license or licenses which We are using on the date You Submit the Contribution for the Material or any licenses which are approved by the Open Source Initiative on or after the date You Submit the Contribution.
+
+### 2.4 Moral Rights
+
+If moral rights apply to the Contribution, to the maximum extent permitted by law, You waive and agree not to assert such moral rights against Us or our successors in interest, or any of our licensees, either direct or indirect.
+
+### 2.5 Our Rights
+
+You acknowledge that We are not obligated to use Your Contribution as part of the Material and may decide to include any Contribution We consider appropriate.
+
+### 2.6 Reservation of Rights
+
+Any rights not expressly licensed under this section are expressly reserved by You.
+
+## 3. Agreement
+
+You confirm that:
+
+(a) You have the legal authority to enter into this Agreement.
+
+(b) You own the Copyright and patent claims covering the Contribution which are required to grant the rights under Section 2.
+
+(c) The grant of rights under Section 2 does not violate any grant of rights which You have made to third parties, including Your employer. If You are an employee, You have had Your employer approve this Agreement or sign the Entity version of this document. If You are less than eighteen years old, please have Your parents or guardian sign the Agreement.
+
+(d) You have followed the instructions in the Contribution guide, if any.
+
+## 4. Disclaimer
+
+EXCEPT FOR THE EXPRESS WARRANTIES IN SECTION 3, THE CONTRIBUTION IS PROVIDED "AS IS". MORE PARTICULARLY, ALL EXPRESS OR IMPLIED WARRANTIES INCLUDING, WITHOUT LIMITATION, ANY IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE EXPRESSLY DISCLAIMED BY YOU TO US AND BY US TO YOU. TO THE EXTENT THAT ANY SUCH WARRANTIES CANNOT BE DISCLAIMED, SUCH WARRANTY IS LIMITED IN DURATION TO THE MINIMUM PERIOD PERMITTED BY LAW.
+
+## 5. Consequential Damage Waiver
+
+TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT WILL YOU OR US BE LIABLE FOR ANY LOSS OF PROFITS, LOSS OF ANTICIPATED SAVINGS, LOSS OF DATA, INDIRECT, SPECIAL, INCIDENTAL, CONSEQUENTIAL AND EXEMPLARY DAMAGES ARISING OUT OF THIS AGREEMENT REGARDLESS OF THE LEGAL OR EQUITABLE THEORY (CONTRACT, TORT OR OTHERWISE) UPON WHICH THE CLAIM IS BASED.
+
+## 6. Miscellaneous
+
+6.1 This Agreement will be governed by and construed in accordance with the laws of the United States excluding its conflicts of law provisions. Under certain circumstances, the governing law in this section might be superseded by the United Nations Convention on Contracts for the International Sale of Goods ("UN Convention") and the parties intend to avoid the application of the UN Convention to this Agreement and, thus, exclude the application of the UN Convention in its entirety to this Agreement.
+
+6.2 This Agreement sets out the entire agreement between You and Us for Your Contributions to Us and overrides all other agreements or understandings.
+
+6.3 If You or We assign the rights or obligations received through this Agreement to a third party, as a condition of the assignment, that third party must agree in writing to abide by all the rights and obligations in the Agreement.
+
+6.4 The failure of either party to require performance by the other party of any provision of this Agreement in one situation shall not affect the right of a party to require such performance at any time in the future. A waiver of performance under a provision in one situation shall not be considered a waiver of the performance of the provision in the future or a waiver of the provision in its entirety.
+
+6.5 If any provision of this Agreement is found void and unenforceable, such provision will be replaced to the extent possible with a provision that comes closest to the meaning of the original provision and which is enforceable. The terms and conditions set forth in this Agreement shall apply notwithstanding any failure of essential purpose of this Agreement or any limited remedy to the maximum extent possible under law.


### PR DESCRIPTION
- Created CLA.md with contributor license agreement
- Added GitHub Action workflow for automated CLA checking
- Contributors must sign by commenting "I have read the CLA Document and I hereby sign the CLA" on PRs
- Signatures stored in signatures/version1/cla.json
- Bots automatically allowlisted

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets up automated CLA enforcement via GitHub Actions and adds the repository’s CLA document.
> 
> - Adds `CLA.md` defining contributor license terms and signing instructions
> - Introduces `.github/workflows/cla.yml` using `contributor-assistant/github-action@v2.6.1` triggered on `pull_request_target` and `issue_comment`
> - Stores signatures at `signatures/version1/cla.json` on `main`; bots allowlisted via `allowlist`
> - Customizes PR comments for unsigned/signed states and locks PRs after merge to prevent tampering
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03080c65e8ca0dd3481e6340fb7ff98f0ac112a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set up a CLA bot for GitHub PRs to require contributors to sign our Contributor License Agreement before merging. Adds the CLA document and automates signature checks and storage.

- **New Features**
  - Added CLA.md.
  - Added a GitHub Action to check CLA on PRs and comments, post messages, and lock PRs after merge.
  - Stores signatures in signatures/version1/cla.json; common bots are allowlisted.

- **Migration**
  - Add a PERSONAL_ACCESS_TOKEN secret with repo scope.
  - Contributors sign by commenting: "I have read the CLA Document and I hereby sign the CLA".

<sup>Written for commit 03080c65e8ca0dd3481e6340fb7ff98f0ac112a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

