### PR TITLE
Allow #skip-bb as shorthand for #skip-bugbot

### DIFF
--- a/.github/workflows/bugbot-trigger.yml
+++ b/.github/workflows/bugbot-trigger.yml
@@ -12,7 +12,8 @@ jobs:
       (github.event.pull_request.user.login == 'wwwillchen' ||
       github.event.pull_request.user.login == 'azizmejri1' ||
       github.event.pull_request.user.login == 'princeaden1') &&
-      !contains(github.event.pull_request.body, '#skip-bugbot')
+      !contains(github.event.pull_request.body, '#skip-bugbot') &&
+      !contains(github.event.pull_request.body, '#skip-bb')
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
Add support for using #skip-bb in PR descriptions to skip BugBot reviews, in addition to the existing #skip-bugbot tag.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow #skip-bb as shorthand for #skip-bugbot in PR descriptions to skip BugBot reviews. Updates the BugBot GitHub Action to check for both tags before running.

<sup>Written for commit 73c922c234e8c983895a0b0a460105d0ebab77ce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

