### PR TITLE
Update Claude settings and AGENTS.md

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,5 +1,12 @@
 {
   "permissions": {
-    "allow": ["Bash(gh pr:*)", "Bash(npm test)", "Bash(npm test:*)"]
+    "allow": [
+      "Edit",
+      "Write",
+      "Bash(npm run:*)",
+      "Bash(npm install:*)",
+      "Bash(git:*)",
+      "Bash(gh:*)"
+    ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,7 +6,9 @@
       "Bash(npm run:*)",
       "Bash(npm install:*)",
       "Bash(git:*)",
-      "Bash(gh:*)"
+      "Bash(gh pr:*)",
+      "Bash(gh issue:*)",
+      "Bash(gh repo view:*)"
     ]
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,3 +82,12 @@ When pushing changes and creating PRs:
 1. If the branch already has an associated PR, push to whichever remote the branch is tracking.
 2. If the branch hasn't been pushed before, default to pushing to `origin` (the fork `wwwillchen/dyad`), then create a PR from the fork to the upstream repo (`dyad-sh/dyad`).
 3. If you cannot push to the fork due to permissions, push directly to `upstream` (`dyad-sh/dyad`) as a last resort.
+
+### Skipping automated review
+
+Add `#skip-bugbot` to the PR description for trivial PRs that won't affect end-users, such as:
+
+- Claude settings, commands, or agent configuration
+- Linting or test setup changes
+- Documentation-only changes
+- CI/build configuration updates


### PR DESCRIPTION
## Summary
- Update local Claude permissions with common allow patterns
- Add #skip-bugbot guidance to AGENTS.md for trivial PRs

#skip-bugbot

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expanded local Claude permissions to include Edit/Write and common npm, git, and gh commands to support standard local workflows. Updated AGENTS.md with guidance to add #skip-bugbot for trivial, non-user-facing changes to avoid noisy automated reviews.

<sup>Written for commit 4f9a6fa93a292e3e680bca38aee16ada71876ea0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

