### PR TITLE
Add setting to disable auto-expand of preview panel

### DIFF
--- a/src/__tests__/readSettings.test.ts
+++ b/src/__tests__/readSettings.test.ts
@@ -53,6 +53,7 @@ describe("readSettings", () => {
       );
       expect(scrubSettings(result)).toMatchInlineSnapshot(`
         {
+          "autoExpandPreviewPanel": true,
           "enableAutoFixProblems": false,
           "enableAutoUpdate": true,
           "enableNativeGit": true,
@@ -308,6 +309,7 @@ describe("readSettings", () => {
 
       expect(scrubSettings(result)).toMatchInlineSnapshot(`
         {
+          "autoExpandPreviewPanel": true,
           "enableAutoFixProblems": false,
           "enableAutoUpdate": true,
           "enableNativeGit": true,

--- a/src/components/AutoExpandPreviewSwitch.tsx
+++ b/src/components/AutoExpandPreviewSwitch.tsx
@@ -1,0 +1,24 @@
+import { useSettings } from "@/hooks/useSettings";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+
+export function AutoExpandPreviewSwitch() {
+  const { settings, updateSettings } = useSettings();
+  // Default to true if not set (preserve existing behavior)
+  const isEnabled = settings?.autoExpandPreviewPanel ?? true;
+
+  return (
+    <div className="flex items-center space-x-2">
+      <Switch
+        id="auto-expand-preview"
+        checked={isEnabled}
+        onCheckedChange={(checked) => {
+          updateSettings({
+            autoExpandPreviewPanel: checked,
+          });
+        }}
+      />
+      <Label htmlFor="auto-expand-preview">Auto-expand preview panel</Label>
+    </div>
+  );
+}

--- a/src/components/AutoExpandPreviewSwitch.tsx
+++ b/src/components/AutoExpandPreviewSwitch.tsx
@@ -4,8 +4,7 @@ import { Switch } from "@/components/ui/switch";
 
 export function AutoExpandPreviewSwitch() {
   const { settings, updateSettings } = useSettings();
-  // Default to true if not set (preserve existing behavior)
-  const isEnabled = settings?.autoExpandPreviewPanel ?? true;
+  const isEnabled = settings?.autoExpandPreviewPanel;
 
   return (
     <div className="flex items-center space-x-2">

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -256,8 +256,7 @@ export function ChatInput({ chatId }: { chatId?: number }) {
       setError((err as Error)?.message || "An error occurred while approving");
     } finally {
       setIsApproving(false);
-      // Only auto-expand preview if setting is enabled (default: true)
-      if (settings?.autoExpandPreviewPanel !== false) {
+      if (settings?.autoExpandPreviewPanel) {
         setIsPreviewOpen(true);
       }
       refreshVersions();

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -256,7 +256,10 @@ export function ChatInput({ chatId }: { chatId?: number }) {
       setError((err as Error)?.message || "An error occurred while approving");
     } finally {
       setIsApproving(false);
-      setIsPreviewOpen(true);
+      // Only auto-expand preview if setting is enabled (default: true)
+      if (settings?.autoExpandPreviewPanel !== false) {
+        setIsPreviewOpen(true);
+      }
       refreshVersions();
       if (settings?.enableAutoFixProblems) {
         checkProblems();

--- a/src/hooks/useStreamChat.ts
+++ b/src/hooks/useStreamChat.ts
@@ -176,7 +176,10 @@ export function useStreamChat({
               pendingStreamChatIds.delete(chatId);
 
               if (response.updatedFiles) {
-                setIsPreviewOpen(true);
+                // Only auto-expand preview if setting is enabled (default: true)
+                if (settings?.autoExpandPreviewPanel !== false) {
+                  setIsPreviewOpen(true);
+                }
                 refreshAppIframe();
                 if (settings?.enableAutoFixProblems) {
                   checkProblems();

--- a/src/hooks/useStreamChat.ts
+++ b/src/hooks/useStreamChat.ts
@@ -176,8 +176,7 @@ export function useStreamChat({
               pendingStreamChatIds.delete(chatId);
 
               if (response.updatedFiles) {
-                // Only auto-expand preview if setting is enabled (default: true)
-                if (settings?.autoExpandPreviewPanel !== false) {
+                if (settings?.autoExpandPreviewPanel) {
                   setIsPreviewOpen(true);
                 }
                 refreshAppIframe();

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -300,6 +300,7 @@ export const UserSettingsSchema = z
     previewDeviceMode: DeviceModeSchema.optional(),
 
     enableAutoFixProblems: z.boolean().optional(),
+    autoExpandPreviewPanel: z.boolean().optional(),
     enableNativeGit: z.boolean().optional(),
     enableAutoUpdate: z.boolean(),
     releaseChannel: ReleaseChannelSchema,

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -40,6 +40,7 @@ const DEFAULT_SETTINGS: UserSettings = {
   lastKnownPerformance: undefined,
   // Enabled by default in 0.33.0-beta.1
   enableNativeGit: true,
+  autoExpandPreviewPanel: true,
 };
 
 const SETTINGS_FILE = "user-settings.json";

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -20,6 +20,7 @@ import { SupabaseIntegration } from "@/components/SupabaseIntegration";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { AutoFixProblemsSwitch } from "@/components/AutoFixProblemsSwitch";
+import { AutoExpandPreviewSwitch } from "@/components/AutoExpandPreviewSwitch";
 import { AutoUpdateSwitch } from "@/components/AutoUpdateSwitch";
 import { ReleaseChannelSelector } from "@/components/ReleaseChannelSelector";
 import { NeonIntegration } from "@/components/NeonIntegration";
@@ -327,6 +328,13 @@ export function WorkflowSettings() {
         <AutoFixProblemsSwitch />
         <div className="text-sm text-gray-500 dark:text-gray-400">
           This will automatically fix TypeScript errors.
+        </div>
+      </div>
+
+      <div className="space-y-1 mt-4">
+        <AutoExpandPreviewSwitch />
+        <div className="text-sm text-gray-500 dark:text-gray-400">
+          Automatically expand the preview panel when code changes are made.
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Adds new "Auto-expand preview panel" toggle in Workflow Settings
- When disabled, the preview panel stays collapsed after chat responses and proposal approvals
- Defaults to enabled to preserve existing behavior

Fixes #2090

## Test plan
1. Go to Settings > Workflow Settings
2. Disable "Auto-expand preview panel"
3. Collapse the preview panel manually
4. Send a chat message that generates code changes
5. Verify the preview panel stays collapsed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2352">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a user setting to control automatic preview expansion after code changes.
> 
> - Adds `autoExpandPreviewPanel` to `UserSettings` with default `true` and schema support
> - New `AutoExpandPreviewSwitch` and integrates it into Workflow Settings UI
> - Gates preview opening in `ChatInput` (on approve) and `useStreamChat` (on stream end) behind the new setting
> - Updates settings defaults and unit tests to include the new field
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74064a7eb9092556833afd8fcb37527e59de14cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an “Auto-expand preview panel” toggle in Workflow Settings to control whether the preview opens automatically after chat file updates or proposal approvals. Defaults to on to preserve current behavior and addresses Linear issue #2090.

<sup>Written for commit 74064a7eb9092556833afd8fcb37527e59de14cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

