### PR TITLE
Local agent auto

### DIFF
--- a/e2e-tests/helpers/test_helper.ts
+++ b/e2e-tests/helpers/test_helper.ts
@@ -326,6 +326,14 @@ export class PageObject {
     }
     await this.setUpDyadProvider();
     await this.goToAppsTab();
+    // Select a non-openAI model for local agent mode,
+    // since openAI models go to the responses API.
+    if (localAgent) {
+      await this.selectModel({
+        provider: "Anthropic",
+        model: "Claude Opus 4.5",
+      });
+    }
   }
 
   async ensurePnpmInstall() {
@@ -722,6 +730,18 @@ export class PageObject {
       name,
       timeout: Timeout.LONG,
     });
+  }
+
+  ////////////////////////////////
+  // Security review
+  ////////////////////////////////
+  async clickRunSecurityReview() {
+    const runSecurityReviewButton = this.page
+      .getByRole("button", { name: "Run Security Review" })
+      .first();
+    await runSecurityReviewButton.click();
+    await runSecurityReviewButton.waitFor({ state: "hidden" });
+    await this.waitForChatCompletion();
   }
 
   async snapshotSecurityFindingsTable() {

--- a/e2e-tests/local_agent_advanced.spec.ts
+++ b/e2e-tests/local_agent_advanced.spec.ts
@@ -11,11 +11,7 @@ testSkipIfWindows("local-agent - security review fix", async ({ po }) => {
 
   // First, trigger a security review
   await po.selectPreviewMode("security");
-  await po.page
-    .getByRole("button", { name: "Run Security Review" })
-    .first()
-    .click();
-  await po.waitForChatCompletion();
+  await po.clickRunSecurityReview();
 
   await po.snapshotServerDump("all-messages");
 });

--- a/e2e-tests/security_review.spec.ts
+++ b/e2e-tests/security_review.spec.ts
@@ -9,11 +9,7 @@ testSkipIfWindows("security review", async ({ po }) => {
 
   await po.selectPreviewMode("security");
 
-  await po.page
-    .getByRole("button", { name: "Run Security Review" })
-    .first()
-    .click();
-  await po.waitForChatCompletion();
+  await po.clickRunSecurityReview();
   await po.snapshotServerDump("all-messages");
   await po.snapshotSecurityFindingsTable();
 
@@ -36,11 +32,7 @@ test("security review - edit and use knowledge", async ({ po }) => {
     .fill("testing\nrules123");
   await po.page.getByRole("button", { name: "Save" }).click();
 
-  await po.page
-    .getByRole("button", { name: "Run Security Review" })
-    .first()
-    .click();
-  await po.waitForChatCompletion();
+  await po.clickRunSecurityReview();
   await po.snapshotServerDump("all-messages");
 });
 

--- a/e2e-tests/snapshots/engine.spec.ts_regular-auto-should-send-message-to-engine-1.txt
+++ b/e2e-tests/snapshots/engine.spec.ts_regular-auto-should-send-message-to-engine-1.txt
@@ -14,11 +14,7 @@
       }
     ],
     "stream": true,
-    "thinking": {
-      "type": "enabled",
-      "include_thoughts": true,
-      "budget_tokens": 4000
-    },
+    "reasoning_effort": "medium",
     "dyad_options": {
       "files": [
         {

--- a/e2e-tests/snapshots/engine.spec.ts_smart-auto-should-send-message-to-engine-1.txt
+++ b/e2e-tests/snapshots/engine.spec.ts_smart-auto-should-send-message-to-engine-1.txt
@@ -14,11 +14,7 @@
       }
     ],
     "stream": true,
-    "thinking": {
-      "type": "enabled",
-      "include_thoughts": true,
-      "budget_tokens": 4000
-    },
+    "reasoning_effort": "medium",
     "dyad_options": {
       "versioned_files": {
         "fileIdToContent": {

--- a/e2e-tests/snapshots/local_agent_advanced.spec.ts_local-agent---mention-apps-1.txt
+++ b/e2e-tests/snapshots/local_agent_advanced.spec.ts_local-agent---mention-apps-1.txt
@@ -1,6 +1,6 @@
 {
   "body": {
-    "model": "dyad/auto",
+    "model": "anthropic/claude-opus-4-5",
     "max_tokens": 32000,
     "temperature": 0,
     "messages": [
@@ -14,11 +14,6 @@
       }
     ],
     "stream": true,
-    "thinking": {
-      "type": "enabled",
-      "include_thoughts": true,
-      "budget_tokens": 4000
-    },
     "dyad_options": {
       "files": [
         {

--- a/e2e-tests/snapshots/local_agent_basic.spec.ts_local-agent---dump-request-1.txt
+++ b/e2e-tests/snapshots/local_agent_basic.spec.ts_local-agent---dump-request-1.txt
@@ -1,6 +1,6 @@
 {
   "body": {
-    "model": "dyad/auto",
+    "model": "anthropic/claude-opus-4-5",
     "max_tokens": 32000,
     "temperature": 0,
     "messages": [
@@ -327,12 +327,7 @@
       }
     ],
     "tool_choice": "auto",
-    "stream": true,
-    "thinking": {
-      "type": "enabled",
-      "include_thoughts": true,
-      "budget_tokens": 4000
-    }
+    "stream": true
   },
   "headers": {
     "authorization": "Bearer testdyadkey"

--- a/e2e-tests/snapshots/local_agent_basic.spec.ts_local-agent---read-then-edit-1.aria.yml
+++ b/e2e-tests/snapshots/local_agent_basic.spec.ts_local-agent---read-then-edit-1.aria.yml
@@ -9,7 +9,7 @@
 - button:
   - img
 - img
-- text: auto
+- text: claude-opus-4-5
 - img
 - text: less than a minute ago
 - button "Request ID":
@@ -27,7 +27,7 @@
 - button:
   - img
 - img
-- text: auto
+- text: claude-opus-4-5
 - img
 - text: less than a minute ago
 - button "Request ID":

--- a/e2e-tests/snapshots/local_agent_read_logs.spec.ts_local-agent---read-logs-with-filters-1.aria.yml
+++ b/e2e-tests/snapshots/local_agent_read_logs.spec.ts_local-agent---read-logs-with-filters-1.aria.yml
@@ -9,7 +9,7 @@
 - button:
   - img
 - img
-- text: auto
+- text: claude-opus-4-5
 - img
 - text: less than a minute ago
 - button "Request ID":
@@ -17,7 +17,7 @@
 - paragraph: tc=local-agent/read-logs
 - paragraph: Let me check the recent console logs to see what's happening in the application.
 - img
-- text: /LOGSReading \d+ logs?/
+- text: LOGSReading 1 logs
 - img
 - paragraph: Now let me filter for only error logs to identify any issues.
 - img
@@ -31,7 +31,7 @@
 - button:
   - img
 - img
-- text: auto
+- text: claude-opus-4-5
 - img
 - text: less than a minute ago
 - button "Request ID":

--- a/e2e-tests/snapshots/mention_app.spec.ts_mention-app-with-pro-1.txt
+++ b/e2e-tests/snapshots/mention_app.spec.ts_mention-app-with-pro-1.txt
@@ -14,11 +14,7 @@
       }
     ],
     "stream": true,
-    "thinking": {
-      "type": "enabled",
-      "include_thoughts": true,
-      "budget_tokens": 4000
-    },
+    "reasoning_effort": "medium",
     "dyad_options": {
       "files": [
         {

--- a/e2e-tests/snapshots/smart_context_balanced.spec.ts_smart-context-balanced---simple-1.txt
+++ b/e2e-tests/snapshots/smart_context_balanced.spec.ts_smart-context-balanced---simple-1.txt
@@ -14,11 +14,7 @@
       }
     ],
     "stream": true,
-    "thinking": {
-      "type": "enabled",
-      "include_thoughts": true,
-      "budget_tokens": 4000
-    },
+    "reasoning_effort": "medium",
     "dyad_options": {
       "files": [
         {

--- a/e2e-tests/snapshots/smart_context_deep.spec.ts_smart-context-deep---mention-app-should-fallback-to-balanced-1.txt
+++ b/e2e-tests/snapshots/smart_context_deep.spec.ts_smart-context-deep---mention-app-should-fallback-to-balanced-1.txt
@@ -14,11 +14,7 @@
       }
     ],
     "stream": true,
-    "thinking": {
-      "type": "enabled",
-      "include_thoughts": true,
-      "budget_tokens": 4000
-    },
+    "reasoning_effort": "medium",
     "dyad_options": {
       "files": [
         {

--- a/e2e-tests/snapshots/smart_context_deep.spec.ts_smart-context-deep---read-write-read-1.txt
+++ b/e2e-tests/snapshots/smart_context_deep.spec.ts_smart-context-deep---read-write-read-1.txt
@@ -38,11 +38,7 @@
       }
     ],
     "stream": true,
-    "thinking": {
-      "type": "enabled",
-      "include_thoughts": true,
-      "budget_tokens": 4000
-    },
+    "reasoning_effort": "medium",
     "dyad_options": {
       "versioned_files": {
         "fileIdToContent": {

--- a/e2e-tests/snapshots/turbo_edits_v2.spec.ts_turbo-edits-v2---search-replace-dump-1.txt
+++ b/e2e-tests/snapshots/turbo_edits_v2.spec.ts_turbo-edits-v2---search-replace-dump-1.txt
@@ -14,11 +14,7 @@
       }
     ],
     "stream": true,
-    "thinking": {
-      "type": "enabled",
-      "include_thoughts": true,
-      "budget_tokens": 4000
-    },
+    "reasoning_effort": "medium",
     "dyad_options": {
       "versioned_files": {
         "fileIdToContent": {

--- a/e2e-tests/snapshots/turbo_edits_v2.spec.ts_turbo-edits-v2---search-replace-fallback-1.txt
+++ b/e2e-tests/snapshots/turbo_edits_v2.spec.ts_turbo-edits-v2---search-replace-fallback-1.txt
@@ -30,11 +30,7 @@
       }
     ],
     "stream": true,
-    "thinking": {
-      "type": "enabled",
-      "include_thoughts": true,
-      "budget_tokens": 4000
-    },
+    "reasoning_effort": "medium",
     "dyad_options": {
       "versioned_files": {
         "fileIdToContent": {

--- a/src/ipc/shared/language_model_constants.ts
+++ b/src/ipc/shared/language_model_constants.ts
@@ -18,11 +18,15 @@ export interface ModelOption {
   contextWindow?: number;
 }
 
+export const GPT_5_2_MODEL_NAME = "gpt-5.2";
+export const SONNET_4_5 = "claude-sonnet-4-5-20250929";
+export const GEMINI_3_FLASH = "gemini-3-flash-preview";
+
 export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
   openai: [
     // https://platform.openai.com/docs/models/gpt-5.1
     {
-      name: "gpt-5.2",
+      name: GPT_5_2_MODEL_NAME,
       displayName: "GPT 5.2",
       description: "OpenAI's latest model",
       // Technically it's 128k but OpenAI errors if you set max_tokens instead of max_completion_tokens
@@ -121,7 +125,7 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
       dollarSigns: 5,
     },
     {
-      name: "claude-sonnet-4-5-20250929",
+      name: SONNET_4_5,
       displayName: "Claude Sonnet 4.5",
       description:
         "Anthropic's best model for coding (note: >200k tokens is very expensive!)",
@@ -158,7 +162,7 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
     },
     // https://ai.google.dev/gemini-api/docs/models#gemini-3-pro
     {
-      name: "gemini-3-flash-preview",
+      name: GEMINI_3_FLASH,
       displayName: "Gemini 3 Flash (Preview)",
       description: "Powerful coding model at a good price",
       // See Flash 2.5 comment below (go 1 below just to be safe, even though it seems OK now).

--- a/src/ipc/shared/language_model_constants.ts
+++ b/src/ipc/shared/language_model_constants.ts
@@ -3,7 +3,6 @@ import { LanguageModel } from "../ipc_types";
 export const PROVIDERS_THAT_SUPPORT_THINKING: (keyof typeof MODEL_OPTIONS)[] = [
   "google",
   "vertex",
-  "auto",
 ];
 
 export interface ModelOption {

--- a/src/ipc/utils/get_model_client.ts
+++ b/src/ipc/utils/get_model_client.ts
@@ -15,10 +15,18 @@ import type {
 } from "../../lib/schemas";
 import { getEnvVar } from "./read_env";
 import log from "electron-log";
-import { FREE_OPENROUTER_MODEL_NAMES } from "../shared/language_model_constants";
+import {
+  FREE_OPENROUTER_MODEL_NAMES,
+  GEMINI_3_FLASH,
+  GPT_5_2_MODEL_NAME,
+  SONNET_4_5,
+} from "../shared/language_model_constants";
 import { getLanguageModelProviders } from "../shared/language_model_helpers";
 import { LanguageModelProvider } from "../ipc_types";
-import { createDyadEngine } from "./llm_engine_provider";
+import {
+  createDyadEngine,
+  type DyadEngineProvider,
+} from "./llm_engine_provider";
 
 import { LM_STUDIO_BASE_URL } from "./lm_studio_utils";
 import { createOllamaProvider } from "./ollama_provider";
@@ -106,16 +114,15 @@ export async function getModelClient(
 
       // Do not use free variant (for openrouter).
       const modelName = model.name.split(":free")[0];
-      const autoModelClient = {
-        model: (settings.selectedChatMode === "local-agent" &&
-          model.provider === "openai"
-          ? provider.responses
-          : provider)(`${providerConfig.gatewayPrefix || ""}${modelName}`),
-        builtinProviderId: model.provider,
-      };
+      const proModelClient = getProModelClient({
+        model,
+        settings,
+        provider,
+        modelId: `${providerConfig.gatewayPrefix || ""}${modelName}`,
+      });
 
       return {
-        modelClient: autoModelClient,
+        modelClient: proModelClient,
         isEngineEnabled: true,
         isSmartContextEnabled: enableSmartFilesContext,
       };
@@ -182,6 +189,50 @@ export async function getModelClient(
     );
   }
   return getRegularModelClient(model, settings, providerConfig);
+}
+
+function getProModelClient({
+  model,
+  settings,
+  provider,
+  modelId,
+}: {
+  model: LargeLanguageModel;
+  settings: UserSettings;
+  provider: DyadEngineProvider;
+  modelId: string;
+}): ModelClient {
+  if (
+    settings.selectedChatMode === "local-agent" &&
+    model.provider === "auto"
+  ) {
+    return {
+      // We need to do the fallback here (and not server-side)
+      // because GPT-5* models need to use responses API to get
+      // full functionality (e.g. thinking summaries).
+      model: createFallback({
+        models: [
+          provider.responses(`openai/${GPT_5_2_MODEL_NAME}`),
+          provider(`anthropic/${SONNET_4_5}`),
+          provider(`gemini/${GEMINI_3_FLASH}`),
+        ],
+      }),
+      builtinProviderId: model.provider,
+    };
+  }
+  if (
+    settings.selectedChatMode === "local-agent" &&
+    model.provider === "openai"
+  ) {
+    return {
+      model: provider.responses(modelId),
+      builtinProviderId: model.provider,
+    };
+  }
+  return {
+    model: provider(modelId),
+    builtinProviderId: model.provider,
+  };
 }
 
 function getRegularModelClient(

--- a/src/ipc/utils/get_model_client.ts
+++ b/src/ipc/utils/get_model_client.ts
@@ -204,7 +204,8 @@ function getProModelClient({
 }): ModelClient {
   if (
     settings.selectedChatMode === "local-agent" &&
-    model.provider === "auto"
+    model.provider === "auto" &&
+    model.name === "auto"
   ) {
     return {
       // We need to do the fallback here (and not server-side)
@@ -212,12 +213,14 @@ function getProModelClient({
       // full functionality (e.g. thinking summaries).
       model: createFallback({
         models: [
-          provider.responses(`openai/${GPT_5_2_MODEL_NAME}`),
+          // openai requires no prefix.
+          provider.responses(`${GPT_5_2_MODEL_NAME}`),
           provider(`anthropic/${SONNET_4_5}`),
           provider(`gemini/${GEMINI_3_FLASH}`),
         ],
       }),
-      builtinProviderId: model.provider,
+      // Using openAI as the default provider.
+      builtinProviderId: "openai",
     };
   }
   if (

--- a/src/ipc/utils/thinking_utils.ts
+++ b/src/ipc/utils/thinking_utils.ts
@@ -23,7 +23,7 @@ export function getExtraProviderOptions(
   if (!providerId) {
     return {};
   }
-  if (providerId === "openai") {
+  if (providerId === "openai" || providerId === "auto") {
     if (settings.selectedChatMode === "local-agent") {
       return {
         reasoning: {

--- a/src/ipc/utils/thinking_utils.ts
+++ b/src/ipc/utils/thinking_utils.ts
@@ -23,7 +23,7 @@ export function getExtraProviderOptions(
   if (!providerId) {
     return {};
   }
-  if (providerId === "openai" || providerId === "auto") {
+  if (providerId === "openai") {
     if (settings.selectedChatMode === "local-agent") {
       return {
         reasoning: {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Implements reliable local‑agent auto behavior with model fallbacks and routes OpenAI through the Responses API; updates tests and snapshots accordingly.
> 
> - **Core logic**: Centralizes Pro model routing in `getProModelClient` with local‑agent handling:
>   - `auto` uses a client‑side fallback chain: `GPT_5.2` (Responses), `anthropic/claude-sonnet-4-5-20250929`, `gemini/gemini-3-flash-preview`
>   - OpenAI models in local‑agent go via `provider.responses(...)`
> - **Model constants**: Adds `GPT_5_2_MODEL_NAME`, `SONNET_4_5`, `GEMINI_3_FLASH`; updates `MODEL_OPTIONS` to use them; removes `auto` from `PROVIDERS_THAT_SUPPORT_THINKING`.
> - **E2E**: Adds `clickRunSecurityReview()` helper and switches tests to use it; in local‑agent setup selects Anthropic model; snapshots updated (`thinking` → `reasoning_effort`, model labels reflect Anthropic).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a583f343f777c33c49336f31f22d4783040f73f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables reliable local-agent auto mode with smart model fallback and routes OpenAI models through Responses to keep reasoning features working. Standardizes model names with constants.

- **New Features**
  - Auto mode falls back across GPT‑5.2 (OpenAI), Claude Sonnet 4.5 (Anthropic), and Gemini 3 Flash (Google).
  - OpenAI models use the Responses API to support thinking summaries and full functionality.
  - Auto provider enables reasoning options in local-agent.

- **Refactors**
  - Centralized pro model routing in getProModelClient and avoids free variants.
  - Added constants for model IDs (GPT_5_2_MODEL_NAME, SONNET_4_5, GEMINI_3_FLASH).

<sup>Written for commit a583f343f777c33c49336f31f22d4783040f73f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

