### PR TITLE
Fix git 'dubious ownership' error on Windows when renaming app

### DIFF
--- a/src/ipc/handlers/app_handlers.ts
+++ b/src/ipc/handlers/app_handlers.ts
@@ -54,7 +54,6 @@ import {
   gitInit,
   gitListBranches,
   gitRenameBranch,
-  gitAddSafeDirectory,
 } from "../utils/git_utils";
 import { safeSend } from "../utils/safe_sender";
 import { normalizePath } from "../../../shared/normalizePath";
@@ -1601,12 +1600,6 @@ export function registerAppHandlers() {
             .where(eq(apps.id, appId))
             .returning();
 
-          // Add new path to git safe.directory (required for Windows)
-          const settings = readSettings();
-          if (settings.enableNativeGit && newAppPath !== oldAppPath) {
-            gitAddSafeDirectory(newAppPath);
-          }
-
           return;
         } catch (error: any) {
           // Attempt to rollback the file move
@@ -2032,12 +2025,6 @@ export function registerAppHandlers() {
               `Error deleting old app directory ${currentResolvedPath}:`,
               error,
             );
-          }
-
-          // Add new path to git safe.directory (required for Windows)
-          const settings = readSettings();
-          if (settings.enableNativeGit) {
-            gitAddSafeDirectory(nextResolvedPath);
           }
 
           return {

--- a/src/ipc/handlers/app_handlers.ts
+++ b/src/ipc/handlers/app_handlers.ts
@@ -54,6 +54,7 @@ import {
   gitInit,
   gitListBranches,
   gitRenameBranch,
+  gitAddSafeDirectory,
 } from "../utils/git_utils";
 import { safeSend } from "../utils/safe_sender";
 import { normalizePath } from "../../../shared/normalizePath";
@@ -1600,6 +1601,12 @@ export function registerAppHandlers() {
             .where(eq(apps.id, appId))
             .returning();
 
+          // Add new path to git safe.directory (required for Windows)
+          const settings = readSettings();
+          if (settings.enableNativeGit && newAppPath !== oldAppPath) {
+            gitAddSafeDirectory(newAppPath);
+          }
+
           return;
         } catch (error: any) {
           // Attempt to rollback the file move
@@ -2025,6 +2032,12 @@ export function registerAppHandlers() {
               `Error deleting old app directory ${currentResolvedPath}:`,
               error,
             );
+          }
+
+          // Add new path to git safe.directory (required for Windows)
+          const settings = readSettings();
+          if (settings.enableNativeGit) {
+            gitAddSafeDirectory(nextResolvedPath);
           }
 
           return {

--- a/src/main.ts
+++ b/src/main.ts
@@ -94,11 +94,13 @@ export async function onReady() {
 
   const settings = readSettings();
 
-  // Add dyad-apps directory to git safe.directory (required for Windows)
+  // Add dyad-apps directory to git safe.directory (required for Windows).
+  // The trailing /* allows access to all repositories under the named directory.
+  // See: https://git-scm.com/docs/git-config#Documentation/git-config.txt-safedirectory
   if (settings.enableNativeGit) {
     // Don't need to await because this only needs to run before
     // the user starts interacting with Dyad app and uses a git-related feature.
-    gitAddSafeDirectory(getDyadAppsBaseDirectory());
+    gitAddSafeDirectory(`${getDyadAppsBaseDirectory()}/*`);
   }
 
   // Check if app was force-closed


### PR DESCRIPTION
## Summary
- Add gitAddSafeDirectory call after moving app directory during rename and change-app-location operations
- This ensures the new path is added to Git's safe.directory config on Windows
- Prevents dubious ownership error that occurs when Git operations are performed on directories owned by different users

Fixes #2303

## Test plan
- Existing rename_app.spec.ts E2E tests pass
- On Windows: rename an app that has git history, verify git operations (like listing branches) work without errors

Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures Git trusts all repositories under the Dyad apps base directory on Windows when native Git is enabled.
> 
> - Change `gitAddSafeDirectory(getDyadAppsBaseDirectory())` to `gitAddSafeDirectory(`${getDyadAppsBaseDirectory()}/*`)` during app startup
> - Update comments to document rationale and Git config reference
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b49181edd3612228952e9475c64424b9370f79d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add dyad-apps/* to Git safe.directory at startup so Git works after app renames or moves on Windows when native Git is enabled. Replaces per-app updates with a single wildcard entry. Fixes #2303.

<sup>Written for commit b49181edd3612228952e9475c64424b9370f79d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

