### PR TITLE
fix image attachments for agent mode

### DIFF
--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -1606,13 +1606,19 @@ async function prepareMessageWithAttachments(
     const ext = path.extname(filePath).toLowerCase();
     if ([".jpg", ".jpeg", ".png", ".gif", ".webp"].includes(ext)) {
       try {
-        // Read the file as a buffer
+        // Read the file as a buffer and convert to base64 string
+        // Using base64 strings instead of raw Buffers ensures proper JSON serialization
+        // for storage in aiMessagesJson (raw Buffers serialize inefficiently and exceed size limits)
         const imageBuffer = await readFile(filePath);
+        const mimeType =
+          ext === ".jpg" ? "image/jpeg" : `image/${ext.slice(1)}`;
+        const base64Data = imageBuffer.toString("base64");
 
-        // Add the image to the content parts
+        // Add the image to the content parts with base64 data and mediaType
         contentParts.push({
           type: "image",
-          image: imageBuffer,
+          image: base64Data,
+          mediaType: mimeType,
         });
 
         logger.log(`Added image attachment: ${filePath}`);

--- a/src/ipc/utils/ai_messages_utils.ts
+++ b/src/ipc/utils/ai_messages_utils.ts
@@ -4,8 +4,8 @@ import log from "electron-log";
 
 const logger = log.scope("ai_messages_utils");
 
-/** Maximum size in bytes for ai_messages_json (1MB) */
-export const MAX_AI_MESSAGES_SIZE = 1_000_000;
+/** Maximum size in bytes for ai_messages_json (10MB) */
+export const MAX_AI_MESSAGES_SIZE = 10_000_000;
 
 /**
  * Check if ai_messages_json is within size limits and return the value to save.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> - **Image attachments handling:** In `prepareMessageWithAttachments`, images are now read, converted to base64, and included as `image` (base64) with `mediaType` instead of raw Buffers, ensuring proper JSON serialization for `aiMessagesJson`.
> - **Storage limit increase:** `MAX_AI_MESSAGES_SIZE` raised from 1MB to 10MB in `ai_messages_utils.ts` to accommodate larger serialized message payloads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b81483775dc7e6535c7396f417818eb638003248. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes image attachments by storing images as base64 with a mediaType so they serialize to JSON correctly. Also increases ai_messages_json size limit to 10MB to prevent save failures.

- **Bug Fixes**
  - Store .jpg, .jpeg, .png, .gif, .webp as base64 and set mediaType (e.g., image/jpeg, image/png) for safe JSON serialization.
  - Raise MAX_AI_MESSAGES_SIZE from 1MB to 10MB.

<sup>Written for commit b81483775dc7e6535c7396f417818eb638003248. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

