### PR TITLE
Update E2E snapshots for HTML escaping fix

### DIFF
--- a/e2e-tests/snapshots/local_agent_grep.spec.ts_local-agent---grep-search-2.aria.yml
+++ b/e2e-tests/snapshots/local_agent_grep.spec.ts_local-agent---grep-search-2.aria.yml
@@ -5,4 +5,4 @@
 - button "Copy":
   - img
 - text: log
-- code: "src/main.tsx:1: import { createRoot } from \"react-dom/client\"; src/main.tsx:4: createRoot(document.getElementById(\"root\")!).render(&lt;App /&gt;);"
+- code: "src/main.tsx:1: import { createRoot } from \"react-dom/client\"; src/main.tsx:4: createRoot(document.getElementById(\"root\")!).render(<App />);"

--- a/e2e-tests/snapshots/local_agent_grep.spec.ts_local-agent---grep-search-3.aria.yml
+++ b/e2e-tests/snapshots/local_agent_grep.spec.ts_local-agent---grep-search-3.aria.yml
@@ -5,4 +5,4 @@
 - button "Copy":
   - img
 - text: log
-- code: "src/main.tsx:2: import App from \"./App.tsx\"; src/main.tsx:4: createRoot(document.getElementById(\"root\")!).render(&lt;App /&gt;); src/App.tsx:1: const App = () =&gt; &lt;div&gt;Minimal imported app&lt;/div&gt;; src/App.tsx:3: export default App;"
+- code: "src/main.tsx:2: import App from \"./App.tsx\"; src/main.tsx:4: createRoot(document.getElementById(\"root\")!).render(<App />); src/App.tsx:1: const App = () => <div>Minimal imported app</div>; src/App.tsx:3: export default App;"

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -67,7 +67,7 @@ import { cleanFullResponse } from "../utils/cleanFullResponse";
 import { generateProblemReport } from "../processors/tsc";
 import { createProblemFixPrompt } from "@/shared/problem_prompt";
 import { AsyncVirtualFileSystem } from "../../../shared/VirtualFilesystem";
-import { escapeXmlAttr } from "../../../shared/xmlEscape";
+import { escapeXmlAttr, escapeXmlContent } from "../../../shared/xmlEscape";
 import {
   getDyadAddDependencyTags,
   getDyadWriteTags,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated E2E snapshots to match the HTML escaping fix so tests align with the new rendering. Snapshots now expect raw JSX/HTML characters in grep results instead of escaped entities, and a missing escapeXmlContent import was added to chat_stream_handlers.

<sup>Written for commit 0e1be9ad5d5cf0300cc1cf5bd361b1fd44f61ad7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns tests with updated HTML/JSX escaping behavior and completes XML escaping utilities in the chat handler.
> 
> - Updates `local_agent_grep` snapshots to expect raw JSX (e.g., `<App />`) rather than escaped entities in grep results
> - Adds `escapeXmlContent` import alongside `escapeXmlAttr` in `chat_stream_handlers.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e1be9ad5d5cf0300cc1cf5bd361b1fd44f61ad7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->