### PR TITLE
prototype: anthropic thinking budget

### DIFF
--- a/src/ipc/shared/language_model_constants.ts
+++ b/src/ipc/shared/language_model_constants.ts
@@ -120,7 +120,8 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
       // Set to 32k since context window is 1M tokens
       maxOutputTokens: 32_000,
       contextWindow: 200_000,
-      temperature: 0,
+      // Requires temperature of 1 to enable thinking
+      temperature: 1,
       dollarSigns: 5,
     },
     {
@@ -131,7 +132,8 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
       // Set to 32k since context window is 1M tokens
       maxOutputTokens: 32_000,
       contextWindow: 1_000_000,
-      temperature: 0,
+      // Requires temperature of 1 to enable thinking
+      temperature: 1,
       dollarSigns: 5,
     },
     {
@@ -141,7 +143,8 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
       // Set to 32k since context window is 1M tokens
       maxOutputTokens: 32_000,
       contextWindow: 1_000_000,
-      temperature: 0,
+      // Requires temperature of 1 to enable thinking
+      temperature: 1,
       dollarSigns: 5,
     },
   ],

--- a/src/ipc/utils/ai_sdk/chat/convert-openai-compatible-chat-usage.ts
+++ b/src/ipc/utils/ai_sdk/chat/convert-openai-compatible-chat-usage.ts
@@ -1,0 +1,55 @@
+import { LanguageModelV3Usage } from '@ai-sdk/provider';
+
+export function convertOpenAICompatibleChatUsage(
+  usage:
+    | {
+        prompt_tokens?: number | null;
+        completion_tokens?: number | null;
+        prompt_tokens_details?: {
+          cached_tokens?: number | null;
+        } | null;
+        completion_tokens_details?: {
+          reasoning_tokens?: number | null;
+        } | null;
+      }
+    | undefined
+    | null,
+): LanguageModelV3Usage {
+  if (usage == null) {
+    return {
+      inputTokens: {
+        total: undefined,
+        noCache: undefined,
+        cacheRead: undefined,
+        cacheWrite: undefined,
+      },
+      outputTokens: {
+        total: undefined,
+        text: undefined,
+        reasoning: undefined,
+      },
+      raw: undefined,
+    };
+  }
+
+  const promptTokens = usage.prompt_tokens ?? 0;
+  const completionTokens = usage.completion_tokens ?? 0;
+  const cacheReadTokens = usage.prompt_tokens_details?.cached_tokens ?? 0;
+  const reasoningTokens =
+    usage.completion_tokens_details?.reasoning_tokens ?? 0;
+
+  return {
+    inputTokens: {
+      total: promptTokens,
+      noCache: promptTokens - cacheReadTokens,
+      cacheRead: cacheReadTokens,
+      cacheWrite: undefined,
+    },
+    outputTokens: {
+      total: completionTokens,
+      text: completionTokens - reasoningTokens,
+      reasoning: reasoningTokens,
+    },
+    raw: usage,
+  };
+}

--- a/src/ipc/utils/ai_sdk/chat/convert-to-openai-compatible-chat-messages.test.ts
+++ b/src/ipc/utils/ai_sdk/chat/convert-to-openai-compatible-chat-messages.test.ts
@@ -1,0 +1,940 @@
+import { convertToOpenAICompatibleChatMessages } from './convert-to-openai-compatible-chat-messages';
+import { describe, it, expect } from 'vitest';
+
+describe('user messages', () => {
+  it('should convert messages with only a text part to a string content', async () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Hello' }],
+      },
+    ]);
+
+    expect(result).toEqual([{ role: 'user', content: 'Hello' }]);
+  });
+
+  it('should convert messages with image parts', async () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Hello' },
+          {
+            type: 'file',
+            data: Buffer.from([0, 1, 2, 3]).toString('base64'),
+            mediaType: 'image/png',
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Hello' },
+          {
+            type: 'image_url',
+            image_url: { url: 'data:image/png;base64,AAECAw==' },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should convert messages with image parts from Uint8Array', async () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Hi' },
+          {
+            type: 'file',
+            data: new Uint8Array([0, 1, 2, 3]),
+            mediaType: 'image/png',
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Hi' },
+          {
+            type: 'image_url',
+            image_url: { url: 'data:image/png;base64,AAECAw==' },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should handle URL-based images', async () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: new URL('https://example.com/image.jpg'),
+            mediaType: 'image/*',
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'image_url',
+            image_url: { url: 'https://example.com/image.jpg' },
+          },
+        ],
+      },
+    ]);
+  });
+});
+
+describe('tool calls', () => {
+  it('should stringify arguments to tool calls', () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            input: { foo: 'bar123' },
+            toolCallId: 'quux',
+            toolName: 'thwomp',
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'quux',
+            toolName: 'thwomp',
+            output: { type: 'json', value: { oof: '321rab' } },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'assistant',
+        content: '',
+        tool_calls: [
+          {
+            type: 'function',
+            id: 'quux',
+            function: {
+              name: 'thwomp',
+              arguments: JSON.stringify({ foo: 'bar123' }),
+            },
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: JSON.stringify({ oof: '321rab' }),
+        tool_call_id: 'quux',
+      },
+    ]);
+  });
+
+  it('should handle text output type in tool results', () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            input: { query: 'weather' },
+            toolCallId: 'call-1',
+            toolName: 'getWeather',
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call-1',
+            toolName: 'getWeather',
+            output: { type: 'text', value: 'It is sunny today' },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'assistant',
+        content: '',
+        tool_calls: [
+          {
+            type: 'function',
+            id: 'call-1',
+            function: {
+              name: 'getWeather',
+              arguments: JSON.stringify({ query: 'weather' }),
+            },
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: 'It is sunny today',
+        tool_call_id: 'call-1',
+      },
+    ]);
+  });
+});
+
+describe('provider-specific metadata merging', () => {
+  it('should merge system message metadata', async () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'system',
+        content: 'You are a helpful assistant.',
+        providerOptions: {
+          openaiCompatible: {
+            cacheControl: { type: 'ephemeral' },
+          },
+        },
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'system',
+        content: 'You are a helpful assistant.',
+        cacheControl: { type: 'ephemeral' },
+      },
+    ]);
+  });
+
+  it('should merge user message content metadata', async () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'Hello',
+            providerOptions: {
+              openaiCompatible: {
+                cacheControl: { type: 'ephemeral' },
+              },
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: 'Hello',
+        cacheControl: { type: 'ephemeral' },
+      },
+    ]);
+  });
+
+  it('should prioritize content-level metadata when merging', async () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'user',
+        providerOptions: {
+          openaiCompatible: {
+            messageLevel: true,
+          },
+        },
+        content: [
+          {
+            type: 'text',
+            text: 'Hello',
+            providerOptions: {
+              openaiCompatible: {
+                contentLevel: true,
+              },
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: 'Hello',
+        contentLevel: true,
+      },
+    ]);
+  });
+
+  it('should handle tool calls with metadata', async () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call1',
+            toolName: 'calculator',
+            input: { x: 1, y: 2 },
+            providerOptions: {
+              openaiCompatible: {
+                cacheControl: { type: 'ephemeral' },
+              },
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'assistant',
+        content: '',
+        tool_calls: [
+          {
+            id: 'call1',
+            type: 'function',
+            function: {
+              name: 'calculator',
+              arguments: JSON.stringify({ x: 1, y: 2 }),
+            },
+            cacheControl: { type: 'ephemeral' },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should handle image content with metadata', async () => {
+    const imageUrl = new URL('https://example.com/image.jpg');
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: imageUrl,
+            mediaType: 'image/*',
+            providerOptions: {
+              openaiCompatible: {
+                cacheControl: { type: 'ephemeral' },
+              },
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'image_url',
+            image_url: { url: imageUrl.toString() },
+            cacheControl: { type: 'ephemeral' },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should omit non-openaiCompatible metadata', async () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'system',
+        content: 'Hello',
+        providerOptions: {
+          someOtherProvider: {
+            shouldBeIgnored: true,
+          },
+        },
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'system',
+        content: 'Hello',
+      },
+    ]);
+  });
+
+  it('should handle a user message with multiple content parts (text + image)', () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'Hello from part 1',
+            providerOptions: {
+              openaiCompatible: { sentiment: 'positive' },
+              leftoverKey: { foo: 'some leftover data' },
+            },
+          },
+          {
+            type: 'file',
+            data: Buffer.from([0, 1, 2, 3]).toString('base64'),
+            mediaType: 'image/png',
+            providerOptions: {
+              openaiCompatible: { alt_text: 'A sample image' },
+            },
+          },
+        ],
+        providerOptions: {
+          openaiCompatible: { priority: 'high' },
+        },
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        priority: 'high', // hoisted from message-level providerOptions
+        content: [
+          {
+            type: 'text',
+            text: 'Hello from part 1',
+            sentiment: 'positive', // hoisted from part-level openaiCompatible
+          },
+          {
+            type: 'image_url',
+            image_url: {
+              url: 'data:image/png;base64,AAECAw==',
+            },
+            alt_text: 'A sample image',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should handle a user message with multiple text parts (flattening disabled)', () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Part 1' },
+          { type: 'text', text: 'Part 2' },
+        ],
+      },
+    ]);
+
+    // Because there are multiple text parts, the converter won't flatten them
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Part 1' },
+          { type: 'text', text: 'Part 2' },
+        ],
+      },
+    ]);
+  });
+
+  it('should handle an assistant message with text plus multiple tool calls', () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Checking that now...' },
+          {
+            type: 'tool-call',
+            toolCallId: 'call1',
+            toolName: 'searchTool',
+            input: { query: 'Weather' },
+            providerOptions: {
+              openaiCompatible: { function_call_reason: 'user request' },
+            },
+          },
+          { type: 'text', text: 'Almost there...' },
+          {
+            type: 'tool-call',
+            toolCallId: 'call2',
+            toolName: 'mapsTool',
+            input: { location: 'Paris' },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'assistant',
+        content: 'Checking that now...Almost there...',
+        tool_calls: [
+          {
+            id: 'call1',
+            type: 'function',
+            function: {
+              name: 'searchTool',
+              arguments: JSON.stringify({ query: 'Weather' }),
+            },
+            function_call_reason: 'user request',
+          },
+          {
+            id: 'call2',
+            type: 'function',
+            function: {
+              name: 'mapsTool',
+              arguments: JSON.stringify({ location: 'Paris' }),
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should handle a single tool role message with multiple tool-result parts', () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'tool',
+        providerOptions: {
+          // this just gets omitted as we prioritize content-level metadata
+          openaiCompatible: { responseTier: 'detailed' },
+        },
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call123',
+            toolName: 'calculator',
+            output: { type: 'json', value: { stepOne: 'data chunk 1' } },
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'call123',
+            toolName: 'calculator',
+            providerOptions: {
+              openaiCompatible: { partial: true },
+            },
+            output: { type: 'json', value: { stepTwo: 'data chunk 2' } },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'tool',
+        tool_call_id: 'call123',
+        content: JSON.stringify({ stepOne: 'data chunk 1' }),
+      },
+      {
+        role: 'tool',
+        tool_call_id: 'call123',
+        content: JSON.stringify({ stepTwo: 'data chunk 2' }),
+        partial: true,
+      },
+    ]);
+  });
+
+  it('should handle multiple content parts with multiple metadata layers', () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'user',
+        providerOptions: {
+          openaiCompatible: { messageLevel: 'global-metadata' },
+          leftoverForMessage: { x: 123 },
+        },
+        content: [
+          {
+            type: 'text',
+            text: 'Part A',
+            providerOptions: {
+              openaiCompatible: { textPartLevel: 'localized' },
+              leftoverForText: { info: 'text leftover' },
+            },
+          },
+          {
+            type: 'file',
+            data: Buffer.from([9, 8, 7, 6]).toString('base64'),
+            mediaType: 'image/png',
+            providerOptions: {
+              openaiCompatible: { imagePartLevel: 'image-data' },
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        messageLevel: 'global-metadata',
+        content: [
+          {
+            type: 'text',
+            text: 'Part A',
+            textPartLevel: 'localized',
+          },
+          {
+            type: 'image_url',
+            image_url: {
+              url: 'data:image/png;base64,CQgHBg==',
+            },
+            imagePartLevel: 'image-data',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should handle different tool metadata vs. message-level metadata', () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'assistant',
+        providerOptions: {
+          openaiCompatible: { globalPriority: 'high' },
+        },
+        content: [
+          { type: 'text', text: 'Initiating tool calls...' },
+          {
+            type: 'tool-call',
+            toolCallId: 'callXYZ',
+            toolName: 'awesomeTool',
+            input: { param: 'someValue' },
+            providerOptions: {
+              openaiCompatible: {
+                toolPriority: 'critical',
+              },
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'assistant',
+        globalPriority: 'high',
+        content: 'Initiating tool calls...',
+        tool_calls: [
+          {
+            id: 'callXYZ',
+            type: 'function',
+            function: {
+              name: 'awesomeTool',
+              arguments: JSON.stringify({ param: 'someValue' }),
+            },
+            toolPriority: 'critical',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should handle metadata collisions and overwrites in tool calls', () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'assistant',
+        providerOptions: {
+          openaiCompatible: {
+            cacheControl: { type: 'default' },
+            sharedKey: 'assistantLevel',
+          },
+        },
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'collisionToolCall',
+            toolName: 'collider',
+            input: { num: 42 },
+            providerOptions: {
+              openaiCompatible: {
+                cacheControl: { type: 'ephemeral' }, // overwrites top-level
+                sharedKey: 'toolLevel',
+              },
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'assistant',
+        cacheControl: { type: 'default' },
+        sharedKey: 'assistantLevel',
+        content: '',
+        tool_calls: [
+          {
+            id: 'collisionToolCall',
+            type: 'function',
+            function: {
+              name: 'collider',
+              arguments: JSON.stringify({ num: 42 }),
+            },
+            cacheControl: { type: 'ephemeral' },
+            sharedKey: 'toolLevel',
+          },
+        ],
+      },
+    ]);
+  });
+});
+
+describe('Google Gemini thought signatures (OpenAI compatibility)', () => {
+  it('should serialize thought signature to extra_content for single tool call', () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'function-call-1',
+            toolName: 'check_flight',
+            input: { flight: 'AA100' },
+            providerOptions: {
+              google: {
+                thoughtSignature: '<Signature A>',
+              },
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'assistant',
+        content: '',
+        tool_calls: [
+          {
+            id: 'function-call-1',
+            type: 'function',
+            function: {
+              name: 'check_flight',
+              arguments: JSON.stringify({ flight: 'AA100' }),
+            },
+            extra_content: {
+              google: {
+                thought_signature: '<Signature A>',
+              },
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should handle sequential tool calls with separate signatures (Turn 1 Step 3 scenario)', () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'Check flight status for AA100 and book a taxi 2 hours before if delayed.',
+          },
+        ],
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'function-call-1',
+            toolName: 'check_flight',
+            input: { flight: 'AA100' },
+            providerOptions: {
+              google: {
+                thoughtSignature: '<Signature A>',
+              },
+            },
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'function-call-1',
+            toolName: 'check_flight',
+            output: {
+              type: 'json',
+              value: { status: 'delayed', departure_time: '12 PM' },
+            },
+          },
+        ],
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'function-call-2',
+            toolName: 'book_taxi',
+            input: { time: '10 AM' },
+            providerOptions: {
+              google: {
+                thoughtSignature: '<Signature B>',
+              },
+            },
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'function-call-2',
+            toolName: 'book_taxi',
+            output: { type: 'json', value: { booking_status: 'success' } },
+          },
+        ],
+      },
+    ]);
+
+    // Verify both signatures are preserved
+    expect(result[1]).toEqual({
+      role: 'assistant',
+      content: '',
+      tool_calls: [
+        {
+          id: 'function-call-1',
+          type: 'function',
+          function: {
+            name: 'check_flight',
+            arguments: JSON.stringify({ flight: 'AA100' }),
+          },
+          extra_content: {
+            google: {
+              thought_signature: '<Signature A>',
+            },
+          },
+        },
+      ],
+    });
+
+    expect(result[3]).toEqual({
+      role: 'assistant',
+      content: '',
+      tool_calls: [
+        {
+          id: 'function-call-2',
+          type: 'function',
+          function: {
+            name: 'book_taxi',
+            arguments: JSON.stringify({ time: '10 AM' }),
+          },
+          extra_content: {
+            google: {
+              thought_signature: '<Signature B>',
+            },
+          },
+        },
+      ],
+    });
+  });
+
+  it('should handle parallel tool calls with signature only on first call', () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'function-call-paris',
+            toolName: 'get_current_temperature',
+            input: { location: 'Paris' },
+            providerOptions: {
+              google: {
+                thoughtSignature: '<Signature A>',
+              },
+            },
+          },
+          {
+            type: 'tool-call',
+            toolCallId: 'function-call-london',
+            toolName: 'get_current_temperature',
+            input: { location: 'London' },
+            // No signature on parallel function call
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'assistant',
+        content: '',
+        tool_calls: [
+          {
+            id: 'function-call-paris',
+            type: 'function',
+            function: {
+              name: 'get_current_temperature',
+              arguments: JSON.stringify({ location: 'Paris' }),
+            },
+            extra_content: {
+              google: {
+                thought_signature: '<Signature A>',
+              },
+            },
+          },
+          {
+            id: 'function-call-london',
+            type: 'function',
+            function: {
+              name: 'get_current_temperature',
+              arguments: JSON.stringify({ location: 'London' }),
+            },
+            // No extra_content for second parallel call
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should not include extra_content when no thought signature is present', () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-1',
+            toolName: 'some_tool',
+            input: { param: 'value' },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'assistant',
+        content: '',
+        tool_calls: [
+          {
+            id: 'call-1',
+            type: 'function',
+            function: {
+              name: 'some_tool',
+              arguments: JSON.stringify({ param: 'value' }),
+            },
+            // No extra_content field
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/src/ipc/utils/ai_sdk/chat/convert-to-openai-compatible-chat-messages.ts
+++ b/src/ipc/utils/ai_sdk/chat/convert-to-openai-compatible-chat-messages.ts
@@ -1,0 +1,177 @@
+import {
+  LanguageModelV3Prompt,
+  SharedV3ProviderMetadata,
+  UnsupportedFunctionalityError,
+} from '@ai-sdk/provider';
+import { OpenAICompatibleChatPrompt } from './openai-compatible-api-types';
+import { convertToBase64 } from '@ai-sdk/provider-utils';
+
+function getOpenAIMetadata(message: {
+  providerOptions?: SharedV3ProviderMetadata;
+}) {
+  return message?.providerOptions?.openaiCompatible ?? {};
+}
+
+export function convertToOpenAICompatibleChatMessages(
+  prompt: LanguageModelV3Prompt,
+): OpenAICompatibleChatPrompt {
+  const messages: OpenAICompatibleChatPrompt = [];
+  for (const { role, content, ...message } of prompt) {
+    const metadata = getOpenAIMetadata({ ...message });
+    switch (role) {
+      case 'system': {
+        messages.push({ role: 'system', content, ...metadata });
+        break;
+      }
+
+      case 'user': {
+        if (content.length === 1 && content[0].type === 'text') {
+          messages.push({
+            role: 'user',
+            content: content[0].text,
+            ...getOpenAIMetadata(content[0]),
+          });
+          break;
+        }
+
+        messages.push({
+          role: 'user',
+          content: content.map(part => {
+            const partMetadata = getOpenAIMetadata(part);
+            switch (part.type) {
+              case 'text': {
+                return { type: 'text', text: part.text, ...partMetadata };
+              }
+              case 'file': {
+                if (part.mediaType.startsWith('image/')) {
+                  const mediaType =
+                    part.mediaType === 'image/*'
+                      ? 'image/jpeg'
+                      : part.mediaType;
+
+                  return {
+                    type: 'image_url',
+                    image_url: {
+                      url:
+                        part.data instanceof URL
+                          ? part.data.toString()
+                          : `data:${mediaType};base64,${convertToBase64(part.data)}`,
+                    },
+                    ...partMetadata,
+                  };
+                } else {
+                  throw new UnsupportedFunctionalityError({
+                    functionality: `file part media type ${part.mediaType}`,
+                  });
+                }
+              }
+            }
+          }),
+          ...metadata,
+        });
+
+        break;
+      }
+
+      case 'assistant': {
+        let text = '';
+        const toolCalls: Array<{
+          id: string;
+          type: 'function';
+          function: { name: string; arguments: string };
+          extra_content?: {
+            google?: {
+              thought_signature?: string;
+            };
+          };
+        }> = [];
+
+        for (const part of content) {
+          const partMetadata = getOpenAIMetadata(part);
+          switch (part.type) {
+            case 'text': {
+              text += part.text;
+              break;
+            }
+            case 'tool-call': {
+              // TODO: thoughtSignature should be abstracted once we add support for other providers
+              const thoughtSignature =
+                part.providerOptions?.google?.thoughtSignature;
+              toolCalls.push({
+                id: part.toolCallId,
+                type: 'function',
+                function: {
+                  name: part.toolName,
+                  arguments: JSON.stringify(part.input),
+                },
+                ...partMetadata,
+                // Include extra_content for Google Gemini thought signatures
+                ...(thoughtSignature
+                  ? {
+                      extra_content: {
+                        google: {
+                          thought_signature: String(thoughtSignature),
+                        },
+                      },
+                    }
+                  : {}),
+              });
+              break;
+            }
+          }
+        }
+
+        messages.push({
+          role: 'assistant',
+          content: text,
+          tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
+          ...metadata,
+        });
+
+        break;
+      }
+
+      case 'tool': {
+        for (const toolResponse of content) {
+          if (toolResponse.type === 'tool-approval-response') {
+            continue;
+          }
+
+          const output = toolResponse.output;
+
+          let contentValue: string;
+          switch (output.type) {
+            case 'text':
+            case 'error-text':
+              contentValue = output.value;
+              break;
+            case 'execution-denied':
+              contentValue = output.reason ?? 'Tool execution denied.';
+              break;
+            case 'content':
+            case 'json':
+            case 'error-json':
+              contentValue = JSON.stringify(output.value);
+              break;
+          }
+
+          const toolResponseMetadata = getOpenAIMetadata(toolResponse);
+          messages.push({
+            role: 'tool',
+            tool_call_id: toolResponse.toolCallId,
+            content: contentValue,
+            ...toolResponseMetadata,
+          });
+        }
+        break;
+      }
+
+      default: {
+        const _exhaustiveCheck: never = role;
+        throw new Error(`Unsupported role: ${_exhaustiveCheck}`);
+      }
+    }
+  }
+
+  return messages;
+}

--- a/src/ipc/utils/ai_sdk/chat/get-response-metadata.ts
+++ b/src/ipc/utils/ai_sdk/chat/get-response-metadata.ts
@@ -1,0 +1,15 @@
+export function getResponseMetadata({
+  id,
+  model,
+  created,
+}: {
+  id?: string | undefined | null;
+  created?: number | undefined | null;
+  model?: string | undefined | null;
+}) {
+  return {
+    id: id ?? undefined,
+    modelId: model ?? undefined,
+    timestamp: created != null ? new Date(created * 1000) : undefined,
+  };
+}

--- a/src/ipc/utils/ai_sdk/chat/map-openai-compatible-finish-reason.ts
+++ b/src/ipc/utils/ai_sdk/chat/map-openai-compatible-finish-reason.ts
@@ -1,0 +1,19 @@
+import { LanguageModelV3FinishReason } from '@ai-sdk/provider';
+
+export function mapOpenAICompatibleFinishReason(
+  finishReason: string | null | undefined,
+): LanguageModelV3FinishReason['unified'] {
+  switch (finishReason) {
+    case 'stop':
+      return 'stop';
+    case 'length':
+      return 'length';
+    case 'content_filter':
+      return 'content-filter';
+    case 'function_call':
+    case 'tool_calls':
+      return 'tool-calls';
+    default:
+      return 'other';
+  }
+}

--- a/src/ipc/utils/ai_sdk/chat/openai-compatible-api-types.ts
+++ b/src/ipc/utils/ai_sdk/chat/openai-compatible-api-types.ts
@@ -1,0 +1,72 @@
+import { JSONValue } from '@ai-sdk/provider';
+
+export type OpenAICompatibleChatPrompt = Array<OpenAICompatibleMessage>;
+
+export type OpenAICompatibleMessage =
+  | OpenAICompatibleSystemMessage
+  | OpenAICompatibleUserMessage
+  | OpenAICompatibleAssistantMessage
+  | OpenAICompatibleToolMessage;
+
+// Allow for arbitrary additional properties for general purpose
+// provider-metadata-specific extensibility.
+type JsonRecord<T = never> = Record<
+  string,
+  JSONValue | JSONValue[] | T | T[] | undefined
+>;
+
+export interface OpenAICompatibleSystemMessage extends JsonRecord {
+  role: 'system';
+  content: string;
+}
+
+export interface OpenAICompatibleUserMessage
+  extends JsonRecord<OpenAICompatibleContentPart> {
+  role: 'user';
+  content: string | Array<OpenAICompatibleContentPart>;
+}
+
+export type OpenAICompatibleContentPart =
+  | OpenAICompatibleContentPartText
+  | OpenAICompatibleContentPartImage;
+
+export interface OpenAICompatibleContentPartImage extends JsonRecord {
+  type: 'image_url';
+  image_url: { url: string };
+}
+
+export interface OpenAICompatibleContentPartText extends JsonRecord {
+  type: 'text';
+  text: string;
+}
+
+export interface OpenAICompatibleAssistantMessage
+  extends JsonRecord<OpenAICompatibleMessageToolCall> {
+  role: 'assistant';
+  content?: string | null;
+  tool_calls?: Array<OpenAICompatibleMessageToolCall>;
+}
+
+export interface OpenAICompatibleMessageToolCall extends JsonRecord {
+  type: 'function';
+  id: string;
+  function: {
+    arguments: string;
+    name: string;
+  };
+  /**
+   * Additional content for provider-specific features.
+   * Used by Google Gemini for thought signatures via OpenAI compatibility.
+   */
+  extra_content?: {
+    google?: {
+      thought_signature?: string;
+    };
+  };
+}
+
+export interface OpenAICompatibleToolMessage extends JsonRecord {
+  role: 'tool';
+  content: string;
+  tool_call_id: string;
+}

--- a/src/ipc/utils/ai_sdk/chat/openai-compatible-chat-language-model.test.ts
+++ b/src/ipc/utils/ai_sdk/chat/openai-compatible-chat-language-model.test.ts
@@ -1,0 +1,3136 @@
+import { describe, it, expect } from 'vitest';
+import { LanguageModelV3Prompt } from '@ai-sdk/provider';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import {
+  convertReadableStreamToArray,
+  isNodeVersion,
+} from '@ai-sdk/provider-utils/test';
+import { createOpenAICompatible } from '../openai-compatible-provider';
+import { OpenAICompatibleChatLanguageModel } from './openai-compatible-chat-language-model';
+
+const TEST_PROMPT: LanguageModelV3Prompt = [
+  { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+];
+
+const provider = createOpenAICompatible({
+  baseURL: 'https://my.api.com/v1/',
+  name: 'test-provider',
+  headers: {
+    Authorization: `Bearer test-api-key`,
+  },
+});
+
+const model = provider('grok-beta');
+
+const server = createTestServer({
+  'https://my.api.com/v1/chat/completions': {},
+});
+
+describe('config', () => {
+  it('should extract base name from provider string', () => {
+    const model = new OpenAICompatibleChatLanguageModel('gpt-4', {
+      provider: 'anthropic.beta',
+      url: () => '',
+      headers: () => ({}),
+    });
+
+    expect(model['providerOptionsName']).toBe('anthropic');
+  });
+
+  it('should handle provider without dot notation', () => {
+    const model = new OpenAICompatibleChatLanguageModel('gpt-4', {
+      provider: 'openai',
+      url: () => '',
+      headers: () => ({}),
+    });
+
+    expect(model['providerOptionsName']).toBe('openai');
+  });
+
+  it('should return empty for empty provider', () => {
+    const model = new OpenAICompatibleChatLanguageModel('gpt-4', {
+      provider: '',
+      url: () => '',
+      headers: () => ({}),
+    });
+
+    expect(model['providerOptionsName']).toBe('');
+  });
+});
+
+describe('doGenerate', () => {
+  function prepareJsonResponse({
+    content = '',
+    reasoning_content = '',
+    reasoning = '',
+    tool_calls,
+    function_call,
+    usage = {
+      prompt_tokens: 4,
+      total_tokens: 34,
+      completion_tokens: 30,
+    },
+    finish_reason = 'stop',
+    id = 'chatcmpl-95ZTZkhr0mHNKqerQfiwkuox3PHAd',
+    created = 1711115037,
+    model = 'grok-beta',
+    headers,
+  }: {
+    content?: string;
+    reasoning_content?: string;
+    reasoning?: string;
+    tool_calls?: Array<{
+      id: string;
+      type: 'function';
+      function: {
+        name: string;
+        arguments: string;
+      };
+      extra_content?: {
+        google?: {
+          thought_signature?: string;
+        };
+      };
+    }>;
+    function_call?: {
+      name: string;
+      arguments: string;
+    };
+    usage?: {
+      prompt_tokens?: number;
+      total_tokens?: number;
+      completion_tokens?: number;
+      prompt_tokens_details?: {
+        cached_tokens?: number;
+      };
+      completion_tokens_details?: {
+        reasoning_tokens?: number;
+        accepted_prediction_tokens?: number;
+        rejected_prediction_tokens?: number;
+      };
+    };
+    finish_reason?: string;
+    created?: number;
+    id?: string;
+    model?: string;
+    headers?: Record<string, string>;
+  } = {}) {
+    server.urls['https://my.api.com/v1/chat/completions'].response = {
+      type: 'json-value',
+      headers,
+      body: {
+        id,
+        object: 'chat.completion',
+        created,
+        model,
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: 'assistant',
+              content,
+              reasoning_content,
+              reasoning,
+              tool_calls,
+              function_call,
+            },
+            finish_reason,
+          },
+        ],
+        usage,
+        system_fingerprint: 'fp_3bc1b5746c',
+      },
+    };
+  }
+
+  it('should pass user setting to requests', async () => {
+    prepareJsonResponse({ content: 'Hello, World!' });
+    const modelWithUser = provider('grok-beta');
+    await modelWithUser.doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        xai: {
+          user: 'test-user-id',
+        },
+      },
+    });
+    expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+      {
+        "messages": [
+          {
+            "content": "Hello",
+            "role": "user",
+          },
+        ],
+        "model": "grok-beta",
+      }
+    `);
+  });
+
+  it('should extract text response', async () => {
+    prepareJsonResponse({ content: 'Hello, World!' });
+
+    const { content } = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(content).toMatchInlineSnapshot(`
+      [
+        {
+          "text": "Hello, World!",
+          "type": "text",
+        },
+      ]
+    `);
+  });
+
+  it('should extract reasoning content', async () => {
+    prepareJsonResponse({
+      content: 'Hello, World!',
+      reasoning_content: 'This is the reasoning behind the response',
+    });
+
+    const { content } = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(content).toMatchInlineSnapshot(`
+      [
+        {
+          "text": "Hello, World!",
+          "type": "text",
+        },
+        {
+          "text": "This is the reasoning behind the response",
+          "type": "reasoning",
+        },
+      ]
+    `);
+  });
+
+  it('should extract reasoning from reasoning field when reasoning_content is not provided', async () => {
+    prepareJsonResponse({
+      content: 'Hello, World!',
+      reasoning: 'This is the reasoning from the reasoning field',
+    });
+
+    const { content } = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(content).toMatchInlineSnapshot(`
+      [
+        {
+          "text": "Hello, World!",
+          "type": "text",
+        },
+      ]
+    `);
+  });
+
+  it('should prefer reasoning_content over reasoning field when both are provided', async () => {
+    prepareJsonResponse({
+      content: 'Hello, World!',
+      reasoning_content: 'This is from reasoning_content',
+      reasoning: 'This is from reasoning field',
+    });
+
+    const { content } = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(content).toMatchInlineSnapshot(`
+      [
+        {
+          "text": "Hello, World!",
+          "type": "text",
+        },
+        {
+          "text": "This is from reasoning_content",
+          "type": "reasoning",
+        },
+      ]
+    `);
+  });
+
+  it('should extract usage', async () => {
+    prepareJsonResponse({
+      usage: { prompt_tokens: 20, total_tokens: 25, completion_tokens: 5 },
+    });
+
+    const { usage } = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(usage).toMatchInlineSnapshot(`
+      {
+        "inputTokens": {
+          "cacheRead": 0,
+          "cacheWrite": undefined,
+          "noCache": 20,
+          "total": 20,
+        },
+        "outputTokens": {
+          "reasoning": 0,
+          "text": 5,
+          "total": 5,
+        },
+        "raw": {
+          "completion_tokens": 5,
+          "prompt_tokens": 20,
+          "total_tokens": 25,
+        },
+      }
+    `);
+  });
+
+  it('should send additional response information', async () => {
+    prepareJsonResponse({
+      id: 'test-id',
+      created: 123,
+      model: 'test-model',
+    });
+
+    const { response } = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(response).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "choices": [
+            {
+              "finish_reason": "stop",
+              "index": 0,
+              "message": {
+                "content": "",
+                "reasoning": "",
+                "reasoning_content": "",
+                "role": "assistant",
+              },
+            },
+          ],
+          "created": 123,
+          "id": "test-id",
+          "model": "test-model",
+          "object": "chat.completion",
+          "system_fingerprint": "fp_3bc1b5746c",
+          "usage": {
+            "completion_tokens": 30,
+            "prompt_tokens": 4,
+            "total_tokens": 34,
+          },
+        },
+        "headers": {
+          "content-length": "313",
+          "content-type": "application/json",
+        },
+        "id": "test-id",
+        "modelId": "test-model",
+        "timestamp": 1970-01-01T00:02:03.000Z,
+      }
+    `);
+  });
+
+  it('should support partial usage', async () => {
+    prepareJsonResponse({
+      usage: { prompt_tokens: 20, total_tokens: 20 },
+    });
+
+    const { usage } = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(usage).toMatchInlineSnapshot(`
+      {
+        "inputTokens": {
+          "cacheRead": 0,
+          "cacheWrite": undefined,
+          "noCache": 20,
+          "total": 20,
+        },
+        "outputTokens": {
+          "reasoning": 0,
+          "text": 0,
+          "total": 0,
+        },
+        "raw": {
+          "prompt_tokens": 20,
+          "total_tokens": 20,
+        },
+      }
+    `);
+  });
+
+  it('should extract finish reason', async () => {
+    prepareJsonResponse({
+      finish_reason: 'stop',
+    });
+
+    const response = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(response.finishReason).toMatchInlineSnapshot(`
+      {
+        "raw": "stop",
+        "unified": "stop",
+      }
+    `);
+  });
+
+  it('should support unknown finish reason', async () => {
+    prepareJsonResponse({
+      finish_reason: 'eos',
+    });
+
+    const response = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(response.finishReason).toMatchInlineSnapshot(`
+          {
+            "raw": "eos",
+            "unified": "other",
+          }
+        `);
+  });
+
+  it('should expose the raw response headers', async () => {
+    prepareJsonResponse({
+      headers: { 'test-header': 'test-value' },
+    });
+
+    const { response } = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(response?.headers).toStrictEqual({
+      // default headers:
+      'content-length': '350',
+      'content-type': 'application/json',
+
+      // custom header
+      'test-header': 'test-value',
+    });
+  });
+
+  it('should pass the model and the messages', async () => {
+    prepareJsonResponse({ content: '' });
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      model: 'grok-beta',
+      messages: [{ role: 'user', content: 'Hello' }],
+    });
+  });
+
+  it('should pass settings', async () => {
+    prepareJsonResponse();
+
+    await provider('grok-beta').doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        'openai-compatible': {
+          user: 'test-user-id',
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      model: 'grok-beta',
+      messages: [{ role: 'user', content: 'Hello' }],
+      user: 'test-user-id',
+    });
+  });
+
+  it('should include provider-specific options', async () => {
+    prepareJsonResponse();
+
+    await provider('grok-beta').doGenerate({
+      providerOptions: {
+        'test-provider': {
+          someCustomOption: 'test-value',
+        },
+      },
+      prompt: TEST_PROMPT,
+    });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      model: 'grok-beta',
+      messages: [{ role: 'user', content: 'Hello' }],
+      someCustomOption: 'test-value',
+    });
+  });
+
+  it('should not include provider-specific options for different provider', async () => {
+    prepareJsonResponse();
+
+    await provider('grok-beta').doGenerate({
+      providerOptions: {
+        notThisProviderName: {
+          someCustomOption: 'test-value',
+        },
+      },
+      prompt: TEST_PROMPT,
+    });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      model: 'grok-beta',
+      messages: [{ role: 'user', content: 'Hello' }],
+    });
+  });
+
+  it('should pass tools and toolChoice', async () => {
+    prepareJsonResponse({ content: '' });
+
+    await model.doGenerate({
+      tools: [
+        {
+          type: 'function',
+          name: 'test-tool',
+          inputSchema: {
+            type: 'object',
+            properties: { value: { type: 'string' } },
+            required: ['value'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+      ],
+      toolChoice: {
+        type: 'tool',
+        toolName: 'test-tool',
+      },
+      prompt: TEST_PROMPT,
+    });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      model: 'grok-beta',
+      messages: [{ role: 'user', content: 'Hello' }],
+      tools: [
+        {
+          type: 'function',
+          function: {
+            name: 'test-tool',
+            parameters: {
+              type: 'object',
+              properties: { value: { type: 'string' } },
+              required: ['value'],
+              additionalProperties: false,
+              $schema: 'http://json-schema.org/draft-07/schema#',
+            },
+          },
+        },
+      ],
+      tool_choice: {
+        type: 'function',
+        function: { name: 'test-tool' },
+      },
+    });
+  });
+
+  it('should pass headers', async () => {
+    prepareJsonResponse({ content: '' });
+
+    const provider = createOpenAICompatible({
+      baseURL: 'https://my.api.com/v1/',
+      name: 'test-provider',
+      headers: {
+        Authorization: `Bearer test-api-key`,
+        'Custom-Provider-Header': 'provider-header-value',
+      },
+    });
+
+    await provider('grok-beta').doGenerate({
+      prompt: TEST_PROMPT,
+      headers: {
+        'Custom-Request-Header': 'request-header-value',
+      },
+    });
+
+    expect(server.calls[0].requestHeaders).toStrictEqual({
+      authorization: 'Bearer test-api-key',
+      'content-type': 'application/json',
+      'custom-provider-header': 'provider-header-value',
+      'custom-request-header': 'request-header-value',
+    });
+  });
+
+  it('should parse tool results', async () => {
+    prepareJsonResponse({
+      tool_calls: [
+        {
+          id: 'call_O17Uplv4lJvD6DVdIvFFeRMw',
+          type: 'function',
+          function: {
+            name: 'test-tool',
+            arguments: '{"value":"Spark"}',
+          },
+        },
+      ],
+    });
+
+    const result = await model.doGenerate({
+      tools: [
+        {
+          type: 'function',
+          name: 'test-tool',
+          inputSchema: {
+            type: 'object',
+            properties: { value: { type: 'string' } },
+            required: ['value'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+      ],
+      toolChoice: {
+        type: 'tool',
+        toolName: 'test-tool',
+      },
+      prompt: TEST_PROMPT,
+    });
+
+    expect(result.content).toMatchInlineSnapshot(`
+      [
+        {
+          "input": "{"value":"Spark"}",
+          "toolCallId": "call_O17Uplv4lJvD6DVdIvFFeRMw",
+          "toolName": "test-tool",
+          "type": "tool-call",
+        },
+      ]
+    `);
+  });
+
+  describe('Google Gemini thought signatures (OpenAI compatibility)', () => {
+    it('should parse thought signature from extra_content and include in providerMetadata', async () => {
+      prepareJsonResponse({
+        tool_calls: [
+          {
+            id: 'function-call-1',
+            type: 'function',
+            function: {
+              name: 'check_flight',
+              arguments: '{"flight":"AA100"}',
+            },
+            extra_content: {
+              google: {
+                thought_signature: '<Signature A>',
+              },
+            },
+          },
+        ],
+      });
+
+      const result = await model.doGenerate({
+        tools: [
+          {
+            type: 'function',
+            name: 'check_flight',
+            inputSchema: {
+              type: 'object',
+              properties: { flight: { type: 'string' } },
+              required: ['flight'],
+              additionalProperties: false,
+              $schema: 'http://json-schema.org/draft-07/schema#',
+            },
+          },
+        ],
+        prompt: TEST_PROMPT,
+      });
+
+      expect(result.content).toMatchInlineSnapshot(`
+        [
+          {
+            "input": "{"flight":"AA100"}",
+            "providerMetadata": {
+              "test-provider": {
+                "thoughtSignature": "<Signature A>",
+              },
+            },
+            "toolCallId": "function-call-1",
+            "toolName": "check_flight",
+            "type": "tool-call",
+          },
+        ]
+      `);
+    });
+
+    it('should handle parallel tool calls with signature only on first call', async () => {
+      prepareJsonResponse({
+        tool_calls: [
+          {
+            id: 'function-call-paris',
+            type: 'function',
+            function: {
+              name: 'get_current_temperature',
+              arguments: '{"location":"Paris"}',
+            },
+            extra_content: {
+              google: {
+                thought_signature: '<Signature A>',
+              },
+            },
+          },
+          {
+            id: 'function-call-london',
+            type: 'function',
+            function: {
+              name: 'get_current_temperature',
+              arguments: '{"location":"London"}',
+            },
+            // No extra_content - parallel calls don't have signatures
+          },
+        ],
+      });
+
+      const result = await model.doGenerate({
+        tools: [
+          {
+            type: 'function',
+            name: 'get_current_temperature',
+            inputSchema: {
+              type: 'object',
+              properties: { location: { type: 'string' } },
+              required: ['location'],
+              additionalProperties: false,
+              $schema: 'http://json-schema.org/draft-07/schema#',
+            },
+          },
+        ],
+        prompt: TEST_PROMPT,
+      });
+
+      expect(result.content).toMatchInlineSnapshot(`
+        [
+          {
+            "input": "{"location":"Paris"}",
+            "providerMetadata": {
+              "test-provider": {
+                "thoughtSignature": "<Signature A>",
+              },
+            },
+            "toolCallId": "function-call-paris",
+            "toolName": "get_current_temperature",
+            "type": "tool-call",
+          },
+          {
+            "input": "{"location":"London"}",
+            "toolCallId": "function-call-london",
+            "toolName": "get_current_temperature",
+            "type": "tool-call",
+          },
+        ]
+      `);
+    });
+
+    it('should not include providerMetadata when no thought signature is present', async () => {
+      prepareJsonResponse({
+        tool_calls: [
+          {
+            id: 'call-1',
+            type: 'function',
+            function: {
+              name: 'some_tool',
+              arguments: '{"param":"value"}',
+            },
+            // No extra_content
+          },
+        ],
+      });
+
+      const result = await model.doGenerate({
+        tools: [
+          {
+            type: 'function',
+            name: 'some_tool',
+            inputSchema: {
+              type: 'object',
+              properties: { param: { type: 'string' } },
+              required: ['param'],
+              additionalProperties: false,
+              $schema: 'http://json-schema.org/draft-07/schema#',
+            },
+          },
+        ],
+        prompt: TEST_PROMPT,
+      });
+
+      expect(result.content).toMatchInlineSnapshot(`
+        [
+          {
+            "input": "{"param":"value"}",
+            "toolCallId": "call-1",
+            "toolName": "some_tool",
+            "type": "tool-call",
+          },
+        ]
+      `);
+    });
+  });
+
+  describe('response format', () => {
+    it('should not send a response_format when response format is text', async () => {
+      prepareJsonResponse({ content: '{"value":"Spark"}' });
+
+      const model = new OpenAICompatibleChatLanguageModel('gpt-4o-2024-08-06', {
+        provider: 'test-provider',
+        url: () => 'https://my.api.com/v1/chat/completions',
+        headers: () => ({}),
+        supportsStructuredOutputs: false,
+      });
+
+      await model.doGenerate({
+        prompt: TEST_PROMPT,
+        responseFormat: { type: 'text' },
+      });
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        model: 'gpt-4o-2024-08-06',
+        messages: [{ role: 'user', content: 'Hello' }],
+      });
+    });
+
+    it('should forward json response format as "json_object" without schema', async () => {
+      prepareJsonResponse({ content: '{"value":"Spark"}' });
+
+      const model = provider('gpt-4o-2024-08-06');
+
+      await model.doGenerate({
+        prompt: TEST_PROMPT,
+        responseFormat: { type: 'json' },
+      });
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        model: 'gpt-4o-2024-08-06',
+        messages: [{ role: 'user', content: 'Hello' }],
+        response_format: { type: 'json_object' },
+      });
+    });
+
+    it('should forward json response format as "json_object" and omit schema when structuredOutputs are disabled', async () => {
+      prepareJsonResponse({ content: '{"value":"Spark"}' });
+
+      const model = new OpenAICompatibleChatLanguageModel('gpt-4o-2024-08-06', {
+        provider: 'test-provider',
+        url: () => 'https://my.api.com/v1/chat/completions',
+        headers: () => ({}),
+        supportsStructuredOutputs: false,
+      });
+
+      const { warnings } = await model.doGenerate({
+        prompt: TEST_PROMPT,
+        responseFormat: {
+          type: 'json',
+          schema: {
+            type: 'object',
+            properties: { value: { type: 'string' } },
+            required: ['value'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        model: 'gpt-4o-2024-08-06',
+        messages: [{ role: 'user', content: 'Hello' }],
+        response_format: { type: 'json_object' },
+      });
+
+      expect(warnings).toMatchInlineSnapshot(`
+        [
+          {
+            "details": "JSON response format schema is only supported with structuredOutputs",
+            "feature": "responseFormat",
+            "type": "unsupported",
+          },
+        ]
+      `);
+    });
+
+    it('should forward json response format as "json_object" and include schema when structuredOutputs are enabled', async () => {
+      prepareJsonResponse({ content: '{"value":"Spark"}' });
+
+      const model = new OpenAICompatibleChatLanguageModel('gpt-4o-2024-08-06', {
+        provider: 'test-provider',
+        url: () => 'https://my.api.com/v1/chat/completions',
+        headers: () => ({}),
+        supportsStructuredOutputs: true,
+      });
+
+      const { warnings } = await model.doGenerate({
+        prompt: TEST_PROMPT,
+        responseFormat: {
+          type: 'json',
+          schema: {
+            type: 'object',
+            properties: { value: { type: 'string' } },
+            required: ['value'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        model: 'gpt-4o-2024-08-06',
+        messages: [{ role: 'user', content: 'Hello' }],
+        response_format: {
+          type: 'json_schema',
+          json_schema: {
+            strict: true,
+            name: 'response',
+            schema: {
+              type: 'object',
+              properties: { value: { type: 'string' } },
+              required: ['value'],
+              additionalProperties: false,
+              $schema: 'http://json-schema.org/draft-07/schema#',
+            },
+          },
+        },
+      });
+
+      expect(warnings).toEqual([]);
+    });
+
+    it('should pass reasoningEffort setting from providerOptions', async () => {
+      prepareJsonResponse({ content: '{"value":"test"}' });
+
+      const model = new OpenAICompatibleChatLanguageModel('gpt-5', {
+        provider: 'test-provider',
+        url: () => 'https://my.api.com/v1/chat/completions',
+        headers: () => ({}),
+      });
+
+      await model.doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          'test-provider': { reasoningEffort: 'high' },
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        model: 'gpt-5',
+        messages: [{ role: 'user', content: 'Hello' }],
+        reasoning_effort: 'high',
+      });
+    });
+
+    it('should not duplicate reasoningEffort in request body', async () => {
+      prepareJsonResponse({ content: '{"value":"test"}' });
+
+      const model = new OpenAICompatibleChatLanguageModel('gpt-5', {
+        provider: 'test-provider',
+        url: () => 'https://my.api.com/v1/chat/completions',
+        headers: () => ({}),
+      });
+
+      await model.doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          'test-provider': {
+            reasoningEffort: 'high',
+            customOption: 'should-be-included',
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+
+      expect(body.reasoning_effort).toBe('high');
+      expect(body.reasoningEffort).toBeUndefined();
+      expect(body.customOption).toBe('should-be-included');
+    });
+
+    it('should pass textVerbosity setting from providerOptions', async () => {
+      prepareJsonResponse({ content: '{"value":"test"}' });
+
+      const model = new OpenAICompatibleChatLanguageModel('gpt-5', {
+        provider: 'test-provider',
+        url: () => 'https://my.api.com/v1/chat/completions',
+        headers: () => ({}),
+      });
+
+      await model.doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          'test-provider': { textVerbosity: 'low' },
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        model: 'gpt-5',
+        messages: [{ role: 'user', content: 'Hello' }],
+        verbosity: 'low',
+      });
+    });
+
+    it('should not duplicate textVerbosity in request body', async () => {
+      prepareJsonResponse({ content: '{"value":"test"}' });
+
+      const model = new OpenAICompatibleChatLanguageModel('gpt-5', {
+        provider: 'test-provider',
+        url: () => 'https://my.api.com/v1/chat/completions',
+        headers: () => ({}),
+      });
+
+      await model.doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          'test-provider': {
+            textVerbosity: 'medium',
+            customOption: 'should-be-included',
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+
+      expect(body.verbosity).toBe('medium');
+      expect(body.textVerbosity).toBeUndefined();
+      expect(body.customOption).toBe('should-be-included');
+    });
+
+    it('should use json_schema & strict with responseFormat json when structuredOutputs are enabled', async () => {
+      prepareJsonResponse({ content: '{"value":"Spark"}' });
+
+      const model = new OpenAICompatibleChatLanguageModel('gpt-4o-2024-08-06', {
+        provider: 'test-provider',
+        url: () => 'https://my.api.com/v1/chat/completions',
+        headers: () => ({}),
+        supportsStructuredOutputs: true,
+      });
+
+      await model.doGenerate({
+        responseFormat: {
+          type: 'json',
+          schema: {
+            type: 'object',
+            properties: { value: { type: 'string' } },
+            required: ['value'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+        prompt: TEST_PROMPT,
+      });
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        model: 'gpt-4o-2024-08-06',
+        messages: [{ role: 'user', content: 'Hello' }],
+        response_format: {
+          type: 'json_schema',
+          json_schema: {
+            strict: true,
+            name: 'response',
+            schema: {
+              type: 'object',
+              properties: { value: { type: 'string' } },
+              required: ['value'],
+              additionalProperties: false,
+              $schema: 'http://json-schema.org/draft-07/schema#',
+            },
+          },
+        },
+      });
+    });
+
+    it('should set name & description with responseFormat json when structuredOutputs are enabled', async () => {
+      prepareJsonResponse({ content: '{"value":"Spark"}' });
+
+      const model = new OpenAICompatibleChatLanguageModel('gpt-4o-2024-08-06', {
+        provider: 'test-provider',
+        url: () => 'https://my.api.com/v1/chat/completions',
+        headers: () => ({}),
+        supportsStructuredOutputs: true,
+      });
+
+      await model.doGenerate({
+        responseFormat: {
+          type: 'json',
+          name: 'test-name',
+          description: 'test description',
+          schema: {
+            type: 'object',
+            properties: { value: { type: 'string' } },
+            required: ['value'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+        prompt: TEST_PROMPT,
+      });
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        model: 'gpt-4o-2024-08-06',
+        messages: [{ role: 'user', content: 'Hello' }],
+        response_format: {
+          type: 'json_schema',
+          json_schema: {
+            strict: true,
+            name: 'test-name',
+            description: 'test description',
+            schema: {
+              type: 'object',
+              properties: { value: { type: 'string' } },
+              required: ['value'],
+              additionalProperties: false,
+              $schema: 'http://json-schema.org/draft-07/schema#',
+            },
+          },
+        },
+      });
+    });
+
+    it('should send strict: false when strictJsonSchema is explicitly disabled', async () => {
+      prepareJsonResponse({ content: '{"value":"Spark"}' });
+
+      const model = new OpenAICompatibleChatLanguageModel('gpt-4o-2024-08-06', {
+        provider: 'test-provider',
+        url: () => 'https://my.api.com/v1/chat/completions',
+        headers: () => ({}),
+        supportsStructuredOutputs: true,
+      });
+
+      await model.doGenerate({
+        responseFormat: {
+          type: 'json',
+          name: 'test-name',
+          description: 'test description',
+          schema: {
+            type: 'object',
+            properties: { value: { type: 'string' } },
+            required: ['value'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+        providerOptions: {
+          'test-provider': {
+            strictJsonSchema: false,
+          },
+        },
+        prompt: TEST_PROMPT,
+      });
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        model: 'gpt-4o-2024-08-06',
+        messages: [{ role: 'user', content: 'Hello' }],
+        response_format: {
+          type: 'json_schema',
+          json_schema: {
+            strict: false,
+            name: 'test-name',
+            description: 'test description',
+            schema: {
+              type: 'object',
+              properties: { value: { type: 'string' } },
+              required: ['value'],
+              additionalProperties: false,
+              $schema: 'http://json-schema.org/draft-07/schema#',
+            },
+          },
+        },
+      });
+    });
+
+    it('should allow for undefined schema with responseFormat json when structuredOutputs are enabled', async () => {
+      prepareJsonResponse({ content: '{"value":"Spark"}' });
+
+      const model = new OpenAICompatibleChatLanguageModel('gpt-4o-2024-08-06', {
+        provider: 'test-provider',
+        url: () => 'https://my.api.com/v1/chat/completions',
+        headers: () => ({}),
+        supportsStructuredOutputs: true,
+      });
+
+      await model.doGenerate({
+        responseFormat: {
+          type: 'json',
+          name: 'test-name',
+          description: 'test description',
+        },
+        prompt: TEST_PROMPT,
+      });
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        model: 'gpt-4o-2024-08-06',
+        messages: [{ role: 'user', content: 'Hello' }],
+        response_format: {
+          type: 'json_object',
+        },
+      });
+    });
+  });
+
+  it('should send request body', async () => {
+    prepareJsonResponse({ content: '' });
+
+    const { request } = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(request).toStrictEqual({
+      body: '{"model":"grok-beta","messages":[{"role":"user","content":"Hello"}]}',
+    });
+  });
+
+  describe('usage details', () => {
+    it('should extract detailed token usage when available', async () => {
+      prepareJsonResponse({
+        usage: {
+          prompt_tokens: 20,
+          completion_tokens: 30,
+          total_tokens: 50,
+          prompt_tokens_details: {
+            cached_tokens: 5,
+          },
+          completion_tokens_details: {
+            reasoning_tokens: 10,
+            accepted_prediction_tokens: 15,
+            rejected_prediction_tokens: 5,
+          },
+        },
+      });
+
+      const result = await model.doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(result.usage).toMatchInlineSnapshot(`
+        {
+          "inputTokens": {
+            "cacheRead": 5,
+            "cacheWrite": undefined,
+            "noCache": 15,
+            "total": 20,
+          },
+          "outputTokens": {
+            "reasoning": 10,
+            "text": 20,
+            "total": 30,
+          },
+          "raw": {
+            "completion_tokens": 30,
+            "completion_tokens_details": {
+              "accepted_prediction_tokens": 15,
+              "reasoning_tokens": 10,
+              "rejected_prediction_tokens": 5,
+            },
+            "prompt_tokens": 20,
+            "prompt_tokens_details": {
+              "cached_tokens": 5,
+            },
+            "total_tokens": 50,
+          },
+        }
+      `);
+      expect(result.providerMetadata).toMatchInlineSnapshot(`
+        {
+          "test-provider": {
+            "acceptedPredictionTokens": 15,
+            "rejectedPredictionTokens": 5,
+          },
+        }
+      `);
+    });
+
+    it('should handle missing token details', async () => {
+      prepareJsonResponse({
+        usage: {
+          prompt_tokens: 20,
+          completion_tokens: 30,
+          // No token details provided
+        },
+      });
+
+      const result = await model.doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(result.providerMetadata!['test-provider']).toStrictEqual({});
+    });
+
+    it('should handle partial token details', async () => {
+      prepareJsonResponse({
+        usage: {
+          prompt_tokens: 20,
+          completion_tokens: 30,
+          total_tokens: 50,
+          prompt_tokens_details: {
+            cached_tokens: 5,
+          },
+          completion_tokens_details: {
+            // Only reasoning tokens provided
+            reasoning_tokens: 10,
+          },
+        },
+      });
+
+      const result = await model.doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(result.usage).toMatchInlineSnapshot(`
+        {
+          "inputTokens": {
+            "cacheRead": 5,
+            "cacheWrite": undefined,
+            "noCache": 15,
+            "total": 20,
+          },
+          "outputTokens": {
+            "reasoning": 10,
+            "text": 20,
+            "total": 30,
+          },
+          "raw": {
+            "completion_tokens": 30,
+            "completion_tokens_details": {
+              "reasoning_tokens": 10,
+            },
+            "prompt_tokens": 20,
+            "prompt_tokens_details": {
+              "cached_tokens": 5,
+            },
+            "total_tokens": 50,
+          },
+        }
+      `);
+    });
+  });
+});
+
+describe('doStream', () => {
+  function prepareStreamResponse({
+    content = [],
+    finish_reason = 'stop',
+    headers,
+  }: {
+    content?: string[];
+    finish_reason?: string;
+    headers?: Record<string, string>;
+  }) {
+    server.urls['https://my.api.com/v1/chat/completions'].response = {
+      type: 'stream-chunks',
+      headers,
+      chunks: [
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1702657020,"model":"grok-beta",` +
+          `"system_fingerprint":null,"choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}\n\n`,
+        ...content.map(text => {
+          return (
+            `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1702657020,"model":"grok-beta",` +
+            `"system_fingerprint":null,"choices":[{"index":1,"delta":{"content":"${text}"},"finish_reason":null}]}\n\n`
+          );
+        }),
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1702657020,"model":"grok-beta",` +
+          `"system_fingerprint":null,"choices":[{"index":0,"delta":{},"finish_reason":"${finish_reason}"}]}\n\n`,
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1729171479,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_10c08bf97d","choices":[{"index":0,"delta":{},"finish_reason":"${finish_reason}"}],` +
+          `"usage":{"queue_time":0.061348671,"prompt_tokens":18,"prompt_time":0.000211569,` +
+          `"completion_tokens":439,"completion_time":0.798181818,"total_tokens":457,"total_time":0.798393387}}\n\n`,
+        'data: [DONE]\n\n',
+      ],
+    };
+  }
+
+  it('should respect the includeUsage option', async () => {
+    prepareStreamResponse({
+      content: ['Hello', ', ', 'World!'],
+      finish_reason: 'stop',
+    });
+
+    const model = new OpenAICompatibleChatLanguageModel('gpt-4o-2024-08-06', {
+      provider: 'test-provider',
+      url: () => 'https://my.api.com/v1/chat/completions',
+      headers: () => ({}),
+      includeUsage: true,
+    });
+
+    await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    const body = await server.calls[0].requestBodyJson;
+
+    expect(body.stream).toBe(true);
+    expect(body.stream_options).toStrictEqual({ include_usage: true });
+  });
+
+  it('should stream text deltas', async () => {
+    prepareStreamResponse({
+      content: ['Hello', ', ', 'World!'],
+      finish_reason: 'stop',
+    });
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    // note: space moved to last chunk bc of trimming
+    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+      [
+        {
+          "type": "stream-start",
+          "warnings": [],
+        },
+        {
+          "id": "chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798",
+          "modelId": "grok-beta",
+          "timestamp": 2023-12-15T16:17:00.000Z,
+          "type": "response-metadata",
+        },
+        {
+          "id": "txt-0",
+          "type": "text-start",
+        },
+        {
+          "delta": "Hello",
+          "id": "txt-0",
+          "type": "text-delta",
+        },
+        {
+          "delta": ", ",
+          "id": "txt-0",
+          "type": "text-delta",
+        },
+        {
+          "delta": "World!",
+          "id": "txt-0",
+          "type": "text-delta",
+        },
+        {
+          "id": "txt-0",
+          "type": "text-end",
+        },
+        {
+          "finishReason": {
+            "raw": "stop",
+            "unified": "stop",
+          },
+          "providerMetadata": {
+            "test-provider": {},
+          },
+          "type": "finish",
+          "usage": {
+            "inputTokens": {
+              "cacheRead": 0,
+              "cacheWrite": undefined,
+              "noCache": 18,
+              "total": 18,
+            },
+            "outputTokens": {
+              "reasoning": 0,
+              "text": 439,
+              "total": 439,
+            },
+            "raw": {
+              "completion_tokens": 439,
+              "prompt_tokens": 18,
+              "total_tokens": 457,
+            },
+          },
+        },
+      ]
+    `);
+  });
+
+  it('should stream reasoning content before text deltas', async () => {
+    server.urls['https://my.api.com/v1/chat/completions'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1711357598,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"role":"assistant","content":"", "reasoning_content":"Let me think"},"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1711357598,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"content":"", "reasoning_content":" about this"},"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1711357598,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"content":"Here's"},"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1711357598,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"content":" my response"},"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1729171479,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_10c08bf97d","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],` +
+          `"usage":{"prompt_tokens":18,"completion_tokens":439}}\n\n`,
+        'data: [DONE]\n\n',
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+      [
+        {
+          "type": "stream-start",
+          "warnings": [],
+        },
+        {
+          "id": "chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798",
+          "modelId": "grok-beta",
+          "timestamp": 2024-03-25T09:06:38.000Z,
+          "type": "response-metadata",
+        },
+        {
+          "id": "reasoning-0",
+          "type": "reasoning-start",
+        },
+        {
+          "delta": "Let me think",
+          "id": "reasoning-0",
+          "type": "reasoning-delta",
+        },
+        {
+          "delta": " about this",
+          "id": "reasoning-0",
+          "type": "reasoning-delta",
+        },
+        {
+          "id": "reasoning-0",
+          "type": "reasoning-end",
+        },
+        {
+          "id": "txt-0",
+          "type": "text-start",
+        },
+        {
+          "delta": "Here's",
+          "id": "txt-0",
+          "type": "text-delta",
+        },
+        {
+          "delta": " my response",
+          "id": "txt-0",
+          "type": "text-delta",
+        },
+        {
+          "id": "txt-0",
+          "type": "text-end",
+        },
+        {
+          "finishReason": {
+            "raw": "stop",
+            "unified": "stop",
+          },
+          "providerMetadata": {
+            "test-provider": {},
+          },
+          "type": "finish",
+          "usage": {
+            "inputTokens": {
+              "cacheRead": 0,
+              "cacheWrite": undefined,
+              "noCache": 18,
+              "total": 18,
+            },
+            "outputTokens": {
+              "reasoning": 0,
+              "text": 439,
+              "total": 439,
+            },
+            "raw": {
+              "completion_tokens": 439,
+              "prompt_tokens": 18,
+            },
+          },
+        },
+      ]
+    `);
+  });
+
+  it('should stream reasoning from reasoning field when reasoning_content is not provided', async () => {
+    server.urls['https://my.api.com/v1/chat/completions'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1711357598,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"role":"assistant","content":"", "reasoning":"Let me consider"},"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1711357598,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"content":"", "reasoning":" this carefully"},"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1711357598,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"content":"My answer is"},"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1711357598,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"content":" correct"},"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1729171479,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_10c08bf97d","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],` +
+          `"usage":{"prompt_tokens":18,"completion_tokens":439}}\n\n`,
+        'data: [DONE]\n\n',
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+      [
+        {
+          "type": "stream-start",
+          "warnings": [],
+        },
+        {
+          "id": "chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798",
+          "modelId": "grok-beta",
+          "timestamp": 2024-03-25T09:06:38.000Z,
+          "type": "response-metadata",
+        },
+        {
+          "id": "reasoning-0",
+          "type": "reasoning-start",
+        },
+        {
+          "delta": "Let me consider",
+          "id": "reasoning-0",
+          "type": "reasoning-delta",
+        },
+        {
+          "delta": " this carefully",
+          "id": "reasoning-0",
+          "type": "reasoning-delta",
+        },
+        {
+          "id": "reasoning-0",
+          "type": "reasoning-end",
+        },
+        {
+          "id": "txt-0",
+          "type": "text-start",
+        },
+        {
+          "delta": "My answer is",
+          "id": "txt-0",
+          "type": "text-delta",
+        },
+        {
+          "delta": " correct",
+          "id": "txt-0",
+          "type": "text-delta",
+        },
+        {
+          "id": "txt-0",
+          "type": "text-end",
+        },
+        {
+          "finishReason": {
+            "raw": "stop",
+            "unified": "stop",
+          },
+          "providerMetadata": {
+            "test-provider": {},
+          },
+          "type": "finish",
+          "usage": {
+            "inputTokens": {
+              "cacheRead": 0,
+              "cacheWrite": undefined,
+              "noCache": 18,
+              "total": 18,
+            },
+            "outputTokens": {
+              "reasoning": 0,
+              "text": 439,
+              "total": 439,
+            },
+            "raw": {
+              "completion_tokens": 439,
+              "prompt_tokens": 18,
+            },
+          },
+        },
+      ]
+    `);
+  });
+
+  it('should prefer reasoning_content over reasoning field in streaming when both are provided', async () => {
+    server.urls['https://my.api.com/v1/chat/completions'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1711357598,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"role":"assistant","content":"", "reasoning_content":"From reasoning_content", "reasoning":"From reasoning"},"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1711357598,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"content":"Final response"},"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1729171479,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_10c08bf97d","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],` +
+          `"usage":{"prompt_tokens":18,"completion_tokens":439}}\n\n`,
+        'data: [DONE]\n\n',
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+      [
+        {
+          "type": "stream-start",
+          "warnings": [],
+        },
+        {
+          "id": "chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798",
+          "modelId": "grok-beta",
+          "timestamp": 2024-03-25T09:06:38.000Z,
+          "type": "response-metadata",
+        },
+        {
+          "id": "reasoning-0",
+          "type": "reasoning-start",
+        },
+        {
+          "delta": "From reasoning_content",
+          "id": "reasoning-0",
+          "type": "reasoning-delta",
+        },
+        {
+          "id": "reasoning-0",
+          "type": "reasoning-end",
+        },
+        {
+          "id": "txt-0",
+          "type": "text-start",
+        },
+        {
+          "delta": "Final response",
+          "id": "txt-0",
+          "type": "text-delta",
+        },
+        {
+          "id": "txt-0",
+          "type": "text-end",
+        },
+        {
+          "finishReason": {
+            "raw": "stop",
+            "unified": "stop",
+          },
+          "providerMetadata": {
+            "test-provider": {},
+          },
+          "type": "finish",
+          "usage": {
+            "inputTokens": {
+              "cacheRead": 0,
+              "cacheWrite": undefined,
+              "noCache": 18,
+              "total": 18,
+            },
+            "outputTokens": {
+              "reasoning": 0,
+              "text": 439,
+              "total": 439,
+            },
+            "raw": {
+              "completion_tokens": 439,
+              "prompt_tokens": 18,
+            },
+          },
+        },
+      ]
+    `);
+  });
+
+  it('should stream tool deltas', async () => {
+    server.urls['https://my.api.com/v1/chat/completions'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1711357598,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"role":"assistant","content":null,` +
+          `"tool_calls":[{"index":0,"id":"call_O17Uplv4lJvD6DVdIvFFeRMw","type":"function","function":{"name":"test-tool","arguments":""}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1711357598,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\""}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1711357598,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"value"}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1711357598,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\\":\\""}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1711357598,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"Spark"}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1711357598,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"le"}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1711357598,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":" Day"}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1711357598,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\\"}"}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1729171479,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_10c08bf97d","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],` +
+          `"usage":{"queue_time":0.061348671,"prompt_tokens":18,"prompt_time":0.000211569,` +
+          `"completion_tokens":439,"completion_time":0.798181818,"total_tokens":457,"total_time":0.798393387}}\n\n`,
+        'data: [DONE]\n\n',
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      tools: [
+        {
+          type: 'function',
+          name: 'test-tool',
+          inputSchema: {
+            type: 'object',
+            properties: { value: { type: 'string' } },
+            required: ['value'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+      ],
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+      [
+        {
+          "type": "stream-start",
+          "warnings": [],
+        },
+        {
+          "id": "chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798",
+          "modelId": "grok-beta",
+          "timestamp": 2024-03-25T09:06:38.000Z,
+          "type": "response-metadata",
+        },
+        {
+          "id": "call_O17Uplv4lJvD6DVdIvFFeRMw",
+          "toolName": "test-tool",
+          "type": "tool-input-start",
+        },
+        {
+          "delta": "{"",
+          "id": "call_O17Uplv4lJvD6DVdIvFFeRMw",
+          "type": "tool-input-delta",
+        },
+        {
+          "delta": "value",
+          "id": "call_O17Uplv4lJvD6DVdIvFFeRMw",
+          "type": "tool-input-delta",
+        },
+        {
+          "delta": "":"",
+          "id": "call_O17Uplv4lJvD6DVdIvFFeRMw",
+          "type": "tool-input-delta",
+        },
+        {
+          "delta": "Spark",
+          "id": "call_O17Uplv4lJvD6DVdIvFFeRMw",
+          "type": "tool-input-delta",
+        },
+        {
+          "delta": "le",
+          "id": "call_O17Uplv4lJvD6DVdIvFFeRMw",
+          "type": "tool-input-delta",
+        },
+        {
+          "delta": " Day",
+          "id": "call_O17Uplv4lJvD6DVdIvFFeRMw",
+          "type": "tool-input-delta",
+        },
+        {
+          "delta": ""}",
+          "id": "call_O17Uplv4lJvD6DVdIvFFeRMw",
+          "type": "tool-input-delta",
+        },
+        {
+          "id": "call_O17Uplv4lJvD6DVdIvFFeRMw",
+          "type": "tool-input-end",
+        },
+        {
+          "input": "{"value":"Sparkle Day"}",
+          "toolCallId": "call_O17Uplv4lJvD6DVdIvFFeRMw",
+          "toolName": "test-tool",
+          "type": "tool-call",
+        },
+        {
+          "finishReason": {
+            "raw": "tool_calls",
+            "unified": "tool-calls",
+          },
+          "providerMetadata": {
+            "test-provider": {},
+          },
+          "type": "finish",
+          "usage": {
+            "inputTokens": {
+              "cacheRead": 0,
+              "cacheWrite": undefined,
+              "noCache": 18,
+              "total": 18,
+            },
+            "outputTokens": {
+              "reasoning": 0,
+              "text": 439,
+              "total": 439,
+            },
+            "raw": {
+              "completion_tokens": 439,
+              "prompt_tokens": 18,
+              "total_tokens": 457,
+            },
+          },
+        },
+      ]
+    `);
+  });
+
+  it('should stream tool call with thought signature from extra_content', async () => {
+    server.urls['https://my.api.com/v1/chat/completions'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        // First chunk with tool call start and thought signature in extra_content
+        `data: {"id":"chatcmpl-gemini-thought","object":"chat.completion.chunk","created":1711357598,"model":"gemini-3-pro",` +
+          `"choices":[{"index":0,"delta":{"role":"assistant","content":null,` +
+          `"tool_calls":[{"index":0,"id":"function-call-1","type":"function","function":{"name":"check_flight","arguments":""},` +
+          `"extra_content":{"google":{"thought_signature":"<Signature A>"}}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        // Subsequent chunks with arguments
+        `data: {"id":"chatcmpl-gemini-thought","object":"chat.completion.chunk","created":1711357598,"model":"gemini-3-pro",` +
+          `"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\"flight\\":"}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-gemini-thought","object":"chat.completion.chunk","created":1711357598,"model":"gemini-3-pro",` +
+          `"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\\"AA100\\"}"}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-gemini-thought","object":"chat.completion.chunk","created":1711357598,"model":"gemini-3-pro",` +
+          `"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],` +
+          `"usage":{"prompt_tokens":10,"completion_tokens":20,"total_tokens":30}}\n\n`,
+        'data: [DONE]\n\n',
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      tools: [
+        {
+          type: 'function',
+          name: 'check_flight',
+          inputSchema: {
+            type: 'object',
+            properties: { flight: { type: 'string' } },
+            required: ['flight'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+      ],
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    const result = await convertReadableStreamToArray(stream);
+
+    // Find the tool-call event and verify it has the thought signature in providerMetadata
+    const toolCallEvent = result.find(
+      (event: { type: string }) => event.type === 'tool-call',
+    );
+    expect(toolCallEvent).toMatchObject({
+      type: 'tool-call',
+      toolCallId: 'function-call-1',
+      toolName: 'check_flight',
+      input: '{"flight":"AA100"}',
+      providerMetadata: {
+        'test-provider': {
+          thoughtSignature: '<Signature A>',
+        },
+      },
+    });
+  });
+
+  it('should stream parallel tool calls with signature only on first call', async () => {
+    server.urls['https://my.api.com/v1/chat/completions'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        // First chunk with two tool calls - only first has thought signature
+        `data: {"id":"chatcmpl-gemini-parallel","object":"chat.completion.chunk","created":1711357598,"model":"gemini-3-pro",` +
+          `"choices":[{"index":0,"delta":{"role":"assistant","content":null,` +
+          `"tool_calls":[` +
+          `{"index":0,"id":"call-paris","type":"function","function":{"name":"get_weather","arguments":""},` +
+          `"extra_content":{"google":{"thought_signature":"<Signature A>"}}},` +
+          `{"index":1,"id":"call-london","type":"function","function":{"name":"get_weather","arguments":""}}` +
+          `]},` +
+          `"finish_reason":null}]}\n\n`,
+        // Arguments for first call
+        `data: {"id":"chatcmpl-gemini-parallel","object":"chat.completion.chunk","created":1711357598,"model":"gemini-3-pro",` +
+          `"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\"location\\":\\"Paris\\"}"}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        // Arguments for second call
+        `data: {"id":"chatcmpl-gemini-parallel","object":"chat.completion.chunk","created":1711357598,"model":"gemini-3-pro",` +
+          `"choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"function":{"arguments":"{\\"location\\":\\"London\\"}"}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-gemini-parallel","object":"chat.completion.chunk","created":1711357598,"model":"gemini-3-pro",` +
+          `"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],` +
+          `"usage":{"prompt_tokens":10,"completion_tokens":20,"total_tokens":30}}\n\n`,
+        'data: [DONE]\n\n',
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      tools: [
+        {
+          type: 'function',
+          name: 'get_weather',
+          inputSchema: {
+            type: 'object',
+            properties: { location: { type: 'string' } },
+            required: ['location'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+      ],
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    const result = await convertReadableStreamToArray(stream);
+
+    const toolCallEvents = result.filter(
+      (event: { type: string }) => event.type === 'tool-call',
+    );
+
+    expect(toolCallEvents).toHaveLength(2);
+
+    // First tool call should have thought signature
+    expect(toolCallEvents[0]).toMatchObject({
+      type: 'tool-call',
+      toolCallId: 'call-paris',
+      toolName: 'get_weather',
+      providerMetadata: {
+        'test-provider': {
+          thoughtSignature: '<Signature A>',
+        },
+      },
+    });
+
+    // Second tool call should NOT have thought signature
+    expect(toolCallEvents[1]).toMatchObject({
+      type: 'tool-call',
+      toolCallId: 'call-london',
+      toolName: 'get_weather',
+    });
+    expect(
+      (toolCallEvents[1] as { providerMetadata?: unknown }).providerMetadata,
+    ).toBeUndefined();
+  });
+
+  it('should stream tool call deltas when tool call arguments are passed in the first chunk', async () => {
+    server.urls['https://my.api.com/v1/chat/completions'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1711357598,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"role":"assistant","content":null,` +
+          `"tool_calls":[{"index":0,"id":"call_O17Uplv4lJvD6DVdIvFFeRMw","type":"function","function":{"name":"test-tool","arguments":"{\\""}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1711357598,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"va"}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1711357598,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"lue"}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1711357598,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\\":\\""}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1711357598,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"Spark"}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1711357598,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"le"}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1711357598,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":" Day"}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1711357598,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\\"}"}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1729171479,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_10c08bf97d","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],` +
+          `"usage":{"queue_time":0.061348671,"prompt_tokens":18,"prompt_time":0.000211569,` +
+          `"completion_tokens":439,"completion_time":0.798181818,"total_tokens":457,"total_time":0.798393387}}\n\n`,
+        'data: [DONE]\n\n',
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      tools: [
+        {
+          type: 'function',
+          name: 'test-tool',
+          inputSchema: {
+            type: 'object',
+            properties: { value: { type: 'string' } },
+            required: ['value'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+      ],
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+      [
+        {
+          "type": "stream-start",
+          "warnings": [],
+        },
+        {
+          "id": "chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798",
+          "modelId": "grok-beta",
+          "timestamp": 2024-03-25T09:06:38.000Z,
+          "type": "response-metadata",
+        },
+        {
+          "id": "call_O17Uplv4lJvD6DVdIvFFeRMw",
+          "toolName": "test-tool",
+          "type": "tool-input-start",
+        },
+        {
+          "delta": "{"",
+          "id": "call_O17Uplv4lJvD6DVdIvFFeRMw",
+          "type": "tool-input-delta",
+        },
+        {
+          "delta": "va",
+          "id": "call_O17Uplv4lJvD6DVdIvFFeRMw",
+          "type": "tool-input-delta",
+        },
+        {
+          "delta": "lue",
+          "id": "call_O17Uplv4lJvD6DVdIvFFeRMw",
+          "type": "tool-input-delta",
+        },
+        {
+          "delta": "":"",
+          "id": "call_O17Uplv4lJvD6DVdIvFFeRMw",
+          "type": "tool-input-delta",
+        },
+        {
+          "delta": "Spark",
+          "id": "call_O17Uplv4lJvD6DVdIvFFeRMw",
+          "type": "tool-input-delta",
+        },
+        {
+          "delta": "le",
+          "id": "call_O17Uplv4lJvD6DVdIvFFeRMw",
+          "type": "tool-input-delta",
+        },
+        {
+          "delta": " Day",
+          "id": "call_O17Uplv4lJvD6DVdIvFFeRMw",
+          "type": "tool-input-delta",
+        },
+        {
+          "delta": ""}",
+          "id": "call_O17Uplv4lJvD6DVdIvFFeRMw",
+          "type": "tool-input-delta",
+        },
+        {
+          "id": "call_O17Uplv4lJvD6DVdIvFFeRMw",
+          "type": "tool-input-end",
+        },
+        {
+          "input": "{"value":"Sparkle Day"}",
+          "toolCallId": "call_O17Uplv4lJvD6DVdIvFFeRMw",
+          "toolName": "test-tool",
+          "type": "tool-call",
+        },
+        {
+          "finishReason": {
+            "raw": "tool_calls",
+            "unified": "tool-calls",
+          },
+          "providerMetadata": {
+            "test-provider": {},
+          },
+          "type": "finish",
+          "usage": {
+            "inputTokens": {
+              "cacheRead": 0,
+              "cacheWrite": undefined,
+              "noCache": 18,
+              "total": 18,
+            },
+            "outputTokens": {
+              "reasoning": 0,
+              "text": 439,
+              "total": 439,
+            },
+            "raw": {
+              "completion_tokens": 439,
+              "prompt_tokens": 18,
+              "total_tokens": 457,
+            },
+          },
+        },
+      ]
+    `);
+  });
+
+  it('should not duplicate tool calls when there is an additional empty chunk after the tool call has been completed', async () => {
+    server.urls['https://my.api.com/v1/chat/completions'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: {"id":"chat-2267f7e2910a4254bac0650ba74cfc1c","object":"chat.completion.chunk","created":1733162241,` +
+          `"model":"meta/llama-3.1-8b-instruct:fp8","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}],` +
+          `"usage":{"prompt_tokens":226,"total_tokens":226,"completion_tokens":0}}\n\n`,
+        `data: {"id":"chat-2267f7e2910a4254bac0650ba74cfc1c","object":"chat.completion.chunk","created":1733162241,` +
+          `"model":"meta/llama-3.1-8b-instruct:fp8","choices":[{"index":0,"delta":{"tool_calls":[{"id":"chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",` +
+          `"type":"function","index":0,"function":{"name":"searchGoogle"}}]},"logprobs":null,"finish_reason":null}],` +
+          `"usage":{"prompt_tokens":226,"total_tokens":233,"completion_tokens":7}}\n\n`,
+        `data: {"id":"chat-2267f7e2910a4254bac0650ba74cfc1c","object":"chat.completion.chunk","created":1733162241,` +
+          `"model":"meta/llama-3.1-8b-instruct:fp8","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,` +
+          `"function":{"arguments":"{\\"query\\": \\""}}]},"logprobs":null,"finish_reason":null}],` +
+          `"usage":{"prompt_tokens":226,"total_tokens":241,"completion_tokens":15}}\n\n`,
+        `data: {"id":"chat-2267f7e2910a4254bac0650ba74cfc1c","object":"chat.completion.chunk","created":1733162241,` +
+          `"model":"meta/llama-3.1-8b-instruct:fp8","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,` +
+          `"function":{"arguments":"latest"}}]},"logprobs":null,"finish_reason":null}],` +
+          `"usage":{"prompt_tokens":226,"total_tokens":242,"completion_tokens":16}}\n\n`,
+        `data: {"id":"chat-2267f7e2910a4254bac0650ba74cfc1c","object":"chat.completion.chunk","created":1733162241,` +
+          `"model":"meta/llama-3.1-8b-instruct:fp8","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,` +
+          `"function":{"arguments":" news"}}]},"logprobs":null,"finish_reason":null}],` +
+          `"usage":{"prompt_tokens":226,"total_tokens":243,"completion_tokens":17}}\n\n`,
+        `data: {"id":"chat-2267f7e2910a4254bac0650ba74cfc1c","object":"chat.completion.chunk","created":1733162241,` +
+          `"model":"meta/llama-3.1-8b-instruct:fp8","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,` +
+          `"function":{"arguments":" on"}}]},"logprobs":null,"finish_reason":null}],` +
+          `"usage":{"prompt_tokens":226,"total_tokens":244,"completion_tokens":18}}\n\n`,
+        `data: {"id":"chat-2267f7e2910a4254bac0650ba74cfc1c","object":"chat.completion.chunk","created":1733162241,` +
+          `"model":"meta/llama-3.1-8b-instruct:fp8","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,` +
+          `"function":{"arguments":" ai\\"}"}}]},"logprobs":null,"finish_reason":null}],` +
+          `"usage":{"prompt_tokens":226,"total_tokens":245,"completion_tokens":19}}\n\n`,
+        // empty arguments chunk after the tool call has already been finished:
+        `data: {"id":"chat-2267f7e2910a4254bac0650ba74cfc1c","object":"chat.completion.chunk","created":1733162241,` +
+          `"model":"meta/llama-3.1-8b-instruct:fp8","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,` +
+          `"function":{"arguments":""}}]},"logprobs":null,"finish_reason":"tool_calls","stop_reason":128008}],` +
+          `"usage":{"prompt_tokens":226,"total_tokens":246,"completion_tokens":20}}\n\n`,
+        `data: {"id":"chat-2267f7e2910a4254bac0650ba74cfc1c","object":"chat.completion.chunk","created":1733162241,` +
+          `"model":"meta/llama-3.1-8b-instruct:fp8","choices":[],` +
+          `"usage":{"prompt_tokens":226,"total_tokens":246,"completion_tokens":20}}\n\n`,
+        `data: [DONE]\n\n`,
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      tools: [
+        {
+          type: 'function',
+          name: 'searchGoogle',
+          inputSchema: {
+            type: 'object',
+            properties: { query: { type: 'string' } },
+            required: ['query'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+      ],
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+      [
+        {
+          "type": "stream-start",
+          "warnings": [],
+        },
+        {
+          "id": "chat-2267f7e2910a4254bac0650ba74cfc1c",
+          "modelId": "meta/llama-3.1-8b-instruct:fp8",
+          "timestamp": 2024-12-02T17:57:21.000Z,
+          "type": "response-metadata",
+        },
+        {
+          "id": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
+          "toolName": "searchGoogle",
+          "type": "tool-input-start",
+        },
+        {
+          "delta": "{"query": "",
+          "id": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
+          "type": "tool-input-delta",
+        },
+        {
+          "delta": "latest",
+          "id": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
+          "type": "tool-input-delta",
+        },
+        {
+          "delta": " news",
+          "id": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
+          "type": "tool-input-delta",
+        },
+        {
+          "delta": " on",
+          "id": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
+          "type": "tool-input-delta",
+        },
+        {
+          "delta": " ai"}",
+          "id": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
+          "type": "tool-input-delta",
+        },
+        {
+          "id": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
+          "type": "tool-input-end",
+        },
+        {
+          "input": "{"query": "latest news on ai"}",
+          "toolCallId": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
+          "toolName": "searchGoogle",
+          "type": "tool-call",
+        },
+        {
+          "finishReason": {
+            "raw": "tool_calls",
+            "unified": "tool-calls",
+          },
+          "providerMetadata": {
+            "test-provider": {},
+          },
+          "type": "finish",
+          "usage": {
+            "inputTokens": {
+              "cacheRead": 0,
+              "cacheWrite": undefined,
+              "noCache": 226,
+              "total": 226,
+            },
+            "outputTokens": {
+              "reasoning": 0,
+              "text": 20,
+              "total": 20,
+            },
+            "raw": {
+              "completion_tokens": 20,
+              "prompt_tokens": 226,
+              "total_tokens": 246,
+            },
+          },
+        },
+      ]
+    `);
+  });
+
+  it('should stream tool call that is sent in one chunk', async () => {
+    server.urls['https://my.api.com/v1/chat/completions'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1711357598,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"role":"assistant","content":null,` +
+          `"tool_calls":[{"index":0,"id":"call_O17Uplv4lJvD6DVdIvFFeRMw","type":"function","function":{"name":"test-tool","arguments":"{\\"value\\":\\"Sparkle Day\\"}"}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1729171479,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_10c08bf97d","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],` +
+          `"usage":{"queue_time":0.061348671,"prompt_tokens":18,"prompt_time":0.000211569,` +
+          `"completion_tokens":439,"completion_time":0.798181818,"total_tokens":457,"total_time":0.798393387}}\n\n`,
+        'data: [DONE]\n\n',
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      tools: [
+        {
+          type: 'function',
+          name: 'test-tool',
+          inputSchema: {
+            type: 'object',
+            properties: { value: { type: 'string' } },
+            required: ['value'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+      ],
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+      [
+        {
+          "type": "stream-start",
+          "warnings": [],
+        },
+        {
+          "id": "chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798",
+          "modelId": "grok-beta",
+          "timestamp": 2024-03-25T09:06:38.000Z,
+          "type": "response-metadata",
+        },
+        {
+          "id": "call_O17Uplv4lJvD6DVdIvFFeRMw",
+          "toolName": "test-tool",
+          "type": "tool-input-start",
+        },
+        {
+          "delta": "{"value":"Sparkle Day"}",
+          "id": "call_O17Uplv4lJvD6DVdIvFFeRMw",
+          "type": "tool-input-delta",
+        },
+        {
+          "id": "call_O17Uplv4lJvD6DVdIvFFeRMw",
+          "type": "tool-input-end",
+        },
+        {
+          "input": "{"value":"Sparkle Day"}",
+          "toolCallId": "call_O17Uplv4lJvD6DVdIvFFeRMw",
+          "toolName": "test-tool",
+          "type": "tool-call",
+        },
+        {
+          "finishReason": {
+            "raw": "tool_calls",
+            "unified": "tool-calls",
+          },
+          "providerMetadata": {
+            "test-provider": {},
+          },
+          "type": "finish",
+          "usage": {
+            "inputTokens": {
+              "cacheRead": 0,
+              "cacheWrite": undefined,
+              "noCache": 18,
+              "total": 18,
+            },
+            "outputTokens": {
+              "reasoning": 0,
+              "text": 439,
+              "total": 439,
+            },
+            "raw": {
+              "completion_tokens": 439,
+              "prompt_tokens": 18,
+              "total_tokens": 457,
+            },
+          },
+        },
+      ]
+    `);
+  });
+
+  it('should stream empty tool call that is sent in one chunk', async () => {
+    server.urls['https://my.api.com/v1/chat/completions'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1711357598,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"role":"assistant","content":null,` +
+          `"tool_calls":[{"index":0,"id":"call_O17Uplv4lJvD6DVdIvFFeRMw","type":"function","function":{"name":"test-tool","arguments":""}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1729171479,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_10c08bf97d","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],` +
+          `"usage":{"queue_time":0.061348671,"prompt_tokens":18,"prompt_time":0.000211569,` +
+          `"completion_tokens":439,"completion_time":0.798181818,"total_tokens":457,"total_time":0.798393387}}\n\n`,
+        'data: [DONE]\n\n',
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      tools: [
+        {
+          type: 'function',
+          name: 'test-tool',
+          inputSchema: {
+            type: 'object',
+            properties: {},
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+      ],
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+      [
+        {
+          "type": "stream-start",
+          "warnings": [],
+        },
+        {
+          "id": "chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798",
+          "modelId": "grok-beta",
+          "timestamp": 2024-03-25T09:06:38.000Z,
+          "type": "response-metadata",
+        },
+        {
+          "id": "call_O17Uplv4lJvD6DVdIvFFeRMw",
+          "toolName": "test-tool",
+          "type": "tool-input-start",
+        },
+        {
+          "id": "call_O17Uplv4lJvD6DVdIvFFeRMw",
+          "type": "tool-input-end",
+        },
+        {
+          "input": "",
+          "toolCallId": "call_O17Uplv4lJvD6DVdIvFFeRMw",
+          "toolName": "test-tool",
+          "type": "tool-call",
+        },
+        {
+          "finishReason": {
+            "raw": "tool_calls",
+            "unified": "tool-calls",
+          },
+          "providerMetadata": {
+            "test-provider": {},
+          },
+          "type": "finish",
+          "usage": {
+            "inputTokens": {
+              "cacheRead": 0,
+              "cacheWrite": undefined,
+              "noCache": 18,
+              "total": 18,
+            },
+            "outputTokens": {
+              "reasoning": 0,
+              "text": 439,
+              "total": 439,
+            },
+            "raw": {
+              "completion_tokens": 439,
+              "prompt_tokens": 18,
+              "total_tokens": 457,
+            },
+          },
+        },
+      ]
+    `);
+  });
+
+  it('should handle error stream parts', async () => {
+    server.urls['https://my.api.com/v1/chat/completions'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: {"error": {"message": "Incorrect API key provided: as***T7. You can obtain an API key from https://console.api.com.", "code": "Client specified an invalid argument"}}\n\n`,
+        'data: [DONE]\n\n',
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+      [
+        {
+          "type": "stream-start",
+          "warnings": [],
+        },
+        {
+          "error": "Incorrect API key provided: as***T7. You can obtain an API key from https://console.api.com.",
+          "type": "error",
+        },
+        {
+          "finishReason": {
+            "raw": undefined,
+            "unified": "error",
+          },
+          "providerMetadata": {
+            "test-provider": {},
+          },
+          "type": "finish",
+          "usage": {
+            "inputTokens": {
+              "cacheRead": undefined,
+              "cacheWrite": undefined,
+              "noCache": undefined,
+              "total": undefined,
+            },
+            "outputTokens": {
+              "reasoning": undefined,
+              "text": undefined,
+              "total": undefined,
+            },
+            "raw": undefined,
+          },
+        },
+      ]
+    `);
+  });
+
+  it.skipIf(isNodeVersion(20))(
+    'should handle unparsable stream parts',
+    async () => {
+      server.urls['https://my.api.com/v1/chat/completions'].response = {
+        type: 'stream-chunks',
+        chunks: [`data: {unparsable}\n\n`, 'data: [DONE]\n\n'],
+      };
+
+      const { stream } = await model.doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+      });
+
+      expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+        [
+          {
+            "type": "stream-start",
+            "warnings": [],
+          },
+          {
+            "error": [AI_JSONParseError: JSON parsing failed: Text: {unparsable}.
+        Error message: Expected property name or '}' in JSON at position 1 (line 1 column 2)],
+            "type": "error",
+          },
+          {
+            "finishReason": {
+              "raw": undefined,
+              "unified": "error",
+            },
+            "providerMetadata": {
+              "test-provider": {},
+            },
+            "type": "finish",
+            "usage": {
+              "inputTokens": {
+                "cacheRead": undefined,
+                "cacheWrite": undefined,
+                "noCache": undefined,
+                "total": undefined,
+              },
+              "outputTokens": {
+                "reasoning": undefined,
+                "text": undefined,
+                "total": undefined,
+              },
+              "raw": undefined,
+            },
+          },
+        ]
+      `);
+    },
+  );
+
+  it('should expose the raw response headers', async () => {
+    prepareStreamResponse({
+      headers: { 'test-header': 'test-value' },
+    });
+
+    const { response } = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    expect(response?.headers).toStrictEqual({
+      // default headers:
+      'content-type': 'text/event-stream',
+      'cache-control': 'no-cache',
+      connection: 'keep-alive',
+
+      // custom header
+      'test-header': 'test-value',
+    });
+  });
+
+  it('should pass the messages and the model', async () => {
+    prepareStreamResponse({ content: [] });
+
+    await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      stream: true,
+      model: 'grok-beta',
+      messages: [{ role: 'user', content: 'Hello' }],
+    });
+  });
+
+  it('should pass headers', async () => {
+    prepareStreamResponse({ content: [] });
+
+    const provider = createOpenAICompatible({
+      baseURL: 'https://my.api.com/v1',
+      name: 'test-provider',
+      headers: {
+        Authorization: `Bearer test-api-key`,
+        'Custom-Provider-Header': 'provider-header-value',
+      },
+    });
+
+    await provider('grok-beta').doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+      headers: {
+        'Custom-Request-Header': 'request-header-value',
+      },
+    });
+
+    expect(await server.calls[0].requestHeaders).toStrictEqual({
+      authorization: 'Bearer test-api-key',
+      'content-type': 'application/json',
+      'custom-provider-header': 'provider-header-value',
+      'custom-request-header': 'request-header-value',
+    });
+  });
+
+  it('should include provider-specific options', async () => {
+    prepareStreamResponse({ content: [] });
+
+    await provider('grok-beta').doStream({
+      providerOptions: {
+        'test-provider': {
+          someCustomOption: 'test-value',
+        },
+      },
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      stream: true,
+      model: 'grok-beta',
+      messages: [{ role: 'user', content: 'Hello' }],
+      someCustomOption: 'test-value',
+    });
+  });
+
+  it('should not include provider-specific options for different provider', async () => {
+    prepareStreamResponse({ content: [] });
+
+    await provider('grok-beta').doStream({
+      providerOptions: {
+        notThisProviderName: {
+          someCustomOption: 'test-value',
+        },
+      },
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      stream: true,
+      model: 'grok-beta',
+      messages: [{ role: 'user', content: 'Hello' }],
+    });
+  });
+
+  it('should send request body', async () => {
+    prepareStreamResponse({ content: [] });
+
+    const { request } = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    expect(request).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "frequency_penalty": undefined,
+          "max_tokens": undefined,
+          "messages": [
+            {
+              "content": "Hello",
+              "role": "user",
+            },
+          ],
+          "model": "grok-beta",
+          "presence_penalty": undefined,
+          "reasoning_effort": undefined,
+          "response_format": undefined,
+          "seed": undefined,
+          "stop": undefined,
+          "stream": true,
+          "stream_options": undefined,
+          "temperature": undefined,
+          "tool_choice": undefined,
+          "tools": undefined,
+          "top_p": undefined,
+          "user": undefined,
+          "verbosity": undefined,
+        },
+      }
+    `);
+  });
+
+  describe('usage details in streaming', () => {
+    it('should extract detailed token usage from stream finish', async () => {
+      server.urls['https://my.api.com/v1/chat/completions'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data: {"id":"chat-id","choices":[{"delta":{"content":"Hello"}}]}\n\n`,
+          `data: {"choices":[{"delta":{},"finish_reason":"stop"}],` +
+            `"usage":{"prompt_tokens":20,"completion_tokens":30,` +
+            `"prompt_tokens_details":{"cached_tokens":5},` +
+            `"completion_tokens_details":{` +
+            `"reasoning_tokens":10,` +
+            `"accepted_prediction_tokens":15,` +
+            `"rejected_prediction_tokens":5}}}\n\n`,
+          'data: [DONE]\n\n',
+        ],
+      };
+
+      const { stream } = await model.doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+      });
+
+      const parts = await convertReadableStreamToArray(stream);
+      const finishPart = parts.find(part => part.type === 'finish');
+
+      expect(finishPart).toMatchInlineSnapshot(`
+        {
+          "finishReason": {
+            "raw": "stop",
+            "unified": "stop",
+          },
+          "providerMetadata": {
+            "test-provider": {
+              "acceptedPredictionTokens": 15,
+              "rejectedPredictionTokens": 5,
+            },
+          },
+          "type": "finish",
+          "usage": {
+            "inputTokens": {
+              "cacheRead": 5,
+              "cacheWrite": undefined,
+              "noCache": 15,
+              "total": 20,
+            },
+            "outputTokens": {
+              "reasoning": 10,
+              "text": 20,
+              "total": 30,
+            },
+            "raw": {
+              "completion_tokens": 30,
+              "completion_tokens_details": {
+                "accepted_prediction_tokens": 15,
+                "reasoning_tokens": 10,
+                "rejected_prediction_tokens": 5,
+              },
+              "prompt_tokens": 20,
+              "prompt_tokens_details": {
+                "cached_tokens": 5,
+              },
+            },
+          },
+        }
+      `);
+    });
+
+    it('should handle missing token details in stream', async () => {
+      server.urls['https://my.api.com/v1/chat/completions'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data: {"id":"chat-id","choices":[{"delta":{"content":"Hello"}}]}\n\n`,
+          `data: {"choices":[{"delta":{},"finish_reason":"stop"}],` +
+            `"usage":{"prompt_tokens":20,"completion_tokens":30}}\n\n`,
+          'data: [DONE]\n\n',
+        ],
+      };
+
+      const { stream } = await model.doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+      });
+
+      const parts = await convertReadableStreamToArray(stream);
+      const finishPart = parts.find(part => part.type === 'finish');
+
+      expect(finishPart?.providerMetadata!['test-provider']).toStrictEqual({});
+    });
+
+    it('should handle partial token details in stream', async () => {
+      server.urls['https://my.api.com/v1/chat/completions'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data: {"id":"chat-id","choices":[{"delta":{"content":"Hello"}}]}\n\n`,
+          `data: {"choices":[{"delta":{},"finish_reason":"stop"}],` +
+            `"usage":{"prompt_tokens":20,"completion_tokens":30,` +
+            `"total_tokens":50,` +
+            `"prompt_tokens_details":{"cached_tokens":5},` +
+            `"completion_tokens_details":{"reasoning_tokens":10}}}\n\n`,
+          'data: [DONE]\n\n',
+        ],
+      };
+
+      const { stream } = await model.doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+      });
+
+      const parts = await convertReadableStreamToArray(stream);
+      const finishPart = parts.find(part => part.type === 'finish');
+
+      expect(finishPart).toMatchInlineSnapshot(`
+        {
+          "finishReason": {
+            "raw": "stop",
+            "unified": "stop",
+          },
+          "providerMetadata": {
+            "test-provider": {},
+          },
+          "type": "finish",
+          "usage": {
+            "inputTokens": {
+              "cacheRead": 5,
+              "cacheWrite": undefined,
+              "noCache": 15,
+              "total": 20,
+            },
+            "outputTokens": {
+              "reasoning": 10,
+              "text": 20,
+              "total": 30,
+            },
+            "raw": {
+              "completion_tokens": 30,
+              "completion_tokens_details": {
+                "reasoning_tokens": 10,
+              },
+              "prompt_tokens": 20,
+              "prompt_tokens_details": {
+                "cached_tokens": 5,
+              },
+              "total_tokens": 50,
+            },
+          },
+        }
+      `);
+    });
+  });
+});
+
+describe('metadata extraction', () => {
+  const testMetadataExtractor = {
+    extractMetadata: async ({ parsedBody }: { parsedBody: unknown }) => {
+      if (
+        typeof parsedBody !== 'object' ||
+        !parsedBody ||
+        !('test_field' in parsedBody)
+      ) {
+        return undefined;
+      }
+      return {
+        'test-provider': {
+          value: parsedBody.test_field as string,
+        },
+      };
+    },
+    createStreamExtractor: () => {
+      let accumulatedValue: string | undefined;
+
+      return {
+        processChunk: (chunk: unknown) => {
+          if (
+            typeof chunk === 'object' &&
+            chunk &&
+            'choices' in chunk &&
+            Array.isArray(chunk.choices) &&
+            chunk.choices[0]?.finish_reason === 'stop' &&
+            'test_field' in chunk
+          ) {
+            accumulatedValue = chunk.test_field as string;
+          }
+        },
+        buildMetadata: () =>
+          accumulatedValue
+            ? {
+                'test-provider': {
+                  value: accumulatedValue,
+                },
+              }
+            : undefined,
+      };
+    },
+  };
+
+  it('should process metadata from complete response', async () => {
+    server.urls['https://my.api.com/v1/chat/completions'].response = {
+      type: 'json-value',
+      body: {
+        id: 'chatcmpl-123',
+        object: 'chat.completion',
+        created: 1711115037,
+        model: 'gpt-4',
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: 'assistant',
+            },
+            finish_reason: 'stop',
+          },
+        ],
+        test_field: 'test_value',
+      },
+    };
+
+    const model = new OpenAICompatibleChatLanguageModel('gpt-4', {
+      provider: 'test-provider',
+      url: () => 'https://my.api.com/v1/chat/completions',
+      headers: () => ({}),
+      metadataExtractor: testMetadataExtractor,
+    });
+
+    const result = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(result.providerMetadata).toEqual({
+      'test-provider': {
+        value: 'test_value',
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      model: 'gpt-4',
+      messages: [{ role: 'user', content: 'Hello' }],
+    });
+  });
+
+  it('should process metadata from streaming response', async () => {
+    server.urls['https://my.api.com/v1/chat/completions'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        'data: {"choices":[{"delta":{"content":"Hello"}}]}\n\n',
+        'data: {"choices":[{"finish_reason":"stop"}],"test_field":"test_value"}\n\n',
+        'data: [DONE]\n\n',
+      ],
+    };
+
+    const model = new OpenAICompatibleChatLanguageModel('gpt-4', {
+      provider: 'test-provider',
+      url: () => 'https://my.api.com/v1/chat/completions',
+      headers: () => ({}),
+      metadataExtractor: testMetadataExtractor,
+    });
+
+    const result = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    const parts = await convertReadableStreamToArray(result.stream);
+    const finishPart = parts.find(part => part.type === 'finish');
+
+    expect(finishPart?.providerMetadata).toEqual({
+      'test-provider': {
+        value: 'test_value',
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      model: 'gpt-4',
+      messages: [{ role: 'user', content: 'Hello' }],
+      stream: true,
+    });
+  });
+});
+
+describe('raw chunks', () => {
+  it('should include raw chunks when includeRawChunks is true', async () => {
+    server.urls['https://my.api.com/v1/chat/completions'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: {"id":"chat-id","choices":[{"delta":{"content":"Hello"}}]}\n\n`,
+        `data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n`,
+        'data: [DONE]\n\n',
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: true,
+    });
+
+    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+      [
+        {
+          "type": "stream-start",
+          "warnings": [],
+        },
+        {
+          "rawValue": {
+            "choices": [
+              {
+                "delta": {
+                  "content": "Hello",
+                },
+              },
+            ],
+            "id": "chat-id",
+          },
+          "type": "raw",
+        },
+        {
+          "id": "chat-id",
+          "modelId": undefined,
+          "timestamp": undefined,
+          "type": "response-metadata",
+        },
+        {
+          "id": "txt-0",
+          "type": "text-start",
+        },
+        {
+          "delta": "Hello",
+          "id": "txt-0",
+          "type": "text-delta",
+        },
+        {
+          "rawValue": {
+            "choices": [
+              {
+                "delta": {},
+                "finish_reason": "stop",
+              },
+            ],
+          },
+          "type": "raw",
+        },
+        {
+          "id": "txt-0",
+          "type": "text-end",
+        },
+        {
+          "finishReason": {
+            "raw": "stop",
+            "unified": "stop",
+          },
+          "providerMetadata": {
+            "test-provider": {},
+          },
+          "type": "finish",
+          "usage": {
+            "inputTokens": {
+              "cacheRead": undefined,
+              "cacheWrite": undefined,
+              "noCache": undefined,
+              "total": undefined,
+            },
+            "outputTokens": {
+              "reasoning": undefined,
+              "text": undefined,
+              "total": undefined,
+            },
+            "raw": undefined,
+          },
+        },
+      ]
+    `);
+  });
+});

--- a/src/ipc/utils/ai_sdk/chat/openai-compatible-chat-language-model.ts
+++ b/src/ipc/utils/ai_sdk/chat/openai-compatible-chat-language-model.ts
@@ -1,0 +1,804 @@
+import {
+  APICallError,
+  InvalidResponseDataError,
+  LanguageModelV3,
+  LanguageModelV3CallOptions,
+  LanguageModelV3Content,
+  LanguageModelV3FinishReason,
+  LanguageModelV3GenerateResult,
+  LanguageModelV3StreamPart,
+  LanguageModelV3StreamResult,
+  SharedV3ProviderMetadata,
+  SharedV3Warning,
+} from '@ai-sdk/provider';
+import {
+  combineHeaders,
+  createEventSourceResponseHandler,
+  createJsonErrorResponseHandler,
+  createJsonResponseHandler,
+  FetchFunction,
+  generateId,
+  isParsableJson,
+  parseProviderOptions,
+  ParseResult,
+  postJsonToApi,
+  ResponseHandler,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+import {
+  defaultOpenAICompatibleErrorStructure,
+  ProviderErrorStructure,
+} from '../openai-compatible-error';
+import { convertOpenAICompatibleChatUsage } from './convert-openai-compatible-chat-usage';
+import { convertToOpenAICompatibleChatMessages } from './convert-to-openai-compatible-chat-messages';
+import { getResponseMetadata } from './get-response-metadata';
+import { mapOpenAICompatibleFinishReason } from './map-openai-compatible-finish-reason';
+import {
+  OpenAICompatibleChatModelId,
+  openaiCompatibleProviderOptions,
+} from './openai-compatible-chat-options';
+import { MetadataExtractor } from './openai-compatible-metadata-extractor';
+import { prepareTools } from './openai-compatible-prepare-tools';
+
+export type OpenAICompatibleChatConfig = {
+  provider: string;
+  headers: () => Record<string, string | undefined>;
+  url: (options: { modelId: string; path: string }) => string;
+  fetch?: FetchFunction;
+  includeUsage?: boolean;
+  errorStructure?: ProviderErrorStructure<any>;
+  metadataExtractor?: MetadataExtractor;
+
+  /**
+   * Whether the model supports structured outputs.
+   */
+  supportsStructuredOutputs?: boolean;
+
+  /**
+   * The supported URLs for the model.
+   */
+  supportedUrls?: () => LanguageModelV3['supportedUrls'];
+};
+
+export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
+  readonly specificationVersion = 'v3';
+
+  readonly supportsStructuredOutputs: boolean;
+
+  readonly modelId: OpenAICompatibleChatModelId;
+  private readonly config: OpenAICompatibleChatConfig;
+  private readonly failedResponseHandler: ResponseHandler<APICallError>;
+  private readonly chunkSchema; // type inferred via constructor
+
+  constructor(
+    modelId: OpenAICompatibleChatModelId,
+    config: OpenAICompatibleChatConfig,
+  ) {
+    this.modelId = modelId;
+    this.config = config;
+
+    // initialize error handling:
+    const errorStructure =
+      config.errorStructure ?? defaultOpenAICompatibleErrorStructure;
+    this.chunkSchema = createOpenAICompatibleChatChunkSchema(
+      errorStructure.errorSchema,
+    );
+    this.failedResponseHandler = createJsonErrorResponseHandler(errorStructure);
+
+    this.supportsStructuredOutputs = config.supportsStructuredOutputs ?? false;
+  }
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  private get providerOptionsName(): string {
+    return this.config.provider.split('.')[0].trim();
+  }
+
+  get supportedUrls() {
+    return this.config.supportedUrls?.() ?? {};
+  }
+
+  private async getArgs({
+    prompt,
+    maxOutputTokens,
+    temperature,
+    topP,
+    topK,
+    frequencyPenalty,
+    presencePenalty,
+    providerOptions,
+    stopSequences,
+    responseFormat,
+    seed,
+    toolChoice,
+    tools,
+  }: LanguageModelV3CallOptions) {
+    const warnings: SharedV3Warning[] = [];
+
+    // Parse provider options
+    const compatibleOptions = Object.assign(
+      (await parseProviderOptions({
+        provider: 'openai-compatible',
+        providerOptions,
+        schema: openaiCompatibleProviderOptions,
+      })) ?? {},
+      (await parseProviderOptions({
+        provider: this.providerOptionsName,
+        providerOptions,
+        schema: openaiCompatibleProviderOptions,
+      })) ?? {},
+    );
+
+    const strictJsonSchema = compatibleOptions?.strictJsonSchema ?? true;
+
+    if (topK != null) {
+      warnings.push({ type: 'unsupported', feature: 'topK' });
+    }
+
+    if (
+      responseFormat?.type === 'json' &&
+      responseFormat.schema != null &&
+      !this.supportsStructuredOutputs
+    ) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'responseFormat',
+        details:
+          'JSON response format schema is only supported with structuredOutputs',
+      });
+    }
+
+    const {
+      tools: openaiTools,
+      toolChoice: openaiToolChoice,
+      toolWarnings,
+    } = prepareTools({
+      tools,
+      toolChoice,
+    });
+
+    return {
+      args: {
+        // model id:
+        model: this.modelId,
+
+        // model specific settings:
+        user: compatibleOptions.user,
+
+        // standardized settings:
+        max_tokens: maxOutputTokens,
+        temperature,
+        top_p: topP,
+        frequency_penalty: frequencyPenalty,
+        presence_penalty: presencePenalty,
+        response_format:
+          responseFormat?.type === 'json'
+            ? this.supportsStructuredOutputs === true &&
+              responseFormat.schema != null
+              ? {
+                  type: 'json_schema',
+                  json_schema: {
+                    schema: responseFormat.schema,
+                    strict: strictJsonSchema,
+                    name: responseFormat.name ?? 'response',
+                    description: responseFormat.description,
+                  },
+                }
+              : { type: 'json_object' }
+            : undefined,
+
+        stop: stopSequences,
+        seed,
+        ...Object.fromEntries(
+          Object.entries(
+            providerOptions?.[this.providerOptionsName] ?? {},
+          ).filter(
+            ([key]) =>
+              !Object.keys(openaiCompatibleProviderOptions.shape).includes(key),
+          ),
+        ),
+
+        reasoning_effort: compatibleOptions.reasoningEffort,
+        verbosity: compatibleOptions.textVerbosity,
+
+        // messages:
+        messages: convertToOpenAICompatibleChatMessages(prompt),
+
+        // tools:
+        tools: openaiTools,
+        tool_choice: openaiToolChoice,
+      },
+      warnings: [...warnings, ...toolWarnings],
+    };
+  }
+
+  async doGenerate(
+    options: LanguageModelV3CallOptions,
+  ): Promise<LanguageModelV3GenerateResult> {
+    const { args, warnings } = await this.getArgs({ ...options });
+
+    const body = JSON.stringify(args);
+
+    const {
+      responseHeaders,
+      value: responseBody,
+      rawValue: rawResponse,
+    } = await postJsonToApi({
+      url: this.config.url({
+        path: '/chat/completions',
+        modelId: this.modelId,
+      }),
+      headers: combineHeaders(this.config.headers(), options.headers),
+      body: args,
+      failedResponseHandler: this.failedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        OpenAICompatibleChatResponseSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    const choice = responseBody.choices[0];
+    const content: Array<LanguageModelV3Content> = [];
+
+    // text content:
+    const text = choice.message.content;
+    if (text != null && text.length > 0) {
+      content.push({ type: 'text', text });
+    }
+
+    // reasoning content:
+    const reasoning =
+      choice.message.reasoning_content ?? choice.message.reasoning;
+    if (reasoning != null && reasoning.length > 0) {
+      content.push({
+        type: 'reasoning',
+        text: reasoning,
+      });
+    }
+
+    // tool calls:
+    if (choice.message.tool_calls != null) {
+      for (const toolCall of choice.message.tool_calls) {
+        const thoughtSignature =
+          toolCall.extra_content?.google?.thought_signature;
+        content.push({
+          type: 'tool-call',
+          toolCallId: toolCall.id ?? generateId(),
+          toolName: toolCall.function.name,
+          input: toolCall.function.arguments!,
+          ...(thoughtSignature
+            ? {
+                providerMetadata: {
+                  [this.providerOptionsName]: { thoughtSignature },
+                },
+              }
+            : {}),
+        });
+      }
+    }
+
+    // provider metadata:
+    const providerMetadata: SharedV3ProviderMetadata = {
+      [this.providerOptionsName]: {},
+      ...(await this.config.metadataExtractor?.extractMetadata?.({
+        parsedBody: rawResponse,
+      })),
+    };
+    const completionTokenDetails =
+      responseBody.usage?.completion_tokens_details;
+    if (completionTokenDetails?.accepted_prediction_tokens != null) {
+      providerMetadata[this.providerOptionsName].acceptedPredictionTokens =
+        completionTokenDetails?.accepted_prediction_tokens;
+    }
+    if (completionTokenDetails?.rejected_prediction_tokens != null) {
+      providerMetadata[this.providerOptionsName].rejectedPredictionTokens =
+        completionTokenDetails?.rejected_prediction_tokens;
+    }
+
+    return {
+      content,
+      finishReason: {
+        unified: mapOpenAICompatibleFinishReason(choice.finish_reason),
+        raw: choice.finish_reason ?? undefined,
+      },
+      usage: convertOpenAICompatibleChatUsage(responseBody.usage),
+      providerMetadata,
+      request: { body },
+      response: {
+        ...getResponseMetadata(responseBody),
+        headers: responseHeaders,
+        body: rawResponse,
+      },
+      warnings,
+    };
+  }
+
+  async doStream(
+    options: LanguageModelV3CallOptions,
+  ): Promise<LanguageModelV3StreamResult> {
+    const { args, warnings } = await this.getArgs({ ...options });
+
+    const body = {
+      ...args,
+      stream: true,
+
+      // only include stream_options when in strict compatibility mode:
+      stream_options: this.config.includeUsage
+        ? { include_usage: true }
+        : undefined,
+    };
+
+    const metadataExtractor =
+      this.config.metadataExtractor?.createStreamExtractor();
+
+    const { responseHeaders, value: response } = await postJsonToApi({
+      url: this.config.url({
+        path: '/chat/completions',
+        modelId: this.modelId,
+      }),
+      headers: combineHeaders(this.config.headers(), options.headers),
+      body,
+      failedResponseHandler: this.failedResponseHandler,
+      successfulResponseHandler: createEventSourceResponseHandler(
+        this.chunkSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    const toolCalls: Array<{
+      id: string;
+      type: 'function';
+      function: {
+        name: string;
+        arguments: string;
+      };
+      hasFinished: boolean;
+      thoughtSignature?: string;
+    }> = [];
+
+    let finishReason: LanguageModelV3FinishReason = {
+      unified: 'other',
+      raw: undefined,
+    };
+    let usage: z.infer<typeof openaiCompatibleTokenUsageSchema> | undefined =
+      undefined;
+    let isFirstChunk = true;
+    const providerOptionsName = this.providerOptionsName;
+    let isActiveReasoning = false;
+    let isActiveText = false;
+
+    return {
+      stream: response.pipeThrough(
+        new TransformStream<
+          ParseResult<z.infer<typeof this.chunkSchema>>,
+          LanguageModelV3StreamPart
+        >({
+          start(controller) {
+            controller.enqueue({ type: 'stream-start', warnings });
+          },
+
+          transform(chunk, controller) {
+            // Emit raw chunk if requested (before anything else)
+            if (options.includeRawChunks) {
+              controller.enqueue({ type: 'raw', rawValue: chunk.rawValue });
+            }
+
+            // handle failed chunk parsing / validation:
+            if (!chunk.success) {
+              finishReason = { unified: 'error', raw: undefined };
+              controller.enqueue({ type: 'error', error: chunk.error });
+              return;
+            }
+
+            metadataExtractor?.processChunk(chunk.rawValue);
+
+            // handle error chunks:
+            if ('error' in chunk.value) {
+              finishReason = { unified: 'error', raw: undefined };
+              controller.enqueue({
+                type: 'error',
+                error: chunk.value.error.message,
+              });
+              return;
+            }
+
+            // TODO we lost type safety on Chunk, most likely due to the error schema. MUST FIX
+            // remove this workaround when the issue is fixed
+            const value = chunk.value as z.infer<typeof chunkBaseSchema>;
+
+            if (isFirstChunk) {
+              isFirstChunk = false;
+
+              controller.enqueue({
+                type: 'response-metadata',
+                ...getResponseMetadata(value),
+              });
+            }
+
+            if (value.usage != null) {
+              usage = value.usage;
+            }
+
+            const choice = value.choices[0];
+
+            if (choice?.finish_reason != null) {
+              finishReason = {
+                unified: mapOpenAICompatibleFinishReason(choice.finish_reason),
+                raw: choice.finish_reason ?? undefined,
+              };
+            }
+
+            if (choice?.delta == null) {
+              return;
+            }
+
+            const delta = choice.delta;
+
+            // enqueue reasoning before text deltas:
+            const reasoningContent = delta.reasoning_content ?? delta.reasoning;
+            if (reasoningContent) {
+              if (!isActiveReasoning) {
+                controller.enqueue({
+                  type: 'reasoning-start',
+                  id: 'reasoning-0',
+                });
+                isActiveReasoning = true;
+              }
+
+              controller.enqueue({
+                type: 'reasoning-delta',
+                id: 'reasoning-0',
+                delta: reasoningContent,
+              });
+            }
+
+            if (delta.content) {
+              // end active reasoning block before text starts
+              if (isActiveReasoning) {
+                controller.enqueue({
+                  type: 'reasoning-end',
+                  id: 'reasoning-0',
+                });
+                isActiveReasoning = false;
+              }
+
+              if (!isActiveText) {
+                controller.enqueue({ type: 'text-start', id: 'txt-0' });
+                isActiveText = true;
+              }
+
+              controller.enqueue({
+                type: 'text-delta',
+                id: 'txt-0',
+                delta: delta.content,
+              });
+            }
+
+            if (delta.tool_calls != null) {
+              // end active reasoning block before tool calls start
+              if (isActiveReasoning) {
+                controller.enqueue({
+                  type: 'reasoning-end',
+                  id: 'reasoning-0',
+                });
+                isActiveReasoning = false;
+              }
+
+              for (const toolCallDelta of delta.tool_calls) {
+                const index = toolCallDelta.index ?? toolCalls.length;
+
+                if (toolCalls[index] == null) {
+                  if (toolCallDelta.id == null) {
+                    throw new InvalidResponseDataError({
+                      data: toolCallDelta,
+                      message: `Expected 'id' to be a string.`,
+                    });
+                  }
+
+                  if (toolCallDelta.function?.name == null) {
+                    throw new InvalidResponseDataError({
+                      data: toolCallDelta,
+                      message: `Expected 'function.name' to be a string.`,
+                    });
+                  }
+
+                  controller.enqueue({
+                    type: 'tool-input-start',
+                    id: toolCallDelta.id,
+                    toolName: toolCallDelta.function.name,
+                  });
+
+                  toolCalls[index] = {
+                    id: toolCallDelta.id,
+                    type: 'function',
+                    function: {
+                      name: toolCallDelta.function.name,
+                      arguments: toolCallDelta.function.arguments ?? '',
+                    },
+                    hasFinished: false,
+                    thoughtSignature:
+                      toolCallDelta.extra_content?.google?.thought_signature ??
+                      undefined,
+                  };
+
+                  const toolCall = toolCalls[index];
+
+                  if (
+                    toolCall.function?.name != null &&
+                    toolCall.function?.arguments != null
+                  ) {
+                    // send delta if the argument text has already started:
+                    if (toolCall.function.arguments.length > 0) {
+                      controller.enqueue({
+                        type: 'tool-input-delta',
+                        id: toolCall.id,
+                        delta: toolCall.function.arguments,
+                      });
+                    }
+
+                    // check if tool call is complete
+                    // (some providers send the full tool call in one chunk):
+                    if (isParsableJson(toolCall.function.arguments)) {
+                      controller.enqueue({
+                        type: 'tool-input-end',
+                        id: toolCall.id,
+                      });
+
+                      controller.enqueue({
+                        type: 'tool-call',
+                        toolCallId: toolCall.id ?? generateId(),
+                        toolName: toolCall.function.name,
+                        input: toolCall.function.arguments,
+                        ...(toolCall.thoughtSignature
+                          ? {
+                              providerMetadata: {
+                                [providerOptionsName]: {
+                                  thoughtSignature: toolCall.thoughtSignature,
+                                },
+                              },
+                            }
+                          : {}),
+                      });
+                      toolCall.hasFinished = true;
+                    }
+                  }
+
+                  continue;
+                }
+
+                // existing tool call, merge if not finished
+                const toolCall = toolCalls[index];
+
+                if (toolCall.hasFinished) {
+                  continue;
+                }
+
+                if (toolCallDelta.function?.arguments != null) {
+                  toolCall.function!.arguments +=
+                    toolCallDelta.function?.arguments ?? '';
+                }
+
+                // send delta
+                controller.enqueue({
+                  type: 'tool-input-delta',
+                  id: toolCall.id,
+                  delta: toolCallDelta.function.arguments ?? '',
+                });
+
+                // check if tool call is complete
+                if (
+                  toolCall.function?.name != null &&
+                  toolCall.function?.arguments != null &&
+                  isParsableJson(toolCall.function.arguments)
+                ) {
+                  controller.enqueue({
+                    type: 'tool-input-end',
+                    id: toolCall.id,
+                  });
+
+                  controller.enqueue({
+                    type: 'tool-call',
+                    toolCallId: toolCall.id ?? generateId(),
+                    toolName: toolCall.function.name,
+                    input: toolCall.function.arguments,
+                    ...(toolCall.thoughtSignature
+                      ? {
+                          providerMetadata: {
+                            [providerOptionsName]: {
+                              thoughtSignature: toolCall.thoughtSignature,
+                            },
+                          },
+                        }
+                      : {}),
+                  });
+                  toolCall.hasFinished = true;
+                }
+              }
+            }
+          },
+
+          flush(controller) {
+            if (isActiveReasoning) {
+              controller.enqueue({ type: 'reasoning-end', id: 'reasoning-0' });
+            }
+
+            if (isActiveText) {
+              controller.enqueue({ type: 'text-end', id: 'txt-0' });
+            }
+
+            // go through all tool calls and send the ones that are not finished
+            for (const toolCall of toolCalls.filter(
+              toolCall => !toolCall.hasFinished,
+            )) {
+              controller.enqueue({
+                type: 'tool-input-end',
+                id: toolCall.id,
+              });
+
+              controller.enqueue({
+                type: 'tool-call',
+                toolCallId: toolCall.id ?? generateId(),
+                toolName: toolCall.function.name,
+                input: toolCall.function.arguments,
+                ...(toolCall.thoughtSignature
+                  ? {
+                      providerMetadata: {
+                        [providerOptionsName]: {
+                          thoughtSignature: toolCall.thoughtSignature,
+                        },
+                      },
+                    }
+                  : {}),
+              });
+            }
+
+            const providerMetadata: SharedV3ProviderMetadata = {
+              [providerOptionsName]: {},
+              ...metadataExtractor?.buildMetadata(),
+            };
+            if (
+              usage?.completion_tokens_details?.accepted_prediction_tokens !=
+              null
+            ) {
+              providerMetadata[providerOptionsName].acceptedPredictionTokens =
+                usage?.completion_tokens_details?.accepted_prediction_tokens;
+            }
+            if (
+              usage?.completion_tokens_details?.rejected_prediction_tokens !=
+              null
+            ) {
+              providerMetadata[providerOptionsName].rejectedPredictionTokens =
+                usage?.completion_tokens_details?.rejected_prediction_tokens;
+            }
+
+            controller.enqueue({
+              type: 'finish',
+              finishReason,
+              usage: convertOpenAICompatibleChatUsage(usage),
+              providerMetadata,
+            });
+          },
+        }),
+      ),
+      request: { body },
+      response: { headers: responseHeaders },
+    };
+  }
+}
+
+const openaiCompatibleTokenUsageSchema = z
+  .object({
+    prompt_tokens: z.number().nullish(),
+    completion_tokens: z.number().nullish(),
+    total_tokens: z.number().nullish(),
+    prompt_tokens_details: z
+      .object({
+        cached_tokens: z.number().nullish(),
+      })
+      .nullish(),
+    completion_tokens_details: z
+      .object({
+        reasoning_tokens: z.number().nullish(),
+        accepted_prediction_tokens: z.number().nullish(),
+        rejected_prediction_tokens: z.number().nullish(),
+      })
+      .nullish(),
+  })
+  .nullish();
+
+// limited version of the schema, focussed on what is needed for the implementation
+// this approach limits breakages when the API changes and increases efficiency
+const OpenAICompatibleChatResponseSchema = z.looseObject({
+  id: z.string().nullish(),
+  created: z.number().nullish(),
+  model: z.string().nullish(),
+  choices: z.array(
+    z.object({
+      message: z.object({
+        role: z.literal('assistant').nullish(),
+        content: z.string().nullish(),
+        reasoning_content: z.string().nullish(),
+        reasoning: z.string().nullish(),
+        tool_calls: z
+          .array(
+            z.object({
+              id: z.string().nullish(),
+              function: z.object({
+                name: z.string(),
+                arguments: z.string(),
+              }),
+              // Support for Google Gemini thought signatures via OpenAI compatibility
+              extra_content: z
+                .object({
+                  google: z
+                    .object({
+                      thought_signature: z.string().nullish(),
+                    })
+                    .nullish(),
+                })
+                .nullish(),
+            }),
+          )
+          .nullish(),
+      }),
+      finish_reason: z.string().nullish(),
+    }),
+  ),
+  usage: openaiCompatibleTokenUsageSchema,
+});
+
+const chunkBaseSchema = z.looseObject({
+  id: z.string().nullish(),
+  created: z.number().nullish(),
+  model: z.string().nullish(),
+  choices: z.array(
+    z.object({
+      delta: z
+        .object({
+          role: z.enum(['assistant']).nullish(),
+          content: z.string().nullish(),
+          // Most openai-compatible models set `reasoning_content`, but some
+          // providers serving `gpt-oss` set `reasoning`. See #7866
+          reasoning_content: z.string().nullish(),
+          reasoning: z.string().nullish(),
+          tool_calls: z
+            .array(
+              z.object({
+                index: z.number().nullish(), //google does not send index
+                id: z.string().nullish(),
+                function: z.object({
+                  name: z.string().nullish(),
+                  arguments: z.string().nullish(),
+                }),
+                // Support for Google Gemini thought signatures via OpenAI compatibility
+                extra_content: z
+                  .object({
+                    google: z
+                      .object({
+                        thought_signature: z.string().nullish(),
+                      })
+                      .nullish(),
+                  })
+                  .nullish(),
+              }),
+            )
+            .nullish(),
+        })
+        .nullish(),
+      finish_reason: z.string().nullish(),
+    }),
+  ),
+  usage: openaiCompatibleTokenUsageSchema,
+});
+
+// limited version of the schema, focussed on what is needed for the implementation
+// this approach limits breakages when the API changes and increases efficiency
+const createOpenAICompatibleChatChunkSchema = <
+  ERROR_SCHEMA extends z.core.$ZodType,
+>(
+  errorSchema: ERROR_SCHEMA,
+) => z.union([chunkBaseSchema, errorSchema]);

--- a/src/ipc/utils/ai_sdk/chat/openai-compatible-chat-options.ts
+++ b/src/ipc/utils/ai_sdk/chat/openai-compatible-chat-options.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod/v4';
+
+export type OpenAICompatibleChatModelId = string;
+
+export const openaiCompatibleProviderOptions = z.object({
+  /**
+   * A unique identifier representing your end-user, which can help the provider to
+   * monitor and detect abuse.
+   */
+  user: z.string().optional(),
+
+  /**
+   * Reasoning effort for reasoning models. Defaults to `medium`.
+   */
+  reasoningEffort: z.string().optional(),
+
+  /**
+   * Controls the verbosity of the generated text. Defaults to `medium`.
+   */
+  textVerbosity: z.string().optional(),
+
+  /**
+   * Whether to use strict JSON schema validation.
+   * When true, the model uses constrained decoding to guarantee schema compliance.
+   * Only used when the provider supports structured outputs and a schema is provided.
+   *
+   * @default true
+   */
+  strictJsonSchema: z.boolean().optional(),
+});
+
+export type OpenAICompatibleProviderOptions = z.infer<
+  typeof openaiCompatibleProviderOptions
+>;

--- a/src/ipc/utils/ai_sdk/chat/openai-compatible-metadata-extractor.ts
+++ b/src/ipc/utils/ai_sdk/chat/openai-compatible-metadata-extractor.ts
@@ -1,0 +1,48 @@
+import { SharedV3ProviderMetadata } from '@ai-sdk/provider';
+
+/**
+Extracts provider-specific metadata from API responses.
+Used to standardize metadata handling across different LLM providers while allowing
+provider-specific metadata to be captured.
+*/
+export type MetadataExtractor = {
+  /**
+   * Extracts provider metadata from a complete, non-streaming response.
+   *
+   * @param parsedBody - The parsed response JSON body from the provider's API.
+   *
+   * @returns Provider-specific metadata or undefined if no metadata is available.
+   *          The metadata should be under a key indicating the provider id.
+   */
+  extractMetadata: ({
+    parsedBody,
+  }: {
+    parsedBody: unknown;
+  }) => Promise<SharedV3ProviderMetadata | undefined>;
+
+  /**
+   * Creates an extractor for handling streaming responses. The returned object provides
+   * methods to process individual chunks and build the final metadata from the accumulated
+   * stream data.
+   *
+   * @returns An object with methods to process chunks and build metadata from a stream
+   */
+  createStreamExtractor: () => {
+    /**
+     * Process an individual chunk from the stream. Called for each chunk in the response stream
+     * to accumulate metadata throughout the streaming process.
+     *
+     * @param parsedChunk - The parsed JSON response chunk from the provider's API
+     */
+    processChunk(parsedChunk: unknown): void;
+
+    /**
+     * Builds the metadata object after all chunks have been processed.
+     * Called at the end of the stream to generate the complete provider metadata.
+     *
+     * @returns Provider-specific metadata or undefined if no metadata is available.
+     *          The metadata should be under a key indicating the provider id.
+     */
+    buildMetadata(): SharedV3ProviderMetadata | undefined;
+  };
+};

--- a/src/ipc/utils/ai_sdk/chat/openai-compatible-prepare-tools.test.ts
+++ b/src/ipc/utils/ai_sdk/chat/openai-compatible-prepare-tools.test.ts
@@ -1,0 +1,336 @@
+import { describe, expect, it } from 'vitest';
+import { prepareTools } from './openai-compatible-prepare-tools';
+
+describe('prepareTools', () => {
+  it('should return undefined tools and toolChoice when tools are null', () => {
+    const result = prepareTools({
+      tools: undefined,
+      toolChoice: undefined,
+    });
+
+    expect(result).toEqual({
+      tools: undefined,
+      toolChoice: undefined,
+      toolWarnings: [],
+    });
+  });
+
+  it('should return undefined tools and toolChoice when tools are empty', () => {
+    const result = prepareTools({
+      tools: [],
+      toolChoice: undefined,
+    });
+
+    expect(result).toEqual({
+      tools: undefined,
+      toolChoice: undefined,
+      toolWarnings: [],
+    });
+  });
+
+  it('should correctly prepare function tools', () => {
+    const result = prepareTools({
+      tools: [
+        {
+          type: 'function',
+          name: 'testFunction',
+          description: 'A test function',
+          inputSchema: { type: 'object', properties: {} },
+        },
+      ],
+      toolChoice: undefined,
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "toolChoice": undefined,
+        "toolWarnings": [],
+        "tools": [
+          {
+            "function": {
+              "description": "A test function",
+              "name": "testFunction",
+              "parameters": {
+                "properties": {},
+                "type": "object",
+              },
+            },
+            "type": "function",
+          },
+        ],
+      }
+    `);
+  });
+
+  it('should add warnings for unsupported provider-defined tools', () => {
+    const result = prepareTools({
+      tools: [
+        {
+          type: 'provider',
+          id: 'some.unsupported_tool',
+          name: 'unsupported_tool',
+          args: {},
+        },
+      ],
+      toolChoice: undefined,
+    });
+
+    expect(result.tools).toEqual([]);
+    expect(result.toolChoice).toBeUndefined();
+    expect(result.toolWarnings).toMatchInlineSnapshot(`
+      [
+        {
+          "feature": "provider-defined tool some.unsupported_tool",
+          "type": "unsupported",
+        },
+      ]
+    `);
+  });
+
+  it('should handle tool choice "auto"', () => {
+    const result = prepareTools({
+      tools: [
+        {
+          type: 'function',
+          name: 'testFunction',
+          description: 'Test',
+          inputSchema: {},
+        },
+      ],
+      toolChoice: { type: 'auto' },
+    });
+
+    expect(result.toolChoice).toEqual('auto');
+  });
+
+  it('should handle tool choice "required"', () => {
+    const result = prepareTools({
+      tools: [
+        {
+          type: 'function',
+          name: 'testFunction',
+          description: 'Test',
+          inputSchema: {},
+        },
+      ],
+      toolChoice: { type: 'required' },
+    });
+
+    expect(result.toolChoice).toEqual('required');
+  });
+
+  it('should handle tool choice "none"', () => {
+    const result = prepareTools({
+      tools: [
+        {
+          type: 'function',
+          name: 'testFunction',
+          description: 'Test',
+          inputSchema: {},
+        },
+      ],
+      toolChoice: { type: 'none' },
+    });
+
+    expect(result.toolChoice).toEqual('none');
+  });
+
+  it('should handle tool choice "tool"', () => {
+    const result = prepareTools({
+      tools: [
+        {
+          type: 'function',
+          name: 'testFunction',
+          description: 'Test',
+          inputSchema: {},
+        },
+      ],
+      toolChoice: { type: 'tool', toolName: 'testFunction' },
+    });
+
+    expect(result.toolChoice).toEqual({
+      type: 'function',
+      function: { name: 'testFunction' },
+    });
+  });
+
+  describe('strict mode', () => {
+    it('should pass through strict mode when strict is true', () => {
+      const result = prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'A test function',
+            inputSchema: { type: 'object', properties: {} },
+            strict: true,
+          },
+        ],
+        toolChoice: undefined,
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "toolChoice": undefined,
+          "toolWarnings": [],
+          "tools": [
+            {
+              "function": {
+                "description": "A test function",
+                "name": "testFunction",
+                "parameters": {
+                  "properties": {},
+                  "type": "object",
+                },
+                "strict": true,
+              },
+              "type": "function",
+            },
+          ],
+        }
+      `);
+    });
+
+    it('should pass through strict mode when strict is false', () => {
+      const result = prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'A test function',
+            inputSchema: { type: 'object', properties: {} },
+            strict: false,
+          },
+        ],
+        toolChoice: undefined,
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "toolChoice": undefined,
+          "toolWarnings": [],
+          "tools": [
+            {
+              "function": {
+                "description": "A test function",
+                "name": "testFunction",
+                "parameters": {
+                  "properties": {},
+                  "type": "object",
+                },
+                "strict": false,
+              },
+              "type": "function",
+            },
+          ],
+        }
+      `);
+    });
+
+    it('should not include strict mode when strict is undefined', () => {
+      const result = prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'A test function',
+            inputSchema: { type: 'object', properties: {} },
+          },
+        ],
+        toolChoice: undefined,
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "toolChoice": undefined,
+          "toolWarnings": [],
+          "tools": [
+            {
+              "function": {
+                "description": "A test function",
+                "name": "testFunction",
+                "parameters": {
+                  "properties": {},
+                  "type": "object",
+                },
+              },
+              "type": "function",
+            },
+          ],
+        }
+      `);
+    });
+
+    it('should pass through strict mode for multiple tools with different strict settings', () => {
+      const result = prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'strictTool',
+            description: 'A strict tool',
+            inputSchema: { type: 'object', properties: {} },
+            strict: true,
+          },
+          {
+            type: 'function',
+            name: 'nonStrictTool',
+            description: 'A non-strict tool',
+            inputSchema: { type: 'object', properties: {} },
+            strict: false,
+          },
+          {
+            type: 'function',
+            name: 'defaultTool',
+            description: 'A tool without strict setting',
+            inputSchema: { type: 'object', properties: {} },
+          },
+        ],
+        toolChoice: undefined,
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "toolChoice": undefined,
+          "toolWarnings": [],
+          "tools": [
+            {
+              "function": {
+                "description": "A strict tool",
+                "name": "strictTool",
+                "parameters": {
+                  "properties": {},
+                  "type": "object",
+                },
+                "strict": true,
+              },
+              "type": "function",
+            },
+            {
+              "function": {
+                "description": "A non-strict tool",
+                "name": "nonStrictTool",
+                "parameters": {
+                  "properties": {},
+                  "type": "object",
+                },
+                "strict": false,
+              },
+              "type": "function",
+            },
+            {
+              "function": {
+                "description": "A tool without strict setting",
+                "name": "defaultTool",
+                "parameters": {
+                  "properties": {},
+                  "type": "object",
+                },
+              },
+              "type": "function",
+            },
+          ],
+        }
+      `);
+    });
+  });
+});

--- a/src/ipc/utils/ai_sdk/chat/openai-compatible-prepare-tools.ts
+++ b/src/ipc/utils/ai_sdk/chat/openai-compatible-prepare-tools.ts
@@ -1,0 +1,98 @@
+import {
+  LanguageModelV3CallOptions,
+  SharedV3Warning,
+  UnsupportedFunctionalityError,
+} from '@ai-sdk/provider';
+
+export function prepareTools({
+  tools,
+  toolChoice,
+}: {
+  tools: LanguageModelV3CallOptions['tools'];
+  toolChoice?: LanguageModelV3CallOptions['toolChoice'];
+}): {
+  tools:
+    | undefined
+    | Array<{
+        type: 'function';
+        function: {
+          name: string;
+          description: string | undefined;
+          parameters: unknown;
+          strict?: boolean;
+        };
+      }>;
+  toolChoice:
+    | { type: 'function'; function: { name: string } }
+    | 'auto'
+    | 'none'
+    | 'required'
+    | undefined;
+  toolWarnings: SharedV3Warning[];
+} {
+  // when the tools array is empty, change it to undefined to prevent errors:
+  tools = tools?.length ? tools : undefined;
+
+  const toolWarnings: SharedV3Warning[] = [];
+
+  if (tools == null) {
+    return { tools: undefined, toolChoice: undefined, toolWarnings };
+  }
+
+  const openaiCompatTools: Array<{
+    type: 'function';
+    function: {
+      name: string;
+      description: string | undefined;
+      parameters: unknown;
+      strict?: boolean;
+    };
+  }> = [];
+
+  for (const tool of tools) {
+    if (tool.type === 'provider') {
+      toolWarnings.push({
+        type: 'unsupported',
+        feature: `provider-defined tool ${tool.id}`,
+      });
+    } else {
+      openaiCompatTools.push({
+        type: 'function',
+        function: {
+          name: tool.name,
+          description: tool.description,
+          parameters: tool.inputSchema,
+          ...(tool.strict != null ? { strict: tool.strict } : {}),
+        },
+      });
+    }
+  }
+
+  if (toolChoice == null) {
+    return { tools: openaiCompatTools, toolChoice: undefined, toolWarnings };
+  }
+
+  const type = toolChoice.type;
+
+  switch (type) {
+    case 'auto':
+    case 'none':
+    case 'required':
+      return { tools: openaiCompatTools, toolChoice: type, toolWarnings };
+    case 'tool':
+      return {
+        tools: openaiCompatTools,
+        toolChoice: {
+          type: 'function',
+          function: { name: toolChoice.toolName },
+        },
+        toolWarnings,
+      };
+    default: {
+      const _exhaustiveCheck: never = type;
+      throw new UnsupportedFunctionalityError({
+        functionality: `tool choice type: ${_exhaustiveCheck}`,
+      });
+    }
+  }
+}

--- a/src/ipc/utils/ai_sdk/openai-compatible-error.ts
+++ b/src/ipc/utils/ai_sdk/openai-compatible-error.ts
@@ -1,0 +1,30 @@
+import { z, ZodType } from 'zod/v4';
+
+export const openaiCompatibleErrorDataSchema = z.object({
+  error: z.object({
+    message: z.string(),
+
+    // The additional information below is handled loosely to support
+    // OpenAI-compatible providers that have slightly different error
+    // responses:
+    type: z.string().nullish(),
+    param: z.any().nullish(),
+    code: z.union([z.string(), z.number()]).nullish(),
+  }),
+});
+
+export type OpenAICompatibleErrorData = z.infer<
+  typeof openaiCompatibleErrorDataSchema
+>;
+
+export type ProviderErrorStructure<T> = {
+  errorSchema: ZodType<T>;
+  errorToMessage: (error: T) => string;
+  isRetryable?: (response: Response, error?: T) => boolean;
+};
+
+export const defaultOpenAICompatibleErrorStructure: ProviderErrorStructure<OpenAICompatibleErrorData> =
+  {
+    errorSchema: openaiCompatibleErrorDataSchema,
+    errorToMessage: data => data.error.message,
+  };

--- a/src/ipc/utils/llm_engine_provider.ts
+++ b/src/ipc/utils/llm_engine_provider.ts
@@ -1,4 +1,3 @@
-import { OpenAICompatibleChatLanguageModel } from "@ai-sdk/openai-compatible";
 import { OpenAIResponsesLanguageModel } from "@ai-sdk/openai/internal";
 import {
   FetchFunction,
@@ -10,6 +9,7 @@ import log from "electron-log";
 import { getExtraProviderOptions } from "./thinking_utils";
 import type { UserSettings } from "../../lib/schemas";
 import type { LanguageModel } from "ai";
+import { OpenAICompatibleChatLanguageModel } from "./ai_sdk/chat/openai-compatible-chat-language-model";
 
 const logger = log.scope("llm_engine_provider");
 
@@ -118,6 +118,7 @@ export function createDyadEngine(
           ...JSON.parse(init.body),
           ...getExtraProviderOptions(providerId, options.settings),
         };
+        console.log("***parsedBody***", JSON.stringify(parsedBody, null, 2));
         const dyadVersionedFiles = parsedBody.dyadVersionedFiles;
         if ("dyadVersionedFiles" in parsedBody) {
           delete parsedBody.dyadVersionedFiles;

--- a/src/ipc/utils/provider_options.ts
+++ b/src/ipc/utils/provider_options.ts
@@ -99,7 +99,7 @@ export function getAiHeaders({
 }: GetAiHeadersParams): Record<string, string> | undefined {
   if (builtinProviderId === "anthropic") {
     return {
-      "anthropic-beta": "context-1m-2025-08-07",
+      "anthropic-beta": "context-1m-2025-08-07,interleaved-thinking-2025-05-14",
     };
   }
   return undefined;

--- a/src/pro/main/ipc/handlers/local_agent/prepare_step_utils.ts
+++ b/src/pro/main/ipc/handlers/local_agent/prepare_step_utils.ts
@@ -112,6 +112,7 @@ export function prepareStepMessages<
   allInjectedMessages: InjectedMessage[],
 ): (Omit<T, "messages"> & { messages: TMessage[] }) | undefined {
   const { messages, ...rest } = options;
+  console.log("prepareStepMessages", JSON.stringify(messages, null, 2));
 
   // Move any new pending messages to the permanent injected list
   processPendingMessages(


### PR DESCRIPTION
- right now thought signatures are not getting received nor sent properly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an OpenAI-compatible chat model wrapper with full tool-call support and Google Gemini thought signatures. Also wires up thinking budgets for Anthropic and Google and enables provider settings needed for “thinking” mode.

- New Features
  - Introduced OpenAI-compatible chat model (streaming + non-streaming) with message/usage conversion, finish-reason mapping, and tool handling.
  - Thought signatures: serialize to tool_calls.extra_content.google.thought_signature and extract back into providerMetadata for responses and streams.
  - Thinking budgets: map user settings (low/medium/high) to budget_tokens for Anthropic and Google; dynamic “high” (-1) for Google, 32k for Anthropic; default medium is 16k.
  - Provider setup: add Anthropic interleaved-thinking beta header and set temperature=1 for Gemini models to enable thinking.

- Bug Fixes
  - Thought signatures are now sent and received correctly across tool calls and streaming responses.
  - More robust prompt conversion: supports images, multi-part content, and tool results in OpenAI-compatible format.

<sup>Written for commit 337f6d33a89c05f7d217c24fc574748ca1584546. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

