### PR TITLE
update title in issue triage bot

### DIFF
--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -121,3 +121,33 @@ jobs:
             ### If No Duplicates Found
 
             Do not comment.
+
+            ## Task 3: Update Issue Title (if necessary)
+
+            Review the issue title and improve it **only if** it meets one of these conditions:
+
+            | Condition | Example (Before → After) |
+            |-----------|--------------------------|
+            | Template placeholder not filled in | `[session report] <add title>` → `[session report] App freezes when saving` |
+            | Too vague or generic | `not able to deploy to vercel` → `Vercel deployment fails with authentication error` |
+            | Unclear error description | `[bug] <npm and pnpm is not recogized >` → `[bug] npm/pnpm not recognized on Windows` |
+
+            ### How to Update
+
+            ```bash
+            gh issue edit [number] --title "New descriptive title"
+            ```
+
+            ### Guidelines
+
+            - Keep titles **short** (under 60 characters if possible)
+            - Start with the **what**: component, action, or error
+            - Preserve prefixes like `[bug]` or `[session report]` if present
+            - Be specific but not overly technical
+            - Don't change titles that are already clear and descriptive
+
+            ### When NOT to Update
+
+            - Title already describes the issue well (e.g., "Vercel Project Selection not always available")
+            - You'd only be making minor wording tweaks
+            - The issue body is too unclear to write a better title (use `issue/incomplete` label instead)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a new triage step to improve issue titles when they’re unclear, vague, or contain placeholders.
> 
> - Extends the Claude triage prompt in `.github/workflows/claude-triage.yml` with **Task 3: Update Issue Title** including criteria, before/after examples, the `gh issue edit --title` command, concise guidelines, and “when not to update” rules
> - No code/logic changes beyond prompt text; scope limited to the workflow file
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit adb5f2f7975dc6cb90c157052b9625c48bf52fb5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a new title-improvement step to the issue triage bot to keep issue titles clear and consistent while avoiding unnecessary edits.

- **New Features**
  - Introduces “Task 3: Update Issue Title” with clear conditions for when to update (placeholders, vague titles, unclear errors).
  - Includes a simple edit command (gh issue edit [number] --title "...").
  - Sets guidelines: keep titles short, lead with the “what,” preserve prefixes (e.g., [bug]), be specific.
  - Lists “do not update” cases: already clear, minor tweaks only, or unclear issue body (use issue/incomplete).

<sup>Written for commit adb5f2f7975dc6cb90c157052b9625c48bf52fb5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

