### PR TITLE
List files: recursive

### DIFF
--- a/e2e-tests/fixtures/engine/local-agent/list-files-non-recursive.ts
+++ b/e2e-tests/fixtures/engine/local-agent/list-files-non-recursive.ts
@@ -1,0 +1,22 @@
+import type { LocalAgentFixture } from "../../../../testing/fake-llm-server/localAgentTypes";
+
+export const fixture: LocalAgentFixture = {
+  description: "List files in directory without recursion",
+  turns: [
+    {
+      text: "I'll list the files in the src directory for you.",
+      toolCalls: [
+        {
+          name: "list_files",
+          args: {
+            directory: "src",
+            recursive: false,
+          },
+        },
+      ],
+    },
+    {
+      text: "Here are the files in the src directory.",
+    },
+  ],
+};

--- a/e2e-tests/fixtures/engine/local-agent/list-files-recursive.ts
+++ b/e2e-tests/fixtures/engine/local-agent/list-files-recursive.ts
@@ -1,0 +1,22 @@
+import type { LocalAgentFixture } from "../../../../testing/fake-llm-server/localAgentTypes";
+
+export const fixture: LocalAgentFixture = {
+  description: "List files in directory recursively",
+  turns: [
+    {
+      text: "I'll list all files in the src directory recursively for you.",
+      toolCalls: [
+        {
+          name: "list_files",
+          args: {
+            directory: "src",
+            recursive: true,
+          },
+        },
+      ],
+    },
+    {
+      text: "Here are all the files in the src directory and its subdirectories.",
+    },
+  ],
+};

--- a/e2e-tests/local_agent_list_files.spec.ts
+++ b/e2e-tests/local_agent_list_files.spec.ts
@@ -1,0 +1,25 @@
+import { testSkipIfWindows } from "./helpers/test_helper";
+
+/**
+ * E2E tests for list_files tool with recursive parameter
+ */
+
+testSkipIfWindows("local-agent - list_files non-recursive", async ({ po }) => {
+  await po.setUpDyadPro({ localAgent: true });
+  await po.importApp("minimal");
+  await po.selectLocalAgentMode();
+
+  await po.sendPrompt("tc=local-agent/list-files-non-recursive");
+
+  await po.snapshotMessages();
+});
+
+testSkipIfWindows("local-agent - list_files recursive", async ({ po }) => {
+  await po.setUpDyadPro({ localAgent: true });
+  await po.importApp("minimal");
+  await po.selectLocalAgentMode();
+
+  await po.sendPrompt("tc=local-agent/list-files-recursive");
+
+  await po.snapshotMessages();
+});

--- a/e2e-tests/local_agent_list_files.spec.ts
+++ b/e2e-tests/local_agent_list_files.spec.ts
@@ -1,25 +1,22 @@
+import { expect } from "@playwright/test";
 import { testSkipIfWindows } from "./helpers/test_helper";
 
 /**
- * E2E tests for list_files tool with recursive parameter
+ * E2E tests for list_files tool
  */
 
-testSkipIfWindows("local-agent - list_files non-recursive", async ({ po }) => {
+testSkipIfWindows("local-agent - list_files", async ({ po }) => {
   await po.setUpDyadPro({ localAgent: true });
   await po.importApp("minimal");
   await po.selectLocalAgentMode();
 
   await po.sendPrompt("tc=local-agent/list-files-non-recursive");
-
-  await po.snapshotMessages();
-});
-
-testSkipIfWindows("local-agent - list_files recursive", async ({ po }) => {
-  await po.setUpDyadPro({ localAgent: true });
-  await po.importApp("minimal");
-  await po.selectLocalAgentMode();
-
   await po.sendPrompt("tc=local-agent/list-files-recursive");
+  const listFiles1 = po.page.getByTestId("dyad-list-files").first();
+  await listFiles1.click();
+  await expect(listFiles1).toMatchAriaSnapshot();
 
-  await po.snapshotMessages();
+  const listFiles2 = po.page.getByTestId("dyad-list-files").nth(1);
+  await listFiles2.click();
+  await expect(listFiles2).toMatchAriaSnapshot();
 });

--- a/e2e-tests/snapshots/local_agent_basic.spec.ts_local-agent---dump-request-1.txt
+++ b/e2e-tests/snapshots/local_agent_basic.spec.ts_local-agent---dump-request-1.txt
@@ -178,13 +178,17 @@
         "type": "function",
         "function": {
           "name": "list_files",
-          "description": "List all files in the application directory recursively. If you are not sure, list all files by omitting the directory parameter.",
+          "description": "List files in the application directory. By default, lists only the immediate directory contents. Use recursive=true to list all files recursively. If you are not sure, list all files by omitting the directory parameter.",
           "parameters": {
             "type": "object",
             "properties": {
               "directory": {
                 "type": "string",
                 "description": "Optional subdirectory to list"
+              },
+              "recursive": {
+                "type": "boolean",
+                "description": "Whether to list files recursively (default: false)"
               }
             },
             "additionalProperties": false,

--- a/e2e-tests/snapshots/local_agent_list_files.spec.ts_local-agent---list-files-1.aria.yml
+++ b/e2e-tests/snapshots/local_agent_list_files.spec.ts_local-agent---list-files-1.aria.yml
@@ -1,0 +1,4 @@
+- 'button "List Files: src"':
+  - img
+  - img
+- text: "- src/App.tsx - src/main.tsx - src/vite-env.d.ts (3 files total)"

--- a/e2e-tests/snapshots/local_agent_list_files.spec.ts_local-agent---list-files-2.aria.yml
+++ b/e2e-tests/snapshots/local_agent_list_files.spec.ts_local-agent---list-files-2.aria.yml
@@ -1,0 +1,4 @@
+- 'button "List Files: src (recursive)"':
+  - img
+  - img
+- text: "- src/App.tsx - src/main.tsx - src/vite-env.d.ts (3 files total)"

--- a/src/__tests__/local_agent_list_files_path_safety.test.ts
+++ b/src/__tests__/local_agent_list_files_path_safety.test.ts
@@ -11,13 +11,22 @@ describe("resolveDirectoryWithinAppPath", () => {
     expect(relativePathFromApp).toBe("src");
   });
 
+  it("rejects any '..' segment (Windows)", () => {
+    expect(() =>
+      resolveDirectoryWithinAppPath({
+        appPath: "C:/Users/project",
+        directory: "src\\..\\src",
+      }),
+    ).toThrow(/contains "\.\." path traversal segment/);
+  });
+
   it("rejects traversal outside appPath (Windows)", () => {
     expect(() =>
       resolveDirectoryWithinAppPath({
         appPath: "C:/Users/project",
         directory: "..\\..\\Windows",
       }),
-    ).toThrow(/escapes the project directory/);
+    ).toThrow(/contains "\.\." path traversal segment/);
   });
 
   it("rejects absolute paths outside appPath (Windows)", () => {
@@ -38,13 +47,22 @@ describe("resolveDirectoryWithinAppPath", () => {
     expect(relativePathFromApp).toBe("src");
   });
 
+  it("rejects any '..' segment (POSIX)", () => {
+    expect(() =>
+      resolveDirectoryWithinAppPath({
+        appPath: "/Users/project",
+        directory: "src/../src",
+      }),
+    ).toThrow(/contains "\.\." path traversal segment/);
+  });
+
   it("rejects traversal outside appPath on POSIX paths", () => {
     expect(() =>
       resolveDirectoryWithinAppPath({
         appPath: "/Users/project",
         directory: "../../etc",
       }),
-    ).toThrow(/escapes the project directory/);
+    ).toThrow(/contains "\.\." path traversal segment/);
   });
 
   it("rejects absolute paths outside appPath on POSIX paths", () => {

--- a/src/__tests__/local_agent_list_files_path_safety.test.ts
+++ b/src/__tests__/local_agent_list_files_path_safety.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { resolveDirectoryWithinAppPath } from "@/pro/main/ipc/handlers/local_agent/tools/path_safety";
+
+describe("resolveDirectoryWithinAppPath", () => {
+  it("allows valid subdirectories even if appPath uses forward slashes (Windows)", () => {
+    const relativePathFromApp = resolveDirectoryWithinAppPath({
+      appPath: "C:/Users/project",
+      directory: "src",
+    });
+
+    expect(relativePathFromApp).toBe("src");
+  });
+
+  it("rejects traversal outside appPath (Windows)", () => {
+    expect(() =>
+      resolveDirectoryWithinAppPath({
+        appPath: "C:/Users/project",
+        directory: "..\\..\\Windows",
+      }),
+    ).toThrow(/escapes the project directory/);
+  });
+
+  it("rejects absolute paths outside appPath (Windows)", () => {
+    expect(() =>
+      resolveDirectoryWithinAppPath({
+        appPath: "C:/Users/project",
+        directory: "C:\\Windows",
+      }),
+    ).toThrow(/escapes the project directory/);
+  });
+
+  it("allows valid subdirectories on POSIX paths", () => {
+    const relativePathFromApp = resolveDirectoryWithinAppPath({
+      appPath: "/Users/project",
+      directory: "src",
+    });
+
+    expect(relativePathFromApp).toBe("src");
+  });
+
+  it("rejects traversal outside appPath on POSIX paths", () => {
+    expect(() =>
+      resolveDirectoryWithinAppPath({
+        appPath: "/Users/project",
+        directory: "../../etc",
+      }),
+    ).toThrow(/escapes the project directory/);
+  });
+
+  it("rejects absolute paths outside appPath on POSIX paths", () => {
+    expect(() =>
+      resolveDirectoryWithinAppPath({
+        appPath: "/Users/project",
+        directory: "/etc",
+      }),
+    ).toThrow(/escapes the project directory/);
+  });
+
+  it("allows absolute paths inside appPath on POSIX paths", () => {
+    const relativePathFromApp = resolveDirectoryWithinAppPath({
+      appPath: "/Users/project",
+      directory: "/Users/project/src",
+    });
+
+    expect(relativePathFromApp).toBe("src");
+  });
+});

--- a/src/components/ChatModeSelector.tsx
+++ b/src/components/ChatModeSelector.tsx
@@ -66,7 +66,8 @@ export function ChatModeSelector() {
             }}
           />
         ),
-        { duration: 8000 },
+        // Make the toast shorter in test mode for faster tests.
+        { duration: settings?.isTestMode ? 50 : 8000 },
       );
     }
   };

--- a/src/components/chat/DyadListFiles.tsx
+++ b/src/components/chat/DyadListFiles.tsx
@@ -32,7 +32,10 @@ export function DyadListFiles({ node, children }: DyadListFilesProps) {
   };
 
   return (
-    <div className="my-2 border rounded-md overflow-hidden">
+    <div
+      data-testid="dyad-list-files"
+      className="my-2 border rounded-md overflow-hidden"
+    >
       <button
         type="button"
         onClick={() => setIsExpanded(!isExpanded)}

--- a/src/components/chat/DyadListFiles.tsx
+++ b/src/components/chat/DyadListFiles.tsx
@@ -1,11 +1,12 @@
-import React from "react";
+import React, { useState } from "react";
 import { CustomTagState } from "./stateTypes";
-import { FolderOpen, Loader2 } from "lucide-react";
+import { ChevronRight, FolderOpen, Loader2 } from "lucide-react";
 
 interface DyadListFilesProps {
   node: {
     properties: {
       directory?: string;
+      recursive?: string;
       state?: CustomTagState;
     };
   };
@@ -13,24 +14,42 @@ interface DyadListFilesProps {
 }
 
 export function DyadListFiles({ node, children }: DyadListFilesProps) {
-  const { directory, state } = node.properties;
+  const { directory, recursive, state } = node.properties;
   const isLoading = state === "pending";
+  const isRecursive = recursive === "true";
   const content = typeof children === "string" ? children : "";
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const getTitle = () => {
+    const parts: string[] = ["List Files"];
+    if (directory) {
+      parts[0] = `List Files: ${directory}`;
+    }
+    if (isRecursive) {
+      parts.push("(recursive)");
+    }
+    return parts.join(" ");
+  };
 
   return (
     <div className="my-2 border rounded-md overflow-hidden">
-      <div className="flex items-center gap-2 px-3 py-2 bg-muted/50 border-b">
+      <button
+        type="button"
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="flex items-center gap-2 px-3 py-2 bg-muted/50 w-full text-left hover:bg-muted/70 transition-colors"
+      >
+        <ChevronRight
+          className={`size-4 text-muted-foreground transition-transform ${isExpanded ? "rotate-90" : ""}`}
+        />
         {isLoading ? (
           <Loader2 className="size-4 animate-spin text-muted-foreground" />
         ) : (
           <FolderOpen className="size-4 text-muted-foreground" />
         )}
-        <span className="font-medium text-sm">
-          {directory ? `List Files: ${directory}` : "List Files"}
-        </span>
-      </div>
-      {content && (
-        <div className="p-3 text-xs font-mono whitespace-pre-wrap max-h-60 overflow-y-auto bg-muted/20">
+        <span className="font-medium text-sm">{getTitle()}</span>
+      </button>
+      {isExpanded && content && (
+        <div className="p-3 text-xs font-mono whitespace-pre-wrap max-h-60 overflow-y-auto bg-muted/20 border-t">
           {content}
         </div>
       )}

--- a/src/components/chat/DyadMarkdownParser.tsx
+++ b/src/components/chat/DyadMarkdownParser.tsx
@@ -642,6 +642,7 @@ function renderCustomTag(
           node={{
             properties: {
               directory: attributes.directory || "",
+              recursive: attributes.recursive || "",
               state: getState({ isStreaming, inProgress }),
             },
           }}

--- a/src/pro/main/ipc/handlers/local_agent/tools/list_files.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/list_files.ts
@@ -4,38 +4,81 @@ import { extractCodebase } from "../../../../../../utils/codebase";
 
 const listFilesSchema = z.object({
   directory: z.string().optional().describe("Optional subdirectory to list"),
+  recursive: z
+    .boolean()
+    .optional()
+    .describe("Whether to list files recursively (default: false)"),
 });
 
 export const listFilesTool: ToolDefinition<z.infer<typeof listFilesSchema>> = {
   name: "list_files",
   description:
-    "List all files in the application directory recursively. If you are not sure, list all files by omitting the directory parameter.",
+    "List files in the application directory. By default, lists only the immediate directory contents. Use recursive=true to list all files recursively. If you are not sure, list all files by omitting the directory parameter.",
   inputSchema: listFilesSchema,
   defaultConsent: "always",
 
-  getConsentPreview: (args) =>
-    args.directory ? `List ${args.directory}` : "List all files",
+  getConsentPreview: (args) => {
+    const recursiveText = args.recursive ? " (recursive)" : "";
+    return args.directory
+      ? `List ${args.directory}${recursiveText}`
+      : `List all files${recursiveText}`;
+  },
 
-  buildXml: (args, _isComplete) => {
+  buildXml: (args, isComplete) => {
+    if (isComplete) {
+      return undefined;
+    }
     const dirAttr = args.directory
       ? ` directory="${escapeXmlAttr(args.directory)}"`
       : "";
-    return `<dyad-list-files${dirAttr}></dyad-list-files>`;
+    const recursiveAttr =
+      args.recursive !== undefined ? ` recursive="${args.recursive}"` : "";
+    return `<dyad-list-files${dirAttr}${recursiveAttr}></dyad-list-files>`;
   },
 
   execute: async (args, ctx: AgentContext) => {
+    console.log("list_files", args);
+    // Use "**" for recursive, "*" for non-recursive (immediate children only)
+    const globSuffix = args.recursive ? "/**" : "/*";
+    const globPath = args.directory
+      ? args.directory + globSuffix
+      : globSuffix.slice(1); // Remove leading "/" for root directory
+
     const { files } = await extractCodebase({
       appPath: ctx.appPath,
-      // TODO
       chatContext: {
-        contextPaths: args.directory
-          ? [{ globPath: args.directory + "/**" }]
-          : [],
+        contextPaths: [{ globPath }],
         smartContextAutoIncludes: [],
         excludePaths: [],
       },
     });
 
-    return files.map((file) => " - " + file.path).join("\n") || "";
+    // Build full file list for LLM
+    const allFilesList =
+      files.map((file) => " - " + file.path).join("\n") || "";
+
+    // Build abbreviated list for UI display
+    const MAX_FILES_TO_SHOW = 20;
+    const totalCount = files.length;
+    const displayedFiles = files.slice(0, MAX_FILES_TO_SHOW);
+    const abbreviatedList =
+      displayedFiles.map((file) => " - " + file.path).join("\n") || "";
+    const countInfo =
+      totalCount > MAX_FILES_TO_SHOW
+        ? `\n... and ${totalCount - MAX_FILES_TO_SHOW} more files (${totalCount} total)`
+        : `\n(${totalCount} files total)`;
+
+    // Write abbreviated list to UI
+    const dirAttr = args.directory
+      ? ` directory="${escapeXmlAttr(args.directory)}"`
+      : "";
+    const recursiveAttr =
+      args.recursive !== undefined ? ` recursive="${args.recursive}"` : "";
+    ctx.onXmlComplete(
+      `<dyad-list-files${dirAttr}${recursiveAttr}>${abbreviatedList}${countInfo}</dyad-list-files>`,
+    );
+
+    // Return full file list for LLM
+    return allFilesList;
   },
 };

--- a/src/pro/main/ipc/handlers/local_agent/tools/path_safety.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/path_safety.ts
@@ -14,6 +14,14 @@ export function resolveDirectoryWithinAppPath(params: {
   appPath: string;
   directory: string;
 }): string {
+  // Disallow any ".." path segment (even if the resolved path would remain within root).
+  // This makes path traversal attempts explicit and avoids surprising "a/../b" style inputs.
+  if (/(^|[\\/])\.\.([\\/]|$)/.test(params.directory)) {
+    throw new Error(
+      `Invalid directory path: "${params.directory}" contains ".." path traversal segment`,
+    );
+  }
+
   // We sometimes persist Windows paths with forward slashes (e.g. "C:/..."),
   // so detect win32-style roots and use win32 semantics for the safety check.
   const looksLikeWin32Path =

--- a/src/pro/main/ipc/handlers/local_agent/tools/path_safety.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/path_safety.ts
@@ -1,0 +1,52 @@
+import path from "node:path";
+
+/**
+ * Resolve and validate that `directory` stays within `appPath`.
+ *
+ * Why not `startsWith`?
+ * - On Windows, `path.resolve` normalizes to backslashes, while stored `appPath`
+ *   values may contain forward slashes. A string `startsWith` check can then
+ *   falsely reject valid subdirectories.
+ *
+ * This uses `path.relative` instead, and treats Windows paths as case-insensitive.
+ */
+export function resolveDirectoryWithinAppPath(params: {
+  appPath: string;
+  directory: string;
+}): string {
+  // We sometimes persist Windows paths with forward slashes (e.g. "C:/..."),
+  // so detect win32-style roots and use win32 semantics for the safety check.
+  const looksLikeWin32Path =
+    /^[a-zA-Z]:[\\/]/.test(params.appPath) ||
+    params.appPath.startsWith("\\\\") ||
+    params.appPath.includes("\\");
+
+  const pathImpl = looksLikeWin32Path ? path.win32 : path.posix;
+  const caseInsensitive = looksLikeWin32Path;
+
+  const resolvedAppPath = pathImpl.resolve(params.appPath);
+  const resolvedPath = pathImpl.resolve(resolvedAppPath, params.directory);
+
+  const appForCheck = caseInsensitive
+    ? resolvedAppPath.toLowerCase()
+    : resolvedAppPath;
+  const targetForCheck = caseInsensitive
+    ? resolvedPath.toLowerCase()
+    : resolvedPath;
+
+  const relForCheck = pathImpl.relative(appForCheck, targetForCheck);
+
+  const isWithinRoot =
+    relForCheck === "" ||
+    (!relForCheck.startsWith(`..${pathImpl.sep}`) &&
+      relForCheck !== ".." &&
+      !pathImpl.isAbsolute(relForCheck));
+
+  if (!isWithinRoot) {
+    throw new Error(
+      `Invalid directory path: "${params.directory}" escapes the project directory`,
+    );
+  }
+
+  return pathImpl.relative(resolvedAppPath, resolvedPath);
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Enhancements**
> - `list_files` now accepts `recursive` (default: false); non-recursive uses `/*`, recursive uses `/**`; consent preview/XML reflect recursion and UI title shows "(recursive)".
> - UI: `dyad-list-files` renders as a collapsible panel with chevron toggle and abbreviated file list with total count; wired through `DyadMarkdownParser`.
> 
> **Safety/Infra**
> - Validates directory input via `resolveDirectoryWithinAppPath` to prevent traversal (Windows/POSIX cases covered) with unit tests.
> - Fake LLM server resets fixture turn counting per prompt (counts tool results after last user message) for stable multi-prompt E2E.
> - E2E: adds fixtures and snapshots for recursive and non-recursive modes; shorter toast duration in test mode to speed tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f366934b050a583ae66168e4c924a97a5529f51. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add recursive support to the local agent list_files tool and make results collapsible in the chat UI. Includes E2E coverage and a fix to fixture turn counting for stable multi-prompt runs.

- **New Features**
  - list_files accepts recursive (default: false); uses "/*" for non-recursive and "/**" for recursive.
  - Consent preview/XML and UI reflect recursion; collapsible panel shows abbreviated list with total count.
  - Recursive attribute wired through the markdown parser; added E2E tests and snapshots for both modes.

- **Bug Fixes**
  - Validate directory paths to prevent path traversal outside the app directory.
  - Fake LLM server counts tool results after the last user message to reset turns per prompt.
  - Shorter toast duration in test mode to speed up E2E runs.

<sup>Written for commit 3f366934b050a583ae66168e4c924a97a5529f51. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

