### PR TITLE
Fix chat mode test

### DIFF
--- a/e2e-tests/helpers/test_helper.ts
+++ b/e2e-tests/helpers/test_helper.ts
@@ -409,12 +409,12 @@ export class PageObject {
 
   async selectChatMode(mode: "build" | "ask" | "agent" | "local-agent") {
     await this.page.getByTestId("chat-mode-selector").click();
-    // local-agent appears as "Agent v2 (experimental)" in the UI
+    // local-agent appears as "Agent v2" in the UI
     const optionName =
       mode === "local-agent"
-        ? "Agent v2 (experimental)"
+        ? "Agent v2"
         : mode === "agent"
-          ? "Build with MCP (experimental)"
+          ? "Build with MCP"
           : mode;
     await this.page
       .getByRole("option", {


### PR DESCRIPTION
fix test breakage from https://github.com/dyad-sh/dyad/pull/2155

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 22342fd91b4708311796b51552b0106acea66b9b. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adjusted chat mode selection in e2e tests to match updated UI labels and prevent failures. Uses "Agent v2" and "Build with MCP" instead of the old "(experimental)" labels.

<sup>Written for commit 22342fd91b4708311796b51552b0106acea66b9b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

