### PR TITLE
Consolidate build-time logs into server logs

### DIFF
--- a/e2e-tests/logs_server.spec.ts
+++ b/e2e-tests/logs_server.spec.ts
@@ -1,0 +1,58 @@
+import { expect } from "@playwright/test";
+import { testSkipIfWindows, Timeout } from "./helpers/test_helper";
+
+/**
+ * E2E tests for server logs in System Messages UI
+ * Validates that server stdout/stderr logs are correctly classified as "server" type
+ */
+
+testSkipIfWindows(
+  "system messages UI shows server logs with correct type",
+  async ({ po }) => {
+    await po.setUp();
+
+    // Create an app to generate server logs
+    await po.sendPrompt("tc=write-index");
+    await po.approveProposal();
+
+    // Wait for app to run - this generates server logs from stdout/stderr
+    const picker = po.page.getByTestId("preview-pick-element-button");
+    await expect(picker).toBeEnabled({ timeout: Timeout.EXTRA_LONG });
+
+    // Open the system messages console
+    const consoleHeader = po.page.locator('text="System Messages"').first();
+    await consoleHeader.click();
+
+    // Wait for console entries to appear
+    await expect(async () => {
+      const allLogs = po.page.getByTestId("console-entry");
+      const count = await allLogs.count();
+      expect(count).toBeGreaterThan(0);
+      await expect(allLogs.first()).toBeVisible();
+    }).toPass({ timeout: Timeout.MEDIUM });
+
+    // Verify that server logs have the "server" type badge visible
+    // When typeFilter is "all" (default), the type badge should be shown
+    // Server stdout/stderr logs and restart messages should show "server" type
+    await expect(async () => {
+      const serverTypeBadge = po.page
+        .getByTestId("console-entry")
+        .filter({ hasText: "server" });
+      const count = await serverTypeBadge.count();
+      expect(count).toBeGreaterThan(0);
+    }).toPass({ timeout: Timeout.MEDIUM });
+
+    // Test the type filter dropdown - filter by "server" type
+    const typeFilter = po.page
+      .locator("select")
+      .filter({ hasText: "All Types" });
+    await typeFilter.selectOption("server");
+
+    // Verify logs are still visible after filtering by server type
+    await expect(async () => {
+      const serverLogs = po.page.getByTestId("console-entry");
+      const count = await serverLogs.count();
+      expect(count).toBeGreaterThan(0);
+    }).toPass({ timeout: Timeout.MEDIUM });
+  },
+);

--- a/e2e-tests/snapshots/local_agent_auto.spec.ts_local-agent---auto-model-1.txt
+++ b/e2e-tests/snapshots/local_agent_auto.spec.ts_local-agent---auto-model-1.txt
@@ -305,10 +305,9 @@
                 "client",
                 "server",
                 "edge-function",
-                "network-requests",
-                "build-time"
+                "network-requests"
               ],
-              "description": "Filter by log source type (default: all). Types: 'client' = browser console logs; 'server' = backend/SSR logs; 'edge-function' = edge function logs; 'network-requests' = HTTP requests and responses (outgoing calls and their responses); 'build-time' = build and bundler output."
+              "description": "Filter by log source type (default: all). Types: 'client' = browser console logs; 'server' = backend (including development server) logs and build output; 'edge-function' = edge function logs; 'network-requests' = HTTP requests and responses (outgoing calls and their responses)."
             },
             "level": {
               "type": "string",

--- a/e2e-tests/snapshots/local_agent_basic.spec.ts_local-agent---dump-request-1.txt
+++ b/e2e-tests/snapshots/local_agent_basic.spec.ts_local-agent---dump-request-1.txt
@@ -310,10 +310,9 @@
                   "client",
                   "server",
                   "edge-function",
-                  "network-requests",
-                  "build-time"
+                  "network-requests"
                 ],
-                "description": "Filter by log source type (default: all). Types: 'client' = browser console logs; 'server' = backend/SSR logs; 'edge-function' = edge function logs; 'network-requests' = HTTP requests and responses (outgoing calls and their responses); 'build-time' = build and bundler output."
+                "description": "Filter by log source type (default: all). Types: 'client' = browser console logs; 'server' = backend (including development server) logs and build output; 'edge-function' = edge function logs; 'network-requests' = HTTP requests and responses (outgoing calls and their responses)."
               },
               "level": {
                 "type": "string",

--- a/src/components/preview_panel/Console.tsx
+++ b/src/components/preview_panel/Console.tsx
@@ -83,12 +83,7 @@ export const Console = () => {
     "all" | "info" | "warn" | "error"
   >("all");
   const [typeFilter, setTypeFilter] = useState<
-    | "all"
-    | "server"
-    | "client"
-    | "edge-function"
-    | "network-requests"
-    | "build-time"
+    "all" | "server" | "client" | "edge-function" | "network-requests"
   >("all");
   const [sourceFilter, setSourceFilter] = useState<string>("");
 

--- a/src/components/preview_panel/ConsoleEntry.tsx
+++ b/src/components/preview_panel/ConsoleEntry.tsx
@@ -9,12 +9,7 @@ import { useSetAtom } from "jotai";
 import { chatInputValueAtom } from "@/atoms/chatAtoms";
 
 interface ConsoleEntryProps {
-  type:
-    | "server"
-    | "client"
-    | "edge-function"
-    | "network-requests"
-    | "build-time";
+  type: "server" | "client" | "edge-function" | "network-requests";
   level: "info" | "warn" | "error";
   timestamp: number;
   message: string;

--- a/src/components/preview_panel/ConsoleFilters.tsx
+++ b/src/components/preview_panel/ConsoleFilters.tsx
@@ -13,18 +13,11 @@ interface ConsoleFiltersProps {
     | "server"
     | "client"
     | "edge-function"
-    | "network-requests"
-    | "build-time";
+    | "network-requests";
   sourceFilter: string;
   onLevelFilterChange: (value: "all" | "info" | "warn" | "error") => void;
   onTypeFilterChange: (
-    value:
-      | "all"
-      | "server"
-      | "client"
-      | "edge-function"
-      | "network-requests"
-      | "build-time",
+    value: "all" | "server" | "client" | "edge-function" | "network-requests",
   ) => void;
   onSourceFilterChange: (value: string) => void;
   onClearFilters: () => void;
@@ -82,8 +75,7 @@ export const ConsoleFilters = ({
               | "server"
               | "client"
               | "edge-function"
-              | "network-requests"
-              | "build-time",
+              | "network-requests",
           )
         }
         className="text-xs px-2 py-1 border border-border rounded bg-transparent hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
@@ -93,7 +85,6 @@ export const ConsoleFilters = ({
         <option value="client">Client</option>
         <option value="edge-function">Edge Function</option>
         <option value="network-requests">Network Requests</option>
-        <option value="build-time">Build Time</option>
       </select>
 
       {/* Source filter */}

--- a/src/hooks/useRunApp.ts
+++ b/src/hooks/useRunApp.ts
@@ -66,12 +66,14 @@ export function useRunApp() {
       }
 
       // Add to console entries
+      // Use "server" type for stdout/stderr to match the backend log store
+      // (app_handlers.ts stores these as type: "server")
       const logEntry = {
         level:
           output.type === "stderr" || output.type === "client-error"
             ? ("error" as const)
             : ("info" as const),
-        type: "build-time" as const,
+        type: "server" as const,
         message: output.message,
         appId: output.appId,
         timestamp: output.timestamp,
@@ -108,7 +110,7 @@ export function useRunApp() {
 
         const logEntry = {
           level: "info" as const,
-          type: "build-time" as const,
+          type: "server" as const,
           message: "Trying to restart app...",
           appId,
           timestamp: Date.now(),
@@ -195,7 +197,7 @@ export function useRunApp() {
 
         const logEntry = {
           level: "info" as const,
-          type: "build-time" as const,
+          type: "server" as const,
           message: "Restarting app...",
           appId: appId!,
           timestamp: Date.now(),

--- a/src/ipc/ipc_types.ts
+++ b/src/ipc/ipc_types.ts
@@ -12,12 +12,7 @@ export interface AppOutput {
 
 export interface ConsoleEntry {
   level: "info" | "warn" | "error";
-  type:
-    | "server"
-    | "client"
-    | "edge-function"
-    | "network-requests"
-    | "build-time";
+  type: "server" | "client" | "edge-function" | "network-requests";
   message: string;
   timestamp: number;
   sourceName?: string;

--- a/src/pro/main/ipc/handlers/local_agent/tools/read_logs.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/read_logs.ts
@@ -11,7 +11,7 @@ const readLogsSchema = z.object({
     .enum(["all", "client", "server", "edge-function", "network-requests"])
     .optional()
     .describe(
-      "Filter by log source type (default: all). Types: 'client' = browser console logs; 'server' = backend/SSR logs and build output; 'edge-function' = edge function logs; 'network-requests' = HTTP requests and responses (outgoing calls and their responses).",
+      "Filter by log source type (default: all). Types: 'client' = browser console logs; 'server' = backend (including development server) logs and build output; 'edge-function' = edge function logs; 'network-requests' = HTTP requests and responses (outgoing calls and their responses).",
     ),
 
   level: z

--- a/src/pro/main/ipc/handlers/local_agent/tools/read_logs.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/read_logs.ts
@@ -8,17 +8,10 @@ import type { ConsoleEntry } from "@/ipc/ipc_types";
 
 const readLogsSchema = z.object({
   type: z
-    .enum([
-      "all",
-      "client",
-      "server",
-      "edge-function",
-      "network-requests",
-      "build-time",
-    ])
+    .enum(["all", "client", "server", "edge-function", "network-requests"])
     .optional()
     .describe(
-      "Filter by log source type (default: all). Types: 'client' = browser console logs; 'server' = backend/SSR logs; 'edge-function' = edge function logs; 'network-requests' = HTTP requests and responses (outgoing calls and their responses); 'build-time' = build and bundler output.",
+      "Filter by log source type (default: all). Types: 'client' = browser console logs; 'server' = backend/SSR logs and build output; 'edge-function' = edge function logs; 'network-requests' = HTTP requests and responses (outgoing calls and their responses).",
     ),
 
   level: z


### PR DESCRIPTION
The two categories cannot be categorized properly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Consolidates log taxonomy by removing `build-time` and treating all build/stdout/stderr and restart messages as `server` for consistent System Messages display and filtering.
> 
> - Reclassifies app stdout/stderr and restart notices to `type: "server"` in `useRunApp`
> - Removes `build-time` from UI/IPC types and filters (`Console.tsx`, `ConsoleEntry.tsx`, `ConsoleFilters.tsx`, `ipc_types.ts`)
> - Updates `read_logs` tool schema/enums and description to exclude `build-time` and clarify `server` includes dev server and build output
> - Adds E2E test `e2e-tests/logs_server.spec.ts` and updates snapshots to validate `server` badge and filtering
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e28efdd2ff60aaf168084f447f65cda191b4367. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidated all build-time logs into the "server" type so they appear consistently in System Messages and filters. This removes the "build-time" category and simplifies log filtering.

- **Refactors**
  - Removed the "build-time" log type from UI components, IPC types, and read_logs schema.
  - Emitted stdout/stderr and restart messages as type "server" in useRunApp.
  - Clarified read_logs description: server includes dev server logs and build output.
  - Added a Playwright E2E test to verify server log classification and filtering in System Messages.

<sup>Written for commit 4e28efdd2ff60aaf168084f447f65cda191b4367. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

