### PR TITLE
Improve PR Review Responder workflow

### DIFF
--- a/.claude/commands/dyad/pr-fix.md
+++ b/.claude/commands/dyad/pr-fix.md
@@ -24,8 +24,33 @@ This is a meta-skill that orchestrates two sub-skills to comprehensively fix PR 
    - Update snapshots if needed
    - Ensure all checks pass
 
-3. **Summary:**
-   After both sub-skills complete, provide a consolidated summary of:
+3. **Post Summary Comment:**
+   After both sub-skills complete, post a comment on the PR with a consolidated summary using `gh pr comment`. The comment should include:
+   - A header indicating success (✅) or failure (❌)
    - Review comments addressed, resolved, or flagged
    - CI checks that were fixed
    - Any remaining issues requiring human attention
+   - Use `<details>` tags to collapse verbose details (e.g., full error messages, lengthy explanations)
+   - If there were any errors, include specific error messages in the collapsed details
+
+   Example format:
+
+   ```
+   ## ✅ Claude Code completed successfully
+
+   ### Summary
+   - Fixed 2 review comments
+   - Resolved 1 CI failure (lint error in `src/foo.ts`)
+
+   <details>
+   <summary>Details</summary>
+
+   ... detailed information here ...
+
+   </details>
+
+   ---
+   [Workflow run](https://github.com/dyad-sh/dyad/actions/runs/12345678)
+   ```
+
+   Note: Include a link to the workflow run at the end. Use the `GITHUB_REPOSITORY` and `GITHUB_RUN_ID` environment variables to construct the URL: `https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID`

--- a/.claude/commands/dyad/pr-fix.md
+++ b/.claude/commands/dyad/pr-fix.md
@@ -33,7 +33,11 @@ This is a meta-skill that orchestrates two sub-skills to comprehensively fix PR 
    - Use `<details>` tags to collapse verbose details (e.g., full error messages, lengthy explanations)
    - If there were any errors, include specific error messages in the collapsed details
 
-   Example format:
+   **Error handling:** If `gh pr comment` fails (e.g., due to network issues, rate limits, or permissions), log a warning but do not fail the entire skill if the underlying fixes were successful. The comment is informational and should not block a successful run.
+
+   Example formats:
+
+   **Success:**
 
    ```
    ## ✅ Claude Code completed successfully
@@ -53,4 +57,30 @@ This is a meta-skill that orchestrates two sub-skills to comprehensively fix PR 
    [Workflow run](https://github.com/dyad-sh/dyad/actions/runs/12345678)
    ```
 
-   Note: Include a link to the workflow run at the end. Use the `GITHUB_REPOSITORY` and `GITHUB_RUN_ID` environment variables to construct the URL: `https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID`
+   **Failure:**
+
+   ```
+   ## ❌ Claude Code failed
+
+   ### Summary
+   - Attempted to fix 2 review comments
+   - Failed to resolve 1 CI failure (lint error in `src/foo.ts`)
+
+   <details>
+   <summary>Error Details</summary>
+
+   **Error:** `lint` command failed with exit code 1.
+
+   ```
+
+   ... linter output ...
+
+   ```
+
+   </details>
+
+   ---
+   [Workflow run](https://github.com/dyad-sh/dyad/actions/runs/12345678)
+   ```
+
+   Note: Include a link to the workflow run at the end. If the `GITHUB_REPOSITORY` and `GITHUB_RUN_ID` environment variables are available, use them to construct the URL: `https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID`. If these environment variables are not set, omit the workflow run link.

--- a/.github/workflows/pr-review-responder.yml
+++ b/.github/workflows/pr-review-responder.yml
@@ -119,16 +119,33 @@ jobs:
             /dyad:pr-fix ${{ steps.pr-info.outputs.pr_number }}
 
       - name: Re-trigger CI if commits were pushed
-        if: steps.pr-info.outputs.should_continue == 'true' && success()
+        # Use always() to ensure commits get tested even if Claude Code fails partway through
+        if: steps.pr-info.outputs.should_continue == 'true' && always()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git fetch origin
-          NEW_SHA=$(git rev-parse origin/${{ github.event.workflow_run.head_branch }})
-          if [ "${{ steps.before-claude.outputs.sha }}" != "$NEW_SHA" ]; then
-            echo "Claude pushed new commits, re-triggering CI by closing and reopening PR"
-            gh pr close ${{ steps.pr-info.outputs.pr_number }} --repo ${{ github.repository }}
-            gh pr reopen ${{ steps.pr-info.outputs.pr_number }} --repo ${{ github.repository }}
+          # Fetch using the PR's head ref to handle both fork and same-repo PRs correctly
+          # Use the GitHub API to get the current head SHA, avoiding race conditions with git fetch
+          PR_HEAD_SHA=$(gh pr view ${{ steps.pr-info.outputs.pr_number }} --repo ${{ github.repository }} --json headRefOid --jq '.headRefOid')
+          if [ -z "$PR_HEAD_SHA" ]; then
+            echo "Failed to get PR head SHA, falling back to git fetch"
+            git fetch origin ${{ github.event.workflow_run.head_branch }} || git fetch origin
+            PR_HEAD_SHA=$(git rev-parse FETCH_HEAD 2>/dev/null || git rev-parse origin/${{ github.event.workflow_run.head_branch }})
+          fi
+
+          if [ "${{ steps.before-claude.outputs.sha }}" != "$PR_HEAD_SHA" ]; then
+            echo "Claude pushed new commits (before: ${{ steps.before-claude.outputs.sha }}, after: $PR_HEAD_SHA)"
+            echo "Re-triggering CI by closing and reopening PR"
+            if gh pr close ${{ steps.pr-info.outputs.pr_number }} --repo ${{ github.repository }}; then
+              if ! gh pr reopen ${{ steps.pr-info.outputs.pr_number }} --repo ${{ github.repository }}; then
+                echo "::warning::Failed to reopen PR after close. Attempting recovery..."
+                # Retry reopen once after a short delay
+                sleep 2
+                gh pr reopen ${{ steps.pr-info.outputs.pr_number }} --repo ${{ github.repository }} || echo "::error::PR may be left closed. Manual intervention required."
+              fi
+            else
+              echo "::warning::Failed to close PR, skipping re-trigger"
+            fi
           else
             echo "No new commits pushed, skipping CI re-trigger"
           fi

--- a/.github/workflows/pr-review-responder.yml
+++ b/.github/workflows/pr-review-responder.yml
@@ -97,6 +97,11 @@ jobs:
           ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: 0
 
+      - name: Record HEAD before Claude Code
+        if: steps.pr-info.outputs.should_continue == 'true'
+        id: before-claude
+        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
       - name: Update labels to pending
         if: steps.pr-info.outputs.should_continue == 'true'
         run: |
@@ -112,6 +117,21 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             /dyad:pr-fix ${{ steps.pr-info.outputs.pr_number }}
+
+      - name: Re-trigger CI if commits were pushed
+        if: steps.pr-info.outputs.should_continue == 'true' && success()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git fetch origin
+          NEW_SHA=$(git rev-parse origin/${{ github.event.workflow_run.head_branch }})
+          if [ "${{ steps.before-claude.outputs.sha }}" != "$NEW_SHA" ]; then
+            echo "Claude pushed new commits, re-triggering CI by closing and reopening PR"
+            gh pr close ${{ steps.pr-info.outputs.pr_number }} --repo ${{ github.repository }}
+            gh pr reopen ${{ steps.pr-info.outputs.pr_number }} --repo ${{ github.repository }}
+          else
+            echo "No new commits pushed, skipping CI re-trigger"
+          fi
 
       - name: Update labels to done
         if: steps.pr-info.outputs.should_continue == 'true' && success()


### PR DESCRIPTION
## Summary

- Re-triggers CI after Claude Code pushes commits by closing and reopening the PR (workaround for GITHUB_TOKEN commits not triggering workflows)
- Updates pr-fix command to post a summary comment on the PR when done, with collapsible details

## Background

When Claude Code pushes commits using `GITHUB_TOKEN`, GitHub's anti-recursion protection prevents other workflows from triggering. This PR adds a step to close and reopen the PR after Claude pushes, which triggers the `reopened` event that CI listens for.

Also adds instructions to the pr-fix command to have Claude post a summary comment on the PR summarizing what was done.

## Test plan

- [ ] Verify CI re-triggers after Claude Code pushes commits
- [ ] Verify summary comment is posted on the PR

#skip-bugbot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2339">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically re-triggers CI after Claude Code pushes and adds a clear PR summary comment when pr-fix completes. This avoids missed builds from GITHUB_TOKEN commits and helps reviewers see what changed.

- **New Features**
  - Detects new commits from Claude and re-triggers CI by closing/reopening the PR (uses HEAD tracking, GitHub API, and a reopen retry for reliability).
  - pr-fix posts a success/failure summary comment with addressed review items, CI fixes, remaining issues, collapsible details, plus a workflow run link; handles comment failures and missing env vars gracefully.

<sup>Written for commit 77be40a076e264333efb046a81fbc6920b5adc64. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

