### PR TITLE
triage bot: claude base action

### DIFF
--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -12,10 +12,10 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-base-action@beta
         with:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt_file: .github/prompts/triage.md
-          claude_args: |
-            --model claude-opus-4-5-20251101 --allowedTools "Bash(gh issue:*),Bash(gh search:*)"
+          model: claude-opus-4-5-20251101
+          allowed_tools: "Bash(gh issue:*),Bash(gh search:*)"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates the issue triage workflow to use Anthropic’s new base action and input format.
> 
> - Replace `anthropics/claude-code-action@v1` with `anthropics/claude-code-base-action@beta` in `claude-triage.yml`
> - Move from `claude_args` flags to explicit `model` and `allowed_tools` inputs; retain `prompt_file` and `claude_code_oauth_token`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0afa14937dcb473c58bd129d5692c2ef65d53c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch the triage workflow to the Claude base action and migrate inputs to the new schema for clearer config and future compatibility.

- **Dependencies**
  - Replaced anthropics/claude-code-action@v1 with anthropics/claude-code-base-action@beta.
  - Split claude_args into explicit inputs: model and allowed_tools (same values as before).

<sup>Written for commit e0afa14937dcb473c58bd129d5692c2ef65d53c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

