### PR TITLE
Fix unit test in retryWithRateLimit

### DIFF
--- a/src/__tests__/retryWithRateLimit.test.ts
+++ b/src/__tests__/retryWithRateLimit.test.ts
@@ -277,7 +277,7 @@ describe("retryWithRateLimit", () => {
       await vi.runAllTimersAsync();
 
       await expectation;
-      expect(operation).toHaveBeenCalledTimes(7); // 1 initial + 6 retries
+      expect(operation).toHaveBeenCalledTimes(9); // 1 initial + 8 retries
     });
   });
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Fix test expectation for default retry count**
> 
> - Update `retryWithRateLimit.test.ts` exhausted-retries test to expect `operation` called 9 times (1 initial + 8 retries) when using defaults
> - No production code changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ef340ba4e26fc3d41a2ea5fea9772ba669f3bd0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the retryWithRateLimit unit test to expect 9 calls (1 initial + 8 retries), matching the current retry behavior. This fixes the failing test and aligns it with the rate-limit backoff logic.

<sup>Written for commit 4ef340ba4e26fc3d41a2ea5fea9772ba669f3bd0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

