### PR TITLE
Add uncommitted files banner with review & commit dialog

### DIFF
--- a/e2e-tests/uncommitted_files_banner.spec.ts
+++ b/e2e-tests/uncommitted_files_banner.spec.ts
@@ -1,0 +1,147 @@
+import { expect } from "@playwright/test";
+import { test, Timeout } from "./helpers/test_helper";
+import * as fs from "fs";
+import * as path from "path";
+
+test("should show uncommitted files banner when there are changes", async ({
+  po,
+}) => {
+  await po.setUp();
+  await po.sendPrompt("tc=basic");
+
+  // Get the app path
+  const appPath = await po.getCurrentAppPath();
+  if (!appPath) {
+    throw new Error("No app path found");
+  }
+
+  // Create a new file to simulate uncommitted changes
+  const testFilePath = path.join(appPath, "test-uncommitted.txt");
+  fs.writeFileSync(testFilePath, "This is a test file for uncommitted changes");
+
+  // Wait for the banner to appear (it polls every 5 seconds, but let's also trigger a refresh)
+  await po.page.waitForTimeout(1000);
+
+  // The banner should be visible
+  await expect(po.page.getByTestId("uncommitted-files-banner")).toBeVisible({
+    timeout: Timeout.MEDIUM,
+  });
+
+  // Verify the banner text mentions uncommitted changes
+  await expect(po.page.getByTestId("uncommitted-files-banner")).toContainText(
+    "uncommitted",
+  );
+
+  // Click the "Review & commit" button
+  await po.page.getByTestId("review-commit-button").click();
+
+  // Verify the dialog appears
+  await expect(po.page.getByTestId("commit-dialog")).toBeVisible();
+
+  // Verify the commit message input has a default value
+  const commitInput = po.page.getByTestId("commit-message-input");
+  await expect(commitInput).toBeVisible();
+  const commitMessage = await commitInput.inputValue();
+  expect(commitMessage.length).toBeGreaterThan(0);
+
+  // Verify the changed files list shows our file
+  await expect(po.page.getByTestId("changed-files-list")).toContainText(
+    "test-uncommitted.txt",
+  );
+
+  // The file should be marked as "Added"
+  await expect(po.page.getByTestId("changed-files-list")).toContainText(
+    "Added",
+  );
+
+  // Edit the commit message
+  await commitInput.clear();
+  await commitInput.fill("Add test file for E2E test");
+
+  // Click the commit button
+  await po.page.getByTestId("commit-button").click();
+
+  // Wait for success toast
+  await po.waitForToast("success");
+
+  // The dialog should close
+  await expect(po.page.getByTestId("commit-dialog")).not.toBeVisible();
+
+  // The banner should disappear after commit
+  await expect(po.page.getByTestId("uncommitted-files-banner")).not.toBeVisible(
+    {
+      timeout: Timeout.MEDIUM,
+    },
+  );
+});
+
+test("should show multiple file statuses correctly", async ({ po }) => {
+  await po.setUp();
+  await po.sendPrompt("tc=basic");
+
+  const appPath = await po.getCurrentAppPath();
+  if (!appPath) {
+    throw new Error("No app path found");
+  }
+
+  // Create a new file (added)
+  const newFilePath = path.join(appPath, "new-file.txt");
+  fs.writeFileSync(newFilePath, "New file content");
+
+  // Modify an existing file (modified)
+  const indexPath = path.join(appPath, "index.html");
+  if (fs.existsSync(indexPath)) {
+    const content = fs.readFileSync(indexPath, "utf-8");
+    fs.writeFileSync(indexPath, content + "\n<!-- Modified for test -->");
+  }
+
+  // Wait for the banner to appear
+  await po.page.waitForTimeout(1000);
+
+  await expect(po.page.getByTestId("uncommitted-files-banner")).toBeVisible({
+    timeout: Timeout.MEDIUM,
+  });
+
+  // Click review & commit
+  await po.page.getByTestId("review-commit-button").click();
+
+  // Verify the dialog shows multiple files
+  await expect(po.page.getByTestId("commit-dialog")).toBeVisible();
+  await expect(po.page.getByTestId("changed-files-list")).toContainText(
+    "new-file.txt",
+  );
+
+  // Close the dialog
+  await po.page.getByRole("button", { name: "Cancel" }).click();
+  await expect(po.page.getByTestId("commit-dialog")).not.toBeVisible();
+});
+
+test("should not show banner when there are no uncommitted changes", async ({
+  po,
+}) => {
+  await po.setUp();
+  await po.sendPrompt("tc=basic");
+
+  // Wait a bit for the query to complete
+  await po.page.waitForTimeout(2000);
+
+  // The banner should NOT be visible when there are no uncommitted changes
+  // Note: This test assumes tc=basic creates a clean git state
+  // If this fails, it may be because the test fixture has uncommitted changes
+  const banner = po.page.getByTestId("uncommitted-files-banner");
+  const isVisible = await banner.isVisible().catch(() => false);
+
+  // If there's no banner visible, the test passes
+  // If there is a banner, we need to commit first to get a clean state
+  if (isVisible) {
+    // Commit any existing changes to get a clean state
+    await po.page.getByTestId("review-commit-button").click();
+    await po.page.getByTestId("commit-button").click();
+    await po.waitForToast("success");
+
+    // Now verify the banner is gone
+    await expect(banner).not.toBeVisible({
+      timeout: Timeout.MEDIUM,
+    });
+  }
+});

--- a/e2e-tests/uncommitted_files_banner.spec.ts
+++ b/e2e-tests/uncommitted_files_banner.spec.ts
@@ -2,35 +2,48 @@ import { expect } from "@playwright/test";
 import { test, Timeout } from "./helpers/test_helper";
 import * as fs from "fs";
 import * as path from "path";
+import { execSync } from "child_process";
 
-test("should show uncommitted files banner when there are changes", async ({
-  po,
-}) => {
+test("uncommitted files banner - full commit workflow", async ({ po }) => {
   await po.setUp();
   await po.sendPrompt("tc=basic");
 
-  // Get the app path
   const appPath = await po.getCurrentAppPath();
   if (!appPath) {
     throw new Error("No app path found");
   }
 
-  // Create a new file to simulate uncommitted changes
-  const testFilePath = path.join(appPath, "test-uncommitted.txt");
-  fs.writeFileSync(testFilePath, "This is a test file for uncommitted changes");
-
-  // Wait for the banner to appear (it polls every 5 seconds, but let's also trigger a refresh)
+  // Ensure clean state - commit any existing changes first
   await po.page.waitForTimeout(1000);
+  const banner = po.page.getByTestId("uncommitted-files-banner");
+  const isInitiallyVisible = await banner.isVisible().catch(() => false);
 
-  // The banner should be visible
-  await expect(po.page.getByTestId("uncommitted-files-banner")).toBeVisible({
-    timeout: Timeout.MEDIUM,
-  });
+  if (isInitiallyVisible) {
+    await po.page.getByTestId("review-commit-button").click();
+    await po.page.getByTestId("commit-button").click();
+    await po.waitForToast("success");
+    await expect(banner).not.toBeVisible({ timeout: Timeout.MEDIUM });
+  }
+
+  // Verify banner is NOT visible when there are no uncommitted changes
+  await expect(banner).not.toBeVisible();
+
+  // Create a new file (tests "added" status)
+  const newFilePath = path.join(appPath, "new-file.txt");
+  fs.writeFileSync(newFilePath, "New file content for E2E test");
+
+  // Modify an existing file (tests "modified" status)
+  const indexPath = path.join(appPath, "index.html");
+  if (fs.existsSync(indexPath)) {
+    const content = fs.readFileSync(indexPath, "utf-8");
+    fs.writeFileSync(indexPath, content + "\n<!-- Modified for E2E test -->");
+  }
+
+  // Wait for the banner to appear
+  await expect(banner).toBeVisible({ timeout: Timeout.MEDIUM });
 
   // Verify the banner text mentions uncommitted changes
-  await expect(po.page.getByTestId("uncommitted-files-banner")).toContainText(
-    "uncommitted",
-  );
+  await expect(banner).toContainText("uncommitted");
 
   // Click the "Review & commit" button
   await po.page.getByTestId("review-commit-button").click();
@@ -41,22 +54,24 @@ test("should show uncommitted files banner when there are changes", async ({
   // Verify the commit message input has a default value
   const commitInput = po.page.getByTestId("commit-message-input");
   await expect(commitInput).toBeVisible();
-  const commitMessage = await commitInput.inputValue();
-  expect(commitMessage.length).toBeGreaterThan(0);
+  const defaultMessage = await commitInput.inputValue();
+  expect(defaultMessage.length).toBeGreaterThan(0);
 
-  // Verify the changed files list shows our file
-  await expect(po.page.getByTestId("changed-files-list")).toContainText(
-    "test-uncommitted.txt",
-  );
+  // Verify the changed files list shows our files
+  const changedFilesList = po.page.getByTestId("changed-files-list");
+  await expect(changedFilesList).toContainText("new-file.txt");
+  await expect(changedFilesList).toContainText("Added");
 
-  // The file should be marked as "Added"
-  await expect(po.page.getByTestId("changed-files-list")).toContainText(
-    "Added",
-  );
+  // Check for modified file if index.html exists
+  if (fs.existsSync(indexPath)) {
+    await expect(changedFilesList).toContainText("index.html");
+    await expect(changedFilesList).toContainText("Modified");
+  }
 
-  // Edit the commit message
+  // Edit the commit message with a unique identifier we can verify in git
+  const testCommitMessage = "E2E test commit - uncommitted files banner";
   await commitInput.clear();
-  await commitInput.fill("Add test file for E2E test");
+  await commitInput.fill(testCommitMessage);
 
   // Click the commit button
   await po.page.getByTestId("commit-button").click();
@@ -68,80 +83,22 @@ test("should show uncommitted files banner when there are changes", async ({
   await expect(po.page.getByTestId("commit-dialog")).not.toBeVisible();
 
   // The banner should disappear after commit
-  await expect(po.page.getByTestId("uncommitted-files-banner")).not.toBeVisible(
+  await expect(banner).not.toBeVisible({ timeout: Timeout.MEDIUM });
+
+  // Verify the git commit was actually made with the correct message
+  const gitLog = execSync("git log -1 --format=%s", {
+    cwd: appPath,
+    encoding: "utf-8",
+  }).trim();
+  expect(gitLog).toBe(testCommitMessage);
+
+  // Verify the files were committed
+  const lastCommitFiles = execSync(
+    "git diff-tree --no-commit-id --name-only -r HEAD",
     {
-      timeout: Timeout.MEDIUM,
+      cwd: appPath,
+      encoding: "utf-8",
     },
-  );
-});
-
-test("should show multiple file statuses correctly", async ({ po }) => {
-  await po.setUp();
-  await po.sendPrompt("tc=basic");
-
-  const appPath = await po.getCurrentAppPath();
-  if (!appPath) {
-    throw new Error("No app path found");
-  }
-
-  // Create a new file (added)
-  const newFilePath = path.join(appPath, "new-file.txt");
-  fs.writeFileSync(newFilePath, "New file content");
-
-  // Modify an existing file (modified)
-  const indexPath = path.join(appPath, "index.html");
-  if (fs.existsSync(indexPath)) {
-    const content = fs.readFileSync(indexPath, "utf-8");
-    fs.writeFileSync(indexPath, content + "\n<!-- Modified for test -->");
-  }
-
-  // Wait for the banner to appear
-  await po.page.waitForTimeout(1000);
-
-  await expect(po.page.getByTestId("uncommitted-files-banner")).toBeVisible({
-    timeout: Timeout.MEDIUM,
-  });
-
-  // Click review & commit
-  await po.page.getByTestId("review-commit-button").click();
-
-  // Verify the dialog shows multiple files
-  await expect(po.page.getByTestId("commit-dialog")).toBeVisible();
-  await expect(po.page.getByTestId("changed-files-list")).toContainText(
-    "new-file.txt",
-  );
-
-  // Close the dialog
-  await po.page.getByRole("button", { name: "Cancel" }).click();
-  await expect(po.page.getByTestId("commit-dialog")).not.toBeVisible();
-});
-
-test("should not show banner when there are no uncommitted changes", async ({
-  po,
-}) => {
-  await po.setUp();
-  await po.sendPrompt("tc=basic");
-
-  // Wait a bit for the query to complete
-  await po.page.waitForTimeout(2000);
-
-  // The banner should NOT be visible when there are no uncommitted changes
-  // Note: This test assumes tc=basic creates a clean git state
-  // If this fails, it may be because the test fixture has uncommitted changes
-  const banner = po.page.getByTestId("uncommitted-files-banner");
-  const isVisible = await banner.isVisible().catch(() => false);
-
-  // If there's no banner visible, the test passes
-  // If there is a banner, we need to commit first to get a clean state
-  if (isVisible) {
-    // Commit any existing changes to get a clean state
-    await po.page.getByTestId("review-commit-button").click();
-    await po.page.getByTestId("commit-button").click();
-    await po.waitForToast("success");
-
-    // Now verify the banner is gone
-    await expect(banner).not.toBeVisible({
-      timeout: Timeout.MEDIUM,
-    });
-  }
+  ).trim();
+  expect(lastCommitFiles).toContain("new-file.txt");
 });

--- a/e2e-tests/uncommitted_files_banner.spec.ts
+++ b/e2e-tests/uncommitted_files_banner.spec.ts
@@ -22,7 +22,6 @@ const runUncommittedFilesBannerTest = async (
   }
 
   // Ensure clean state - commit any existing changes first
-  await po.page.waitForTimeout(1000);
   const banner = po.page.getByTestId("uncommitted-files-banner");
   const isInitiallyVisible = await banner.isVisible().catch(() => false);
 

--- a/e2e-tests/uncommitted_files_banner.spec.ts
+++ b/e2e-tests/uncommitted_files_banner.spec.ts
@@ -23,14 +23,6 @@ const runUncommittedFilesBannerTest = async (
 
   // Ensure clean state - commit any existing changes first
   const banner = po.page.getByTestId("uncommitted-files-banner");
-  const isInitiallyVisible = await banner.isVisible().catch(() => false);
-
-  if (isInitiallyVisible) {
-    await po.page.getByTestId("review-commit-button").click();
-    await po.page.getByTestId("commit-button").click();
-    await po.waitForToast("success");
-    await expect(banner).not.toBeVisible({ timeout: Timeout.MEDIUM });
-  }
 
   // Verify banner is NOT visible when there are no uncommitted changes
   await expect(banner).not.toBeVisible();

--- a/e2e-tests/uncommitted_files_banner.spec.ts
+++ b/e2e-tests/uncommitted_files_banner.spec.ts
@@ -1,11 +1,19 @@
 import { expect } from "@playwright/test";
-import { test, Timeout } from "./helpers/test_helper";
+import {
+  PageObject,
+  test,
+  testSkipIfWindows,
+  Timeout,
+} from "./helpers/test_helper";
 import * as fs from "fs";
 import * as path from "path";
 import { execSync } from "child_process";
 
-test("uncommitted files banner - full commit workflow", async ({ po }) => {
-  await po.setUp();
+const runUncommittedFilesBannerTest = async (
+  po: PageObject,
+  nativeGit: boolean,
+) => {
+  await po.setUp({ disableNativeGit: !nativeGit });
   await po.sendPrompt("tc=basic");
 
   const appPath = await po.getCurrentAppPath();
@@ -101,4 +109,15 @@ test("uncommitted files banner - full commit workflow", async ({ po }) => {
     },
   ).trim();
   expect(lastCommitFiles).toContain("new-file.txt");
+};
+
+test("uncommitted files banner", async ({ po }) => {
+  await runUncommittedFilesBannerTest(po, false);
 });
+
+testSkipIfWindows(
+  "uncommitted files banner with native git",
+  async ({ po }) => {
+    await runUncommittedFilesBannerTest(po, true);
+  },
+);

--- a/src/components/chat/ChatHeader.tsx
+++ b/src/components/chat/ChatHeader.tsx
@@ -28,6 +28,7 @@ import { useCheckoutVersion } from "@/hooks/useCheckoutVersion";
 import { useRenameBranch } from "@/hooks/useRenameBranch";
 import { isAnyCheckoutVersionInProgressAtom } from "@/store/appAtoms";
 import { LoadingBar } from "../ui/LoadingBar";
+import { UncommittedFilesBanner } from "./UncommittedFilesBanner";
 
 interface ChatHeaderProps {
   isVersionPaneOpen: boolean;
@@ -176,6 +177,11 @@ export function ChatHeader({
             </Button>
           )}
         </div>
+      )}
+
+      {/* Show uncommitted files banner when on main branch and there are uncommitted changes */}
+      {!isVersionPaneOpen && branchInfo?.branch === "main" && (
+        <UncommittedFilesBanner appId={appId} />
       )}
 
       {/* Why is this pt-0.5? Because the loading bar is h-1 (it always takes space) and we want the vertical spacing to be consistent.*/}

--- a/src/components/chat/ChatHeader.tsx
+++ b/src/components/chat/ChatHeader.tsx
@@ -179,8 +179,8 @@ export function ChatHeader({
         </div>
       )}
 
-      {/* Show uncommitted files banner when on main branch and there are uncommitted changes */}
-      {!isVersionPaneOpen && branchInfo?.branch === "main" && (
+      {/* Show uncommitted files banner when on a branch and there are uncommitted changes */}
+      {!isVersionPaneOpen && branchInfo?.branch && (
         <UncommittedFilesBanner appId={appId} />
       )}
 

--- a/src/components/chat/UncommittedFilesBanner.tsx
+++ b/src/components/chat/UncommittedFilesBanner.tsx
@@ -1,0 +1,209 @@
+import { useState, useEffect } from "react";
+import { FileWarning, Plus, Pencil, Trash2, ArrowRightLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { useUncommittedFiles, type UncommittedFile } from "@/hooks/useUncommittedFiles";
+import { useCommitChanges } from "@/hooks/useCommitChanges";
+import { cn } from "@/lib/utils";
+
+interface UncommittedFilesBannerProps {
+  appId: number | null;
+}
+
+function getStatusIcon(status: UncommittedFile["status"]) {
+  switch (status) {
+    case "added":
+      return <Plus className="h-4 w-4 text-green-500" />;
+    case "modified":
+      return <Pencil className="h-4 w-4 text-yellow-500" />;
+    case "deleted":
+      return <Trash2 className="h-4 w-4 text-red-500" />;
+    case "renamed":
+      return <ArrowRightLeft className="h-4 w-4 text-blue-500" />;
+    default:
+      return null;
+  }
+}
+
+function getStatusLabel(status: UncommittedFile["status"]) {
+  switch (status) {
+    case "added":
+      return "Added";
+    case "modified":
+      return "Modified";
+    case "deleted":
+      return "Deleted";
+    case "renamed":
+      return "Renamed";
+    default:
+      return status;
+  }
+}
+
+function generateDefaultCommitMessage(files: UncommittedFile[]): string {
+  if (files.length === 0) return "";
+
+  const added = files.filter((f) => f.status === "added").length;
+  const modified = files.filter((f) => f.status === "modified").length;
+  const deleted = files.filter((f) => f.status === "deleted").length;
+  const renamed = files.filter((f) => f.status === "renamed").length;
+
+  const parts: string[] = [];
+  if (added > 0) parts.push(`add ${added} file${added > 1 ? "s" : ""}`);
+  if (modified > 0) parts.push(`update ${modified} file${modified > 1 ? "s" : ""}`);
+  if (deleted > 0) parts.push(`remove ${deleted} file${deleted > 1 ? "s" : ""}`);
+  if (renamed > 0) parts.push(`rename ${renamed} file${renamed > 1 ? "s" : ""}`);
+
+  if (parts.length === 0) return "Update files";
+
+  // Capitalize first letter
+  const message = parts.join(", ");
+  return message.charAt(0).toUpperCase() + message.slice(1);
+}
+
+export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
+  const { uncommittedFiles, hasUncommittedFiles, isLoading } = useUncommittedFiles(appId);
+  const { commitChanges, isCommitting } = useCommitChanges();
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [commitMessage, setCommitMessage] = useState("");
+
+  // Update commit message when files change or dialog opens
+  useEffect(() => {
+    if (isDialogOpen && uncommittedFiles.length > 0) {
+      setCommitMessage(generateDefaultCommitMessage(uncommittedFiles));
+    }
+  }, [isDialogOpen, uncommittedFiles]);
+
+  if (!appId || isLoading || !hasUncommittedFiles) {
+    return null;
+  }
+
+  const handleCommit = async () => {
+    if (!appId || !commitMessage.trim()) return;
+
+    await commitChanges({ appId, message: commitMessage.trim() });
+    setIsDialogOpen(false);
+    setCommitMessage("");
+  };
+
+  return (
+    <>
+      <div
+        className="flex flex-col @sm:flex-row items-center justify-between px-4 py-2 bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200"
+        data-testid="uncommitted-files-banner"
+      >
+        <div className="flex items-center gap-2 text-sm">
+          <FileWarning size={16} />
+          <span>
+            You have <strong>{uncommittedFiles.length}</strong> uncommitted{" "}
+            {uncommittedFiles.length === 1 ? "change" : "changes"}.
+          </span>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setIsDialogOpen(true)}
+          data-testid="review-commit-button"
+        >
+          Review & commit
+        </Button>
+      </div>
+
+      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+        <DialogContent className="sm:max-w-lg" data-testid="commit-dialog">
+          <DialogHeader>
+            <DialogTitle>Review & Commit Changes</DialogTitle>
+            <DialogDescription>
+              Review your changes and enter a commit message.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4">
+            <div>
+              <label
+                htmlFor="commit-message"
+                className="text-sm font-medium mb-2 block"
+              >
+                Commit message
+              </label>
+              <Input
+                id="commit-message"
+                value={commitMessage}
+                onChange={(e) => setCommitMessage(e.target.value)}
+                placeholder="Enter commit message..."
+                data-testid="commit-message-input"
+              />
+            </div>
+
+            <div>
+              <p className="text-sm font-medium mb-2">
+                Changed files ({uncommittedFiles.length})
+              </p>
+              <div
+                className="max-h-60 overflow-y-auto rounded-md border p-2 space-y-1"
+                data-testid="changed-files-list"
+              >
+                {uncommittedFiles.map((file) => (
+                  <div
+                    key={file.path}
+                    className="flex items-center gap-2 text-sm py-1 px-2 rounded hover:bg-muted"
+                  >
+                    {getStatusIcon(file.status)}
+                    <span
+                      className={cn(
+                        "flex-1 truncate font-mono text-xs",
+                        file.status === "deleted" && "line-through opacity-60"
+                      )}
+                    >
+                      {file.path}
+                    </span>
+                    <span
+                      className={cn(
+                        "text-xs px-1.5 py-0.5 rounded",
+                        file.status === "added" &&
+                          "bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300",
+                        file.status === "modified" &&
+                          "bg-yellow-100 text-yellow-700 dark:bg-yellow-900 dark:text-yellow-300",
+                        file.status === "deleted" &&
+                          "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300",
+                        file.status === "renamed" &&
+                          "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300"
+                      )}
+                    >
+                      {getStatusLabel(file.status)}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setIsDialogOpen(false)}
+              disabled={isCommitting}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleCommit}
+              disabled={!commitMessage.trim() || isCommitting}
+              data-testid="commit-button"
+            >
+              {isCommitting ? "Committing..." : "Commit"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/chat/UncommittedFilesBanner.tsx
+++ b/src/components/chat/UncommittedFilesBanner.tsx
@@ -1,5 +1,11 @@
-import { useState, useEffect } from "react";
-import { FileWarning, Plus, Pencil, Trash2, ArrowRightLeft } from "lucide-react";
+import { useState } from "react";
+import {
+  FileWarning,
+  Plus,
+  Pencil,
+  Trash2,
+  ArrowRightLeft,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -10,7 +16,10 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
-import { useUncommittedFiles, type UncommittedFile } from "@/hooks/useUncommittedFiles";
+import {
+  useUncommittedFiles,
+  type UncommittedFile,
+} from "@/hooks/useUncommittedFiles";
 import { useCommitChanges } from "@/hooks/useCommitChanges";
 import { cn } from "@/lib/utils";
 
@@ -58,9 +67,12 @@ function generateDefaultCommitMessage(files: UncommittedFile[]): string {
 
   const parts: string[] = [];
   if (added > 0) parts.push(`add ${added} file${added > 1 ? "s" : ""}`);
-  if (modified > 0) parts.push(`update ${modified} file${modified > 1 ? "s" : ""}`);
-  if (deleted > 0) parts.push(`remove ${deleted} file${deleted > 1 ? "s" : ""}`);
-  if (renamed > 0) parts.push(`rename ${renamed} file${renamed > 1 ? "s" : ""}`);
+  if (modified > 0)
+    parts.push(`update ${modified} file${modified > 1 ? "s" : ""}`);
+  if (deleted > 0)
+    parts.push(`remove ${deleted} file${deleted > 1 ? "s" : ""}`);
+  if (renamed > 0)
+    parts.push(`rename ${renamed} file${renamed > 1 ? "s" : ""}`);
 
   if (parts.length === 0) return "Update files";
 
@@ -70,21 +82,22 @@ function generateDefaultCommitMessage(files: UncommittedFile[]): string {
 }
 
 export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
-  const { uncommittedFiles, hasUncommittedFiles, isLoading } = useUncommittedFiles(appId);
+  const { uncommittedFiles, hasUncommittedFiles, isLoading } =
+    useUncommittedFiles(appId);
   const { commitChanges, isCommitting } = useCommitChanges();
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [commitMessage, setCommitMessage] = useState("");
 
-  // Update commit message when files change or dialog opens
-  useEffect(() => {
-    if (isDialogOpen && uncommittedFiles.length > 0) {
-      setCommitMessage(generateDefaultCommitMessage(uncommittedFiles));
-    }
-  }, [isDialogOpen, uncommittedFiles]);
-
   if (!appId || isLoading || !hasUncommittedFiles) {
     return null;
   }
+
+  const handleOpenDialog = () => {
+    // Set default commit message only when opening the dialog
+    // This prevents overwriting user's custom message during polling
+    setCommitMessage(generateDefaultCommitMessage(uncommittedFiles));
+    setIsDialogOpen(true);
+  };
 
   const handleCommit = async () => {
     if (!appId || !commitMessage.trim()) return;
@@ -110,7 +123,7 @@ export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
         <Button
           variant="outline"
           size="sm"
-          onClick={() => setIsDialogOpen(true)}
+          onClick={handleOpenDialog}
           data-testid="review-commit-button"
         >
           Review & commit
@@ -160,7 +173,7 @@ export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
                     <span
                       className={cn(
                         "flex-1 truncate font-mono text-xs",
-                        file.status === "deleted" && "line-through opacity-60"
+                        file.status === "deleted" && "line-through opacity-60",
                       )}
                     >
                       {file.path}
@@ -175,7 +188,7 @@ export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
                         file.status === "deleted" &&
                           "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300",
                         file.status === "renamed" &&
-                          "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300"
+                          "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300",
                       )}
                     >
                       {getStatusLabel(file.status)}

--- a/src/components/chat/UncommittedFilesBanner.tsx
+++ b/src/components/chat/UncommittedFilesBanner.tsx
@@ -130,7 +130,14 @@ export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
         </Button>
       </div>
 
-      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+      <Dialog
+        open={isDialogOpen}
+        onOpenChange={(open) => {
+          // Prevent closing while committing
+          if (!open && isCommitting) return;
+          setIsDialogOpen(open);
+        }}
+      >
         <DialogContent className="sm:max-w-lg" data-testid="commit-dialog">
           <DialogHeader>
             <DialogTitle>Review & Commit Changes</DialogTitle>

--- a/src/hooks/useCommitChanges.ts
+++ b/src/hooks/useCommitChanges.ts
@@ -14,7 +14,7 @@ export function useCommitChanges() {
       message: string;
     }) => {
       const ipcClient = IpcClient.getInstance();
-      return ipcClient.commitChanges(appId, message);
+      return ipcClient.commitChanges({ appId, message });
     },
     onSuccess: (_, { appId }) => {
       showSuccess("Changes committed successfully");

--- a/src/hooks/useCommitChanges.ts
+++ b/src/hooks/useCommitChanges.ts
@@ -1,0 +1,35 @@
+import { IpcClient } from "@/ipc/ipc_client";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { showError, showSuccess } from "@/lib/toast";
+
+export function useCommitChanges() {
+  const queryClient = useQueryClient();
+
+  const { mutateAsync: commitChanges, isPending: isCommitting } = useMutation({
+    mutationFn: async ({
+      appId,
+      message,
+    }: {
+      appId: number;
+      message: string;
+    }) => {
+      const ipcClient = IpcClient.getInstance();
+      return ipcClient.commitChanges(appId, message);
+    },
+    onSuccess: (_, { appId }) => {
+      showSuccess("Changes committed successfully");
+      // Invalidate uncommitted files query
+      queryClient.invalidateQueries({ queryKey: ["uncommittedFiles", appId] });
+      // Also invalidate versions query to update version count
+      queryClient.invalidateQueries({ queryKey: ["versions", appId] });
+    },
+    onError: (error: Error) => {
+      showError(`Failed to commit: ${error.message}`);
+    },
+  });
+
+  return {
+    commitChanges,
+    isCommitting,
+  };
+}

--- a/src/hooks/useUncommittedFiles.ts
+++ b/src/hooks/useUncommittedFiles.ts
@@ -1,0 +1,34 @@
+import { IpcClient } from "@/ipc/ipc_client";
+import { useQuery } from "@tanstack/react-query";
+
+export type UncommittedFile = {
+  path: string;
+  status: "added" | "modified" | "deleted" | "renamed";
+};
+
+export function useUncommittedFiles(appId: number | null) {
+  const {
+    data: uncommittedFiles,
+    isLoading,
+    refetch: refetchUncommittedFiles,
+  } = useQuery<UncommittedFile[], Error>({
+    queryKey: ["uncommittedFiles", appId],
+    queryFn: async (): Promise<UncommittedFile[]> => {
+      if (appId === null) {
+        throw new Error("appId is null, cannot fetch uncommitted files.");
+      }
+      const ipcClient = IpcClient.getInstance();
+      return ipcClient.getUncommittedFiles(appId);
+    },
+    enabled: appId !== null,
+    // Refetch every 5 seconds to keep the status updated
+    refetchInterval: 5000,
+  });
+
+  return {
+    uncommittedFiles: uncommittedFiles ?? [],
+    hasUncommittedFiles: (uncommittedFiles?.length ?? 0) > 0,
+    isLoading,
+    refetchUncommittedFiles,
+  };
+}

--- a/src/hooks/useUncommittedFiles.ts
+++ b/src/hooks/useUncommittedFiles.ts
@@ -1,10 +1,8 @@
 import { IpcClient } from "@/ipc/ipc_client";
 import { useQuery } from "@tanstack/react-query";
+import type { UncommittedFile } from "@/ipc/ipc_types";
 
-export type UncommittedFile = {
-  path: string;
-  status: "added" | "modified" | "deleted" | "renamed";
-};
+export type { UncommittedFile };
 
 export function useUncommittedFiles(appId: number | null) {
   const {

--- a/src/ipc/handlers/git_branch_handlers.ts
+++ b/src/ipc/handlers/git_branch_handlers.ts
@@ -32,7 +32,6 @@ import type {
   CreateGitBranchParams,
   GitBranchParams,
   RenameGitBranchParams,
-  CommitChangesParams,
 } from "../ipc_types";
 
 const logger = log.scope("git_branch_handlers");
@@ -345,8 +344,6 @@ async function handleCommitChanges(
 
     return commitHash;
   });
-}
-  return commitHash;
 }
 
 // --- Registration ---

--- a/src/ipc/handlers/git_branch_handlers.ts
+++ b/src/ipc/handlers/git_branch_handlers.ts
@@ -18,8 +18,8 @@ import {
   getGitUncommittedFilesWithStatus,
   gitAddAll,
   gitCommit,
-  type UncommittedFile,
 } from "../utils/git_utils";
+import type { UncommittedFile } from "../ipc_types";
 import { getDyadAppPath } from "../../paths/paths";
 import { db } from "../../db";
 import { apps } from "../../db/schema";

--- a/src/ipc/ipc_client.ts
+++ b/src/ipc/ipc_client.ts
@@ -95,6 +95,7 @@ import type {
   ConsoleEntry,
   SetAppThemeParams,
   GetAppThemeParams,
+  UncommittedFile,
 } from "./ipc_types";
 import type { Template } from "../shared/templates";
 import type { Theme } from "../shared/themes";
@@ -1007,12 +1008,7 @@ export class IpcClient {
     return this.ipcRenderer.invoke("github:get-git-state", { appId });
   }
 
-  public async getUncommittedFiles(appId: number): Promise<
-    Array<{
-      path: string;
-      status: "added" | "modified" | "deleted" | "renamed";
-    }>
-  > {
+  public async getUncommittedFiles(appId: number): Promise<UncommittedFile[]> {
     return this.ipcRenderer.invoke("git:get-uncommitted-files", {
       appId,
     } satisfies GitBranchAppIdParams);

--- a/src/ipc/ipc_client.ts
+++ b/src/ipc/ipc_client.ts
@@ -33,6 +33,12 @@ import type {
   ImportAppResult,
   ImportAppParams,
   RenameBranchParams,
+  GitBranchAppIdParams,
+  CreateGitBranchParams,
+  GitBranchParams,
+  RenameGitBranchParams,
+  ListRemoteGitBranchesParams,
+  CommitChangesParams,
   UserBudgetInfo,
   CopyAppParams,
   App,
@@ -896,7 +902,7 @@ export class IpcClient {
   public async abortGithubMerge(appId: number): Promise<void> {
     await this.ipcRenderer.invoke("github:merge-abort", {
       appId,
-    });
+    } satisfies GitBranchAppIdParams);
   }
 
   public async continueGithubRebase(appId: number): Promise<void> {
@@ -916,7 +922,9 @@ export class IpcClient {
   }
 
   public async fetchGithubRepo(appId: number): Promise<void> {
-    await this.ipcRenderer.invoke("github:fetch", { appId });
+    await this.ipcRenderer.invoke("github:fetch", {
+      appId,
+    } satisfies GitBranchAppIdParams);
   }
 
   public async createGithubBranch(
@@ -928,21 +936,27 @@ export class IpcClient {
       appId,
       branch,
       from,
-    });
+    } satisfies CreateGitBranchParams);
   }
 
   public async deleteGithubBranch(
     appId: number,
     branch: string,
   ): Promise<void> {
-    await this.ipcRenderer.invoke("github:delete-branch", { appId, branch });
+    await this.ipcRenderer.invoke("github:delete-branch", {
+      appId,
+      branch,
+    } satisfies GitBranchParams);
   }
 
   public async switchGithubBranch(
     appId: number,
     branch: string,
   ): Promise<void> {
-    await this.ipcRenderer.invoke("github:switch-branch", { appId, branch });
+    await this.ipcRenderer.invoke("github:switch-branch", {
+      appId,
+      branch,
+    } satisfies GitBranchParams);
   }
 
   public async renameGithubBranch(
@@ -954,11 +968,14 @@ export class IpcClient {
       appId,
       oldBranch,
       newBranch,
-    });
+    } satisfies RenameGitBranchParams);
   }
 
   public async mergeGithubBranch(appId: number, branch: string): Promise<void> {
-    await this.ipcRenderer.invoke("github:merge-branch", { appId, branch });
+    await this.ipcRenderer.invoke("github:merge-branch", {
+      appId,
+      branch,
+    } satisfies GitBranchParams);
   }
 
   public async getGithubMergeConflicts(appId: number): Promise<string[]> {
@@ -968,7 +985,9 @@ export class IpcClient {
   public async listLocalGithubBranches(
     appId: number,
   ): Promise<{ branches: string[]; current: string | null }> {
-    return this.ipcRenderer.invoke("github:list-local-branches", { appId });
+    return this.ipcRenderer.invoke("github:list-local-branches", {
+      appId,
+    } satisfies GitBranchAppIdParams);
   }
 
   public async listRemoteGithubBranches(
@@ -978,7 +997,7 @@ export class IpcClient {
     return this.ipcRenderer.invoke("github:list-remote-branches", {
       appId,
       remote,
-    });
+    } satisfies ListRemoteGitBranchesParams);
   }
 
   public async getGithubState(appId: number): Promise<{
@@ -994,14 +1013,13 @@ export class IpcClient {
       status: "added" | "modified" | "deleted" | "renamed";
     }>
   > {
-    return this.ipcRenderer.invoke("git:get-uncommitted-files", { appId });
+    return this.ipcRenderer.invoke("git:get-uncommitted-files", {
+      appId,
+    } satisfies GitBranchAppIdParams);
   }
 
-  public async commitChanges(
-    appId: number,
-    message: string,
-  ): Promise<string> {
-    return this.ipcRenderer.invoke("git:commit-changes", { appId, message });
+  public async commitChanges(params: CommitChangesParams): Promise<string> {
+    return this.ipcRenderer.invoke("git:commit-changes", params);
   }
 
   public async listCollaborators(

--- a/src/ipc/ipc_client.ts
+++ b/src/ipc/ipc_client.ts
@@ -988,6 +988,22 @@ export class IpcClient {
     return this.ipcRenderer.invoke("github:get-git-state", { appId });
   }
 
+  public async getUncommittedFiles(appId: number): Promise<
+    Array<{
+      path: string;
+      status: "added" | "modified" | "deleted" | "renamed";
+    }>
+  > {
+    return this.ipcRenderer.invoke("git:get-uncommitted-files", { appId });
+  }
+
+  public async commitChanges(
+    appId: number,
+    message: string,
+  ): Promise<string> {
+    return this.ipcRenderer.invoke("git:commit-changes", { appId, message });
+  }
+
   public async listCollaborators(
     appId: number,
   ): Promise<{ login: string; avatar_url: string; permissions: any }[]> {

--- a/src/ipc/ipc_types.ts
+++ b/src/ipc/ipc_types.ts
@@ -299,6 +299,38 @@ export interface RenameBranchParams {
   newBranchName: string;
 }
 
+// --- Git Branch Handler Types ---
+export interface GitBranchAppIdParams {
+  appId: number;
+}
+
+export interface CreateGitBranchParams {
+  appId: number;
+  branch: string;
+  from?: string;
+}
+
+export interface GitBranchParams {
+  appId: number;
+  branch: string;
+}
+
+export interface RenameGitBranchParams {
+  appId: number;
+  oldBranch: string;
+  newBranch: string;
+}
+
+export interface ListRemoteGitBranchesParams {
+  appId: number;
+  remote?: string;
+}
+
+export interface CommitChangesParams {
+  appId: number;
+  message: string;
+}
+
 export interface ChangeAppLocationParams {
   appId: number;
   parentDirectory: string;

--- a/src/ipc/ipc_types.ts
+++ b/src/ipc/ipc_types.ts
@@ -778,3 +778,15 @@ export interface SetAppThemeParams {
 export interface GetAppThemeParams {
   appId: number;
 }
+
+// --- Uncommitted Files Types ---
+export type UncommittedFileStatus =
+  | "added"
+  | "modified"
+  | "deleted"
+  | "renamed";
+
+export interface UncommittedFile {
+  path: string;
+  status: UncommittedFileStatus;
+}

--- a/src/ipc/utils/git_utils.ts
+++ b/src/ipc/utils/git_utils.ts
@@ -416,7 +416,11 @@ export async function getGitUncommittedFiles({
   }
 }
 
-export type UncommittedFileStatus = "added" | "modified" | "deleted" | "renamed";
+export type UncommittedFileStatus =
+  | "added"
+  | "modified"
+  | "deleted"
+  | "renamed";
 
 export interface UncommittedFile {
   path: string;

--- a/src/ipc/utils/git_utils.ts
+++ b/src/ipc/utils/git_utils.ts
@@ -463,11 +463,13 @@ export async function getGitUncommittedFilesWithStatus({
         }
 
         // Determine status based on status codes
+        // Check deleted first: for status code "AD" (added to index, then deleted
+        // from working directory), the file no longer exists so report as deleted
         let status: UncommittedFileStatus;
-        if (statusCode === "??" || statusCode.includes("A")) {
-          status = "added";
-        } else if (statusCode.includes("D")) {
+        if (statusCode.includes("D")) {
           status = "deleted";
+        } else if (statusCode === "??" || statusCode.includes("A")) {
+          status = "added";
         } else {
           status = "modified";
         }
@@ -488,13 +490,15 @@ export async function getGitUncommittedFilesWithStatus({
         const head = row[1];
         const workdir = row[2];
 
+        // Check workdir === 0 first: for a file added to index then deleted from
+        // working directory, the file no longer exists so report as deleted
         let status: UncommittedFileStatus;
-        if (head === 0) {
-          // File not in HEAD = new file
-          status = "added";
-        } else if (workdir === 0) {
+        if (workdir === 0) {
           // File deleted from workdir
           status = "deleted";
+        } else if (head === 0) {
+          // File not in HEAD = new file
+          status = "added";
         } else {
           status = "modified";
         }

--- a/src/ipc/utils/git_utils.ts
+++ b/src/ipc/utils/git_utils.ts
@@ -416,6 +416,90 @@ export async function getGitUncommittedFiles({
   }
 }
 
+export type UncommittedFileStatus = "added" | "modified" | "deleted" | "renamed";
+
+export interface UncommittedFile {
+  path: string;
+  status: UncommittedFileStatus;
+}
+
+/**
+ * Get uncommitted files with their status (added, modified, deleted, renamed).
+ * This parses git status --porcelain output to determine the file status.
+ */
+export async function getGitUncommittedFilesWithStatus({
+  path,
+}: GitBaseParams): Promise<UncommittedFile[]> {
+  const settings = readSettings();
+  if (settings.enableNativeGit) {
+    const result = await exec(["status", "--porcelain"], path);
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `Failed to get uncommitted files: ${result.stderr.trim() || result.stdout.trim()}`,
+      );
+    }
+    return result.stdout
+      .toString()
+      .split("\n")
+      .filter((line) => line.trim() !== "")
+      .map((line) => {
+        // Git status --porcelain format: XY filename
+        // X = staged status, Y = unstaged status
+        // Common codes: M=modified, A=added, D=deleted, R=renamed, ??=untracked
+        const statusCode = line.substring(0, 2);
+        let filePath = line.slice(3).trim();
+
+        // Handle renamed files: R  old -> new
+        if (statusCode.startsWith("R")) {
+          const arrowIndex = filePath.indexOf(" -> ");
+          if (arrowIndex !== -1) {
+            filePath = filePath.substring(arrowIndex + 4);
+          }
+          return { path: filePath, status: "renamed" as UncommittedFileStatus };
+        }
+
+        // Determine status based on status codes
+        let status: UncommittedFileStatus;
+        if (statusCode === "??" || statusCode.includes("A")) {
+          status = "added";
+        } else if (statusCode.includes("D")) {
+          status = "deleted";
+        } else {
+          status = "modified";
+        }
+
+        return { path: filePath, status };
+      });
+  } else {
+    // For isomorphic-git, we use the status matrix
+    // [filepath, HEAD, WORKDIR, STAGE]
+    // HEAD: 0=absent, 1=present
+    // WORKDIR: 0=absent, 1=identical to HEAD, 2=modified
+    // STAGE: 0=absent, 1=identical to HEAD, 2=added, 3=modified
+    const statusMatrix = await git.statusMatrix({ fs, dir: path });
+    return statusMatrix
+      .filter((row) => row[1] !== 1 || row[2] !== 1 || row[3] !== 1)
+      .map((row) => {
+        const filePath = row[0];
+        const head = row[1];
+        const workdir = row[2];
+
+        let status: UncommittedFileStatus;
+        if (head === 0) {
+          // File not in HEAD = new file
+          status = "added";
+        } else if (workdir === 0) {
+          // File deleted from workdir
+          status = "deleted";
+        } else {
+          status = "modified";
+        }
+
+        return { path: filePath, status };
+      });
+  }
+}
+
 export async function getFileAtCommit({
   path,
   filePath,

--- a/src/ipc/utils/git_utils.ts
+++ b/src/ipc/utils/git_utils.ts
@@ -8,6 +8,7 @@ import pathModule from "node:path";
 import { readSettings } from "../../main/settings";
 import log from "electron-log";
 import { normalizePath } from "../../../shared/normalizePath";
+import type { UncommittedFile, UncommittedFileStatus } from "../ipc_types";
 const logger = log.scope("git_utils");
 import type {
   GitBaseParams,
@@ -416,16 +417,8 @@ export async function getGitUncommittedFiles({
   }
 }
 
-export type UncommittedFileStatus =
-  | "added"
-  | "modified"
-  | "deleted"
-  | "renamed";
-
-export interface UncommittedFile {
-  path: string;
-  status: UncommittedFileStatus;
-}
+// Re-export from ipc_types for backwards compatibility
+export type { UncommittedFile, UncommittedFileStatus } from "../ipc_types";
 
 /**
  * Get uncommitted files with their status (added, modified, deleted, renamed).

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -80,6 +80,8 @@ const validInvokeChannels = [
   "github:delete-branch",
   "github:get-git-state",
   "github:disconnect",
+  "git:get-uncommitted-files",
+  "git:commit-changes",
   "neon:create-project",
   "neon:get-project",
   "neon:delete-branch",


### PR DESCRIPTION
- Add IPC handlers for getting uncommitted files with status and committing changes
- Create useUncommittedFiles and useCommitChanges hooks
- Add UncommittedFilesBanner component that shows when there are uncommitted changes
- Display file status (added, modified, deleted, renamed) in the review dialog
- Auto-generate sensible commit messages based on changes
- Add E2E tests for the uncommitted files banner feature

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an uncommitted files banner with a review & commit dialog in ChatHeader to make it easy to see changes and commit from the app. Shows when on a branch and streamlines committing with sensible default messages.

- **New Features**
  - Show banner in ChatHeader when on a branch and there are uncommitted changes; includes count and “Review & commit”.
  - Dialog lists changed files with status (Added/Modified/Deleted/Renamed) and generates an editable default commit message.
  - Hooks and IPC: useUncommittedFiles (polls every 5s) and useCommitChanges; git:get-uncommitted-files and git:commit-changes.
  - Commit stages all changes, blocks during merge/rebase, and invalidates queries so the banner disappears and versions refresh.
  - E2E tests cover banner visibility, review/commit flow, success toast, multiple file statuses, and native Git path.

<sup>Written for commit 5c07e58d870d8f88005b44dd9581f680625bf358. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an in-app workflow to surface and commit working directory changes.
> 
> - Add `UncommittedFilesBanner` to `ChatHeader` showing count and "Review & commit" dialog with file statuses and generated default message
> - New hooks: `useUncommittedFiles` (polls every 5s) and `useCommitChanges` (commits, shows toasts, invalidates `uncommittedFiles` and `versions`)
> - IPC: add `git:get-uncommitted-files` and `git:commit-changes` (wired in handlers, client, preload, and typed in `ipc_types`) with merge/rebase guards
> - Git utils: implement `getGitUncommittedFilesWithStatus` (native porcelain parsing + isomorphic-git matrix), `gitAddAll`, and use `gitCommit`
> - E2E: `e2e-tests/uncommitted_files_banner.spec.ts` verifies banner visibility, dialog content, commit flow, and supports native and non-native git
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c07e58d870d8f88005b44dd9581f680625bf358. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->