### PR TITLE
Minor import clean-ups 

### DIFF
--- a/src/__tests__/prepare_step_utils.test.ts
+++ b/src/__tests__/prepare_step_utils.test.ts
@@ -7,7 +7,7 @@ import {
   type InjectedMessage,
 } from "@/pro/main/ipc/handlers/local_agent/prepare_step_utils";
 import type { UserMessageContentPart } from "@/pro/main/ipc/handlers/local_agent/tools/types";
-import { ImagePart, ModelMessage } from "node_modules/ai/dist";
+import { ImagePart, ModelMessage } from "ai";
 
 describe("prepare_step_utils", () => {
   describe("transformContentPart", () => {

--- a/src/pro/main/ipc/handlers/local_agent/prepare_step_utils.ts
+++ b/src/pro/main/ipc/handlers/local_agent/prepare_step_utils.ts
@@ -5,12 +5,7 @@
  * in local_agent_handler.ts, enabling isolated unit testing.
  */
 
-import {
-  ImagePart,
-  ModelMessage,
-  TextPart,
-  UserModelMessage,
-} from "node_modules/ai/dist";
+import { ImagePart, ModelMessage, TextPart, UserModelMessage } from "ai";
 import type { UserMessageContentPart } from "./tools/types";
 
 /**


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates AI SDK imports to use the top-level `ai` package instead of `node_modules/ai/dist`.
> 
> - In `prepare_step_utils.ts` and its tests, replace imports of `ImagePart`, `ModelMessage`, `TextPart`, and `UserModelMessage` to come from `ai`
> - No functional code changes beyond import paths
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 117078577aa8f7a86564f8a133c2708601f4acb1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replaced deep imports from node_modules/ai/dist with the ai package entrypoint to standardize and simplify module imports. This avoids brittle paths and improves build compatibility.

<sup>Written for commit 117078577aa8f7a86564f8a133c2708601f4acb1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

