### PR TITLE
Add sync apps from folder feature (#2264)

### DIFF
--- a/e2e-tests/fixtures/sync-app/untracked-app/package.json
+++ b/e2e-tests/fixtures/sync-app/untracked-app/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "untracked-app",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "echo 'Hello World'"
+  }
+}

--- a/e2e-tests/sync_apps_from_folder.spec.ts
+++ b/e2e-tests/sync_apps_from_folder.spec.ts
@@ -1,0 +1,80 @@
+import path from "path";
+import fs from "fs";
+import { testWithConfig } from "./helpers/test_helper";
+import { expect } from "@playwright/test";
+
+const test = testWithConfig({
+  preLaunchHook: async ({ userDataDir }) => {
+    // Create the dyad-apps directory with an untracked app
+    const dyadAppsDir = path.join(userDataDir, "dyad-apps");
+    const untrackedAppDir = path.join(dyadAppsDir, "untracked-test-app");
+    fs.mkdirSync(untrackedAppDir, { recursive: true });
+
+    // Copy the fixture package.json
+    const fixtureDir = path.join(
+      __dirname,
+      "fixtures",
+      "sync-app",
+      "untracked-app",
+    );
+    fs.copyFileSync(
+      path.join(fixtureDir, "package.json"),
+      path.join(untrackedAppDir, "package.json"),
+    );
+  },
+});
+
+test("sync apps from folder - imports untracked app", async ({ po }) => {
+  await po.setUp();
+
+  // Navigate to Settings
+  await po.goToSettingsTab();
+
+  // Scroll to the Restore section and click Sync Apps
+  await po.page
+    .getByRole("heading", { name: "Restore" })
+    .scrollIntoViewIfNeeded();
+  await po.page.getByRole("button", { name: "Sync Apps" }).click();
+
+  // Confirm the sync dialog
+  await po.page.getByRole("button", { name: "Sync Apps" }).last().click();
+
+  // Wait for success toast
+  await po.waitForToastWithText("Successfully synced 1 app");
+
+  // Navigate to Apps tab and verify the app appears
+  await po.goToAppsTab();
+
+  // Check that the synced app is visible in the app list
+  await expect(
+    po.getAppListItem({ appName: "untracked-test-app" }),
+  ).toBeVisible();
+});
+
+test("sync apps from folder - no new apps message", async ({ po }) => {
+  await po.setUp();
+
+  // Navigate to Settings
+  await po.goToSettingsTab();
+
+  // Scroll to the Restore section and click Sync Apps
+  await po.page
+    .getByRole("heading", { name: "Restore" })
+    .scrollIntoViewIfNeeded();
+  await po.page.getByRole("button", { name: "Sync Apps" }).click();
+
+  // Confirm the sync dialog
+  await po.page.getByRole("button", { name: "Sync Apps" }).last().click();
+
+  // Wait for success toast showing the app was synced
+  await po.waitForToastWithText("Successfully synced 1 app");
+
+  // Click sync again - this time no new apps should be found
+  await po.page.getByRole("button", { name: "Sync Apps" }).click();
+
+  // Confirm the sync dialog
+  await po.page.getByRole("button", { name: "Sync Apps" }).last().click();
+
+  // Should show "no new apps" message
+  await po.waitForToastWithText("No new apps found to sync");
+});

--- a/src/components/settings/RestoreSettings.tsx
+++ b/src/components/settings/RestoreSettings.tsx
@@ -1,0 +1,80 @@
+import { useState } from "react";
+import { IpcClient } from "@/ipc/ipc_client";
+import { showSuccess, showError, showInfo } from "@/lib/toast";
+import ConfirmationDialog from "@/components/ConfirmationDialog";
+import { Loader2 } from "lucide-react";
+import { useQueryClient } from "@tanstack/react-query";
+
+export function RestoreSettings() {
+  const [isSyncDialogOpen, setIsSyncDialogOpen] = useState(false);
+  const [isSyncing, setIsSyncing] = useState(false);
+  const queryClient = useQueryClient();
+
+  const handleSyncApps = async () => {
+    setIsSyncing(true);
+    setIsSyncDialogOpen(false);
+    try {
+      const ipcClient = IpcClient.getInstance();
+      const result = await ipcClient.syncAppsFromFolder();
+
+      if (result.imported.length === 0 && result.errors.length === 0) {
+        showInfo("No new apps found to sync.");
+      } else if (result.imported.length > 0) {
+        showSuccess(
+          `Successfully synced ${result.imported.length} app${result.imported.length === 1 ? "" : "s"}: ${result.imported.join(", ")}`,
+        );
+        // Invalidate the apps list query to refresh the UI
+        queryClient.invalidateQueries({ queryKey: ["apps"] });
+      }
+
+      if (result.errors.length > 0) {
+        const errorMessages = result.errors
+          .map((e) => `${e.folder}: ${e.error}`)
+          .join("; ");
+        showError(`Failed to sync some apps: ${errorMessages}`);
+      }
+    } catch (error) {
+      console.error("Error syncing apps:", error);
+      showError(
+        error instanceof Error ? error.message : "An unknown error occurred",
+      );
+    } finally {
+      setIsSyncing(false);
+    }
+  };
+
+  return (
+    <>
+      <div className="flex items-start justify-between flex-col sm:flex-row sm:items-center gap-4">
+        <div>
+          <h3 className="text-sm font-medium text-gray-900 dark:text-white">
+            Sync Apps from Folder
+          </h3>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+            Import apps from the dyad-apps folder that are not tracked in the
+            database. Useful after database resets or migrations.
+          </p>
+        </div>
+        <button
+          onClick={() => setIsSyncDialogOpen(true)}
+          disabled={isSyncing}
+          className="rounded-md border border-transparent bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+        >
+          {isSyncing && <Loader2 className="h-4 w-4 animate-spin" />}
+          {isSyncing ? "Syncing..." : "Sync Apps"}
+        </button>
+      </div>
+
+      <ConfirmationDialog
+        isOpen={isSyncDialogOpen}
+        title="Sync Apps from Folder"
+        message="This will scan your dyad-apps folder and import any apps that exist on disk but are not tracked in the database. Existing apps will not be affected."
+        confirmText="Sync Apps"
+        cancelText="Cancel"
+        confirmButtonClass="bg-blue-600 hover:bg-blue-700 focus:ring-blue-500"
+        onConfirm={handleSyncApps}
+        onCancel={() => setIsSyncDialogOpen(false)}
+      />
+    </>
+  );
+}

--- a/src/ipc/handlers/restore_handlers.ts
+++ b/src/ipc/handlers/restore_handlers.ts
@@ -1,0 +1,120 @@
+import fs from "fs/promises";
+import path from "path";
+import { createLoggedHandler } from "./safe_handle";
+import log from "electron-log";
+import { getDyadAppsBaseDirectory, getDyadAppPath } from "../../paths/paths";
+import { apps, chats } from "@/db/schema";
+import { db } from "@/db";
+import { SyncAppsFromFolderResult } from "../ipc_types";
+import { gitCommit, gitAdd, gitInit } from "../utils/git_utils";
+
+const logger = log.scope("restore-handlers");
+const handle = createLoggedHandler(logger);
+
+export function registerRestoreHandlers() {
+  handle(
+    "sync-apps-from-folder",
+    async (): Promise<SyncAppsFromFolderResult> => {
+      const result: SyncAppsFromFolderResult = {
+        imported: [],
+        skipped: [],
+        errors: [],
+      };
+
+      const dyadAppsDir = getDyadAppsBaseDirectory();
+
+      // Check if dyad-apps directory exists
+      try {
+        await fs.access(dyadAppsDir);
+      } catch {
+        // Directory doesn't exist, return empty result
+        logger.info(
+          `dyad-apps directory does not exist at ${dyadAppsDir}, nothing to sync`,
+        );
+        return result;
+      }
+
+      // Get all subdirectories in dyad-apps
+      const entries = await fs.readdir(dyadAppsDir, { withFileTypes: true });
+      const folders = entries.filter((entry) => entry.isDirectory());
+
+      // Get all existing apps from database
+      const existingApps = await db.query.apps.findMany();
+      const existingPaths = new Set(
+        existingApps.map((app) => getDyadAppPath(app.path)),
+      );
+
+      for (const folder of folders) {
+        const folderPath = path.join(dyadAppsDir, folder.name);
+
+        try {
+          // Check if this folder is already tracked in the database
+          if (existingPaths.has(folderPath)) {
+            result.skipped.push(folder.name);
+            logger.debug(
+              `Skipping ${folder.name}: already tracked in database`,
+            );
+            continue;
+          }
+
+          // Check if the folder has a package.json (valid app)
+          const packageJsonPath = path.join(folderPath, "package.json");
+          try {
+            await fs.access(packageJsonPath);
+          } catch {
+            result.skipped.push(folder.name);
+            logger.debug(
+              `Skipping ${folder.name}: no package.json found (not a valid app)`,
+            );
+            continue;
+          }
+
+          // Initialize git if needed
+          const isGitRepo = await fs
+            .access(path.join(folderPath, ".git"))
+            .then(() => true)
+            .catch(() => false);
+
+          if (!isGitRepo) {
+            await gitInit({ path: folderPath, ref: "main" });
+            await gitAdd({ path: folderPath, filepath: "." });
+            await gitCommit({
+              path: folderPath,
+              message: "Init Dyad app",
+            });
+          }
+
+          // Create database entry for the app
+          const [app] = await db
+            .insert(apps)
+            .values({
+              name: folder.name,
+              path: folder.name, // Store relative path
+            })
+            .returning();
+
+          // Create an initial chat for this app
+          await db.insert(chats).values({
+            appId: app.id,
+          });
+
+          result.imported.push(folder.name);
+          logger.info(`Imported app: ${folder.name}`);
+        } catch (error: any) {
+          result.errors.push({
+            folder: folder.name,
+            error: error.message || "Unknown error",
+          });
+          logger.error(`Error importing ${folder.name}: ${error.message}`);
+        }
+      }
+
+      logger.info(
+        `Sync complete: ${result.imported.length} imported, ${result.skipped.length} skipped, ${result.errors.length} errors`,
+      );
+      return result;
+    },
+  );
+
+  logger.debug("Registered restore IPC handlers");
+}

--- a/src/ipc/ipc_client.ts
+++ b/src/ipc/ipc_client.ts
@@ -105,6 +105,7 @@ import type {
   SaveThemeImageResult,
   CleanupThemeImagesParams,
   UncommittedFile,
+  SyncAppsFromFolderResult,
 } from "./ipc_types";
 import type { Template } from "../shared/templates";
 import type { Theme } from "../shared/themes";
@@ -1796,6 +1797,11 @@ export class IpcClient {
     params: AnalyseComponentParams,
   ): Promise<{ isDynamic: boolean; hasStaticText: boolean }> {
     return this.ipcRenderer.invoke("analyze-component", params);
+  }
+
+  // --- Restore ---
+  public async syncAppsFromFolder(): Promise<SyncAppsFromFolderResult> {
+    return this.ipcRenderer.invoke("sync-apps-from-folder");
   }
 
   // --- Console Logs ---

--- a/src/ipc/ipc_host.ts
+++ b/src/ipc/ipc_host.ts
@@ -36,6 +36,7 @@ import { registerMcpHandlers } from "./handlers/mcp_handlers";
 import { registerSecurityHandlers } from "./handlers/security_handlers";
 import { registerVisualEditingHandlers } from "../pro/main/ipc/handlers/visual_editing_handlers";
 import { registerAgentToolHandlers } from "../pro/main/ipc/handlers/local_agent/agent_tool_handlers";
+import { registerRestoreHandlers } from "./handlers/restore_handlers";
 
 export function registerIpcHandlers() {
   // Register all IPC handlers by category
@@ -77,4 +78,5 @@ export function registerIpcHandlers() {
   registerSecurityHandlers();
   registerVisualEditingHandlers();
   registerAgentToolHandlers();
+  registerRestoreHandlers();
 }

--- a/src/ipc/ipc_types.ts
+++ b/src/ipc/ipc_types.ts
@@ -849,3 +849,10 @@ export interface UncommittedFile {
   path: string;
   status: UncommittedFileStatus;
 }
+
+// --- Restore Types ---
+export interface SyncAppsFromFolderResult {
+  imported: string[];
+  skipped: string[];
+  errors: Array<{ folder: string; error: string }>;
+}

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -31,6 +31,7 @@ import { ZoomSelector } from "@/components/ZoomSelector";
 import { DefaultChatModeSelector } from "@/components/DefaultChatModeSelector";
 import { useSetAtom } from "jotai";
 import { activeSettingsSectionAtom } from "@/atoms/viewAtoms";
+import { RestoreSettings } from "@/components/settings/RestoreSettings";
 
 export default function SettingsPage() {
   const [isResetDialogOpen, setIsResetDialogOpen] = useState(false);
@@ -182,6 +183,17 @@ export default function SettingsPage() {
                 </div>
               </div>
             </div>
+          </div>
+
+          {/* Restore Section */}
+          <div
+            id="restore"
+            className="bg-white dark:bg-gray-800 rounded-xl shadow-sm p-6"
+          >
+            <h2 className="text-lg font-medium text-gray-900 dark:text-white mb-4">
+              Restore
+            </h2>
+            <RestoreSettings />
           </div>
 
           {/* Danger Zone */}

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -180,6 +180,8 @@ const validInvokeChannels = [
   "generate-theme-prompt",
   "save-theme-image",
   "cleanup-theme-images",
+  // Restore
+  "sync-apps-from-folder",
   // Test-only channels
   // These should ALWAYS be guarded with IS_TEST_BUILD in the main process.
   // We can't detect with IS_TEST_BUILD in the preload script because


### PR DESCRIPTION
## Summary
- Add a "Restore" section in Settings with a button to sync apps from the dyad-apps folder
- Imports apps that exist on disk but are not tracked in the database
- Useful after database resets or migrations

## Implementation
- Added `SyncAppsFromFolderResult` type to `ipc_types.ts`
- Created `restore_handlers.ts` with the `sync-apps-from-folder` IPC handler
- Added `RestoreSettings.tsx` component with sync button and confirmation dialog
- Added Restore section to Settings page (before Danger Zone)
- Includes E2E tests for the sync functionality

## Test plan
- [x] Navigate to Settings → Restore section
- [x] Click "Sync Apps" button → confirm dialog
- [x] Verify apps from dyad-apps folder appear in app list
- [x] Click sync again → verify "no new apps" message (already tracked)

Closes #2264

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a Settings restore action to import apps existing on disk but not in the database.
> 
> - New `Restore` section with `RestoreSettings` UI: confirmation dialog, "Sync Apps" button, loading state, success/info/error toasts, and invalidates `apps` query
> - IPC plumbing: `sync-apps-from-folder` channel exposed in `preload`, client method in `ipc_client`, and registration in `ipc_host`; adds `SyncAppsFromFolderResult` type
> - Core handler `handlers/restore_handlers.ts`: scans `dyad-apps`, skips already-tracked or invalid folders (no `package.json`), initializes git if missing, inserts app and initial chat, returns `imported/skipped/errors` and logs summary
> - E2E tests `e2e-tests/sync_apps_from_folder.spec.ts` with fixture app to verify import and "no new apps" cases
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b08797690ba0887cf3f6cb5257341fd1dae0c0c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Restore section in Settings with a “Sync Apps” button to import apps from the dyad-apps folder that aren’t tracked in the database. Helps recover apps after DB resets/migrations and satisfies #2264.

- **New Features**
  - Restore Settings UI with confirmation dialog and loading state.
  - IPC: sync-apps-from-folder handler and SyncAppsFromFolderResult type.
  - Logic: scans dyad-apps, requires package.json, initializes git if missing, creates DB app and initial chat, skips already tracked, and reports errors.
  - UX: success/info/error toasts and app list refresh; E2E tests for import and “no new apps” flows.

<sup>Written for commit 0b08797690ba0887cf3f6cb5257341fd1dae0c0c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

