### PR TITLE
Cancel previous claude-pr-review runs on new push

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -6,6 +6,10 @@ on:
   pull_request_target:
     types: [opened, synchronize, ready_for_review, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   claude-review:
     # Has Anthropic API key, etc.


### PR DESCRIPTION
## Summary
- Adds concurrency block to the claude-pr-review workflow
- When a new push is made to a PR, any in-progress review workflow for that PR is automatically cancelled
- Avoids wasting resources reviewing outdated code

## Test plan
- [ ] Push multiple commits in quick succession to a PR and verify only the latest run completes

#skip-bugbot

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add GitHub Actions concurrency to the claude-pr-review workflow so only the latest run per PR executes. New pushes automatically cancel any in-progress review, avoiding outdated reviews and saving CI resources.

<sup>Written for commit 8a0a3d25f25657ed9fc34580b7cb51feb43a2c9c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

