### PR TITLE
Use GITHUB_TOKEN in release: npm ci to avoid rate limit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,9 @@ jobs:
         with:
           node-version: 20
       - run: npm ci
+        env:
+          # Required for @vscode/ripgrep to download binaries without hitting GitHub API rate limits
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: add macos cert
         if: contains(matrix.os.name, 'macos')
         env:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates CI to prevent rate-limit failures during dependency install.
> 
> - In `.github/workflows/release.yml`, adds `GITHUB_TOKEN` env to the `npm ci` step so `@vscode/ripgrep` can download binaries without hitting GitHub API rate limits
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94f4dc13b99b26825feb17eae2a9fcdda6f950a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set GITHUB_TOKEN for npm ci in the release workflow so @vscode/ripgrep can download binaries without hitting GitHub API rate limits. Prevents install failures in release builds across the matrix.

<sup>Written for commit 94f4dc13b99b26825feb17eae2a9fcdda6f950a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

