### PR TITLE
Adding reference to the DeepWiki documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,7 @@ Before opening a pull request, please open an issue and discuss whether the chan
 
 - For a high-level overview of how Dyad works, please see the [Architecture Guide](./docs/architecture.md). Understanding the architecture will help ensure your contributions align with the overall design of the project.
 - For a detailed architecture on how the new local agent mode (aka Agent v2) works, please read the [Agent Architecture Guide](./docs/agent_architecture.md)
+- For an in-depth overview of the Dyad codebase, see the DeepWiki documentation [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/dyad-sh/dyad)
 
 > **Note:** By submitting a contribution within `src/pro`, you agree that such contribution is licensed under the Fair Source License (FSL) used by that directory.
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a link to the DeepWiki documentation in CONTRIBUTING.md to give contributors an in-depth overview of the Dyad codebase.

<sup>Written for commit 035bc8d1951dfcb99113f80953b82dc10173c66a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

