### PR TITLE
Rebaseline e2e tests

### DIFF
--- a/e2e-tests/snapshots/engine.spec.ts_regular-auto-should-send-message-to-engine-1.txt
+++ b/e2e-tests/snapshots/engine.spec.ts_regular-auto-should-send-message-to-engine-1.txt
@@ -14,7 +14,6 @@
       }
     ],
     "stream": true,
-    "reasoning_effort": "medium",
     "dyad_options": {
       "files": [
         {

--- a/e2e-tests/snapshots/engine.spec.ts_smart-auto-should-send-message-to-engine-1.txt
+++ b/e2e-tests/snapshots/engine.spec.ts_smart-auto-should-send-message-to-engine-1.txt
@@ -14,7 +14,6 @@
       }
     ],
     "stream": true,
-    "reasoning_effort": "medium",
     "dyad_options": {
       "versioned_files": {
         "fileIdToContent": {

--- a/e2e-tests/snapshots/mention_app.spec.ts_mention-app-with-pro-1.txt
+++ b/e2e-tests/snapshots/mention_app.spec.ts_mention-app-with-pro-1.txt
@@ -14,7 +14,6 @@
       }
     ],
     "stream": true,
-    "reasoning_effort": "medium",
     "dyad_options": {
       "files": [
         {

--- a/e2e-tests/snapshots/smart_context_balanced.spec.ts_smart-context-balanced---simple-1.txt
+++ b/e2e-tests/snapshots/smart_context_balanced.spec.ts_smart-context-balanced---simple-1.txt
@@ -14,7 +14,6 @@
       }
     ],
     "stream": true,
-    "reasoning_effort": "medium",
     "dyad_options": {
       "files": [
         {

--- a/e2e-tests/snapshots/smart_context_deep.spec.ts_smart-context-deep---mention-app-should-fallback-to-balanced-1.txt
+++ b/e2e-tests/snapshots/smart_context_deep.spec.ts_smart-context-deep---mention-app-should-fallback-to-balanced-1.txt
@@ -14,7 +14,6 @@
       }
     ],
     "stream": true,
-    "reasoning_effort": "medium",
     "dyad_options": {
       "files": [
         {

--- a/e2e-tests/snapshots/smart_context_deep.spec.ts_smart-context-deep---read-write-read-1.txt
+++ b/e2e-tests/snapshots/smart_context_deep.spec.ts_smart-context-deep---read-write-read-1.txt
@@ -38,7 +38,6 @@
       }
     ],
     "stream": true,
-    "reasoning_effort": "medium",
     "dyad_options": {
       "versioned_files": {
         "fileIdToContent": {

--- a/e2e-tests/snapshots/turbo_edits_v2.spec.ts_turbo-edits-v2---search-replace-dump-1.txt
+++ b/e2e-tests/snapshots/turbo_edits_v2.spec.ts_turbo-edits-v2---search-replace-dump-1.txt
@@ -14,7 +14,6 @@
       }
     ],
     "stream": true,
-    "reasoning_effort": "medium",
     "dyad_options": {
       "versioned_files": {
         "fileIdToContent": {

--- a/e2e-tests/snapshots/turbo_edits_v2.spec.ts_turbo-edits-v2---search-replace-fallback-1.txt
+++ b/e2e-tests/snapshots/turbo_edits_v2.spec.ts_turbo-edits-v2---search-replace-fallback-1.txt
@@ -30,7 +30,6 @@
       }
     ],
     "stream": true,
-    "reasoning_effort": "medium",
     "dyad_options": {
       "versioned_files": {
         "fileIdToContent": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Rebaselines e2e test snapshots to reflect updated request payloads.
> 
> - Removes `"reasoning_effort": "medium"` from multiple `e2e-tests/snapshots/*` JSON transcripts
> - No production code changes; only snapshot/test data updates
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ddc1ebc593ed63e1a3508c4ebc99ca49d3c9943f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Rebaselined e2e test snapshots to remove reasoning_effort from request payloads. Aligns snapshots with the latest API and fixes failing tests.

<sup>Written for commit ddc1ebc593ed63e1a3508c4ebc99ca49d3c9943f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

