### PR TITLE
Add workflow to cancel CI runs after PR merge

### DIFF
--- a/.github/workflows/cancel-ci-after-merge.yml
+++ b/.github/workflows/cancel-ci-after-merge.yml
@@ -17,52 +17,52 @@ jobs:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const branch = context.payload.pull_request.head.ref;
+            const pr = context.payload.pull_request;
+            const branch = pr.head.ref;
+
+            // Skip fork PRs - their CI runs in the fork's context, not the base repo
+            if (pr.head.repo.full_name !== pr.base.repo.full_name) {
+              console.log(`Skipping fork PR from ${pr.head.repo.full_name}`);
+              return;
+            }
 
             console.log(`Looking for CI workflows to cancel for branch: ${branch}`);
 
-            // List workflow runs for the CI workflow on the PR's head branch
-            const { data: workflows } = await github.rest.actions.listRepoWorkflows({
-              owner,
-              repo,
-            });
+            // Use workflow file path instead of display name for reliable matching
+            const workflowFile = 'ci.yml';
 
-            const ciWorkflow = workflows.workflows.find(w => w.name === 'CI');
-            if (!ciWorkflow) {
-              console.log('CI workflow not found');
-              return;
+            // Query all cancelable statuses: in_progress, queued, pending, waiting
+            const statuses = ['in_progress', 'queued', 'pending', 'waiting'];
+            const allRuns = [];
+
+            for (const status of statuses) {
+              try {
+                const { data } = await github.rest.actions.listWorkflowRuns({
+                  owner,
+                  repo,
+                  workflow_id: workflowFile,
+                  branch,
+                  status,
+                });
+                allRuns.push(...data.workflow_runs);
+              } catch (error) {
+                // Status may not be supported or no runs found
+                console.log(`No runs found for status '${status}': ${error.message}`);
+              }
             }
-
-            console.log(`Found CI workflow with ID: ${ciWorkflow.id}`);
-
-            // Get in-progress and queued runs for the CI workflow on the merged branch
-            const { data: runs } = await github.rest.actions.listWorkflowRuns({
-              owner,
-              repo,
-              workflow_id: ciWorkflow.id,
-              branch,
-              status: 'in_progress',
-            });
-
-            const { data: queuedRuns } = await github.rest.actions.listWorkflowRuns({
-              owner,
-              repo,
-              workflow_id: ciWorkflow.id,
-              branch,
-              status: 'queued',
-            });
-
-            const allRuns = [...runs.workflow_runs, ...queuedRuns.workflow_runs];
 
             if (allRuns.length === 0) {
-              console.log('No running or queued CI workflows found for this branch');
+              console.log('No cancelable CI workflows found for this branch');
               return;
             }
 
-            console.log(`Found ${allRuns.length} workflow run(s) to cancel`);
+            // Deduplicate runs by ID (in case a run appears in multiple status queries)
+            const uniqueRuns = [...new Map(allRuns.map(run => [run.id, run])).values()];
 
-            // Cancel each running workflow
-            for (const run of allRuns) {
+            console.log(`Found ${uniqueRuns.length} workflow run(s) to cancel`);
+
+            // Cancel each workflow run
+            for (const run of uniqueRuns) {
               console.log(`Cancelling workflow run ${run.id} (status: ${run.status})`);
               try {
                 await github.rest.actions.cancelWorkflowRun({

--- a/.github/workflows/cancel-ci-after-merge.yml
+++ b/.github/workflows/cancel-ci-after-merge.yml
@@ -1,0 +1,77 @@
+name: Cancel CI after merge
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cancel-ci:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Cancel CI workflows for merged PR branch
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const branch = context.payload.pull_request.head.ref;
+
+            console.log(`Looking for CI workflows to cancel for branch: ${branch}`);
+
+            // List workflow runs for the CI workflow on the PR's head branch
+            const { data: workflows } = await github.rest.actions.listRepoWorkflows({
+              owner,
+              repo,
+            });
+
+            const ciWorkflow = workflows.workflows.find(w => w.name === 'CI');
+            if (!ciWorkflow) {
+              console.log('CI workflow not found');
+              return;
+            }
+
+            console.log(`Found CI workflow with ID: ${ciWorkflow.id}`);
+
+            // Get in-progress and queued runs for the CI workflow on the merged branch
+            const { data: runs } = await github.rest.actions.listWorkflowRuns({
+              owner,
+              repo,
+              workflow_id: ciWorkflow.id,
+              branch,
+              status: 'in_progress',
+            });
+
+            const { data: queuedRuns } = await github.rest.actions.listWorkflowRuns({
+              owner,
+              repo,
+              workflow_id: ciWorkflow.id,
+              branch,
+              status: 'queued',
+            });
+
+            const allRuns = [...runs.workflow_runs, ...queuedRuns.workflow_runs];
+
+            if (allRuns.length === 0) {
+              console.log('No running or queued CI workflows found for this branch');
+              return;
+            }
+
+            console.log(`Found ${allRuns.length} workflow run(s) to cancel`);
+
+            // Cancel each running workflow
+            for (const run of allRuns) {
+              console.log(`Cancelling workflow run ${run.id} (status: ${run.status})`);
+              try {
+                await github.rest.actions.cancelWorkflowRun({
+                  owner,
+                  repo,
+                  run_id: run.id,
+                });
+                console.log(`Successfully cancelled workflow run ${run.id}`);
+              } catch (error) {
+                console.log(`Failed to cancel workflow run ${run.id}: ${error.message}`);
+              }
+            }

--- a/.github/workflows/cancel-ci-after-merge.yml
+++ b/.github/workflows/cancel-ci-after-merge.yml
@@ -18,15 +18,11 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const pr = context.payload.pull_request;
-            const branch = pr.head.ref;
+            // Use head SHA instead of branch name - works for both fork and non-fork PRs
+            // since workflow runs are registered to the base repo regardless
+            const headSha = pr.head.sha;
 
-            // Skip fork PRs - their CI runs in the fork's context, not the base repo
-            if (pr.head.repo.full_name !== pr.base.repo.full_name) {
-              console.log(`Skipping fork PR from ${pr.head.repo.full_name}`);
-              return;
-            }
-
-            console.log(`Looking for CI workflows to cancel for branch: ${branch}`);
+            console.log(`Looking for CI workflows to cancel for SHA: ${headSha}`);
 
             // Use workflow file path instead of display name for reliable matching
             const workflowFile = 'ci.yml';
@@ -41,7 +37,7 @@ jobs:
                   owner,
                   repo,
                   workflow_id: workflowFile,
-                  branch,
+                  head_sha: headSha,
                   status,
                 });
                 allRuns.push(...data.workflow_runs);
@@ -52,7 +48,7 @@ jobs:
             }
 
             if (allRuns.length === 0) {
-              console.log('No cancelable CI workflows found for this branch');
+              console.log('No cancelable CI workflows found for this SHA');
               return;
             }
 


### PR DESCRIPTION
#skip-bb

## Summary
This PR adds a new GitHub Actions workflow that automatically cancels in-progress and queued CI workflow runs when a pull request is merged. This helps reduce unnecessary CI resource consumption and prevents stale workflow runs from completing after their changes have already been integrated.

## Changes
- Added `.github/workflows/cancel-ci-after-merge.yml` workflow that:
  - Triggers when a pull request is closed (merged)
  - Finds the CI workflow in the repository
  - Queries for all in-progress and queued CI runs on the merged PR's branch
  - Cancels each identified workflow run with error handling and logging
  - Includes comprehensive console logging for debugging and monitoring

## Implementation Details
- The workflow uses `actions/github-script@v7` to interact with the GitHub Actions API
- It specifically targets the "CI" workflow by name
- Handles both "in_progress" and "queued" statuses to catch all active runs
- Includes try-catch error handling to gracefully handle cancellation failures
- Requires `actions: write` permission to cancel workflow runs
- Only executes when `github.event.pull_request.merged == true` to avoid running on rejected PRs


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically cancel active CI runs for the merged PR’s head commit. Frees up runners and prevents stale builds from finishing.

- **New Features**
  - Adds .github/workflows/cancel-ci-after-merge.yml triggered on PR closed, gated to merged PRs.
  - Targets the CI workflow via file path ci.yml and lists runs for the PR head SHA.
  - Cancels active runs (in_progress, queued, pending, waiting) with try/catch error handling and de-duplicates by run ID.
  - Supports fork and non-fork PRs; uses actions/github-script@v7 with actions: write permissions and clear console logs.

<sup>Written for commit 4d631b3ccb9d127c4781b185b9d6eac90d2fd710. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



