### PR TITLE
fix: Upload file to code base dosen't work

### DIFF
--- a/src/components/chat/FileAttachmentDropdown.tsx
+++ b/src/components/chat/FileAttachmentDropdown.tsx
@@ -58,7 +58,10 @@ export function FileAttachmentDropdown({
         <Tooltip>
           <TooltipTrigger asChild>
             <DropdownMenuItem
-              onClick={handleChatContextClick}
+              onSelect={(e) => {
+                e.preventDefault();
+                handleChatContextClick();
+              }}
               className="py-3 px-4"
             >
               <MessageSquare size={16} className="mr-2" />
@@ -75,7 +78,10 @@ export function FileAttachmentDropdown({
         <Tooltip>
           <TooltipTrigger asChild>
             <DropdownMenuItem
-              onClick={handleUploadToCodebaseClick}
+              onSelect={(e) => {
+                e.preventDefault();
+                handleUploadToCodebaseClick();
+              }}
               className="py-3 px-4"
             >
               <Upload size={16} className="mr-2" />

--- a/src/components/chat/FileAttachmentDropdown.tsx
+++ b/src/components/chat/FileAttachmentDropdown.tsx
@@ -12,7 +12,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Button } from "@/components/ui/button";
-import { useRef } from "react";
+import { useRef, useState } from "react";
 
 interface FileAttachmentDropdownProps {
   onFileSelect: (
@@ -32,13 +32,18 @@ export function FileAttachmentDropdown({
 }: FileAttachmentDropdownProps) {
   const chatContextFileInputRef = useRef<HTMLInputElement>(null);
   const uploadToCodebaseFileInputRef = useRef<HTMLInputElement>(null);
+  const [dropdownOpen, setDropdownOpen] = useState(false);
 
   const handleChatContextClick = () => {
     chatContextFileInputRef.current?.click();
+    // Close dropdown after triggering file input
+    setDropdownOpen(false);
   };
 
   const handleUploadToCodebaseClick = () => {
     uploadToCodebaseFileInputRef.current?.click();
+    // Close dropdown after triggering file input
+    setDropdownOpen(false);
   };
 
   const handleFileChange = (
@@ -134,7 +139,7 @@ export function FileAttachmentDropdown({
     <>
       <TooltipProvider>
         <Tooltip>
-          <DropdownMenu>
+          <DropdownMenu open={dropdownOpen} onOpenChange={setDropdownOpen}>
             <DropdownMenuTrigger asChild>
               <TooltipTrigger asChild>
                 <Button


### PR DESCRIPTION
Closes #2130 #2127

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dropdown menu actions so “Upload to codebase” and “Add chat context” reliably trigger and the menu closes after selection.

Replaces onClick with onSelect + preventDefault, and adds a controlled open state to close the dropdown after starting file selection.

<sup>Written for commit daffec7e90af2202263b2e153dda4ae4a7a7abf3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes dropdown actions in `FileAttachmentDropdown.tsx` so file selections reliably open.
> 
> - Replace `onClick` with `onSelect` on `DropdownMenuItem` for both "Attach file as chat context" and "Upload file to codebase"
> - Call `e.preventDefault()` in `onSelect` handlers before invoking `handleChatContextClick`/`handleUploadToCodebaseClick`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45f6722ee9e86c52f329d105e6933c593b11b520. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->