### PR TITLE
Fix : Keep plus button enabled while streaming

### DIFF
--- a/src/components/chat/AuxiliaryActionsMenu.tsx
+++ b/src/components/chat/AuxiliaryActionsMenu.tsx
@@ -19,14 +19,12 @@ interface AuxiliaryActionsMenuProps {
     files: FileList,
     type: "chat-context" | "upload-to-codebase",
   ) => void;
-  disabled?: boolean;
   showTokenBar: boolean;
   toggleShowTokenBar: () => void;
 }
 
 export function AuxiliaryActionsMenu({
   onFileSelect,
-  disabled,
   showTokenBar,
   toggleShowTokenBar,
 }: AuxiliaryActionsMenuProps) {
@@ -38,7 +36,6 @@ export function AuxiliaryActionsMenu({
         <Button
           variant="ghost"
           size="sm"
-          disabled={disabled}
           className="has-[>svg]:px-2 hover:bg-muted bg-primary/10 text-primary cursor-pointer rounded-xl"
           data-testid="auxiliary-actions-menu"
         >

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -476,7 +476,6 @@ export function ChatInput({ chatId }: { chatId?: number }) {
 
             <AuxiliaryActionsMenu
               onFileSelect={handleFileSelect}
-              disabled={isStreaming}
               showTokenBar={showTokenBar}
               toggleShowTokenBar={toggleShowTokenBar}
             />


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Keep the + button in chat enabled while a message is streaming, so users can attach files or toggle the token bar without waiting. Removed the disabled prop from AuxiliaryActionsMenu and stopped passing disabled={isStreaming} from ChatInput.

<sup>Written for commit fbe88ac6e708be9e06c9d7a8afe08a913905bddf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

