### PR TITLE
Bump to v0.33 stable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dyad",
-  "version": "0.33.0-beta.3",
+  "version": "0.33.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dyad",
-      "version": "0.33.0-beta.3",
+      "version": "0.33.0",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/amazon-bedrock": "^4.0.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dyad",
   "productName": "dyad",
-  "version": "0.33.0-beta.3",
+  "version": "0.33.0",
   "description": "Free, local, open-source AI app builder",
   "main": ".vite/build/main.js",
   "repository": {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Promoted Dyad v0.33.0 from beta to stable to prepare the v0.33 stable release. Updated package.json and package-lock.json versions; no functional changes.

<sup>Written for commit 0f1ce1fbb98a6407b7188c487c18b72ea06a88df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Promotes the app from beta to stable release with no functional code changes.
> 
> - Bumps version from `0.33.0-beta.3` to `0.33.0` in `package.json` and `package-lock.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f1ce1fbb98a6407b7188c487c18b72ea06a88df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->