### PR TITLE
built-in themes

### DIFF
--- a/src/components/chat/AuxiliaryActionsMenu.tsx
+++ b/src/components/chat/AuxiliaryActionsMenu.tsx
@@ -6,6 +6,7 @@ import {
   Palette,
   Check,
   Ban,
+  Apple,
 } from "lucide-react";
 import {
   DropdownMenu,
@@ -145,6 +146,12 @@ export function AuxiliaryActionsMenu({
                       <div className="flex items-center w-full">
                         {theme.icon === "palette" && (
                           <Palette
+                            size={16}
+                            className="mr-2 text-muted-foreground"
+                          />
+                        )}
+                        {theme.icon === "apple" && (
+                          <Apple
                             size={16}
                             className="mr-2 text-muted-foreground"
                           />


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a built-in Apple (Cupertino) theme and exposed it in the theme menu with an Apple icon. This enables a consistent iOS/macOS look via semantic tokens and clear UI rules.

- **New Features**
  - New “Apple Theme” in themesData with CSS variables, dark-mode tokens, and component patterns (buttons, lists, search).
  - AuxiliaryActionsMenu shows the Apple icon for this theme and supports selecting it.

<sup>Written for commit 46261725369b78387c1f2137f02fbf347e796c58. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new built-in `apple` theme alongside the default theme.
> 
> - Defines `APPLE_THEME_PROMPT` with detailed Cupertino design rules in `shared/themes.ts` and registers it in `themesData`
> - Updates `AuxiliaryActionsMenu.tsx` to import `Apple` icon and display it for themes with `icon === "apple"`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46261725369b78387c1f2137f02fbf347e796c58. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->