### PR TITLE
Add bugbot trigger & update claude PR review for all

### DIFF
--- a/.github/workflows/bugbot-trigger.yml
+++ b/.github/workflows/bugbot-trigger.yml
@@ -15,6 +15,6 @@ jobs:
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         with:
           # Use a PAT from wwwillchen to post on their behalf
-          token: ${{ secrets.WWWILLCHEN_PAT }}
+          token: ${{ secrets.WWWILLCHEN_PR_RW_PAT }}
           issue-number: ${{ github.event.pull_request.number }}
           body: "@BugBot run"

--- a/.github/workflows/bugbot-trigger.yml
+++ b/.github/workflows/bugbot-trigger.yml
@@ -1,0 +1,20 @@
+name: BugBot Trigger
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  trigger-bugbot:
+    environment: ai-bots
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Comment @BugBot run
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
+        with:
+          # Use a PAT from wwwillchen to post on their behalf
+          token: ${{ secrets.WWWILLCHEN_PAT }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: "@BugBot run"

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -10,12 +10,6 @@ jobs:
   claude-review:
     # Has Anthropic API key, etc.
     environment: ai-bots
-    # Only review code from regular contributors since claude code has non-trivial costs
-    # https://github.com/anthropics/claude-code-action/blob/main/examples/pr-review-filtered-authors.yml
-    if: |
-      github.event.pull_request.user.login == 'wwwillchen' ||
-      github.event.pull_request.user.login == 'azizmejri1' ||
-      github.event.pull_request.user.login == 'princeaden1'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Add BugBot trigger workflow**
> 
> - New `/.github/workflows/bugbot-trigger.yml` posts `"@BugBot run"` to PRs on open/sync/ready/reopen using a PAT.
> 
> **Broaden Claude PR review scope**
> 
> - Updates `/.github/workflows/claude-pr-review.yml` to remove the author allowlist condition so the review runs for all PRs.
> - Minor action tweak: `actions/checkout` now uses `fetch-depth: 1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5eb852bc1c572086ff4b0f11aad01f0af711416c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->