### PR TITLE
Update command for TypeScript type checks

### DIFF
--- a/.claude/commands/pr-fix.md
+++ b/.claude/commands/pr-fix.md
@@ -58,7 +58,7 @@ Address review comments and failing checks on a GitHub Pull Request.
 7. **After making all changes, verify the fixes:**
 
    - Run relevant linters: `npm run lint:fix`
-   - Run type checks if TypeScript files were modified: `npm run typecheck`
+   - Run type checks if TypeScript files were modified: `npm run ts`
    - Run any relevant unit tests for modified code
 
 8. **Review all changes made:**


### PR DESCRIPTION
#skip-bugbot

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the PR fix guide to use the correct TypeScript type check command: npm run ts. Aligns with current package scripts and prevents confusion from the old npm run typecheck reference.

<sup>Written for commit 2beee8e7af6983b8e65a0b5d83f8fc852f03c2eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

