### PR TITLE
Retry rate limit errors for Supabase API callsites

### DIFF
--- a/src/__tests__/retryWithRateLimit.test.ts
+++ b/src/__tests__/retryWithRateLimit.test.ts
@@ -1,0 +1,375 @@
+import {
+  isRateLimitError,
+  retryWithRateLimit,
+} from "@/ipc/utils/retryWithRateLimit";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+describe("isRateLimitError", () => {
+  describe("returns true for rate limit errors", () => {
+    it("should return true for error with response.status === 429", () => {
+      const error = { response: { status: 429 } };
+      expect(isRateLimitError(error)).toBe(true);
+    });
+
+    it("should return true for error with additional properties", () => {
+      const error = {
+        message: "Rate limited",
+        response: { status: 429, data: { error: "Too many requests" } },
+      };
+      expect(isRateLimitError(error)).toBe(true);
+    });
+  });
+
+  describe("returns false for non-rate-limit errors", () => {
+    it("should return false for 400 status", () => {
+      const error = { response: { status: 400 } };
+      expect(isRateLimitError(error)).toBe(false);
+    });
+
+    it("should return false for 401 status", () => {
+      const error = { response: { status: 401 } };
+      expect(isRateLimitError(error)).toBe(false);
+    });
+
+    it("should return false for 403 status", () => {
+      const error = { response: { status: 403 } };
+      expect(isRateLimitError(error)).toBe(false);
+    });
+
+    it("should return false for 404 status", () => {
+      const error = { response: { status: 404 } };
+      expect(isRateLimitError(error)).toBe(false);
+    });
+
+    it("should return false for 500 status", () => {
+      const error = { response: { status: 500 } };
+      expect(isRateLimitError(error)).toBe(false);
+    });
+
+    it("should return false for 503 status", () => {
+      const error = { response: { status: 503 } };
+      expect(isRateLimitError(error)).toBe(false);
+    });
+  });
+
+  describe("returns false for invalid error shapes", () => {
+    it("should return false for null", () => {
+      expect(isRateLimitError(null)).toBe(false);
+    });
+
+    it("should return false for undefined", () => {
+      expect(isRateLimitError(undefined)).toBe(false);
+    });
+
+    it("should return false for empty object", () => {
+      expect(isRateLimitError({})).toBe(false);
+    });
+
+    it("should return false for error without response", () => {
+      const error = { message: "Something went wrong" };
+      expect(isRateLimitError(error)).toBe(false);
+    });
+
+    it("should return false for error with null response", () => {
+      const error = { response: null };
+      expect(isRateLimitError(error)).toBe(false);
+    });
+
+    it("should return false for error with response but no status", () => {
+      const error = { response: { data: "error" } };
+      expect(isRateLimitError(error)).toBe(false);
+    });
+
+    it("should return false for string error", () => {
+      expect(isRateLimitError("Rate limited")).toBe(false);
+    });
+
+    it("should return false for Error instance without response", () => {
+      expect(isRateLimitError(new Error("Rate limited"))).toBe(false);
+    });
+  });
+});
+
+describe("retryWithRateLimit", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("successful operations", () => {
+    it("should return result on first successful attempt", async () => {
+      const operation = vi.fn().mockResolvedValue("success");
+
+      const resultPromise = retryWithRateLimit(operation, "test-operation");
+      const result = await resultPromise;
+
+      expect(result).toBe("success");
+      expect(operation).toHaveBeenCalledTimes(1);
+    });
+
+    it("should return result after retry on rate limit then success", async () => {
+      const rateLimitError = { response: { status: 429 } };
+      const operation = vi
+        .fn()
+        .mockRejectedValueOnce(rateLimitError)
+        .mockResolvedValueOnce("success after retry");
+
+      const resultPromise = retryWithRateLimit(operation, "test-operation");
+
+      // First attempt fails immediately
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Wait for the retry delay
+      await vi.advanceTimersByTimeAsync(3000);
+
+      const result = await resultPromise;
+
+      expect(result).toBe("success after retry");
+      expect(operation).toHaveBeenCalledTimes(2);
+    });
+
+    it("should succeed after multiple rate limit errors", async () => {
+      const rateLimitError = { response: { status: 429 } };
+      const operation = vi
+        .fn()
+        .mockRejectedValueOnce(rateLimitError)
+        .mockRejectedValueOnce(rateLimitError)
+        .mockRejectedValueOnce(rateLimitError)
+        .mockResolvedValueOnce("success after 3 retries");
+
+      const resultPromise = retryWithRateLimit(operation, "test-operation");
+
+      // Advance through all retry delays
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(3000); // First retry
+      await vi.advanceTimersByTimeAsync(5000); // Second retry
+      await vi.advanceTimersByTimeAsync(10000); // Third retry
+
+      const result = await resultPromise;
+
+      expect(result).toBe("success after 3 retries");
+      expect(operation).toHaveBeenCalledTimes(4);
+    });
+  });
+
+  describe("non-rate-limit errors", () => {
+    it("should throw immediately for 400 error", async () => {
+      const badRequestError = { response: { status: 400 } };
+      const operation = vi.fn().mockRejectedValue(badRequestError);
+
+      await expect(
+        retryWithRateLimit(operation, "test-operation"),
+      ).rejects.toEqual(badRequestError);
+      expect(operation).toHaveBeenCalledTimes(1);
+    });
+
+    it("should throw immediately for 500 error", async () => {
+      const serverError = { response: { status: 500 } };
+      const operation = vi.fn().mockRejectedValue(serverError);
+
+      await expect(
+        retryWithRateLimit(operation, "test-operation"),
+      ).rejects.toEqual(serverError);
+      expect(operation).toHaveBeenCalledTimes(1);
+    });
+
+    it("should throw immediately for generic Error", async () => {
+      const error = new Error("Network failure");
+      const operation = vi.fn().mockRejectedValue(error);
+
+      await expect(
+        retryWithRateLimit(operation, "test-operation"),
+      ).rejects.toThrow("Network failure");
+      expect(operation).toHaveBeenCalledTimes(1);
+    });
+
+    it("should throw immediately for error without response", async () => {
+      const error = { message: "Connection timeout" };
+      const operation = vi.fn().mockRejectedValue(error);
+
+      await expect(
+        retryWithRateLimit(operation, "test-operation"),
+      ).rejects.toEqual(error);
+      expect(operation).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("exhausted retries", () => {
+    it("should throw after max retries are exhausted", async () => {
+      const rateLimitError = { response: { status: 429 } };
+      const operation = vi.fn().mockRejectedValue(rateLimitError);
+
+      const resultPromise = retryWithRateLimit(operation, "test-operation", {
+        maxRetries: 2,
+        baseDelay: 100,
+      });
+
+      // Attach rejection handler BEFORE running timers to avoid unhandled rejection
+      const expectation = expect(resultPromise).rejects.toEqual(rateLimitError);
+
+      // Run all timers to completion
+      await vi.runAllTimersAsync();
+
+      await expectation;
+      expect(operation).toHaveBeenCalledTimes(3); // 1 initial + 2 retries
+    });
+
+    it("should throw after default max retries (6)", async () => {
+      const rateLimitError = { response: { status: 429 } };
+      const operation = vi.fn().mockRejectedValue(rateLimitError);
+
+      const resultPromise = retryWithRateLimit(operation, "test-operation", {
+        baseDelay: 100,
+      });
+
+      // Attach rejection handler BEFORE running timers to avoid unhandled rejection
+      const expectation = expect(resultPromise).rejects.toEqual(rateLimitError);
+
+      // Run all timers to completion
+      await vi.runAllTimersAsync();
+
+      await expectation;
+      expect(operation).toHaveBeenCalledTimes(7); // 1 initial + 6 retries
+    });
+  });
+
+  describe("custom options", () => {
+    it("should respect custom maxRetries", async () => {
+      const rateLimitError = { response: { status: 429 } };
+      const operation = vi.fn().mockRejectedValue(rateLimitError);
+
+      const resultPromise = retryWithRateLimit(operation, "test-operation", {
+        maxRetries: 1,
+        baseDelay: 100,
+      });
+
+      // Attach rejection handler BEFORE running timers to avoid unhandled rejection
+      const expectation = expect(resultPromise).rejects.toEqual(rateLimitError);
+
+      // Run all timers to completion
+      await vi.runAllTimersAsync();
+
+      await expectation;
+      expect(operation).toHaveBeenCalledTimes(2); // 1 initial + 1 retry
+    });
+
+    it("should respect custom baseDelay", async () => {
+      const rateLimitError = { response: { status: 429 } };
+      const operation = vi
+        .fn()
+        .mockRejectedValueOnce(rateLimitError)
+        .mockResolvedValueOnce("success");
+
+      const resultPromise = retryWithRateLimit(operation, "test-operation", {
+        baseDelay: 5000,
+      });
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Should not have retried yet (baseDelay is 5000ms)
+      await vi.advanceTimersByTimeAsync(4000);
+      expect(operation).toHaveBeenCalledTimes(1);
+
+      // Now it should retry
+      await vi.advanceTimersByTimeAsync(2000);
+      const result = await resultPromise;
+
+      expect(result).toBe("success");
+      expect(operation).toHaveBeenCalledTimes(2);
+    });
+
+    it("should cap delay at maxDelay", async () => {
+      const rateLimitError = { response: { status: 429 } };
+      const operation = vi
+        .fn()
+        .mockRejectedValueOnce(rateLimitError) // attempt 0
+        .mockRejectedValueOnce(rateLimitError) // attempt 1
+        .mockRejectedValueOnce(rateLimitError) // attempt 2
+        .mockRejectedValueOnce(rateLimitError) // attempt 3
+        .mockResolvedValueOnce("success"); // attempt 4
+
+      const resultPromise = retryWithRateLimit(operation, "test-operation", {
+        baseDelay: 1000,
+        maxDelay: 5000,
+        maxRetries: 10,
+      });
+
+      // Advance through retries - delays should be capped at maxDelay
+      for (let i = 0; i < 5; i++) {
+        await vi.advanceTimersByTimeAsync(6000);
+      }
+
+      const result = await resultPromise;
+      expect(result).toBe("success");
+      expect(operation).toHaveBeenCalledTimes(5);
+    });
+
+    it("should use defaults when options is undefined", async () => {
+      const operation = vi.fn().mockResolvedValue("success");
+
+      const result = await retryWithRateLimit(operation, "test-operation");
+
+      expect(result).toBe("success");
+      expect(operation).toHaveBeenCalledTimes(1);
+    });
+
+    it("should use defaults for unspecified options", async () => {
+      const rateLimitError = { response: { status: 429 } };
+      const operation = vi
+        .fn()
+        .mockRejectedValueOnce(rateLimitError)
+        .mockResolvedValueOnce("success");
+
+      const resultPromise = retryWithRateLimit(operation, "test-operation", {
+        maxRetries: 3,
+        // baseDelay and maxDelay should use defaults
+      });
+
+      // Default baseDelay is 2000ms
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(3000);
+
+      const result = await resultPromise;
+      expect(result).toBe("success");
+    });
+  });
+
+  describe("return types", () => {
+    it("should preserve return type for objects", async () => {
+      const data = { id: 1, name: "test" };
+      const operation = vi.fn().mockResolvedValue(data);
+
+      const result = await retryWithRateLimit(operation, "test-operation");
+
+      expect(result).toEqual(data);
+    });
+
+    it("should preserve return type for arrays", async () => {
+      const data = [1, 2, 3];
+      const operation = vi.fn().mockResolvedValue(data);
+
+      const result = await retryWithRateLimit(operation, "test-operation");
+
+      expect(result).toEqual(data);
+    });
+
+    it("should preserve return type for null", async () => {
+      const operation = vi.fn().mockResolvedValue(null);
+
+      const result = await retryWithRateLimit(operation, "test-operation");
+
+      expect(result).toBeNull();
+    });
+
+    it("should preserve return type for undefined", async () => {
+      const operation = vi.fn().mockResolvedValue(undefined);
+
+      const result = await retryWithRateLimit(operation, "test-operation");
+
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/src/ipc/utils/retryWithRateLimit.ts
+++ b/src/ipc/utils/retryWithRateLimit.ts
@@ -33,11 +33,12 @@ export function isRateLimitError(error: any): boolean {
   const status = error?.response?.status;
   return status === 429;
 }
+
 // Retry configuration
 const RETRY_CONFIG = {
-  maxRetries: 6,
+  maxRetries: 8,
   baseDelay: 2_000, // 2 seconds
-  maxDelay: 180_000, // 180 seconds
+  maxDelay: 30_000, // 30 seconds
   jitterFactor: 0.1, // 10% jitter
 };
 

--- a/src/ipc/utils/retryWithRateLimit.ts
+++ b/src/ipc/utils/retryWithRateLimit.ts
@@ -1,0 +1,87 @@
+import log from "electron-log";
+
+export const logger = log.scope("retryWithRateLimit");
+
+/**
+ * Checks if an error is a rate limit error (HTTP 429).
+ */
+export function isRateLimitError(error: any): boolean {
+  const status = error?.response?.status;
+  return status === 429;
+}
+// Retry configuration
+const RETRY_CONFIG = {
+  maxRetries: 6,
+  baseDelay: 2_000, // 2 seconds
+  maxDelay: 180_000, // 180 seconds
+  jitterFactor: 0.1, // 10% jitter
+};
+
+export interface RetryWithRateLimitOptions {
+  /** Maximum number of retries */
+  maxRetries?: number;
+  /** Base delay in ms for exponential backoff */
+  baseDelay?: number;
+  /** Maximum delay in ms */
+  maxDelay?: number;
+}
+
+/**
+ * Retries an async operation with exponential backoff on rate limit errors (429).
+ * Uses exponential backoff.
+ *
+ * @param operation - The async operation to retry
+ * @param context - A descriptive context string for logging
+ * @param options - Optional retry configuration
+ */
+export async function retryWithRateLimit<T>(
+  operation: () => Promise<T>,
+  context: string,
+  options?: RetryWithRateLimitOptions,
+): Promise<T> {
+  const maxRetries = options?.maxRetries ?? RETRY_CONFIG.maxRetries;
+  const baseDelay = options?.baseDelay ?? RETRY_CONFIG.baseDelay;
+  const maxDelay = options?.maxDelay ?? RETRY_CONFIG.maxDelay;
+
+  let lastError: any;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      const result = await operation();
+      if (attempt > 0) {
+        logger.info(`${context}: Success after ${attempt + 1} attempts`);
+      }
+      return result;
+    } catch (error: any) {
+      lastError = error;
+
+      // Only retry on rate limit errors
+      if (!isRateLimitError(error)) {
+        throw error;
+      }
+
+      // Don't retry if we've exhausted all attempts
+      if (attempt === maxRetries) {
+        logger.error(
+          `${context}: Failed after ${maxRetries + 1} attempts due to rate limit`,
+        );
+        throw error;
+      }
+
+      let delay: number;
+
+      // Use exponential backoff with jitter
+      const exponentialDelay = baseDelay * Math.pow(2, attempt);
+      const jitter =
+        exponentialDelay * RETRY_CONFIG.jitterFactor * Math.random();
+      delay = Math.min(exponentialDelay + jitter, maxDelay);
+      logger.warn(
+        `${context}: Rate limited (attempt ${attempt + 1}/${maxRetries + 1}), retrying in ${Math.round(delay)}ms`,
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+
+  throw lastError;
+}

--- a/src/supabase_admin/supabase_management_client.ts
+++ b/src/supabase_admin/supabase_management_client.ts
@@ -354,28 +354,28 @@ export async function getSupabaseClientForOrganization(
 export async function listSupabaseOrganizations(
   accessToken: string,
 ): Promise<SupabaseOrganizationDetails[]> {
-  return retryWithRateLimit(async () => {
-    const response = await fetch("https://api.supabase.com/v1/organizations", {
+  const response = await retryWithRateLimit(async () => {
+    return await fetch("https://api.supabase.com/v1/organizations", {
       method: "GET",
       headers: {
         Authorization: `Bearer ${accessToken}`,
       },
     });
-
-    if (response.status !== 200) {
-      const errorText = await response.text();
-      logger.error(
-        `Failed to fetch organizations (${response.status}): ${errorText}`,
-      );
-      throw new SupabaseManagementAPIError(
-        `Failed to fetch organizations: ${response.statusText}`,
-        response,
-      );
-    }
-
-    const organizations: SupabaseOrganizationDetails[] = await response.json();
-    return organizations;
   }, "List Supabase organizations");
+
+  if (response.status !== 200) {
+    const errorText = await response.text();
+    logger.error(
+      `Failed to fetch organizations (${response.status}): ${errorText}`,
+    );
+    throw new SupabaseManagementAPIError(
+      `Failed to fetch organizations: ${response.statusText}`,
+      response,
+    );
+  }
+
+  const organizations: SupabaseOrganizationDetails[] = await response.json();
+  return organizations;
 }
 
 export interface SupabaseOrganizationMember {
@@ -413,8 +413,8 @@ export async function getOrganizationMembers(
   const client = await getSupabaseClientForOrganization(organizationSlug);
   const accessToken = (client as any).options.accessToken;
 
-  return retryWithRateLimit(async () => {
-    const response = await fetch(
+  const response = await retryWithRateLimit(async () => {
+    return await fetch(
       `https://api.supabase.com/v1/organizations/${organizationSlug}/members`,
       {
         method: "GET",
@@ -423,26 +423,26 @@ export async function getOrganizationMembers(
         },
       },
     );
-
-    if (response.status !== 200) {
-      const errorText = await response.text();
-      logger.error(
-        `Failed to fetch organization members (${response.status}): ${errorText}`,
-      );
-      throw new SupabaseManagementAPIError(
-        `Failed to fetch organization members: ${response.statusText}`,
-        response,
-      );
-    }
-
-    const members: SupabaseRawMember[] = await response.json();
-    return members.map((m) => ({
-      userId: m.user_id,
-      email: m.primary_email || m.email,
-      role: m.role_name,
-      username: m.username,
-    }));
   }, `Get organization members for ${organizationSlug}`);
+
+  if (response.status !== 200) {
+    const errorText = await response.text();
+    logger.error(
+      `Failed to fetch organization members (${response.status}): ${errorText}`,
+    );
+    throw new SupabaseManagementAPIError(
+      `Failed to fetch organization members: ${response.statusText}`,
+      response,
+    );
+  }
+
+  const members: SupabaseRawMember[] = await response.json();
+  return members.map((m) => ({
+    userId: m.user_id,
+    email: m.primary_email || m.email,
+    role: m.role_name,
+    username: m.username,
+  }));
 }
 
 export interface SupabaseOrganizationDetails {
@@ -468,8 +468,8 @@ export async function getOrganizationDetails(
   const client = await getSupabaseClientForOrganization(organizationSlug);
   const accessToken = (client as any).options.accessToken;
 
-  return retryWithRateLimit(async () => {
-    const response = await fetch(
+  const response = await retryWithRateLimit(async () => {
+    return await fetch(
       `https://api.supabase.com/v1/organizations/${organizationSlug}`,
       {
         method: "GET",
@@ -478,25 +478,25 @@ export async function getOrganizationDetails(
         },
       },
     );
-
-    if (response.status !== 200) {
-      const errorText = await response.text();
-      logger.error(
-        `Failed to fetch organization details (${response.status}): ${errorText}`,
-      );
-      throw new SupabaseManagementAPIError(
-        `Failed to fetch organization details: ${response.statusText}`,
-        response,
-      );
-    }
-
-    const org = await response.json();
-    return {
-      id: org.id,
-      name: org.name,
-      slug: org.slug,
-    };
   }, `Get organization details for ${organizationSlug}`);
+
+  if (response.status !== 200) {
+    const errorText = await response.text();
+    logger.error(
+      `Failed to fetch organization details (${response.status}): ${errorText}`,
+    );
+    throw new SupabaseManagementAPIError(
+      `Failed to fetch organization details: ${response.statusText}`,
+      response,
+    );
+  }
+
+  const org = await response.json();
+  return {
+    id: org.id,
+    name: org.name,
+    slug: org.slug,
+  };
 }
 
 export async function getSupabaseProjectName(
@@ -554,28 +554,28 @@ LIMIT 1000`;
 
   logger.info(`Fetching logs from: ${url}`);
 
-  return retryWithRateLimit(async () => {
-    const response = await fetch(url, {
+  const response = await retryWithRateLimit(async () => {
+    return await fetch(url, {
       method: "GET",
       headers: {
         Authorization: `Bearer ${(supabase as any).options.accessToken}`,
       },
     });
-
-    if (response.status !== 200) {
-      const errorText = await response.text();
-      logger.error(`Failed to fetch logs (${response.status}): ${errorText}`);
-      throw new SupabaseManagementAPIError(
-        `Failed to fetch logs: ${response.statusText} (${response.status}) - ${errorText}`,
-        response,
-      );
-    }
-
-    const jsonResponse: SupabaseProjectLogsResponse = await response.json();
-    logger.info(`Received ${jsonResponse.result?.length || 0} logs`);
-
-    return jsonResponse;
   }, `Get Supabase project logs for ${projectId}`);
+
+  if (response.status !== 200) {
+    const errorText = await response.text();
+    logger.error(`Failed to fetch logs (${response.status}): ${errorText}`);
+    throw new SupabaseManagementAPIError(
+      `Failed to fetch logs: ${response.statusText} (${response.status}) - ${errorText}`,
+      response,
+    );
+  }
+
+  const jsonResponse: SupabaseProjectLogsResponse = await response.json();
+  logger.info(`Received ${jsonResponse.result?.length || 0} logs`);
+
+  return jsonResponse;
 }
 
 export async function executeSupabaseSql({
@@ -651,8 +651,8 @@ export async function listSupabaseBranches({
   logger.info(`Listing Supabase branches for project: ${supabaseProjectId}`);
   const supabase = await getSupabaseClient({ organizationSlug });
 
-  return retryWithRateLimit(async () => {
-    const response = await fetch(
+  const response = await retryWithRateLimit(async () => {
+    return await fetch(
       `https://api.supabase.com/v1/projects/${supabaseProjectId}/branches`,
       {
         method: "GET",
@@ -661,15 +661,15 @@ export async function listSupabaseBranches({
         },
       },
     );
-
-    if (response.status !== 200) {
-      throw await createResponseError(response, "list branches");
-    }
-
-    logger.info(`Listed Supabase branches for project: ${supabaseProjectId}`);
-    const jsonResponse: SupabaseProjectBranch[] = await response.json();
-    return jsonResponse;
   }, `List Supabase branches for ${supabaseProjectId}`);
+
+  if (response.status !== 200) {
+    throw await createResponseError(response, "list branches");
+  }
+
+  logger.info(`Listed Supabase branches for project: ${supabaseProjectId}`);
+  const jsonResponse: SupabaseProjectBranch[] = await response.json();
+  return jsonResponse;
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -730,24 +730,26 @@ export async function deploySupabaseFunction({
 
   // 5) Prepare multipart form-data
   const supabase = await getSupabaseClient({ organizationSlug });
-  const formData = new FormData();
+  function buildFormData() {
+    const formData = new FormData();
 
-  // Metadata: instruct Supabase to use our import map
-  const metadata = {
-    entrypoint_path: entrypointPath,
-    name: functionName,
-    verify_jwt: false,
-    import_map_path: importMapRelPath,
-  };
+    const metadata = {
+      entrypoint_path: entrypointPath,
+      name: functionName,
+      verify_jwt: false,
+      import_map_path: importMapRelPath,
+    };
 
-  formData.append("metadata", JSON.stringify(metadata));
+    formData.append("metadata", JSON.stringify(metadata));
 
-  // Add all files to form data
-  for (const f of filesToUpload) {
-    const buf: Buffer = f.content;
-    const mime = guessMimeType(f.relativePath);
-    const blob = new Blob([new Uint8Array(buf)], { type: mime });
-    formData.append("file", blob, f.relativePath);
+    for (const f of filesToUpload) {
+      const buf: Buffer = f.content;
+      const mime = guessMimeType(f.relativePath);
+      const blob = new Blob([new Uint8Array(buf)], { type: mime });
+      formData.append("file", blob, f.relativePath);
+    }
+
+    return formData;
   }
 
   // 6) Perform the deploy request
@@ -755,21 +757,22 @@ export async function deploySupabaseFunction({
     supabaseProjectId,
   )}/functions/deploy?slug=${encodeURIComponent(functionName)}${bundleOnly ? "&bundleOnly=true" : ""}`;
 
-  const result = await retryWithRateLimit(async () => {
-    const response = await fetch(deployUrl, {
+  const response = await retryWithRateLimit(async () => {
+    return await fetch(deployUrl, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${(supabase as any).options.accessToken}`,
       },
-      body: formData,
+      // Safer to rebuild form data each time.
+      body: buildFormData(),
     });
-
-    if (response.status !== 201) {
-      throw await createResponseError(response, "create function");
-    }
-
-    return (await response.json()) as DeployedFunctionResponse;
   }, `Deploy Supabase function ${functionName}`);
+
+  if (response.status !== 201) {
+    throw await createResponseError(response, "create function");
+  }
+
+  const result = (await response.json()) as DeployedFunctionResponse;
 
   logger.info(
     `Deployed Supabase function: ${functionName} to project: ${supabaseProjectId}${bundleOnly ? " (bundle only)" : ""}`,
@@ -793,8 +796,8 @@ export async function bulkUpdateFunctions({
 
   const supabase = await getSupabaseClient({ organizationSlug });
 
-  await retryWithRateLimit(async () => {
-    const response = await fetch(
+  const response = await retryWithRateLimit(async () => {
+    return await fetch(
       `https://api.supabase.com/v1/projects/${encodeURIComponent(supabaseProjectId)}/functions`,
       {
         method: "PUT",
@@ -805,11 +808,11 @@ export async function bulkUpdateFunctions({
         body: JSON.stringify(functions),
       },
     );
-
-    if (response.status !== 200) {
-      throw await createResponseError(response, "bulk update functions");
-    }
   }, `Bulk update functions for ${supabaseProjectId}`);
+
+  if (response.status !== 200) {
+    throw await createResponseError(response, "bulk update functions");
+  }
 
   logger.info(
     `Successfully bulk updated ${functions.length} functions for project: ${supabaseProjectId}`,

--- a/src/supabase_admin/supabase_utils.ts
+++ b/src/supabase_admin/supabase_utils.ts
@@ -139,7 +139,7 @@ export async function deployAllSupabaseFunctions({
     const deployResults = await Promise.allSettled(
       validFunctions.map(async (functionName) => {
         logger.info(`Bundling function: ${functionName}`);
-        const result = deploySupabaseFunction({
+        const result = await deploySupabaseFunction({
           supabaseProjectId,
           organizationSlug: supabaseOrganizationSlug,
           functionName,
@@ -172,7 +172,7 @@ export async function deployAllSupabaseFunctions({
         `Activating ${successfulDeploys.length} functions via bulk update...`,
       );
       try {
-        bulkUpdateFunctions({
+        await bulkUpdateFunctions({
           supabaseProjectId,
           functions: successfulDeploys,
           organizationSlug: supabaseOrganizationSlug,


### PR DESCRIPTION
Addresses #2147

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds robust retry handling for Supabase API interactions to reduce flakiness on HTTP 429.
> 
> - Introduces `RateLimitError`, `isRateLimitError`, `retryWithRateLimit` (defaults: 6 retries, 2s base, capped, jitter, scoped logging) and `fetchWithRetry`
> - Applies retries to key callsites: project API keys, schema/queries, secrets, orgs/members/details, projects, project logs, branches, function deploy/delete, bulk update, and SQL execution
> - Standardizes non-429 fetch failures to throw `SupabaseManagementAPIError` to preserve response context
> - Improves function deploy by rebuilding `FormData` per attempt and converting 429 to `RateLimitError`
> - Adds thorough unit tests covering error detection, backoff behavior, options, and retry exhaustion
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eaf86cffb2d2b3a3771e8607a52f4e04af630ecd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add automatic retries for Supabase API calls on HTTP 429 using exponential backoff with jitter to reduce flakiness and improve reliability. Addresses #2147 by applying retries across key management and context callsites and adding thorough tests.

- **New Features**
  - Added retryWithRateLimit (defaults: 8 retries, 2s base delay, 30s max, 10% jitter, scoped logging), isRateLimitError, RateLimitError, and fetchWithRetry.
  - Applied retries to fetch-based endpoints and runQuery operations: orgs/members/details/projects, project logs, schema/table/function queries, secrets/API keys, branches, function deploy/delete and bulk update, and SQL execution.
  - Standardized error handling by throwing SupabaseManagementAPIError for failed fetches to preserve response details.
  - Added unit tests covering detection, backoff timing, options, retry exhaustion, and fetchWithRetry behavior.

<sup>Written for commit c1fbffaf9c559c7f43a6999f4160a81b97ed9eaf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

