### PR TITLE
Upgrade oxlint and enable recommended rules

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -2,26 +2,11 @@
   "$schema": "./node_modules/oxlint/configuration_schema.json",
   "ignorePatterns": ["e2e-tests/fixtures/**/*"],
   "categories": {
-    "correctness": "warn",
-    "suspicious": "warn",
-    "perf": "warn"
+    "correctness": "warn"
   },
   "rules": {
     "eslint/no-unused-vars": "error",
     "eslint/no-empty-pattern": "off",
-    "eslint/sort-keys": "off",
-    "eslint/sort-imports": "off",
-    "eslint/no-ternary": "off",
-    "eslint/capitalized-comments": "off",
-    "eslint/func-style": "off",
-    "eslint/no-magic-numbers": "off",
-    "eslint/max-statements": "off",
-    "eslint/id-length": "off",
-    "eslint/arrow-body-style": "off",
-    "eslint/no-nested-ternary": "off",
-    "typescript-eslint/consistent-type-definitions": "off",
-    "typescript-eslint/consistent-type-imports": "off",
-    "eslint-plugin-unicorn/filename-case": "off",
-    "eslint-plugin-unicorn/no-nested-ternary": "off"
+    "eslint/no-control-regex": "off"
   }
 }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,7 +1,27 @@
 {
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
   "ignorePatterns": ["e2e-tests/fixtures/**/*"],
+  "categories": {
+    "correctness": "warn",
+    "suspicious": "warn",
+    "perf": "warn"
+  },
   "rules": {
     "eslint/no-unused-vars": "error",
-    "eslint/no-empty-pattern": "off"
+    "eslint/no-empty-pattern": "off",
+    "eslint/sort-keys": "off",
+    "eslint/sort-imports": "off",
+    "eslint/no-ternary": "off",
+    "eslint/capitalized-comments": "off",
+    "eslint/func-style": "off",
+    "eslint/no-magic-numbers": "off",
+    "eslint/max-statements": "off",
+    "eslint/id-length": "off",
+    "eslint/arrow-body-style": "off",
+    "eslint/no-nested-ternary": "off",
+    "typescript-eslint/consistent-type-definitions": "off",
+    "typescript-eslint/consistent-type-imports": "off",
+    "eslint-plugin-unicorn/filename-case": "off",
+    "eslint-plugin-unicorn/no-nested-ternary": "off"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -137,7 +137,7 @@
         "happy-dom": "^17.4.4",
         "husky": "^9.1.7",
         "lint-staged": "^15.5.2",
-        "oxlint": "^1.8.0",
+        "oxlint": "^1.41.0",
         "prettier": "3.5.3",
         "rimraf": "^6.0.1",
         "typescript": "^5.8.3",
@@ -4954,9 +4954,9 @@
       }
     },
     "node_modules/@oxlint/darwin-arm64": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-1.14.0.tgz",
-      "integrity": "sha512-rcTw0QWeOc6IeVp+Up7WtcwdS9l4j7TOq4tihF0Ud/fl+VUVdvDCPuZ9QTnLXJhwMXiyQRWdxRyI6XBwf80ncQ==",
+      "version": "1.41.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-1.41.0.tgz",
+      "integrity": "sha512-K0Bs0cNW11oWdSrKmrollKF44HMM2HKr4QidZQHMlhJcSX8pozxv0V5FLdqB4sddzCY0J9Wuuw+oRAfR8sdRwA==",
       "cpu": [
         "arm64"
       ],
@@ -4968,9 +4968,9 @@
       ]
     },
     "node_modules/@oxlint/darwin-x64": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-1.14.0.tgz",
-      "integrity": "sha512-TWFSEmyl2/DN4HoXNwQl0y/y3EXFJDctfv5MiDtVOV1GJKX80cGSIxMxXb08Q3CCWqteqEijmfSMo5TG8X1H/A==",
+      "version": "1.41.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-1.41.0.tgz",
+      "integrity": "sha512-1LCCXCe9nN8LbrJ1QOGari2HqnxrZrveYKysWDIg8gFsQglIg00XF/8lRbA0kWHMdLgt4X0wfNYhhFz+c3XXLQ==",
       "cpu": [
         "x64"
       ],
@@ -4982,9 +4982,9 @@
       ]
     },
     "node_modules/@oxlint/linux-arm64-gnu": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-1.14.0.tgz",
-      "integrity": "sha512-N1FqdKfwhVWPpMElv8qlGqdEefTbDYaRVhdGWOjs/2f7FESa5vX0cvA7ToqzkoXyXZI5DqByWiPML33njK30Kg==",
+      "version": "1.41.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-1.41.0.tgz",
+      "integrity": "sha512-Fow7H84Bs8XxuaK1yfSEWBC8HI7rfEQB9eR2A0J61un1WgCas7jNrt1HbT6+p6KmUH2bhR+r/RDu/6JFAvvj4g==",
       "cpu": [
         "arm64"
       ],
@@ -4996,9 +4996,9 @@
       ]
     },
     "node_modules/@oxlint/linux-arm64-musl": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-1.14.0.tgz",
-      "integrity": "sha512-v/BPuiateLBb7Gz1STb69EWjkgKdlPQ1NM56z+QQur21ly2hiMkBX2n0zEhqfu9PQVRUizu6AlsYuzcPY/zsIQ==",
+      "version": "1.41.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-1.41.0.tgz",
+      "integrity": "sha512-WoRRDNwgP5W3rjRh42Zdx8ferYnqpKoYCv2QQLenmdrLjRGYwAd52uywfkcS45mKEWHeY1RPwPkYCSROXiGb2w==",
       "cpu": [
         "arm64"
       ],
@@ -5010,9 +5010,9 @@
       ]
     },
     "node_modules/@oxlint/linux-x64-gnu": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-1.14.0.tgz",
-      "integrity": "sha512-gUTp8KIrSYt97dn+tRRC3LKnH4xlHKCwrPwiDcGmLbCxojuN9/H5mnIhPKEfwNuZNdoKGS/ABuq3neVyvRCRtQ==",
+      "version": "1.41.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-1.41.0.tgz",
+      "integrity": "sha512-75k3CKj3fOc/a/2aSgO81s3HsTZOFROthPJ+UI2Oatic1LhvH6eKjKfx3jDDyVpzeDS2qekPlc/y3N33iZz5Og==",
       "cpu": [
         "x64"
       ],
@@ -5024,9 +5024,9 @@
       ]
     },
     "node_modules/@oxlint/linux-x64-musl": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-1.14.0.tgz",
-      "integrity": "sha512-DpN6cW2HPjYXeENG0JBbmubO8LtfKt6qJqEMBw9gUevbyBaX+k+Jn7sYgh6S23wGOkzmTNphBsf/7ulj4nIVYA==",
+      "version": "1.41.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-1.41.0.tgz",
+      "integrity": "sha512-8r82eBwGPoAPn67ZvdxTlX/Z3gVb+ZtN6nbkyFzwwHWAh8yGutX+VBcVkyrePSl6XgBP4QAaddPnHmkvJjqY0g==",
       "cpu": [
         "x64"
       ],
@@ -5038,9 +5038,9 @@
       ]
     },
     "node_modules/@oxlint/win32-arm64": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-1.14.0.tgz",
-      "integrity": "sha512-oXxJksnUTUMgJ0NvjKS1mrCXAy1ttPgIVacRSlxQ+1XHy+aJDMM7I8fsCtoKoEcTIpPaD98eqUqlLYs0H2MGjA==",
+      "version": "1.41.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-1.41.0.tgz",
+      "integrity": "sha512-aK+DAcckQsNCOXKruatyYuY/ROjNiRejQB1PeJtkZwM21+8rV9ODYbvKNvt0pW+YCws7svftBSFMCpl3ke2unw==",
       "cpu": [
         "arm64"
       ],
@@ -5052,9 +5052,9 @@
       ]
     },
     "node_modules/@oxlint/win32-x64": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-1.14.0.tgz",
-      "integrity": "sha512-iRYy2rhTQKFztyx0jtNMRBnFpzsRwFdjWQ7sKKzJpmbijA3Tw3DCqlGT7QRgoVRF0+X/ccNGvvsrgMohPVfLeQ==",
+      "version": "1.41.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-1.41.0.tgz",
+      "integrity": "sha512-dVBXkZ6MGLd3owV7jvuqJsZwiF3qw7kEkDVsYVpS/O96eEvlHcxVbaPjJjrTBgikXqyC22vg3dxBU7MW0utGfw==",
       "cpu": [
         "x64"
       ],
@@ -18052,33 +18052,32 @@
       }
     },
     "node_modules/oxlint": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.14.0.tgz",
-      "integrity": "sha512-oo0nq3zF9hmgATGc9esoMahLuEESOodUxEDeHDA2K7tbYcSfcmReE9G2QNppnq9rOSQHLTwlMtzGAjjttYaufQ==",
+      "version": "1.41.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.41.0.tgz",
+      "integrity": "sha512-Dyaoup82uhgAgp5xLNt4dPdvl5eSJTIzqzL7DcKbkooUE4PDViWURIPlSUF8hu5a+sCnNIp/LlQMDsKoyaLTBA==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "oxc_language_server": "bin/oxc_language_server",
         "oxlint": "bin/oxlint"
       },
       "engines": {
-        "node": ">=8.*"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/darwin-arm64": "1.14.0",
-        "@oxlint/darwin-x64": "1.14.0",
-        "@oxlint/linux-arm64-gnu": "1.14.0",
-        "@oxlint/linux-arm64-musl": "1.14.0",
-        "@oxlint/linux-x64-gnu": "1.14.0",
-        "@oxlint/linux-x64-musl": "1.14.0",
-        "@oxlint/win32-arm64": "1.14.0",
-        "@oxlint/win32-x64": "1.14.0"
+        "@oxlint/darwin-arm64": "1.41.0",
+        "@oxlint/darwin-x64": "1.41.0",
+        "@oxlint/linux-arm64-gnu": "1.41.0",
+        "@oxlint/linux-arm64-musl": "1.41.0",
+        "@oxlint/linux-x64-gnu": "1.41.0",
+        "@oxlint/linux-x64-musl": "1.41.0",
+        "@oxlint/win32-arm64": "1.41.0",
+        "@oxlint/win32-x64": "1.41.0"
       },
       "peerDependencies": {
-        "oxlint-tsgolint": ">=0.1.5"
+        "oxlint-tsgolint": ">=0.11.1"
       },
       "peerDependenciesMeta": {
         "oxlint-tsgolint": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "happy-dom": "^17.4.4",
     "husky": "^9.1.7",
     "lint-staged": "^15.5.2",
-    "oxlint": "^1.8.0",
+    "oxlint": "^1.41.0",
     "prettier": "3.5.3",
     "rimraf": "^6.0.1",
     "typescript": "^5.8.3",


### PR DESCRIPTION
- Upgrade oxlint from v1.8.0 to v1.41.0
- Enable correctness, suspicious, and perf categories for better code quality checks
- Disable overly pedantic style rules (sort-keys, sort-imports, no-ternary, etc.)
- Add JSON schema reference for IDE support

#skip-bugbot

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade oxlint to v1.41.0 and enable only the correctness rule category to catch real issues while keeping suspicious and perf off. Added a JSON schema reference in .oxlintrc for IDE support.

- **Dependencies**
  - Bump oxlint to ^1.41.0.
  - oxlint now requires Node ^20.19.0 or >=22.12.0.

- **Migration**
  - Update CI and local Node to meet the new requirement.
  - Run lint; expect new warnings from correctness rules.

<sup>Written for commit f182e37e55dfa51ab2b97225f899a7cf1a4d6f46. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

