### PR TITLE
Restrict expensive automatic PR reviews for outside contributors

### DIFF
--- a/.github/workflows/bugbot-trigger.yml
+++ b/.github/workflows/bugbot-trigger.yml
@@ -7,8 +7,13 @@ on:
 jobs:
   trigger-bugbot:
     environment: ai-bots
+    # Only review code from regular contributors since bug bot has a capped # of PR reviews.
+    if: |
+      (github.event.pull_request.user.login == 'wwwillchen' ||
+      github.event.pull_request.user.login == 'azizmejri1' ||
+      github.event.pull_request.user.login == 'princeaden1') &&
+      !contains(github.event.pull_request.body, '#skip-bugbot')
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.body, '#skip-bugbot') }}
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -10,6 +10,14 @@ jobs:
   claude-review:
     # Has Anthropic API key, etc.
     environment: ai-bots
+    # Only review code from regular contributors since claude code has non-trivial costs.
+    # It's also a safe-guard for preventing malicious PRs from doing bad things although we restrict
+    # the permissions and tools allowed in this job.
+    # https://github.com/anthropics/claude-code-action/blob/main/examples/pr-review-filtered-authors.yml
+    if: |
+      github.event.pull_request.user.login == 'wwwillchen' ||
+      github.event.pull_request.user.login == 'azizmejri1' ||
+      github.event.pull_request.user.login == 'princeaden1'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Tightens CI review automation to only run for specific trusted contributors.
> 
> - Adds author filter `if:` conditions in `bugbot-trigger.yml` and `claude-pr-review.yml` to allow only `wwwillchen`, `azizmejri1`, and `princeaden1`
> - Preserves `#skip-bugbot` opt-out for BugBot; removes previous unconditional check in favor of combined author + skip filter
> - No functional changes to steps beyond gating; environments and permissions remain the same
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0de70045d0c98e4cec45f0a3b90100a223a0be9e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restricts automatic PR reviews (BugBot and Claude) to an allowlist of regular contributors. This controls review costs/limits and reduces risk from external PRs.

- **New Features**
  - BugBot: Only runs for PRs by wwwillchen, azizmejri1, or princeaden1; can be disabled with #skip-bugbot in the PR body.
  - Claude: Only runs for PRs by wwwillchen, azizmejri1, or princeaden1.

<sup>Written for commit 0de70045d0c98e4cec45f0a3b90100a223a0be9e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

