### PR TITLE
Skip E2E tests in CI when only .claude files changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,61 @@ defaults:
     shell: bash
 
 jobs:
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run_tests: ${{ steps.check.outputs.should_run_tests }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check if only .claude files changed
+        id: check
+        run: |
+          if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            # Always run tests on pushes to main
+            echo "should_run_tests=true" >> $GITHUB_OUTPUT
+            echo "Running tests: push to main branch"
+            exit 0
+          fi
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          else
+            # For push events, compare with parent commit
+            BASE_SHA="${{ github.event.before }}"
+            HEAD_SHA="${{ github.sha }}"
+          fi
+
+          # Get list of changed files
+          CHANGED_FILES=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" 2>/dev/null || echo "")
+
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "should_run_tests=true" >> $GITHUB_OUTPUT
+            echo "Running tests: could not determine changed files"
+            exit 0
+          fi
+
+          echo "Changed files:"
+          echo "$CHANGED_FILES"
+
+          # Check if all changed files are in .claude directory
+          NON_CLAUDE_FILES=$(echo "$CHANGED_FILES" | grep -v "^\.claude/" || true)
+
+          if [ -z "$NON_CLAUDE_FILES" ]; then
+            echo "should_run_tests=false" >> $GITHUB_OUTPUT
+            echo "Skipping tests: all changed files are in .claude/"
+          else
+            echo "should_run_tests=true" >> $GITHUB_OUTPUT
+            echo "Running tests: found non-.claude files:"
+            echo "$NON_CLAUDE_FILES"
+          fi
+
   test:
+    needs: [check-changes]
+    if: needs.check-changes.outputs.should_run_tests == 'true'
     # Why Mac and Windows?
     # I can't run electron playwright on ubuntu-latest and
     # Linux support for Dyad is experimental so not as important
@@ -110,8 +164,9 @@ jobs:
 
   merge-reports:
     # Merge reports after playwright-tests, even if some shards have failed
-    if: ${{ !cancelled() }}
-    needs: [test]
+    # Skip if tests were skipped (only .claude files changed)
+    if: ${{ !cancelled() && needs.check-changes.outputs.should_run_tests == 'true' }}
+    needs: [check-changes, test]
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary
- Adds a `check-changes` job to CI that detects if a PR only modifies files in `.claude/`
- Skips the expensive `test` and `merge-reports` jobs when only Claude config files are changed
- Always runs tests on pushes to main branch for safety

## Test plan
- Create a PR that only changes files in `.claude/` → CI should skip E2E tests
- Create a PR that changes files outside `.claude/` → CI should run E2E tests normally
- Push to main → CI should always run E2E tests

#skip-bugbot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2362">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip E2E tests in CI when a PR only changes files in .claude/, cutting build time and saving resources. Tests always run on pushes to main; aligns with Linear issue 1769548046265.

- **New Features**
  - Added a check-changes job that outputs should_run_tests based on the diff (PR vs push).
  - Gated test and merge-reports jobs on should_run_tests; skip when only .claude/ files changed.
  - Falls back to running tests if changed files can’t be determined.

<sup>Written for commit a75bfed9498b31634a8944d63a435688e0bac8ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

