### PR TITLE
Add chat panel visibility toggle functionality

### DIFF
--- a/e2e-tests/chat_panel_toggle.spec.ts
+++ b/e2e-tests/chat_panel_toggle.spec.ts
@@ -1,0 +1,25 @@
+import { testSkipIfWindows } from "./helpers/test_helper";
+import { expect } from "@playwright/test";
+
+testSkipIfWindows("toggle chat panel visibility", async ({ po }) => {
+  await po.setUp({ autoApprove: true });
+  // We are in the chat view after setUp
+  await po.sendPrompt("basic");
+
+  // Chat panel should be visible initially.
+  const chatPanel = po.page.locator("#chat-panel");
+  await expect(chatPanel).toBeVisible();
+
+  // Toggle button
+  const toggleButton = po.page.getByTestId("preview-toggle-chat-panel-button");
+  // Collapse
+  await toggleButton.click();
+
+  await expect(chatPanel).toBeHidden();
+
+  // Expand
+  await toggleButton.click();
+
+  // Expect chat panel to be visible
+  await expect(chatPanel).toBeVisible();
+});

--- a/src/atoms/viewAtoms.ts
+++ b/src/atoms/viewAtoms.ts
@@ -2,6 +2,7 @@ import { atom } from "jotai";
 import { SECTION_IDS } from "@/lib/settingsSearchIndex";
 
 export const isPreviewOpenAtom = atom(true);
+export const isChatPanelHiddenAtom = atom(false);
 export const selectedFileAtom = atom<{
   path: string;
   line?: number | null;

--- a/src/components/preview_panel/PreviewIframe.tsx
+++ b/src/components/preview_panel/PreviewIframe.tsx
@@ -25,6 +25,8 @@ import {
   Tablet,
   Smartphone,
   Pen,
+  Maximize2,
+  Minimize2,
 } from "lucide-react";
 import { selectedChatIdAtom } from "@/atoms/chatAtoms";
 import { CopyErrorMessage } from "@/components/CopyErrorMessage";
@@ -47,6 +49,7 @@ import {
   screenshotDataUrlAtom,
   pendingVisualChangesAtom,
 } from "@/atoms/previewAtoms";
+import { isChatPanelHiddenAtom } from "@/atoms/viewAtoms";
 import { ComponentSelection } from "@/ipc/types";
 import {
   Popover,
@@ -219,6 +222,9 @@ export const PreviewIframe = ({ loading }: { loading: boolean }) => {
   const [annotatorMode, setAnnotatorMode] = useAtom(annotatorModeAtom);
   const [screenshotDataUrl, setScreenshotDataUrl] = useAtom(
     screenshotDataUrlAtom,
+  );
+  const [isChatPanelHidden, setIsChatPanelHidden] = useAtom(
+    isChatPanelHiddenAtom,
   );
 
   const { addAttachments } = useAttachments();
@@ -983,6 +989,18 @@ export const PreviewIframe = ({ loading }: { loading: boolean }) => {
         <div className="flex items-center p-2 border-b space-x-2">
           {/* Navigation Buttons */}
           <div className="flex space-x-1">
+            <button
+              onClick={() => setIsChatPanelHidden(!isChatPanelHidden)}
+              className="p-1 rounded transition-colors duration-200 hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300"
+              data-testid="preview-toggle-chat-panel-button"
+              title={isChatPanelHidden ? "Show chat" : "Hide chat"}
+            >
+              {isChatPanelHidden ? (
+                <Minimize2 size={16} />
+              ) : (
+                <Maximize2 size={16} />
+              )}
+            </button>
             <button
               onClick={handleActivateComponentSelector}
               className={`p-1 rounded transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed ${

--- a/src/components/preview_panel/PreviewIframe.tsx
+++ b/src/components/preview_panel/PreviewIframe.tsx
@@ -996,9 +996,9 @@ export const PreviewIframe = ({ loading }: { loading: boolean }) => {
               title={isChatPanelHidden ? "Show chat" : "Hide chat"}
             >
               {isChatPanelHidden ? (
-                <Minimize2 size={16} />
-              ) : (
                 <Maximize2 size={16} />
+              ) : (
+                <Minimize2 size={16} />
               )}
             </button>
             <button


### PR DESCRIPTION
Closes #2140
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2345">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements a chat panel visibility toggle and syncs it with the resizable layout.
> 
> - Adds `isChatPanelHiddenAtom` to manage chat panel visibility state
> - Adds a header toggle in `PreviewIframe` (with tooltip, icons, and `data-testid`) to hide/show the chat panel
> - Makes `chat` page's `Panel` for `#chat-panel` collapsible; wires refs to expand/collapse and syncs with the atom; preserves preview panel behavior and resize handle
> - Adds Playwright e2e test `e2e-tests/chat_panel_toggle.spec.ts` verifying collapse/expand behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d27fd58182f7012ad2b07fb3d1584a07b584bf45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a toolbar toggle to hide and show the chat panel, helping users focus on the preview when needed. The chat panel is now collapsible and synced with app state and the resize handle, with an e2e test covering the flow.

- New Features
  - Preview toolbar button toggles chat visibility (Maximize2/Minimize2 with tooltip).
  - Added isChatPanelHiddenAtom; syncs panel size with hidden state, restores previous size on re-open, and updates visibility when the handle is dragged (hidden below ~5% width).
  - Playwright test confirms #chat-panel hides/shows via data-testid="preview-toggle-chat-panel-button".

<sup>Written for commit f41058bfec814dde3d70a53cf20792e9d997f217. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

