### PR TITLE
Fix preview navigation forward/back buttons and add E2E test

### DIFF
--- a/e2e-tests/refresh.spec.ts
+++ b/e2e-tests/refresh.spec.ts
@@ -71,3 +71,73 @@ testSkipIfWindows("refresh preserves current route", async ({ po }) => {
       .getByRole("heading", { name: "Home Page" }),
   ).not.toBeVisible();
 });
+
+testSkipIfWindows(
+  "preview navigation - forward and back buttons work",
+  async ({ po }) => {
+    await po.setUp({ autoApprove: true });
+
+    // Create a multi-page app with react-router navigation
+    await po.sendPrompt("tc=multi-page");
+
+    // Wait for the preview iframe to be visible and loaded
+    await po.expectPreviewIframeIsVisible();
+
+    // Wait for the Home Page content to be visible in the iframe
+    await expect(
+      po.getPreviewIframeElement().contentFrame().getByText("Home Page"),
+    ).toBeVisible({ timeout: Timeout.LONG });
+
+    // Verify back button is disabled initially (no history)
+    await expect(
+      po.page.getByTestId("preview-navigate-back-button"),
+    ).toBeDisabled();
+
+    // Click on the navigation link to go to /about
+    await po
+      .getPreviewIframeElement()
+      .contentFrame()
+      .getByText("Go to About Page")
+      .click();
+
+    // Wait for the About Page content to be visible
+    await expect(
+      po
+        .getPreviewIframeElement()
+        .contentFrame()
+        .getByRole("heading", { name: "About Page" }),
+    ).toBeVisible({ timeout: Timeout.MEDIUM });
+
+    // Now back button should be enabled
+    await expect(
+      po.page.getByTestId("preview-navigate-back-button"),
+    ).toBeEnabled();
+
+    // Click back button to go back to Home Page
+    await po.clickPreviewNavigateBack();
+
+    // Verify we're back on Home Page
+    await expect(
+      po
+        .getPreviewIframeElement()
+        .contentFrame()
+        .getByRole("heading", { name: "Home Page" }),
+    ).toBeVisible({ timeout: Timeout.MEDIUM });
+
+    // Now forward button should be enabled
+    await expect(
+      po.page.getByTestId("preview-navigate-forward-button"),
+    ).toBeEnabled();
+
+    // Click forward button to go back to About Page
+    await po.clickPreviewNavigateForward();
+
+    // Verify we're on About Page again
+    await expect(
+      po
+        .getPreviewIframeElement()
+        .contentFrame()
+        .getByRole("heading", { name: "About Page" }),
+    ).toBeVisible({ timeout: Timeout.MEDIUM });
+  },
+);

--- a/src/components/preview_panel/PreviewIframe.tsx
+++ b/src/components/preview_panel/PreviewIframe.tsx
@@ -775,7 +775,9 @@ export const PreviewIframe = ({ loading }: { loading: boolean }) => {
   const handleNavigateBack = () => {
     if (canGoBack && iframeRef.current?.contentWindow) {
       const newPosition = currentHistoryPosition - 1;
+      if (newPosition < 0 || newPosition >= navigationHistory.length) return;
       const targetUrl = navigationHistory[newPosition];
+      if (!targetUrl) return;
 
       // Send the target URL to navigate to (browser history.back() doesn't work in Electron iframes)
       iframeRef.current.contentWindow.postMessage(
@@ -824,7 +826,9 @@ export const PreviewIframe = ({ loading }: { loading: boolean }) => {
   const handleNavigateForward = () => {
     if (canGoForward && iframeRef.current?.contentWindow) {
       const newPosition = currentHistoryPosition + 1;
+      if (newPosition < 0 || newPosition >= navigationHistory.length) return;
       const targetUrl = navigationHistory[newPosition];
+      if (!targetUrl) return;
 
       // Send the target URL to navigate to (browser history.forward() doesn't work in Electron iframes)
       iframeRef.current.contentWindow.postMessage(

--- a/src/components/preview_panel/PreviewIframe.tsx
+++ b/src/components/preview_panel/PreviewIframe.tsx
@@ -774,38 +774,48 @@ export const PreviewIframe = ({ loading }: { loading: boolean }) => {
   // Function to navigate back
   const handleNavigateBack = () => {
     if (canGoBack && iframeRef.current?.contentWindow) {
+      const newPosition = currentHistoryPosition - 1;
+      const targetUrl = navigationHistory[newPosition];
+
+      // Send the target URL to navigate to (browser history.back() doesn't work in Electron iframes)
       iframeRef.current.contentWindow.postMessage(
         {
           type: "navigate",
-          payload: { direction: "backward" },
+          payload: { direction: "backward", url: targetUrl },
         },
         "*",
       );
 
       // Update our local state
-      setCurrentHistoryPosition((prev) => prev - 1);
-      setCanGoBack(currentHistoryPosition - 1 > 0);
+      setCurrentHistoryPosition(newPosition);
+      setCanGoBack(newPosition > 0);
       setCanGoForward(true);
+      // Update iframe URL ref to match
+      currentIframeUrlRef.current = targetUrl;
     }
   };
 
   // Function to navigate forward
   const handleNavigateForward = () => {
     if (canGoForward && iframeRef.current?.contentWindow) {
+      const newPosition = currentHistoryPosition + 1;
+      const targetUrl = navigationHistory[newPosition];
+
+      // Send the target URL to navigate to (browser history.forward() doesn't work in Electron iframes)
       iframeRef.current.contentWindow.postMessage(
         {
           type: "navigate",
-          payload: { direction: "forward" },
+          payload: { direction: "forward", url: targetUrl },
         },
         "*",
       );
 
       // Update our local state
-      setCurrentHistoryPosition((prev) => prev + 1);
+      setCurrentHistoryPosition(newPosition);
       setCanGoBack(true);
-      setCanGoForward(
-        currentHistoryPosition + 1 < navigationHistory.length - 1,
-      );
+      setCanGoForward(newPosition < navigationHistory.length - 1);
+      // Update iframe URL ref to match
+      currentIframeUrlRef.current = targetUrl;
     }
   };
 

--- a/src/components/preview_panel/PreviewIframe.tsx
+++ b/src/components/preview_panel/PreviewIframe.tsx
@@ -792,6 +792,31 @@ export const PreviewIframe = ({ loading }: { loading: boolean }) => {
       setCanGoForward(true);
       // Update iframe URL ref to match
       currentIframeUrlRef.current = targetUrl;
+
+      // Update preservedUrls to match navigation (for HMR remounts)
+      if (selectedAppId && appUrl) {
+        try {
+          const targetUrlObj = new URL(targetUrl);
+          const appUrlObj = new URL(appUrl);
+          if (targetUrlObj.origin === appUrlObj.origin) {
+            // Clear preserved URL if navigating back to root, otherwise update it
+            if (targetUrlObj.pathname === "/" || targetUrlObj.pathname === "") {
+              setPreservedUrls((prev) => {
+                const newUrls = { ...prev };
+                delete newUrls[selectedAppId];
+                return newUrls;
+              });
+            } else {
+              setPreservedUrls((prev) => ({
+                ...prev,
+                [selectedAppId]: targetUrl,
+              }));
+            }
+          }
+        } catch {
+          // Invalid URL, don't update preservedUrls
+        }
+      }
     }
   };
 
@@ -816,6 +841,31 @@ export const PreviewIframe = ({ loading }: { loading: boolean }) => {
       setCanGoForward(newPosition < navigationHistory.length - 1);
       // Update iframe URL ref to match
       currentIframeUrlRef.current = targetUrl;
+
+      // Update preservedUrls to match navigation (for HMR remounts)
+      if (selectedAppId && appUrl) {
+        try {
+          const targetUrlObj = new URL(targetUrl);
+          const appUrlObj = new URL(appUrl);
+          if (targetUrlObj.origin === appUrlObj.origin) {
+            // Clear preserved URL if navigating forward to root, otherwise update it
+            if (targetUrlObj.pathname === "/" || targetUrlObj.pathname === "") {
+              setPreservedUrls((prev) => {
+                const newUrls = { ...prev };
+                delete newUrls[selectedAppId];
+                return newUrls;
+              });
+            } else {
+              setPreservedUrls((prev) => ({
+                ...prev,
+                [selectedAppId]: targetUrl,
+              }));
+            }
+          }
+        } catch {
+          // Invalid URL, don't update preservedUrls
+        }
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- Add E2E test for preview navigation forward/back buttons
- Fix back/forward navigation by sending target URL instead of using `history.back()`/`history.forward()` which don't work reliably in Electron iframes
- Update dyad-shim.js to handle URL-based navigation with `location.replace`
- Add popstate event handler to notify parent of navigation changes

## Test plan
- Run `npm run e2e -- --grep "forward and back"` to verify the new test passes
- Run `npm run e2e -- --grep "refresh"` to verify all refresh-related tests pass
- Manually test back/forward navigation buttons in the preview panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2372">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures preview back/forward navigation works reliably in Electron iframes and preserves routes across refresh/HMR. Adds targeted E2E coverage.
> 
> - In `PreviewIframe.tsx`, switch back/forward handling to send the target URL via `postMessage` and update local `navigationHistory`, `currentHistoryPosition`, and `preservedUrls`; keep `currentIframeUrlRef` in sync.
> - In `worker/dyad-shim.js`, add `popstate` handler to notify parent (`replaceState` message) and handle `navigate` messages by validating http/https URLs and using `location.replace`, with fallback to `history.go(±1)`.
> - Add E2E test `refresh.spec.ts` for preview forward/back buttons, verifying initial disabled state, navigation to About, back to Home, then forward to About again.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f9f790158262b9e3100ead96bf25f8e3ee8cac7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes preview forward/back navigation and preserves the current route on refresh and HMR so the preview behaves like a real browser. Adds E2E tests for both flows.

- **Bug Fixes**
  - Make back/forward work in Electron by posting the target URL to the iframe and navigating with location.replace; notify parent on popstate; validate http/https URLs to block unsafe protocols.
  - Track and restore the current route across refresh and HMR via previewCurrentUrlAtom and a URL ref; clear preserved URL on root path; reset on app switch and validate same-origin URLs.

- **E2E Tests**
  - Add a multi-page react-router fixture (Home/About).
  - Add tests for route preservation on refresh and for forward/back buttons, including enabled/disabled states.

<sup>Written for commit 7f9f790158262b9e3100ead96bf25f8e3ee8cac7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

