### PR TITLE
Add React.js upgrade app upgrade using react2shell

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,7 +142,7 @@ npm run build
 To run e2e tests without opening the HTML report (which blocks the terminal), use:
 
 ```sh
-PLAYWRIGHT_HTML_OPEN=never npm run e2e
+npm run pre:e2e
 ```
 
 To get additional debug logs when a test is failing, use:

--- a/e2e-tests/fixtures/import-app/react-upgrade/.gitignore
+++ b/e2e-tests/fixtures/import-app/react-upgrade/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/e2e-tests/fixtures/import-app/react-upgrade/index.html
+++ b/e2e-tests/fixtures/import-app/react-upgrade/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>dyad-generated-app</title>
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/e2e-tests/fixtures/import-app/react-upgrade/package.json
+++ b/e2e-tests/fixtures/import-app/react-upgrade/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "vite_react_shadcn_ts",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "build:dev": "vite build --mode development",
+    "lint": "eslint .",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.5.5",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react-swc": "^3.9.0",
+    "typescript": "^5.5.3",
+    "vite": "^6.3.4"
+  }
+}

--- a/e2e-tests/fixtures/import-app/react-upgrade/src/App.tsx
+++ b/e2e-tests/fixtures/import-app/react-upgrade/src/App.tsx
@@ -1,0 +1,3 @@
+const App = () => <div>Minimal imported app</div>;
+
+export default App;

--- a/e2e-tests/fixtures/import-app/react-upgrade/src/main.tsx
+++ b/e2e-tests/fixtures/import-app/react-upgrade/src/main.tsx
@@ -1,0 +1,4 @@
+import { createRoot } from "react-dom/client";
+import App from "./App.tsx";
+
+createRoot(document.getElementById("root")!).render(<App />);

--- a/e2e-tests/fixtures/import-app/react-upgrade/src/vite-env.d.ts
+++ b/e2e-tests/fixtures/import-app/react-upgrade/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/e2e-tests/fixtures/import-app/react-upgrade/tsconfig.app.json
+++ b/e2e-tests/fixtures/import-app/react-upgrade/tsconfig.app.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "strict": false,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitAny": false,
+    "noFallthroughCasesInSwitch": false,
+
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/e2e-tests/fixtures/import-app/react-upgrade/tsconfig.json
+++ b/e2e-tests/fixtures/import-app/react-upgrade/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "noImplicitAny": false,
+    "noUnusedParameters": false,
+    "skipLibCheck": true,
+    "allowJs": true,
+    "noUnusedLocals": false,
+    "strictNullChecks": false
+  }
+}

--- a/e2e-tests/fixtures/import-app/react-upgrade/tsconfig.node.json
+++ b/e2e-tests/fixtures/import-app/react-upgrade/tsconfig.node.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/e2e-tests/fixtures/import-app/react-upgrade/vite.config.ts
+++ b/e2e-tests/fixtures/import-app/react-upgrade/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react-swc";
+import path from "path";
+
+export default defineConfig(() => ({
+  server: {
+    host: "::",
+    port: 8080,
+  },
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+}));

--- a/e2e-tests/react_upgrade.spec.ts
+++ b/e2e-tests/react_upgrade.spec.ts
@@ -25,8 +25,7 @@ testSkipIfWindows(
       timeout: Timeout.MEDIUM,
     });
 
-    // Wait for upgrade to complete (button becomes enabled again or hidden)
-    // Note: The actual upgrade may not work in test environment due to external tool dependencies
-    await po.page.waitForTimeout(5000);
+    // Verify the upgrade completes and button becomes hidden
+    await po.expectAppUpgradeButtonIsNotVisible({ upgradeId: "react-upgrade" });
   },
 );

--- a/e2e-tests/react_upgrade.spec.ts
+++ b/e2e-tests/react_upgrade.spec.ts
@@ -1,0 +1,32 @@
+import { expect } from "@playwright/test";
+import { testSkipIfWindows, Timeout } from "./helpers/test_helper";
+
+testSkipIfWindows(
+  "react upgrade button shown for older react version",
+  async ({ po }) => {
+    await po.setUp();
+    await po.importApp("react-upgrade");
+    await po.getTitleBarAppNameButton().click();
+
+    // Verify the React upgrade button is visible for an app with React 18.2.0
+    await expect(
+      po.locateAppUpgradeButton({ upgradeId: "react-upgrade" }),
+    ).toBeVisible({
+      timeout: Timeout.MEDIUM,
+    });
+
+    // Click the upgrade button
+    await po.clickAppUpgradeButton({ upgradeId: "react-upgrade" });
+
+    // Verify the button becomes disabled during upgrade
+    await expect(
+      po.locateAppUpgradeButton({ upgradeId: "react-upgrade" }),
+    ).toBeDisabled({
+      timeout: Timeout.MEDIUM,
+    });
+
+    // Wait for upgrade to complete (button becomes enabled again or hidden)
+    // Note: The actual upgrade may not work in test environment due to external tool dependencies
+    await po.page.waitForTimeout(5000);
+  },
+);

--- a/src/ipc/handlers/app_upgrade_handlers.ts
+++ b/src/ipc/handlers/app_upgrade_handlers.ts
@@ -100,11 +100,15 @@ function isCapacitorUpgradeNeeded(appPath: string): boolean {
   return true;
 }
 
-async function getLatestReactVersion(majorVersion: number): Promise<string | null> {
+async function getLatestReactVersion(
+  majorVersion: number,
+): Promise<string | null> {
   try {
     const response = await fetch("https://registry.npmjs.org/react");
     if (!response.ok) {
-      logger.error(`Failed to fetch React versions from NPM: ${response.status}`);
+      logger.error(
+        `Failed to fetch React versions from NPM: ${response.status}`,
+      );
       return null;
     }
     const data = await response.json();
@@ -346,7 +350,7 @@ async function applyCapacitor({
 async function applyReactUpgrade(appPath: string) {
   // Run react2shell to upgrade React
   await simpleSpawn({
-    command: "npx react2shell",
+    command: "npx fix-react2shell-next",
     cwd: appPath,
     successMessage: "React upgrade completed successfully",
     errorPrefix: "Failed to upgrade React",
@@ -387,7 +391,7 @@ export function registerAppUpgradeHandlers() {
             isNeeded = await isReactUpgradeNeeded(appPath);
           }
           return { ...upgrade, isNeeded };
-        })
+        }),
       );
 
       return upgradesWithStatus;


### PR DESCRIPTION
Add a new app upgrade option that allows users to upgrade their React apps to the latest version using react2shell. The upgrade is offered to Vite apps that have React version below 19.

#skip-bugbot

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an app upgrade to update React using fix-react2shell-next for Vite apps on React 18 or 19 when they’re not on the latest patch for that major. This keeps React apps current with minimal effort.

- **New Features**
  - Detects Vite apps and reads React version from package.json.
  - Checks NPM for the latest React 18/19 and only offers the upgrade when you’re behind.
  - Runs npx fix-react2shell-next to perform the upgrade and auto-commits changes.

<sup>Written for commit cb30e6a769a67ef53ec0eff6fe1b5b7801b6849f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2261">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
