### PR TITLE
Support component tagger for Next.js with Turbopack

### DIFF
--- a/packages/@dyad-sh/nextjs-webpack-component-tagger/README.md
+++ b/packages/@dyad-sh/nextjs-webpack-component-tagger/README.md
@@ -1,6 +1,8 @@
 # @dyad-sh/nextjs-webpack-component-tagger
 
-A webpack loader for Next.js that automatically adds `data-dyad-id` and `data-dyad-name` attributes to your React components. This is useful for identifying components in the DOM, for example for testing or analytics.
+A loader for Next.js that automatically adds `data-dyad-id` and `data-dyad-name` attributes to your React components. This is useful for identifying components in the DOM, for example for testing or analytics.
+
+This loader works with both **webpack** (default) and **Turbopack** (`next dev --turbo`).
 
 ## Installation
 
@@ -14,7 +16,34 @@ pnpm add @dyad-sh/nextjs-webpack-component-tagger
 
 ## Usage
 
-Add the loader to your `next.config.js` file:
+### With Turbopack (Recommended)
+
+If you're using Turbopack (`next dev --turbo`), add the loader to the `turbopack.rules` configuration in your `next.config.ts` file:
+
+```ts
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  turbopack: {
+    rules: {
+      "*.tsx": {
+        loaders: ["@dyad-sh/nextjs-webpack-component-tagger"],
+        as: "*.tsx",
+      },
+      "*.jsx": {
+        loaders: ["@dyad-sh/nextjs-webpack-component-tagger"],
+        as: "*.jsx",
+      },
+    },
+  },
+};
+
+export default nextConfig;
+```
+
+### With Webpack
+
+If you're using webpack (the default bundler), add the loader to your `next.config.ts` file:
 
 ```ts
 import type { NextConfig } from "next";
@@ -35,6 +64,46 @@ const nextConfig: NextConfig = {
 
 export default nextConfig;
 ```
+
+### Supporting Both Webpack and Turbopack
+
+If you want your app to work with both bundlers, you can include both configurations:
+
+```ts
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  // Turbopack configuration (for next dev --turbo)
+  turbopack: {
+    rules: {
+      "*.tsx": {
+        loaders: ["@dyad-sh/nextjs-webpack-component-tagger"],
+        as: "*.tsx",
+      },
+      "*.jsx": {
+        loaders: ["@dyad-sh/nextjs-webpack-component-tagger"],
+        as: "*.jsx",
+      },
+    },
+  },
+  // Webpack configuration (for next dev without --turbo)
+  webpack: (config) => {
+    if (process.env.NODE_ENV === "development") {
+      config.module.rules.push({
+        test: /\.(jsx|tsx)$/,
+        exclude: /node_modules/,
+        enforce: "pre",
+        use: "@dyad-sh/nextjs-webpack-component-tagger",
+      });
+    }
+    return config;
+  },
+};
+
+export default nextConfig;
+```
+
+## How It Works
 
 The loader will automatically add `data-dyad-id` and `data-dyad-name` to all your React components.
 


### PR DESCRIPTION
- Update nextjs-webpack-component-tagger README with Turbopack configuration instructions
- Add Next.js app detection and component tagger upgrade support in app_upgrade_handlers.ts
- The upgrade now automatically adds turbopack.rules config for Next.js apps

Fixes #2265

#skip-bugbot

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Turbopack support for the Next.js component tagger and auto-configure it during app upgrades. This enables component attributes in Next.js apps using next dev --turbo with minimal setup.

- **New Features**
  - Detects Next.js apps and adds turbopack.rules for .tsx/.jsx to use @dyad-sh/nextjs-webpack-component-tagger.
  - Installs the correct tagger package during upgrade.
  - Updates README with Turbopack and Webpack setup, plus a dual-bundler example.

- **Migration**
  - If next.config already defines turbopack.rules, the upgrade will not modify them. Add the loader rules manually: https://dyad.sh/docs/upgrades/select-component

<sup>Written for commit 841b70181576bde94d160b1b6c4721d92e0d3856. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

