### PR TITLE
Add a refresh button for supabase projects

### DIFF
--- a/src/components/SupabaseConnector.tsx
+++ b/src/components/SupabaseConnector.tsx
@@ -37,7 +37,7 @@ import connectSupabaseDark from "../../assets/supabase/connect-supabase-dark.svg
 // @ts-ignore
 import connectSupabaseLight from "../../assets/supabase/connect-supabase-light.svg";
 
-import { ExternalLink, Plus, Trash2 } from "lucide-react";
+import { ExternalLink, Plus, RefreshCw, Trash2 } from "lucide-react";
 import { useTheme } from "@/contexts/ThemeContext";
 import type { SupabaseProject } from "@/ipc/ipc_types";
 import { isSupabaseConnected } from "@/lib/schemas";
@@ -272,15 +272,28 @@ export function SupabaseConnector({ appId }: { appId: number }) {
         <CardHeader>
           <CardTitle className="flex items-center justify-between">
             Supabase Projects
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleAddAccount}
-              className="gap-1"
-            >
-              <Plus className="h-4 w-4" />
-              Add Organization
-            </Button>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="icon"
+                onClick={() => refetchProjects()}
+                disabled={isFetchingProjects}
+                title="Refresh projects"
+              >
+                <RefreshCw
+                  className={`h-4 w-4 ${isFetchingProjects ? "animate-spin" : ""}`}
+                />
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleAddAccount}
+                className="gap-1"
+              >
+                <Plus className="h-4 w-4" />
+                Add Organization
+              </Button>
+            </div>
           </CardTitle>
           <CardDescription>
             Select a Supabase project to connect to this app


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enhances the Supabase projects selector with a manual refresh and improved states.
> 
> - Adds `RefreshCw` icon button to `SupabaseConnector` to `refetchProjects()`; shows spinner while `isFetchingProjects` and disables the button
> - Displays error state from `projectsError` with a `Retry` button to refetch
> - Adjusts header layout to place refresh control alongside "Add Organization"
> - Updates imports to include `RefreshCw`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce452519cd5a90fec693969c559247e068d795f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a refresh button to the Supabase Projects header to reload the project list on demand. The button disables while fetching and shows a spinning icon during refresh.

<sup>Written for commit ce452519cd5a90fec693969c559247e068d795f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

