### PR TITLE
Add PR review responder workflow

### DIFF
--- a/.github/workflows/pr-review-responder.yml
+++ b/.github/workflows/pr-review-responder.yml
@@ -36,6 +36,13 @@ jobs:
               pull_number: prNumber
             });
 
+            // Only allow wwwillchen to use this workflow
+            if (pr.user.login !== 'wwwillchen') {
+              console.log(`PR #${prNumber} author ${pr.user.login} is not allowed to use this workflow`);
+              core.setOutput('should_continue', 'false');
+              return;
+            }
+
             const hasRequestLabel = pr.labels.some(label => label.name === 'cc:request');
 
             if (!hasRequestLabel) {
@@ -66,8 +73,8 @@ jobs:
             /dyad:pr-fix ${{ steps.pr-info.outputs.pr_number }}
 
       - name: Update labels
-        if: steps.pr-info.outputs.should_continue == 'true'
+        if: steps.pr-info.outputs.should_continue == 'true' && success()
         run: |
-          gh pr edit ${{ steps.pr-info.outputs.pr_number }} --remove-label "cc:help" --add-label "cc:responded"
+          gh pr edit ${{ steps.pr-info.outputs.pr_number }} --remove-label "cc:request" --add-label "cc:responded" || gh pr edit ${{ steps.pr-info.outputs.pr_number }} --add-label "cc:responded"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-review-responder.yml
+++ b/.github/workflows/pr-review-responder.yml
@@ -98,3 +98,10 @@ jobs:
           gh pr edit ${{ steps.pr-info.outputs.pr_number }} --remove-label "cc:pending" --add-label "cc:done"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update labels to failed
+        if: steps.pr-info.outputs.should_continue == 'true' && failure()
+        run: |
+          gh pr edit ${{ steps.pr-info.outputs.pr_number }} --remove-label "cc:pending" --add-label "cc:failed"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-review-responder.yml
+++ b/.github/workflows/pr-review-responder.yml
@@ -1,8 +1,17 @@
+# VERY IMPORTANT:
+# This workflow has a lot of permissions!
+# It should ONLY run on trusted maintainers code (e.g. wwwillchen)
 name: PR Review Responder
 
 on:
   workflow_run:
     workflows: ["CI"]
+    # Regardless of success or fail, we want to run this workflow.
+    # Why?
+    # If it's failure, we want to fix the errors.
+    # If it's success, we want to address the PR review comments from the AI code reviewers.
+    #
+    # The CI workflow is almost always the last workflow to finish, so that's why we wait for it.
     types: [completed]
 
 jobs:
@@ -59,9 +68,20 @@ jobs:
         if: steps.pr-info.outputs.should_continue == 'true'
         uses: actions/checkout@v5
         with:
+          # Security note: The pr.user.login check verifies who opened the PR, but this
+          # checks out code from whoever last pushed. If "Allow edits from maintainers" is
+          # enabled, other maintainers could push to the branch. This is acceptable because
+          # maintainers already have write access to the repo and are trusted.
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: 0
+
+      - name: Update labels to pending
+        if: steps.pr-info.outputs.should_continue == 'true'
+        run: |
+          gh pr edit ${{ steps.pr-info.outputs.pr_number }} --remove-label "cc:request" --add-label "cc:pending"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run PR Fix
         if: steps.pr-info.outputs.should_continue == 'true'
@@ -72,9 +92,9 @@ jobs:
           prompt: |
             /dyad:pr-fix ${{ steps.pr-info.outputs.pr_number }}
 
-      - name: Update labels
+      - name: Update labels to done
         if: steps.pr-info.outputs.should_continue == 'true' && success()
         run: |
-          gh pr edit ${{ steps.pr-info.outputs.pr_number }} --remove-label "cc:request" --add-label "cc:responded" || gh pr edit ${{ steps.pr-info.outputs.pr_number }} --add-label "cc:responded"
+          gh pr edit ${{ steps.pr-info.outputs.pr_number }} --remove-label "cc:pending" --add-label "cc:done"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-review-responder.yml
+++ b/.github/workflows/pr-review-responder.yml
@@ -1,0 +1,73 @@
+name: PR Review Responder
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+jobs:
+  respond-to-pr:
+    environment: ai-bots
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Get PR info and check labels
+        id: pr-info
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const run = context.payload.workflow_run;
+
+            // Get PR associated with this workflow run
+            if (!run.pull_requests || run.pull_requests.length === 0) {
+              console.log('No pull requests associated with this workflow run');
+              core.setOutput('should_continue', 'false');
+              return;
+            }
+
+            const prNumber = run.pull_requests[0].number;
+
+            // Fetch full PR details to get labels
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber
+            });
+
+            const hasRequestLabel = pr.labels.some(label => label.name === 'cc:request');
+
+            if (!hasRequestLabel) {
+              console.log(`PR #${prNumber} does not have the cc:request label`);
+              core.setOutput('should_continue', 'false');
+              return;
+            }
+
+            console.log(`PR #${prNumber} has cc:request label, proceeding with pr-fix`);
+            core.setOutput('pr_number', prNumber);
+            core.setOutput('should_continue', 'true');
+
+      - name: Checkout repository
+        if: steps.pr-info.outputs.should_continue == 'true'
+        uses: actions/checkout@v5
+        with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth: 0
+
+      - name: Run PR Fix
+        if: steps.pr-info.outputs.should_continue == 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: |
+            /dyad:pr-fix ${{ steps.pr-info.outputs.pr_number }}
+
+      - name: Update labels
+        if: steps.pr-info.outputs.should_continue == 'true'
+        run: |
+          gh pr edit ${{ steps.pr-info.outputs.pr_number }} --remove-label "cc:help" --add-label "cc:responded"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Creates a GitHub Action that triggers when CI completes for PRs with the cc:request label. It runs /dyad:pr-fix to address failing checks and review comments, then updates labels (removes cc:help, adds cc:responded)

#skip-bugbot

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Action that auto-responds to PRs after CI completes. It runs /dyad:pr-fix on PRs labeled cc:request from wwwillchen and updates labels based on status.

- **New Features**
  - Triggers on CI workflow_run completion.
  - Checks out the PR’s head repo/branch and runs /dyad:pr-fix.
  - Restricts usage to PRs authored by wwwillchen.
  - Updates labels: cc:request → cc:pending; then cc:done on success or cc:failed on failure.
  - Uses write permissions for contents and pull-requests.

<sup>Written for commit 21cef82a88b2e3d591f4c3955b679dd28aad0477. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

