### PR TITLE
Format prettier

### DIFF
--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -665,8 +665,7 @@ ${componentSnippet}
         ) {
           const supabaseClientCode = await getSupabaseClientCode({
             projectId: updatedChat.app.supabaseProjectId,
-            organizationSlug:
-              updatedChat.app.supabaseOrganizationSlug ?? null,
+            organizationSlug: updatedChat.app.supabaseOrganizationSlug ?? null,
           });
           systemPrompt +=
             "\n\n" +


### PR DESCRIPTION
#skip-bugbot

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ran Prettier on chat_stream_handlers.ts to inline the organizationSlug option in getSupabaseClientCode for consistent formatting. No functional changes.

<sup>Written for commit 7c6a5b8cfa06d2ef197deb22b6711afc28b3b523. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

