### PR TITLE
log chat mode used in chat submit

### DIFF
--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -217,7 +217,7 @@ export function ChatInput({ chatId }: { chatId?: number }) {
       selectedComponents: componentsToSend,
     });
     clearAttachments();
-    posthog.capture("chat:submit");
+    posthog.capture("chat:submit", { chatMode: settings?.selectedChatMode });
   };
 
   const handleCancel = () => {

--- a/src/components/chat/HomeChatInput.tsx
+++ b/src/components/chat/HomeChatInput.tsx
@@ -59,7 +59,9 @@ export function HomeChatInput({
 
     // Clear attachments as part of submission process
     clearAttachments();
-    posthog.capture("chat:home_submit");
+    posthog.capture("chat:home_submit", {
+      chatMode: settings?.selectedChatMode,
+    });
   };
 
   if (!settings) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds analytics context to chat submissions.
> 
> - Update `ChatInput.tsx` to capture `chat:submit` with `{ chatMode: settings?.selectedChatMode }`
> - Update `HomeChatInput.tsx` to capture `chat:home_submit` with `{ chatMode: settings?.selectedChatMode }`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b84eb984bd1c5368c1aeba03db5fd1a2f431bd9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add chatMode to PostHog analytics on chat submission to track which chat mode was used. Applies to chat:submit and chat:home_submit events.

<sup>Written for commit 2b84eb984bd1c5368c1aeba03db5fd1a2f431bd9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

