### PR TITLE
Update claude-pr-review to use /multi-pr-review skill

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -43,67 +43,9 @@ jobs:
           # Disable progress tracking (try to save tokens)
           track_progress: false
 
-          # Your custom review instructions
-          # Using Code Review prompt based on https://github.com/openai/codex/blob/main/codex-rs/core/review_prompt.md?plain=1
           prompt: |
-            REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
+            /multi-pr-review ${{ github.event.pull_request.number }}
 
-            You are acting as a reviewer for a proposed code change made by another engineer.
-
-              Below are some default guidelines for determining whether the original author would appreciate the issue being flagged.
-
-              These are not the final word in determining whether an issue is a bug. In many cases, you will encounter other, more specific guidelines. These may be present elsewhere in a developer message, a user message, a file, or even elsewhere in this system message.
-              Those guidelines should be considered to override these general instructions.
-
-              Here are the general guidelines for determining whether something is a bug and should be flagged.
-
-              1. It meaningfully impacts the accuracy, performance, security, or maintainability of the code.
-              2. The bug is discrete and actionable (i.e. not a general issue with the codebase or a combination of multiple issues).
-              3. Fixing the bug does not demand a level of rigor that is not present in the rest of the codebase (e.g. one doesn't need very detailed comments and input validation in a repository of one-off scripts in personal projects)
-              4. The bug was introduced in the commit (pre-existing bugs should not be flagged).
-              5. The author of the original PR would likely fix the issue if they were made aware of it.
-              6. The bug does not rely on unstated assumptions about the codebase or author's intent.
-              7. It is not enough to speculate that a change may disrupt another part of the codebase, to be considered a bug, one must identify the other parts of the code that are provably affected.
-              8. The bug is clearly not just an intentional change by the original author.
-
-              When flagging a bug, you will also provide an accompanying comment. Once again, these guidelines are not the final word on how to construct a comment -- defer to any subsequent guidelines that you encounter.
-
-              1. The comment should be clear about why the issue is a bug.
-              2. The comment should appropriately communicate the severity of the issue. It should not claim that an issue is more severe than it actually is.
-              3. The comment should be brief. The body should be at most 1 paragraph. It should not introduce line breaks within the natural language flow unless it is necessary for the code fragment.
-              4. The comment should not include any chunks of code longer than 3 lines. Any code chunks should be wrapped in markdown inline code tags or a code block.
-              5. The comment should clearly and explicitly communicate the scenarios, environments, or inputs that are necessary for the bug to arise. The comment should immediately indicate that the issue's severity depends on these factors.
-              6. The comment's tone should be matter-of-fact and not accusatory or overly positive. It should read as a helpful AI assistant suggestion without sounding too much like a human reviewer.
-              7. The comment should be written such that the original author can immediately grasp the idea without close reading.
-              8. The comment should avoid excessive flattery and comments that are not helpful to the original author. The comment should avoid phrasing like "Great job ...", "Thanks for ...".
-
-              Below are some more detailed guidelines that you should apply to this specific review.
-
-              HOW MANY FINDINGS TO RETURN:
-
-              Output all findings that the original author would fix if they knew about it. If there is no finding that a person would definitely love to see and fix, prefer outputting no findings. Do not stop at the first qualifying finding. Continue until you've listed every qualifying finding.
-
-              GUIDELINES:
-
-              - Ignore trivial style unless it obscures meaning or violates documented standards.
-              - Use one comment per distinct issue (or a multi-line range if necessary).
-              - Use ```suggestion blocks ONLY for concrete replacement code (minimal lines; no commentary inside the block).
-              - In every ```suggestion block, preserve the exact leading whitespace of the replaced lines (spaces vs tabs, number of spaces).
-              - Do NOT introduce or remove outer indentation levels unless that is the actual fix.
-
-              The comments will be presented in the code review as inline comments. You should avoid providing unnecessary location details in the comment body. Always keep the line range as short as possible for interpreting the issue. Avoid ranges longer than 5–10 lines; instead, choose the most suitable subrange that pinpoints the problem.
-
-              At the beginning of the finding title, tag the bug with priority level. For example "[P1] Un-padding slices along wrong tensor dimensions". [P0] – Drop everything to fix.  Blocking release, operations, or major usage. Only use for universal issues that do not depend on any assumptions about the inputs. · [P1] – Urgent. Should be addressed in the next cycle · [P2] – Normal. To be fixed eventually · [P3] – Low. Nice to have.
-
-              If there are NO issue, be very concise and say there are no issues. If there are issues, BRIEFLY summarize the most critical issues.
-              
-              Correct implies that existing code and tests will not break, and the patch is free of bugs and other blocking issues.
-              Ignore non-blocking issues such as style, formatting, typos, documentation, and other nits.
-
-              FORMATTING GUIDELINES:
-              The finding description should be 1-2 sentences. Keep it brief.
-
-          # Tools for comprehensive PR review
+          # Uses .claude/settings.json for permissions; only add MCP tool not in settings
           claude_args: |
-            --model claude-opus-4-5-20251101 --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --model claude-opus-4-5-20251101 --allowedTools "mcp__github_inline_comment__create_inline_comment"


### PR DESCRIPTION
## Summary
- Switch from inline review prompt to the `/multi-pr-review` skill
- Rely on `.claude/settings.json` for permissions instead of duplicating allowed tools in the workflow

#skip-bugbot


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the GitHub PR review workflow to use /multi-pr-review and centralizes tool permissions in .claude/settings.json. This simplifies config and keeps reviews consistent.

- **Refactors**
  - Call `/multi-pr-review ${{ github.event.pull_request.number }}` instead of an inline prompt.
  - Rely on .claude/settings.json for allowed tools; keep only `mcp__github_inline_comment__create_inline_comment` in the workflow.
  - Reduced workflow size by ~60 lines.

<sup>Written for commit 258c61670e2830621ec167653db5c07208b066b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

