### PR TITLE
Replace prompt-based stop hook with Sonnet-powered analysis

### DIFF
--- a/.claude/hooks/permission-request-hook.py
+++ b/.claude/hooks/permission-request-hook.py
@@ -84,6 +84,7 @@ Analyze this request and provide your safety assessment. Respond with ONLY a JSO
                 "--print",
                 "--output-format", "text",
                 "--model", "sonnet",
+                "--no-session-persistence",
                 prompt
             ],
             capture_output=True,

--- a/.claude/hooks/stop-hook.py
+++ b/.claude/hooks/stop-hook.py
@@ -225,6 +225,7 @@ JSON response:"""
                 "--print",
                 "--output-format", "text",
                 "--model", "sonnet",
+                "--no-session-persistence",
                 "-p", "-"
             ],
             input=prompt,

--- a/.claude/hooks/tests/fixtures/completed_tasks.jsonl
+++ b/.claude/hooks/tests/fixtures/completed_tasks.jsonl
@@ -1,0 +1,22 @@
+{"type": "user", "message": {"content": "Fix all the PR review comments on this branch"}}
+{"type": "assistant", "message": {"content": [{"type": "text", "text": "I'll help you fix the PR review comments. Let me create a task list."}, {"type": "tool_use", "name": "TaskCreate", "input": {"subject": "Determine the PR", "activeForm": "Determining PR"}}]}}
+{"type": "tool_result", "content": "Task 1 created"}
+{"type": "assistant", "message": {"content": [{"type": "tool_use", "name": "TaskCreate", "input": {"subject": "Fetch review threads", "activeForm": "Fetching threads"}}]}}
+{"type": "tool_result", "content": "Task 2 created"}
+{"type": "assistant", "message": {"content": [{"type": "tool_use", "name": "TaskCreate", "input": {"subject": "Address comments", "activeForm": "Addressing comments"}}]}}
+{"type": "tool_result", "content": "Task 3 created"}
+{"type": "assistant", "message": {"content": [{"type": "tool_use", "name": "TaskUpdate", "input": {"taskId": "1", "status": "in_progress"}}]}}
+{"type": "tool_result", "content": "Task 1 in_progress"}
+{"type": "assistant", "message": {"content": [{"type": "tool_use", "name": "TaskUpdate", "input": {"taskId": "1", "status": "completed"}}]}}
+{"type": "tool_result", "content": "Task 1 completed"}
+{"type": "assistant", "message": {"content": [{"type": "tool_use", "name": "TaskUpdate", "input": {"taskId": "2", "status": "in_progress"}}]}}
+{"type": "tool_result", "content": "Task 2 in_progress"}
+{"type": "assistant", "message": {"content": [{"type": "tool_use", "name": "TaskUpdate", "input": {"taskId": "2", "status": "completed"}}]}}
+{"type": "tool_result", "content": "Task 2 completed"}
+{"type": "assistant", "message": {"content": [{"type": "tool_use", "name": "TaskUpdate", "input": {"taskId": "3", "status": "in_progress"}}]}}
+{"type": "tool_result", "content": "Task 3 in_progress"}
+{"type": "assistant", "message": {"content": [{"type": "tool_use", "name": "Edit", "input": {"file_path": "src/main.ts"}}]}}
+{"type": "tool_result", "content": "File edited"}
+{"type": "assistant", "message": {"content": [{"type": "tool_use", "name": "TaskUpdate", "input": {"taskId": "3", "status": "completed"}}]}}
+{"type": "tool_result", "content": "Task 3 completed"}
+{"type": "assistant", "message": {"content": [{"type": "text", "text": "I've completed all the PR review comments. Here's a summary:\n\n1. Found PR #123\n2. Fetched 2 review threads\n3. Fixed both issues by updating src/main.ts\n\nAll tasks are complete. The changes have been committed and pushed."}]}}

--- a/.claude/hooks/tests/fixtures/incomplete_tasks.jsonl
+++ b/.claude/hooks/tests/fixtures/incomplete_tasks.jsonl
@@ -1,0 +1,33 @@
+{"type": "user", "message": {"content": "Fix all the PR review comments on this branch"}}
+{"type": "assistant", "message": {"content": [{"type": "text", "text": "I'll help you fix the PR review comments. Let me create a task list to track progress."}, {"type": "tool_use", "name": "TaskCreate", "input": {"subject": "Determine the PR to work on", "description": "Get the current branch's PR", "activeForm": "Determining PR"}}]}}
+{"type": "tool_result", "content": "Task 1 created"}
+{"type": "assistant", "message": {"content": [{"type": "tool_use", "name": "TaskCreate", "input": {"subject": "Fetch unresolved PR review threads", "description": "Get all review threads", "activeForm": "Fetching review threads"}}]}}
+{"type": "tool_result", "content": "Task 2 created"}
+{"type": "assistant", "message": {"content": [{"type": "tool_use", "name": "TaskCreate", "input": {"subject": "Process and address review comments", "description": "Fix each comment", "activeForm": "Processing comments"}}]}}
+{"type": "tool_result", "content": "Task 3 created"}
+{"type": "assistant", "message": {"content": [{"type": "tool_use", "name": "TaskCreate", "input": {"subject": "Verify, commit, and push changes", "description": "Run lint, commit, push", "activeForm": "Verifying and pushing"}}]}}
+{"type": "tool_result", "content": "Task 4 created"}
+{"type": "assistant", "message": {"content": [{"type": "tool_use", "name": "TaskCreate", "input": {"subject": "Provide summary to user", "description": "Report what was done", "activeForm": "Providing summary"}}]}}
+{"type": "tool_result", "content": "Task 5 created"}
+{"type": "assistant", "message": {"content": [{"type": "tool_use", "name": "TaskUpdate", "input": {"taskId": "1", "status": "in_progress"}}]}}
+{"type": "tool_result", "content": "Task 1 updated to in_progress"}
+{"type": "assistant", "message": {"content": [{"type": "tool_use", "name": "Bash", "input": {"command": "gh pr view --json number"}}]}}
+{"type": "tool_result", "content": "PR #123"}
+{"type": "assistant", "message": {"content": [{"type": "tool_use", "name": "TaskUpdate", "input": {"taskId": "1", "status": "completed"}}]}}
+{"type": "tool_result", "content": "Task 1 completed"}
+{"type": "assistant", "message": {"content": [{"type": "tool_use", "name": "TaskUpdate", "input": {"taskId": "2", "status": "in_progress"}}]}}
+{"type": "tool_result", "content": "Task 2 updated to in_progress"}
+{"type": "assistant", "message": {"content": [{"type": "tool_use", "name": "Bash", "input": {"command": "gh api graphql"}}]}}
+{"type": "tool_result", "content": "Found 2 review threads"}
+{"type": "assistant", "message": {"content": [{"type": "tool_use", "name": "TaskUpdate", "input": {"taskId": "2", "status": "completed"}}]}}
+{"type": "tool_result", "content": "Task 2 completed"}
+{"type": "assistant", "message": {"content": [{"type": "tool_use", "name": "TaskUpdate", "input": {"taskId": "3", "status": "in_progress"}}]}}
+{"type": "tool_result", "content": "Task 3 updated to in_progress"}
+{"type": "assistant", "message": {"content": [{"type": "text", "text": "I found 2 review comments to address."}, {"type": "tool_use", "name": "Edit", "input": {"file_path": "src/main.ts", "old_string": "foo", "new_string": "bar"}}]}}
+{"type": "tool_result", "content": "File edited"}
+{"type": "assistant", "message": {"content": [{"type": "tool_use", "name": "TaskUpdate", "input": {"taskId": "3", "status": "completed"}}]}}
+{"type": "tool_result", "content": "Task 3 completed"}
+{"type": "assistant", "message": {"content": [{"type": "tool_use", "name": "TaskUpdate", "input": {"taskId": "4", "status": "in_progress"}}]}}
+{"type": "tool_result", "content": "Task 4 updated to in_progress"}
+{"type": "assistant", "message": {"content": [{"type": "text", "text": "Now running lint checks..."}, {"type": "tool_use", "name": "Bash", "input": {"command": "npm run lint"}}]}}
+{"type": "tool_result", "content": "Lint passed"}

--- a/.claude/hooks/tests/test_stop_hook.py
+++ b/.claude/hooks/tests/test_stop_hook.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""
+Tests for the AI-powered Stop hook.
+
+This is a Stop hook that runs when Claude is about to stop working.
+It can block stopping to force continuation if tasks are incomplete.
+
+Response format: { "decision": "block", "reason": "..." } or no output to allow stop
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Get the hook path
+HOOK_PATH = Path(__file__).parent.parent / "stop-hook.py"
+
+
+def run_hook(input_data: dict) -> tuple[int, str]:
+    """Run the hook with the given input and return (returncode, stdout)."""
+    input_json = json.dumps(input_data)
+
+    result = subprocess.run(
+        [sys.executable, str(HOOK_PATH)],
+        input=input_json,
+        capture_output=True,
+        text=True,
+    )
+
+    return result.returncode, result.stdout
+
+
+def parse_response(stdout: str) -> dict | None:
+    """Parse the hook response, return None if empty/invalid."""
+    if not stdout.strip():
+        return None
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+class TestHookBasics:
+    """Test basic hook behavior without AI."""
+
+    def test_invalid_json_allows_stop(self):
+        """Invalid JSON should allow stop (exit 0, no output)."""
+        result = subprocess.run(
+            [sys.executable, str(HOOK_PATH)],
+            input="not valid json",
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+    def test_stop_hook_active_allows_stop(self):
+        """When stop_hook_active is true, should allow stop to prevent infinite loop."""
+        returncode, stdout = run_hook({
+            "session_id": "test",
+            "transcript_path": "/nonexistent/path",
+            "cwd": "/tmp",
+            "stop_hook_active": True
+        })
+        assert returncode == 0
+        assert stdout == ""
+
+    def test_missing_transcript_allows_stop(self):
+        """Missing transcript should allow stop."""
+        returncode, stdout = run_hook({
+            "session_id": "test",
+            "cwd": "/tmp",
+            "stop_hook_active": False
+        })
+        assert returncode == 0
+        assert stdout == ""
+
+    def test_nonexistent_transcript_allows_stop(self):
+        """Nonexistent transcript path should allow stop."""
+        returncode, stdout = run_hook({
+            "session_id": "test",
+            "transcript_path": "/nonexistent/path/to/transcript.jsonl",
+            "cwd": "/tmp",
+            "stop_hook_active": False
+        })
+        assert returncode == 0
+        assert stdout == ""
+
+
+class TestNoCLI:
+    """Test behavior when claude CLI is not available."""
+
+    def test_no_claude_cli_allows_stop(self, monkeypatch, tmp_path):
+        """Without claude CLI, should allow stop (no AI analysis possible)."""
+        # Create a minimal transcript
+        transcript = tmp_path / "transcript.jsonl"
+        transcript.write_text('{"type": "user", "message": {"content": "hello"}}\n')
+
+        # Remove claude from PATH
+        monkeypatch.setenv("PATH", "/nonexistent")
+
+        returncode, stdout = run_hook({
+            "session_id": "test",
+            "transcript_path": str(transcript),
+            "cwd": str(tmp_path),
+            "stop_hook_active": False
+        })
+        assert returncode == 0
+        # Without claude CLI, allows stop
+        assert parse_response(stdout) is None
+
+
+class TestResponseFormat:
+    """Test that responses follow Stop hook format."""
+
+    def test_response_format_documented(self):
+        """Response format should be documented in the hook."""
+        hook_content = HOOK_PATH.read_text()
+        assert '"decision"' in hook_content
+        assert '"block"' in hook_content
+        assert '"reason"' in hook_content
+
+    def test_hook_checks_stop_hook_active(self):
+        """Hook should check stop_hook_active to prevent infinite loops."""
+        hook_content = HOOK_PATH.read_text()
+        assert "stop_hook_active" in hook_content
+
+
+class TestTranscriptReading:
+    """Test transcript reading functionality."""
+
+    def test_reads_user_messages(self, tmp_path):
+        """Should be able to read user messages from transcript."""
+        transcript = tmp_path / "transcript.jsonl"
+        transcript.write_text(
+            '{"type": "user", "message": {"content": "test message"}}\n'
+        )
+
+        # Import the function directly for unit testing
+        import importlib.util
+        spec = importlib.util.spec_from_file_location("stop_hook", HOOK_PATH)
+        assert spec is not None
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+
+        result = module.read_transcript(str(transcript))
+        assert "USER:" in result
+        assert "test message" in result
+
+    def test_reads_assistant_messages(self, tmp_path):
+        """Should be able to read assistant messages from transcript."""
+        transcript = tmp_path / "transcript.jsonl"
+        transcript.write_text(
+            '{"type": "assistant", "message": {"content": [{"type": "text", "text": "response text"}]}}\n'
+        )
+
+        import importlib.util
+        spec = importlib.util.spec_from_file_location("stop_hook", HOOK_PATH)
+        assert spec is not None
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+
+        result = module.read_transcript(str(transcript))
+        assert "ASSISTANT:" in result
+        assert "response text" in result
+
+    def test_truncates_large_transcripts(self, tmp_path):
+        """Should truncate large transcripts to max_chars limit."""
+        transcript = tmp_path / "transcript.jsonl"
+        # Create a large transcript with many messages
+        lines = []
+        for i in range(100):
+            lines.append(f'{{"type": "user", "message": {{"content": "message {i} with some extra content to make it longer"}}}}')
+        transcript.write_text("\n".join(lines))
+
+        import importlib.util
+        spec = importlib.util.spec_from_file_location("stop_hook", HOOK_PATH)
+        assert spec is not None
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+
+        # With a small max_chars, should truncate
+        result = module.read_transcript(str(transcript), max_chars=500)
+        assert len(result) <= 520  # Allow some buffer for truncation marker
+        assert "...(truncated)" in result
+        # Should keep the most recent messages (higher numbers)
+        assert "message 99" in result or "message 98" in result
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/.claude/hooks/tests/test_stop_hook.py
+++ b/.claude/hooks/tests/test_stop_hook.py
@@ -169,7 +169,7 @@ class TestTranscriptReading:
         assert "response text" in result
 
     def test_truncates_large_transcripts(self, tmp_path):
-        """Should truncate large transcripts to max_chars limit."""
+        """Should truncate large transcripts from the middle, keeping beginning and end."""
         transcript = tmp_path / "transcript.jsonl"
         # Create a large transcript with many messages
         lines = []
@@ -184,11 +184,13 @@ class TestTranscriptReading:
         assert spec.loader is not None
         spec.loader.exec_module(module)
 
-        # With a small max_chars, should truncate
+        # With a small max_chars, should truncate from the middle
         result = module.read_transcript(str(transcript), max_chars=500)
-        assert len(result) <= 520  # Allow some buffer for truncation marker
-        assert "...(truncated)" in result
-        # Should keep the most recent messages (higher numbers)
+        assert len(result) <= 600  # Allow buffer for truncation marker
+        assert "...(middle truncated)..." in result
+        # Should keep beginning messages (lower numbers)
+        assert "message 0" in result or "message 1" in result
+        # Should keep end messages (higher numbers)
         assert "message 99" in result or "message 98" in result
 
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -152,9 +152,9 @@
       {
         "hooks": [
           {
-            "type": "prompt",
-            "prompt": "You are evaluating whether Claude should stop working. Your default bias should be to CONTINUE WORKING (ok: false). Only allow stopping when absolutely certain all work is complete.\n\nContext: $ARGUMENTS\n\nAnalyze the conversation and determine:\n\n1. TASK COMPLETION CHECK\n   - Has EVERY task the user requested been fully completed?\n   - Not just acknowledged, but actually done with verifiable output?\n   - Are there any implied subtasks that haven't been addressed?\n\n2. ERROR CHECK\n   - Did any errors occur that weren't resolved?\n   - Are there failed operations that need retry?\n   - Did Claude say it would do something but didn't actually do it?\n\n3. FOLLOW-UP CHECK\n   - Is there obvious next-step work that should be done?\n   - Did the user's request imply multiple steps where only some were completed?\n   - Would a thorough assistant do more here?\n\n4. QUALITY CHECK\n   - Was the work done to completion, not just partially?\n   - Are there placeholders, TODOs, or incomplete sections?\n   - Did Claude stop prematurely mid-task?\n\nDECISION RULES:\n- If ANY task is incomplete → continue (ok: false)\n- If ANY error is unresolved → continue (ok: false)\n- If there's reasonable follow-up work → continue (ok: false)\n- If Claude said \"I'll do X\" but didn't → continue (ok: false)\n- If work quality is partial/rushed → continue (ok: false)\n- ONLY return ok: true if ALL tasks are genuinely, fully complete AND no errors exist AND no reasonable follow-up remains\n\nRespond with JSON:\n- {\"ok\": false, \"reason\": \"specific explanation of what still needs to be done\"} — DEFAULT, use this unless everything is truly complete\n- {\"ok\": true} — ONLY when absolutely certain all work is finished and nothing remains",
-            "timeout": 30
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/stop-hook.py",
+            "timeout": 30000
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Replace broken prompt-based Stop hook with command-based hook using Claude Sonnet
- Add .claude/hooks/stop-hook.py that reads conversation transcript and uses Sonnet to analyze task completion
- Includes infinite loop prevention via stop_hook_active check
- Add unit tests for the stop hook

## Test plan
- [x] Run pytest .claude/hooks/tests/test_stop_hook.py -v - all 9 tests pass
- [ ] Manual testing: verify stop hook fires and correctly analyzes task completion

#skip-bugbot

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the broken prompt-based stop hook with a command-based hook that blocks when tasks remain and uses Sonnet analysis as a fallback. Adds loop protection and tests.

- **New Features**
  - Added .claude/hooks/stop-hook.py that blocks when TaskCreate/TaskUpdate show remaining tasks, returning {"decision":"block","reason":...}. If none remain, it analyzes a 32k transcript (middle truncation) with Sonnet.
  - Added unit tests and a stop_hook_active guard to prevent infinite loops.

- **Refactors**
  - Updated .claude/settings.json to use the command-based hook (30000 ms timeout) instead of the prompt hook.
  - Added --no-session-persistence to Claude CLI calls in stop-hook.py and permission-request-hook.py.

<sup>Written for commit 575426cee9efb0fa7e1f4be64a8405ae2e717a3b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2331">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
