### PR TITLE
Code search tool

### DIFF
--- a/e2e-tests/fixtures/engine/local-agent/code-search.ts
+++ b/e2e-tests/fixtures/engine/local-agent/code-search.ts
@@ -1,0 +1,21 @@
+import type { LocalAgentFixture } from "../../../../testing/fake-llm-server/localAgentTypes";
+
+export const fixture: LocalAgentFixture = {
+  description: "Search for relevant files in codebase using code_search tool",
+  turns: [
+    {
+      text: "I'll search for files related to React components in the codebase.",
+      toolCalls: [
+        {
+          name: "code_search",
+          args: {
+            query: "React component rendering",
+          },
+        },
+      ],
+    },
+    {
+      text: "I found the relevant files! The main React component is in src/App.tsx which handles the app rendering.",
+    },
+  ],
+};

--- a/e2e-tests/local_agent_code_search.spec.ts
+++ b/e2e-tests/local_agent_code_search.spec.ts
@@ -1,0 +1,16 @@
+import { testSkipIfWindows } from "./helpers/test_helper";
+
+/**
+ * E2E tests for the code_search agent tool
+ * Tests semantic code search in local-agent mode
+ */
+
+testSkipIfWindows("local-agent - code search", async ({ po }) => {
+  await po.setUpDyadPro({ localAgent: true });
+  await po.importApp("minimal");
+  await po.selectLocalAgentMode();
+
+  await po.sendPrompt("tc=local-agent/code-search");
+
+  await po.snapshotMessages();
+});

--- a/e2e-tests/snapshots/local_agent_basic.spec.ts_local-agent---dump-request-1.txt
+++ b/e2e-tests/snapshots/local_agent_basic.spec.ts_local-agent---dump-request-1.txt
@@ -228,6 +228,27 @@
       {
         "type": "function",
         "function": {
+          "name": "code_search",
+          "description": "Search the codebase semantically to find files relevant to a query. Use this tool when you need to discover which files contain code related to a specific concept, feature, or functionality. Returns a list of file paths that are most relevant to the search query.\n\n### When to Use This Tool\n\n- Explore unfamiliar codebases\n- Ask \"how / where / what\" questions to understand behavior\n- Find code by meaning rather than exact text\n\n### When NOT to Use\n\nSkip this tool for:\n1. Exact text matches (use `grep`)\n2. Reading known files (use `read_file`)\n3. Simple symbol lookups (use `grep`)\n",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "query": {
+                "type": "string",
+                "description": "Search query to find relevant files"
+              }
+            },
+            "required": [
+              "query"
+            ],
+            "additionalProperties": false,
+            "$schema": "http://json-schema.org/draft-07/schema#"
+          }
+        }
+      },
+      {
+        "type": "function",
+        "function": {
           "name": "set_chat_summary",
           "description": "Set the title/summary for this chat message. You should always call this message at the end of the turn when you have finished calling all the other tools.",
           "parameters": {

--- a/e2e-tests/snapshots/local_agent_code_search.spec.ts_local-agent---code-search-1.aria.yml
+++ b/e2e-tests/snapshots/local_agent_code_search.spec.ts_local-agent---code-search-1.aria.yml
@@ -1,0 +1,34 @@
+- paragraph: /Generate an AI_RULES\.md file for this app\. Describe the tech stack in 5-\d+ bullet points and describe clear rules about what libraries to use for what\./
+- img
+- text: file1.txt
+- button "Edit":
+  - img
+- img
+- text: file1.txt
+- paragraph: More EOM
+- button:
+  - img
+- img
+- text: claude-opus-4-5
+- img
+- text: less than a minute ago
+- button "Request ID":
+  - img
+- paragraph: tc=local-agent/code-search
+- paragraph: I'll search for files related to React components in the codebase.
+- 'button "Code Search React component rendering Query: React component rendering Results: - .gitignore - index.html - package.json"':
+  - img
+  - img
+- paragraph: I found the relevant files! The main React component is in src/App.tsx which handles the app rendering.
+- button:
+  - img
+- img
+- text: claude-opus-4-5
+- img
+- text: less than a minute ago
+- button "Request ID":
+  - img
+- button "Undo":
+  - img
+- button "Retry":
+  - img

--- a/src/components/chat/DyadCodeSearch.tsx
+++ b/src/components/chat/DyadCodeSearch.tsx
@@ -5,7 +5,7 @@ import { CustomTagState } from "./stateTypes";
 
 interface DyadCodeSearchProps {
   children?: ReactNode;
-  node?: any;
+  node?: { properties?: { query?: string; state?: CustomTagState } };
 }
 
 export const DyadCodeSearch: React.FC<DyadCodeSearchProps> = ({

--- a/src/components/chat/DyadCodeSearch.tsx
+++ b/src/components/chat/DyadCodeSearch.tsx
@@ -1,30 +1,95 @@
 import type React from "react";
-import type { ReactNode } from "react";
-import { FileCode } from "lucide-react";
+import { useState, type ReactNode } from "react";
+import { ChevronDown, ChevronUp, FileCode, Loader } from "lucide-react";
+import { CustomTagState } from "./stateTypes";
 
 interface DyadCodeSearchProps {
   children?: ReactNode;
   node?: any;
-  query?: string;
 }
 
 export const DyadCodeSearch: React.FC<DyadCodeSearchProps> = ({
   children,
-  node: _node,
-  query: queryProp,
+  node,
 }) => {
-  const query = queryProp || (typeof children === "string" ? children : "");
+  const [isExpanded, setIsExpanded] = useState(false);
+  const query =
+    node?.properties?.query || (typeof children === "string" ? children : "");
+  const state = node?.properties?.state as CustomTagState;
+  const inProgress = state === "pending";
 
   return (
-    <div className="bg-(--background-lightest) rounded-lg px-4 py-2 border my-2">
+    <div
+      className={`bg-(--background-lightest) dark:bg-zinc-900 hover:bg-(--background-lighter) rounded-lg px-4 py-2 border my-2 cursor-pointer ${
+        inProgress ? "border-purple-500" : "border-border"
+      }`}
+      onClick={() => setIsExpanded(!isExpanded)}
+      role="button"
+      aria-expanded={isExpanded}
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          setIsExpanded(!isExpanded);
+        }
+      }}
+    >
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <FileCode size={16} className="text-purple-600" />
           <div className="text-xs text-purple-600 font-medium">Code Search</div>
+          {inProgress && (
+            <div className="flex items-center text-purple-600 text-xs">
+              <Loader size={14} className="mr-1 animate-spin" />
+              <span>Searching...</span>
+            </div>
+          )}
+        </div>
+        <div className="p-1 text-gray-500">
+          {isExpanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
         </div>
       </div>
-      <div className="text-sm italic text-gray-600 dark:text-gray-300 mt-2">
-        {query || children}
+
+      {/* Collapsed preview - show query */}
+      <div
+        className="text-sm italic text-gray-600 dark:text-gray-300 mt-2 overflow-hidden transition-all duration-300 ease-in-out"
+        style={{
+          maxHeight: isExpanded ? "0px" : "3em",
+          opacity: isExpanded ? 0 : 1,
+        }}
+      >
+        {query}
+      </div>
+
+      {/* Expanded content */}
+      <div
+        className="overflow-hidden transition-all duration-300 ease-in-out"
+        style={{
+          maxHeight: isExpanded ? "none" : "0px",
+          opacity: isExpanded ? 1 : 0,
+          marginTop: isExpanded ? "0.5rem" : "0",
+        }}
+      >
+        <div className="text-sm text-gray-600 dark:text-gray-300 space-y-2">
+          {query && (
+            <div>
+              <span className="text-xs font-medium text-gray-500 dark:text-gray-400">
+                Query:
+              </span>
+              <div className="italic mt-0.5">{query}</div>
+            </div>
+          )}
+          {children && (
+            <div>
+              <span className="text-xs font-medium text-gray-500 dark:text-gray-400">
+                Results:
+              </span>
+              <div className="mt-0.5 whitespace-pre-wrap font-mono text-xs">
+                {children}
+              </div>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/components/chat/DyadMarkdownParser.tsx
+++ b/src/components/chat/DyadMarkdownParser.tsx
@@ -374,7 +374,10 @@ function renderCustomTag(
       return (
         <DyadCodeSearch
           node={{
-            properties: {},
+            properties: {
+              query: attributes.query || "",
+              state: getState({ isStreaming, inProgress }),
+            },
           }}
         >
           {content}

--- a/src/pro/main/ipc/handlers/local_agent/tool_definitions.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tool_definitions.ts
@@ -25,6 +25,7 @@ import { webCrawlTool } from "./tools/web_crawl";
 import { updateTodosTool } from "./tools/update_todos";
 import { runTypeChecksTool } from "./tools/run_type_checks";
 import { grepTool } from "./tools/grep";
+import { codeSearchTool } from "./tools/code_search";
 import type { LanguageModelV3ToolResultOutput } from "@ai-sdk/provider";
 import {
   escapeXmlAttr,
@@ -48,6 +49,7 @@ export const TOOL_DEFINITIONS: readonly ToolDefinition[] = [
   readFileTool,
   listFilesTool,
   grepTool,
+  codeSearchTool,
   getSupabaseProjectInfoTool,
   getSupabaseTableSchemaTool,
   setChatSummaryTool,

--- a/src/pro/main/ipc/handlers/local_agent/tools/code_search.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/code_search.ts
@@ -1,0 +1,152 @@
+import { z } from "zod";
+import log from "electron-log";
+import {
+  ToolDefinition,
+  AgentContext,
+  escapeXmlAttr,
+  escapeXmlContent,
+} from "./types";
+import { extractCodebase } from "../../../../../../utils/codebase";
+import { readSettings } from "@/main/settings";
+
+const logger = log.scope("code_search");
+
+const DYAD_ENGINE_URL =
+  process.env.DYAD_ENGINE_URL ?? "https://engine.dyad.sh/v1";
+
+const codeSearchSchema = z.object({
+  query: z.string().describe("Search query to find relevant files"),
+});
+
+const FileContextSchema = z.object({
+  path: z.string(),
+  content: z.string(),
+});
+
+const codeSearchResponseSchema = z.object({
+  relevantFiles: z.array(z.string()).describe("Paths of relevant files"),
+});
+
+async function callCodeSearch(
+  params: {
+    query: string;
+    filesContext: z.infer<typeof FileContextSchema>[];
+  },
+  ctx: AgentContext,
+): Promise<string[]> {
+  const settings = readSettings();
+  const apiKey = settings.providerSettings?.auto?.apiKey?.value;
+
+  if (!apiKey) {
+    throw new Error("Dyad Pro API key is required for code_search tool");
+  }
+
+  // Stream initial state to UI
+  ctx.onXmlStream(`<dyad-code-search query="${escapeXmlAttr(params.query)}">`);
+
+  const response = await fetch(`${DYAD_ENGINE_URL}/tools/code-search`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      query: params.query,
+      filesContext: params.filesContext,
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(
+      `Code search failed: ${response.status} ${response.statusText} - ${errorText}`,
+    );
+  }
+
+  const data = codeSearchResponseSchema.parse(await response.json());
+  return data.relevantFiles;
+}
+
+const DESCRIPTION = `Search the codebase semantically to find files relevant to a query. Use this tool when you need to discover which files contain code related to a specific concept, feature, or functionality. Returns a list of file paths that are most relevant to the search query.
+
+### When to Use This Tool
+
+- Explore unfamiliar codebases
+- Ask "how / where / what" questions to understand behavior
+- Find code by meaning rather than exact text
+
+### When NOT to Use
+
+Skip this tool for:
+1. Exact text matches (use \`grep\`)
+2. Reading known files (use \`read_file\`)
+3. Simple symbol lookups (use \`grep\`)
+`;
+
+export const codeSearchTool: ToolDefinition<z.infer<typeof codeSearchSchema>> =
+  {
+    name: "code_search",
+    description: DESCRIPTION,
+    inputSchema: codeSearchSchema,
+    defaultConsent: "always",
+
+    getConsentPreview: (args) => `Search for "${args.query}"`,
+
+    buildXml: (args, isComplete) => {
+      if (!args.query) return undefined;
+      if (isComplete) return undefined;
+      return `<dyad-code-search query="${escapeXmlAttr(args.query)}">Searching...`;
+    },
+
+    execute: async (args, ctx: AgentContext) => {
+      logger.log(`Executing code search: ${args.query}`);
+
+      // Gather all files from the project
+      const { files } = await extractCodebase({
+        appPath: ctx.appPath,
+        chatContext: {
+          contextPaths: [],
+          smartContextAutoIncludes: [],
+          excludePaths: [],
+        },
+      });
+
+      // Map files to FileContext format
+      const filesContext = files.map((file) => ({
+        path: file.path,
+        content: file.content,
+      }));
+
+      logger.log(
+        `Searching ${filesContext.length} files for query: "${args.query}"`,
+      );
+
+      // Call the code-search endpoint
+      const relevantFiles = await callCodeSearch(
+        {
+          query: args.query,
+          filesContext,
+        },
+        ctx,
+      );
+
+      // Format results
+      const resultText =
+        relevantFiles.length === 0
+          ? "No relevant files found."
+          : relevantFiles.map((f) => ` - ${f}`).join("\n");
+
+      // Write final result to UI and DB with dyad-code-search wrapper
+      ctx.onXmlComplete(
+        `<dyad-code-search query="${escapeXmlAttr(args.query)}">${escapeXmlContent(resultText)}</dyad-code-search>`,
+      );
+
+      logger.log(`Code search completed for query: ${args.query}`);
+
+      if (relevantFiles.length === 0) {
+        return "No relevant files found for the given query.";
+      }
+
+      return `Found ${relevantFiles.length} relevant file(s):\n${resultText}`;
+    },
+  };

--- a/testing/fake-llm-server/index.ts
+++ b/testing/fake-llm-server/index.ts
@@ -202,6 +202,27 @@ app.post("/engine/v1/tools/turbo-file-edit", (req, res) => {
   }
 });
 
+// Dyad Engine code-search endpoint for code_search tool
+app.post("/engine/v1/tools/code-search", (req, res) => {
+  const { query, filesContext } = req.body;
+  console.log(
+    `* code-search: "${query}" - searching ${filesContext?.length || 0} files`,
+  );
+
+  try {
+    // Return mock relevant files based on the files provided
+    // For testing, return the first few files that exist in the context
+    const relevantFiles = (filesContext || [])
+      .slice(0, 3)
+      .map((f: { path: string }) => f.path);
+
+    res.json({ relevantFiles });
+  } catch (error) {
+    console.error(`* code-search error:`, error);
+    res.status(400).json({ error: String(error) });
+  }
+});
+
 // Start the server
 const server = createServer(app);
 server.listen(PORT, () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces semantic code search so the agent can find relevant files by meaning, not exact text.
> 
> - New `code_search` tool wired into `tool_definitions.ts`; implementation (`tools/code_search.ts`) extracts project files, calls `${DYAD_ENGINE_URL}/tools/code-search`, streams `<dyad-code-search>` while pending, and outputs relevant file paths (requires Dyad Pro API key)
> - Adds `DyadCodeSearch` collapsible UI (query preview, results, loading state) and updates `DyadMarkdownParser` to pass `query`/`state` and render `dyad-code-search`/`dyad-code-search-result`
> - E2E coverage: new fixture, spec, and snapshots; fake LLM server mocks `/engine/v1/tools/code-search`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34ad7b90353cf18ca9750170b7e74ea13d81c97e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a semantic code search tool to the local agent with an interactive UI card, so the agent can find relevant files by meaning, not just text. Includes E2E coverage for the full flow.

- New Features
  - code_search tool: gathers project files, calls Dyad Engine /tools/code-search, and returns relevant file paths.
  - Streams a dyad-code-search tag while running; shows pending state in the UI. Requires a Dyad Pro API key.
  - DyadCodeSearch UI: collapsible card with query preview, results, and loading indicator.
  - Markdown parser now passes query and state; tool registered in tool_definitions.

- Tests
  - Added E2E spec, fixture, and snapshot for local-agent code search.
  - Fake LLM server includes a mock /engine/v1/tools/code-search endpoint.

<sup>Written for commit 34ad7b90353cf18ca9750170b7e74ea13d81c97e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

