### PR TITLE
Fix PR lookup in pr-review-responder workflow for fork PRs

### DIFF
--- a/.github/workflows/pr-review-responder.yml
+++ b/.github/workflows/pr-review-responder.yml
@@ -30,13 +30,28 @@ jobs:
             const run = context.payload.workflow_run;
 
             // Get PR associated with this workflow run
-            if (!run.pull_requests || run.pull_requests.length === 0) {
-              console.log('No pull requests associated with this workflow run');
-              core.setOutput('should_continue', 'false');
-              return;
-            }
+            // Note: run.pull_requests can be empty for cross-repo PRs (forks)
+            // So we also search by head SHA as a fallback
+            let prNumber;
 
-            const prNumber = run.pull_requests[0].number;
+            if (run.pull_requests && run.pull_requests.length > 0) {
+              prNumber = run.pull_requests[0].number;
+            } else {
+              // Search for PRs with matching head SHA
+              const { data: prs } = await github.rest.pulls.list({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                head: `${run.head_repository.owner.login}:${run.head_branch}`
+              });
+
+              if (prs.length === 0) {
+                console.log('No pull requests found for this workflow run');
+                core.setOutput('should_continue', 'false');
+                return;
+              }
+              prNumber = prs[0].number;
+            }
 
             // Fetch full PR details to get labels
             const { data: pr } = await github.rest.pulls.get({

--- a/.github/workflows/pr-review-responder.yml
+++ b/.github/workflows/pr-review-responder.yml
@@ -37,7 +37,13 @@ jobs:
             if (run.pull_requests && run.pull_requests.length > 0) {
               prNumber = run.pull_requests[0].number;
             } else {
-              // Search for PRs with matching head SHA
+              // Search for PRs with matching head branch
+              // Note: head_repository can be null if the fork was deleted
+              if (!run.head_repository) {
+                console.log('Head repository not available');
+                core.setOutput('should_continue', 'false');
+                return;
+              }
               const { data: prs } = await github.rest.pulls.list({
                 owner: context.repo.owner,
                 repo: context.repo.repo,


### PR DESCRIPTION
## Summary
- Fixed the pr-review-responder workflow failing to find PRs from forks
- Added a fallback that searches for open PRs using `pulls.list` API with the head repository owner and branch name when `workflow_run.pull_requests` array is empty

## Test plan
- Create a PR from a fork with the `cc:request` label
- Verify the workflow can now correctly find and process the PR

#skip-bugbot

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes PR lookup in the pr-review-responder workflow for forked PRs. Adds a fallback search by head owner and branch when workflow_run.pull_requests is empty, so fork PRs are processed correctly.

- **Bug Fixes**
  - Handle empty workflow_run.pull_requests for cross-repo PRs.
  - Use pulls.list with head "<owner>:<branch>" to find the PR number.
  - Exit early (should_continue=false) if head repository is missing or no matching open PR is found.

<sup>Written for commit 5c3a8ae0dd9b3becc1a33647b53e9e50ab9c9e71. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

