### PR TITLE
Better UX for keep going in Supabase integration

### DIFF
--- a/src/components/chat/DyadAddIntegration.tsx
+++ b/src/components/chat/DyadAddIntegration.tsx
@@ -2,9 +2,11 @@ import React from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { Button } from "@/components/ui/button";
 import { selectedAppIdAtom } from "@/atoms/appAtoms";
+import { selectedChatIdAtom } from "@/atoms/chatAtoms";
 import { useAtomValue } from "jotai";
 import { showError } from "@/lib/toast";
 import { useLoadApp } from "@/hooks/useLoadApp";
+import { useStreamChat } from "@/hooks/useStreamChat";
 
 interface DyadAddIntegrationProps {
   node: {
@@ -20,10 +22,23 @@ export const DyadAddIntegration: React.FC<DyadAddIntegrationProps> = ({
   children,
 }) => {
   const navigate = useNavigate();
+  const { streamMessage } = useStreamChat();
 
   const { provider } = node.properties;
   const appId = useAtomValue(selectedAppIdAtom);
+  const chatId = useAtomValue(selectedChatIdAtom);
   const { app } = useLoadApp(appId);
+
+  const handleKeepGoingClick = () => {
+    if (!chatId) {
+      showError("No chat found");
+      return;
+    }
+    streamMessage({
+      prompt: "Continue. I have completed the Supabase integration.",
+      chatId,
+    });
+  };
 
   const handleSetupClick = () => {
     if (!appId) {
@@ -69,8 +84,14 @@ export const DyadAddIntegration: React.FC<DyadAddIntegrationProps> = ({
               {app.supabaseProjectName}
             </span>
           </p>
-          <p>Click the chat suggestion "Keep going" to continue.</p>
         </div>
+        <Button
+          onClick={handleKeepGoingClick}
+          className="self-start mt-2"
+          variant="outline"
+        >
+          Continue
+        </Button>
       </div>
     );
   }

--- a/src/components/chat/DyadAddIntegration.tsx
+++ b/src/components/chat/DyadAddIntegration.tsx
@@ -22,7 +22,7 @@ export const DyadAddIntegration: React.FC<DyadAddIntegrationProps> = ({
   children,
 }) => {
   const navigate = useNavigate();
-  const { streamMessage } = useStreamChat();
+  const { streamMessage, isStreaming } = useStreamChat();
 
   const { provider } = node.properties;
   const appId = useAtomValue(selectedAppIdAtom);
@@ -89,6 +89,7 @@ export const DyadAddIntegration: React.FC<DyadAddIntegrationProps> = ({
           onClick={handleKeepGoingClick}
           className="self-start mt-2"
           variant="outline"
+          disabled={isStreaming}
         >
           Continue
         </Button>

--- a/src/components/chat/DyadAddIntegration.tsx
+++ b/src/components/chat/DyadAddIntegration.tsx
@@ -30,7 +30,7 @@ export const DyadAddIntegration: React.FC<DyadAddIntegrationProps> = ({
   const { app } = useLoadApp(appId);
 
   const handleKeepGoingClick = () => {
-    if (!chatId) {
+    if (chatId === null) {
       showError("No chat found");
       return;
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves the Supabase integration completion UX by adding an actionable control that advances the chat flow.
> 
> - Adds a `Continue` button (using `useStreamChat`) that sends `"Continue. I have completed the Supabase integration."` to the active chat via `selectedChatIdAtom`
> - Disables the button while `isStreaming` and shows an error toast if no chat is available
> - Removes the prior instructional text about clicking a chat suggestion
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b384d8756c6861c7682b422883314eea522cc060. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Continue button to the Supabase integration flow that sends a “Continue. I have completed the Supabase integration.” message to the current chat, so users can proceed without hunting for the chat suggestion.

- **New Features**
  - Added Continue button that calls streamMessage with the active chatId and disables while streaming.
  - Shows an error toast if no chat is available.

<sup>Written for commit b384d8756c6861c7682b422883314eea522cc060. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

