### PR TITLE
Graduate local agent from experiment

### DIFF
--- a/e2e-tests/helpers/test_helper.ts
+++ b/e2e-tests/helpers/test_helper.ts
@@ -326,9 +326,6 @@ export class PageObject {
     if (autoApprove) {
       await this.toggleAutoApprove();
     }
-    if (localAgent) {
-      await this.toggleLocalAgentMode();
-    }
     await this.setUpDyadProvider();
     await this.goToAppsTab();
     // Select a non-openAI model for local agent mode,

--- a/e2e-tests/snapshots/local_agent_auto.spec.ts_local-agent---auto-model-1.txt
+++ b/e2e-tests/snapshots/local_agent_auto.spec.ts_local-agent---auto-model-1.txt
@@ -183,13 +183,17 @@
       {
         "type": "function",
         "name": "list_files",
-        "description": "List all files in the application directory recursively. If you are not sure, list all files by omitting the directory parameter.",
+        "description": "List files in the application directory. By default, lists only the immediate directory contents. Use recursive=true to list all files recursively. If you are not sure, list all files by omitting the directory parameter.",
         "parameters": {
           "type": "object",
           "properties": {
             "directory": {
               "type": "string",
               "description": "Optional subdirectory to list"
+            },
+            "recursive": {
+              "type": "boolean",
+              "description": "Whether to list files recursively (default: false)"
             }
           },
           "additionalProperties": false,

--- a/src/components/ChatModeSelector.tsx
+++ b/src/components/ChatModeSelector.tsx
@@ -141,7 +141,7 @@ export function ChatModeSelector() {
             </span>
           </div>
         </SelectItem>
-        {isProEnabled && settings?.experiments?.enableLocalAgent && (
+        {isProEnabled && (
           <SelectItem value="local-agent">
             <div className="flex flex-col items-start">
               <div className="flex items-center gap-1.5">

--- a/src/components/SettingsList.tsx
+++ b/src/components/SettingsList.tsx
@@ -1,16 +1,13 @@
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
-import { useEffect, useMemo } from "react";
+import { useEffect } from "react";
 import { useScrollAndNavigateTo } from "@/hooks/useScrollAndNavigateTo";
 import { useAtom } from "jotai";
 import { activeSettingsSectionAtom } from "@/atoms/viewAtoms";
-import { useSettings } from "@/hooks/useSettings";
-import type { UserSettings } from "@/lib/schemas";
 
 type SettingsSection = {
   id: string;
   label: string;
-  isEnabled?: (settings: UserSettings | null) => boolean;
 };
 
 const SETTINGS_SECTIONS: SettingsSection[] = [
@@ -23,7 +20,6 @@ const SETTINGS_SECTIONS: SettingsSection[] = [
   {
     id: "agent-permissions",
     label: "Agent Permissions",
-    isEnabled: (settings) => !!settings?.experiments?.enableLocalAgent,
   },
   { id: "tools-mcp", label: "Tools (MCP)" },
   { id: "experiments", label: "Experiments" },
@@ -32,17 +28,13 @@ const SETTINGS_SECTIONS: SettingsSection[] = [
 
 export function SettingsList({ show }: { show: boolean }) {
   const [activeSection, setActiveSection] = useAtom(activeSettingsSectionAtom);
-  const { settings } = useSettings();
+
   const scrollAndNavigateTo = useScrollAndNavigateTo("/settings", {
     behavior: "smooth",
     block: "start",
   });
 
-  const settingsSections = useMemo(() => {
-    return SETTINGS_SECTIONS.filter(
-      (section) => !section.isEnabled || section.isEnabled(settings ?? null),
-    );
-  }, [settings]);
+  const settingsSections = SETTINGS_SECTIONS;
 
   useEffect(() => {
     const observer = new IntersectionObserver(

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -192,8 +192,8 @@ export const NeonSchema = z.object({
 export type Neon = z.infer<typeof NeonSchema>;
 
 export const ExperimentsSchema = z.object({
-  enableLocalAgent: z.boolean().optional(),
   // Deprecated
+  enableLocalAgent: z.boolean().describe("DEPRECATED").optional(),
   enableSupabaseIntegration: z.boolean().describe("DEPRECATED").optional(),
   enableFileEditing: z.boolean().describe("DEPRECATED").optional(),
 });

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -131,17 +131,16 @@ export default function SettingsPage() {
           </div>
 
           {/* Agent v2 Permissions */}
-          {settings?.experiments?.enableLocalAgent && (
-            <div
-              id="agent-permissions"
-              className="bg-white dark:bg-gray-800 rounded-xl shadow-sm p-6"
-            >
-              <h2 className="text-lg font-medium text-gray-900 dark:text-white mb-4">
-                Agent Permissions
-              </h2>
-              <AgentToolsSettings />
-            </div>
-          )}
+
+          <div
+            id="agent-permissions"
+            className="bg-white dark:bg-gray-800 rounded-xl shadow-sm p-6"
+          >
+            <h2 className="text-lg font-medium text-gray-900 dark:text-white mb-4">
+              Agent Permissions (Pro)
+            </h2>
+            <AgentToolsSettings />
+          </div>
 
           {/* Tools (MCP) */}
           <div
@@ -179,27 +178,6 @@ export default function SettingsPage() {
                 <div className="text-sm text-gray-500 dark:text-gray-400">
                   This doesn't require any external Git installation and offers
                   a faster, native-Git performance experience.
-                </div>
-              </div>
-              <div className="space-y-1 mt-4">
-                <div className="flex items-center space-x-2">
-                  <Switch
-                    id="enable-local-agent"
-                    checked={!!settings?.experiments?.enableLocalAgent}
-                    onCheckedChange={(checked) => {
-                      updateSettings({
-                        experiments: {
-                          ...settings?.experiments,
-                          enableLocalAgent: checked,
-                        },
-                      });
-                    }}
-                  />
-                  <Label htmlFor="enable-local-agent">Enable Agent v2</Label>
-                </div>
-                <div className="text-sm text-gray-500 dark:text-gray-400">
-                  Enables the local agent with enhanced capabilities and tool
-                  permissions.
                 </div>
               </div>
             </div>

--- a/testing/fake-llm-server/responsesHandler.ts
+++ b/testing/fake-llm-server/responsesHandler.ts
@@ -91,7 +91,7 @@ function extractTestCaseName(promptText: string): string | null {
   // - "tc=foo"
   // - "[dump] tc=foo"
   // Stops at "[" to mimic existing fixture naming convention.
-  const m = promptText.match(/(?:^|\s)tc=([^\[]+)/);
+  const m = promptText.match(/(?:^|\s)tc=([^[]+)/);
   if (!m) return null;
   return m[1].trim().split(/\s+/)[0] || null;
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Graduates `local-agent` from experimental gating and makes it available to Pro users by default.
> 
> - **UI/Settings**
>   - `ChatModeSelector`: show `Agent v2` for Pro without experiment flag
>   - `SettingsList`: remove experiment-based filtering; always include `agent-permissions`
>   - `settings.tsx`: always render `Agent Permissions (Pro)`; remove "Enable Agent v2" experiment toggle
>   - `schemas.ts`: mark `experiments.enableLocalAgent` as DEPRECATED
> 
> - **Tests/Fixtures**
>   - `test_helper.ts`: stop toggling local agent mode during setup
>   - Update snapshot tool schema: `list_files` now supports `recursive` with clarified description
>   - `responsesHandler.ts`: minor regex fix for test case name parsing
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 132f2aa633d9ba8ea920f73cd07c8408e3c083e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Graduate the Local Agent (Agent v2) from the experiments flag. It’s now available to Pro users by default and the settings reflect this.

- **Refactors**
  - Show Local Agent in ChatModeSelector for Pro without experiment gating.
  - Always show the Agent Permissions section; label updated to “Agent Permissions (Pro)”.
  - Removed the “Enable Agent v2” toggle from Experiments.
  - Marked experiments.enableLocalAgent as DEPRECATED in the schema.
  - Cleaned up e2e helper to stop toggling local agent mode; minor test regex fix.

- **Migration**
  - No action needed. The old experiments.enableLocalAgent flag is ignored.

<sup>Written for commit 132f2aa633d9ba8ea920f73cd07c8408e3c083e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

