### PR TITLE
feat: enable read-only local agent for pro ask mode

### DIFF
--- a/e2e-tests/fixtures/engine/local-agent/ask-read-file.ts
+++ b/e2e-tests/fixtures/engine/local-agent/ask-read-file.ts
@@ -1,0 +1,21 @@
+import type { LocalAgentFixture } from "../../../../testing/fake-llm-server/localAgentTypes";
+
+export const fixture: LocalAgentFixture = {
+  description: "Read a file in ask mode (read-only)",
+  turns: [
+    {
+      text: "Let me read the file to explain its contents.",
+      toolCalls: [
+        {
+          name: "read_file",
+          args: {
+            path: "src/App.tsx",
+          },
+        },
+      ],
+    },
+    {
+      text: "This is a simple React component that renders a div with the text 'Minimal imported app'. The component is exported as the default export.",
+    },
+  ],
+};

--- a/e2e-tests/local_agent_ask.spec.ts
+++ b/e2e-tests/local_agent_ask.spec.ts
@@ -1,0 +1,22 @@
+import { testSkipIfWindows } from "./helpers/test_helper";
+
+/**
+ * E2E tests for local-agent in ask mode (read-only mode for Pro users)
+ * Tests that Pro users in ask mode get access to read-only tools
+ */
+
+testSkipIfWindows("local-agent ask mode", async ({ po }) => {
+  await po.setUpDyadPro({ localAgent: true });
+  await po.importApp("minimal");
+
+  // Select ask mode - local agent will be used in read-only mode for Pro users
+  await po.selectChatMode("ask");
+
+  // Test read-only tools work
+  await po.sendPrompt("tc=local-agent/ask-read-file");
+  await po.snapshotMessages();
+
+  // Dump request to verify only read-only tools are provided
+  await po.sendPrompt("[dump]");
+  await po.snapshotServerDump("request");
+});

--- a/e2e-tests/snapshots/local_agent_ask.spec.ts_local-agent-ask-mode-1.aria.yml
+++ b/e2e-tests/snapshots/local_agent_ask.spec.ts_local-agent-ask-mode-1.aria.yml
@@ -1,0 +1,35 @@
+- paragraph: /Generate an AI_RULES\.md file for this app\. Describe the tech stack in 5-\d+ bullet points and describe clear rules about what libraries to use for what\./
+- img
+- text: file1.txt
+- button "Edit":
+  - img
+- img
+- text: file1.txt
+- paragraph: More EOM
+- button:
+  - img
+- img
+- text: Approved
+- img
+- text: claude-opus-4-5
+- img
+- text: less than a minute ago
+- button "Request ID":
+  - img
+- paragraph: tc=local-agent/ask-read-file
+- paragraph: Let me read the file to explain its contents.
+- img
+- text: App.tsx Read src/App.tsx
+- paragraph: This is a simple React component that renders a div with the text 'Minimal imported app'. The component is exported as the default export.
+- button:
+  - img
+- img
+- text: claude-opus-4-5
+- img
+- text: less than a minute ago
+- button "Request ID":
+  - img
+- button "Undo":
+  - img
+- button "Retry":
+  - img

--- a/e2e-tests/snapshots/local_agent_ask.spec.ts_local-agent-ask-mode-1.txt
+++ b/e2e-tests/snapshots/local_agent_ask.spec.ts_local-agent-ask-mode-1.txt
@@ -1,0 +1,337 @@
+{
+  "body": {
+    "model": "anthropic/claude-opus-4-5",
+    "max_tokens": 32000,
+    "temperature": 0,
+    "messages": [
+      {
+        "role": "system",
+        "content": "[[SYSTEM_MESSAGE]]"
+      },
+      {
+        "role": "user",
+        "content": "Generate an AI_RULES.md file for this app. Describe the tech stack in 5-10 bullet points and describe clear rules about what libraries to use for what."
+      },
+      {
+        "role": "assistant",
+        "content": "\n  <dyad-write path=\"file1.txt\">\n  A file (2)\n  </dyad-write>\n  More\n  EOM"
+      },
+      {
+        "role": "user",
+        "content": "tc=local-agent/ask-read-file"
+      },
+      {
+        "role": "assistant",
+        "content": "Let me read the file to explain its contents.",
+        "tool_calls": [
+          {
+            "id": "[[TOOL_CALL_0]]",
+            "type": "function",
+            "function": {
+              "name": "read_file",
+              "arguments": "{\"path\":\"src/App.tsx\"}"
+            }
+          }
+        ]
+      },
+      {
+        "role": "tool",
+        "tool_call_id": "[[TOOL_CALL_0]]",
+        "content": "{\"type\":\"text\",\"value\":\"const App = () => <div>Minimal imported app</div>;\\n\\nexport default App;\\n\"}"
+      },
+      {
+        "role": "assistant",
+        "content": "This is a simple React component that renders a div with the text 'Minimal imported app'. The component is exported as the default export."
+      },
+      {
+        "role": "user",
+        "content": "[dump]"
+      }
+    ],
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "read_file",
+          "description": "Read the content of a file from the codebase.\n  \n- You have the capability to call multiple tools in a single response. It is always better to speculatively read multiple files as a batch that are potentially useful.",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "path": {
+                "type": "string",
+                "description": "The file path to read"
+              }
+            },
+            "required": [
+              "path"
+            ],
+            "additionalProperties": false,
+            "$schema": "http://json-schema.org/draft-07/schema#"
+          }
+        }
+      },
+      {
+        "type": "function",
+        "function": {
+          "name": "list_files",
+          "description": "List files in the application directory. By default, lists only the immediate directory contents. Use recursive=true to list all files recursively. If you are not sure, list all files by omitting the directory parameter.",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "directory": {
+                "type": "string",
+                "description": "Optional subdirectory to list"
+              },
+              "recursive": {
+                "type": "boolean",
+                "description": "Whether to list files recursively (default: false)"
+              }
+            },
+            "additionalProperties": false,
+            "$schema": "http://json-schema.org/draft-07/schema#"
+          }
+        }
+      },
+      {
+        "type": "function",
+        "function": {
+          "name": "grep",
+          "description": "Search for a regex pattern in the codebase using ripgrep.\n\n- Returns matching lines with file paths and line numbers\n- By default, the search is case-insensitive\n- Use include_pattern to filter by file type (e.g. '*.tsx')\n- Use exclude_pattern to skip certain files (e.g. '*.test.ts')",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "query": {
+                "type": "string",
+                "description": "The regex pattern to search for"
+              },
+              "include_pattern": {
+                "type": "string",
+                "description": "Glob pattern for files to include (e.g. '*.ts' for TypeScript files)"
+              },
+              "exclude_pattern": {
+                "type": "string",
+                "description": "Glob pattern for files to exclude"
+              },
+              "case_sensitive": {
+                "type": "boolean",
+                "description": "Whether the search should be case sensitive (default: false)"
+              }
+            },
+            "required": [
+              "query"
+            ],
+            "additionalProperties": false,
+            "$schema": "http://json-schema.org/draft-07/schema#"
+          }
+        }
+      },
+      {
+        "type": "function",
+        "function": {
+          "name": "code_search",
+          "description": "Search the codebase semantically to find files relevant to a query. Use this tool when you need to discover which files contain code related to a specific concept, feature, or functionality. Returns a list of file paths that are most relevant to the search query.\n\n### When to Use This Tool\n\n- Explore unfamiliar codebases\n- Ask \"how / where / what\" questions to understand behavior\n- Find code by meaning rather than exact text\n\n### When NOT to Use\n\nSkip this tool for:\n1. Exact text matches (use `grep`)\n2. Reading known files (use `read_file`)\n3. Simple symbol lookups (use `grep`)\n",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "query": {
+                "type": "string",
+                "description": "Search query to find relevant files"
+              }
+            },
+            "required": [
+              "query"
+            ],
+            "additionalProperties": false,
+            "$schema": "http://json-schema.org/draft-07/schema#"
+          }
+        }
+      },
+      {
+        "type": "function",
+        "function": {
+          "name": "set_chat_summary",
+          "description": "Set the title/summary for this chat message. You should always call this message at the end of the turn when you have finished calling all the other tools.",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "summary": {
+                "type": "string",
+                "description": "A short summary/title for the chat"
+              }
+            },
+            "required": [
+              "summary"
+            ],
+            "additionalProperties": false,
+            "$schema": "http://json-schema.org/draft-07/schema#"
+          }
+        }
+      },
+      {
+        "type": "function",
+        "function": {
+          "name": "read_logs",
+          "description": "Read logs at the moment this tool is called. Includes client logs, server logs, edge function logs, and network requests. Use this to debug errors, investigate issues, or understand app behavior. IMPORTANT: Logs are a snapshot from when you call this tool - they will NOT update while you are writing code or making changes. Use filters (searchTerm, type, level) to narrow down relevant logs on the first call.",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "all",
+                  "client",
+                  "server",
+                  "edge-function",
+                  "network-requests"
+                ],
+                "description": "Filter by log source type (default: all). Types: 'client' = browser console logs; 'server' = backend (including development server) logs and build output; 'edge-function' = edge function logs; 'network-requests' = HTTP requests and responses (outgoing calls and their responses)."
+              },
+              "level": {
+                "type": "string",
+                "enum": [
+                  "all",
+                  "info",
+                  "warn",
+                  "error"
+                ],
+                "description": "Filter by log level (default: all)"
+              },
+              "searchTerm": {
+                "type": "string",
+                "description": "Search for logs containing this text (case-insensitive)"
+              },
+              "limit": {
+                "type": "number",
+                "minimum": 1,
+                "maximum": 200,
+                "description": "Maximum number of logs to return (default: 50, max: 200)"
+              }
+            },
+            "additionalProperties": false,
+            "$schema": "http://json-schema.org/draft-07/schema#"
+          }
+        }
+      },
+      {
+        "type": "function",
+        "function": {
+          "name": "web_search",
+          "description": "\nUse this tool to access real-time information beyond your training data cutoff.\n\nWhen to Search:\n- Current API documentation, library versions, or breaking changes\n- Latest best practices, security advisories, or bug fixes\n- Specific error messages or troubleshooting solutions\n- Recent framework updates or deprecation notices\n\nQuery Tips:\n- Be specific: Include version numbers, exact error messages, or technical terms\n- Add context: \"React 19 useEffect cleanup\" not just \"React hooks\"\n\nExamples:\n\n<example>\nOpenAI GPT-5 API model names\n</example>\n\n<example>\nNextJS 14 app router middleware auth\n</example>\n",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "query": {
+                "type": "string",
+                "description": "The search query to look up on the web"
+              }
+            },
+            "required": [
+              "query"
+            ],
+            "additionalProperties": false,
+            "$schema": "http://json-schema.org/draft-07/schema#"
+          }
+        }
+      },
+      {
+        "type": "function",
+        "function": {
+          "name": "web_crawl",
+          "description": "\nYou can crawl a website so you can clone it.\n\n### When You MUST Trigger a Crawl\nTrigger a crawl ONLY if BOTH conditions are true:\n\n1. The user's message shows intent to CLONE / COPY / REPLICATE / RECREATE / DUPLICATE / MIMIC a website.\n   - Keywords include: clone, copy, replicate, recreate, duplicate, mimic, build the same, make the same.\n\n2. The user's message contains a URL or something that appears to be a domain name.\n   - e.g. \"example.com\", \"https://example.com\"\n   - Do not require 'http://' or 'https://'.\n",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "url": {
+                "type": "string",
+                "description": "URL to crawl"
+              }
+            },
+            "required": [
+              "url"
+            ],
+            "additionalProperties": false,
+            "$schema": "http://json-schema.org/draft-07/schema#"
+          }
+        }
+      },
+      {
+        "type": "function",
+        "function": {
+          "name": "update_todos",
+          "description": "\n### When to Use This Tool\n\nUse proactively for:\n1. Complex multi-step tasks (3+ distinct steps)\n2. Non-trivial tasks requiring careful planning\n3. User explicitly requests todo list\n4. User provides multiple tasks (numbered/comma-separated)\n5. After completing tasks - mark complete with merge=true and add follow-ups\n6. When starting new tasks - mark as in_progress (ideally only one at a time)\n\n### When NOT to Use\n\nSkip for:\n1. Single, straightforward tasks\n2. Trivial tasks with no organizational benefit\n3. Tasks completable in < 3 trivial steps\n4. Purely conversational/informational requests\n5. Todo items should NOT include operational actions done in service of higher-level tasks.\n\nNEVER INCLUDE THESE IN TODOS: linting; testing; searching or examining the codebase.\n\n### Examples\n\n<example>\nUser: Add dark mode toggle to settings\nAssistant:\n- *Creates todo list:*\n1. Add state management [in_progress]\n2. Implement styles\n3. Create toggle component\n4. Update components\n- [Immediately begins working on todo 1 in the same tool call batch]\n<reasoning>\nMulti-step feature with dependencies.\n</reasoning>\n</example>\n\n<example>\n// User: Implement user registration, product catalog, shopping cart, checkout flow.\nAssistant: *Creates todo list breaking down each feature into specific tasks*\n<reasoning>\nMultiple complex features provided as list requiring organized task management.\n</reasoning>\n</example>\n\n### Task States and Management\n\n1. **Task States:**\n- pending: Not yet started\n- in_progress: Currently working on\n- completed: Finished successfully\n\n2. **Task Management:**\n- Update status in real-time\n- Mark complete IMMEDIATELY after finishing\n- Only ONE task in_progress at a time\n- Complete current tasks before starting new ones\n\n3. **Task Breakdown:**\n- Create specific, actionable items\n- Break complex tasks into manageable steps\n- Use clear, descriptive names\n\n4. **Parallel Todo Writes:**\n- Prefer creating the first todo as in_progress\n- Start working on todos by using tool calls in the same tool call batch as the todo write\n- Batch todo updates with other tool calls for better latency and lower costs for the user\n",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "merge": {
+                "type": "boolean",
+                "description": "Whether to merge the todos with the existing todos. If true, the todos will be merged into the existing todos based on the id field. You can leave unchanged properties undefined. If false, the new todos will replace the existing todos."
+              },
+              "todos": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "description": "Unique identifier for the todo item"
+                    },
+                    "content": {
+                      "type": "string",
+                      "description": "The description/content of the todo item"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "pending",
+                        "in_progress",
+                        "completed"
+                      ],
+                      "description": "The current status of the todo item"
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ],
+                  "additionalProperties": false
+                },
+                "description": "Array of todo items. When merge is true, only include todos that need updates. When merge is false, this is the complete list."
+              }
+            },
+            "required": [
+              "merge",
+              "todos"
+            ],
+            "additionalProperties": false,
+            "$schema": "http://json-schema.org/draft-07/schema#"
+          }
+        }
+      },
+      {
+        "type": "function",
+        "function": {
+          "name": "run_type_checks",
+          "description": "Run TypeScript type checks on the current workspace. You can provide paths to specific files or directories, or omit the argument to get diagnostics for all files.\n\n- If a file path is provided, returns diagnostics for that file only\n- If a directory path is provided, returns diagnostics for all files within that directory\n- If no path is provided, returns diagnostics for all files in the workspace\n- This tool can return type errors that were already present before your edits, so avoid calling it with a very wide scope of files\n- NEVER call this tool on a file unless you've edited it or are about to edit it",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "paths": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Optional. An array of paths to files or directories to read type errors for. If provided, returns diagnostics for the specified files/directories only. If not provided, returns diagnostics for all files in the workspace."
+              }
+            },
+            "additionalProperties": false,
+            "$schema": "http://json-schema.org/draft-07/schema#"
+          }
+        }
+      }
+    ],
+    "tool_choice": "auto",
+    "stream": true
+  },
+  "headers": {
+    "authorization": "Bearer testdyadkey"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dyad",
-  "version": "0.33.0",
+  "version": "0.34.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dyad",
-      "version": "0.33.0",
+      "version": "0.34.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/amazon-bedrock": "^4.0.9",
@@ -451,7 +451,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1365,7 +1364,6 @@
       "integrity": "sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chalk": "^4.1.1",
         "fs-extra": "^9.0.1",
@@ -2216,6 +2214,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2232,6 +2231,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2248,6 +2248,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2264,6 +2265,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2280,6 +2282,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2296,6 +2299,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2312,6 +2316,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2328,6 +2333,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2344,6 +2350,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2360,6 +2367,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2376,6 +2384,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2392,6 +2401,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2408,6 +2418,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2424,6 +2435,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2440,6 +2452,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2456,6 +2469,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2472,6 +2486,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2488,6 +2503,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2504,6 +2520,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2520,6 +2537,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2536,6 +2554,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2552,6 +2571,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2568,6 +2588,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2584,6 +2605,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2600,6 +2622,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2616,6 +2639,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2793,6 +2817,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -2815,6 +2840,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -2837,6 +2863,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -2853,6 +2880,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -2869,6 +2897,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -2885,6 +2914,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -2901,6 +2931,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -2917,6 +2948,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -2933,6 +2965,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -2949,6 +2982,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -2965,6 +2999,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -2981,6 +3016,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3003,6 +3039,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3025,6 +3062,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3047,6 +3085,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3069,6 +3108,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3091,6 +3131,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3113,6 +3154,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3132,6 +3174,7 @@
       ],
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/runtime": "^1.4.4"
       },
@@ -3154,6 +3197,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3173,6 +3217,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3192,6 +3237,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3477,7 +3523,6 @@
       "integrity": "sha512-yl43JD/86CIj3Mz5mvvLJqAOfIup7ncxfJ0Btnl0/v5TouVUyeEdcpknfgc+yMevS/48oH9WAkkw93m7otLb/A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^3.0.1",
         "@inquirer/confirm": "^4.0.1",
@@ -4119,6 +4164,7 @@
       "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.35.0.tgz",
       "integrity": "sha512-2H393EYDnFznYCDFOW3MHiRzwEO5M/UBhtUjvTT+9kc+qhX4U3zc8ixQalo5UmZ5B2nh7L/inXdTFzvSRXtsRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@lexical/list": "0.35.0",
         "@lexical/selection": "0.35.0",
@@ -4131,6 +4177,7 @@
       "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.35.0.tgz",
       "integrity": "sha512-ko7xSIIiayvDiqjNDX6fgH9RlcM6r9vrrvJYTcfGVBor5httx16lhIi0QJZ4+RNPvGtTjyFv4bwRmsixRRwImg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@lexical/html": "0.35.0",
         "@lexical/list": "0.35.0",
@@ -4144,6 +4191,7 @@
       "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.35.0.tgz",
       "integrity": "sha512-rXGFE5S5rKsg3tVnr1s4iEgOfCApNXGpIFI3T2jGEShaCZ5HLaBY9NVBXnE9Nb49e9bkDkpZ8FZd1qokCbQXbw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@lexical/selection": "0.35.0",
         "@lexical/utils": "0.35.0",
@@ -4155,6 +4203,7 @@
       "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.35.0.tgz",
       "integrity": "sha512-owsmc8iwgExBX8sFe8fKTiwJVhYULt9hD1RZ/HwfaiEtRZZkINijqReOBnW2mJfRxBzhFSWc4NG3ISB+fHYzqw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@lexical/selection": "0.35.0",
         "@lexical/utils": "0.35.0",
@@ -4166,6 +4215,7 @@
       "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.35.0.tgz",
       "integrity": "sha512-mMtDE7Q0nycXdFTTH/+ta6EBrBwxBB4Tg8QwsGntzQ1Cq//d838dpXpFjJOqHEeVHUqXpiuj+cBG8+bvz/rPRw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lexical": "0.35.0"
       }
@@ -4175,6 +4225,7 @@
       "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.35.0.tgz",
       "integrity": "sha512-9jlTlkVideBKwsEnEkqkdg7A3mije1SvmfiqoYnkl1kKJCLA5iH90ywx327PU0p+bdnURAytWUeZPXaEuEl2OA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@lexical/clipboard": "0.35.0",
         "@lexical/utils": "0.35.0",
@@ -4185,7 +4236,8 @@
       "version": "0.35.0",
       "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.35.0.tgz",
       "integrity": "sha512-3VuV8xXhh5xJA6tzvfDvE0YBCMkIZUmxtRilJQDDdCgJCc+eut6qAv2qbN+pbqvarqcQqPN1UF+8YvsjmyOZpw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@lexical/yjs": {
       "version": "0.33.1",
@@ -4313,7 +4365,6 @@
       "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-1.0.1.tgz",
       "integrity": "sha512-O6yC5TT0jbw86VZVkmnzCZJB0hfxBl0JJz6f+3KHoZabjb/X08r9eFA+vuY06z1/qaovykvdkrXYq3SPUuvogA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "^22.15.30",
         "@types/pg": "^8.8.0"
@@ -4326,7 +4377,8 @@
       "version": "15.5.2",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.2.tgz",
       "integrity": "sha512-Qe06ew4zt12LeO6N7j8/nULSOe3fMXE4dM6xgpBQNvdzyK1sv5y4oAP3bq4LamrvGCZtmRYnW8URFCeX5nFgGg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@next/swc-darwin-arm64": {
       "version": "15.5.2",
@@ -4340,6 +4392,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -4356,6 +4409,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -4372,6 +4426,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -4388,6 +4443,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -4404,6 +4460,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -4420,6 +4477,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -4436,6 +4494,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -4452,6 +4511,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -4578,7 +4638,6 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -5028,7 +5087,6 @@
       "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.55.0"
       },
@@ -6590,6 +6648,7 @@
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
       "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -7124,7 +7183,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -7173,7 +7233,6 @@
       "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -7404,7 +7463,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.12.tgz",
       "integrity": "sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -7415,7 +7473,6 @@
       "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -7517,7 +7574,6 @@
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -7953,7 +8009,6 @@
       "integrity": "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.4",
         "fflate": "^0.8.2",
@@ -8257,7 +8312,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8477,6 +8531,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -8795,7 +8850,6 @@
       "integrity": "sha512-3yVdyZhklTiNrtg+4WqHpJpFDd+WHTg2oM7UcR80GqL05AOV0xEJzc6qNvFYoEtE+hRp1n9MpN6/+4yhlGkDXQ==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -8918,7 +8972,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -9480,7 +9533,8 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -9601,6 +9655,7 @@
       "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1",
         "color-string": "^1.9.0"
@@ -9633,6 +9688,7 @@
       "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -10212,7 +10268,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
@@ -11819,7 +11876,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -13220,7 +13276,6 @@
       "integrity": "sha512-Newg9X7mRYskoBjSw70l1YnJ/ZGbq64VPyR821H5WVkTGpHG2O0mQILxCeUhxdYERLFY9B4tUyKLyf3uMTjtKw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@petamoriken/float16": "^3.8.7",
         "debug": "^4.3.4",
@@ -13713,7 +13768,6 @@
       "integrity": "sha512-UVIHeVhxmxedbWPCfgS55Jg2rDfwf2BCKeylcPSqazLz5w3Kri7Q4xdBJubsr/+VUzFLh0VjIvh13RaDA2/Xug==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "webidl-conversions": "^7.0.0",
         "whatwg-mimetype": "^3.0.0"
@@ -14795,6 +14849,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -15098,8 +15153,7 @@
           "url": "https://github.com/sponsors/lavrton"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -15119,8 +15173,7 @@
       "version": "0.33.1",
       "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.33.1.tgz",
       "integrity": "sha512-+kiCS/GshQmCs/meMb8MQT4AMvw3S3Ef0lSCv2Xi6Itvs59OD+NjQWNfYkDteIbKtVE/w0Yiqh56VyGwIb8UcA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lexical-beautiful-mentions": {
       "version": "0.1.48",
@@ -15140,6 +15193,7 @@
       "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.114.tgz",
       "integrity": "sha512-gcxmNFzA4hv8UYi8j43uPlQ7CGcyMJ2KQb5kZASw6SnAKAf10hK12i2fjrS3Cl/ugZa5Ui6WwIu1/6MIXiHttQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -15910,6 +15964,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -17311,8 +17366,7 @@
       "version": "0.52.2",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
       "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/motion-dom": {
       "version": "12.23.12",
@@ -18462,6 +18516,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -18648,6 +18703,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -18663,6 +18719,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -18901,7 +18958,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18911,7 +18967,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -18940,7 +18995,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-konva": {
       "version": "19.2.1",
@@ -19666,7 +19722,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.50.1.tgz",
       "integrity": "sha512-78E9voJHwnXQMiQdiqswVLZwJIzdBKJ1GdI5Zx6XwoFKUIk09/sSrr+05QFzvYb8q6Y9pPV45zzDuYa3907TZA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -19855,7 +19910,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -19996,7 +20050,6 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.3.2.tgz",
       "integrity": "sha512-RbcPH1n5cfwKrru7v7+zrZvjLurgHhGyso3HTyGtRivGWgYjbOmGuivCQaORNELjNONoK35nj28EoWul9sb1zQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -20109,6 +20162,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "color": "^4.2.3",
         "detect-libc": "^2.0.4",
@@ -20501,6 +20555,7 @@
       "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "is-arrayish": "^0.3.1"
       }
@@ -20510,7 +20565,8 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/sirv": {
       "version": "3.0.2",
@@ -21149,6 +21205,7 @@
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
       "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "client-only": "0.0.1"
       },
@@ -21226,8 +21283,7 @@
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.13.tgz",
       "integrity": "sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -21882,7 +21938,6 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -22377,7 +22432,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
       "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -22909,7 +22963,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -23525,7 +23578,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -810,7 +810,14 @@ This conversation includes one or more image attachments. When the user uploads 
                 attachmentPaths,
               );
             }
-            if (settings.selectedChatMode === "local-agent") {
+            // Save aiMessagesJson for modes that use handleLocalAgentStream
+            // (which reads from DB and needs structured image content)
+            const willUseLocalAgentStream =
+              settings.selectedChatMode === "local-agent" ||
+              (settings.selectedChatMode === "ask" &&
+                isDyadProEnabled(settings) &&
+                !mentionedAppsCodebases.length);
+            if (willUseLocalAgentStream) {
               // Insert into DB (with size guard)
               const userAiMessagesJson = getAiMessagesJsonIfWithinLimit([
                 chatMessages[lastUserIndex],

--- a/src/pro/main/ipc/handlers/local_agent/tool_definitions.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tool_definitions.ts
@@ -255,15 +255,31 @@ function convertToolResultForAiSdk(
   throw new Error(`Unsupported tool result type: ${typeof result}`);
 }
 
+export interface BuildAgentToolSetOptions {
+  /**
+   * If true, exclude tools that modify state (files, database, etc.).
+   * Used for read-only modes like "ask" mode.
+   */
+  readOnly?: boolean;
+}
+
 /**
  * Build ToolSet for AI SDK from tool definitions
  */
-export function buildAgentToolSet(ctx: AgentContext) {
+export function buildAgentToolSet(
+  ctx: AgentContext,
+  options: BuildAgentToolSetOptions = {},
+) {
   const toolSet: Record<string, any> = {};
 
   for (const tool of TOOL_DEFINITIONS) {
     const consent = getAgentToolConsent(tool.name);
     if (consent === "never") {
+      continue;
+    }
+
+    // In read-only mode, skip tools that modify state
+    if (options.readOnly && tool.modifiesState) {
       continue;
     }
 

--- a/src/pro/main/ipc/handlers/local_agent/tools/add_dependency.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/add_dependency.ts
@@ -16,6 +16,7 @@ export const addDependencyTool: ToolDefinition<
   description: "Install npm packages",
   inputSchema: addDependencySchema,
   defaultConsent: "ask",
+  modifiesState: true,
 
   getConsentPreview: (args) => `Install ${args.packages.join(", ")}`,
 

--- a/src/pro/main/ipc/handlers/local_agent/tools/add_integration.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/add_integration.ts
@@ -17,6 +17,7 @@ export const addIntegrationTool: ToolDefinition<
     "Add an integration provider to the app (e.g., Supabase for auth, database, or server-side functions). Once you have called this tool, stop and do not call any more tools because you need to wait for the user to set up the integration.",
   inputSchema: addIntegrationSchema,
   defaultConsent: "always",
+  modifiesState: true,
   isEnabled: (ctx) => !ctx.supabaseProjectId,
 
   getConsentPreview: (args) => `Add ${args.provider} integration`,

--- a/src/pro/main/ipc/handlers/local_agent/tools/delete_file.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/delete_file.ts
@@ -27,6 +27,7 @@ export const deleteFileTool: ToolDefinition<z.infer<typeof deleteFileSchema>> =
     description: "Delete a file from the codebase",
     inputSchema: deleteFileSchema,
     defaultConsent: "always",
+    modifiesState: true,
 
     getConsentPreview: (args) => `Delete ${args.path}`,
 

--- a/src/pro/main/ipc/handlers/local_agent/tools/edit_file.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/edit_file.ts
@@ -134,6 +134,7 @@ export const editFileTool: ToolDefinition<z.infer<typeof editFileSchema>> = {
   description: DESCRIPTION,
   inputSchema: editFileSchema,
   defaultConsent: "always",
+  modifiesState: true,
 
   getConsentPreview: (args) => `Edit ${args.path}`,
 

--- a/src/pro/main/ipc/handlers/local_agent/tools/execute_sql.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/execute_sql.ts
@@ -15,6 +15,7 @@ export const executeSqlTool: ToolDefinition<z.infer<typeof executeSqlSchema>> =
     description: "Execute SQL on the Supabase database",
     inputSchema: executeSqlSchema,
     defaultConsent: "ask",
+    modifiesState: true,
     isEnabled: (ctx) => !!ctx.supabaseProjectId,
 
     getConsentPreview: (args) =>

--- a/src/pro/main/ipc/handlers/local_agent/tools/rename_file.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/rename_file.ts
@@ -31,6 +31,7 @@ export const renameFileTool: ToolDefinition<z.infer<typeof renameFileSchema>> =
     description: "Rename or move a file in the codebase",
     inputSchema: renameFileSchema,
     defaultConsent: "always",
+    modifiesState: true,
 
     getConsentPreview: (args) => `Rename ${args.from} to ${args.to}`,
 

--- a/src/pro/main/ipc/handlers/local_agent/tools/types.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/types.ts
@@ -123,6 +123,11 @@ export interface ToolDefinition<T = any> {
   readonly description: string;
   readonly inputSchema: z.ZodType<T>;
   readonly defaultConsent: AgentToolConsent;
+  /**
+   * If true, this tool modifies state (files, database, etc.).
+   * Used to filter out state-modifying tools in read-only mode (e.g., ask mode).
+   */
+  readonly modifiesState?: boolean;
   execute: (args: T, ctx: AgentContext) => Promise<ToolResult>;
 
   /**

--- a/src/pro/main/ipc/handlers/local_agent/tools/write_file.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/write_file.ts
@@ -27,6 +27,7 @@ export const writeFileTool: ToolDefinition<z.infer<typeof writeFileSchema>> = {
   description: "Create or completely overwrite a file in the codebase",
   inputSchema: writeFileSchema,
   defaultConsent: "always",
+  modifiesState: true,
 
   getConsentPreview: (args) => `Write to ${args.path}`,
 

--- a/src/prompts/local_agent_prompt.ts
+++ b/src/prompts/local_agent_prompt.ts
@@ -40,20 +40,6 @@ You have READ-ONLY tools at your disposal to understand the codebase. Follow the
 5. If you are not sure about file content or codebase structure pertaining to the user's request, use your tools to read files and gather the relevant information: do NOT guess or make up an answer.
 </tool_calling>
 
-<available_tools>
-You have access to the following READ-ONLY tools:
-- \`read_file\`: Read the contents of a file
-- \`list_files\`: List files in a directory
-- \`grep\`: Search for text patterns in files
-- \`code_search\`: Semantic code search for finding relevant code
-- \`read_logs\`: Read application logs to help debug issues
-- \`run_type_checks\`: Run TypeScript type checks to identify errors
-- \`web_search\`: Search the web for documentation and information
-- \`web_crawl\`: Fetch and read web pages
-- \`get_supabase_project_info\`: Get information about the connected Supabase project
-- \`get_supabase_table_schema\`: Get the schema of Supabase database tables
-</available_tools>
-
 <workflow>
 1. **Understand the question:** Think about what the user is asking and what information you need
 2. **Gather context:** Use your tools to read relevant files and understand the codebase

--- a/src/prompts/local_agent_prompt.ts
+++ b/src/prompts/local_agent_prompt.ts
@@ -3,6 +3,67 @@
  * Tool-based agent with parallel execution support
  */
 
+/**
+ * System prompt for Local Agent v2 in Ask Mode (read-only)
+ * The agent can read and analyze code, but cannot make changes
+ */
+export const LOCAL_AGENT_ASK_SYSTEM_PROMPT = `
+<role>
+You are Dyad, an AI assistant that helps users understand their web applications. You assist users by answering questions about their code, explaining concepts, and providing guidance. You can read and analyze code in the codebase to provide accurate, context-aware answers.
+You are friendly and helpful, always aiming to provide clear explanations. You take pride in giving thorough, accurate answers based on the actual code.
+</role>
+
+<important_constraints>
+**CRITICAL: You are in READ-ONLY mode.**
+- You can read files, search code, and analyze the codebase
+- You MUST NOT modify any files, create new files, or make any changes
+- You MUST NOT suggest using write_file, edit_file, delete_file, rename_file, add_dependency, or execute_sql tools
+- Focus on explaining, answering questions, and providing guidance
+- If the user asks you to make changes, politely explain that you're in Ask mode and can only provide explanations and guidance
+</important_constraints>
+
+<general_guidelines>
+- Always reply to the user in the same language they are using.
+- Use your tools to read and understand the codebase before answering questions
+- Provide clear, accurate explanations based on the actual code
+- When explaining code, reference specific files and line numbers when helpful
+- If you're not sure about something, read the relevant files to find out
+- Keep explanations clear and focused on what the user is asking about
+</general_guidelines>
+
+<tool_calling>
+You have READ-ONLY tools at your disposal to understand the codebase. Follow these rules:
+1. ALWAYS follow the tool call schema exactly as specified and make sure to provide all necessary parameters.
+2. **NEVER refer to tool names when speaking to the USER.** Instead, just say what you're doing in natural language (e.g., "Let me look at that file" instead of "I'll use read_file").
+3. Use tools proactively to gather information and provide accurate answers.
+4. You can call multiple tools in parallel for independent operations like reading multiple files at once.
+5. If you are not sure about file content or codebase structure pertaining to the user's request, use your tools to read files and gather the relevant information: do NOT guess or make up an answer.
+</tool_calling>
+
+<available_tools>
+You have access to the following READ-ONLY tools:
+- \`read_file\`: Read the contents of a file
+- \`list_files\`: List files in a directory
+- \`grep\`: Search for text patterns in files
+- \`code_search\`: Semantic code search for finding relevant code
+- \`read_logs\`: Read application logs to help debug issues
+- \`run_type_checks\`: Run TypeScript type checks to identify errors
+- \`web_search\`: Search the web for documentation and information
+- \`web_crawl\`: Fetch and read web pages
+- \`get_supabase_project_info\`: Get information about the connected Supabase project
+- \`get_supabase_table_schema\`: Get the schema of Supabase database tables
+</available_tools>
+
+<workflow>
+1. **Understand the question:** Think about what the user is asking and what information you need
+2. **Gather context:** Use your tools to read relevant files and understand the codebase
+3. **Analyze:** Think through the code and how it relates to the user's question
+4. **Explain:** Provide a clear, accurate answer based on what you found
+</workflow>
+
+[[AI_RULES]]
+`;
+
 export const LOCAL_AGENT_SYSTEM_PROMPT = `
 <role>
 You are Dyad, an AI assistant that creates and modifies web applications. You assist users by chatting with them and making changes to their code in real-time. You understand that users can see a live preview of their application in an iframe on the right side of the screen while you make code changes.
@@ -90,11 +151,14 @@ Available packages and libraries:
 export function constructLocalAgentPrompt(
   aiRules: string | undefined,
   themePrompt?: string,
+  options?: { readOnly?: boolean },
 ): string {
-  let prompt = LOCAL_AGENT_SYSTEM_PROMPT.replace(
-    "[[AI_RULES]]",
-    aiRules ?? DEFAULT_AI_RULES,
-  );
+  // Use ask mode prompt if read-only, otherwise use the regular local agent prompt
+  const basePrompt = options?.readOnly
+    ? LOCAL_AGENT_ASK_SYSTEM_PROMPT
+    : LOCAL_AGENT_SYSTEM_PROMPT;
+
+  let prompt = basePrompt.replace("[[AI_RULES]]", aiRules ?? DEFAULT_AI_RULES);
 
   // Append theme prompt if provided
   if (themePrompt) {

--- a/src/prompts/system_prompt.ts
+++ b/src/prompts/system_prompt.ts
@@ -509,14 +509,17 @@ export const constructSystemPrompt = ({
   chatMode = "build",
   enableTurboEditsV2,
   themePrompt,
+  readOnly,
 }: {
   aiRules: string | undefined;
   chatMode?: "build" | "ask" | "agent" | "local-agent";
   enableTurboEditsV2: boolean;
   themePrompt?: string;
+  /** If true, use read-only mode for local-agent (ask mode with tools) */
+  readOnly?: boolean;
 }) => {
   if (chatMode === "local-agent") {
-    return constructLocalAgentPrompt(aiRules, themePrompt);
+    return constructLocalAgentPrompt(aiRules, themePrompt, { readOnly });
   }
 
   let systemPrompt = getSystemPromptForChatMode({


### PR DESCRIPTION
For pro users, ask mode now uses the local agent handler in read-only mode, giving them access to code reading tools (read_file, list_files, grep, code_search, etc.) while preventing any state modifications.

Changes:
- Add `modifiesState` property to ToolDefinition interface
- Mark state-modifying tools (write_file, edit_file, delete_file, rename_file, add_dependency, execute_sql, add_integration)
- Add `readOnly` option to buildAgentToolSet to filter out state-modifying tools
- Add `readOnly` option to handleLocalAgentStream to skip commits/ deploys and exclude MCP tools in read-only mode
- Create LOCAL_AGENT_ASK_SYSTEM_PROMPT for read-only agent mode
- Route pro ask mode users to local agent with readOnly: true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables read-only local-agent behavior for Pro users in `ask` mode, providing code-inspection tools without allowing modifications.
> 
> - Route `ask` → local-agent with `readOnly: true` (when Pro and no mentioned apps); persist `aiMessagesJson` for these modes
> - Add `modifiesState` to `ToolDefinition`; mark state-changing tools and filter them in `buildAgentToolSet({ readOnly })`; exclude MCP tools in read-only
> - Update `handleLocalAgentStream` to support `readOnly`: skip commits/deploys and return `updatedFiles: false`
> - Introduce `LOCAL_AGENT_ASK_SYSTEM_PROMPT` and plumb `readOnly` through `constructSystemPrompt`/`constructLocalAgentPrompt`
> - E2E: new ask-mode tests/fixtures and snapshot updates; add deterministic normalization of tool_call IDs in test helper
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a67cbc1ccad35bf1fad9277bfce14a8999e763ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pro ask mode now uses the local agent in read-only mode, letting users read and search code without changing anything. Commits, deploys, and state-modifying tools are disabled.

- **New Features**
  - Route Pro ask mode to the local agent with readOnly: true when no other apps/codebases are mentioned.
  - Tools declare modifiesState; write/edit/delete/rename/add_dependency/execute_sql/add_integration are marked and excluded in read-only mode.
  - buildAgentToolSet and handleLocalAgentStream support readOnly to filter tools, skip MCP tools, and avoid commits/deploys (updatedFiles: false).
  - Added LOCAL_AGENT_ASK_SYSTEM_PROMPT and prompt wiring to support read-only behavior.

<sup>Written for commit a67cbc1ccad35bf1fad9277bfce14a8999e763ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

