### PR TITLE
Fix refresh to preserve current route (#253)

### DIFF
--- a/e2e-tests/fixtures/multi-page.md
+++ b/e2e-tests/fixtures/multi-page.md
@@ -1,0 +1,76 @@
+Creating a multi-page app with navigation.
+
+<dyad-write path="src/pages/Index.tsx" description="Home page with navigation link">
+import { Link } from "react-router-dom";
+
+const Index = () => {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-100">
+      <div className="text-center">
+        <h1 className="text-4xl font-bold mb-4">Home Page</h1>
+        <Link
+          to="/about"
+          className="text-blue-500 hover:text-blue-700 underline"
+          data-testid="nav-to-about"
+        >
+          Go to About Page
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default Index;
+</dyad-write>
+
+<dyad-write path="src/pages/About.tsx" description="About page with navigation link back">
+import { Link } from "react-router-dom";
+
+const About = () => {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-100">
+      <div className="text-center">
+        <h1 className="text-4xl font-bold mb-4">About Page</h1>
+        <Link
+          to="/"
+          className="text-blue-500 hover:text-blue-700 underline"
+          data-testid="nav-to-home"
+        >
+          Go to Home Page
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default About;
+</dyad-write>
+
+<dyad-write path="src/App.tsx" description="App with router">
+import { Toaster } from "@/components/ui/toaster";
+import { Toaster as Sonner } from "@/components/ui/sonner";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
+import Index from "./pages/Index";
+import About from "./pages/About";
+
+const queryClient = new QueryClient();
+
+const App = () => (
+  <QueryClientProvider client={queryClient}>
+    <TooltipProvider>
+      <Toaster />
+      <Sonner />
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<Index />} />
+          <Route path="/about" element={<About />} />
+        </Routes>
+      </BrowserRouter>
+    </TooltipProvider>
+  </QueryClientProvider>
+);
+
+export default App;
+</dyad-write>

--- a/e2e-tests/refresh.spec.ts
+++ b/e2e-tests/refresh.spec.ts
@@ -53,8 +53,8 @@ testSkipIfWindows("refresh preserves current route", async ({ po }) => {
     po.getPreviewIframeElement().contentFrame().getByText("About Page"),
   ).toBeVisible({ timeout: Timeout.MEDIUM });
 
-  // Wait to see if the page stays on About Page (reproducing local issue)
-  await po.page.waitForTimeout(10000);
+  // Wait to see if the page stays on About Page (reproducing local issue with HMR)
+  await po.page.waitForTimeout(5_000);
 
   // Verify it's STILL on About Page after waiting - check that About Page heading is visible
   // and the Home Page heading is not (use getByRole to match the heading, not the link text)

--- a/e2e-tests/refresh.spec.ts
+++ b/e2e-tests/refresh.spec.ts
@@ -1,4 +1,5 @@
-import { testSkipIfWindows } from "./helpers/test_helper";
+import { testSkipIfWindows, Timeout } from "./helpers/test_helper";
+import { expect } from "@playwright/test";
 
 testSkipIfWindows("refresh app", async ({ po }) => {
   await po.setUp({ autoApprove: true });
@@ -16,4 +17,49 @@ testSkipIfWindows("refresh app", async ({ po }) => {
 
   await po.clickPreviewRefresh();
   await po.snapshotPreview();
+});
+
+testSkipIfWindows("refresh preserves current route", async ({ po }) => {
+  await po.setUp({ autoApprove: true });
+  await po.sendPrompt("hi");
+
+  // Wait for the preview iframe to be visible
+  await po.expectPreviewIframeIsVisible();
+
+  const addressBarPath = po.page.getByTestId("preview-address-bar-path");
+
+  // Wait for the address bar to be visible
+  await expect(addressBarPath).toBeVisible({ timeout: Timeout.MEDIUM });
+
+  // Initially should be at root
+  await expect(addressBarPath).toHaveText("/", { timeout: Timeout.MEDIUM });
+
+  // Navigate to a different route using JavaScript
+  const testRoute = "/test-route";
+  await po
+    .getPreviewIframeElement()
+    .contentFrame()
+    .locator("body")
+    .evaluate((body, route) => {
+      // This triggers a pushState event that updates the navigation history
+      window.history.pushState({}, "", route);
+      // Dispatch a message to notify the parent about the navigation
+      window.parent.postMessage(
+        { type: "pushState", payload: { newUrl: window.location.href } },
+        "*",
+      );
+    }, testRoute);
+
+  // Wait for address bar to update
+  await expect(addressBarPath).toHaveText(testRoute, {
+    timeout: Timeout.MEDIUM,
+  });
+
+  // Click refresh
+  await po.clickPreviewRefresh();
+
+  // Verify the route is preserved after refresh
+  await expect(addressBarPath).toHaveText(testRoute, {
+    timeout: Timeout.MEDIUM,
+  });
 });

--- a/e2e-tests/refresh.spec.ts
+++ b/e2e-tests/refresh.spec.ts
@@ -52,4 +52,22 @@ testSkipIfWindows("refresh preserves current route", async ({ po }) => {
   await expect(
     po.getPreviewIframeElement().contentFrame().getByText("About Page"),
   ).toBeVisible({ timeout: Timeout.MEDIUM });
+
+  // Wait to see if the page stays on About Page (reproducing local issue)
+  await po.page.waitForTimeout(10000);
+
+  // Verify it's STILL on About Page after waiting - check that About Page heading is visible
+  // and the Home Page heading is not (use getByRole to match the heading, not the link text)
+  await expect(
+    po
+      .getPreviewIframeElement()
+      .contentFrame()
+      .getByRole("heading", { name: "About Page" }),
+  ).toBeVisible({ timeout: Timeout.MEDIUM });
+  await expect(
+    po
+      .getPreviewIframeElement()
+      .contentFrame()
+      .getByRole("heading", { name: "Home Page" }),
+  ).not.toBeVisible();
 });

--- a/src/atoms/appAtoms.ts
+++ b/src/atoms/appAtoms.ts
@@ -24,6 +24,10 @@ export const envVarsAtom = atom<Record<string, string | undefined>>({});
 
 export const previewPanelKeyAtom = atom<number>(0);
 
+// Stores the current preview URL to preserve route across HMR-induced remounts
+// Maps appId to the current URL for that app
+export const previewCurrentUrlAtom = atom<Record<number, string>>({});
+
 export const previewErrorMessageAtom = atom<
   { message: string; source: "preview-app" | "dyad-app" } | undefined
 >(undefined);

--- a/src/components/preview_panel/PreviewIframe.tsx
+++ b/src/components/preview_panel/PreviewIframe.tsx
@@ -221,8 +221,6 @@ export const PreviewIframe = ({ loading }: { loading: boolean }) => {
   // Ref to store the URL that the iframe should be showing - initialize with preserved URL if available
   // This is different from appUrl - it tracks the CURRENT route, not just the base URL
   const currentIframeUrlRef = useRef<string | null>(initialUrl || appUrl);
-  // Track if we've consumed the initial preserved URL
-  const consumedInitialUrlRef = useRef(false);
   const [isPicking, setIsPicking] = useState(false);
   const [annotatorMode, setAnnotatorMode] = useAtom(annotatorModeAtom);
   const [screenshotDataUrl, setScreenshotDataUrl] = useAtom(
@@ -702,15 +700,6 @@ export const PreviewIframe = ({ loading }: { loading: boolean }) => {
     setCanGoBack(currentHistoryPosition > 0);
     setCanGoForward(currentHistoryPosition < navigationHistory.length - 1);
   }, [navigationHistory, currentHistoryPosition]);
-
-  // Mark that we've consumed the initial preserved URL (but don't clear it - keep for future HMR remounts)
-  useEffect(() => {
-    if (selectedAppId && initialUrl && !consumedInitialUrlRef.current) {
-      consumedInitialUrlRef.current = true;
-      // Note: We don't clear the preserved URL - it stays until user navigates elsewhere
-      // This ensures subsequent HMR remounts still have access to the preserved route
-    }
-  }, [selectedAppId, initialUrl]);
 
   // Reset navigation when appUrl changes (different app selected)
   const prevAppUrlRef = useRef(appUrl);

--- a/src/components/preview_panel/PreviewIframe.tsx
+++ b/src/components/preview_panel/PreviewIframe.tsx
@@ -201,6 +201,8 @@ export const PreviewIframe = ({ loading }: { loading: boolean }) => {
   );
   const setPreviewIframeRef = useSetAtom(previewIframeRefAtom);
   const iframeRef = useRef<HTMLIFrameElement>(null);
+  // Ref to store the URL to use for the next reload
+  const reloadUrlRef = useRef<string | null>(null);
   const [isPicking, setIsPicking] = useState(false);
   const [annotatorMode, setAnnotatorMode] = useAtom(annotatorModeAtom);
   const [screenshotDataUrl, setScreenshotDataUrl] = useAtom(
@@ -740,14 +742,15 @@ export const PreviewIframe = ({ loading }: { loading: boolean }) => {
 
   // Function to handle reload
   const handleReload = () => {
+    // Store the current URL to preserve the route during reload
+    reloadUrlRef.current =
+      navigationHistory[currentHistoryPosition] || appUrl || null;
     setReloadKey((prevKey) => prevKey + 1);
     setErrorMessage(undefined);
     // Reset visual editing state
     setVisualEditingSelectedComponent(null);
     setPendingChanges(new Map());
     setCurrentComponentCoordinates(null);
-    // Optionally, add logic here if you need to explicitly stop/start the app again
-    // For now, just changing the key should remount the iframe
     console.debug("Reloading iframe preview for app", selectedAppId);
   };
 
@@ -904,7 +907,10 @@ export const PreviewIframe = ({ loading }: { loading: boolean }) => {
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <div className="flex items-center justify-between px-3 py-1 bg-gray-100 dark:bg-gray-700 rounded text-sm text-gray-700 dark:text-gray-200 cursor-pointer w-full min-w-0">
-                  <span className="truncate flex-1 mr-2 min-w-0">
+                  <span
+                    className="truncate flex-1 mr-2 min-w-0"
+                    data-testid="preview-address-bar-path"
+                  >
                     {navigationHistory[currentHistoryPosition]
                       ? new URL(navigationHistory[currentHistoryPosition])
                           .pathname
@@ -1109,7 +1115,7 @@ export const PreviewIframe = ({ loading }: { loading: boolean }) => {
                       ? {}
                       : { width: `${deviceWidthConfig[deviceMode]}px` }
                   }
-                  src={appUrl}
+                  src={reloadUrlRef.current || appUrl}
                   allow="clipboard-read; clipboard-write; fullscreen; microphone; camera; display-capture; geolocation; autoplay; picture-in-picture"
                 />
                 {/* Visual Editing Toolbar */}


### PR DESCRIPTION
## Summary
- When clicking the refresh button in the preview panel, the app now preserves the current route instead of defaulting to the root path (/)
- Store the current URL in a ref when refresh is clicked, then use it as the iframe src during reload
- Added E2E test to verify route preservation on refresh

Fixes #253

## Test plan
- E2E test `refresh preserves current route` verifies the fix:
  1. Create an app
  2. Navigate to a different route using JavaScript (simulating client-side navigation)
  3. Click refresh
  4. Verify the address bar still shows the navigated route (not /)
- Existing `refresh app` test continues to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2336">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the preview refresh keeps the current client-side route and restores it after HMR-induced remounts.
> 
> - Track `pushState`/`replaceState` from the iframe to update local nav history and persist per-app URL via `previewCurrentUrlAtom`; use `currentIframeUrlRef` to set iframe `src` on reload with same-origin validation
> - Reset history when `appUrl` changes; address bar now reflects the current path (`data-testid="preview-address-bar-path"`)
> - Add E2E test `refresh preserves current route` with a React Router multi-page fixture to verify behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8f08e472e0813f553484e38b46cbd77d1865de4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refresh in the preview panel now preserves the current route instead of resetting to /. Routes are also restored after HMR remounts; adds an E2E test to confirm this; fixes #253.

- **Bug Fixes**
  - Track route changes (pushState/replaceState) and persist the current URL per app via previewCurrentUrlAtom; on reload, validate same-origin and use it as the iframe src; reset on app change.
  - Add a data-testid to the address bar and a Playwright test that navigates via a react-router link in a multi-page app, refreshes, waits, and asserts the route remains.

<sup>Written for commit f8f08e472e0813f553484e38b46cbd77d1865de4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

