### PR TITLE
Refactor IPC to modular type-safe pattern

### DIFF
--- a/src/ipc/README_IPC_REFACTOR.md
+++ b/src/ipc/README_IPC_REFACTOR.md
@@ -1,0 +1,303 @@
+# Type-Safe IPC Refactor
+
+This directory contains a refactored, type-safe IPC (Inter-Process Communication) architecture for the Dyad application.
+
+## Overview
+
+The new IPC pattern provides:
+
+- **Type Safety**: Compile-time type checking for all IPC calls
+- **Modularity**: Centralized type definitions with distributed handler implementations
+- **Conciseness**: Reduced boilerplate with automatic logging and error handling
+- **Maintainability**: Single source of truth for channel definitions
+- **Developer Experience**: Auto-complete and refactoring support
+
+## Architecture
+
+### Core Files
+
+1. **`ipc_registry.ts`** - Central type registry
+   - Defines all IPC channels and their request/response types
+   - Single source of truth for the IPC contract
+   - Provides type utilities for handlers and client
+
+2. **`ipc_handler.ts`** - Type-safe handler utilities
+   - `createIpcHandler()` - Register individual handlers
+   - `createHandlerFactory()` - Create handler registrar with shared config
+   - `createSimpleHandler()` - For handlers that don't need the event parameter
+   - Automatic logging, error handling, and type enforcement
+
+3. **`ipc_client_helpers.ts`** - Type-safe client utilities
+   - `typedInvoke()` - Type-safe wrapper for `ipcRenderer.invoke()`
+   - `createTypedIpcClient()` - Factory for type-safe IPC client
+   - `createMockIpcRenderer()` - Testing utilities
+
+4. **`ipc_client.ts`** - Updated IPC client
+   - Existing IPC client methods being gradually migrated
+   - Examples of type-safe method implementations
+
+## Usage
+
+### Defining a New IPC Channel
+
+1. Add the channel to the registry in `ipc_registry.ts`:
+
+```typescript
+export interface IpcChannelRegistry {
+  // ... existing channels
+  "my-new-channel": {
+    params: { userId: number; data: string };
+    returns: { success: boolean; message: string };
+  };
+}
+```
+
+2. Add metadata (optional but recommended):
+
+```typescript
+export const channelMetadata = {
+  // ... existing metadata
+  "my-new-channel": {
+    description: "My new channel description",
+    group: "my-feature",
+  },
+} as const satisfies Record<IpcChannelName, { description: string; group: string }>;
+```
+
+### Creating a Handler
+
+In your handler file (e.g., `handlers/my_feature_handlers.ts`):
+
+```typescript
+import { createHandlerFactory } from "../ipc_handler";
+import log from "electron-log";
+
+const logger = log.scope("my_feature");
+const handle = createHandlerFactory({ logger, logDetails: false });
+
+export function registerMyFeatureHandlers() {
+  handle("my-new-channel", async (event, params) => {
+    // params is automatically typed as { userId: number; data: string }
+    // return type is enforced as { success: boolean; message: string }
+
+    const result = await doSomething(params.userId, params.data);
+
+    return {
+      success: true,
+      message: "Done!",
+    };
+  });
+}
+```
+
+### Using from the Client
+
+In `ipc_client.ts`:
+
+```typescript
+import { typedInvoke } from "./ipc_client_helpers";
+
+export class IpcClient {
+  // ... existing code
+
+  public async myNewMethod(userId: number, data: string) {
+    // Fully type-safe call
+    const result = await typedInvoke(
+      this.ipcRenderer,
+      "my-new-channel",
+      { userId, data }
+    );
+    // result is typed as { success: boolean; message: string }
+    return result;
+  }
+}
+```
+
+## Migration Guide
+
+### Migrating Existing Handlers
+
+**Before:**
+```typescript
+import { createLoggedHandler } from "./safe_handle";
+
+const logger = log.scope("app_handlers");
+const handle = createLoggedHandler(logger);
+
+export function registerAppHandlers() {
+  handle("get-app", async (_, appId: number): Promise<App> => {
+    // Manual type annotations required
+    const app = await db.query.apps.findFirst({
+      where: eq(apps.id, appId),
+    });
+    return app;
+  });
+}
+```
+
+**After:**
+```typescript
+import { createHandlerFactory } from "../ipc_handler";
+
+const logger = log.scope("app_handlers");
+const handle = createHandlerFactory({ logger, logDetails: false });
+
+export function registerAppHandlers() {
+  // Types automatically inferred from registry
+  handle("get-app", async (_, appId) => {
+    const app = await db.query.apps.findFirst({
+      where: eq(apps.id, appId),
+    });
+    return app; // Return type automatically checked
+  });
+}
+```
+
+### Migrating Client Methods
+
+**Before:**
+```typescript
+public async getApp(appId: number): Promise<App> {
+  return this.ipcRenderer.invoke("get-app", appId);
+  // No type safety - easy to typo channel name or pass wrong params
+}
+```
+
+**After:**
+```typescript
+public async getApp(appId: number): Promise<App> {
+  return typedInvoke(this.ipcRenderer, "get-app", appId);
+  // Compile-time type checking for channel, params, and return type
+}
+```
+
+## Benefits
+
+### 1. Type Safety
+
+```typescript
+// ✅ Correct usage
+await typedInvoke(ipcRenderer, "get-app", 123);
+
+// ❌ TypeScript error: wrong param type
+await typedInvoke(ipcRenderer, "get-app", "wrong");
+
+// ❌ TypeScript error: channel doesn't exist
+await typedInvoke(ipcRenderer, "non-existent-channel", {});
+```
+
+### 2. Refactoring Safety
+
+When you rename a channel or change its types:
+- Update the registry once
+- TypeScript shows all locations that need updating
+- No silent runtime failures
+
+### 3. Auto-Complete
+
+Your IDE provides auto-complete for:
+- Channel names
+- Parameter types
+- Return types
+
+### 4. Reduced Boilerplate
+
+**Before:**
+```typescript
+ipcMain.handle("my-channel", async (event, params) => {
+  logger.log(`IPC: my-channel called with args: ${JSON.stringify(params)}`);
+  try {
+    const result = await doSomething(params);
+    logger.log(`IPC: my-channel returned: ${JSON.stringify(result)}`);
+    return result;
+  } catch (error) {
+    logger.error(`Error in my-channel:`, error);
+    throw new Error(`[my-channel] ${error}`);
+  }
+});
+```
+
+**After:**
+```typescript
+handle("my-channel", async (_, params) => {
+  return doSomething(params);
+  // Logging and error handling automatic!
+});
+```
+
+## Testing
+
+Use `createMockIpcRenderer` for unit tests:
+
+```typescript
+import { createMockIpcRenderer, createTypedIpcClient } from "./ipc_client_helpers";
+
+const mockIpc = createMockIpcRenderer({
+  'get-app': async (appId) => ({
+    id: appId,
+    name: 'Test App',
+    // ... other required fields
+  }),
+});
+
+const client = createTypedIpcClient(mockIpc);
+const app = await client.invoke('get-app', 123); // Fully typed!
+```
+
+## Incremental Adoption
+
+You can adopt this pattern incrementally:
+
+1. ✅ Registry and utilities are already set up
+2. ✅ Example handlers have been refactored (see `chat_handlers.ts`, parts of `app_handlers.ts`)
+3. ✅ Example client methods have been migrated (see `ipc_client.ts`)
+4. 🔄 Migrate remaining handlers gradually
+5. 🔄 Migrate remaining client methods gradually
+
+Both old and new patterns can coexist during migration.
+
+## Best Practices
+
+1. **Always add new channels to the registry first**
+   - This ensures type safety from the start
+
+2. **Use `createHandlerFactory` for consistent logging**
+   - Create one factory per handler file with shared logger
+
+3. **Keep handlers focused**
+   - Each handler should do one thing well
+   - Complex logic should be in separate service functions
+
+4. **Use descriptive channel names**
+   - Use kebab-case: `get-user-settings`
+   - Be specific: `create-app` not just `create`
+   - Group related channels: `github:*`, `vercel:*`
+
+5. **Document complex types**
+   - Add JSDoc comments to complex parameter types
+   - Link to related types or schemas
+
+## Examples
+
+See these files for complete examples:
+
+- **Handler**: `handlers/chat_handlers.ts` - Fully refactored handlers
+- **Client**: `ipc_client.ts` - Migrated client methods (see comments)
+- **Types**: `ipc_registry.ts` - Channel definitions
+
+## Future Enhancements
+
+Possible improvements for the future:
+
+1. **Runtime Validation**: Add Zod schemas to registry for runtime param validation
+2. **Auto-Generated Client**: Generate client methods from registry
+3. **OpenAPI-like Docs**: Auto-generate API documentation from registry
+4. **Request/Response Logging**: Configurable logging levels per channel
+5. **Performance Metrics**: Track IPC call durations and frequencies
+
+## Questions?
+
+For questions or issues with the new IPC pattern, please refer to:
+- This README
+- Example code in refactored handlers
+- Type definitions in `ipc_registry.ts`

--- a/src/ipc/ipc_client.ts
+++ b/src/ipc/ipc_client.ts
@@ -7,6 +7,7 @@ import {
   ChatSearchResultsSchema,
   AppSearchResultsSchema,
 } from "../lib/schemas";
+import { typedInvoke } from "./ipc_client_helpers";
 import type {
   AppOutput,
   Chat,
@@ -344,8 +345,21 @@ export class IpcClient {
     return IpcClient.instance;
   }
 
+  /**
+   * NOTE: New type-safe pattern - These methods use the typedInvoke wrapper
+   * for compile-time type safety. The types are automatically inferred from
+   * the IPC registry (ipc_registry.ts).
+   *
+   * Benefits:
+   * - Compile-time type checking for params and returns
+   * - Auto-complete for channel names
+   * - Refactoring safety (rename channels, update types)
+   *
+   * Migrate other methods to this pattern gradually.
+   */
+
   public async restartDyad(): Promise<void> {
-    await this.ipcRenderer.invoke("restart-dyad");
+    await typedInvoke(this.ipcRenderer, "restart-dyad");
   }
 
   public async reloadEnvPath(): Promise<void> {
@@ -354,18 +368,18 @@ export class IpcClient {
 
   // Create a new app with an initial chat
   public async createApp(params: CreateAppParams): Promise<CreateAppResult> {
-    return this.ipcRenderer.invoke("create-app", params);
+    return typedInvoke(this.ipcRenderer, "create-app", params);
   }
 
   public async getApp(appId: number): Promise<App> {
-    return this.ipcRenderer.invoke("get-app", appId);
+    return typedInvoke(this.ipcRenderer, "get-app", appId);
   }
 
   public async addAppToFavorite(
     appId: number,
   ): Promise<{ isFavorite: boolean }> {
     try {
-      const result = await this.ipcRenderer.invoke("add-to-favorite", {
+      const result = await typedInvoke(this.ipcRenderer, "add-to-favorite", {
         appId,
       });
       return result;
@@ -387,7 +401,7 @@ export class IpcClient {
 
   public async getChat(chatId: number): Promise<Chat> {
     try {
-      const data = await this.ipcRenderer.invoke("get-chat", chatId);
+      const data = await typedInvoke(this.ipcRenderer, "get-chat", chatId);
       return data;
     } catch (error) {
       showError(error);
@@ -398,7 +412,7 @@ export class IpcClient {
   // Get all chats
   public async getChats(appId?: number): Promise<ChatSummary[]> {
     try {
-      const data = await this.ipcRenderer.invoke("get-chats", appId);
+      const data = await typedInvoke(this.ipcRenderer, "get-chats", appId);
       return ChatSummariesSchema.parse(data);
     } catch (error) {
       showError(error);
@@ -422,7 +436,7 @@ export class IpcClient {
 
   // Get all apps
   public async listApps(): Promise<ListAppsResponse> {
-    return this.ipcRenderer.invoke("list-apps");
+    return typedInvoke(this.ipcRenderer, "list-apps");
   }
 
   // Search apps by name
@@ -576,19 +590,19 @@ export class IpcClient {
 
   // Create a new chat for an app
   public async createChat(appId: number): Promise<number> {
-    return this.ipcRenderer.invoke("create-chat", appId);
+    return typedInvoke(this.ipcRenderer, "create-chat", appId);
   }
 
   public async updateChat(params: UpdateChatParams): Promise<void> {
-    return this.ipcRenderer.invoke("update-chat", params);
+    return typedInvoke(this.ipcRenderer, "update-chat", params);
   }
 
   public async deleteChat(chatId: number): Promise<void> {
-    await this.ipcRenderer.invoke("delete-chat", chatId);
+    await typedInvoke(this.ipcRenderer, "delete-chat", chatId);
   }
 
   public async deleteMessages(chatId: number): Promise<void> {
-    await this.ipcRenderer.invoke("delete-messages", chatId);
+    await typedInvoke(this.ipcRenderer, "delete-messages", chatId);
   }
 
   // Open an external URL using the default browser

--- a/src/ipc/ipc_client_helpers.ts
+++ b/src/ipc/ipc_client_helpers.ts
@@ -1,0 +1,132 @@
+/**
+ * Type-safe IPC Client Helpers
+ *
+ * Provides utilities for making type-safe IPC calls from the renderer process.
+ * These helpers ensure that the client calls match the registered channel types.
+ */
+
+import type { IpcRenderer } from "electron";
+import type {
+  IpcChannelName,
+  IpcParams,
+  IpcReturns,
+} from "./ipc_registry";
+
+/**
+ * Type-safe wrapper for ipcRenderer.invoke
+ *
+ * This ensures that the channel name, parameters, and return type are all
+ * correctly typed according to the IPC registry.
+ *
+ * @example
+ * ```typescript
+ * const ipcRenderer = (window as any).electron.ipcRenderer as IpcRenderer;
+ *
+ * // Fully type-safe call
+ * const app = await typedInvoke(ipcRenderer, 'get-app', 123);
+ * // app is typed as App
+ *
+ * // TypeScript error if wrong params
+ * const app = await typedInvoke(ipcRenderer, 'get-app', 'wrong'); // Error!
+ * ```
+ */
+export async function typedInvoke<T extends IpcChannelName>(
+  ipcRenderer: IpcRenderer,
+  channel: T,
+  ...params: IpcParams<T> extends void ? [] : [IpcParams<T>]
+): Promise<IpcReturns<T>> {
+  // For channels with void params, don't pass anything
+  if (params.length === 0) {
+    return ipcRenderer.invoke(channel);
+  }
+  // For channels with params, pass the first param
+  return ipcRenderer.invoke(channel, params[0]);
+}
+
+/**
+ * Factory function to create a type-safe IPC client
+ *
+ * This creates a wrapper around ipcRenderer with type-safe invoke methods.
+ * Useful for dependency injection and testing.
+ *
+ * @example
+ * ```typescript
+ * const ipcRenderer = (window as any).electron.ipcRenderer as IpcRenderer;
+ * const ipc = createTypedIpcClient(ipcRenderer);
+ *
+ * // All methods are type-safe
+ * const app = await ipc.invoke('get-app', 123);
+ * const chats = await ipc.invoke('get-chats', 456);
+ * const version = await ipc.invoke('get-app-version');
+ * ```
+ */
+export function createTypedIpcClient(ipcRenderer: IpcRenderer) {
+  return {
+    /**
+     * Make a type-safe IPC call
+     */
+    invoke<T extends IpcChannelName>(
+      channel: T,
+      ...params: IpcParams<T> extends void ? [] : [IpcParams<T>]
+    ): Promise<IpcReturns<T>> {
+      return typedInvoke(ipcRenderer, channel, ...params);
+    },
+
+    /**
+     * Access to the underlying ipcRenderer for non-typed operations
+     */
+    raw: ipcRenderer,
+  };
+}
+
+/**
+ * Type guard to check if a value matches the expected params type
+ * Useful for runtime validation in development
+ */
+export function isValidParams<T extends IpcChannelName>(
+  channel: T,
+  params: unknown,
+): params is IpcParams<T> {
+  // This is a basic runtime check - you can extend this with Zod schemas
+  // for more robust validation
+  if (params === undefined || params === null) {
+    return true; // Allow void params
+  }
+  return typeof params === "object" || typeof params !== "undefined";
+}
+
+/**
+ * Helper to create a mocked IPC renderer for testing
+ *
+ * This allows you to mock specific channels while maintaining type safety.
+ *
+ * @example
+ * ```typescript
+ * const mockIpc = createMockIpcRenderer({
+ *   'get-app': async (appId) => ({ id: appId, name: 'Test App', ... }),
+ *   'get-chats': async () => [],
+ * });
+ *
+ * const client = createTypedIpcClient(mockIpc);
+ * const app = await client.invoke('get-app', 123); // Returns mocked data
+ * ```
+ */
+export function createMockIpcRenderer(
+  mocks: Partial<{
+    [K in IpcChannelName]: (
+      params: IpcParams<K>,
+    ) => Promise<IpcReturns<K>> | IpcReturns<K>;
+  }>,
+): Pick<IpcRenderer, "invoke" | "on" | "removeListener"> {
+  return {
+    invoke: async (channel: string, ...args: any[]) => {
+      const mockFn = mocks[channel as IpcChannelName] as any;
+      if (!mockFn) {
+        throw new Error(`No mock registered for channel: ${channel}`);
+      }
+      return await mockFn(args[0]);
+    },
+    on: () => ({} as any),
+    removeListener: () => ({} as any),
+  } as any;
+}

--- a/src/ipc/ipc_handler.ts
+++ b/src/ipc/ipc_handler.ts
@@ -1,0 +1,187 @@
+/**
+ * Type-safe IPC Handler Utilities
+ *
+ * Provides utilities for creating type-safe IPC handlers with automatic
+ * logging, error handling, and type validation.
+ */
+
+import { ipcMain, type IpcMainInvokeEvent } from "electron";
+import type { LogFunctions } from "electron-log";
+import type {
+  IpcChannelName,
+  IpcParams,
+  IpcReturns,
+} from "./ipc_registry";
+
+/**
+ * Handler function type with proper typing from registry
+ */
+export type IpcHandlerFn<T extends IpcChannelName> = (
+  event: IpcMainInvokeEvent,
+  params: IpcParams<T>,
+) => Promise<IpcReturns<T>> | IpcReturns<T>;
+
+/**
+ * Configuration options for IPC handlers
+ */
+export interface IpcHandlerOptions {
+  /**
+   * Custom logger instance. If not provided, no logging will occur.
+   */
+  logger?: LogFunctions;
+
+  /**
+   * Whether to log handler calls and responses (default: true if logger provided)
+   */
+  enableLogging?: boolean;
+
+  /**
+   * Whether to log full arguments and returns (default: false for security/performance)
+   */
+  logDetails?: boolean;
+
+  /**
+   * Custom error handler. If not provided, errors are re-thrown with channel prefix.
+   */
+  onError?: (channel: string, error: unknown, args: any[]) => void;
+}
+
+/**
+ * Creates a type-safe IPC handler with automatic logging and error handling
+ *
+ * @param channel - The IPC channel name (must be in registry)
+ * @param handler - The handler function with typed parameters and return
+ * @param options - Optional configuration for logging and error handling
+ *
+ * @example
+ * ```typescript
+ * createIpcHandler('create-app', async (event, params) => {
+ *   // params is typed as CreateAppParams
+ *   // return type is enforced as CreateAppResult
+ *   const result = await createAppLogic(params);
+ *   return result;
+ * }, { logger });
+ * ```
+ */
+export function createIpcHandler<T extends IpcChannelName>(
+  channel: T,
+  handler: IpcHandlerFn<T>,
+  options: IpcHandlerOptions = {},
+): void {
+  const {
+    logger,
+    enableLogging = !!logger,
+    logDetails = false,
+    onError,
+  } = options;
+
+  ipcMain.handle(channel, async (event: IpcMainInvokeEvent, ...args: any[]) => {
+    // Extract params (first arg for all our handlers)
+    const params = args[0] as IpcParams<T>;
+
+    // Log invocation
+    if (enableLogging && logger) {
+      if (logDetails) {
+        logger.log(`IPC: ${channel} called with args:`, JSON.stringify(params));
+      } else {
+        logger.log(`IPC: ${channel} called`);
+      }
+    }
+
+    try {
+      // Execute handler
+      const result = await handler(event, params);
+
+      // Log result
+      if (enableLogging && logger) {
+        if (logDetails) {
+          const resultPreview = JSON.stringify(result)?.slice(0, 100);
+          logger.log(`IPC: ${channel} returned: ${resultPreview}...`);
+        } else {
+          logger.log(`IPC: ${channel} completed successfully`);
+        }
+      }
+
+      return result;
+    } catch (error) {
+      // Log error
+      if (enableLogging && logger) {
+        logger.error(`Error in ${channel}:`, error);
+        if (logDetails) {
+          logger.error(`Args were:`, JSON.stringify(params));
+        }
+      }
+
+      // Custom error handler
+      if (onError) {
+        onError(channel, error, args);
+      }
+
+      // Re-throw with channel prefix for better debugging
+      throw new Error(`[${channel}] ${error}`);
+    }
+  });
+}
+
+/**
+ * Factory function to create a handler registrar with consistent options
+ *
+ * This is useful when you want to register multiple handlers with the same
+ * logging/error handling configuration.
+ *
+ * @param options - Default options for all handlers created by this factory
+ *
+ * @example
+ * ```typescript
+ * const logger = log.scope('app_handlers');
+ * const handle = createHandlerFactory({ logger, logDetails: true });
+ *
+ * handle('create-app', async (event, params) => {
+ *   // Automatically logged with the provided logger
+ *   return createAppLogic(params);
+ * });
+ *
+ * handle('get-app', async (event, appId) => {
+ *   return getAppLogic(appId);
+ * });
+ * ```
+ */
+export function createHandlerFactory(options: IpcHandlerOptions = {}) {
+  return function handle<T extends IpcChannelName>(
+    channel: T,
+    handler: IpcHandlerFn<T>,
+    handlerSpecificOptions?: IpcHandlerOptions,
+  ): void {
+    // Merge factory options with handler-specific options
+    const mergedOptions = {
+      ...options,
+      ...handlerSpecificOptions,
+    };
+
+    createIpcHandler(channel, handler, mergedOptions);
+  };
+}
+
+/**
+ * Type-safe wrapper for handlers that don't need the event parameter
+ *
+ * Many handlers don't use the IpcMainInvokeEvent, so this provides a cleaner API
+ *
+ * @example
+ * ```typescript
+ * createSimpleHandler('get-app', async (appId) => {
+ *   return db.query.apps.findFirst({ where: eq(apps.id, appId) });
+ * }, { logger });
+ * ```
+ */
+export function createSimpleHandler<T extends IpcChannelName>(
+  channel: T,
+  handler: (params: IpcParams<T>) => Promise<IpcReturns<T>> | IpcReturns<T>,
+  options: IpcHandlerOptions = {},
+): void {
+  createIpcHandler(
+    channel,
+    async (_event, params) => handler(params),
+    options,
+  );
+}

--- a/src/ipc/ipc_registry.ts
+++ b/src/ipc/ipc_registry.ts
@@ -1,0 +1,238 @@
+/**
+ * Central IPC Registry - Type-safe channel definitions
+ *
+ * This file serves as the single source of truth for all IPC channels,
+ * providing compile-time type safety for both handlers and client calls.
+ */
+
+import { z } from "zod";
+import type {
+  CreateAppParams,
+  CreateAppResult,
+  App,
+  Chat,
+  UpdateChatParams,
+  ListAppsResponse,
+  AppFileSearchResult,
+  BranchResult,
+  GetAppEnvVarsParams,
+  SetAppEnvVarsParams,
+  EnvVar,
+} from "./ipc_types";
+import type { ChatSummary, UserSettings } from "../lib/schemas";
+
+/**
+ * Define all IPC channels with their request and response types
+ *
+ * Pattern:
+ * - For channels with no params: use `void` or `undefined`
+ * - For channels with single primitive param: use the primitive type directly
+ * - For channels with multiple params or object param: use the type/interface
+ * - For channels with no return: use `void`
+ */
+export interface IpcChannelRegistry {
+  // App Management
+  "create-app": {
+    params: CreateAppParams;
+    returns: CreateAppResult;
+  };
+  "get-app": {
+    params: number; // appId
+    returns: App;
+  };
+  "list-apps": {
+    params: void;
+    returns: ListAppsResponse;
+  };
+  "delete-app": {
+    params: { appId: number };
+    returns: void;
+  };
+  "add-to-favorite": {
+    params: { appId: number };
+    returns: { isFavorite: boolean };
+  };
+  "search-app-files": {
+    params: { appId: number; query: string };
+    returns: AppFileSearchResult[];
+  };
+
+  // Chat Management
+  "create-chat": {
+    params: number; // appId
+    returns: number; // chatId
+  };
+  "get-chat": {
+    params: number; // chatId
+    returns: Chat;
+  };
+  "get-chats": {
+    params: number | undefined; // appId (optional)
+    returns: ChatSummary[];
+  };
+  "update-chat": {
+    params: UpdateChatParams;
+    returns: void;
+  };
+  "delete-chat": {
+    params: number; // chatId
+    returns: void;
+  };
+  "delete-messages": {
+    params: number; // chatId
+    returns: void;
+  };
+
+  // Settings
+  "get-user-settings": {
+    params: void;
+    returns: UserSettings;
+  };
+  "set-user-settings": {
+    params: Partial<UserSettings>;
+    returns: UserSettings;
+  };
+
+  // Environment Variables
+  "get-app-env-vars": {
+    params: GetAppEnvVarsParams;
+    returns: EnvVar[];
+  };
+  "set-app-env-vars": {
+    params: SetAppEnvVarsParams;
+    returns: void;
+  };
+
+  // Version Control
+  "get-current-branch": {
+    params: { appId: number };
+    returns: BranchResult;
+  };
+
+  // System
+  "restart-dyad": {
+    params: void;
+    returns: void;
+  };
+  "get-app-version": {
+    params: void;
+    returns: { version: string };
+  };
+  "get-system-platform": {
+    params: void;
+    returns: string;
+  };
+
+  // File Operations
+  "read-app-file": {
+    params: { appId: number; filePath: string };
+    returns: string;
+  };
+}
+
+/**
+ * Helper types to extract params and returns from the registry
+ */
+export type IpcChannelName = keyof IpcChannelRegistry;
+
+export type IpcParams<T extends IpcChannelName> = IpcChannelRegistry[T]["params"];
+
+export type IpcReturns<T extends IpcChannelName> = IpcChannelRegistry[T]["returns"];
+
+/**
+ * Type guard to check if a channel exists in the registry
+ */
+export function isRegisteredChannel(channel: string): channel is IpcChannelName {
+  return channel in channelMetadata;
+}
+
+/**
+ * Channel metadata for runtime validation and documentation
+ * This is optional but provides additional safety and introspection
+ */
+export const channelMetadata = {
+  "create-app": {
+    description: "Create a new app",
+    group: "app",
+  },
+  "get-app": {
+    description: "Get app details by ID",
+    group: "app",
+  },
+  "list-apps": {
+    description: "List all apps",
+    group: "app",
+  },
+  "delete-app": {
+    description: "Delete an app",
+    group: "app",
+  },
+  "add-to-favorite": {
+    description: "Toggle app favorite status",
+    group: "app",
+  },
+  "search-app-files": {
+    description: "Search files within an app",
+    group: "app",
+  },
+  "create-chat": {
+    description: "Create a new chat for an app",
+    group: "chat",
+  },
+  "get-chat": {
+    description: "Get chat details by ID",
+    group: "chat",
+  },
+  "get-chats": {
+    description: "List chats for an app",
+    group: "chat",
+  },
+  "update-chat": {
+    description: "Update chat properties",
+    group: "chat",
+  },
+  "delete-chat": {
+    description: "Delete a chat",
+    group: "chat",
+  },
+  "delete-messages": {
+    description: "Delete all messages in a chat",
+    group: "chat",
+  },
+  "get-user-settings": {
+    description: "Get user settings",
+    group: "settings",
+  },
+  "set-user-settings": {
+    description: "Update user settings",
+    group: "settings",
+  },
+  "get-app-env-vars": {
+    description: "Get app environment variables",
+    group: "env",
+  },
+  "set-app-env-vars": {
+    description: "Set app environment variables",
+    group: "env",
+  },
+  "get-current-branch": {
+    description: "Get current git branch",
+    group: "version-control",
+  },
+  "restart-dyad": {
+    description: "Restart the application",
+    group: "system",
+  },
+  "get-app-version": {
+    description: "Get application version",
+    group: "system",
+  },
+  "get-system-platform": {
+    description: "Get system platform",
+    group: "system",
+  },
+  "read-app-file": {
+    description: "Read a file from an app directory",
+    group: "file",
+  },
+} as const satisfies Record<IpcChannelName, { description: string; group: string }>;


### PR DESCRIPTION
This commit introduces a new type-safe, modular IPC architecture:

## New Files:
- ipc_registry.ts: Central type registry for all IPC channels
- ipc_handler.ts: Type-safe handler creation utilities
- ipc_client_helpers.ts: Type-safe client invocation helpers
- README_IPC_REFACTOR.md: Comprehensive documentation

## Key Features:
1. Type Safety: Compile-time checking for channel names, params, and returns
2. Modularity: Centralized type definitions with distributed implementations
3. Conciseness: Reduced boilerplate with automatic logging/error handling
4. Maintainability: Single source of truth for IPC contract
5. DX: Auto-complete and refactoring support

## Refactored Examples:
- chat_handlers.ts: Fully migrated to new pattern
- app_handlers.ts: Partial migration (restart-dyad, get-app, list-apps, delete-app, add-to-favorite)
- ipc_client.ts: Migrated client methods with typedInvoke wrapper

## Migration Path:
Both old and new patterns coexist. Handlers can be migrated incrementally. See README_IPC_REFACTOR.md for detailed migration guide.

## Benefits:
- TypeScript errors for invalid channel names or params
- Automatic inference of request/response types
- No manual type annotations needed in handlers
- Centralized logging and error handling
- Easy to mock for testing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a modular, type-safe IPC architecture with centralized channel definitions and typed helpers.
> 
> - Adds `ipc_registry.ts`, `ipc_handler.ts`, and `ipc_client_helpers.ts` to define channels, register handlers with logging/error handling, and provide `typedInvoke`/mocked client utilities
> - Fully migrates `handlers/chat_handlers.ts` to the new typed handler factory
> - Partially migrates `handlers/app_handlers.ts` (e.g., `restart-dyad`, `get-app`, `list-apps`, `delete-app`, `add-to-favorite`) while keeping legacy handlers for the rest
> - Updates `ipc_client.ts` to use `typedInvoke` for several methods (`restart-dyad`, `create-app`, `get-app`, `list-apps`, chat CRUD)
> - Adds `README_IPC_REFACTOR.md` with usage, migration guidance, and testing examples
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f48db730cc5550e443b808d6bfc98e4c1b0194d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored IPC to a modular, type-safe pattern with a central registry, typed handlers, and typed client calls. This improves safety, reduces boilerplate, and enables incremental migration without breaking existing handlers.

- **New Features**
  - Added ipc_registry.ts for channel types and metadata.
  - Added ipc_handler.ts with createHandlerFactory, createIpcHandler, and createSimpleHandler.
  - Added ipc_client_helpers.ts with typedInvoke, createTypedIpcClient, and createMockIpcRenderer.
  - Documentation in README_IPC_REFACTOR.md.
  - Compile-time checks for channel names, params, and returns, with centralized logging/error handling.
  - Supports incremental migration; old and new patterns can coexist.

- **Refactors**
  - chat_handlers.ts fully migrated to the new typed handler pattern.
  - app_handlers.ts partially migrated (restart-dyad, get-app, list-apps, delete-app, add-to-favorite).
  - ipc_client.ts switched several methods to typedInvoke (restartDyad, createApp, getApp, favorites, chat read/list/create/update/delete, listApps).

<sup>Written for commit 9f48db730cc5550e443b808d6bfc98e4c1b0194d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

