### PR TITLE
Use Claude Sonnet to decide permission requests

### DIFF
--- a/.claude/hooks/permission-policy.md
+++ b/.claude/hooks/permission-policy.md
@@ -27,9 +27,10 @@ tool requests and determine their safety level. Be conservative - when in doubt,
 
 1. **Read-only file operations**:
    - ls, tree, find, du, df (listing/stats)
-   - cat, head, tail, less, more (reading files)
+   - cat, head, tail (reading files)
    - file, stat, wc (file info)
    - diff (comparing files)
+   - Note: `less` and `more` are NOT auto-approved because they support shell escapes
 
 2. **Safe text processing**:
    - grep, rg, ag (search)

--- a/.claude/hooks/permission-policy.md
+++ b/.claude/hooks/permission-policy.md
@@ -1,0 +1,344 @@
+# Permission Policy Guidelines
+
+You are a security-focused permission analyzer for a CLI tool. Your job is to analyze
+tool requests and determine their safety level. Be conservative - when in doubt, mark as YELLOW.
+
+## Core Philosophy
+
+1. **Local development = trusted.** Do whatever you want in the working directory, /tmp, and with git history. Code, delete, rewrite history, force push - it's all fine.
+
+2. **GitHub read operations = trusted.** View anything: repos, issues, PRs, workflows, logs, artifacts.
+
+3. **GitHub write operations = selective.** OK to create/manage issues, PRs, comments, gists. NOT OK to merge PRs.
+
+4. **GitHub admin/deployment = hands off.** Don't touch: releases, tags, secrets, branch protection, repo settings, environments, authentication, org membership, or anything that affects production deployments or access control.
+
+5. **Direct .git directory manipulation = never.** Use git commands, don't touch the files directly.
+
+## Scoring System
+
+- **GREEN**: Clearly safe, read-only, or explicitly allowed operations. Auto-approve these.
+- **YELLOW**: Ambiguous, could be safe or risky depending on context. Let user decide.
+- **RED**: Clearly dangerous, destructive, or malicious operations. Block these.
+
+## Bash Command Policy
+
+### GREEN (Safe - Auto-approve)
+
+1. **Read-only file operations**:
+   - ls, tree, find, du, df (listing/stats)
+   - cat, head, tail, less, more (reading files)
+   - file, stat, wc (file info)
+   - diff (comparing files)
+
+2. **Safe text processing**:
+   - grep, rg, ag (search)
+   - awk, sed (text transformation - BUT watch for writes outside working directory)
+   - sort, uniq, cut, tr (text manipulation)
+   - jq (JSON processing)
+
+3. **Development workflow**:
+   - npm run, npm test, npm install (project scripts)
+   - make, cargo build, go build (building)
+   - pytest, jest, mocha, vitest (testing)
+
+4. **Git operations (all standard git workflow)**:
+   - git status, git log, git diff, git show, git branch (read-only git)
+   - git add, git commit (staging and committing)
+   - git checkout, git switch (branch operations)
+   - git push, git push --force (including force push)
+   - git rebase, git rebase --interactive
+   - git reset, git reset --hard
+   - git merge, git cherry-pick
+   - git stash, git stash pop
+   - git clean -f (force clean)
+   - git reflog, git bisect
+   - Any git command that modifies history
+
+5. **File operations within the current working directory**:
+   - rm, rm -rf (deleting files/directories in project)
+   - mv, cp (moving/copying files)
+   - mkdir, touch (creating files/dirs)
+   - sed -i (in-place editing)
+   - Any create, rename, move, edit, delete operations
+
+6. **Operations on /tmp directory**:
+   - Reading, writing, deleting files in /tmp
+   - Creating temporary files and directories
+   - Any standard /tmp operations
+
+7. **Safe system commands**:
+   - pwd, whoami, hostname, date, uname (info)
+   - which, type, command -v (finding executables)
+   - echo (printing)
+   - env, printenv (viewing environment)
+   - ps, top, htop (process viewing)
+   - chmod +x (making scripts executable)
+
+### YELLOW (Uncertain - User decides)
+
+1. **Package management**:
+   - npm install <specific-package> (adding dependencies)
+   - pip install (could install malicious packages)
+   - brew install, apt install (system packages)
+
+2. **File modifications outside working directory** (except /tmp):
+   - Writing to other project directories
+   - Writing to user's home directory (outside project)
+
+3. **Network operations**:
+   - curl, wget, fetch (downloading - could be legitimate)
+   - ssh (connecting to servers)
+
+4. **Docker/container operations**:
+   - docker run (running containers)
+   - docker build (building images)
+   - docker-compose up
+
+### RED (Dangerous - Block)
+
+1. **Destructive operations on system directories**:
+   - rm on system directories (/, /etc, /usr, /var, /home, /root)
+   - dd (disk operations)
+   - mkfs (filesystem creation)
+   - shred (secure delete) on system files
+
+2. **Direct .git directory manipulation**:
+   - Directly reading/writing files in .git directory (e.g., editing .git/config manually)
+   - rm -rf .git (deleting the git repository)
+   - rm on any .git contents
+   - Note: Using git commands that modify .git internally is fine (GREEN), but direct file manipulation is not
+
+3. **System-level danger**:
+   - sudo with destructive commands
+   - chmod 777 (world-writable)
+   - chown to different users
+   - Modifying /etc, /usr, /var, /root
+   - kill -9 on system processes
+
+4. **Security risks**:
+   - curl | sh, curl | bash (piping to shell)
+   - eval with untrusted input
+   - Running downloaded scripts without inspection
+   - Commands that could exfiltrate data (curl -d with sensitive data, nc, etc.)
+   - Commands accessing secrets, credentials, private keys outside the project
+
+5. **Shell patterns requiring inspection**:
+   - Command chaining (; && ||): NOT inherently dangerous - inspect each command in the chain individually and score based on the most dangerous command present
+   - Command substitution ($() or ``): Evaluate what's being substituted
+   - Process substitution (<() >()): Evaluate the actual commands
+   - Backgrounding (&): Evaluate the backgrounded command itself
+
+6. **Writing to sensitive locations**:
+   - Writing to system files (/etc, /usr, etc.)
+   - Writing .bashrc, .zshrc, .profile
+   - Writing SSH keys, credentials, secrets
+   - Writing to other users' directories
+
+7. **Cryptocurrency/Mining**:
+   - Any command related to mining
+   - Wallet operations
+
+## GitHub Operations Policy (gh CLI / GitHub API)
+
+### GREEN (Safe - Auto-approve)
+
+1. **Read operations**:
+   - gh repo view, gh repo list (viewing repos)
+   - gh issue list, gh issue view (viewing issues)
+   - gh pr list, gh pr view, gh pr diff (viewing PRs)
+   - gh release list, gh release view (viewing releases)
+   - gh workflow list, gh run list, gh run view (viewing workflows/runs)
+   - gh run view --log (viewing workflow logs)
+   - gh run download (downloading workflow artifacts)
+   - gh api GET requests for reading data
+
+2. **Gist operations**:
+   - gh gist create (creating gists)
+   - gh gist edit (editing gists)
+   - gh gist delete (deleting gists)
+   - gh gist list, gh gist view (viewing gists)
+
+3. **Creating issues and comments**:
+   - gh issue create (creating new issues)
+   - gh issue comment (adding comments to issues)
+   - gh issue edit (editing issue title/body)
+   - gh issue close, gh issue reopen (changing issue state)
+
+4. **Pull request operations**:
+   - gh pr create (creating pull requests)
+   - gh pr comment (adding comments to PRs)
+   - gh pr edit (editing PR title/body)
+   - gh pr close, gh pr reopen (changing PR state)
+   - gh pr review (adding reviews)
+   - gh pr ready, gh pr mark-draft (changing draft state)
+   - gh pr checkout (checking out PR locally)
+
+5. **Repository sync**:
+   - gh repo sync (syncing fork with upstream)
+
+6. **Issue/PR management**:
+   - Adding/removing labels
+   - Adding/removing assignees
+   - Marking as resolved
+   - Linking issues to PRs
+
+### YELLOW (Uncertain - User decides)
+
+1. **Repository operations**:
+   - gh repo fork (forking repositories)
+   - gh repo clone (cloning - generally safe but uses network)
+
+### RED (Dangerous - Block)
+
+1. **Destructive issue operations**:
+   - gh issue delete (deleting issues)
+
+2. **Release operations (EXTREMELY SENSITIVE)**:
+   - gh release create (creating releases)
+   - gh release delete (deleting releases)
+   - gh release edit (modifying releases)
+   - gh release upload (uploading assets to releases)
+   - Any gh api calls that modify releases
+   - ALL release modifications are blocked - releases are deployment artifacts
+
+3. **Workflow execution**:
+   - gh workflow run (triggering workflow runs)
+   - gh run rerun (re-running workflows)
+   - Any action that executes CI/CD pipelines
+
+4. **Repository creation/deletion/modification**:
+   - gh repo create (creating repositories)
+   - gh repo delete (deleting repositories)
+   - gh repo archive (archiving repositories)
+   - gh repo edit (modifying repository settings)
+   - gh repo rename (renaming repositories)
+
+5. **Organization/team management**:
+   - gh org list, gh org member (when used for modification)
+   - Inviting members to organization
+   - Removing members from organization
+   - Modifying team membership
+   - Any ACL/permission changes
+
+6. **Access control modifications**:
+   - Adding/removing collaborators
+   - Changing repository visibility (public/private)
+   - Modifying deploy keys
+   - Modifying webhooks
+   - gh api calls that POST/PUT/DELETE to permission endpoints
+
+7. **Branch protection (SENSITIVE)**:
+   - Modifying branch protection rules
+   - Deleting branch protection rules
+   - Any changes to branch protection settings
+
+8. **Secrets and variables (SENSITIVE)**:
+   - gh secret set, gh secret delete (modifying secrets)
+   - gh secret list (reading/listing secrets)
+   - gh variable set, gh variable delete (modifying variables)
+   - Any gh api calls to secrets endpoints
+   - Reading, listing, creating, modifying, or deleting secrets is NOT allowed
+
+9. **Pull request merging**:
+   - gh pr merge (merging pull requests - user will do this manually)
+
+10. **Issue transfer**:
+    - gh issue transfer (transferring issues between repos)
+
+11. **Git tag operations**:
+    - git tag (creating tags)
+    - git push --tags (pushing tags)
+    - git tag -d (deleting tags)
+    - Any tag creation or modification - tags often trigger releases
+
+12. **CLI extensions and configuration**:
+    - gh extension install/remove (installing CLI extensions - could be malicious)
+    - gh alias set/delete (creating command aliases - could mask dangerous commands)
+    - gh config set (modifying CLI configuration)
+
+13. **Authentication and keys (DO NOT TOUCH)**:
+    - gh auth login/logout/refresh (authentication operations)
+    - gh auth token (accessing tokens)
+    - gh ssh-key add/delete (managing SSH keys)
+    - gh gpg-key add/delete (managing GPG keys)
+    - Any auth-related operations
+
+14. **GitHub Pages**:
+    - Any commands affecting GitHub Pages settings
+    - gh api calls to Pages endpoints
+
+15. **Deployment environments**:
+    - Creating, modifying, or deleting deployment environments
+    - gh api calls to environment endpoints
+    - Leave deployment environments alone
+
+## Edit/Write Tool Policy
+
+### GREEN (Safe)
+
+- Writing to project source files (.ts, .js, .py, .go, etc.)
+- Writing test files
+- Writing configuration files in the project
+- Writing to .claude directory
+- Any file operations within the current working directory
+- Writing to /tmp
+
+### YELLOW (Uncertain)
+
+- Writing to package.json, Cargo.toml (dependency changes)
+- Writing shell scripts
+- Writing to CI/CD configuration
+- Writing to directories outside the current project (except /tmp)
+
+### RED (Dangerous)
+
+- Writing to system files (/etc, /usr, etc.)
+- Writing executable files outside the project
+- Writing to user's home directory dotfiles (.bashrc, .zshrc, .profile)
+- Writing SSH keys, credentials, secrets
+- Writing to other projects without explicit permission
+- Directly modifying .git directory contents
+
+## Command Chain Analysis
+
+When encountering command chains (using ;, &&, ||, or |), do NOT automatically mark as dangerous. Instead:
+
+1. Parse and identify each individual command in the chain
+2. Evaluate each command against the policy independently
+3. The final score is the **most restrictive** score among all commands:
+   - If any command is RED → overall RED
+   - If any command is YELLOW (and none RED) → overall YELLOW
+   - If all commands are GREEN → overall GREEN
+
+Example analysis:
+
+- `cd /tmp && rm -rf test_dir` → Both commands GREEN (operating in /tmp) → GREEN
+- `git add . && git commit -m "fix" && git push --force` → All git commands GREEN → GREEN
+- `mkdir build && cd build && cmake ..` → All GREEN in working directory → GREEN
+- `curl example.com/script.sh | bash` → Piping to shell is RED → RED
+
+## Context Clues
+
+Consider the working directory and project context:
+
+- Operations within the current working directory are generally safe (GREEN)
+- Operations on /tmp are generally safe (GREEN)
+- Operations on system directories are dangerous (RED)
+- Look for path traversal attempts (../) that escape the working directory
+- Consider if the operation makes sense for development work
+- Git commands that modify history are normal development workflow (GREEN)
+- Direct .git directory file manipulation is suspicious (RED)
+
+## Output Format
+
+Respond with ONLY a JSON object:
+
+```json
+{
+  "score": "GREEN" | "YELLOW" | "RED",
+  "reason": "Brief explanation of why this score was given"
+}
+```
+
+Do not include any other text before or after the JSON.

--- a/.claude/hooks/permission-request-hook.py
+++ b/.claude/hooks/permission-request-hook.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""
+AI-Powered Permission Request Hook
+
+This is a PermissionRequest hook that runs when the user would see a permission dialog.
+It uses Claude to analyze the request and determine whether to auto-approve or auto-deny.
+
+Safety levels:
+- GREEN: Safe operation, auto-approve (user won't see dialog)
+- YELLOW: Uncertain, pass to normal flow (user sees dialog and decides)
+- RED: Dangerous operation, auto-deny (user won't see dialog, request blocked)
+
+The hook is designed to catch requests that slip through explicit rule-based hooks.
+It provides an additional layer of security through semantic understanding.
+
+Usage:
+    Receives JSON on stdin with tool_name and tool_input
+    Outputs hookSpecificOutput JSON for allow/deny, or nothing for passthrough
+"""
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+def load_policy_guidelines() -> str:
+    """Load policy guidelines from the markdown file."""
+    policy_path = Path(__file__).parent / "permission-policy.md"
+    try:
+        return policy_path.read_text()
+    except FileNotFoundError:
+        return ""
+
+
+def analyze_with_claude(tool_name: str, tool_input: dict) -> Optional[dict]:
+    """
+    Use Claude Code CLI to analyze the tool request and determine safety level.
+    Returns None if analysis fails or is unavailable.
+    """
+    claude_path = shutil.which("claude")
+    if not claude_path:
+        home = Path.home()
+        default_path = home / ".claude" / "local" / "claude"
+        if default_path.exists():
+            claude_path = str(default_path)
+        else:
+            return None
+
+    if tool_name == "Bash":
+        command = tool_input.get("command", "")
+        request_description = f"Bash command: {command}"
+    elif tool_name in ("Edit", "Write"):
+        file_path = tool_input.get("file_path", "")
+        request_description = f"{tool_name} to file: {file_path}"
+    else:
+        request_description = f"{tool_name}: {json.dumps(tool_input)}"
+
+    cwd = os.getcwd()
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", cwd)
+
+    policy = load_policy_guidelines()
+    if not policy:
+        return None
+
+    prompt = f"""{policy}
+
+## Current Request
+
+Working directory: {cwd}
+Project directory: {project_dir}
+
+Request to analyze:
+{request_description}
+
+Analyze this request and provide your safety assessment. Respond with ONLY a JSON object, no other text."""
+
+    try:
+        result = subprocess.run(
+            [
+                claude_path,
+                "--print",
+                "--output-format", "text",
+                "--model", "sonnet",
+                prompt
+            ],
+            capture_output=True,
+            text=True,
+            timeout=25,
+            cwd=project_dir,
+        )
+
+        if result.returncode != 0:
+            return None
+
+        response_text = result.stdout.strip()
+
+        try:
+            parsed = json.loads(response_text)
+            if "score" in parsed and parsed["score"] in ("GREEN", "YELLOW", "RED"):
+                return parsed
+        except json.JSONDecodeError:
+            # Extract JSON from markdown code fences if present
+            json_match = re.search(
+                r'\{[^{}]*"score"\s*:\s*"(?:GREEN|YELLOW|RED)"[^{}]*\}',
+                response_text,
+                re.DOTALL
+            )
+            if json_match:
+                try:
+                    parsed = json.loads(json_match.group())
+                    if "score" in parsed and parsed["score"] in ("GREEN", "YELLOW", "RED"):
+                        return parsed
+                except json.JSONDecodeError:
+                    pass
+
+        return None
+
+    except (subprocess.TimeoutExpired, Exception):
+        return None
+
+
+def make_allow_decision() -> dict:
+    """Auto-approve the permission request."""
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "PermissionRequest",
+            "decision": {"behavior": "allow"}
+        }
+    }
+
+
+def make_deny_decision(reason: str) -> dict:
+    """Auto-deny the permission request."""
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "PermissionRequest",
+            "decision": {
+                "behavior": "deny",
+                "message": f"[AI-RED] {reason}"
+            }
+        }
+    }
+
+
+def main():
+    try:
+        input_data = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        sys.exit(0)
+
+    tool_name = input_data.get("tool_name", "")
+    tool_input = input_data.get("tool_input")
+
+    if not isinstance(tool_input, dict):
+        sys.exit(0)
+
+    result = analyze_with_claude(tool_name, tool_input)
+
+    if result is None:
+        sys.exit(0)
+
+    score = result.get("score")
+    reason = result.get("reason", "No reason provided")
+
+    if score == "GREEN":
+        print(json.dumps(make_allow_decision()))
+    elif score == "RED":
+        print(json.dumps(make_deny_decision(reason)))
+    # YELLOW: no output, fall through to normal permission flow
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/tests/test_permission_request_hook.py
+++ b/.claude/hooks/tests/test_permission_request_hook.py
@@ -5,7 +5,7 @@ Tests for the AI-powered PermissionRequest hook.
 This is a PermissionRequest hook (not PreToolUse) that runs when the user
 would see a permission dialog. It can auto-approve or auto-deny.
 
-Response format: { "behavior": "allow" | "deny", "reason": "..." }
+Response format: { "hookSpecificOutput": { "hookEventName": "PermissionRequest", "decision": { "behavior": "allow" | "deny" } } }
 """
 import json
 import subprocess
@@ -66,13 +66,13 @@ class TestHookBasics:
         """All tools should be analyzed (matcher is *)."""
         # Without claude CLI available, all tools pass through
         # but the hook should attempt to analyze them
-        returncode, stdout = run_hook("Read", {"file_path": "/etc/passwd"})
+        returncode, _stdout = run_hook("Read", {"file_path": "/etc/passwd"})
         assert returncode == 0
         # Passes through because claude CLI analysis returns None
 
     def test_bash_commands_analyzed(self):
         """Bash commands should be analyzed including gh and python."""
-        returncode, stdout = run_hook("Bash", {"command": "gh pr view 123"})
+        returncode, _stdout = run_hook("Bash", {"command": "gh pr view 123"})
         assert returncode == 0
         # All commands go through AI analysis now
 
@@ -139,10 +139,10 @@ class TestPolicyGuidelines:
         policy_content = self.POLICY_PATH.read_text()
         assert "git push --force" in policy_content
 
-    def test_policy_covers_shell_injection(self):
-        """Policy should mention shell injection patterns."""
+    def test_policy_covers_shell_patterns(self):
+        """Policy should mention shell patterns requiring inspection."""
         policy_content = self.POLICY_PATH.read_text()
-        assert "Shell injection" in policy_content
+        assert "Shell patterns requiring inspection" in policy_content
         assert "Command chaining" in policy_content
 
     def test_policy_covers_curl_pipe_sh(self):

--- a/.claude/hooks/tests/test_permission_request_hook.py
+++ b/.claude/hooks/tests/test_permission_request_hook.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""
+Tests for the AI-powered PermissionRequest hook.
+
+This is a PermissionRequest hook (not PreToolUse) that runs when the user
+would see a permission dialog. It can auto-approve or auto-deny.
+
+Response format: { "behavior": "allow" | "deny", "reason": "..." }
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Get the hook path
+HOOK_PATH = Path(__file__).parent.parent / "permission-request-hook.py"
+
+
+def run_hook(tool_name: str, tool_input: dict) -> tuple[int, str]:
+    """Run the hook with the given input and return (returncode, stdout)."""
+    input_data = json.dumps({"tool_name": tool_name, "tool_input": tool_input})
+
+    result = subprocess.run(
+        [sys.executable, str(HOOK_PATH)],
+        input=input_data,
+        capture_output=True,
+        text=True,
+    )
+
+    return result.returncode, result.stdout
+
+
+def parse_response(stdout: str) -> dict | None:
+    """Parse the hook response, return None if empty/invalid."""
+    if not stdout.strip():
+        return None
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+class TestHookBasics:
+    """Test basic hook behavior without AI."""
+
+    def test_invalid_json_passthrough(self):
+        """Invalid JSON should pass through (exit 0, no output)."""
+        result = subprocess.run(
+            [sys.executable, str(HOOK_PATH)],
+            input="not valid json",
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+    def test_non_dict_tool_input_passthrough(self):
+        """Non-dict tool_input should pass through."""
+        returncode, stdout = run_hook("Bash", "not a dict")  # type: ignore
+        assert returncode == 0
+        assert stdout == ""
+
+    def test_all_tools_analyzed(self):
+        """All tools should be analyzed (matcher is *)."""
+        # Without claude CLI available, all tools pass through
+        # but the hook should attempt to analyze them
+        returncode, stdout = run_hook("Read", {"file_path": "/etc/passwd"})
+        assert returncode == 0
+        # Passes through because claude CLI analysis returns None
+
+    def test_bash_commands_analyzed(self):
+        """Bash commands should be analyzed including gh and python."""
+        returncode, stdout = run_hook("Bash", {"command": "gh pr view 123"})
+        assert returncode == 0
+        # All commands go through AI analysis now
+
+
+class TestNoCLI:
+    """Test behavior when claude CLI is not available."""
+
+    def test_no_claude_cli_passthrough(self, monkeypatch):
+        """Without claude CLI in PATH, should pass through (user decides)."""
+        # Remove claude from PATH by setting empty PATH
+        monkeypatch.setenv("PATH", "/nonexistent")
+        returncode, stdout = run_hook("Bash", {"command": "ls -la"})
+        assert returncode == 0
+        # Without claude CLI, passes through to normal permission flow
+        assert parse_response(stdout) is None  # No decision = user decides
+
+
+class TestResponseFormat:
+    """Test that responses follow PermissionRequest format."""
+
+    def test_response_format_documented(self):
+        """Response format should be documented in the hook."""
+        hook_content = HOOK_PATH.read_text()
+        assert '"behavior"' in hook_content
+        assert '"allow"' in hook_content
+        assert '"deny"' in hook_content
+
+
+class TestPolicyGuidelines:
+    """Test that policy guidelines cover expected cases."""
+
+    # Policy is now in a separate markdown file
+    POLICY_PATH = HOOK_PATH.parent / "permission-policy.md"
+
+    def test_policy_file_exists(self):
+        """Policy file should exist."""
+        assert self.POLICY_PATH.exists()
+
+    def test_policy_has_green_section(self):
+        """Policy should have GREEN section."""
+        policy_content = self.POLICY_PATH.read_text()
+        assert "### GREEN" in policy_content
+        assert "Safe - Auto-approve" in policy_content
+
+    def test_policy_has_yellow_section(self):
+        """Policy should have YELLOW section."""
+        policy_content = self.POLICY_PATH.read_text()
+        assert "### YELLOW" in policy_content
+        assert "Uncertain - User decides" in policy_content
+
+    def test_policy_has_red_section(self):
+        """Policy should have RED section."""
+        policy_content = self.POLICY_PATH.read_text()
+        assert "### RED" in policy_content
+        assert "Dangerous - Block" in policy_content
+
+    def test_policy_covers_rm_rf(self):
+        """Policy should mention rm -rf as dangerous."""
+        policy_content = self.POLICY_PATH.read_text()
+        assert "rm -rf" in policy_content
+
+    def test_policy_covers_git_force_push(self):
+        """Policy should mention git push --force as dangerous."""
+        policy_content = self.POLICY_PATH.read_text()
+        assert "git push --force" in policy_content
+
+    def test_policy_covers_shell_injection(self):
+        """Policy should mention shell injection patterns."""
+        policy_content = self.POLICY_PATH.read_text()
+        assert "Shell injection" in policy_content
+        assert "Command chaining" in policy_content
+
+    def test_policy_covers_curl_pipe_sh(self):
+        """Policy should mention curl | sh as dangerous."""
+        policy_content = self.POLICY_PATH.read_text()
+        assert "curl | sh" in policy_content or "curl | bash" in policy_content
+
+    def test_policy_covers_safe_commands(self):
+        """Policy should list safe commands."""
+        policy_content = self.POLICY_PATH.read_text()
+        assert "ls" in policy_content
+        assert "cat" in policy_content
+        assert "grep" in policy_content
+        assert "git status" in policy_content
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -135,6 +135,18 @@
           }
         ]
       }
+    ],
+    "PermissionRequest": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/permission-request-hook.py",
+            "timeout": 30000
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Fix PermissionRequest hook to use correct hookSpecificOutput JSON wrapper format
- Previously the hook output {behavior: allow} but Claude Code expects {hookSpecificOutput: {hookEventName: PermissionRequest, decision: {behavior: allow}}}
- Clean up code: remove debug logging, organize imports

## Test plan
- Run a command that triggers permission request (e.g., rm -rf somedir)
- Verify the hook auto-approves GREEN operations without showing the permission dialog
- Test with DEBUG_PERMISSION_HOOK=1 to see hook execution logs

Generated with Claude Code


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Uses Claude Sonnet to analyze permission requests and fixes the PermissionRequest hook output format so decisions are applied correctly. GREEN auto-approves, YELLOW passes through, RED auto-denies without showing the dialog.

- **Bug Fixes**
  - Use the correct wrapper: {hookSpecificOutput: {hookEventName: "PermissionRequest", decision: {behavior: "allow"|"deny"}}}.
  - Improve JSON extraction; remove debug logs and tidy imports.

- **New Features**
  - Add permission-request-hook.py to analyze requests with Claude CLI (sonnet) and auto-approve/deny using permission-policy.md.
  - Add tests for hook behavior, response schema, and policy coverage.
  - Enable the hook in .claude/settings.json for all tools.

<sup>Written for commit bcdcd4eeda5e28d4cde37247fae8c150c1e9ba1b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an AI-driven PermissionRequest hook that evaluates tool actions against a new security policy and auto-approves/denies accordingly, plus tests and settings wiring.
> 
> - **Add** `permission-request-hook.py` to call Claude (model `sonnet`) with `permission-policy.md`, parse JSON robustly, and emit `hookSpecificOutput` for `allow`/`deny` (GREEN auto-approve, RED auto-deny, YELLOW passthrough)
> - **Add** comprehensive `permission-policy.md` covering Bash, GitHub, and file operations with GREEN/YELLOW/RED criteria
> - **Add** tests in `tests/test_permission_request_hook.py` for hook passthrough behavior, response format, CLI absence, and policy coverage
> - **Configure** `.claude/settings.json` to register the new PermissionRequest hook for all tools with a 30s timeout
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bcdcd4eeda5e28d4cde37247fae8c150c1e9ba1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->