### PR TITLE
Passthrough settings so downgrading Dyad doesn't cause issues

### DIFF
--- a/src/__tests__/readSettings.test.ts
+++ b/src/__tests__/readSettings.test.ts
@@ -248,7 +248,7 @@ describe("readSettings", () => {
       );
     });
 
-    it("should strip extra fields not recognized by the schema", () => {
+    it("should preserve extra fields not recognized by the schema", () => {
       const mockFileContent = {
         selectedModel: {
           name: "gpt-4",
@@ -256,8 +256,8 @@ describe("readSettings", () => {
         },
         telemetryConsent: "opted_in",
         hasRunBefore: true,
-        // Extra fields that are not in the schema
-        unknownField: "should be removed",
+        // Extra fields that are not in the schema (should be preserved)
+        unknownField: "should be preserved",
         deprecatedSetting: true,
         extraConfig: {
           someValue: 123,
@@ -281,10 +281,15 @@ describe("readSettings", () => {
       expect(result.telemetryConsent).toBe("opted_in");
       expect(result.hasRunBefore).toBe(true);
 
-      // Extra fields should be stripped by schema validation
-      expect(result).not.toHaveProperty("unknownField");
-      expect(result).not.toHaveProperty("deprecatedSetting");
-      expect(result).not.toHaveProperty("extraConfig");
+      // Extra fields should be preserved by passthrough()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const resultAny = result as any;
+      expect(resultAny.unknownField).toBe("should be preserved");
+      expect(resultAny.deprecatedSetting).toBe(true);
+      expect(resultAny.extraConfig).toEqual({
+        someValue: 123,
+        anotherValue: "test",
+      });
 
       // Should still have defaults for missing properties
       expect(result.enableAutoUpdate).toBe(true);

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -248,70 +248,74 @@ export type AgentToolConsent = z.infer<typeof AgentToolConsentSchema>;
 /**
  * Zod schema for user settings
  */
-export const UserSettingsSchema = z.object({
-  ////////////////////////////////
-  // E2E TESTING ONLY.
-  ////////////////////////////////
-  isTestMode: z.boolean().optional(),
+export const UserSettingsSchema = z
+  .object({
+    ////////////////////////////////
+    // E2E TESTING ONLY.
+    ////////////////////////////////
+    isTestMode: z.boolean().optional(),
 
-  ////////////////////////////////
-  // DEPRECATED.
-  ////////////////////////////////
-  enableProSaverMode: z.boolean().optional(),
-  dyadProBudget: DyadProBudgetSchema.optional(),
-  runtimeMode: RuntimeModeSchema.optional(),
+    ////////////////////////////////
+    // DEPRECATED.
+    ////////////////////////////////
+    enableProSaverMode: z.boolean().optional(),
+    dyadProBudget: DyadProBudgetSchema.optional(),
+    runtimeMode: RuntimeModeSchema.optional(),
 
-  ////////////////////////////////
-  // ACTIVE FIELDS.
-  ////////////////////////////////
-  selectedModel: LargeLanguageModelSchema,
-  providerSettings: z.record(z.string(), ProviderSettingSchema),
-  agentToolConsents: z.record(z.string(), AgentToolConsentSchema).optional(),
-  githubUser: GithubUserSchema.optional(),
-  githubAccessToken: SecretSchema.optional(),
-  vercelAccessToken: SecretSchema.optional(),
-  supabase: SupabaseSchema.optional(),
-  neon: NeonSchema.optional(),
-  autoApproveChanges: z.boolean().optional(),
-  telemetryConsent: z.enum(["opted_in", "opted_out", "unset"]).optional(),
-  telemetryUserId: z.string().optional(),
-  hasRunBefore: z.boolean().optional(),
-  enableDyadPro: z.boolean().optional(),
-  experiments: ExperimentsSchema.optional(),
-  lastShownReleaseNotesVersion: z.string().optional(),
-  maxChatTurnsInContext: z.number().optional(),
-  thinkingBudget: z.enum(["low", "medium", "high"]).optional(),
-  enableProLazyEditsMode: z.boolean().optional(),
-  proLazyEditsMode: z.enum(["off", "v1", "v2"]).optional(),
-  enableProSmartFilesContextMode: z.boolean().optional(),
-  enableProWebSearch: z.boolean().optional(),
-  proSmartContextOption: SmartContextModeSchema.optional(),
-  selectedTemplateId: z.string(),
-  selectedThemeId: z.string().optional(),
-  enableSupabaseWriteSqlMigration: z.boolean().optional(),
-  selectedChatMode: ChatModeSchema.optional(),
-  acceptedCommunityCode: z.boolean().optional(),
-  zoomLevel: ZoomLevelSchema.optional(),
+    ////////////////////////////////
+    // ACTIVE FIELDS.
+    ////////////////////////////////
+    selectedModel: LargeLanguageModelSchema,
+    providerSettings: z.record(z.string(), ProviderSettingSchema),
+    agentToolConsents: z.record(z.string(), AgentToolConsentSchema).optional(),
+    githubUser: GithubUserSchema.optional(),
+    githubAccessToken: SecretSchema.optional(),
+    vercelAccessToken: SecretSchema.optional(),
+    supabase: SupabaseSchema.optional(),
+    neon: NeonSchema.optional(),
+    autoApproveChanges: z.boolean().optional(),
+    telemetryConsent: z.enum(["opted_in", "opted_out", "unset"]).optional(),
+    telemetryUserId: z.string().optional(),
+    hasRunBefore: z.boolean().optional(),
+    enableDyadPro: z.boolean().optional(),
+    experiments: ExperimentsSchema.optional(),
+    lastShownReleaseNotesVersion: z.string().optional(),
+    maxChatTurnsInContext: z.number().optional(),
+    thinkingBudget: z.enum(["low", "medium", "high"]).optional(),
+    enableProLazyEditsMode: z.boolean().optional(),
+    proLazyEditsMode: z.enum(["off", "v1", "v2"]).optional(),
+    enableProSmartFilesContextMode: z.boolean().optional(),
+    enableProWebSearch: z.boolean().optional(),
+    proSmartContextOption: SmartContextModeSchema.optional(),
+    selectedTemplateId: z.string(),
+    selectedThemeId: z.string().optional(),
+    enableSupabaseWriteSqlMigration: z.boolean().optional(),
+    selectedChatMode: ChatModeSchema.optional(),
+    acceptedCommunityCode: z.boolean().optional(),
+    zoomLevel: ZoomLevelSchema.optional(),
 
-  enableAutoFixProblems: z.boolean().optional(),
-  enableNativeGit: z.boolean().optional(),
-  enableAutoUpdate: z.boolean(),
-  releaseChannel: ReleaseChannelSchema,
-  runtimeMode2: RuntimeMode2Schema.optional(),
-  customNodePath: z.string().optional().nullable(),
-  isRunning: z.boolean().optional(),
-  lastKnownPerformance: z
-    .object({
-      timestamp: z.number(),
-      memoryUsageMB: z.number(),
-      cpuUsagePercent: z.number().optional(),
-      systemMemoryUsageMB: z.number().optional(),
-      systemMemoryTotalMB: z.number().optional(),
-      systemCpuPercent: z.number().optional(),
-    })
-    .optional(),
-  hideLocalAgentNewChatToast: z.boolean().optional(),
-});
+    enableAutoFixProblems: z.boolean().optional(),
+    enableNativeGit: z.boolean().optional(),
+    enableAutoUpdate: z.boolean(),
+    releaseChannel: ReleaseChannelSchema,
+    runtimeMode2: RuntimeMode2Schema.optional(),
+    customNodePath: z.string().optional().nullable(),
+    isRunning: z.boolean().optional(),
+    lastKnownPerformance: z
+      .object({
+        timestamp: z.number(),
+        memoryUsageMB: z.number(),
+        cpuUsagePercent: z.number().optional(),
+        systemMemoryUsageMB: z.number().optional(),
+        systemMemoryTotalMB: z.number().optional(),
+        systemCpuPercent: z.number().optional(),
+      })
+      .optional(),
+    hideLocalAgentNewChatToast: z.boolean().optional(),
+  })
+  // Allow unknown properties to pass through (e.g. future settings
+  // that should be preserved if user downgrades to an older version)
+  .passthrough();
 
 /**
  * Type derived from the UserSettingsSchema


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Behavior change: preserve unknown settings fields**
> 
> - Apply `.passthrough()` to `UserSettingsSchema` so unknown properties are retained instead of stripped
> - Update `readSettings.test.ts` to assert extra fields (e.g., `unknownField`, `deprecatedSetting`, nested objects) are preserved while defaults still apply
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7bd0311a14cb4b501c698c987706efe069ab975. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Preserves unknown settings fields during validation to prevent data loss when downgrading Dyad. Switches the user settings schema to passthrough and updates tests to match.

- **Bug Fixes**
  - UserSettingsSchema now uses Zod .passthrough() to keep unrecognized fields.
  - Updated readSettings test to assert extra fields are preserved.

<sup>Written for commit d7bd0311a14cb4b501c698c987706efe069ab975. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

