### PR TITLE
Add telemetry for local-agent search-replace operations

### DIFF
--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -178,7 +178,7 @@ export async function handleLocalAgentStream(
     );
 
     // Build tool execute context
-    const fileEditTracker: FileEditTracker = {};
+    const fileEditTracker: FileEditTracker = Object.create(null);
     const ctx: AgentContext = {
       event,
       appId: chat.app.id,
@@ -462,9 +462,7 @@ export async function handleLocalAgentStream(
       if (toolsUsed.length >= 2) {
         sendTelemetryEvent("local_agent:file_edit_retry", {
           filePath,
-          write_file: counts.write_file,
-          edit_file: counts.edit_file,
-          search_replace: counts.search_replace,
+          ...counts,
         });
       }
     }

--- a/src/pro/main/ipc/handlers/local_agent/tools/search_replace.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/search_replace.spec.ts
@@ -47,6 +47,7 @@ describe("searchReplaceTool", () => {
     isSharedModulesChanged: false,
     todos: [],
     dyadRequestId: "test-request",
+    fileEditTracker: {},
     onXmlStream: vi.fn(),
     onXmlComplete: vi.fn(),
     requireConsent: vi.fn().mockResolvedValue(true),

--- a/src/pro/main/ipc/handlers/local_agent/tools/types.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/types.ts
@@ -27,7 +27,12 @@ export {
 export type Todo = AgentTodo;
 
 /** Tracks which file-editing tools were used on each file path */
-export type FileEditToolName = "write_file" | "edit_file" | "search_replace";
+export const FILE_EDIT_TOOL_NAMES = [
+  "write_file",
+  "edit_file",
+  "search_replace",
+] as const;
+export type FileEditToolName = (typeof FILE_EDIT_TOOL_NAMES)[number];
 export interface FileEditTracker {
   [filePath: string]: {
     write_file: number;

--- a/src/pro/main/ipc/handlers/local_agent/tools/types.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/types.ts
@@ -26,6 +26,16 @@ export {
 // Re-export AgentTodo as Todo for backwards compatibility within this module
 export type Todo = AgentTodo;
 
+/** Tracks which file-editing tools were used on each file path */
+export type FileEditToolName = "write_file" | "edit_file" | "search_replace";
+export interface FileEditTracker {
+  [filePath: string]: {
+    write_file: number;
+    edit_file: number;
+    search_replace: number;
+  };
+}
+
 export interface AgentContext {
   event: IpcMainInvokeEvent;
   appId: number;
@@ -40,6 +50,8 @@ export interface AgentContext {
   todos: Todo[];
   /** Request ID for tracking requests to the Dyad engine */
   dyadRequestId: string;
+  /** Tracks file edit tool usage per file for telemetry */
+  fileEditTracker: FileEditTracker;
   /**
    * Streams accumulated XML to UI without persisting to DB (for live preview).
    * Call this repeatedly with the full accumulated XML so far.


### PR DESCRIPTION
## Summary
- Add `local_agent:search_replace:success` and `local_agent:search_replace:failure` telemetry events to track search-replace outcomes in local-agent mode
- Add `local_agent:file_edit_retry` telemetry to detect when multiple edit tool types (write_file, edit_file, search_replace) are used on the same file, indicating retry/fallback behavior
- Add `FileEditTracker` to `AgentContext` to track tool usage per file during an agent session

## Test plan
- [x] TypeScript type checks pass
- [x] Linter passes
- [x] All 654 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

#skip-bugbot
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2371">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds telemetry to local-agent to track search-replace success/failure and when multiple edit tools touch the same file. Introduces a FileEditTracker in AgentContext to record write_file, edit_file, and search_replace usage per file.

- **New Features**
  - Emit local_agent:search_replace:success and local_agent:search_replace:failure (includes filePath and error on failure).
  - Emit local_agent:file_edit_retry when a file uses 2+ different edit tools; includes per-tool counts.
  - Track usage via FileEditTracker on AgentContext with a helper that records tool calls.

- **Migration**
  - Update any AgentContext mocks/constructors to include fileEditTracker: {}.

<sup>Written for commit f8345128b1d29b555c4c787df7103a6cae98373b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

