### PR TITLE
Hide uncommitted files banner during streaming

### DIFF
--- a/src/components/chat/ChatHeader.tsx
+++ b/src/components/chat/ChatHeader.tsx
@@ -180,7 +180,8 @@ export function ChatHeader({
       )}
 
       {/* Show uncommitted files banner when on a branch and there are uncommitted changes */}
-      {!isVersionPaneOpen && branchInfo?.branch && (
+      {/* Hide while streaming to avoid distracting the user */}
+      {!isVersionPaneOpen && branchInfo?.branch && !isStreaming && (
         <UncommittedFilesBanner appId={appId} />
       )}
 


### PR DESCRIPTION
This avoids distracting the user during active chat responses.

https://claude.ai/code/session_018bxH7uX9t4TH4wxh9VE7Ka

#skip-bugbot

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the uncommitted files banner while chat is streaming to reduce distraction. Adds an isStreaming check in ChatHeader so the banner only appears when not streaming.

<sup>Written for commit 4bd7b9fe48f94414e83ae9e4600b4cf898535c1b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

