### PR TITLE
Allow skipping bug bot with #skip-bugbot for PR description

### DIFF
--- a/.github/workflows/bugbot-trigger.yml
+++ b/.github/workflows/bugbot-trigger.yml
@@ -8,6 +8,7 @@ jobs:
   trigger-bugbot:
     environment: ai-bots
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.body, '#skip-bugbot') }}
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allow skipping the bug bot by adding "#skip-bugbot" in the PR description. The workflow checks the PR body and won't trigger the bot when the tag is present.

<sup>Written for commit f329590205ce902baa26839471b1e3e12618a2a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an opt-out for BugBot runs in the GitHub Actions workflow.
> 
> - Adds `if: ${{ !contains(github.event.pull_request.body, '#skip-bugbot') }}` to `bugbot-trigger.yml` so the bot comment is skipped when PR body includes `#skip-bugbot`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f329590205ce902baa26839471b1e3e12618a2a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->