### PR TITLE
Update playwright comment workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,3 +157,12 @@ jobs:
           name: html-report--attempt-${{ github.run_attempt }}
           path: playwright-report
           retention-days: 3
+
+      - name: Generate Playwright summary
+        uses: actions/github-script@v7
+        env:
+          PLAYWRIGHT_RUN_ID: ${{ github.run_id }}
+        with:
+          script: |
+            const { run } = require('./scripts/generate-playwright-summary.js');
+            await run({ github, context, core });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
             { name: "windows", image: "windows-latest" },
             { name: "macos", image: "macos-latest" },
           ]
+        # If you update this, you need to update
+        # scripts/generate-playwright-summary.js
         shard: [1, 2, 3, 4]
         shardTotal: [4]
     runs-on: ${{ matrix.os.image }}


### PR DESCRIPTION
#skip-bugbot

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automates Playwright result comments in CI to make failures easier to spot and fix. Adds missing-shard warnings, collapsible failure lists, and copy-paste snapshot update commands.

- **New Features**
  - Adds a GitHub Actions step to run scripts/generate-playwright-summary.js via github-script (uses PLAYWRIGHT_RUN_ID).
  - Detects missing macOS/Windows shards from blob reports and shows a warning in the PR comment.
  - Collapsible failure sections when there are more than 10 failures per OS.
  - Generates copy-paste npm commands to update snapshots for failed macOS tests.
  - Supports workflow_run and pull_request events; handles push events without a PR gracefully.

<sup>Written for commit ccafd00835b5390949ca18a8743c6c69a44b21d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

