### PR TITLE
Fix local_agent_handler.test.ts

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,5 +1,5 @@
 {
   "permissions": {
-    "allow": ["Bash(gh pr:*)"]
+    "allow": ["Bash(gh pr:*)", "Bash(npm test)", "Bash(npm test:*)"]
   }
 }

--- a/src/__tests__/local_agent_handler.test.ts
+++ b/src/__tests__/local_agent_handler.test.ts
@@ -210,6 +210,7 @@ let mockStreamResult: ReturnType<typeof createFakeStream> | null = null;
 vi.mock("ai", () => ({
   streamText: vi.fn(() => mockStreamResult),
   stepCountIs: vi.fn((n: number) => ({ steps: n })),
+  hasToolCall: vi.fn((toolName: string) => ({ toolName })),
 }));
 
 vi.mock("@/ipc/utils/get_model_client", () => ({


### PR DESCRIPTION
#skip-bugbot

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed failing local_agent_handler.test.ts by adding a mock for ai.hasToolCall to match the current API. Updated .claude/settings.local.json to allow Bash(npm test) and Bash(npm test:*) so tests can be run from the tool.

<sup>Written for commit 8071671c79e031a565ddb3cdccee441b93df1049. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

