### PR TITLE
Stop agent loop on add_integration tool call

### DIFF
--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -8,6 +8,7 @@ import {
   streamText,
   ToolSet,
   stepCountIs,
+  hasToolCall,
   ModelMessage,
   type ToolExecutionOptions,
 } from "ai";
@@ -244,7 +245,7 @@ export async function handleLocalAgentStream(
       system: systemPrompt,
       messages: messageHistory,
       tools: allTools,
-      stopWhen: stepCountIs(25), // Allow multiple tool call rounds
+      stopWhen: [stepCountIs(25), hasToolCall("add_integration")], // Allow multiple tool call rounds, stop on add_integration
       abortSignal: abortController.signal,
       // Inject pending user messages (e.g., images from web_crawl) between steps
       // We must re-inject all accumulated messages each step because the AI SDK

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -245,7 +245,7 @@ export async function handleLocalAgentStream(
       system: systemPrompt,
       messages: messageHistory,
       tools: allTools,
-      stopWhen: [stepCountIs(25), hasToolCall("add_integration")], // Allow multiple tool call rounds, stop on add_integration
+      stopWhen: [stepCountIs(25), hasToolCall(addIntegrationTool.name)], // Allow multiple tool call rounds, stop on add_integration
       abortSignal: abortController.signal,
       // Inject pending user messages (e.g., images from web_crawl) between steps
       // We must re-inject all accumulated messages each step because the AI SDK

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -56,6 +56,7 @@ import {
 import { TOOL_DEFINITIONS } from "./tool_definitions";
 import { parseAiMessagesJson } from "@/ipc/utils/ai_messages_utils";
 import { parseMcpToolKey, sanitizeMcpName } from "@/ipc/utils/mcp_tool_utils";
+import { addIntegrationTool } from "./tools/add_integration";
 
 const logger = log.scope("local_agent_handler");
 


### PR DESCRIPTION
Use the AI SDK's hasToolCall() function to stop the agent loop when the add_integration tool is invoked, allowing the user to set up the integration before the agent continues.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop the local agent loop when the add_integration tool is called, pausing the run so the user can finish setup. Adds hasToolCall('add_integration') to stopWhen and keeps the 25-step cap.

<sup>Written for commit b5826e0563b4b0925715733a86e02707f9387e45. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an early stop condition to pause the local agent when integration setup is triggered.
> 
> - Imports `hasToolCall` and `addIntegrationTool`
> - Updates `stopWhen` to `[stepCountIs(25), hasToolCall(addIntegrationTool.name)]` to halt on `add_integration` tool invocation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5826e0563b4b0925715733a86e02707f9387e45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->