### PR TITLE
env token

### DIFF
--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -8,11 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
-      id-token: write
       contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: anthropics/claude-code-base-action@beta
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Configures the issue triage GitHub Action and tightens permissions.
> 
> - Adds `GITHUB_TOKEN` to `env` for `anthropics/claude-code-base-action@beta` in `claude-triage.yml`
> - Removes `id-token: write` from workflow `permissions`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74c71075c08ec0731bc49fb7e1f4e4fb798e0284. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Passed GITHUB_TOKEN to the claude triage GitHub Action to fix auth and allow issue updates. Removed the id-token permission since it’s not needed.

<sup>Written for commit 74c71075c08ec0731bc49fb7e1f4e4fb798e0284. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

