### PR TITLE
Add fail-fast: false to release workflow matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,11 @@ jobs:
         shell: bash
         # Publish (all platforms)
       - name: Publish app
+        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          command: ./node_modules/.bin/electron-forge publish
         env:
           DEBUG: "@electron/*,electron-forge:*,electron-windows-installer:main"
           NODE_OPTIONS: "--max-old-space-size=4096"
@@ -77,9 +82,6 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-        # Don't use npm run because we don't get logs
-        # https://github.com/electron/forge/blob/main/SUPPORT.md
-        run: ./node_modules/.bin/electron-forge publish
 
   verify-assets:
     name: Verify Release Assets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
   build:
     environment: release
     strategy:
+      # Continue building other platforms even if one fails
+      fail-fast: false
       # Uncomment max-parallel to prevent race condition (where multiple releases are
       # created concurrently). Typically though, we'll create a release manually ahead of time
       # which prevents the race.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
         shell: bash
         # Publish (all platforms)
       - name: Publish app
-        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:
           timeout_minutes: 30
           max_attempts: 3


### PR DESCRIPTION
## Summary
- Allow build jobs to continue independently even if one platform fails
- The verify-assets job will still only run if all builds succeed

#skip-bugbot

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set fail-fast: false in the release workflow build matrix so other platform builds continue even if one fails. Add retry to the publish step (3 attempts, 30m timeout) to reduce flakiness; verify-assets still only runs if all builds succeed.

<sup>Written for commit 2f09fc1f6ae1d524f6e626f4acc91bb7adfa4aab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

