### PR TITLE
Add PLAYWRIGHT_HTML_OPEN=never to e2e test commands

### DIFF
--- a/.claude/commands/dyad/deflake-e2e.md
+++ b/.claude/commands/dyad/deflake-e2e.md
@@ -35,7 +35,7 @@ Identify and fix flaky E2E tests by running them repeatedly and investigating fa
    For each test file, run it 10 times:
 
    ```
-   npm run e2e -- e2e-tests/<testfile>.spec.ts --repeat-each=10
+   PLAYWRIGHT_HTML_OPEN=never npm run e2e -- e2e-tests/<testfile>.spec.ts --repeat-each=10
    ```
 
    Notes:
@@ -48,7 +48,7 @@ Identify and fix flaky E2E tests by running them repeatedly and investigating fa
    Run the failing test with Playwright browser debugging enabled:
 
    ```
-   DEBUG=pw:browser npm run e2e -- e2e-tests/<testfile>.spec.ts
+   DEBUG=pw:browser PLAYWRIGHT_HTML_OPEN=never npm run e2e -- e2e-tests/<testfile>.spec.ts
    ```
 
    Analyze the debug output to understand:
@@ -75,7 +75,7 @@ Identify and fix flaky E2E tests by running them repeatedly and investigating fa
    If the flakiness is due to legitimate visual differences:
 
    ```
-   npm run e2e -- e2e-tests/<testfile>.spec.ts --update-snapshots
+   PLAYWRIGHT_HTML_OPEN=never npm run e2e -- e2e-tests/<testfile>.spec.ts --update-snapshots
    ```
 
 8. **Verify the fix:**
@@ -83,7 +83,7 @@ Identify and fix flaky E2E tests by running them repeatedly and investigating fa
    Re-run the test 10 times to confirm it's no longer flaky:
 
    ```
-   npm run e2e -- e2e-tests/<testfile>.spec.ts --repeat-each=10
+   PLAYWRIGHT_HTML_OPEN=never npm run e2e -- e2e-tests/<testfile>.spec.ts --repeat-each=10
    ```
 
    The test should pass all 10 runs consistently.

--- a/.claude/commands/dyad/e2e-rebase.md
+++ b/.claude/commands/dyad/e2e-rebase.md
@@ -21,13 +21,13 @@ Rebase E2E test snapshots based on failed tests from the PR comments.
 5. For each failed test file, run the e2e test with snapshot update:
 
    ```
-   npm run e2e e2e-tests/<testFilename>.spec.ts -- --update-snapshots
+   PLAYWRIGHT_HTML_OPEN=never npm run e2e e2e-tests/<testFilename>.spec.ts -- --update-snapshots
    ```
 
 6. After updating snapshots, re-run the same tests WITHOUT `--update-snapshots` to verify they pass consistently:
 
    ```
-   npm run e2e e2e-tests/<testFilename>.spec.ts
+   PLAYWRIGHT_HTML_OPEN=never npm run e2e e2e-tests/<testFilename>.spec.ts
    ```
 
    If any test fails on this verification run, inform the user that the snapshots may be flaky and stop.

--- a/.claude/commands/dyad/pr-fix/actions.md
+++ b/.claude/commands/dyad/pr-fix/actions.md
@@ -54,7 +54,7 @@ Fix failing CI checks and GitHub Actions on a Pull Request.
    - If the failures are not snapshot-related:
      - Run the failing tests locally with debug output:
        ```
-       DEBUG=pw:browser npm run e2e -- <test-file>
+       DEBUG=pw:browser PLAYWRIGHT_HTML_OPEN=never npm run e2e -- <test-file>
        ```
      - Investigate and fix the underlying issues
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,10 +133,16 @@ If you would need to mock a lot of things to unit test a feature, prefer to writ
 
 Do NOT write lots of e2e test cases for one feature. Each e2e test case adds a significant amount of overhead, so instead prefer just one or two E2E test cases that each have broad coverage of the feature in question.
 
+To run e2e tests without opening the HTML report (which blocks the terminal), use:
+
+```sh
+PLAYWRIGHT_HTML_OPEN=never npm run e2e
+```
+
 To get additional debug logs when a test is failing, use:
 
 ```sh
-DEBUG=pw:browser npm run e2e
+DEBUG=pw:browser PLAYWRIGHT_HTML_OPEN=never npm run e2e
 ```
 
 ## Git workflow


### PR DESCRIPTION
## Summary
- Add `PLAYWRIGHT_HTML_OPEN=never` environment variable to all e2e test commands in AGENTS.md and Claude command files
- Prevents the Playwright HTML reporter from opening a browser and blocking the terminal after tests complete

## Test plan
- Run `npm run e2e` with and without the env var to verify behavior
- Agents running e2e tests should no longer hang waiting for user input

#skip-bugbot

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop the Playwright HTML reporter from auto-opening and blocking the terminal by setting PLAYWRIGHT_HTML_OPEN=never on all e2e commands. Updated AGENTS.md and Claude command files so local runs and agent workflows no longer hang after tests.

<sup>Written for commit 2ee4139f8a43a5bc20ae1933b6c629d19c96937b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

