### PR TITLE
Agent TODOs tool

### DIFF
--- a/e2e-tests/snapshots/local_agent_basic.spec.ts_local-agent---dump-request-1.txt
+++ b/e2e-tests/snapshots/local_agent_basic.spec.ts_local-agent---dump-request-1.txt
@@ -324,6 +324,58 @@
             "$schema": "http://json-schema.org/draft-07/schema#"
           }
         }
+      },
+      {
+        "type": "function",
+        "function": {
+          "name": "update_todos",
+          "description": "\n### When to Use This Tool\n\nUse proactively for:\n1. Complex multi-step tasks (3+ distinct steps)\n2. Non-trivial tasks requiring careful planning\n3. User explicitly requests todo list\n4. User provides multiple tasks (numbered/comma-separated)\n5. After completing tasks - mark complete with merge=true and add follow-ups\n6. When starting new tasks - mark as in_progress (ideally only one at a time)\n\n### When NOT to Use\n\nSkip for:\n1. Single, straightforward tasks\n2. Trivial tasks with no organizational benefit\n3. Tasks completable in < 3 trivial steps\n4. Purely conversational/informational requests\n5. Todo items should NOT include operational actions done in service of higher-level tasks.\n\nNEVER INCLUDE THESE IN TODOS: linting; testing; searching or examining the codebase.\n\n### Examples\n\n<example>\nUser: Add dark mode toggle to settings\nAssistant:\n- *Creates todo list:*\n1. Add state management [in_progress]\n2. Implement styles\n3. Create toggle component\n4. Update components\n- [Immediately begins working on todo 1 in the same tool call batch]\n<reasoning>\nMulti-step feature with dependencies.\n</reasoning>\n</example>\n\n<example>\n// User: Implement user registration, product catalog, shopping cart, checkout flow.\nAssistant: *Creates todo list breaking down each feature into specific tasks*\n<reasoning>\nMultiple complex features provided as list requiring organized task management.\n</reasoning>\n</example>\n\n### Task States and Management\n\n1. **Task States:**\n- pending: Not yet started\n- in_progress: Currently working on\n- completed: Finished successfully\n\n2. **Task Management:**\n- Update status in real-time\n- Mark complete IMMEDIATELY after finishing\n- Only ONE task in_progress at a time\n- Complete current tasks before starting new ones\n\n3. **Task Breakdown:**\n- Create specific, actionable items\n- Break complex tasks into manageable steps\n- Use clear, descriptive names\n\n4. **Parallel Todo Writes:**\n- Prefer creating the first todo as in_progress\n- Start working on todos by using tool calls in the same tool call batch as the todo write\n- Batch todo updates with other tool calls for better latency and lower costs for the user\n",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "merge": {
+                "type": "boolean",
+                "description": "Whether to merge the todos with the existing todos. If true, the todos will be merged into the existing todos based on the id field. You can leave unchanged properties undefined. If false, the new todos will replace the existing todos."
+              },
+              "todos": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "description": "Unique identifier for the todo item"
+                    },
+                    "content": {
+                      "type": "string",
+                      "description": "The description/content of the todo item"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "pending",
+                        "in_progress",
+                        "completed"
+                      ],
+                      "description": "The current status of the todo item"
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ],
+                  "additionalProperties": false
+                },
+                "description": "Array of todo items. When merge is true, only include todos that need updates. When merge is false, this is the complete list."
+              }
+            },
+            "required": [
+              "merge",
+              "todos"
+            ],
+            "additionalProperties": false,
+            "$schema": "http://json-schema.org/draft-07/schema#"
+          }
+        }
       }
     ],
     "tool_choice": "auto",

--- a/src/atoms/chatAtoms.ts
+++ b/src/atoms/chatAtoms.ts
@@ -1,4 +1,4 @@
-import type { FileAttachment, Message } from "@/ipc/ipc_types";
+import type { FileAttachment, Message, AgentTodo } from "@/ipc/ipc_types";
 import { atom } from "jotai";
 
 // Per-chat atoms implemented with maps keyed by chatId
@@ -28,3 +28,6 @@ export interface PendingAgentConsent {
 }
 
 export const pendingAgentConsentsAtom = atom<PendingAgentConsent[]>([]);
+
+// Agent todos per chat
+export const agentTodosByChatIdAtom = atom<Map<number, AgentTodo[]>>(new Map());

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -27,6 +27,7 @@ import {
   chatMessagesByIdAtom,
   selectedChatIdAtom,
   pendingAgentConsentsAtom,
+  agentTodosByChatIdAtom,
 } from "@/atoms/chatAtoms";
 import { atom, useAtom, useSetAtom, useAtomValue } from "jotai";
 import { useStreamChat } from "@/hooks/useStreamChat";
@@ -63,6 +64,7 @@ import { useSummarizeInNewChat } from "./SummarizeInNewChatButton";
 import { ChatInputControls } from "../ChatInputControls";
 import { ChatErrorBox } from "./ChatErrorBox";
 import { AgentConsentBanner } from "./AgentConsentBanner";
+import { TodoList } from "./TodoList";
 import {
   selectedComponentsPreviewAtom,
   previewIframeRefAtom,
@@ -121,6 +123,10 @@ export function ChatInput({ chatId }: { chatId?: number }) {
     (c) => c.chatId === chatId,
   );
   const pendingAgentConsent = consentsForThisChat[0] ?? null;
+
+  // Get todos for this chat
+  const agentTodosByChatId = useAtomValue(agentTodosByChatIdAtom);
+  const chatTodos = chatId ? (agentTodosByChatId.get(chatId) ?? []) : [];
   const { checkProblems } = useCheckProblems(appId);
   const { refreshAppIframe } = useRunApp();
   // Use the attachments hook
@@ -319,6 +325,8 @@ export function ChatInput({ chatId }: { chatId?: number }) {
           onDragLeave={handleDragLeave}
           onDrop={handleDrop}
         >
+          {/* Show todo list if there are todos for this chat */}
+          {chatTodos.length > 0 && <TodoList todos={chatTodos} />}
           {/* Show agent consent banner if there's a pending consent request */}
           {pendingAgentConsent && (
             <AgentConsentBanner

--- a/src/components/chat/TodoList.tsx
+++ b/src/components/chat/TodoList.tsx
@@ -1,0 +1,123 @@
+import React, { useState } from "react";
+import type { AgentTodo } from "@/ipc/ipc_types";
+import {
+  CheckCircle2,
+  Circle,
+  Loader2,
+  ChevronDown,
+  ChevronUp,
+  ListTodo,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface TodoListProps {
+  todos: AgentTodo[];
+}
+
+function getStatusIcon(status: AgentTodo["status"], size: "sm" | "md" = "sm") {
+  const sizeClass = size === "sm" ? "w-3.5 h-3.5" : "w-4 h-4";
+  switch (status) {
+    case "completed":
+      return (
+        <CheckCircle2
+          className={cn(sizeClass, "text-green-500 flex-shrink-0")}
+        />
+      );
+    case "in_progress":
+      return (
+        <Loader2
+          className={cn(sizeClass, "text-blue-500 animate-spin flex-shrink-0")}
+        />
+      );
+    case "pending":
+    default:
+      return (
+        <Circle
+          className={cn(sizeClass, "text-muted-foreground flex-shrink-0")}
+        />
+      );
+  }
+}
+
+export function TodoList({ todos }: TodoListProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  if (!todos.length) return null;
+
+  const completed = todos.filter((t) => t.status === "completed").length;
+  const total = todos.length;
+  const inProgressTask = todos.find((t) => t.status === "in_progress");
+
+  return (
+    <div className="border-b border-border bg-muted/30">
+      <button
+        type="button"
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="w-full flex items-center justify-between px-3 py-2 hover:bg-muted/50 transition-colors"
+      >
+        <div className="flex items-center gap-2.5 min-w-0 flex-1">
+          {isExpanded ? (
+            <>
+              <ListTodo className="w-4 h-4 text-muted-foreground flex-shrink-0" />
+              <span className="text-sm">
+                {completed} of {total} To-dos Completed
+              </span>
+            </>
+          ) : inProgressTask ? (
+            <>
+              {getStatusIcon("in_progress", "md")}
+              <span className="text-sm truncate">{inProgressTask.content}</span>
+              <span className="text-xs text-muted-foreground tabular-nums flex-shrink-0">
+                ({completed}/{total})
+              </span>
+            </>
+          ) : (
+            <>
+              {completed === total ? (
+                <CheckCircle2 className="w-4 h-4 text-green-500 flex-shrink-0" />
+              ) : (
+                <Circle className="w-4 h-4 text-muted-foreground flex-shrink-0" />
+              )}
+              <span className="text-sm text-muted-foreground">
+                {completed === total
+                  ? "All tasks completed"
+                  : "No task in progress"}
+              </span>
+              <span className="text-xs text-muted-foreground tabular-nums flex-shrink-0">
+                ({completed}/{total})
+              </span>
+            </>
+          )}
+        </div>
+        <div className="flex items-center gap-2 flex-shrink-0 ml-3">
+          {isExpanded ? (
+            <ChevronUp className="w-4 h-4 text-muted-foreground" />
+          ) : (
+            <ChevronDown className="w-4 h-4 text-muted-foreground" />
+          )}
+        </div>
+      </button>
+
+      {isExpanded && (
+        <ul className="px-3 pb-2.5 space-y-1.5">
+          {todos.map((todo) => (
+            <li
+              key={todo.id}
+              className={cn(
+                "flex items-center gap-2.5 text-sm py-0.5",
+                todo.status === "completed" && "text-muted-foreground",
+              )}
+            >
+              {getStatusIcon(todo.status)}
+              <span
+                className={cn(todo.status === "completed" && "line-through")}
+              >
+                {todo.content}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/ipc/ipc_client.ts
+++ b/src/ipc/ipc_client.ts
@@ -1007,7 +1007,7 @@ export class IpcClient {
   }
 
   /**
-   * Subscribe to be notified when any chat stream ends (either successfully or with an error).
+   * Subscribe to be notified when any chat stream starts.
    * Useful for cleanup tasks like clearing pending consent requests.
    * @returns Unsubscribe function
    */

--- a/src/ipc/ipc_types.ts
+++ b/src/ipc/ipc_types.ts
@@ -704,6 +704,21 @@ export interface AgentToolConsentResponseParams {
 
 export type AgentToolConsent = "ask" | "always";
 
+// ============================================================================
+// Agent Todo Types
+// ============================================================================
+
+export interface AgentTodo {
+  id: string;
+  content: string;
+  status: "pending" | "in_progress" | "completed";
+}
+
+export interface AgentTodosUpdatePayload {
+  chatId: number;
+  todos: AgentTodo[];
+}
+
 export interface TelemetryEventPayload {
   eventName: string;
   properties?: Record<string, unknown>;

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -175,6 +175,8 @@ const validReceiveChannels = [
   "mcp:tool-consent-request",
   // Agent tool consent request from main to renderer
   "agent-tool:consent-request",
+  // Agent todos update from main to renderer
+  "agent-tool:todos-update",
   // Telemetry events from main to renderer
   "telemetry:event",
 ] as const;

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -166,6 +166,7 @@ export async function handleLocalAgentStream(
       supabaseOrganizationSlug: chat.app.supabaseOrganizationSlug,
       messageId: placeholderMessageId,
       isSharedModulesChanged: false,
+      todos: [],
       onXmlStream: (accumulatedXml: string) => {
         // Stream accumulated XML to UI without persisting
         streamingPreview = accumulatedXml;
@@ -197,6 +198,12 @@ export async function handleLocalAgentStream(
       },
       appendUserMessage: (content: UserMessageContentPart[]) => {
         pendingUserMessages.push(content);
+      },
+      onUpdateTodos: (todos) => {
+        safeSend(event.sender, "agent-tool:todos-update", {
+          chatId: chat.id,
+          todos,
+        });
       },
     };
 

--- a/src/pro/main/ipc/handlers/local_agent/tool_definitions.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tool_definitions.ts
@@ -22,6 +22,7 @@ import { readLogsTool } from "./tools/read_logs";
 import { editFileTool } from "./tools/edit_file";
 import { webSearchTool } from "./tools/web_search";
 import { webCrawlTool } from "./tools/web_crawl";
+import { updateTodosTool } from "./tools/update_todos";
 import type { LanguageModelV3ToolResultOutput } from "@ai-sdk/provider";
 import {
   escapeXmlAttr,
@@ -51,6 +52,7 @@ export const TOOL_DEFINITIONS: readonly ToolDefinition[] = [
   readLogsTool,
   webSearchTool,
   webCrawlTool,
+  updateTodosTool,
 ];
 // ============================================================================
 // Agent Tool Name Type (derived from TOOL_DEFINITIONS)

--- a/src/pro/main/ipc/handlers/local_agent/tools/types.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/types.ts
@@ -5,7 +5,7 @@
 import { z } from "zod";
 import { IpcMainInvokeEvent } from "electron";
 import { jsonrepair } from "jsonrepair";
-import { AgentToolConsent } from "@/ipc/ipc_types";
+import { AgentToolConsent, AgentTodo } from "@/ipc/ipc_types";
 
 // ============================================================================
 // XML Escape Helpers
@@ -23,6 +23,13 @@ export function escapeXmlContent(str: string): string {
   return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
+// ============================================================================
+// Todo Types
+// ============================================================================
+
+// Re-export AgentTodo as Todo for backwards compatibility within this module
+export type Todo = AgentTodo;
+
 export interface AgentContext {
   event: IpcMainInvokeEvent;
   appPath: string;
@@ -32,6 +39,8 @@ export interface AgentContext {
   messageId: number;
   isSharedModulesChanged: boolean;
   chatSummary?: string;
+  /** Turn-scoped todo list for agent task tracking */
+  todos: Todo[];
   /**
    * Streams accumulated XML to UI without persisting to DB (for live preview).
    * Call this repeatedly with the full accumulated XML so far.
@@ -53,6 +62,11 @@ export interface AgentContext {
    * that models don't support in tool result messages.
    */
   appendUserMessage: (content: UserMessageContentPart[]) => void;
+  /**
+   * Sends updated todos to the renderer for UI display.
+   * Call this when todos are updated to show them in the chat input area.
+   */
+  onUpdateTodos: (todos: Todo[]) => void;
 }
 
 // ============================================================================

--- a/src/pro/main/ipc/handlers/local_agent/tools/update_todos.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/update_todos.ts
@@ -1,0 +1,162 @@
+import { z } from "zod";
+import { ToolDefinition, AgentContext, Todo } from "./types";
+
+const todoSchema = z.object({
+  id: z.string().describe("Unique identifier for the todo item"),
+  content: z
+    .string()
+    .optional()
+    .describe("The description/content of the todo item"),
+  status: z
+    .enum(["pending", "in_progress", "completed"])
+    .optional()
+    .describe("The current status of the todo item"),
+});
+
+const updateTodosSchema = z.object({
+  merge: z
+    .boolean()
+    .describe(
+      "Whether to merge the todos with the existing todos. If true, the todos will be merged into the existing todos based on the id field. You can leave unchanged properties undefined. If false, the new todos will replace the existing todos.",
+    ),
+  todos: z
+    .array(todoSchema)
+    .describe(
+      "Array of todo items. When merge is true, only include todos that need updates. When merge is false, this is the complete list.",
+    ),
+});
+const DESCRIPTION = `
+### When to Use This Tool
+
+Use proactively for:
+1. Complex multi-step tasks (3+ distinct steps)
+2. Non-trivial tasks requiring careful planning
+3. User explicitly requests todo list
+4. User provides multiple tasks (numbered/comma-separated)
+5. After completing tasks - mark complete with merge=true and add follow-ups
+6. When starting new tasks - mark as in_progress (ideally only one at a time)
+
+### When NOT to Use
+
+Skip for:
+1. Single, straightforward tasks
+2. Trivial tasks with no organizational benefit
+3. Tasks completable in < 3 trivial steps
+4. Purely conversational/informational requests
+5. Todo items should NOT include operational actions done in service of higher-level tasks.
+
+NEVER INCLUDE THESE IN TODOS: linting; testing; searching or examining the codebase.
+
+### Examples
+
+<example>
+User: Add dark mode toggle to settings
+Assistant:
+- *Creates todo list:*
+1. Add state management [in_progress]
+2. Implement styles
+3. Create toggle component
+4. Update components
+- [Immediately begins working on todo 1 in the same tool call batch]
+<reasoning>
+Multi-step feature with dependencies.
+</reasoning>
+</example>
+
+<example>
+// User: Implement user registration, product catalog, shopping cart, checkout flow.
+Assistant: *Creates todo list breaking down each feature into specific tasks*
+<reasoning>
+Multiple complex features provided as list requiring organized task management.
+</reasoning>
+</example>
+
+### Task States and Management
+
+1. **Task States:**
+- pending: Not yet started
+- in_progress: Currently working on
+- completed: Finished successfully
+
+2. **Task Management:**
+- Update status in real-time
+- Mark complete IMMEDIATELY after finishing
+- Only ONE task in_progress at a time
+- Complete current tasks before starting new ones
+
+3. **Task Breakdown:**
+- Create specific, actionable items
+- Break complex tasks into manageable steps
+- Use clear, descriptive names
+
+4. **Parallel Todo Writes:**
+- Prefer creating the first todo as in_progress
+- Start working on todos by using tool calls in the same tool call batch as the todo write
+- Batch todo updates with other tool calls for better latency and lower costs for the user
+`;
+export const updateTodosTool: ToolDefinition<
+  z.infer<typeof updateTodosSchema>
+> = {
+  name: "update_todos",
+  description: DESCRIPTION,
+  inputSchema: updateTodosSchema,
+  defaultConsent: "always",
+
+  getConsentPreview: (args) => {
+    const count = args.todos.length;
+    const completed = args.todos.filter((t) => t.status === "completed").length;
+    return `${completed}/${count} todos completed`;
+  },
+
+  execute: async (args, ctx: AgentContext) => {
+    if (args.merge) {
+      // Merge todos based on id
+      const existingTodosMap = new Map(ctx.todos.map((t) => [t.id, t]));
+      for (const todo of args.todos) {
+        const existing = existingTodosMap.get(todo.id);
+        if (existing) {
+          // Merge: only update defined properties
+          existingTodosMap.set(todo.id, {
+            ...existing,
+            ...(todo.content !== undefined && { content: todo.content }),
+            ...(todo.status !== undefined && { status: todo.status }),
+          });
+        } else {
+          // New todo - require all fields
+          if (todo.content === undefined || todo.status === undefined) {
+            throw new Error(
+              `New todo with id "${todo.id}" must have content and status defined`,
+            );
+          }
+          existingTodosMap.set(todo.id, todo as Todo);
+        }
+      }
+      ctx.todos = Array.from(existingTodosMap.values());
+    } else {
+      // Replace mode: require all fields
+      for (const todo of args.todos) {
+        if (todo.content === undefined || todo.status === undefined) {
+          throw new Error(
+            `Todo with id "${todo.id}" must have content and status defined when merge is false`,
+          );
+        }
+      }
+      ctx.todos = args.todos as Todo[];
+    }
+
+    // Send todos to renderer for UI display
+    ctx.onUpdateTodos(ctx.todos);
+
+    const completed = ctx.todos.filter((t) => t.status === "completed").length;
+    const inProgressTodos = ctx.todos.filter((t) => t.status === "in_progress");
+    const pendingTodos = ctx.todos.filter((t) => t.status === "pending");
+
+    const outstandingTodos = [...inProgressTodos, ...pendingTodos];
+    const outstandingList =
+      outstandingTodos.length > 0
+        ? `\n\nOutstanding todos:\n${outstandingTodos.map((t) => `- [${t.status}] ${t.content}`).join("\n")}`
+        : "";
+
+    return `Updated todos: ${completed} completed, ${inProgressTodos.length} in progress, ${pendingTodos.length} pending${outstandingList}`;
+  },
+};


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds end-to-end todo tracking for local agent runs with live UI updates.
> 
> - **New tool**: `update_todos` (merge/replace semantics, status updates) wired into agent `ToolSet` and exposed in model tools
> - **IPC plumbing**: new `agent-tool:todos-update` channel; `IpcClient.onAgentTodosUpdate`; preload whitelist updated; global `onChatStreamStart` hook to notify UI
> - **Types/state**: adds `AgentTodo` and `AgentTodosUpdatePayload`; new `agentTodosByChatIdAtom`; extends `AgentContext` with `todos` and `onUpdateTodos`
> - **UI**: new `TodoList` component; `ChatInput` renders todos when present
> - **Handler changes**: local agent handler emits todo updates; tool definitions register `update_todos`
> - **Tests**: e2e snapshot updated to include `update_todos` tool in available functions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d26de3cb0d0ca65cca67ab75b97dcea2ef046f7f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Agent TODOs tool and UI to track task progress during local agent runs. Live updates stream to the chat and display in a collapsible todo list, which clears when a new stream starts.

- **New Features**
  - Added update_todos tool with merge/replace support and status updates; broadcasts via onUpdateTodos.
  - Introduced IPC channel agent-tool:todos-update with IpcClient.onAgentTodosUpdate and preload whitelist.
  - Defined AgentTodo and AgentTodosUpdatePayload types.
  - Added agentTodosByChatIdAtom and cleanup on chat stream start.
  - Implemented TodoList UI and wired into ChatInput to show live progress and counts.

<sup>Written for commit d26de3cb0d0ca65cca67ab75b97dcea2ef046f7f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

