### PR TITLE
Fix gh pr edit failing on fork PRs by specifying --repo flag

### DIFF
--- a/.github/workflows/pr-review-responder.yml
+++ b/.github/workflows/pr-review-responder.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Update labels to pending
         if: steps.pr-info.outputs.should_continue == 'true'
         run: |
-          gh pr edit ${{ steps.pr-info.outputs.pr_number }} --remove-label "cc:request" --add-label "cc:pending"
+          gh pr edit ${{ steps.pr-info.outputs.pr_number }} --repo ${{ github.repository }} --remove-label "cc:request" --add-label "cc:pending"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -116,13 +116,13 @@ jobs:
       - name: Update labels to done
         if: steps.pr-info.outputs.should_continue == 'true' && success()
         run: |
-          gh pr edit ${{ steps.pr-info.outputs.pr_number }} --remove-label "cc:pending" --add-label "cc:done"
+          gh pr edit ${{ steps.pr-info.outputs.pr_number }} --repo ${{ github.repository }} --remove-label "cc:pending" --add-label "cc:done"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update labels to failed
         if: steps.pr-info.outputs.should_continue == 'true' && failure()
         run: |
-          gh pr edit ${{ steps.pr-info.outputs.pr_number }} --remove-label "cc:pending" --add-label "cc:failed"
+          gh pr edit ${{ steps.pr-info.outputs.pr_number }} --repo ${{ github.repository }} --remove-label "cc:pending" --add-label "cc:failed"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Fixed `gh pr edit` commands failing with "Could not resolve to a PullRequest" error
- When the workflow checks out a fork repository, the `gh` CLI operates in that context and tries to find the PR in the fork instead of the upstream repo
- Added `--repo ${{ github.repository }}` flag to all `gh pr edit` commands to ensure they target the correct repository

## Test plan
- Create a PR from a fork with the `cc:request` label
- Verify the PR Review Responder workflow can successfully update labels

#skip-bugbot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2338">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes gh pr edit failures on fork-based PRs by forcing the repo context with --repo ${{ github.repository }}. The PR Review Responder now reliably updates cc:request/pending/done/failed labels in the upstream repo even when the workflow runs in a fork.

<sup>Written for commit b2d37c8852965f102932662d309da8c45bf9f2f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

