### PR TITLE
Fix Vercel Live URL not updating after new deployments

### DIFF
--- a/src/components/VercelConnector.tsx
+++ b/src/components/VercelConnector.tsx
@@ -63,6 +63,8 @@ function ConnectedVercelConnector({
     try {
       const minLoadingTime = new Promise((resolve) => setTimeout(resolve, 750));
       await Promise.all([getDeployments(), minLoadingTime]);
+      // Refresh app data to get the updated deployment URL
+      refreshApp();
     } finally {
       setIsRefreshing(false);
     }

--- a/src/ipc/handlers/vercel_handlers.ts
+++ b/src/ipc/handlers/vercel_handlers.ts
@@ -464,7 +464,7 @@ async function handleGetVercelDeployments(
     // Get deployments for the project
     const deploymentsResponse = await vercel.deployments.getDeployments({
       projectId: app.vercelProjectId,
-      limit: 3, // Get last 3 deployments
+      limit: 5, // Get last 5 deployments
     });
 
     if (!deploymentsResponse.deployments) {


### PR DESCRIPTION
## Summary
- Updates the Vercel deployment URL when refreshing deployments to show the most recent READY production deployment
- Previously, the Live URL was only set once during project creation or connection and never updated
- Now when users click "Refresh Deployments", the Live URL will update to reflect the latest production deployment

Fixes #2208

## Test plan
- [ ] Connect an app to a Vercel project
- [ ] Verify the Live URL is shown correctly
- [ ] Push a new deployment to Vercel
- [ ] Click "Refresh Deployments" in Dyad
- [ ] Verify the Live URL updates to reflect the new deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the app’s Vercel Live URL stays current after refreshing deployments.
> 
> - In `vercel_handlers.ts`, when fetching deployments, finds the most recent `READY` production deployment and updates `apps.vercelDeploymentUrl` if it changed (with logging)
> - In `VercelConnector.tsx`, after `getDeployments()` completes, calls `refreshApp()` so the updated Live URL is shown in the UI
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f2cccc87b91a3653b70d008b7f208a9aebd7af6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures the Vercel Live URL updates to the latest READY production deployment when users refresh deployments, fixing the stale URL issue. Fixes #2208.

- **Bug Fixes**
  - Call refreshApp() after getDeployments in VercelConnector to refresh the Live URL.
  - In IPC handler, detect the most recent READY production deployment and update vercelDeploymentUrl in the DB only when it changes.

<sup>Written for commit 586994c14a9dede577b8786f3c52b5664d7ac1e2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

