### PR TITLE
Add UI for Git Pull Support

### DIFF
--- a/e2e-tests/helpers/test_helper.ts
+++ b/e2e-tests/helpers/test_helper.ts
@@ -1129,6 +1129,27 @@ export class PageObject {
     return this.getAppPath({ appName: currentAppName });
   }
 
+  async configureGitUser({
+    email = "test@example.com",
+    name = "Test User",
+    disableGpgSign = true,
+  }: {
+    email?: string;
+    name?: string;
+    disableGpgSign?: boolean;
+  } = {}) {
+    const appPath = await this.getCurrentAppPath();
+    if (!appPath) {
+      throw new Error("App path not found");
+    }
+
+    execSync(`git config user.email '${email}'`, { cwd: appPath });
+    execSync(`git config user.name '${name}'`, { cwd: appPath });
+    if (disableGpgSign) {
+      execSync("git config commit.gpgsign false", { cwd: appPath });
+    }
+  }
+
   getAppPath({ appName }: { appName: string }) {
     return path.join(this.userDataDir, "dyad-apps", appName);
   }

--- a/e2e-tests/snapshots/git_collaboration.spec.ts_Git-Collaboration-should-create-switch-rename-merge-and-delete-branches-1.aria.yml
+++ b/e2e-tests/snapshots/git_collaboration.spec.ts_Git-Collaboration-should-create-switch-rename-merge-and-delete-branches-1.aria.yml
@@ -3,9 +3,7 @@
 - combobox:
   - img
   - text: "Branch: main"
-- button "Refresh branches":
-  - img
-- button "Create new branch":
+- button "Branch actions":
   - img
 - img
 - heading "Branches" [level=3]

--- a/e2e-tests/snapshots/github.spec.ts_create-and-sync-to-existing-repo---custom-branch-1.aria.yml
+++ b/e2e-tests/snapshots/github.spec.ts_create-and-sync-to-existing-repo---custom-branch-1.aria.yml
@@ -3,9 +3,7 @@
 - combobox:
   - img
   - text: "Branch: new-branch"
-- button "Refresh branches":
-  - img
-- button "Create new branch":
+- button "Branch actions":
   - img
 - img
 - heading "Branches" [level=3]

--- a/e2e-tests/snapshots/github.spec.ts_create-and-sync-to-existing-repo-1.aria.yml
+++ b/e2e-tests/snapshots/github.spec.ts_create-and-sync-to-existing-repo-1.aria.yml
@@ -3,9 +3,7 @@
 - combobox:
   - img
   - text: "Branch: main"
-- button "Refresh branches":
-  - img
-- button "Create new branch":
+- button "Branch actions":
   - img
 - img
 - heading "Branches" [level=3]

--- a/e2e-tests/snapshots/github.spec.ts_create-and-sync-to-new-repo---custom-branch-1.aria.yml
+++ b/e2e-tests/snapshots/github.spec.ts_create-and-sync-to-new-repo---custom-branch-1.aria.yml
@@ -3,9 +3,7 @@
 - combobox:
   - img
   - text: "Branch: new-branch"
-- button "Refresh branches":
-  - img
-- button "Create new branch":
+- button "Branch actions":
   - img
 - img
 - heading "Branches" [level=3]

--- a/e2e-tests/snapshots/github.spec.ts_create-and-sync-to-new-repo-1.aria.yml
+++ b/e2e-tests/snapshots/github.spec.ts_create-and-sync-to-new-repo-1.aria.yml
@@ -3,9 +3,7 @@
 - combobox:
   - img
   - text: "Branch: main"
-- button "Refresh branches":
-  - img
-- button "Create new branch":
+- button "Branch actions":
   - img
 - img
 - heading "Branches" [level=3]

--- a/e2e-tests/snapshots/github.spec.ts_create-and-sync-to-new-repo-2.aria.yml
+++ b/e2e-tests/snapshots/github.spec.ts_create-and-sync-to-new-repo-2.aria.yml
@@ -3,9 +3,7 @@
 - combobox:
   - img
   - text: "Branch: main"
-- button "Refresh branches":
-  - img
-- button "Create new branch":
+- button "Branch actions":
   - img
 - img
 - heading "Branches" [level=3]

--- a/src/ipc/types/github.ts
+++ b/src/ipc/types/github.ts
@@ -186,6 +186,12 @@ export const githubContracts = {
     output: z.void(),
   }),
 
+  pull: defineContract({
+    channel: "github:pull",
+    input: GitBranchAppIdParamsSchema,
+    output: z.void(),
+  }),
+
   rebase: defineContract({
     channel: "github:rebase",
     input: z.object({ appId: z.number() }),


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2342">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a pull workflow and consolidates branch operations into a single actions menu.
> 
> - UI: Replace standalone buttons with `Branch actions` dropdown (`GithubBranchManager.tsx`) containing `Create new branch`, `Refresh branches`, and new `Git pull`; disables controls while pulling
> - IPC: New `github:pull` contract and handler that pulls from `origin` on current branch, uses auth token, tolerates missing remote branch, and reloads branches (`src/ipc/types/github.ts`, `src/ipc/handlers/git_branch_handlers.ts`)
> - E2E: Update flows to use `branch-actions-menu-trigger`; add pull test and snapshots; factor `configureGitUser()` helper (`e2e-tests/...`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40bb9e7cd72308acf34563e9758884d2b0c2cd4e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Git pull support and consolidates branch actions into a single “Branch actions” menu, making it easy to pull remote changes from the UI. Includes IPC wiring and an end-to-end test.

- **New Features**
  - Added “Branch actions” dropdown with Create branch, Refresh branches, and Git pull.
  - Git pull action with loading state and success/error toasts.
  - New IPC contract and handler (github:pull) that pulls from origin and tolerates missing remote branch.

- **Refactors**
  - Replaced separate buttons with a dropdown in GithubBranchManager and updated test IDs.
  - Added configureGitUser helper and new e2e test for pulling from remote.
  - Updated snapshots to reflect the new menu.

<sup>Written for commit 40bb9e7cd72308acf34563e9758884d2b0c2cd4e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

