### PR TITLE
Rebase supabase stale ui baseline

### DIFF
--- a/e2e-tests/snapshots/supabase_stale_ui.spec.ts_supabase---stale-ui-2.aria.yml
+++ b/e2e-tests/snapshots/supabase_stale_ui.spec.ts_supabase---stale-ui-2.aria.yml
@@ -3,6 +3,14 @@
 - img
 - text: Supabase integration complete
 - paragraph: "This app is connected to Supabase project: Fake Supabase Project"
-- paragraph: Click the chat suggestion "Keep going" to continue.
+- button "Continue"
+- button:
+  - img
+- img
+- text: test-model
+- img
+- text: less than a minute ago
+- button "Undo":
+  - img
 - button "Retry":
   - img


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates E2E snapshot for Supabase stale UI to match current UI.
> 
> - Refreshes `supabase_stale_ui.spec.ts_supabase---stale-ui-2.aria.yml` with new elements: `button "Continue"`, `button "Undo"`, additional imgs, and texts like `test-model` and `less than a minute ago`
> - Removes prior instructional paragraph about clicking the chat suggestion
> - No app logic changes; test snapshot only
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a481c54b412432d8b892a0b344107cb96c1bb25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the Supabase stale UI e2e snapshot to match the rebased UI, replacing the “Keep going” paragraph with a “Continue” button and capturing new elements (Undo, test-model label, recent timestamp). This aligns the baseline with the current Supabase integration screen and prevents snapshot test failures.

<sup>Written for commit 5a481c54b412432d8b892a0b344107cb96c1bb25. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

