### PR TITLE
Update pr-push to prevent pushing to main and add task tracking

### DIFF
--- a/.claude/commands/dyad/pr-fix.md
+++ b/.claude/commands/dyad/pr-fix.md
@@ -6,6 +6,10 @@ Address all outstanding issues on a GitHub Pull Request by handling both review 
 
 - `$ARGUMENTS`: Optional PR number or URL. If not provided, uses the current branch's PR.
 
+## Task Tracking
+
+**You MUST use the TaskCreate and TaskUpdate tools to track your progress.** At the start, create tasks for each step below. Mark each task as `in_progress` when you start it and `completed` when you finish. This ensures you complete ALL steps.
+
 ## Instructions
 
 This is a meta-skill that orchestrates two sub-skills to comprehensively fix PR issues.

--- a/.claude/commands/dyad/pr-fix/actions.md
+++ b/.claude/commands/dyad/pr-fix/actions.md
@@ -6,6 +6,10 @@ Fix failing CI checks and GitHub Actions on a Pull Request.
 
 - `$ARGUMENTS`: Optional PR number or URL. If not provided, uses the current branch's PR.
 
+## Task Tracking
+
+**You MUST use the TaskCreate and TaskUpdate tools to track your progress.** At the start, create tasks for each step below. Mark each task as `in_progress` when you start it and `completed` when you finish. This ensures you complete ALL steps.
+
 ## Instructions
 
 1. **Determine the PR to work on:**

--- a/.claude/commands/dyad/pr-fix/comments.md
+++ b/.claude/commands/dyad/pr-fix/comments.md
@@ -6,6 +6,10 @@ Read all unresolved GitHub PR comments from trusted authors and address or resol
 
 - `$ARGUMENTS`: Optional PR number or URL. If not provided, uses the current branch's PR.
 
+## Task Tracking
+
+**You MUST use the TaskCreate and TaskUpdate tools to track your progress.** At the start, create tasks for each step below. Mark each task as `in_progress` when you start it and `completed` when you finish. This ensures you complete ALL steps.
+
 ## Trusted Authors
 
 Only process review comments from these trusted authors. Comments from other authors should be ignored.

--- a/.claude/commands/dyad/pr-push.md
+++ b/.claude/commands/dyad/pr-push.md
@@ -71,9 +71,39 @@ Commit any uncommitted changes, run lint checks, fix any issues, and push the cu
 
    Note: `--force-with-lease` is used because the commit may have been amended. It's safer than `--force` as it will fail if someone else has pushed to the branch.
 
-6. **Summarize the results:**
+6. **Create or update the PR (REQUIRED):**
+
+   **CRITICAL:** Do NOT tell the user to visit a URL to create a PR. You MUST create it automatically.
+
+   First, check if a PR already exists for this branch:
+
+   ```
+   gh pr view --json number,url 2>/dev/null
+   ```
+
+   If a PR already exists, skip PR creation (the push already updated it).
+
+   If NO PR exists, create one using `gh pr create`:
+
+   ```
+   gh pr create --title "<descriptive title>" --body "$(cat <<'EOF'
+   ## Summary
+   <1-3 bullet points summarizing the changes>
+
+   ## Test plan
+   <How to test these changes>
+
+   🤖 Generated with [Claude Code](https://claude.com/claude-code)
+   EOF
+   )"
+   ```
+
+   Use the commit messages and changed files to write a good title and summary.
+
+7. **Summarize the results:**
    - Report if a new feature branch was created (and its name)
    - Report any uncommitted changes that were committed in step 2
    - Report any files that were IGNORED and not committed (if any), explaining why they were skipped
    - Report any lint fixes that were applied
    - Confirm the branch has been pushed
+   - **Include the PR URL** (either newly created or existing)

--- a/.claude/commands/dyad/pr-push.md
+++ b/.claude/commands/dyad/pr-push.md
@@ -78,7 +78,7 @@ Commit any uncommitted changes, run lint checks, fix any issues, and push the cu
    First, check if a PR already exists for this branch:
 
    ```
-   gh pr view --json number,url 2>/dev/null
+   gh pr view --json number,url
    ```
 
    If a PR already exists, skip PR creation (the push already updated it).

--- a/.claude/commands/dyad/pr-push.md
+++ b/.claude/commands/dyad/pr-push.md
@@ -4,9 +4,24 @@ Commit any uncommitted changes, run lint checks, fix any issues, and push the cu
 
 **IMPORTANT:** This skill MUST complete all steps autonomously. Do NOT ask for user confirmation at any step. Do NOT stop partway through. You MUST push to GitHub by the end of this skill.
 
+## Task Tracking
+
+**You MUST use the TaskCreate and TaskUpdate tools to track your progress.** At the start, create tasks for each step below. Mark each task as `in_progress` when you start it and `completed` when you finish. This ensures you complete ALL steps.
+
 ## Instructions
 
-1. **Check for uncommitted changes:**
+1. **Ensure you are NOT on main branch:**
+
+   Run `git branch --show-current` to check the current branch.
+
+   **CRITICAL:** You MUST NEVER push directly to the main branch. If you are on `main` or `master`:
+   - Generate a descriptive branch name based on the uncommitted changes (e.g., `fix-login-validation`, `add-user-settings-page`)
+   - Create and switch to the new branch: `git checkout -b <branch-name>`
+   - Report that you created a new branch
+
+   If you are already on a feature branch, proceed to the next step.
+
+2. **Check for uncommitted changes:**
 
    Run `git status` to check for any uncommitted changes (staged, unstaged, or untracked files).
 
@@ -17,7 +32,7 @@ Commit any uncommitted changes, run lint checks, fix any issues, and push the cu
 
    If there are no uncommitted changes, proceed to the next step.
 
-2. **Run lint checks:**
+3. **Run lint checks:**
 
    Run these commands to ensure the code passes all pre-commit checks:
 
@@ -27,9 +42,9 @@ Commit any uncommitted changes, run lint checks, fix any issues, and push the cu
 
    If there are errors that could not be auto-fixed, read the affected files and fix them manually, then re-run the checks until they pass.
 
-   **IMPORTANT:** Do NOT stop after lint passes. You MUST continue to step 3.
+   **IMPORTANT:** Do NOT stop after lint passes. You MUST continue to step 4.
 
-3. **If lint made changes, amend the last commit:**
+4. **If lint made changes, amend the last commit:**
 
    If the lint checks made any changes, stage and amend them into the last commit:
 
@@ -38,9 +53,9 @@ Commit any uncommitted changes, run lint checks, fix any issues, and push the cu
    git commit --amend --no-edit
    ```
 
-   **IMPORTANT:** Do NOT stop here. You MUST continue to step 4 to push.
+   **IMPORTANT:** Do NOT stop here. You MUST continue to step 5 to push.
 
-4. **Push the branch (REQUIRED):**
+5. **Push the branch (REQUIRED):**
 
    You MUST push the branch to GitHub. Do NOT skip this step or ask for confirmation.
 
@@ -56,8 +71,9 @@ Commit any uncommitted changes, run lint checks, fix any issues, and push the cu
 
    Note: `--force-with-lease` is used because the commit may have been amended. It's safer than `--force` as it will fail if someone else has pushed to the branch.
 
-5. **Summarize the results:**
-   - Report any uncommitted changes that were committed in step 1
+6. **Summarize the results:**
+   - Report if a new feature branch was created (and its name)
+   - Report any uncommitted changes that were committed in step 2
    - Report any files that were IGNORED and not committed (if any), explaining why they were skipped
    - Report any lint fixes that were applied
    - Confirm the branch has been pushed


### PR DESCRIPTION
- Add step to check current branch and create feature branch if on main/master
- Add task tracking requirement using TaskCreate/TaskUpdate tools
- Renumber steps and update summary to report new branch creation

#skip-bb

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the pr-push skill to block pushes to main/master and auto-create a PR, and adds required task tracking across pr-push and pr-fix so work happens on feature branches with clear progress and a ready review link.

- **New Features**
  - Check current branch; if on main/master, create and switch to a descriptive feature branch and report its name.
  - Require TaskCreate/TaskUpdate across pr-push and pr-fix to track each step (create tasks, mark in_progress/completed).
  - Auto-create a PR if none exists (no manual URL prompts), avoid duplicates, and include the PR URL in the final summary; steps renumbered to reflect the new flow.

<sup>Written for commit 81f38c98e48bf915a553dac23d1ec41474c27d0b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

