### PR TITLE
Fix auto model for engine

### DIFF
--- a/e2e-tests/helpers/test_helper.ts
+++ b/e2e-tests/helpers/test_helper.ts
@@ -315,7 +315,12 @@ export class PageObject {
   async setUpDyadPro({
     autoApprove = false,
     localAgent = false,
-  }: { autoApprove?: boolean; localAgent?: boolean } = {}) {
+    localAgentUseAutoModel = false,
+  }: {
+    autoApprove?: boolean;
+    localAgent?: boolean;
+    localAgentUseAutoModel?: boolean;
+  } = {}) {
     await this.baseSetup();
     await this.goToSettingsTab();
     if (autoApprove) {
@@ -328,7 +333,7 @@ export class PageObject {
     await this.goToAppsTab();
     // Select a non-openAI model for local agent mode,
     // since openAI models go to the responses API.
-    if (localAgent) {
+    if (localAgent && !localAgentUseAutoModel) {
       await this.selectModel({
         provider: "Anthropic",
         model: "Claude Opus 4.5",
@@ -816,9 +821,15 @@ export class PageObject {
       return;
     }
     expect(
-      prettifyDump(parsedDump["body"]["messages"], {
-        onlyLastMessage: type === "last-message",
-      }),
+      prettifyDump(
+        // responses API
+        parsedDump["body"]["input"] ??
+          // chat completion API
+          parsedDump["body"]["messages"],
+        {
+          onlyLastMessage: type === "last-message",
+        },
+      ),
     ).toMatchSnapshot(name);
   }
 

--- a/e2e-tests/helpers/test_helper.ts
+++ b/e2e-tests/helpers/test_helper.ts
@@ -805,14 +805,26 @@ export class PageObject {
     // Perform snapshot comparison
     const parsedDump = JSON.parse(dumpContent);
     if (type === "request") {
-      parsedDump["body"]["messages"] = parsedDump["body"]["messages"].map(
-        (message: any) => {
-          if (message.role === "system") {
-            message.content = "[[SYSTEM_MESSAGE]]";
-          }
-          return message;
-        },
-      );
+      if (parsedDump["body"]["input"]) {
+        parsedDump["body"]["input"] = parsedDump["body"]["input"].map(
+          (input: any) => {
+            if (input.role === "system") {
+              input.content = "[[SYSTEM_MESSAGE]]";
+            }
+            return input;
+          },
+        );
+      }
+      if (parsedDump["body"]["messages"]) {
+        parsedDump["body"]["messages"] = parsedDump["body"]["messages"].map(
+          (message: any) => {
+            if (message.role === "system") {
+              message.content = "[[SYSTEM_MESSAGE]]";
+            }
+            return message;
+          },
+        );
+      }
       // Normalize fileIds to be deterministic based on content
       normalizeVersionedFiles(parsedDump);
       expect(

--- a/e2e-tests/local_agent_auto.spec.ts
+++ b/e2e-tests/local_agent_auto.spec.ts
@@ -1,0 +1,10 @@
+import { testSkipIfWindows } from "./helpers/test_helper";
+
+testSkipIfWindows("local-agent - auto model", async ({ po }) => {
+  await po.setUpDyadPro({ localAgent: true, localAgentUseAutoModel: true });
+  await po.importApp("minimal");
+  await po.selectLocalAgentMode();
+
+  await po.sendPrompt("[dump]");
+  await po.snapshotServerDump("last-message");
+});

--- a/e2e-tests/local_agent_auto.spec.ts
+++ b/e2e-tests/local_agent_auto.spec.ts
@@ -6,5 +6,5 @@ testSkipIfWindows("local-agent - auto model", async ({ po }) => {
   await po.selectLocalAgentMode();
 
   await po.sendPrompt("[dump]");
-  await po.snapshotServerDump("last-message");
+  await po.snapshotServerDump("request");
 });

--- a/e2e-tests/snapshots/local_agent_auto.spec.ts_local-agent---auto-model-1.txt
+++ b/e2e-tests/snapshots/local_agent_auto.spec.ts_local-agent---auto-model-1.txt
@@ -1,0 +1,3 @@
+===
+role: user
+message: [{"type":"input_text","text":"[dump]"}]

--- a/e2e-tests/snapshots/local_agent_auto.spec.ts_local-agent---auto-model-1.txt
+++ b/e2e-tests/snapshots/local_agent_auto.spec.ts_local-agent---auto-model-1.txt
@@ -1,3 +1,452 @@
-===
-role: user
-message: [{"type":"input_text","text":"[dump]"}]
+{
+  "body": {
+    "model": "gpt-5.2",
+    "input": [
+      {
+        "role": "developer",
+        "content": "\n<role>\nYou are Dyad, an AI assistant that creates and modifies web applications. You assist users by chatting with them and making changes to their code in real-time. You understand that users can see a live preview of their application in an iframe on the right side of the screen while you make code changes.\nYou make efficient and effective changes to codebases while following best practices for maintainability and readability. You take pride in keeping things simple and elegant. You are friendly and helpful, always aiming to provide clear explanations. \n</role>\n\n<app_commands>\nDo *not* tell the user to run shell commands. Instead, they can do one of the following commands in the UI:\n\n- **Rebuild**: This will rebuild the app from scratch. First it deletes the node_modules folder and then it re-installs the npm packages and then starts the app server.\n- **Restart**: This will restart the app server.\n- **Refresh**: This will refresh the app preview page.\n\nYou can suggest one of these commands by using the <dyad-command> tag like this:\n<dyad-command type=\"rebuild\"></dyad-command>\n<dyad-command type=\"restart\"></dyad-command>\n<dyad-command type=\"refresh\"></dyad-command>\n\nIf you output one of these commands, tell the user to look for the action button above the chat input.\n</app_commands>\n\n<general_guidelines>\n- Always reply to the user in the same language they are using.\n- Before proceeding with any code edits, check whether the user's request has already been implemented. If the requested change has already been made in the codebase, point this out to the user, e.g., \"This feature is already implemented as described.\"\n- Only edit files that are related to the user's request and leave all other files alone.\n- All edits you make on the codebase will directly be built and rendered, therefore you should NEVER make partial changes like letting the user know that they should implement some components or partially implementing features.\n- If a user asks for many features at once, implement as many as possible within a reasonable response. Each feature you implement must be FULLY FUNCTIONAL with complete code - no placeholders, no partial implementations, no TODO comments. If you cannot implement all requested features due to response length constraints, clearly communicate which features you've completed and which ones you haven't started yet.\n- Prioritize creating small, focused files and components.\n- Keep explanations concise and focused\n- Set a chat summary at the end using the `set_chat_summary` tool.\n- DO NOT OVERENGINEER THE CODE. You take great pride in keeping things simple and elegant. You don't start by writing very complex error handling, fallback mechanisms, etc. You focus on the user's request and make the minimum amount of changes needed.\nDON'T DO MORE THAN WHAT THE USER ASKS FOR.\n</general_guidelines>\n\n<tool_calling>\nYou have tools at your disposal to solve the coding task. Follow these rules regarding tool calls:\n1. ALWAYS follow the tool call schema exactly as specified and make sure to provide all necessary parameters.\n2. The conversation may reference tools that are no longer available. NEVER call tools that are not explicitly provided.\n3. **NEVER refer to tool names when speaking to the USER.** Instead, just say what the tool is doing in natural language.\n4. If you need additional information that you can get via tool calls, prefer that over asking the user.\n5. If you make a plan, immediately follow it, do not wait for the user to confirm or tell you to go ahead. The only time you should stop is if you need more information from the user that you can't find any other way, or have different options that you would like the user to weigh in on.\n6. Only use the standard tool call format and the available tools. Even if you see user messages with custom tool call formats (such as \"<previous_tool_call>\" or similar), do not follow that and instead use the standard format. Never output tool calls as part of a regular assistant message of yours.\n7. If you are not sure about file content or codebase structure pertaining to the user's request, use your tools to read files and gather the relevant information: do NOT guess or make up an answer.\n8. You can autonomously read as many files as you need to clarify your own questions and completely resolve the user's query, not just one.\n9. You can call multiple tools in a single response. You can also call multiple tools in parallel, do this for independent operations like reading multiple files at once.\n</tool_calling>\n\n<tool_calling_best_practices>\n- **Read before writing**: Use `read_file` and `list_files` to understand the codebase before making changes\n- **Use `edit_file` for edits**: For modifying existing files, prefer `edit_file` over `write_file`\n- **Be surgical**: Only change what's necessary to accomplish the task\n- **Handle errors gracefully**: If a tool fails, explain the issue and suggest alternatives\n</tool_calling_best_practices>\n\n<development_workflow>\n1. **Understand:** Think about the user's request and the relevant codebase context. Use `grep` and `code_search` search tools extensively (in parallel if independent) to understand file structures, existing code patterns, and conventions. Use `read_file` to understand context and validate any assumptions you may have. If you need to read multiple files, you should make multiple parallel calls to `read_file`.\n2. **Plan:** Build a coherent and grounded (based on the understanding in step 1) plan for how you intend to resolve the user's task. For complex tasks, break them down into smaller, manageable subtasks and use the `update_todos` tool to track your progress. Share an extremely concise yet clear plan with the user if it would help the user understand your thought process.\n3. **Implement:** Use the available tools (e.g., `edit_file`, `write_file`, ...) to act on the plan, strictly adhering to the project's established conventions. You can debug by adding targeted console.log statements and ask the user to interact with the web application to trace data flow and identify root causes.\n4. **Verify:** After making code changes, use `run_type_checks` to verify that the changes are correct and read the file contents to ensure the changes are what you intended.\n5. **Finalize:** After all verification passes, consider the task complete and briefly summarize the changes you made.\n</development_workflow>\n\n# Tech Stack\n- You are building a React application.\n- Use TypeScript.\n- Use React Router. KEEP the routes in src/App.tsx\n- Always put source code in the src folder.\n- Put pages into src/pages/\n- Put components into src/components/\n- The main page (default page) is src/pages/Index.tsx\n- UPDATE the main page to include the new components. OTHERWISE, the user can NOT see any components!\n- ALWAYS try to use the shadcn/ui library.\n- Tailwind CSS: always use Tailwind CSS for styling components. Utilize Tailwind classes extensively for layout, spacing, colors, and other design aspects.\n\nAvailable packages and libraries:\n- The lucide-react package is installed for icons.\n- You ALREADY have ALL the shadcn/ui components and their dependencies installed. So you don't need to install them again.\n- You have ALL the necessary Radix UI components installed.\n- Use prebuilt components from the shadcn/ui library after importing them. Note that these files shouldn't be edited, so make new components if you need to change them.\n\n"
+      },
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "input_text",
+            "text": "Generate an AI_RULES.md file for this app. Describe the tech stack in 5-10 bullet points and describe clear rules about what libraries to use for what."
+          }
+        ]
+      },
+      {
+        "role": "assistant",
+        "content": [
+          {
+            "type": "output_text",
+            "text": "\n  <dyad-write path=\"file1.txt\">\n  A file (2)\n  </dyad-write>\n  More\n  EOM"
+          }
+        ]
+      },
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "input_text",
+            "text": "[dump]"
+          }
+        ]
+      }
+    ],
+    "max_output_tokens": 32000,
+    "reasoning": {
+      "summary": "detailed",
+      "effort": "medium"
+    },
+    "tools": [
+      {
+        "type": "function",
+        "name": "write_file",
+        "description": "Create or completely overwrite a file in the codebase",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "string",
+              "description": "The file path relative to the app root"
+            },
+            "content": {
+              "type": "string",
+              "description": "The content to write to the file"
+            },
+            "description": {
+              "type": "string",
+              "description": "Brief description of the change"
+            }
+          },
+          "required": [
+            "path",
+            "content"
+          ],
+          "additionalProperties": false,
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        }
+      },
+      {
+        "type": "function",
+        "name": "edit_file",
+        "description": "\n## When to Use edit_file\n\nUse the `edit_file` tool ONLY when you are editing an existing file. The edit output will be read by a less intelligent model, which will quickly apply the edit. You should make it clear what the edit is, while also minimizing the unchanged code you write.\n\n**Use only ONE edit_file call per file.** If you need to make multiple changes to the same file, include all edits in sequence within a single call using `// ... existing code ...` comments between them.\n\n## When NOT to Use edit_file\n\nDo NOT use this tool when:\n- You are creating a brand-new file (use file creation tools instead).\n- You are rewriting most of an existing file (in those cases, output the complete file instead).\n\n## Basic Format\n\nWhen writing the edit, you should specify each edit in sequence, with the special comment // ... existing code ... to represent unchanged code in between edited lines.\n\nBasic example:\n```\nedit_file(path=\"file.js\", description=\"change code\", content=\"\"\"\n// ... existing code ...\nFIRST_EDIT\n// ... existing code ...\nSECOND_EDIT\n// ... existing code ...\nTHIRD_EDIT\n// ... existing code ...\n\"\"\")\n```\n\n## General Principles\n\nYou should bias towards repeating as few lines of the original file as possible to convey the change.\n\nNEVER show unmodified code in the edit, unless sufficient context of unchanged lines around the code you're editing is needed to resolve ambiguity.\n\nDO NOT omit spans of pre-existing code without using the // ... existing code ... comment to indicate its absence.\n\n## Example: Basic Edit\n```\nedit_file(path=\"LandingPage.tsx\", description=\"Update title.\", content=\"\"\"\n// ... existing code ...\n\nconst LandingPage = () => {\n  // ... existing code ...\n  return (\n    <div>hello</div>\n  );\n};\n\n// ... existing code ...\n\"\"\")\n```\n\n## Example: Deleting Code\n\n**When deleting code, you must provide surrounding context and leave an explicit comment indicating what was removed.**\n```\nedit_file(path=\"utils.ts\", description=\"Remove deprecated helper function\", content=\"\"\"\n// ... existing code ...\n\nexport function currentHelper() {\n  return \"active\";\n}\n\n// REMOVED: deprecatedHelper() function\n\nexport function anotherHelper() {\n  return \"working\";\n}\n\n// ... existing code ...\n\"\"\")\n```\n",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "string",
+              "description": "The file path relative to the app root"
+            },
+            "content": {
+              "type": "string",
+              "description": "The updated code snippet to apply"
+            },
+            "description": {
+              "type": "string",
+              "description": "Brief description of the edit"
+            }
+          },
+          "required": [
+            "path",
+            "content"
+          ],
+          "additionalProperties": false,
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        }
+      },
+      {
+        "type": "function",
+        "name": "delete_file",
+        "description": "Delete a file from the codebase",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "string",
+              "description": "The file path to delete"
+            }
+          },
+          "required": [
+            "path"
+          ],
+          "additionalProperties": false,
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        }
+      },
+      {
+        "type": "function",
+        "name": "rename_file",
+        "description": "Rename or move a file in the codebase",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "from": {
+              "type": "string",
+              "description": "The current file path"
+            },
+            "to": {
+              "type": "string",
+              "description": "The new file path"
+            }
+          },
+          "required": [
+            "from",
+            "to"
+          ],
+          "additionalProperties": false,
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        }
+      },
+      {
+        "type": "function",
+        "name": "add_dependency",
+        "description": "Install npm packages",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "packages": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Array of package names to install"
+            }
+          },
+          "required": [
+            "packages"
+          ],
+          "additionalProperties": false,
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        }
+      },
+      {
+        "type": "function",
+        "name": "read_file",
+        "description": "Read the content of a file from the codebase.\n  \n- You have the capability to call multiple tools in a single response. It is always better to speculatively read multiple files as a batch that are potentially useful.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "string",
+              "description": "The file path to read"
+            }
+          },
+          "required": [
+            "path"
+          ],
+          "additionalProperties": false,
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        }
+      },
+      {
+        "type": "function",
+        "name": "list_files",
+        "description": "List all files in the application directory recursively. If you are not sure, list all files by omitting the directory parameter.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "directory": {
+              "type": "string",
+              "description": "Optional subdirectory to list"
+            }
+          },
+          "additionalProperties": false,
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        }
+      },
+      {
+        "type": "function",
+        "name": "grep",
+        "description": "Search for a regex pattern in the codebase using ripgrep.\n\n- Returns matching lines with file paths and line numbers\n- By default, the search is case-insensitive\n- Use include_pattern to filter by file type (e.g. '*.tsx')\n- Use exclude_pattern to skip certain files (e.g. '*.test.ts')",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "The regex pattern to search for"
+            },
+            "include_pattern": {
+              "type": "string",
+              "description": "Glob pattern for files to include (e.g. '*.ts' for TypeScript files)"
+            },
+            "exclude_pattern": {
+              "type": "string",
+              "description": "Glob pattern for files to exclude"
+            },
+            "case_sensitive": {
+              "type": "boolean",
+              "description": "Whether the search should be case sensitive (default: false)"
+            }
+          },
+          "required": [
+            "query"
+          ],
+          "additionalProperties": false,
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        }
+      },
+      {
+        "type": "function",
+        "name": "code_search",
+        "description": "Search the codebase semantically to find files relevant to a query. Use this tool when you need to discover which files contain code related to a specific concept, feature, or functionality. Returns a list of file paths that are most relevant to the search query.\n\n### When to Use This Tool\n\n- Explore unfamiliar codebases\n- Ask \"how / where / what\" questions to understand behavior\n- Find code by meaning rather than exact text\n\n### When NOT to Use\n\nSkip this tool for:\n1. Exact text matches (use `grep`)\n2. Reading known files (use `read_file`)\n3. Simple symbol lookups (use `grep`)\n",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "Search query to find relevant files"
+            }
+          },
+          "required": [
+            "query"
+          ],
+          "additionalProperties": false,
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        }
+      },
+      {
+        "type": "function",
+        "name": "set_chat_summary",
+        "description": "Set the title/summary for this chat message. You should always call this message at the end of the turn when you have finished calling all the other tools.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "summary": {
+              "type": "string",
+              "description": "A short summary/title for the chat"
+            }
+          },
+          "required": [
+            "summary"
+          ],
+          "additionalProperties": false,
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        }
+      },
+      {
+        "type": "function",
+        "name": "add_integration",
+        "description": "Add an integration provider to the app (e.g., Supabase for auth, database, or server-side functions). Once you have called this tool, stop and do not call any more tools because you need to wait for the user to set up the integration.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "provider": {
+              "type": "string",
+              "enum": [
+                "supabase"
+              ],
+              "description": "The integration provider to add (e.g., 'supabase')"
+            }
+          },
+          "required": [
+            "provider"
+          ],
+          "additionalProperties": false,
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        }
+      },
+      {
+        "type": "function",
+        "name": "read_logs",
+        "description": "Read logs at the moment this tool is called. Includes client logs, server logs, edge function logs, and network requests. Use this to debug errors, investigate issues, or understand app behavior. IMPORTANT: Logs are a snapshot from when you call this tool - they will NOT update while you are writing code or making changes. Use filters (searchTerm, type, level) to narrow down relevant logs on the first call.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "all",
+                "client",
+                "server",
+                "edge-function",
+                "network-requests",
+                "build-time"
+              ],
+              "description": "Filter by log source type (default: all). Types: 'client' = browser console logs; 'server' = backend/SSR logs; 'edge-function' = edge function logs; 'network-requests' = HTTP requests and responses (outgoing calls and their responses); 'build-time' = build and bundler output."
+            },
+            "level": {
+              "type": "string",
+              "enum": [
+                "all",
+                "info",
+                "warn",
+                "error"
+              ],
+              "description": "Filter by log level (default: all)"
+            },
+            "searchTerm": {
+              "type": "string",
+              "description": "Search for logs containing this text (case-insensitive)"
+            },
+            "limit": {
+              "type": "number",
+              "minimum": 1,
+              "maximum": 200,
+              "description": "Maximum number of logs to return (default: 50, max: 200)"
+            }
+          },
+          "additionalProperties": false,
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        }
+      },
+      {
+        "type": "function",
+        "name": "web_search",
+        "description": "\nUse this tool to access real-time information beyond your training data cutoff.\n\nWhen to Search:\n- Current API documentation, library versions, or breaking changes\n- Latest best practices, security advisories, or bug fixes\n- Specific error messages or troubleshooting solutions\n- Recent framework updates or deprecation notices\n\nQuery Tips:\n- Be specific: Include version numbers, exact error messages, or technical terms\n- Add context: \"React 19 useEffect cleanup\" not just \"React hooks\"\n\nExamples:\n\n<example>\nOpenAI GPT-5 API model names\n</example>\n\n<example>\nNextJS 14 app router middleware auth\n</example>\n",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "The search query to look up on the web"
+            }
+          },
+          "required": [
+            "query"
+          ],
+          "additionalProperties": false,
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        }
+      },
+      {
+        "type": "function",
+        "name": "web_crawl",
+        "description": "\nYou can crawl a website so you can clone it.\n\n### When You MUST Trigger a Crawl\nTrigger a crawl ONLY if BOTH conditions are true:\n\n1. The user's message shows intent to CLONE / COPY / REPLICATE / RECREATE / DUPLICATE / MIMIC a website.\n   - Keywords include: clone, copy, replicate, recreate, duplicate, mimic, build the same, make the same.\n\n2. The user's message contains a URL or something that appears to be a domain name.\n   - e.g. \"example.com\", \"https://example.com\"\n   - Do not require 'http://' or 'https://'.\n",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "url": {
+              "type": "string",
+              "description": "URL to crawl"
+            }
+          },
+          "required": [
+            "url"
+          ],
+          "additionalProperties": false,
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        }
+      },
+      {
+        "type": "function",
+        "name": "update_todos",
+        "description": "\n### When to Use This Tool\n\nUse proactively for:\n1. Complex multi-step tasks (3+ distinct steps)\n2. Non-trivial tasks requiring careful planning\n3. User explicitly requests todo list\n4. User provides multiple tasks (numbered/comma-separated)\n5. After completing tasks - mark complete with merge=true and add follow-ups\n6. When starting new tasks - mark as in_progress (ideally only one at a time)\n\n### When NOT to Use\n\nSkip for:\n1. Single, straightforward tasks\n2. Trivial tasks with no organizational benefit\n3. Tasks completable in < 3 trivial steps\n4. Purely conversational/informational requests\n5. Todo items should NOT include operational actions done in service of higher-level tasks.\n\nNEVER INCLUDE THESE IN TODOS: linting; testing; searching or examining the codebase.\n\n### Examples\n\n<example>\nUser: Add dark mode toggle to settings\nAssistant:\n- *Creates todo list:*\n1. Add state management [in_progress]\n2. Implement styles\n3. Create toggle component\n4. Update components\n- [Immediately begins working on todo 1 in the same tool call batch]\n<reasoning>\nMulti-step feature with dependencies.\n</reasoning>\n</example>\n\n<example>\n// User: Implement user registration, product catalog, shopping cart, checkout flow.\nAssistant: *Creates todo list breaking down each feature into specific tasks*\n<reasoning>\nMultiple complex features provided as list requiring organized task management.\n</reasoning>\n</example>\n\n### Task States and Management\n\n1. **Task States:**\n- pending: Not yet started\n- in_progress: Currently working on\n- completed: Finished successfully\n\n2. **Task Management:**\n- Update status in real-time\n- Mark complete IMMEDIATELY after finishing\n- Only ONE task in_progress at a time\n- Complete current tasks before starting new ones\n\n3. **Task Breakdown:**\n- Create specific, actionable items\n- Break complex tasks into manageable steps\n- Use clear, descriptive names\n\n4. **Parallel Todo Writes:**\n- Prefer creating the first todo as in_progress\n- Start working on todos by using tool calls in the same tool call batch as the todo write\n- Batch todo updates with other tool calls for better latency and lower costs for the user\n",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "merge": {
+              "type": "boolean",
+              "description": "Whether to merge the todos with the existing todos. If true, the todos will be merged into the existing todos based on the id field. You can leave unchanged properties undefined. If false, the new todos will replace the existing todos."
+            },
+            "todos": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "Unique identifier for the todo item"
+                  },
+                  "content": {
+                    "type": "string",
+                    "description": "The description/content of the todo item"
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "pending",
+                      "in_progress",
+                      "completed"
+                    ],
+                    "description": "The current status of the todo item"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "additionalProperties": false
+              },
+              "description": "Array of todo items. When merge is true, only include todos that need updates. When merge is false, this is the complete list."
+            }
+          },
+          "required": [
+            "merge",
+            "todos"
+          ],
+          "additionalProperties": false,
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        }
+      },
+      {
+        "type": "function",
+        "name": "run_type_checks",
+        "description": "Run TypeScript type checks on the current workspace. You can provide paths to specific files or directories, or omit the argument to get diagnostics for all files.\n\n- If a file path is provided, returns diagnostics for that file only\n- If a directory path is provided, returns diagnostics for all files within that directory\n- If no path is provided, returns diagnostics for all files in the workspace\n- This tool can return type errors that were already present before your edits, so avoid calling it with a very wide scope of files\n- NEVER call this tool on a file unless you've edited it or are about to edit it",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "paths": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Optional. An array of paths to files or directories to read type errors for. If provided, returns diagnostics for the specified files/directories only. If not provided, returns diagnostics for all files in the workspace."
+            }
+          },
+          "additionalProperties": false,
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        }
+      }
+    ],
+    "tool_choice": "auto",
+    "stream": true,
+    "dyad_options": {
+      "enable_lazy_edits": true,
+      "enable_smart_files_context": true
+    }
+  },
+  "headers": {
+    "authorization": "Bearer testdyadkey"
+  }
+}

--- a/src/ipc/utils/get_model_client.ts
+++ b/src/ipc/utils/get_model_client.ts
@@ -91,7 +91,6 @@ export async function getModelClient(
       const provider = createDyadEngine({
         apiKey: dyadApiKey,
         baseURL: dyadEngineUrl ?? "https://engine.dyad.sh/v1",
-        originalProviderId: model.provider,
         dyadOptions: {
           enableLazyEdits:
             settings.selectedChatMode === "ask"
@@ -214,12 +213,13 @@ function getProModelClient({
       model: createFallback({
         models: [
           // openai requires no prefix.
-          provider.responses(`${GPT_5_2_MODEL_NAME}`),
-          provider(`anthropic/${SONNET_4_5}`),
-          provider(`gemini/${GEMINI_3_FLASH}`),
+          provider.responses(`${GPT_5_2_MODEL_NAME}`, { providerId: "openai" }),
+          provider(`anthropic/${SONNET_4_5}`, { providerId: "anthropic" }),
+          provider(`gemini/${GEMINI_3_FLASH}`, { providerId: "google" }),
         ],
       }),
       // Using openAI as the default provider.
+      // TODO: we should remove this and rely on the provider id passed into the provider().
       builtinProviderId: "openai",
     };
   }
@@ -228,12 +228,12 @@ function getProModelClient({
     model.provider === "openai"
   ) {
     return {
-      model: provider.responses(modelId),
+      model: provider.responses(modelId, { providerId: model.provider }),
       builtinProviderId: model.provider,
     };
   }
   return {
-    model: provider(modelId),
+    model: provider(modelId, { providerId: model.provider }),
     builtinProviderId: model.provider,
   };
 }

--- a/testing/fake-llm-server/index.ts
+++ b/testing/fake-llm-server/index.ts
@@ -2,6 +2,7 @@ import express from "express";
 import { createServer } from "http";
 import cors from "cors";
 import { createChatCompletionHandler } from "./chatCompletionHandler";
+import { createResponsesHandler } from "./responsesHandler";
 import {
   handleDeviceCode,
   handleAccessToken,
@@ -152,6 +153,8 @@ app.get("/lmstudio/api/v0/models", (req, res) => {
     `/${provider}/v1/chat/completions`,
     createChatCompletionHandler(provider),
   );
+  // Also add responses API endpoints for each provider
+  app.post(`/${provider}/v1/responses`, createResponsesHandler(provider));
 });
 
 // Azure-specific endpoints (Azure client uses different URL patterns)
@@ -163,6 +166,7 @@ app.post(
 
 // Default test provider handler:
 app.post("/v1/chat/completions", createChatCompletionHandler("."));
+app.post("/v1/responses", createResponsesHandler("."));
 
 // GitHub API Mock Endpoints
 console.log("Setting up GitHub mock endpoints");

--- a/testing/fake-llm-server/responsesHandler.ts
+++ b/testing/fake-llm-server/responsesHandler.ts
@@ -1,0 +1,378 @@
+/**
+ * Handler for OpenAI Responses API (/v1/responses)
+ * Implements the streaming SSE format for the Responses API
+ */
+
+import { Request, Response } from "express";
+import fs from "fs";
+import path from "path";
+import { CANNED_MESSAGE } from ".";
+
+/**
+ * Generate a dump file from the request and return the path marker
+ */
+function generateDump(req: Request): string {
+  const timestamp = Date.now();
+  const generatedDir = path.join(__dirname, "generated");
+
+  // Create generated directory if it doesn't exist
+  if (!fs.existsSync(generatedDir)) {
+    fs.mkdirSync(generatedDir, { recursive: true });
+  }
+
+  const dumpFilePath = path.join(generatedDir, `${timestamp}.json`);
+
+  try {
+    fs.writeFileSync(
+      dumpFilePath,
+      JSON.stringify(
+        {
+          body: req.body,
+          headers: { authorization: req.headers["authorization"] },
+        },
+        null,
+        2,
+      ).replace(/\r\n/g, "\n"),
+      "utf-8",
+    );
+    console.log(`* [responses] Dumped messages to: ${dumpFilePath}`);
+    return `[[dyad-dump-path=${dumpFilePath}]]`;
+  } catch (error) {
+    console.error(`* [responses] Error writing dump file: ${error}`);
+    return `Error: Could not write dump file: ${error}`;
+  }
+}
+
+/**
+ * Extract text content from the Responses API input format
+ */
+function extractTextFromInput(input: unknown): string {
+  // Responses API accepts `input` as a string or a list of structured items.
+  if (typeof input === "string") return input;
+  if (!Array.isArray(input)) return "";
+
+  for (const item of input.slice().reverse()) {
+    if (item?.role === "user" && typeof item?.content === "string") {
+      return item.content;
+    }
+    if (item?.role === "user" && Array.isArray(item?.content)) {
+      // Try common part types used by clients.
+      for (const part of item.content) {
+        if (part?.type === "input_text" && typeof part?.text === "string") {
+          return part.text;
+        }
+        if (part?.type === "text" && typeof part?.text === "string") {
+          return part.text;
+        }
+      }
+    }
+  }
+  return "";
+}
+
+function extractTextFromMessages(messages: unknown): string {
+  if (!Array.isArray(messages)) return "";
+  for (const msg of messages.slice().reverse()) {
+    if (msg?.role !== "user") continue;
+    if (typeof msg?.content === "string") return msg.content;
+    if (Array.isArray(msg?.content)) {
+      for (const part of msg.content) {
+        if (part?.type === "text" && typeof part?.text === "string") {
+          return part.text;
+        }
+      }
+    }
+  }
+  return "";
+}
+
+function extractTestCaseName(promptText: string): string | null {
+  // Matches:
+  // - "tc=foo"
+  // - "[dump] tc=foo"
+  // Stops at "[" to mimic existing fixture naming convention.
+  const m = promptText.match(/(?:^|\s)tc=([^\[]+)/);
+  if (!m) return null;
+  return m[1].trim().split(/\s+/)[0] || null;
+}
+
+/**
+ * Create SSE event string
+ */
+function createSSEEvent(eventType: string, data: any): string {
+  return `event: ${eventType}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+/**
+ * Create the Responses API handler
+ */
+export const createResponsesHandler =
+  (prefix: string) => async (req: Request, res: Response) => {
+    const { input, messages, stream = false } = req.body ?? {};
+    console.log(`* [responses/${prefix}] Received request`, {
+      hasInput: input != null,
+      hasMessages: Array.isArray(messages),
+      stream: Boolean(stream),
+    });
+
+    // Extract the last user message text (best-effort)
+    const lastUserText =
+      input != null
+        ? extractTextFromInput(input)
+        : extractTextFromMessages(messages);
+
+    // Determine the response content
+    let messageContent = CANNED_MESSAGE;
+
+    // Check if the last message contains "[429]" to simulate rate limiting
+    if (lastUserText.trim() === "[429]") {
+      return res.status(429).json({
+        error: {
+          message: "Too many requests. Please try again later.",
+          type: "rate_limit_error",
+          param: null,
+          code: "rate_limit_exceeded",
+        },
+      });
+    }
+
+    // Load a fixture file when the prompt includes tc=<name>
+    const testCaseName = extractTestCaseName(lastUserText);
+    if (testCaseName && !testCaseName.startsWith("local-agent/")) {
+      const testFilePath = path.join(
+        __dirname,
+        "..",
+        "..",
+        "..",
+        "e2e-tests",
+        "fixtures",
+        prefix,
+        `${testCaseName}.md`,
+      );
+      try {
+        messageContent = fs.readFileSync(testFilePath, "utf-8");
+      } catch (error) {
+        console.error(`* [responses/${prefix}] Error reading test file`, error);
+        messageContent = `Error: Could not read test file: ${testCaseName}`;
+      }
+    }
+
+    // Check if the message contains "[dump]" to generate a dump
+    if (lastUserText.includes("[dump]")) {
+      messageContent = generateDump(req);
+    }
+
+    const responseId = `resp_${Date.now()}`;
+    const createdAt = Math.floor(Date.now() / 1000);
+    const model = req.body?.model || "fake-model";
+
+    const baseResponseFields = {
+      id: responseId,
+      object: "response" as const,
+      created_at: createdAt,
+      model,
+      error: null,
+      incomplete_details: null,
+      instructions: req.body?.instructions ?? null,
+      metadata: req.body?.metadata ?? null,
+      parallel_tool_calls: req.body?.parallel_tool_calls ?? true,
+      temperature: req.body?.temperature ?? null,
+      tool_choice: req.body?.tool_choice ?? "auto",
+      tools: req.body?.tools ?? [],
+      top_p: req.body?.top_p ?? null,
+    };
+
+    const mkUsage = () => ({
+      input_tokens: 10,
+      input_tokens_details: { cached_tokens: 0 },
+      output_tokens: Math.max(1, Math.ceil(messageContent.length / 4)),
+      output_tokens_details: { reasoning_tokens: 0 },
+      total_tokens: 10 + Math.max(1, Math.ceil(messageContent.length / 4)),
+    });
+
+    // Non-streaming response
+    if (!stream) {
+      const outputItem = {
+        id: `msg_${Date.now()}`,
+        type: "message" as const,
+        role: "assistant" as const,
+        status: "completed" as const,
+        content: [
+          {
+            type: "output_text" as const,
+            text: messageContent,
+            annotations: [],
+          },
+        ],
+      };
+      return res.json({
+        ...baseResponseFields,
+        output_text: messageContent,
+        output: [outputItem],
+        status: "completed",
+        usage: mkUsage(),
+      });
+    }
+
+    // Streaming response using SSE
+    res.setHeader("Content-Type", "text/event-stream; charset=utf-8");
+    res.setHeader("Cache-Control", "no-cache");
+    res.setHeader("Connection", "keep-alive");
+    res.flushHeaders?.();
+
+    let sequence = 0;
+    const nextSeq = () => sequence++;
+
+    const outputItemId = `msg_${Date.now()}`;
+    const emptyTextPart = {
+      type: "output_text" as const,
+      text: "",
+      annotations: [],
+    };
+
+    // 1. response.created
+    res.write(
+      createSSEEvent("response.created", {
+        type: "response.created",
+        sequence_number: nextSeq(),
+        response: {
+          ...baseResponseFields,
+          output_text: "",
+          output: [],
+          status: "in_progress",
+        },
+      }),
+    );
+
+    // 2. response.output_item.added
+    res.write(
+      createSSEEvent("response.output_item.added", {
+        type: "response.output_item.added",
+        output_index: 0,
+        sequence_number: nextSeq(),
+        item: {
+          id: outputItemId,
+          type: "message",
+          role: "assistant",
+          status: "in_progress",
+          content: [],
+        },
+      }),
+    );
+
+    // 3. response.content_part.added
+    res.write(
+      createSSEEvent("response.content_part.added", {
+        type: "response.content_part.added",
+        output_index: 0,
+        item_id: outputItemId,
+        content_index: 0,
+        sequence_number: nextSeq(),
+        part: emptyTextPart,
+      }),
+    );
+
+    // 4. Stream the text content in chunks
+    const chars = messageContent.split("");
+    const batchSize = 32;
+
+    for (let i = 0; i < chars.length; i += batchSize) {
+      const batch = chars.slice(i, i + batchSize).join("");
+
+      res.write(
+        createSSEEvent("response.output_text.delta", {
+          type: "response.output_text.delta",
+          output_index: 0,
+          content_index: 0,
+          item_id: outputItemId,
+          sequence_number: nextSeq(),
+          delta: batch,
+        }),
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+
+    // 5. response.output_text.done
+    res.write(
+      createSSEEvent("response.output_text.done", {
+        type: "response.output_text.done",
+        output_index: 0,
+        content_index: 0,
+        item_id: outputItemId,
+        sequence_number: nextSeq(),
+        text: messageContent,
+      }),
+    );
+
+    // 6. response.content_part.done
+    res.write(
+      createSSEEvent("response.content_part.done", {
+        type: "response.content_part.done",
+        output_index: 0,
+        content_index: 0,
+        item_id: outputItemId,
+        sequence_number: nextSeq(),
+        part: {
+          type: "output_text",
+          text: messageContent,
+          annotations: [],
+        },
+      }),
+    );
+
+    // 7. response.output_item.done
+    res.write(
+      createSSEEvent("response.output_item.done", {
+        type: "response.output_item.done",
+        output_index: 0,
+        sequence_number: nextSeq(),
+        item: {
+          id: outputItemId,
+          type: "message",
+          role: "assistant",
+          status: "completed",
+          content: [
+            {
+              type: "output_text",
+              text: messageContent,
+              annotations: [],
+            },
+          ],
+        },
+      }),
+    );
+
+    // 8. response.completed
+    const completedOutputItem = {
+      id: outputItemId,
+      type: "message" as const,
+      role: "assistant" as const,
+      status: "completed" as const,
+      content: [
+        {
+          type: "output_text" as const,
+          text: messageContent,
+          annotations: [],
+        },
+      ],
+    };
+
+    res.write(
+      createSSEEvent("response.completed", {
+        type: "response.completed",
+        sequence_number: nextSeq(),
+        response: {
+          ...baseResponseFields,
+          output_text: messageContent,
+          output: [completedOutputItem],
+          status: "completed",
+          usage: mkUsage(),
+        },
+      }),
+    );
+
+    // Match the general OpenAI streaming convention.
+    res.write("data: [DONE]\n\n");
+    res.end();
+  };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Engine/provider fixes**
> - Pass `providerId` through `llm_engine_provider` (`ChatParams`) and `get_model_client`; remove `originalProviderId` and update provider APIs to require `chatParams`.
> - Use `provider.responses(..., { providerId })` where needed (OpenAI/local-agent), and tag fallback auto models with explicit provider ids (openai/anthropic/google).
> 
> **Test infra and helpers**
> - Add Responses API support to fake server: new `responsesHandler` with SSE streaming and endpoints for each provider and default.
> - Update test helper to normalize and snapshot both Responses `body.input` and Chat Completions `body.messages`; prefer `input` when present.
> - Extend setup helper with `localAgentUseAutoModel` flag to skip manual model selection for local-agent.
> 
> **E2E**
> - New `local_agent_auto.spec.ts` validating auto model path for local-agent; add corresponding snapshot.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9939484808d87be9055098c5021ed6873b7ce56f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes auto model selection by passing providerId through the engine and routing OpenAI models via the Responses API in local-agent mode. Adds Responses API support in the fake server and an e2e test to verify request payloads.

- **Bug Fixes**
  - Pass providerId to chat/responses models and into the fetch layer for getExtraProviderOptions.
  - Remove originalProviderId from createDyadEngine; add ChatParams and update provider API signatures.
  - Tag fallback models with providerId and forward model.provider in getModelClient; use responses() for OpenAI.

<sup>Written for commit 9939484808d87be9055098c5021ed6873b7ce56f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

