### PR TITLE
Fix snapshot baselines

### DIFF
--- a/e2e-tests/snapshots/context_window.spec.ts_context-window-5.txt
+++ b/e2e-tests/snapshots/context_window.spec.ts_context-window-5.txt
@@ -1084,4 +1084,44 @@ message: OK, got it. I'm ready to help
 
 ===
 role: user
+message: tc=1
+
+===
+role: assistant
+message: 1
+
+===
+role: user
+message: tc=2
+
+===
+role: assistant
+message: 2
+
+===
+role: user
+message: [dump] tc=3
+
+===
+role: assistant
+message: [[dyad-dump-path=*]]
+
+===
+role: user
+message: [dump] tc=4
+
+===
+role: assistant
+message: [[dyad-dump-path=*]]
+
+===
+role: user
+message: [dump] tc=5
+
+===
+role: assistant
+message: [[dyad-dump-path=*]]
+
+===
+role: user
 message: [dump] tc=6

--- a/e2e-tests/snapshots/turbo_edits_v2.spec.ts_after-search-replace.txt
+++ b/e2e-tests/snapshots/turbo_edits_v2.spec.ts_after-search-replace.txt
@@ -1,2 +1,20 @@
 === src/pages/Index.tsx ===
-// FILE IS REPLACED WITH FALLBACK WRITE.
+// Update this page (the content is just a fallback if you fail to update the page)
+
+import { MadeWithDyad } from "@/components/made-with-dyad";
+
+const Index = () => {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-100">
+      <div className="text-center">
+        <h1 className="text-4xl font-bold mb-4">Welcome to the UPDATED App</h1>
+        <p className="text-xl text-gray-600">
+          Start building your amazing project here!
+        </p>
+      </div>
+      <MadeWithDyad />
+    </div>
+  );
+};
+
+export default Index;


### PR DESCRIPTION
these were rebaselined in https://github.com/dyad-sh/dyad/pull/2145/files#diff-86564ff7ca1eca11278e409ada7d9823bc5fb0d8fcb8768313381f652c2450ea but are now failing in CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refreshes E2E snapshot baselines to match current outputs and unblock CI.
> 
> - Update `context_window.spec.ts_context-window-5.txt` to include additional user/assistant exchanges (`tc=1..5`) and dump path placeholders
> - Replace `turbo_edits_v2.spec.ts_after-search-replace.txt` snapshot with full `src/pages/Index.tsx` content showing updated heading "Welcome to the UPDATED App" and inclusion of `MadeWithDyad`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98b9b3e92299b0f0a2513fbcb052231ee910cf62. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated E2E snapshot baselines to match current behavior and fix CI failures introduced after the recent rebaseline.

- **Bug Fixes**
  - context_window snapshot: added expected assistant replies and dump path placeholders for tc=1–5.
  - turbo_edits_v2 snapshot: replaced fallback with the updated Index.tsx content generated by search/replace.

<sup>Written for commit 98b9b3e92299b0f0a2513fbcb052231ee910cf62. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

