### PR TITLE
Fix summarize to new chat in local-agent mode

### DIFF
--- a/e2e-tests/local_agent_summarize.spec.ts
+++ b/e2e-tests/local_agent_summarize.spec.ts
@@ -1,0 +1,42 @@
+import { testSkipIfWindows } from "./helpers/test_helper";
+import { expect } from "@playwright/test";
+
+/**
+ * E2E test for summarization in local-agent mode
+ * Tests that summarize to new chat works correctly when using Agent v2
+ * Regression test for #2292
+ *
+ * This test directly triggers summarization by sending the "Summarize from chat-id=X"
+ * prompt, which is the same mechanism used by the "Summarize into new chat" button.
+ */
+testSkipIfWindows(
+  "local-agent - summarize to new chat works",
+  async ({ po }) => {
+    await po.setUpDyadPro({ localAgent: true });
+    await po.importApp("minimal");
+    await po.selectLocalAgentMode();
+
+    // First, send a message to create a chat with some content
+    // This simulates a chat with technical discussion
+    await po.sendPrompt("tc=local-agent/read-then-edit");
+
+    // Get the current chat URL to extract the chat ID
+    const url = po.page.url();
+    const chatIdMatch = url.match(/[?&]id=(\d+)/);
+    expect(chatIdMatch).toBeTruthy();
+    const originalChatId = chatIdMatch![1];
+
+    // Create a new chat by clicking the "New Chat" button
+    await po.clickNewChat();
+
+    // Now trigger summarization by sending the summarize prompt
+    // This is the same mechanism used by the "Summarize into new chat" button
+    await po.sendPrompt(`Summarize from chat-id=${originalChatId}`);
+
+    // Snapshot the messages in the new chat
+    // This verifies that the summarization actually ran and produced content
+    // (Before the fix, this would fail with "no technical discussion" error
+    // because the local agent handler wasn't receiving the formatted chat content)
+    await po.snapshotMessages();
+  },
+);

--- a/e2e-tests/snapshots/local_agent_summarize.spec.ts_local-agent---summarize-to-new-chat-works-1.aria.yml
+++ b/e2e-tests/snapshots/local_agent_summarize.spec.ts_local-agent---summarize-to-new-chat-works-1.aria.yml
@@ -1,0 +1,20 @@
+- paragraph: Summarize from chat-id=1
+- img
+- text: file1.txt
+- button "Edit":
+  - img
+- img
+- text: file1.txt
+- paragraph: More EOM
+- button:
+  - img
+- img
+- text: claude-opus-4-5
+- img
+- text: less than a minute ago
+- button "Request ID":
+  - img
+- button "Undo":
+  - img
+- button "Retry":
+  - img

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -1020,6 +1020,12 @@ This conversation includes one or more image attachments. When the user uploads 
 
           await handleLocalAgentStream(event, req, abortController, {
             placeholderMessageId: placeholderAssistantMessage.id,
+            // Note: this is using the read-only system prompt rather than the
+            // regular system prompt which gets overrides for special intents
+            // like summarize chat, security review, etc.
+            //
+            // This is OK because those intents should always happen in a new chat
+            // and new chats will default to non-ask modes.
             systemPrompt: readOnlySystemPrompt,
             dyadRequestId: dyadRequestId ?? "[no-request-id]",
             readOnly: true,

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -1023,6 +1023,7 @@ This conversation includes one or more image attachments. When the user uploads 
             systemPrompt: readOnlySystemPrompt,
             dyadRequestId: dyadRequestId ?? "[no-request-id]",
             readOnly: true,
+            messageOverride: isSummarizeIntent ? chatMessages : undefined,
           });
           return;
         }
@@ -1038,6 +1039,7 @@ This conversation includes one or more image attachments. When the user uploads 
             placeholderMessageId: placeholderAssistantMessage.id,
             systemPrompt,
             dyadRequestId: dyadRequestId ?? "[no-request-id]",
+            messageOverride: isSummarizeIntent ? chatMessages : undefined,
           });
           return;
         }


### PR DESCRIPTION
## Summary
- Fixed chat summarization failing in local-agent mode with "no technical discussion" error
- Added `messageOverride` parameter to `handleLocalAgentStream` to pass transformed messages
- When summarize intent is detected, the formatted chat content is now correctly passed to the local agent handler instead of relying on database messages

Fixes #2292

## Test plan
- [ ] In local-agent mode, trigger "Summarize to new chat" from a chat with technical content
- [ ] Verify the summarization completes successfully instead of showing "no technical discussion" error
- [ ] Verify normal chat functionality in local-agent mode is not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes "Summarize to new chat" failing in local-agent mode by passing the formatted chat content to the local agent instead of reading DB history, addressing #2292. Prevents the "no technical discussion" error while keeping normal chat behavior unchanged.

- **Bug Fixes**
  - Added messageOverride to handleLocalAgentStream to use transformed messages.
  - chat_stream_handlers passes chatMessages on summarize intent; otherwise uses DB-derived history.
  - Added Playwright E2E test to verify summarize-to-new-chat works in local-agent mode.

<sup>Written for commit c88a646b22127a655b8e96f77956e3cbd01f4a45. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores summarize-to-new-chat functionality in local-agent by ensuring the agent receives the properly formatted prior chat content.
> 
> - `handleLocalAgentStream` now accepts `messageOverride` and uses it over DB history when provided
> - `chat_stream_handlers` detects summarize intent and passes formatted `chatMessages` via `messageOverride` (both ask/read-only and local-agent modes); uses read-only system prompt for ask mode
> - Adds Playwright E2E test `local_agent_summarize.spec.ts` with snapshot to validate summarization works in local-agent mode
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c88a646b22127a655b8e96f77956e3cbd01f4a45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->