### PR TITLE
Don't throw error when no folder selected for import

### DIFF
--- a/src/components/ImportAppDialog.tsx
+++ b/src/components/ImportAppDialog.tsx
@@ -217,7 +217,8 @@ export function ImportAppDialog({ isOpen, onClose }: ImportAppDialogProps) {
     mutationFn: async () => {
       const result = await IpcClient.getInstance().selectAppFolder();
       if (!result.path || !result.name) {
-        throw new Error("No folder selected");
+        // User cancelled the folder selection dialog
+        return null;
       }
       const aiRulesCheck = await IpcClient.getInstance().checkAiRules({
         path: result.path,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop throwing an error when the user cancels folder selection in the import dialog. The mutation now returns null, so cancelling the picker doesn’t show an error or disrupt the flow.

<sup>Written for commit 3c2e61bc723a3ff72cc269c31f715b440fc3695b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents erroneous failures when the user cancels the folder picker.
> 
> - In `ImportAppDialog`, `selectFolderMutation` now returns `null` when no `path`/`name` is provided (user canceled) instead of throwing, avoiding error toasts and treating cancel as a no-op.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c2e61bc723a3ff72cc269c31f715b440fc3695b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->