### PR TITLE
Fix pr-push skill stopping after lint by inlining commands

### DIFF
--- a/.claude/commands/dyad/pr-push.md
+++ b/.claude/commands/dyad/pr-push.md
@@ -20,16 +20,26 @@ Commit any uncommitted changes, run lint checks, fix any issues, and push the cu
 
 2. **Run lint checks:**
 
-   Run the `/dyad:lint` skill to ensure the code passes all pre-commit checks. Fix any issues that arise.
+   Run these commands to ensure the code passes all pre-commit checks:
+
+   ```
+   npm run prettier && npm run lint:fix && npm run ts
+   ```
+
+   If there are errors that could not be auto-fixed, read the affected files and fix them manually, then re-run the checks until they pass.
+
+   **IMPORTANT:** Do NOT stop after lint passes. You MUST continue to step 3.
 
 3. **If lint made changes, amend the last commit:**
 
-   If the lint skill made any changes, stage and amend them into the last commit:
+   If the lint checks made any changes, stage and amend them into the last commit:
 
    ```
    git add -A
    git commit --amend --no-edit
    ```
+
+   **IMPORTANT:** Do NOT stop here. You MUST continue to step 4 to push.
 
 4. **Push the branch (REQUIRED):**
 


### PR DESCRIPTION
## Summary
- The pr-push skill was consistently stopping after running lint checks instead of continuing to push
- Root cause: calling /dyad:lint as a nested skill created a stopping point when the sub-skill completed
- Fix: inline lint commands directly and add explicit continuation reminders after steps 2 and 3

## Test plan
- [ ] Run /dyad:pr-push and verify it completes all steps through to pushing

#skip-bugbot

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pr-push stopping after lint by inlining lint commands and adding clear “keep going” reminders, so the flow completes and pushes the branch.

- **Bug Fixes**
  - Inline lint commands: npm run prettier && npm run lint:fix && npm run ts
  - Add explicit continuation notes after steps 2 and 3 to prevent stopping mid-flow
  - Clarify amend step when lint modifies files

<sup>Written for commit 75b8c57147f9ff5d0d7aed9d8e3457baf169cea1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

