### PR TITLE
Initial ui theming

### DIFF
--- a/drizzle/0021_kind_luckman.sql
+++ b/drizzle/0021_kind_luckman.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `apps` ADD `theme_id` text;

--- a/drizzle/meta/0021_snapshot.json
+++ b/drizzle/meta/0021_snapshot.json
@@ -1,0 +1,795 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "fe227e2c-ae93-4d47-bdd6-61caf215311e",
+  "prevId": "6572da73-71b6-44ff-b997-05094c580dff",
+  "tables": {
+    "apps": {
+      "name": "apps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "github_org": {
+          "name": "github_org",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_repo": {
+          "name": "github_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_branch": {
+          "name": "github_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supabase_project_id": {
+          "name": "supabase_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supabase_parent_project_id": {
+          "name": "supabase_parent_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supabase_organization_slug": {
+          "name": "supabase_organization_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_project_id": {
+          "name": "neon_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_development_branch_id": {
+          "name": "neon_development_branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_preview_branch_id": {
+          "name": "neon_preview_branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vercel_project_id": {
+          "name": "vercel_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vercel_project_name": {
+          "name": "vercel_project_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vercel_team_id": {
+          "name": "vercel_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vercel_deployment_url": {
+          "name": "vercel_deployment_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "install_command": {
+          "name": "install_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_command": {
+          "name": "start_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chat_context": {
+          "name": "chat_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "theme_id": {
+          "name": "theme_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chats": {
+      "name": "chats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "initial_commit_hash": {
+          "name": "initial_commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chats_app_id_apps_id_fk": {
+          "name": "chats_app_id_apps_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "language_model_providers": {
+      "name": "language_model_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_base_url": {
+          "name": "api_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "env_var_name": {
+          "name": "env_var_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "language_models": {
+      "name": "language_models",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_name": {
+          "name": "api_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "builtin_provider_id": {
+          "name": "builtin_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "custom_provider_id": {
+          "name": "custom_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_output_tokens": {
+          "name": "max_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "language_models_custom_provider_id_language_model_providers_id_fk": {
+          "name": "language_models_custom_provider_id_language_model_providers_id_fk",
+          "tableFrom": "language_models",
+          "tableTo": "language_model_providers",
+          "columnsFrom": [
+            "custom_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "env_json": {
+          "name": "env_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_tool_consents": {
+      "name": "mcp_tool_consents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consent": {
+          "name": "consent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ask'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "uniq_mcp_consent": {
+          "name": "uniq_mcp_consent",
+          "columns": [
+            "server_id",
+            "tool_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "mcp_tool_consents_server_id_mcp_servers_id_fk": {
+          "name": "mcp_tool_consents_server_id_mcp_servers_id_fk",
+          "tableFrom": "mcp_tool_consents",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "approval_state": {
+          "name": "approval_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_commit_hash": {
+          "name": "source_commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "commit_hash": {
+          "name": "commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_tokens_used": {
+          "name": "max_tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ai_messages_json": {
+          "name": "ai_messages_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_chat_id_chats_id_fk": {
+          "name": "messages_chat_id_chats_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompts": {
+      "name": "prompts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "versions": {
+      "name": "versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "commit_hash": {
+          "name": "commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "neon_db_timestamp": {
+          "name": "neon_db_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "versions_app_commit_unique": {
+          "name": "versions_app_commit_unique",
+          "columns": [
+            "app_id",
+            "commit_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "versions_app_id_apps_id_fk": {
+          "name": "versions_app_id_apps_id_fk",
+          "tableFrom": "versions",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1766619976318,
       "tag": "0020_nebulous_patch",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "6",
+      "when": 1768167214574,
+      "tag": "0021_kind_luckman",
+      "breakpoints": true
     }
   ]
 }

--- a/e2e-tests/snapshots/context_window.spec.ts_context-window-1.txt
+++ b/e2e-tests/snapshots/context_window.spec.ts_context-window-1.txt
@@ -27,6 +27,58 @@ Available packages and libraries:
 ${BUILD_SYSTEM_POSTFIX}
 
 
+<theme>
+Any instruction in this theme should override other instructions if there's a contradiction.
+### Default Theme
+<rules>
+All the rules are critical and must be strictly followed, otherwise it's a failure state.
+#### Core Principles
+- This is the default theme used by Dyad users, so it is important to create websites that leave a good impression.
+- AESTHETICS ARE VERY IMPORTANT. All web apps should LOOK AMAZING and have GREAT FUNCTIONALITY!
+- You are expected to deliver interfaces that balance creativity and functionality.
+#### Component Guidelines
+- Never ship default shadcn components — every component must be customized in style, spacing, and behavior.
+- Always prefer rounded shapes.
+#### Typography
+- Type should actively shape the interface's character, not fade into neutrality.
+#### Color System
+- Establish a clear and confident color system.
+- Centralize colors through variables to maintain consistency.
+- Avoid using gradient backgrounds.
+- Avoid using black as the primary color. Aim for colorful websites.
+#### Motion & Interaction
+- Apply motion with restraint and purpose.
+- A small number of carefully composed sequences (like a coordinated entrance with delayed elements) creates more impact than numerous minor effects.
+- Motion should clarify structure and intent, not act as decoration.
+#### Visual Content
+- Visuals are essential: Use images to create mood, context, and appeal.
+- Don't build text-only walls.
+#### Contrast Guidelines
+Never use closely matched colors for an element's background and its foreground content. Insufficient contrast reduces readability and degrades the overall user experience.
+**Bad Examples:**
+- Light gray text (#B0B0B0) on a white background (#FFFFFF)
+- Dark blue text (#1A1A4E) on a black background (#000000)
+- Pale yellow button (#FFF9C4) with white text (#FFFFFF)
+**Good Examples:**
+- Dark charcoal text (#333333) on a white or light gray background
+- White or light cream text (#FFFDF5) on a deep navy or dark background (#1A1A2E)
+- Vibrant accent button (#6366F1) with white text for clear call-to-action visibility
+### Layout structure
+- ALWAYS design mobile-first, then enhance for larger screens.
+</rules>
+<workflow>
+Follow this workflow when building web apps:
+1. **Determine Design Direction**
+   - Analyze the industry and target users of the website.
+   - Define colors, fonts, mood, and visual style.
+   - Ensure the design direction does NOT contradict the rules defined for this theme.
+2. **Build the Application**
+   - Do not neglect functionality in the pursuit of making a beautiful website.
+   - You must achieve both great aesthetics AND great functionality.
+</workflow>
+</theme>
+
+
 If the user wants to use supabase or do something that requires auth, database or server-side functions (e.g. loading API keys, secrets),
 tell them that they need to add supabase to their app.
 

--- a/e2e-tests/snapshots/context_window.spec.ts_context-window-2.txt
+++ b/e2e-tests/snapshots/context_window.spec.ts_context-window-2.txt
@@ -27,6 +27,58 @@ Available packages and libraries:
 ${BUILD_SYSTEM_POSTFIX}
 
 
+<theme>
+Any instruction in this theme should override other instructions if there's a contradiction.
+### Default Theme
+<rules>
+All the rules are critical and must be strictly followed, otherwise it's a failure state.
+#### Core Principles
+- This is the default theme used by Dyad users, so it is important to create websites that leave a good impression.
+- AESTHETICS ARE VERY IMPORTANT. All web apps should LOOK AMAZING and have GREAT FUNCTIONALITY!
+- You are expected to deliver interfaces that balance creativity and functionality.
+#### Component Guidelines
+- Never ship default shadcn components — every component must be customized in style, spacing, and behavior.
+- Always prefer rounded shapes.
+#### Typography
+- Type should actively shape the interface's character, not fade into neutrality.
+#### Color System
+- Establish a clear and confident color system.
+- Centralize colors through variables to maintain consistency.
+- Avoid using gradient backgrounds.
+- Avoid using black as the primary color. Aim for colorful websites.
+#### Motion & Interaction
+- Apply motion with restraint and purpose.
+- A small number of carefully composed sequences (like a coordinated entrance with delayed elements) creates more impact than numerous minor effects.
+- Motion should clarify structure and intent, not act as decoration.
+#### Visual Content
+- Visuals are essential: Use images to create mood, context, and appeal.
+- Don't build text-only walls.
+#### Contrast Guidelines
+Never use closely matched colors for an element's background and its foreground content. Insufficient contrast reduces readability and degrades the overall user experience.
+**Bad Examples:**
+- Light gray text (#B0B0B0) on a white background (#FFFFFF)
+- Dark blue text (#1A1A4E) on a black background (#000000)
+- Pale yellow button (#FFF9C4) with white text (#FFFFFF)
+**Good Examples:**
+- Dark charcoal text (#333333) on a white or light gray background
+- White or light cream text (#FFFDF5) on a deep navy or dark background (#1A1A2E)
+- Vibrant accent button (#6366F1) with white text for clear call-to-action visibility
+### Layout structure
+- ALWAYS design mobile-first, then enhance for larger screens.
+</rules>
+<workflow>
+Follow this workflow when building web apps:
+1. **Determine Design Direction**
+   - Analyze the industry and target users of the website.
+   - Define colors, fonts, mood, and visual style.
+   - Ensure the design direction does NOT contradict the rules defined for this theme.
+2. **Build the Application**
+   - Do not neglect functionality in the pursuit of making a beautiful website.
+   - You must achieve both great aesthetics AND great functionality.
+</workflow>
+</theme>
+
+
 If the user wants to use supabase or do something that requires auth, database or server-side functions (e.g. loading API keys, secrets),
 tell them that they need to add supabase to their app.
 

--- a/e2e-tests/snapshots/context_window.spec.ts_context-window-3.txt
+++ b/e2e-tests/snapshots/context_window.spec.ts_context-window-3.txt
@@ -27,6 +27,58 @@ Available packages and libraries:
 ${BUILD_SYSTEM_POSTFIX}
 
 
+<theme>
+Any instruction in this theme should override other instructions if there's a contradiction.
+### Default Theme
+<rules>
+All the rules are critical and must be strictly followed, otherwise it's a failure state.
+#### Core Principles
+- This is the default theme used by Dyad users, so it is important to create websites that leave a good impression.
+- AESTHETICS ARE VERY IMPORTANT. All web apps should LOOK AMAZING and have GREAT FUNCTIONALITY!
+- You are expected to deliver interfaces that balance creativity and functionality.
+#### Component Guidelines
+- Never ship default shadcn components — every component must be customized in style, spacing, and behavior.
+- Always prefer rounded shapes.
+#### Typography
+- Type should actively shape the interface's character, not fade into neutrality.
+#### Color System
+- Establish a clear and confident color system.
+- Centralize colors through variables to maintain consistency.
+- Avoid using gradient backgrounds.
+- Avoid using black as the primary color. Aim for colorful websites.
+#### Motion & Interaction
+- Apply motion with restraint and purpose.
+- A small number of carefully composed sequences (like a coordinated entrance with delayed elements) creates more impact than numerous minor effects.
+- Motion should clarify structure and intent, not act as decoration.
+#### Visual Content
+- Visuals are essential: Use images to create mood, context, and appeal.
+- Don't build text-only walls.
+#### Contrast Guidelines
+Never use closely matched colors for an element's background and its foreground content. Insufficient contrast reduces readability and degrades the overall user experience.
+**Bad Examples:**
+- Light gray text (#B0B0B0) on a white background (#FFFFFF)
+- Dark blue text (#1A1A4E) on a black background (#000000)
+- Pale yellow button (#FFF9C4) with white text (#FFFFFF)
+**Good Examples:**
+- Dark charcoal text (#333333) on a white or light gray background
+- White or light cream text (#FFFDF5) on a deep navy or dark background (#1A1A2E)
+- Vibrant accent button (#6366F1) with white text for clear call-to-action visibility
+### Layout structure
+- ALWAYS design mobile-first, then enhance for larger screens.
+</rules>
+<workflow>
+Follow this workflow when building web apps:
+1. **Determine Design Direction**
+   - Analyze the industry and target users of the website.
+   - Define colors, fonts, mood, and visual style.
+   - Ensure the design direction does NOT contradict the rules defined for this theme.
+2. **Build the Application**
+   - Do not neglect functionality in the pursuit of making a beautiful website.
+   - You must achieve both great aesthetics AND great functionality.
+</workflow>
+</theme>
+
+
 If the user wants to use supabase or do something that requires auth, database or server-side functions (e.g. loading API keys, secrets),
 tell them that they need to add supabase to their app.
 

--- a/e2e-tests/snapshots/context_window.spec.ts_context-window-5.txt
+++ b/e2e-tests/snapshots/context_window.spec.ts_context-window-5.txt
@@ -27,6 +27,58 @@ Available packages and libraries:
 ${BUILD_SYSTEM_POSTFIX}
 
 
+<theme>
+Any instruction in this theme should override other instructions if there's a contradiction.
+### Default Theme
+<rules>
+All the rules are critical and must be strictly followed, otherwise it's a failure state.
+#### Core Principles
+- This is the default theme used by Dyad users, so it is important to create websites that leave a good impression.
+- AESTHETICS ARE VERY IMPORTANT. All web apps should LOOK AMAZING and have GREAT FUNCTIONALITY!
+- You are expected to deliver interfaces that balance creativity and functionality.
+#### Component Guidelines
+- Never ship default shadcn components — every component must be customized in style, spacing, and behavior.
+- Always prefer rounded shapes.
+#### Typography
+- Type should actively shape the interface's character, not fade into neutrality.
+#### Color System
+- Establish a clear and confident color system.
+- Centralize colors through variables to maintain consistency.
+- Avoid using gradient backgrounds.
+- Avoid using black as the primary color. Aim for colorful websites.
+#### Motion & Interaction
+- Apply motion with restraint and purpose.
+- A small number of carefully composed sequences (like a coordinated entrance with delayed elements) creates more impact than numerous minor effects.
+- Motion should clarify structure and intent, not act as decoration.
+#### Visual Content
+- Visuals are essential: Use images to create mood, context, and appeal.
+- Don't build text-only walls.
+#### Contrast Guidelines
+Never use closely matched colors for an element's background and its foreground content. Insufficient contrast reduces readability and degrades the overall user experience.
+**Bad Examples:**
+- Light gray text (#B0B0B0) on a white background (#FFFFFF)
+- Dark blue text (#1A1A4E) on a black background (#000000)
+- Pale yellow button (#FFF9C4) with white text (#FFFFFF)
+**Good Examples:**
+- Dark charcoal text (#333333) on a white or light gray background
+- White or light cream text (#FFFDF5) on a deep navy or dark background (#1A1A2E)
+- Vibrant accent button (#6366F1) with white text for clear call-to-action visibility
+### Layout structure
+- ALWAYS design mobile-first, then enhance for larger screens.
+</rules>
+<workflow>
+Follow this workflow when building web apps:
+1. **Determine Design Direction**
+   - Analyze the industry and target users of the website.
+   - Define colors, fonts, mood, and visual style.
+   - Ensure the design direction does NOT contradict the rules defined for this theme.
+2. **Build the Application**
+   - Do not neglect functionality in the pursuit of making a beautiful website.
+   - You must achieve both great aesthetics AND great functionality.
+</workflow>
+</theme>
+
+
 If the user wants to use supabase or do something that requires auth, database or server-side functions (e.g. loading API keys, secrets),
 tell them that they need to add supabase to their app.
 
@@ -1029,46 +1081,6 @@ export default defineConfig(() => ({
 ===
 role: assistant
 message: OK, got it. I'm ready to help
-
-===
-role: user
-message: tc=1
-
-===
-role: assistant
-message: 1
-
-===
-role: user
-message: tc=2
-
-===
-role: assistant
-message: 2
-
-===
-role: user
-message: [dump] tc=3
-
-===
-role: assistant
-message: [[dyad-dump-path=*]]
-
-===
-role: user
-message: [dump] tc=4
-
-===
-role: assistant
-message: [[dyad-dump-path=*]]
-
-===
-role: user
-message: [dump] tc=5
-
-===
-role: assistant
-message: [[dyad-dump-path=*]]
 
 ===
 role: user

--- a/e2e-tests/snapshots/dump_messages.spec.ts_dump-messages-1.txt
+++ b/e2e-tests/snapshots/dump_messages.spec.ts_dump-messages-1.txt
@@ -27,6 +27,58 @@ Available packages and libraries:
 ${BUILD_SYSTEM_POSTFIX}
 
 
+<theme>
+Any instruction in this theme should override other instructions if there's a contradiction.
+### Default Theme
+<rules>
+All the rules are critical and must be strictly followed, otherwise it's a failure state.
+#### Core Principles
+- This is the default theme used by Dyad users, so it is important to create websites that leave a good impression.
+- AESTHETICS ARE VERY IMPORTANT. All web apps should LOOK AMAZING and have GREAT FUNCTIONALITY!
+- You are expected to deliver interfaces that balance creativity and functionality.
+#### Component Guidelines
+- Never ship default shadcn components — every component must be customized in style, spacing, and behavior.
+- Always prefer rounded shapes.
+#### Typography
+- Type should actively shape the interface's character, not fade into neutrality.
+#### Color System
+- Establish a clear and confident color system.
+- Centralize colors through variables to maintain consistency.
+- Avoid using gradient backgrounds.
+- Avoid using black as the primary color. Aim for colorful websites.
+#### Motion & Interaction
+- Apply motion with restraint and purpose.
+- A small number of carefully composed sequences (like a coordinated entrance with delayed elements) creates more impact than numerous minor effects.
+- Motion should clarify structure and intent, not act as decoration.
+#### Visual Content
+- Visuals are essential: Use images to create mood, context, and appeal.
+- Don't build text-only walls.
+#### Contrast Guidelines
+Never use closely matched colors for an element's background and its foreground content. Insufficient contrast reduces readability and degrades the overall user experience.
+**Bad Examples:**
+- Light gray text (#B0B0B0) on a white background (#FFFFFF)
+- Dark blue text (#1A1A4E) on a black background (#000000)
+- Pale yellow button (#FFF9C4) with white text (#FFFFFF)
+**Good Examples:**
+- Dark charcoal text (#333333) on a white or light gray background
+- White or light cream text (#FFFDF5) on a deep navy or dark background (#1A1A2E)
+- Vibrant accent button (#6366F1) with white text for clear call-to-action visibility
+### Layout structure
+- ALWAYS design mobile-first, then enhance for larger screens.
+</rules>
+<workflow>
+Follow this workflow when building web apps:
+1. **Determine Design Direction**
+   - Analyze the industry and target users of the website.
+   - Define colors, fonts, mood, and visual style.
+   - Ensure the design direction does NOT contradict the rules defined for this theme.
+2. **Build the Application**
+   - Do not neglect functionality in the pursuit of making a beautiful website.
+   - You must achieve both great aesthetics AND great functionality.
+</workflow>
+</theme>
+
+
 If the user wants to use supabase or do something that requires auth, database or server-side functions (e.g. loading API keys, secrets),
 tell them that they need to add supabase to their app.
 

--- a/e2e-tests/snapshots/mention_app.spec.ts_mention-app-without-pro-1.txt
+++ b/e2e-tests/snapshots/mention_app.spec.ts_mention-app-without-pro-1.txt
@@ -26,6 +26,58 @@ Available packages and libraries:
 
 ${BUILD_SYSTEM_POSTFIX}
 
+
+<theme>
+Any instruction in this theme should override other instructions if there's a contradiction.
+### Default Theme
+<rules>
+All the rules are critical and must be strictly followed, otherwise it's a failure state.
+#### Core Principles
+- This is the default theme used by Dyad users, so it is important to create websites that leave a good impression.
+- AESTHETICS ARE VERY IMPORTANT. All web apps should LOOK AMAZING and have GREAT FUNCTIONALITY!
+- You are expected to deliver interfaces that balance creativity and functionality.
+#### Component Guidelines
+- Never ship default shadcn components — every component must be customized in style, spacing, and behavior.
+- Always prefer rounded shapes.
+#### Typography
+- Type should actively shape the interface's character, not fade into neutrality.
+#### Color System
+- Establish a clear and confident color system.
+- Centralize colors through variables to maintain consistency.
+- Avoid using gradient backgrounds.
+- Avoid using black as the primary color. Aim for colorful websites.
+#### Motion & Interaction
+- Apply motion with restraint and purpose.
+- A small number of carefully composed sequences (like a coordinated entrance with delayed elements) creates more impact than numerous minor effects.
+- Motion should clarify structure and intent, not act as decoration.
+#### Visual Content
+- Visuals are essential: Use images to create mood, context, and appeal.
+- Don't build text-only walls.
+#### Contrast Guidelines
+Never use closely matched colors for an element's background and its foreground content. Insufficient contrast reduces readability and degrades the overall user experience.
+**Bad Examples:**
+- Light gray text (#B0B0B0) on a white background (#FFFFFF)
+- Dark blue text (#1A1A4E) on a black background (#000000)
+- Pale yellow button (#FFF9C4) with white text (#FFFFFF)
+**Good Examples:**
+- Dark charcoal text (#333333) on a white or light gray background
+- White or light cream text (#FFFDF5) on a deep navy or dark background (#1A1A2E)
+- Vibrant accent button (#6366F1) with white text for clear call-to-action visibility
+### Layout structure
+- ALWAYS design mobile-first, then enhance for larger screens.
+</rules>
+<workflow>
+Follow this workflow when building web apps:
+1. **Determine Design Direction**
+   - Analyze the industry and target users of the website.
+   - Define colors, fonts, mood, and visual style.
+   - Ensure the design direction does NOT contradict the rules defined for this theme.
+2. **Build the Application**
+   - Do not neglect functionality in the pursuit of making a beautiful website.
+   - You must achieve both great aesthetics AND great functionality.
+</workflow>
+</theme>
+
 # Referenced Apps
 The user has mentioned the following apps in their prompt: minimal-with-ai-rules. Their codebases have been included in the context for your reference. When referring to these apps, you can understand their structure and code to provide better assistance, however you should NOT edit the files in these referenced apps. The referenced apps are NOT part of the current app and are READ-ONLY.
 

--- a/e2e-tests/snapshots/mention_files.spec.ts_mention-file-1.txt
+++ b/e2e-tests/snapshots/mention_files.spec.ts_mention-file-1.txt
@@ -27,6 +27,58 @@ Available packages and libraries:
 ${BUILD_SYSTEM_POSTFIX}
 
 
+<theme>
+Any instruction in this theme should override other instructions if there's a contradiction.
+### Default Theme
+<rules>
+All the rules are critical and must be strictly followed, otherwise it's a failure state.
+#### Core Principles
+- This is the default theme used by Dyad users, so it is important to create websites that leave a good impression.
+- AESTHETICS ARE VERY IMPORTANT. All web apps should LOOK AMAZING and have GREAT FUNCTIONALITY!
+- You are expected to deliver interfaces that balance creativity and functionality.
+#### Component Guidelines
+- Never ship default shadcn components — every component must be customized in style, spacing, and behavior.
+- Always prefer rounded shapes.
+#### Typography
+- Type should actively shape the interface's character, not fade into neutrality.
+#### Color System
+- Establish a clear and confident color system.
+- Centralize colors through variables to maintain consistency.
+- Avoid using gradient backgrounds.
+- Avoid using black as the primary color. Aim for colorful websites.
+#### Motion & Interaction
+- Apply motion with restraint and purpose.
+- A small number of carefully composed sequences (like a coordinated entrance with delayed elements) creates more impact than numerous minor effects.
+- Motion should clarify structure and intent, not act as decoration.
+#### Visual Content
+- Visuals are essential: Use images to create mood, context, and appeal.
+- Don't build text-only walls.
+#### Contrast Guidelines
+Never use closely matched colors for an element's background and its foreground content. Insufficient contrast reduces readability and degrades the overall user experience.
+**Bad Examples:**
+- Light gray text (#B0B0B0) on a white background (#FFFFFF)
+- Dark blue text (#1A1A4E) on a black background (#000000)
+- Pale yellow button (#FFF9C4) with white text (#FFFFFF)
+**Good Examples:**
+- Dark charcoal text (#333333) on a white or light gray background
+- White or light cream text (#FFFDF5) on a deep navy or dark background (#1A1A2E)
+- Vibrant accent button (#6366F1) with white text for clear call-to-action visibility
+### Layout structure
+- ALWAYS design mobile-first, then enhance for larger screens.
+</rules>
+<workflow>
+Follow this workflow when building web apps:
+1. **Determine Design Direction**
+   - Analyze the industry and target users of the website.
+   - Define colors, fonts, mood, and visual style.
+   - Ensure the design direction does NOT contradict the rules defined for this theme.
+2. **Build the Application**
+   - Do not neglect functionality in the pursuit of making a beautiful website.
+   - You must achieve both great aesthetics AND great functionality.
+</workflow>
+</theme>
+
+
 If the user wants to use supabase or do something that requires auth, database or server-side functions (e.g. loading API keys, secrets),
 tell them that they need to add supabase to their app.
 

--- a/e2e-tests/snapshots/select_component.spec.ts_select-component-1.txt
+++ b/e2e-tests/snapshots/select_component.spec.ts_select-component-1.txt
@@ -27,6 +27,58 @@ Available packages and libraries:
 ${BUILD_SYSTEM_POSTFIX}
 
 
+<theme>
+Any instruction in this theme should override other instructions if there's a contradiction.
+### Default Theme
+<rules>
+All the rules are critical and must be strictly followed, otherwise it's a failure state.
+#### Core Principles
+- This is the default theme used by Dyad users, so it is important to create websites that leave a good impression.
+- AESTHETICS ARE VERY IMPORTANT. All web apps should LOOK AMAZING and have GREAT FUNCTIONALITY!
+- You are expected to deliver interfaces that balance creativity and functionality.
+#### Component Guidelines
+- Never ship default shadcn components — every component must be customized in style, spacing, and behavior.
+- Always prefer rounded shapes.
+#### Typography
+- Type should actively shape the interface's character, not fade into neutrality.
+#### Color System
+- Establish a clear and confident color system.
+- Centralize colors through variables to maintain consistency.
+- Avoid using gradient backgrounds.
+- Avoid using black as the primary color. Aim for colorful websites.
+#### Motion & Interaction
+- Apply motion with restraint and purpose.
+- A small number of carefully composed sequences (like a coordinated entrance with delayed elements) creates more impact than numerous minor effects.
+- Motion should clarify structure and intent, not act as decoration.
+#### Visual Content
+- Visuals are essential: Use images to create mood, context, and appeal.
+- Don't build text-only walls.
+#### Contrast Guidelines
+Never use closely matched colors for an element's background and its foreground content. Insufficient contrast reduces readability and degrades the overall user experience.
+**Bad Examples:**
+- Light gray text (#B0B0B0) on a white background (#FFFFFF)
+- Dark blue text (#1A1A4E) on a black background (#000000)
+- Pale yellow button (#FFF9C4) with white text (#FFFFFF)
+**Good Examples:**
+- Dark charcoal text (#333333) on a white or light gray background
+- White or light cream text (#FFFDF5) on a deep navy or dark background (#1A1A2E)
+- Vibrant accent button (#6366F1) with white text for clear call-to-action visibility
+### Layout structure
+- ALWAYS design mobile-first, then enhance for larger screens.
+</rules>
+<workflow>
+Follow this workflow when building web apps:
+1. **Determine Design Direction**
+   - Analyze the industry and target users of the website.
+   - Define colors, fonts, mood, and visual style.
+   - Ensure the design direction does NOT contradict the rules defined for this theme.
+2. **Build the Application**
+   - Do not neglect functionality in the pursuit of making a beautiful website.
+   - You must achieve both great aesthetics AND great functionality.
+</workflow>
+</theme>
+
+
 If the user wants to use supabase or do something that requires auth, database or server-side functions (e.g. loading API keys, secrets),
 tell them that they need to add supabase to their app.
 

--- a/e2e-tests/snapshots/select_component.spec.ts_select-component-next-js-1.txt
+++ b/e2e-tests/snapshots/select_component.spec.ts_select-component-next-js-1.txt
@@ -81,6 +81,58 @@ By following these guidelines, we can build a more robust, maintainable, and con
 ${BUILD_SYSTEM_POSTFIX}
 
 
+<theme>
+Any instruction in this theme should override other instructions if there's a contradiction.
+### Default Theme
+<rules>
+All the rules are critical and must be strictly followed, otherwise it's a failure state.
+#### Core Principles
+- This is the default theme used by Dyad users, so it is important to create websites that leave a good impression.
+- AESTHETICS ARE VERY IMPORTANT. All web apps should LOOK AMAZING and have GREAT FUNCTIONALITY!
+- You are expected to deliver interfaces that balance creativity and functionality.
+#### Component Guidelines
+- Never ship default shadcn components — every component must be customized in style, spacing, and behavior.
+- Always prefer rounded shapes.
+#### Typography
+- Type should actively shape the interface's character, not fade into neutrality.
+#### Color System
+- Establish a clear and confident color system.
+- Centralize colors through variables to maintain consistency.
+- Avoid using gradient backgrounds.
+- Avoid using black as the primary color. Aim for colorful websites.
+#### Motion & Interaction
+- Apply motion with restraint and purpose.
+- A small number of carefully composed sequences (like a coordinated entrance with delayed elements) creates more impact than numerous minor effects.
+- Motion should clarify structure and intent, not act as decoration.
+#### Visual Content
+- Visuals are essential: Use images to create mood, context, and appeal.
+- Don't build text-only walls.
+#### Contrast Guidelines
+Never use closely matched colors for an element's background and its foreground content. Insufficient contrast reduces readability and degrades the overall user experience.
+**Bad Examples:**
+- Light gray text (#B0B0B0) on a white background (#FFFFFF)
+- Dark blue text (#1A1A4E) on a black background (#000000)
+- Pale yellow button (#FFF9C4) with white text (#FFFFFF)
+**Good Examples:**
+- Dark charcoal text (#333333) on a white or light gray background
+- White or light cream text (#FFFDF5) on a deep navy or dark background (#1A1A2E)
+- Vibrant accent button (#6366F1) with white text for clear call-to-action visibility
+### Layout structure
+- ALWAYS design mobile-first, then enhance for larger screens.
+</rules>
+<workflow>
+Follow this workflow when building web apps:
+1. **Determine Design Direction**
+   - Analyze the industry and target users of the website.
+   - Define colors, fonts, mood, and visual style.
+   - Ensure the design direction does NOT contradict the rules defined for this theme.
+2. **Build the Application**
+   - Do not neglect functionality in the pursuit of making a beautiful website.
+   - You must achieve both great aesthetics AND great functionality.
+</workflow>
+</theme>
+
+
 If the user wants to use supabase or do something that requires auth, database or server-side functions (e.g. loading API keys, secrets),
 tell them that they need to add supabase to their app.
 

--- a/e2e-tests/snapshots/turbo_edits_v2.spec.ts_after-search-replace.txt
+++ b/e2e-tests/snapshots/turbo_edits_v2.spec.ts_after-search-replace.txt
@@ -1,20 +1,2 @@
 === src/pages/Index.tsx ===
-// Update this page (the content is just a fallback if you fail to update the page)
-
-import { MadeWithDyad } from "@/components/made-with-dyad";
-
-const Index = () => {
-  return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100">
-      <div className="text-center">
-        <h1 className="text-4xl font-bold mb-4">Welcome to the UPDATED App</h1>
-        <p className="text-xl text-gray-600">
-          Start building your amazing project here!
-        </p>
-      </div>
-      <MadeWithDyad />
-    </div>
-  );
-};
-
-export default Index;
+// FILE IS REPLACED WITH FALLBACK WRITE.

--- a/e2e-tests/snapshots/turbo_edits_v2.spec.ts_turbo-edits-v2---search-replace-dump-2.txt
+++ b/e2e-tests/snapshots/turbo_edits_v2.spec.ts_turbo-edits-v2---search-replace-dump-2.txt
@@ -114,6 +114,58 @@ def calculate_sum(items):
 
 
 
+<theme>
+Any instruction in this theme should override other instructions if there's a contradiction.
+### Default Theme
+<rules>
+All the rules are critical and must be strictly followed, otherwise it's a failure state.
+#### Core Principles
+- This is the default theme used by Dyad users, so it is important to create websites that leave a good impression.
+- AESTHETICS ARE VERY IMPORTANT. All web apps should LOOK AMAZING and have GREAT FUNCTIONALITY!
+- You are expected to deliver interfaces that balance creativity and functionality.
+#### Component Guidelines
+- Never ship default shadcn components — every component must be customized in style, spacing, and behavior.
+- Always prefer rounded shapes.
+#### Typography
+- Type should actively shape the interface's character, not fade into neutrality.
+#### Color System
+- Establish a clear and confident color system.
+- Centralize colors through variables to maintain consistency.
+- Avoid using gradient backgrounds.
+- Avoid using black as the primary color. Aim for colorful websites.
+#### Motion & Interaction
+- Apply motion with restraint and purpose.
+- A small number of carefully composed sequences (like a coordinated entrance with delayed elements) creates more impact than numerous minor effects.
+- Motion should clarify structure and intent, not act as decoration.
+#### Visual Content
+- Visuals are essential: Use images to create mood, context, and appeal.
+- Don't build text-only walls.
+#### Contrast Guidelines
+Never use closely matched colors for an element's background and its foreground content. Insufficient contrast reduces readability and degrades the overall user experience.
+**Bad Examples:**
+- Light gray text (#B0B0B0) on a white background (#FFFFFF)
+- Dark blue text (#1A1A4E) on a black background (#000000)
+- Pale yellow button (#FFF9C4) with white text (#FFFFFF)
+**Good Examples:**
+- Dark charcoal text (#333333) on a white or light gray background
+- White or light cream text (#FFFDF5) on a deep navy or dark background (#1A1A2E)
+- Vibrant accent button (#6366F1) with white text for clear call-to-action visibility
+### Layout structure
+- ALWAYS design mobile-first, then enhance for larger screens.
+</rules>
+<workflow>
+Follow this workflow when building web apps:
+1. **Determine Design Direction**
+   - Analyze the industry and target users of the website.
+   - Define colors, fonts, mood, and visual style.
+   - Ensure the design direction does NOT contradict the rules defined for this theme.
+2. **Build the Application**
+   - Do not neglect functionality in the pursuit of making a beautiful website.
+   - You must achieve both great aesthetics AND great functionality.
+</workflow>
+</theme>
+
+
 If the user wants to use supabase or do something that requires auth, database or server-side functions (e.g. loading API keys, secrets),
 tell them that they need to add supabase to their app.
 

--- a/e2e-tests/theme_selection.spec.ts
+++ b/e2e-tests/theme_selection.spec.ts
@@ -1,0 +1,77 @@
+import { test } from "./helpers/test_helper";
+import { expect } from "@playwright/test";
+
+test("theme selection - dyad-wide default theme is persisted", async ({
+  po,
+}) => {
+  await po.setUp();
+
+  // Verify initial settings state
+  const initialSettings = po.recordSettings();
+  expect(initialSettings.selectedThemeId).toBe("default");
+
+  // Open menu and select "No Theme"
+  await po
+    .getHomeChatInputContainer()
+    .getByTestId("auxiliary-actions-menu")
+    .click();
+  await po.page.getByRole("menuitem", { name: "Themes" }).hover();
+  await expect(po.page.getByTestId("theme-option-default")).toBeVisible();
+  await po.page.getByTestId("theme-option-none").click();
+  await expect(po.page.getByTestId("theme-option-none")).not.toBeVisible();
+
+  // Verify settings file was updated
+  expect(po.recordSettings().selectedThemeId).toBe("");
+
+  // Re-open and verify UI shows "No Theme" selected, then select "Default Theme" back
+  await po
+    .getHomeChatInputContainer()
+    .getByTestId("auxiliary-actions-menu")
+    .click();
+  await po.page.getByRole("menuitem", { name: "Themes" }).hover();
+  await expect(po.page.getByTestId("theme-option-none")).toHaveClass(
+    /bg-primary/,
+  );
+  await po.page.getByTestId("theme-option-default").click();
+  await expect(po.page.getByTestId("theme-option-default")).not.toBeVisible();
+
+  // Verify settings file was updated back to default
+  expect(po.recordSettings().selectedThemeId).toBe("default");
+});
+
+test("theme selection - app-specific theme is persisted", async ({ po }) => {
+  await po.setUp({ autoApprove: true });
+  await po.importApp("minimal");
+
+  // Open menu and select "Default Theme" for this app
+  await po
+    .getChatInputContainer()
+    .getByTestId("auxiliary-actions-menu")
+    .click();
+  await po.page.getByRole("menuitem", { name: "Themes" }).hover();
+  await expect(po.page.getByTestId("theme-option-none")).toBeVisible();
+  await po.page.getByTestId("theme-option-default").click();
+  await expect(po.page.getByTestId("theme-option-default")).not.toBeVisible();
+
+  // Re-open, verify selection, then switch to "No Theme"
+  await po
+    .getChatInputContainer()
+    .getByTestId("auxiliary-actions-menu")
+    .click();
+  await po.page.getByRole("menuitem", { name: "Themes" }).hover();
+  await expect(po.page.getByTestId("theme-option-default")).toHaveClass(
+    /bg-primary/,
+  );
+  await po.page.getByTestId("theme-option-none").click();
+  await expect(po.page.getByTestId("theme-option-none")).not.toBeVisible();
+
+  // Re-open and verify "No Theme" is selected
+  await po
+    .getChatInputContainer()
+    .getByTestId("auxiliary-actions-menu")
+    .click();
+  await po.page.getByRole("menuitem", { name: "Themes" }).hover();
+  await expect(po.page.getByTestId("theme-option-none")).toHaveClass(
+    /bg-primary/,
+  );
+});

--- a/src/__tests__/readSettings.test.ts
+++ b/src/__tests__/readSettings.test.ts
@@ -70,6 +70,7 @@ describe("readSettings", () => {
             "provider": "auto",
           },
           "selectedTemplateId": "react",
+          "selectedThemeId": "default",
           "telemetryConsent": "unset",
           "telemetryUserId": "[scrubbed]",
         }
@@ -319,6 +320,7 @@ describe("readSettings", () => {
             "provider": "auto",
           },
           "selectedTemplateId": "react",
+          "selectedThemeId": "default",
           "telemetryConsent": "unset",
           "telemetryUserId": "[scrubbed]",
         }

--- a/src/components/chat/AuxiliaryActionsMenu.tsx
+++ b/src/components/chat/AuxiliaryActionsMenu.tsx
@@ -5,6 +5,7 @@ import {
   ChartColumnIncreasing,
   Palette,
   Check,
+  Ban,
 } from "lucide-react";
 import {
   DropdownMenu,
@@ -16,6 +17,11 @@ import {
   DropdownMenuSeparator,
   DropdownMenuItem,
 } from "@/components/ui/dropdown-menu";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { Button } from "@/components/ui/button";
 import { ContextFilesPicker } from "@/components/ContextFilesPicker";
 import { FileAttachmentDropdown } from "./FileAttachmentDropdown";
@@ -116,6 +122,7 @@ export function AuxiliaryActionsMenu({
               data-testid="theme-option-none"
             >
               <div className="flex items-center w-full">
+                <Ban size={16} className="mr-2 text-muted-foreground" />
                 <span className="flex-1">No Theme</span>
                 {currentThemeId === null && (
                   <Check size={16} className="text-primary ml-2" />
@@ -127,19 +134,31 @@ export function AuxiliaryActionsMenu({
             {themes?.map((theme) => {
               const isSelected = currentThemeId === theme.id;
               return (
-                <DropdownMenuItem
-                  key={theme.id}
-                  onClick={() => handleThemeSelect(theme.id)}
-                  className={`py-2 px-3 ${isSelected ? "bg-primary/10" : ""}`}
-                  data-testid={`theme-option-${theme.id}`}
-                >
-                  <div className="flex items-center w-full">
-                    <span className="flex-1">{theme.name}</span>
-                    {isSelected && (
-                      <Check size={16} className="text-primary ml-2" />
-                    )}
-                  </div>
-                </DropdownMenuItem>
+                <Tooltip key={theme.id}>
+                  <TooltipTrigger asChild>
+                    <DropdownMenuItem
+                      onClick={() => handleThemeSelect(theme.id)}
+                      className={`py-2 px-3 ${isSelected ? "bg-primary/10" : ""}`}
+                      data-testid={`theme-option-${theme.id}`}
+                    >
+                      <div className="flex items-center w-full">
+                        {theme.icon === "palette" && (
+                          <Palette
+                            size={16}
+                            className="mr-2 text-muted-foreground"
+                          />
+                        )}
+                        <span className="flex-1">{theme.name}</span>
+                        {isSelected && (
+                          <Check size={16} className="text-primary ml-2" />
+                        )}
+                      </div>
+                    </DropdownMenuItem>
+                  </TooltipTrigger>
+                  <TooltipContent side="right">
+                    {theme.description}
+                  </TooltipContent>
+                </Tooltip>
               );
             })}
           </DropdownMenuSubContent>

--- a/src/components/chat/AuxiliaryActionsMenu.tsx
+++ b/src/components/chat/AuxiliaryActionsMenu.tsx
@@ -57,7 +57,8 @@ export function AuxiliaryActionsMenu({
 
   // Determine current theme: use app theme if appId exists, otherwise use settings
   // Note: settings stores empty string for "no theme", convert to null
-  const currentThemeId = appId ? appThemeId : settings?.selectedThemeId || null;
+  const currentThemeId =
+    appId != null ? appThemeId : settings?.selectedThemeId || null;
 
   const handleThemeSelect = async (themeId: string | null) => {
     if (appId) {

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -27,7 +27,6 @@ import {
   chatMessagesByIdAtom,
   selectedChatIdAtom,
   pendingAgentConsentsAtom,
-  agentTodosByChatIdAtom,
 } from "@/atoms/chatAtoms";
 import { atom, useAtom, useSetAtom, useAtomValue } from "jotai";
 import { useStreamChat } from "@/hooks/useStreamChat";
@@ -64,7 +63,6 @@ import { useSummarizeInNewChat } from "./SummarizeInNewChatButton";
 import { ChatInputControls } from "../ChatInputControls";
 import { ChatErrorBox } from "./ChatErrorBox";
 import { AgentConsentBanner } from "./AgentConsentBanner";
-import { TodoList } from "./TodoList";
 import {
   selectedComponentsPreviewAtom,
   previewIframeRefAtom,
@@ -123,10 +121,6 @@ export function ChatInput({ chatId }: { chatId?: number }) {
     (c) => c.chatId === chatId,
   );
   const pendingAgentConsent = consentsForThisChat[0] ?? null;
-
-  // Get todos for this chat
-  const agentTodosByChatId = useAtomValue(agentTodosByChatIdAtom);
-  const chatTodos = chatId ? (agentTodosByChatId.get(chatId) ?? []) : [];
   const { checkProblems } = useCheckProblems(appId);
   const { refreshAppIframe } = useRunApp();
   // Use the attachments hook
@@ -325,8 +319,6 @@ export function ChatInput({ chatId }: { chatId?: number }) {
           onDragLeave={handleDragLeave}
           onDrop={handleDrop}
         >
-          {/* Show todo list if there are todos for this chat */}
-          {chatTodos.length > 0 && <TodoList todos={chatTodos} />}
           {/* Show agent consent banner if there's a pending consent request */}
           {pendingAgentConsent && (
             <AgentConsentBanner
@@ -486,6 +478,7 @@ export function ChatInput({ chatId }: { chatId?: number }) {
               onFileSelect={handleFileSelect}
               showTokenBar={showTokenBar}
               toggleShowTokenBar={toggleShowTokenBar}
+              appId={appId ?? undefined}
             />
           </div>
           {/* TokenBar is only displayed when showTokenBar is true */}

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -27,6 +27,7 @@ import {
   chatMessagesByIdAtom,
   selectedChatIdAtom,
   pendingAgentConsentsAtom,
+  agentTodosByChatIdAtom,
 } from "@/atoms/chatAtoms";
 import { atom, useAtom, useSetAtom, useAtomValue } from "jotai";
 import { useStreamChat } from "@/hooks/useStreamChat";
@@ -63,6 +64,7 @@ import { useSummarizeInNewChat } from "./SummarizeInNewChatButton";
 import { ChatInputControls } from "../ChatInputControls";
 import { ChatErrorBox } from "./ChatErrorBox";
 import { AgentConsentBanner } from "./AgentConsentBanner";
+import { TodoList } from "./TodoList";
 import {
   selectedComponentsPreviewAtom,
   previewIframeRefAtom,
@@ -121,6 +123,10 @@ export function ChatInput({ chatId }: { chatId?: number }) {
     (c) => c.chatId === chatId,
   );
   const pendingAgentConsent = consentsForThisChat[0] ?? null;
+
+  // Get todos for this chat
+  const agentTodosByChatId = useAtomValue(agentTodosByChatIdAtom);
+  const chatTodos = chatId ? (agentTodosByChatId.get(chatId) ?? []) : [];
   const { checkProblems } = useCheckProblems(appId);
   const { refreshAppIframe } = useRunApp();
   // Use the attachments hook
@@ -319,6 +325,8 @@ export function ChatInput({ chatId }: { chatId?: number }) {
           onDragLeave={handleDragLeave}
           onDrop={handleDrop}
         >
+          {/* Show todo list if there are todos for this chat */}
+          {chatTodos.length > 0 && <TodoList todos={chatTodos} />}
           {/* Show agent consent banner if there's a pending consent request */}
           {pendingAgentConsent && (
             <AgentConsentBanner

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -58,6 +58,8 @@ export const apps = sqliteTable("apps", {
   isFavorite: integer("is_favorite", { mode: "boolean" })
     .notNull()
     .default(sql`0`),
+  // Theme ID for design system theming (null means "no theme")
+  themeId: text("theme_id"),
 });
 
 export const chats = sqliteTable("chats", {

--- a/src/hooks/useAppTheme.ts
+++ b/src/hooks/useAppTheme.ts
@@ -15,7 +15,6 @@ export function useAppTheme(appId: number | undefined) {
       return IpcClient.getInstance().getAppTheme({ appId: appId! });
     },
     enabled: !!appId,
-    staleTime: 30000,
   });
 
   const invalidate = () => {

--- a/src/hooks/useAppTheme.ts
+++ b/src/hooks/useAppTheme.ts
@@ -1,0 +1,32 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { IpcClient } from "@/ipc/ipc_client";
+
+export const APP_THEME_QUERY_KEY = (appId: number | undefined) => [
+  "app-theme",
+  appId,
+];
+
+export function useAppTheme(appId: number | undefined) {
+  const queryClient = useQueryClient();
+
+  const query = useQuery({
+    queryKey: APP_THEME_QUERY_KEY(appId),
+    queryFn: async (): Promise<string | null> => {
+      if (!appId) return null;
+      return IpcClient.getInstance().getAppTheme(appId);
+    },
+    enabled: !!appId,
+    staleTime: 30000, // Cache for 30 seconds
+  });
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: APP_THEME_QUERY_KEY(appId) });
+  };
+
+  return {
+    themeId: query.data ?? null,
+    isLoading: query.isLoading,
+    error: query.error,
+    invalidate,
+  };
+}

--- a/src/hooks/useAppTheme.ts
+++ b/src/hooks/useAppTheme.ts
@@ -12,11 +12,10 @@ export function useAppTheme(appId: number | undefined) {
   const query = useQuery({
     queryKey: APP_THEME_QUERY_KEY(appId),
     queryFn: async (): Promise<string | null> => {
-      if (!appId) return null;
-      return IpcClient.getInstance().getAppTheme(appId);
+      return IpcClient.getInstance().getAppTheme(appId!);
     },
     enabled: !!appId,
-    staleTime: 30000, // Cache for 30 seconds
+    staleTime: 30000,
   });
 
   const invalidate = () => {

--- a/src/hooks/useAppTheme.ts
+++ b/src/hooks/useAppTheme.ts
@@ -12,7 +12,7 @@ export function useAppTheme(appId: number | undefined) {
   const query = useQuery({
     queryKey: APP_THEME_QUERY_KEY(appId),
     queryFn: async (): Promise<string | null> => {
-      return IpcClient.getInstance().getAppTheme(appId!);
+      return IpcClient.getInstance().getAppTheme({ appId: appId! });
     },
     enabled: !!appId,
     staleTime: 30000,

--- a/src/hooks/useThemes.ts
+++ b/src/hooks/useThemes.ts
@@ -1,0 +1,24 @@
+import { useQuery } from "@tanstack/react-query";
+import { IpcClient } from "@/ipc/ipc_client";
+import { themesData, type Theme } from "@/shared/themes";
+
+export function useThemes() {
+  const query = useQuery({
+    queryKey: ["themes"],
+    queryFn: async (): Promise<Theme[]> => {
+      const ipcClient = IpcClient.getInstance();
+      return ipcClient.getThemes();
+    },
+    placeholderData: themesData,
+    meta: {
+      showErrorToast: true,
+    },
+  });
+
+  return {
+    themes: query.data,
+    isLoading: query.isLoading,
+    error: query.error,
+    refetch: query.refetch,
+  };
+}

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -20,6 +20,7 @@ import {
   constructSystemPrompt,
   readAiRules,
 } from "../../prompts/system_prompt";
+import { getThemePrompt } from "../../shared/themes";
 import {
   SUPABASE_AVAILABLE_SYSTEM_PROMPT,
   SUPABASE_NOT_AVAILABLE_SYSTEM_PROMPT,
@@ -609,6 +610,12 @@ ${componentSnippet}
 
         const aiRules = await readAiRules(getDyadAppPath(updatedChat.app.path));
 
+        // Get theme prompt for the app (null/undefined themeId means "no theme")
+        const themePrompt = getThemePrompt(updatedChat.app.themeId);
+        logger.log(
+          `Theme for app ${updatedChat.app.id}: ${updatedChat.app.themeId ?? "none"}, prompt length: ${themePrompt.length} chars`,
+        );
+
         let systemPrompt = constructSystemPrompt({
           aiRules,
           chatMode:
@@ -616,6 +623,7 @@ ${componentSnippet}
               ? "build"
               : settings.selectedChatMode,
           enableTurboEditsV2: isTurboEditsV2Enabled(settings),
+          themePrompt,
         });
 
         // Add information about mentioned apps if any

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -610,7 +610,7 @@ ${componentSnippet}
 
         const aiRules = await readAiRules(getDyadAppPath(updatedChat.app.path));
 
-        // Get theme prompt for the app (null/undefined themeId means "no theme")
+        // Get theme prompt for the app (null themeId means "no theme")
         const themePrompt = getThemePrompt(updatedChat.app.themeId);
         logger.log(
           `Theme for app ${updatedChat.app.id}: ${updatedChat.app.themeId ?? "none"}, prompt length: ${themePrompt.length} chars`,

--- a/src/ipc/handlers/themes_handlers.ts
+++ b/src/ipc/handlers/themes_handlers.ts
@@ -1,0 +1,47 @@
+import { createLoggedHandler } from "./safe_handle";
+import log from "electron-log";
+import { themesData, type Theme } from "../../shared/themes";
+import { db } from "../../db";
+import { apps } from "../../db/schema";
+import { eq, sql } from "drizzle-orm";
+
+const logger = log.scope("themes_handlers");
+const handle = createLoggedHandler(logger);
+
+export function registerThemesHandlers() {
+  handle("get-themes", async (): Promise<Theme[]> => {
+    return themesData;
+  });
+
+  handle(
+    "set-app-theme",
+    async (
+      _,
+      params: { appId: number; themeId: string | null },
+    ): Promise<void> => {
+      const { appId, themeId } = params;
+      // Use raw SQL to properly set NULL when themeId is null/undefined
+      if (themeId === null || themeId === undefined || themeId === "none") {
+        await db
+          .update(apps)
+          .set({ themeId: sql`NULL` })
+          .where(eq(apps.id, appId));
+        logger.log(`Set theme for app ${appId} to none`);
+      } else {
+        await db.update(apps).set({ themeId }).where(eq(apps.id, appId));
+        logger.log(`Set theme for app ${appId} to ${themeId}`);
+      }
+    },
+  );
+
+  handle(
+    "get-app-theme",
+    async (_, params: { appId: number }): Promise<string | null> => {
+      const app = await db.query.apps.findFirst({
+        where: eq(apps.id, params.appId),
+        columns: { themeId: true },
+      });
+      return app?.themeId ?? null;
+    },
+  );
+}

--- a/src/ipc/handlers/themes_handlers.ts
+++ b/src/ipc/handlers/themes_handlers.ts
@@ -4,6 +4,7 @@ import { themesData, type Theme } from "../../shared/themes";
 import { db } from "../../db";
 import { apps } from "../../db/schema";
 import { eq, sql } from "drizzle-orm";
+import type { SetAppThemeParams, GetAppThemeParams } from "../ipc_types";
 
 const logger = log.scope("themes_handlers");
 const handle = createLoggedHandler(logger);
@@ -15,10 +16,7 @@ export function registerThemesHandlers() {
 
   handle(
     "set-app-theme",
-    async (
-      _,
-      params: { appId: number; themeId: string | null },
-    ): Promise<void> => {
+    async (_, params: SetAppThemeParams): Promise<void> => {
       const { appId, themeId } = params;
       // Use raw SQL to properly set NULL when themeId is null (representing "no theme")
       if (!themeId) {
@@ -34,7 +32,7 @@ export function registerThemesHandlers() {
 
   handle(
     "get-app-theme",
-    async (_, params: { appId: number }): Promise<string | null> => {
+    async (_, params: GetAppThemeParams): Promise<string | null> => {
       const app = await db.query.apps.findFirst({
         where: eq(apps.id, params.appId),
         columns: { themeId: true },

--- a/src/ipc/handlers/themes_handlers.ts
+++ b/src/ipc/handlers/themes_handlers.ts
@@ -20,16 +20,14 @@ export function registerThemesHandlers() {
       params: { appId: number; themeId: string | null },
     ): Promise<void> => {
       const { appId, themeId } = params;
-      // Use raw SQL to properly set NULL when themeId is null/undefined
-      if (themeId === null || themeId === undefined || themeId === "none") {
+      // Use raw SQL to properly set NULL when themeId is null (representing "no theme")
+      if (!themeId) {
         await db
           .update(apps)
           .set({ themeId: sql`NULL` })
           .where(eq(apps.id, appId));
-        logger.log(`Set theme for app ${appId} to none`);
       } else {
         await db.update(apps).set({ themeId }).where(eq(apps.id, appId));
-        logger.log(`Set theme for app ${appId} to ${themeId}`);
       }
     },
   );

--- a/src/ipc/handlers/token_count_handlers.ts
+++ b/src/ipc/handlers/token_count_handlers.ts
@@ -5,6 +5,7 @@ import {
   constructSystemPrompt,
   readAiRules,
 } from "../../prompts/system_prompt";
+import { getThemePrompt } from "../../shared/themes";
 import {
   SUPABASE_AVAILABLE_SYSTEM_PROMPT,
   SUPABASE_NOT_AVAILABLE_SYSTEM_PROMPT,
@@ -61,6 +62,7 @@ export function registerTokenCountHandlers() {
       const mentionedAppNames = parseAppMentions(req.input);
 
       // Count system prompt tokens
+      const themePrompt = getThemePrompt(chat.app?.themeId ?? null);
       let systemPrompt = constructSystemPrompt({
         aiRules: await readAiRules(getDyadAppPath(chat.app.path)),
         chatMode:
@@ -69,6 +71,7 @@ export function registerTokenCountHandlers() {
             ? "build"
             : settings.selectedChatMode,
         enableTurboEditsV2: isTurboEditsV2Enabled(settings),
+        themePrompt,
       });
       let supabaseContext = "";
 

--- a/src/ipc/ipc_client.ts
+++ b/src/ipc/ipc_client.ts
@@ -86,6 +86,8 @@ import type {
   TelemetryEventPayload,
   GithubSyncOptions,
   ConsoleEntry,
+  SetAppThemeParams,
+  GetAppThemeParams,
 } from "./ipc_types";
 import type { Template } from "../shared/templates";
 import type { Theme } from "../shared/themes";
@@ -1620,15 +1622,12 @@ export class IpcClient {
     return this.ipcRenderer.invoke("get-themes");
   }
 
-  public async setAppTheme(params: {
-    appId: number;
-    themeId: string | null;
-  }): Promise<void> {
+  public async setAppTheme(params: SetAppThemeParams): Promise<void> {
     await this.ipcRenderer.invoke("set-app-theme", params);
   }
 
-  public async getAppTheme(appId: number): Promise<string | null> {
-    return this.ipcRenderer.invoke("get-app-theme", { appId });
+  public async getAppTheme(params: GetAppThemeParams): Promise<string | null> {
+    return this.ipcRenderer.invoke("get-app-theme", params);
   }
 
   // --- Prompts Library ---

--- a/src/ipc/ipc_client.ts
+++ b/src/ipc/ipc_client.ts
@@ -88,6 +88,7 @@ import type {
   ConsoleEntry,
 } from "./ipc_types";
 import type { Template } from "../shared/templates";
+import type { Theme } from "../shared/themes";
 import type {
   AppChatContext,
   AppSearchResult,
@@ -1612,6 +1613,22 @@ export class IpcClient {
   // Template methods
   public async getTemplates(): Promise<Template[]> {
     return this.ipcRenderer.invoke("get-templates");
+  }
+
+  // --- Themes ---
+  public async getThemes(): Promise<Theme[]> {
+    return this.ipcRenderer.invoke("get-themes");
+  }
+
+  public async setAppTheme(params: {
+    appId: number;
+    themeId: string | null;
+  }): Promise<void> {
+    await this.ipcRenderer.invoke("set-app-theme", params);
+  }
+
+  public async getAppTheme(appId: number): Promise<string | null> {
+    return this.ipcRenderer.invoke("get-app-theme", { appId });
   }
 
   // --- Prompts Library ---

--- a/src/ipc/ipc_host.ts
+++ b/src/ipc/ipc_host.ts
@@ -28,6 +28,7 @@ import { registerCapacitorHandlers } from "./handlers/capacitor_handlers";
 import { registerProblemsHandlers } from "./handlers/problems_handlers";
 import { registerAppEnvVarsHandlers } from "./handlers/app_env_vars_handlers";
 import { registerTemplateHandlers } from "./handlers/template_handlers";
+import { registerThemesHandlers } from "./handlers/themes_handlers";
 import { registerPortalHandlers } from "./handlers/portal_handlers";
 import { registerPromptHandlers } from "./handlers/prompt_handlers";
 import { registerHelpBotHandlers } from "./handlers/help_bot_handlers";
@@ -68,6 +69,7 @@ export function registerIpcHandlers() {
   registerCapacitorHandlers();
   registerAppEnvVarsHandlers();
   registerTemplateHandlers();
+  registerThemesHandlers();
   registerPortalHandlers();
   registerPromptHandlers();
   registerHelpBotHandlers();

--- a/src/ipc/ipc_types.ts
+++ b/src/ipc/ipc_types.ts
@@ -735,3 +735,13 @@ export interface TelemetryEventPayload {
   eventName: string;
   properties?: Record<string, unknown>;
 }
+
+// --- Theme Types ---
+export interface SetAppThemeParams {
+  appId: number;
+  themeId: string | null;
+}
+
+export interface GetAppThemeParams {
+  appId: number;
+}

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -287,6 +287,7 @@ export const UserSettingsSchema = z.object({
   enableProWebSearch: z.boolean().optional(),
   proSmartContextOption: SmartContextModeSchema.optional(),
   selectedTemplateId: z.string(),
+  selectedThemeId: z.string().optional(),
   enableSupabaseWriteSqlMigration: z.boolean().optional(),
   selectedChatMode: ChatModeSchema.optional(),
   acceptedCommunityCode: z.boolean().optional(),

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -11,6 +11,7 @@ import { safeStorage } from "electron";
 import { v4 as uuidv4 } from "uuid";
 import log from "electron-log";
 import { DEFAULT_TEMPLATE_ID } from "@/shared/templates";
+import { DEFAULT_THEME_ID } from "@/shared/themes";
 import { IS_TEST_BUILD } from "@/ipc/utils/test_utils";
 
 const logger = log.scope("settings");
@@ -34,6 +35,7 @@ const DEFAULT_SETTINGS: UserSettings = {
   enableAutoUpdate: true,
   releaseChannel: "stable",
   selectedTemplateId: DEFAULT_TEMPLATE_ID,
+  selectedThemeId: DEFAULT_THEME_ID,
   isRunning: false,
   lastKnownPerformance: undefined,
   // Enabled by default in 0.33.0-beta.1

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -160,11 +160,11 @@ export default function HomePage() {
         });
       }
 
-      // Apply selected theme to the new app
-      if (settings?.selectedThemeId && settings.selectedThemeId !== "none") {
+      // Apply selected theme to the new app (if one is set)
+      if (settings?.selectedThemeId) {
         await IpcClient.getInstance().setAppTheme({
           appId: result.app.id,
-          themeId: settings.selectedThemeId,
+          themeId: settings.selectedThemeId || null,
         });
       }
 

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -160,6 +160,14 @@ export default function HomePage() {
         });
       }
 
+      // Apply selected theme to the new app
+      if (settings?.selectedThemeId && settings.selectedThemeId !== "none") {
+        await IpcClient.getInstance().setAppTheme({
+          appId: result.app.id,
+          themeId: settings.selectedThemeId,
+        });
+      }
+
       // Stream the message with attachments
       streamMessage({
         prompt: inputValue,

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -167,6 +167,10 @@ const validInvokeChannels = [
   // Console logs
   "add-log",
   "clear-logs",
+  // Themes
+  "get-themes",
+  "set-app-theme",
+  "get-app-theme",
   // Test-only channels
   // These should ALWAYS be guarded with IS_TEST_BUILD in the main process.
   // We can't detect with IS_TEST_BUILD in the preload script because

--- a/src/prompts/local_agent_prompt.ts
+++ b/src/prompts/local_agent_prompt.ts
@@ -87,9 +87,19 @@ Available packages and libraries:
 - Use prebuilt components from the shadcn/ui library after importing them. Note that these files shouldn't be edited, so make new components if you need to change them.
 `;
 
-export function constructLocalAgentPrompt(aiRules: string | undefined): string {
-  return LOCAL_AGENT_SYSTEM_PROMPT.replace(
+export function constructLocalAgentPrompt(
+  aiRules: string | undefined,
+  themePrompt?: string,
+): string {
+  let prompt = LOCAL_AGENT_SYSTEM_PROMPT.replace(
     "[[AI_RULES]]",
     aiRules ?? DEFAULT_AI_RULES,
   );
+
+  // Append theme prompt if provided
+  if (themePrompt) {
+    prompt += "\n\n" + themePrompt;
+  }
+
+  return prompt;
 }

--- a/src/prompts/system_prompt.ts
+++ b/src/prompts/system_prompt.ts
@@ -508,20 +508,32 @@ export const constructSystemPrompt = ({
   aiRules,
   chatMode = "build",
   enableTurboEditsV2,
+  themePrompt,
 }: {
   aiRules: string | undefined;
   chatMode?: "build" | "ask" | "agent" | "local-agent";
   enableTurboEditsV2: boolean;
+  themePrompt?: string;
 }) => {
   if (chatMode === "local-agent") {
-    return constructLocalAgentPrompt(aiRules);
+    return constructLocalAgentPrompt(aiRules, themePrompt);
   }
 
-  const systemPrompt = getSystemPromptForChatMode({
+  let systemPrompt = getSystemPromptForChatMode({
     chatMode,
     enableTurboEditsV2,
   });
-  return systemPrompt.replace("[[AI_RULES]]", aiRules ?? DEFAULT_AI_RULES);
+  systemPrompt = systemPrompt.replace(
+    "[[AI_RULES]]",
+    aiRules ?? DEFAULT_AI_RULES,
+  );
+
+  // Append theme prompt if provided
+  if (themePrompt) {
+    systemPrompt += "\n\n" + themePrompt;
+  }
+
+  return systemPrompt;
 };
 
 export const getSystemPromptForChatMode = ({

--- a/src/shared/themes.ts
+++ b/src/shared/themes.ts
@@ -1,0 +1,88 @@
+export interface Theme {
+  id: string;
+  name: string;
+  description: string;
+  prompt: string;
+}
+
+export const DEFAULT_THEME_ID = "none";
+
+const DEFAULT_THEME_PROMPT = `
+<theme>
+Any instruction in this theme should override other instructions if there's a contradiction.
+### Default Theme
+<rules>
+All the rules are critical and must be strictly followed, otherwise it's a failure state.
+#### Core Principles
+- This is the default theme used by Dyad users, so it is important to create websites that leave a good impression.
+- AESTHETICS ARE VERY IMPORTANT. All web apps should LOOK AMAZING and have GREAT FUNCTIONALITY!
+- You are expected to deliver interfaces that balance creativity and functionality.
+#### Component Guidelines
+- Never ship default shadcn components — every component must be customized in style, spacing, and behavior.
+- Always prefer rounded shapes.
+#### Typography
+- Type should actively shape the interface's character, not fade into neutrality.
+#### Color System
+- Establish a clear and confident color system.
+- Centralize colors through variables to maintain consistency.
+- Avoid using gradient backgrounds.
+- Avoid using black as the primary color.Aim for colorful websites.
+#### Motion & Interaction
+- Apply motion with restraint and purpose.
+- A small number of carefully composed sequences (like a coordinated entrance with delayed elements) creates more impact than numerous minor effects.
+- Motion should clarify structure and intent, not act as decoration.
+#### Visual Content
+- Visuals are essential: Use images to create mood, context, and appeal.
+- Don't build text-only walls.
+#### Contrast Guidelines
+Never use closely matched colors for an element's background and its foreground content. Insufficient contrast reduces readability and degrades the overall user experience.
+**Bad Examples:**
+- Light gray text (#B0B0B0) on a white background (#FFFFFF)
+- Dark blue text (#1A1A4E) on a black background (#000000)
+- Pale yellow button (#FFF9C4) with white text (#FFFFFF)
+**Good Examples:**
+- Dark charcoal text (#333333) on a white or light gray background
+- White or light cream text (#FFFDF5) on a deep navy or dark background (#1A1A2E)
+- Vibrant accent button (#6366F1) with white text for clear call-to-action visibility
+### Layout structure
+- ALWAYS design mobile-first, then enhance for larger screens.
+</rules>
+<workflow>
+Follow this workflow when building web apps:
+1. **Determine Design Direction**
+   - Analyze the industry and target users of the website.
+   - Define colors, fonts, mood, and visual style.
+   - Ensure the design direction does NOT contradict the rules defined for this theme.
+2. **Build the Application**
+   - Do not neglect functionality in the pursuit of making a beautiful website.
+   - You must achieve both great aesthetics AND great functionality.
+</workflow>
+</theme>`;
+
+export const themesData: Theme[] = [
+  {
+    id: "none",
+    name: "No Theme",
+    description: "Minimal styling guidance - uses the default AI behavior.",
+    prompt: "",
+  },
+  {
+    id: "default",
+    name: "Default Theme",
+    description:
+      "Balanced design system emphasizing aesthetics, contrast, and functionality.",
+    prompt: DEFAULT_THEME_PROMPT,
+  },
+];
+
+export function getThemeById(themeId: string | null): Theme | undefined {
+  if (!themeId) {
+    return themesData.find((t) => t.id === DEFAULT_THEME_ID);
+  }
+  return themesData.find((t) => t.id === themeId);
+}
+
+export function getThemePrompt(themeId: string | null): string {
+  const theme = getThemeById(themeId);
+  return theme?.prompt ?? "";
+}

--- a/src/shared/themes.ts
+++ b/src/shared/themes.ts
@@ -2,8 +2,11 @@ export interface Theme {
   id: string;
   name: string;
   description: string;
+  icon: string;
   prompt: string;
 }
+
+export const DEFAULT_THEME_ID = "default";
 
 const DEFAULT_THEME_PROMPT = `
 <theme>
@@ -24,7 +27,7 @@ All the rules are critical and must be strictly followed, otherwise it's a failu
 - Establish a clear and confident color system.
 - Centralize colors through variables to maintain consistency.
 - Avoid using gradient backgrounds.
-- Avoid using black as the primary color.Aim for colorful websites.
+- Avoid using black as the primary color. Aim for colorful websites.
 #### Motion & Interaction
 - Apply motion with restraint and purpose.
 - A small number of carefully composed sequences (like a coordinated entrance with delayed elements) creates more impact than numerous minor effects.
@@ -63,6 +66,7 @@ export const themesData: Theme[] = [
     name: "Default Theme",
     description:
       "Balanced design system emphasizing aesthetics, contrast, and functionality.",
+    icon: "palette",
     prompt: DEFAULT_THEME_PROMPT,
   },
 ];

--- a/src/shared/themes.ts
+++ b/src/shared/themes.ts
@@ -5,8 +5,6 @@ export interface Theme {
   prompt: string;
 }
 
-export const DEFAULT_THEME_ID = "none";
-
 const DEFAULT_THEME_PROMPT = `
 <theme>
 Any instruction in this theme should override other instructions if there's a contradiction.
@@ -61,12 +59,6 @@ Follow this workflow when building web apps:
 
 export const themesData: Theme[] = [
   {
-    id: "none",
-    name: "No Theme",
-    description: "Minimal styling guidance - uses the default AI behavior.",
-    prompt: "",
-  },
-  {
     id: "default",
     name: "Default Theme",
     description:
@@ -75,14 +67,19 @@ export const themesData: Theme[] = [
   },
 ];
 
-export function getThemeById(themeId: string | null): Theme | undefined {
+export function getThemeById(themeId: string | null): Theme | null {
+  // null means "no theme" - return null
   if (!themeId) {
-    return themesData.find((t) => t.id === DEFAULT_THEME_ID);
+    return null;
   }
-  return themesData.find((t) => t.id === themeId);
+  return themesData.find((t) => t.id === themeId) ?? null;
 }
 
 export function getThemePrompt(themeId: string | null): string {
+  // null means "no theme" - return empty string (no prompt)
+  if (!themeId) {
+    return "";
+  }
   const theme = getThemeById(themeId);
   return theme?.prompt ?? "";
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces initial UI theming with per-app theme selection and a default theme in settings. Theme rules are added to prompts so generated UIs follow the chosen design.

- **New Features**
  - Theme picker in AuxiliaryActionsMenu with app-specific selection and visual check.
  - New hooks: useThemes and useAppTheme (React Query) with IPC get/set handlers.
  - Themes data and prompts added (includes “No Theme” and “Default Theme”).
  - Theme prompt appended to system and local-agent prompts; included in token counting.
  - Settings now support a default theme (selectedThemeId) applied to new apps.

- **Migration**
  - Adds apps.theme_id (NULL means no theme).

<sup>Written for commit f4ef96ccd02a3d9148bd4e570d2204c7b5a12c10. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces initial theming with persistence and prompt influence.
> 
> - UI: Adds Themes submenu in `AuxiliaryActionsMenu` (supports "No Theme" and `default`, app-specific or global via settings)
> - Data/IPC: New `apps.theme_id` column (nullable), hooks `useThemes`/`useAppTheme`, IPC handlers (`get-themes`, `set-app-theme`, `get-app-theme`) wired through `ipc_client`, `ipc_host`, and `preload`
> - Settings: Adds `selectedThemeId` with default applied to newly created apps
> - Prompting: Appends theme prompt (`getThemePrompt`) to system/local-agent prompts and token counting
> - Integration: `ChatInput` passes `appId` to menu; `schema.ts` updated
> - Tests: E2E verifies default and per-app theme persistence
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee9ba34aad48f8dc49013e01247cfdcff1b77fad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->