### PR TITLE
Add skipPruneEdgeFunctions setting to control edge function pruning

### DIFF
--- a/src/components/SupabaseIntegration.tsx
+++ b/src/components/SupabaseIntegration.tsx
@@ -64,6 +64,17 @@ export function SupabaseIntegration() {
     }
   };
 
+  const handleSkipPruneSettingChange = async (enabled: boolean) => {
+    try {
+      await updateSettings({
+        skipPruneEdgeFunctions: enabled,
+      });
+      showSuccess("Setting updated");
+    } catch (err: any) {
+      showError(err.message || "Failed to update setting");
+    }
+  };
+
   if (!isConnected) {
     return null;
   }
@@ -142,6 +153,29 @@ export function SupabaseIntegration() {
               This helps you track database changes in version control, though
               these files aren't used for chat context, which uses the live
               schema.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-4">
+        <div className="flex items-center space-x-3">
+          <Switch
+            id="skip-prune-edge-functions"
+            checked={!!settings?.skipPruneEdgeFunctions}
+            onCheckedChange={handleSkipPruneSettingChange}
+          />
+          <div className="space-y-1">
+            <Label
+              htmlFor="skip-prune-edge-functions"
+              className="text-sm font-medium"
+            >
+              Keep extra Supabase edge functions
+            </Label>
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              When disabled, edge functions deployed to Supabase but not present
+              in your codebase will be automatically deleted during sync
+              operations (e.g., after reverting or modifying shared modules).
             </p>
           </div>
         </div>

--- a/src/ipc/handlers/app_handlers.ts
+++ b/src/ipc/handlers/app_handlers.ts
@@ -1248,10 +1248,12 @@ export function registerAppHandlers() {
           logger.info(
             `Shared module ${filePath} modified, redeploying all Supabase functions`,
           );
+          const settings = readSettings();
           const deployErrors = await deployAllSupabaseFunctions({
             appPath,
             supabaseProjectId: app.supabaseProjectId,
             supabaseOrganizationSlug: app.supabaseOrganizationSlug ?? null,
+            skipPruneEdgeFunctions: settings.skipPruneEdgeFunctions ?? false,
           });
           if (deployErrors.length > 0) {
             return {

--- a/src/ipc/handlers/version_handlers.ts
+++ b/src/ipc/handlers/version_handlers.ts
@@ -11,6 +11,7 @@ import { createTypedHandler } from "./base";
 import { versionContracts } from "../types/version";
 
 import { deployAllSupabaseFunctions } from "../../supabase_admin/supabase_utils";
+import { readSettings } from "../../main/settings";
 import {
   gitCheckout,
   gitCommit,
@@ -333,10 +334,12 @@ export function registerVersionHandlers() {
           logger.info(
             `Re-deploying all Supabase edge functions for app ${appId} after revert`,
           );
+          const settings = readSettings();
           const deployErrors = await deployAllSupabaseFunctions({
             appPath,
             supabaseProjectId: app.supabaseProjectId,
             supabaseOrganizationSlug: app.supabaseOrganizationSlug ?? null,
+            skipPruneEdgeFunctions: settings.skipPruneEdgeFunctions ?? false,
           });
 
           if (deployErrors.length > 0) {

--- a/src/ipc/processors/response_processor.ts
+++ b/src/ipc/processors/response_processor.ts
@@ -487,11 +487,13 @@ export async function processFullResponseActions(
         logger.info(
           "Shared modules changed, redeploying all Supabase functions",
         );
+        const settings = readSettings();
         const deployErrors = await deployAllSupabaseFunctions({
           appPath,
           supabaseProjectId: chatWithApp.app.supabaseProjectId,
           supabaseOrganizationSlug:
             chatWithApp.app.supabaseOrganizationSlug ?? null,
+          skipPruneEdgeFunctions: settings.skipPruneEdgeFunctions ?? false,
         });
         if (deployErrors.length > 0) {
           for (const err of deployErrors) {

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -293,6 +293,7 @@ export const UserSettingsSchema = z
     selectedTemplateId: z.string(),
     selectedThemeId: z.string().optional(),
     enableSupabaseWriteSqlMigration: z.boolean().optional(),
+    skipPruneEdgeFunctions: z.boolean().optional(),
     selectedChatMode: ChatModeSchema.optional(),
     defaultChatMode: ChatModeSchema.optional(),
     acceptedCommunityCode: z.boolean().optional(),

--- a/src/pro/main/ipc/handlers/local_agent/processors/file_operations.ts
+++ b/src/pro/main/ipc/handlers/local_agent/processors/file_operations.ts
@@ -9,6 +9,7 @@ import {
   getGitUncommittedFiles,
 } from "@/ipc/utils/git_utils";
 import { deployAllSupabaseFunctions } from "../../../../../../supabase_admin/supabase_utils";
+import { readSettings } from "../../../../../../main/settings";
 import type { AgentContext } from "../tools/types";
 
 const logger = log.scope("file_operations");
@@ -37,10 +38,12 @@ export async function deployAllFunctionsIfNeeded(
 
   try {
     logger.info("Shared modules changed, redeploying all Supabase functions");
+    const settings = readSettings();
     const deployErrors = await deployAllSupabaseFunctions({
       appPath: ctx.appPath,
       supabaseProjectId: ctx.supabaseProjectId,
       supabaseOrganizationSlug: ctx.supabaseOrganizationSlug ?? null,
+      skipPruneEdgeFunctions: settings.skipPruneEdgeFunctions ?? false,
     });
 
     if (deployErrors.length > 0) {

--- a/src/supabase_admin/supabase_management_client.ts
+++ b/src/supabase_admin/supabase_management_client.ts
@@ -627,6 +627,42 @@ export async function deleteSupabaseFunction({
   );
 }
 
+export async function listSupabaseFunctions({
+  supabaseProjectId,
+  organizationSlug,
+}: {
+  supabaseProjectId: string;
+  organizationSlug: string | null;
+}): Promise<DeployedFunctionResponse[]> {
+  if (IS_TEST_BUILD) {
+    return [];
+  }
+
+  logger.info(`Listing Supabase functions for project: ${supabaseProjectId}`);
+  const supabase = await getSupabaseClient({ organizationSlug });
+
+  const response = await fetchWithRetry(
+    `https://api.supabase.com/v1/projects/${supabaseProjectId}/functions`,
+    {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${(supabase as any).options.accessToken}`,
+      },
+    },
+    `List Supabase functions for ${supabaseProjectId}`,
+  );
+
+  if (response.status !== 200) {
+    throw await createResponseError(response, "list functions");
+  }
+
+  const functions: DeployedFunctionResponse[] = await response.json();
+  logger.info(
+    `Found ${functions.length} functions for project: ${supabaseProjectId}`,
+  );
+  return functions;
+}
+
 export async function listSupabaseBranches({
   supabaseProjectId,
   organizationSlug,

--- a/src/supabase_admin/supabase_utils.ts
+++ b/src/supabase_admin/supabase_utils.ts
@@ -79,19 +79,19 @@ export function extractFunctionNameFromPath(filePath: string): string {
  * @param appPath - The absolute path to the app directory
  * @param supabaseProjectId - The Supabase project ID
  * @param supabaseOrganizationSlug - The Supabase organization slug
- * @param skipPruneEdgeFunctions - If false (default), delete any deployed edge functions that are not in the codebase
+ * @param skipPruneEdgeFunctions - If false, delete any deployed edge functions that are not in the codebase
  * @returns An array of error messages for functions that failed to deploy (empty if all succeeded)
  */
 export async function deployAllSupabaseFunctions({
   appPath,
   supabaseProjectId,
   supabaseOrganizationSlug,
-  skipPruneEdgeFunctions = false,
+  skipPruneEdgeFunctions,
 }: {
   appPath: string;
   supabaseProjectId: string;
   supabaseOrganizationSlug: string | null;
-  skipPruneEdgeFunctions?: boolean;
+  skipPruneEdgeFunctions: boolean;
 }): Promise<string[]> {
   const functionsDir = path.join(appPath, "supabase", "functions");
 


### PR DESCRIPTION
Add a new setting "Keep extra Supabase edge functions" that controls whether dangling edge functions (deployed to Supabase but not in codebase) are automatically deleted during sync operations.

When disabled (default), edge functions are pruned during batch deployments triggered by:
- Shared module changes
- Version reverts
- Local agent file operations

Changes:
- Add skipPruneEdgeFunctions to UserSettings schema
- Add listSupabaseFunctions API method to management client
- Modify deployAllSupabaseFunctions to prune dangling functions
- Add UI toggle in SupabaseIntegration component
- Update all call sites to pass the setting

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a user setting to control whether Supabase edge functions not present in the codebase are pruned during batch deployments.
> 
> - Adds `skipPruneEdgeFunctions` to `UserSettings` and a toggle in `SupabaseIntegration`
> - Implements `listSupabaseFunctions` and updates `deployAllSupabaseFunctions` to optionally prune unmatched deployed functions (via `deleteSupabaseFunction`)
> - Threads the setting through all batch-deploy paths: shared module changes, version reverts, and local agent operations (`app_handlers.ts`, `version_handlers.ts`, `response_processor.ts`, pro `file_operations.ts`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 433f07478725c5c0770582bc551c10240e9eb21e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a setting to control pruning of extra Supabase edge functions during batch deployments. By default, dangling functions (deployed but not in code) are pruned; enable “Keep extra Supabase edge functions” to skip pruning.

- **New Features**
  - Added skipPruneEdgeFunctions to UserSettings and a toggle in SupabaseIntegration.
  - Implemented listSupabaseFunctions API and pruning in deployAllSupabaseFunctions.
  - Passed the setting through all batch deploy paths (shared module changes, version reverts, local agent file operations).

<sup>Written for commit 433f07478725c5c0770582bc551c10240e9eb21e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2228">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
