### PR TITLE
Add application menu for keyboard shortcuts (Ctrl+C, Ctrl+Z, etc.)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -329,38 +329,40 @@ const createApplicationMenu = () => {
     {
       label: "Edit",
       submenu: [
-        { role: "undo" },
-        { role: "redo" },
-        { type: "separator" },
-        { role: "cut" },
-        { role: "copy" },
-        { role: "paste" },
-        { role: "delete" },
-        { type: "separator" },
-        { role: "selectAll" },
+        { role: "undo" as const },
+        { role: "redo" as const },
+        { type: "separator" as const },
+        { role: "cut" as const },
+        { role: "copy" as const },
+        { role: "paste" as const },
+        { role: "delete" as const },
+        { type: "separator" as const },
+        { role: "selectAll" as const },
       ],
     },
     // View menu
     {
       label: "View",
       submenu: [
-        { role: "reload" },
-        { role: "forceReload" },
-        { role: "toggleDevTools" },
-        { type: "separator" },
-        { role: "resetZoom" },
-        { role: "zoomIn" },
-        { role: "zoomOut" },
-        { type: "separator" },
-        { role: "togglefullscreen" },
+        { role: "reload" as const },
+        { role: "forceReload" as const },
+        ...(process.env.NODE_ENV === "development"
+          ? [{ role: "toggleDevTools" as const }]
+          : []),
+        { type: "separator" as const },
+        { role: "resetZoom" as const },
+        { role: "zoomIn" as const },
+        { role: "zoomOut" as const },
+        { type: "separator" as const },
+        { role: "togglefullscreen" as const },
       ],
     },
     // Window menu
     {
       label: "Window",
       submenu: [
-        { role: "minimize" },
-        { role: "zoom" },
+        { role: "minimize" as const },
+        { role: "zoom" as const },
         ...(isMac
           ? [
               { type: "separator" as const },

--- a/src/main.ts
+++ b/src/main.ts
@@ -122,6 +122,7 @@ export async function onReady() {
 
   await onFirstRunMaybe(settings);
   createWindow();
+  createApplicationMenu();
 
   logger.info("Auto-update enabled=", settings.enableAutoUpdate);
   if (settings.enableAutoUpdate) {
@@ -295,6 +296,85 @@ const createWindow = () => {
     const menu = Menu.buildFromTemplate(template);
     menu.popup({ window: mainWindow! });
   });
+};
+
+/**
+ * Create application menu with Edit shortcuts (Undo, Redo, Cut, Copy, Paste, etc.)
+ * This enables standard keyboard shortcuts like Cmd/Ctrl+C, Cmd/Ctrl+V, etc.
+ */
+const createApplicationMenu = () => {
+  const isMac = process.platform === "darwin";
+
+  const template: Electron.MenuItemConstructorOptions[] = [
+    // App menu (macOS only)
+    ...(isMac
+      ? [
+          {
+            label: app.name,
+            submenu: [
+              { role: "about" as const },
+              { type: "separator" as const },
+              { role: "services" as const },
+              { type: "separator" as const },
+              { role: "hide" as const },
+              { role: "hideOthers" as const },
+              { role: "unhide" as const },
+              { type: "separator" as const },
+              { role: "quit" as const },
+            ],
+          },
+        ]
+      : []),
+    // Edit menu - enables keyboard shortcuts for clipboard operations
+    {
+      label: "Edit",
+      submenu: [
+        { role: "undo" },
+        { role: "redo" },
+        { type: "separator" },
+        { role: "cut" },
+        { role: "copy" },
+        { role: "paste" },
+        { role: "delete" },
+        { type: "separator" },
+        { role: "selectAll" },
+      ],
+    },
+    // View menu
+    {
+      label: "View",
+      submenu: [
+        { role: "reload" },
+        { role: "forceReload" },
+        { role: "toggleDevTools" },
+        { type: "separator" },
+        { role: "resetZoom" },
+        { role: "zoomIn" },
+        { role: "zoomOut" },
+        { type: "separator" },
+        { role: "togglefullscreen" },
+      ],
+    },
+    // Window menu
+    {
+      label: "Window",
+      submenu: [
+        { role: "minimize" },
+        { role: "zoom" },
+        ...(isMac
+          ? [
+              { type: "separator" as const },
+              { role: "front" as const },
+              { type: "separator" as const },
+              { role: "window" as const },
+            ]
+          : [{ role: "close" as const }]),
+      ],
+    },
+  ];
+
+  const appMenu = Menu.buildFromTemplate(template);
+  Menu.setApplicationMenu(appMenu);
 };
 
 const gotTheLock = app.requestSingleInstanceLock();


### PR DESCRIPTION
## Summary

- Adds an application menu with Edit, View, and Window submenus to enable standard keyboard shortcuts
- Fixes #1952: Users can now use Cmd/Ctrl+C, Cmd/Ctrl+V, Cmd/Ctrl+Z, Cmd/Ctrl+X, Cmd/Ctrl+A instead of right-clicking
- The Edit menu provides: Undo, Redo, Cut, Copy, Paste, Delete, Select All

## Test plan

1. Start the app
2. Click in the chat input field and type some text
3. Test Ctrl/Cmd+A (Select All) - should select all text
4. Test Ctrl/Cmd+C (Copy) - should copy selected text
5. Test Ctrl/Cmd+V (Paste) - should paste clipboard content
6. Test Ctrl/Cmd+Z (Undo) - should undo last action
7. Test Ctrl/Cmd+Shift+Z or Ctrl+Y (Redo) - should redo undone action
8. Test Ctrl/Cmd+X (Cut) - should cut selected text
9. Verify right-click context menu still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2335">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a global application menu to enable OS-standard keyboard shortcuts and window/view controls.
> 
> - Adds `createApplicationMenu` in `src/main.ts` with `Edit`, `View`, and `Window` menus (plus macOS `App` menu) providing `undo/redo`, `cut/copy/paste/delete/selectAll`, zoom controls, reload, devtools, and fullscreen
> - Calls `createApplicationMenu()` during startup after `createWindow()` to activate shortcuts across the app
> - Leaves existing right-click context menu behavior intact
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fbd07b8dc49d8ee97f98526ac1d654701734c038. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an application menu to enable standard keyboard shortcuts (Undo, Redo, Cut, Copy, Paste, Select All) across the app. Fixes #1952 so users can use Cmd/Ctrl shortcuts instead of relying on the context menu.

- **New Features**
  - Create and set application menu on startup with Edit, View, and Window menus.
  - Edit menu wires Undo, Redo, Cut, Copy, Paste, Delete, Select All via Electron roles.
  - Includes macOS app menu (About, Services, Hide, Quit); Windows/Linux use Window -> Close.

<sup>Written for commit f2499679fb571476cec5f74a2e5a23c3447512c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

