### PR TITLE
Automatically initialize git safe directory on startup

### DIFF
--- a/src/ipc/utils/git_utils.ts
+++ b/src/ipc/utils/git_utils.ts
@@ -7,6 +7,7 @@ import { promises as fsPromises } from "node:fs";
 import pathModule from "node:path";
 import { readSettings } from "../../main/settings";
 import log from "electron-log";
+import { normalizePath } from "../../../shared/normalizePath";
 const logger = log.scope("git_utils");
 import type {
   GitBaseParams,
@@ -70,7 +71,28 @@ export async function withGitAuthor(args: string[]): Promise<string[]> {
  * Only works for native git.
  */
 export async function gitAddSafeDirectory(directory: string): Promise<void> {
+  // Normalize path to use forward slashes (important for Windows compatibility with git)
+  directory = normalizePath(directory);
+
   try {
+    // First check if the directory is already in the safe.directory list
+    const checkResult = await exec(
+      ["config", "--global", "--get-all", "safe.directory"],
+      ".",
+    );
+
+    // Parse existing safe directories (one per line), normalizing for comparison
+    const existingSafeDirectories = checkResult.stdout
+      .split("\n")
+      .map((line) => normalizePath(line.trim()))
+      .filter((line) => line.length > 0);
+
+    // Check if already present (exact match after normalization)
+    if (existingSafeDirectories.includes(directory)) {
+      logger.debug(`Safe directory already exists: ${directory}`);
+      return;
+    }
+
     const result = await exec(
       ["config", "--global", "--add", "safe.directory", directory],
       ".",

--- a/src/ipc/utils/git_utils.ts
+++ b/src/ipc/utils/git_utils.ts
@@ -63,6 +63,32 @@ export async function withGitAuthor(args: string[]): Promise<string[]> {
   ];
 }
 
+/**
+ * Adds a directory to git's global safe.directory list.
+ * This is required on Windows when git operations are performed on directories
+ * owned by different users.
+ * Only works for native git.
+ */
+export async function gitAddSafeDirectory(directory: string): Promise<void> {
+  try {
+    const result = await exec(
+      ["config", "--global", "--add", "safe.directory", directory],
+      ".",
+    );
+    if (result.exitCode !== 0) {
+      logger.warn(
+        `Failed to add safe directory '${directory}': ${result.stderr.trim() || result.stdout.trim()}`,
+      );
+    } else {
+      logger.info(`Added safe directory: ${directory}`);
+    }
+  } catch (error: any) {
+    logger.warn(
+      `Failed to add safe directory '${directory}': ${error.message}`,
+    );
+  }
+}
+
 export async function getCurrentCommitHash({
   path,
   ref = "HEAD",

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,6 +30,8 @@ import {
 } from "./utils/performance_monitor";
 import { cleanupOldAiMessagesJson } from "./pro/main/ipc/handlers/local_agent/ai_messages_cleanup";
 import fs from "fs";
+import { gitAddSafeDirectory } from "./ipc/utils/git_utils";
+import { getDyadAppsBaseDirectory } from "./paths/paths";
 
 log.errorHandler.startCatching();
 log.eventLogger.startLogging();
@@ -91,6 +93,13 @@ export async function onReady() {
   cleanupOldAiMessagesJson();
 
   const settings = readSettings();
+
+  // Add dyad-apps directory to git safe.directory (required for Windows)
+  if (settings.enableNativeGit) {
+    // Don't need to await because this only needs to run before
+    // the user starts interacting with Dyad app and uses a git-related feature.
+    gitAddSafeDirectory(getDyadAppsBaseDirectory());
+  }
 
   // Check if app was force-closed
   if (settings.isRunning) {

--- a/src/paths/paths.ts
+++ b/src/paths/paths.ts
@@ -2,17 +2,24 @@ import path from "node:path";
 import os from "node:os";
 import { IS_TEST_BUILD } from "../ipc/utils/test_utils";
 
+/**
+ * Gets the base dyad-apps directory path (without a specific app subdirectory)
+ */
+export function getDyadAppsBaseDirectory(): string {
+  if (IS_TEST_BUILD) {
+    const electron = getElectron();
+    return path.join(electron!.app.getPath("userData"), "dyad-apps");
+  }
+  return path.join(os.homedir(), "dyad-apps");
+}
+
 export function getDyadAppPath(appPath: string): string {
   // If appPath is already absolute, use it as-is
   if (path.isAbsolute(appPath)) {
     return appPath;
   }
   // Otherwise, use the default base path
-  if (IS_TEST_BUILD) {
-    const electron = getElectron();
-    return path.join(electron!.app.getPath("userData"), "dyad-apps", appPath);
-  }
-  return path.join(os.homedir(), "dyad-apps", appPath);
+  return path.join(getDyadAppsBaseDirectory(), appPath);
 }
 
 export function getTypeScriptCachePath(): string {


### PR DESCRIPTION
See https://github.com/dyad-sh/dyad/issues/2113

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Automatically ensures Git can operate in `dyad-apps` when native Git is enabled and centralizes base path resolution.
> 
> - Adds `gitAddSafeDirectory(directory)` in `git_utils.ts` to idempotently append to global `safe.directory` (uses `normalizePath`, logs outcomes)
> - On startup (`main.ts`), calls `gitAddSafeDirectory(getDyadAppsBaseDirectory())` without awaiting
> - Introduces `getDyadAppsBaseDirectory()` and updates `getDyadAppPath()` to use it, consolidating test/prod path logic
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99911c273fba66190218ecdb1df40d61f12d49a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically add the dyad-apps directory to Git’s global safe.directory at startup when native Git is enabled. This prevents “detected dubious ownership” errors on Windows and unblocks Git operations.

- New Features
  - Added gitAddSafeDirectory(directory) to run git config --global --add safe.directory <dir> with logging, normalizing paths and skipping duplicates.
  - On app ready, if settings.enableNativeGit, call gitAddSafeDirectory(getDyadAppsBaseDirectory()) without awaiting to keep startup fast.

- Refactors
  - Introduced getDyadAppsBaseDirectory() and updated getDyadAppPath() to use it, centralizing base path logic for test and prod.

<sup>Written for commit 99911c273fba66190218ecdb1df40d61f12d49a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

