### PR TITLE
Add comprehensive session upload schema for debugging chat sessions

### DIFF
--- a/src/ipc/handlers/upload_handlers.ts
+++ b/src/ipc/handlers/upload_handlers.ts
@@ -12,7 +12,13 @@ export function registerUploadHandlers() {
     logger.debug("IPC: upload-to-signed-url called");
 
     // Validate the signed URL
-    if (!url || typeof url !== "string" || !url.startsWith("https://")) {
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(url);
+    } catch {
+      throw new Error("Invalid signed URL provided");
+    }
+    if (parsedUrl.protocol !== "https:") {
       throw new Error("Invalid signed URL provided");
     }
 
@@ -72,7 +78,13 @@ export function registerUploadHandlers() {
       });
 
       // Validate the signed URL
-      if (!url || typeof url !== "string" || !url.startsWith("https://")) {
+      let parsedUrl: URL;
+      try {
+        parsedUrl = new URL(url);
+      } catch {
+        throw new Error("Invalid signed URL provided");
+      }
+      if (parsedUrl.protocol !== "https:") {
         throw new Error("Invalid signed URL provided");
       }
 

--- a/src/ipc/handlers/upload_handlers.ts
+++ b/src/ipc/handlers/upload_handlers.ts
@@ -2,6 +2,7 @@ import log from "electron-log";
 import fetch from "node-fetch";
 import { createTypedHandler } from "./base";
 import { systemContracts } from "../types/system";
+import { sessionUploadContracts } from "../types/session_upload";
 
 const logger = log.scope("upload_handlers");
 
@@ -37,6 +38,73 @@ export function registerUploadHandlers() {
 
     logger.debug("Successfully uploaded data to signed URL");
   });
+
+  /**
+   * Upload session data to a signed URL.
+   * This is the main handler for uploading chat session data including
+   * AI calls, tool calls, timing information, and error tracking.
+   *
+   * @example
+   * ```typescript
+   * await ipc.sessionUpload.uploadSession({
+   *   url: "https://storage.example.com/session-abc123?signature=...",
+   *   payload: {
+   *     schemaVersion: "1.0.0",
+   *     sessionId: "session_abc123",
+   *     uploadedAt: new Date().toISOString(),
+   *     client: { ... },
+   *     settings: { ... },
+   *     app: { ... },
+   *     chat: { ... },
+   *     messages: [ ... ],
+   *     summary: { ... },
+   *   },
+   * });
+   * ```
+   */
+  createTypedHandler(
+    sessionUploadContracts.uploadSession,
+    async (_, params) => {
+      const { url, payload } = params;
+      logger.debug("IPC: session:upload called", {
+        sessionId: payload.sessionId,
+        messageCount: payload.messages.length,
+      });
+
+      // Validate the signed URL
+      if (!url || typeof url !== "string" || !url.startsWith("https://")) {
+        throw new Error("Invalid signed URL provided");
+      }
+
+      // Log session summary for debugging
+      logger.info("Uploading session data:", {
+        sessionId: payload.sessionId,
+        schemaVersion: payload.schemaVersion,
+        chatId: payload.chat.id,
+        appId: payload.app.id,
+        summary: payload.summary,
+      });
+
+      // Perform the upload to the signed URL
+      const response = await fetch(url, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        throw new Error(
+          `Session upload failed with status ${response.status}: ${response.statusText}`,
+        );
+      }
+
+      logger.debug("Successfully uploaded session data", {
+        sessionId: payload.sessionId,
+      });
+    },
+  );
 
   logger.debug("Registered upload IPC handlers");
 }

--- a/src/ipc/types/index.ts
+++ b/src/ipc/types/index.ts
@@ -49,6 +49,7 @@ export { upgradeContracts } from "./upgrade";
 export { visualEditingContracts } from "./visual-editing";
 export { securityContracts } from "./security";
 export { miscContracts, miscEvents } from "./misc";
+export { sessionUploadContracts } from "./session_upload";
 
 // =============================================================================
 // Client Exports
@@ -77,6 +78,7 @@ export { upgradeClient } from "./upgrade";
 export { visualEditingClient } from "./visual-editing";
 export { securityClient } from "./security";
 export { miscClient, miscEventClient } from "./misc";
+export { sessionUploadClient } from "./session_upload";
 
 // =============================================================================
 // Type Exports
@@ -276,6 +278,29 @@ export type { SecurityReviewResult } from "./security";
 // Misc types
 export type { ChatLogsData, DeepLinkData, AppOutput, EnvVar } from "./misc";
 
+// Session upload types
+export type {
+  SessionUploadPayload,
+  SessionSummary,
+  AppInfo,
+  ChatInfo,
+  MessageInfo,
+  UserMessageInfo,
+  AssistantMessageInfo,
+  AiCallInfo,
+  ToolCallInfo,
+  ErrorInfo,
+  TokenUsage,
+  Timing,
+  StreamTiming,
+  SettingsSnapshot,
+  ClientInfo,
+  AttachmentInfo,
+  ComponentSelectionInfo,
+  AiCallFinishReason,
+  ToolCallStatus,
+} from "./session_upload";
+
 // =============================================================================
 // Schema Exports (for validation in handlers/components)
 // =============================================================================
@@ -304,6 +329,27 @@ export {
 
 export { UserBudgetInfoSchema } from "./system";
 
+export {
+  SESSION_UPLOAD_SCHEMA_VERSION,
+  SessionUploadPayloadSchema,
+  SessionSummarySchema,
+  AppInfoSchema,
+  ChatInfoSchema,
+  MessageInfoSchema,
+  UserMessageInfoSchema,
+  AssistantMessageInfoSchema,
+  AiCallInfoSchema,
+  ToolCallInfoSchema,
+  ErrorInfoSchema,
+  TokenUsageSchema,
+  TimingSchema,
+  StreamTimingSchema,
+  SettingsSnapshotSchema,
+  ClientInfoSchema,
+  AttachmentInfoSchema,
+  ComponentSelectionInfoSchema,
+} from "./session_upload";
+
 // =============================================================================
 // Aggregated IPC Client
 // =============================================================================
@@ -331,6 +377,7 @@ import { upgradeClient } from "./upgrade";
 import { visualEditingClient } from "./visual-editing";
 import { securityClient } from "./security";
 import { miscClient, miscEventClient } from "./misc";
+import { sessionUploadClient } from "./session_upload";
 
 /**
  * Unified IPC client with all domains organized by namespace.
@@ -385,6 +432,9 @@ export const ipc = {
   visualEditing: visualEditingClient,
   security: securityClient,
   misc: miscClient,
+
+  // Session upload
+  sessionUpload: sessionUploadClient,
 
   // Event clients for main->renderer pub/sub
   events: {

--- a/src/ipc/types/session_upload.ts
+++ b/src/ipc/types/session_upload.ts
@@ -233,6 +233,8 @@ export const TokenUsageSchema = z.object({
   /** Cache hit ratio (cachedInputTokens / inputTokens). Between 0 and 1. */
   cacheHitRatio: z
     .number()
+    .min(0)
+    .max(1)
     .nullable()
     .optional()
     .describe("Cache hit ratio (0-1)"),

--- a/src/ipc/types/session_upload.ts
+++ b/src/ipc/types/session_upload.ts
@@ -1,0 +1,1055 @@
+/**
+ * Session Upload Schema
+ *
+ * Comprehensive Zod schema for uploading chat session data to external services.
+ * This schema captures all the information needed to debug and analyze chat sessions,
+ * including:
+ * - Full message history with AI SDK message details
+ * - Tool calls and their results (each message can have many tool calls)
+ * - Timing information for durations and performance analysis
+ * - Error tracking with stack traces and correlation
+ * - Token usage and model information
+ *
+ * @example Basic session upload payload
+ * ```typescript
+ * const payload: SessionUploadPayload = {
+ *   schemaVersion: "1.0.0",
+ *   sessionId: "abc123",
+ *   uploadedAt: "2024-01-15T10:30:00.000Z",
+ *   app: {
+ *     id: 1,
+ *     name: "my-app",
+ *     path: "/apps/my-app",
+ *   },
+ *   chat: {
+ *     id: 42,
+ *     title: "Add user authentication",
+ *     createdAt: "2024-01-15T09:00:00.000Z",
+ *     initialCommitHash: "abc123",
+ *   },
+ *   messages: [
+ *     {
+ *       id: 1,
+ *       role: "user",
+ *       content: "Add login form",
+ *       createdAt: "2024-01-15T09:00:00.000Z",
+ *     },
+ *     {
+ *       id: 2,
+ *       role: "assistant",
+ *       content: "I'll create a login form...",
+ *       createdAt: "2024-01-15T09:00:05.000Z",
+ *       model: "claude-sonnet-4-20250514",
+ *       aiCalls: [...],
+ *       toolCalls: [...],
+ *       timing: {
+ *         startedAt: "2024-01-15T09:00:01.000Z",
+ *         completedAt: "2024-01-15T09:00:05.000Z",
+ *         durationMs: 4000,
+ *         firstTokenAt: "2024-01-15T09:00:01.500Z",
+ *         timeToFirstTokenMs: 500,
+ *       },
+ *     },
+ *   ],
+ *   summary: {
+ *     totalMessages: 2,
+ *     totalToolCalls: 5,
+ *     totalAiCalls: 3,
+ *     totalDurationMs: 4000,
+ *     totalInputTokens: 1500,
+ *     totalOutputTokens: 500,
+ *     errorsCount: 0,
+ *   },
+ * };
+ * ```
+ */
+
+import { z } from "zod";
+import { defineContract, createClient } from "../contracts/core";
+
+// =============================================================================
+// Schema Version
+// =============================================================================
+
+/**
+ * Current schema version for backwards compatibility.
+ * Increment this when making breaking changes to the schema.
+ */
+export const SESSION_UPLOAD_SCHEMA_VERSION = "1.0.0" as const;
+
+// =============================================================================
+// Timing Schemas
+// =============================================================================
+
+/**
+ * Timing information for tracking durations.
+ * All timestamps are ISO 8601 strings for consistent serialization.
+ *
+ * @example
+ * ```typescript
+ * const timing: Timing = {
+ *   startedAt: "2024-01-15T10:30:00.000Z",
+ *   completedAt: "2024-01-15T10:30:05.000Z",
+ *   durationMs: 5000,
+ * };
+ * ```
+ */
+export const TimingSchema = z.object({
+  /** When the operation started (ISO 8601) */
+  startedAt: z
+    .string()
+    .datetime()
+    .describe("When the operation started (ISO 8601)"),
+
+  /** When the operation completed (ISO 8601). Null if still in progress or failed. */
+  completedAt: z
+    .string()
+    .datetime()
+    .nullable()
+    .describe("When the operation completed (ISO 8601)"),
+
+  /** Total duration in milliseconds. Null if not completed. */
+  durationMs: z.number().nullable().describe("Total duration in milliseconds"),
+});
+
+export type Timing = z.infer<typeof TimingSchema>;
+
+/**
+ * Extended timing for AI streaming responses.
+ * Includes time-to-first-token metrics for latency analysis.
+ *
+ * @example
+ * ```typescript
+ * const streamTiming: StreamTiming = {
+ *   startedAt: "2024-01-15T10:30:00.000Z",
+ *   completedAt: "2024-01-15T10:30:05.000Z",
+ *   durationMs: 5000,
+ *   firstTokenAt: "2024-01-15T10:30:00.500Z",
+ *   timeToFirstTokenMs: 500,
+ * };
+ * ```
+ */
+export const StreamTimingSchema = TimingSchema.extend({
+  /** When the first token was received (ISO 8601). Null if no tokens received. */
+  firstTokenAt: z
+    .string()
+    .datetime()
+    .nullable()
+    .describe("When the first token was received"),
+
+  /** Time to first token in milliseconds. Key latency metric. */
+  timeToFirstTokenMs: z
+    .number()
+    .nullable()
+    .describe("Time to first token in milliseconds"),
+});
+
+export type StreamTiming = z.infer<typeof StreamTimingSchema>;
+
+// =============================================================================
+// Error Schemas
+// =============================================================================
+
+/**
+ * Detailed error information for debugging.
+ *
+ * @example
+ * ```typescript
+ * const error: ErrorInfo = {
+ *   code: "TOOL_EXECUTION_FAILED",
+ *   message: "Failed to write file: Permission denied",
+ *   stack: "Error: Failed to write file...\n    at writeFile (/app/tools/write_file.ts:42:11)",
+ *   timestamp: "2024-01-15T10:30:02.000Z",
+ *   context: {
+ *     toolName: "write_file",
+ *     filePath: "/etc/passwd",
+ *   },
+ * };
+ * ```
+ */
+export const ErrorInfoSchema = z.object({
+  /** Error code for categorization (e.g., "TOOL_EXECUTION_FAILED", "AI_STREAM_ERROR") */
+  code: z.string().describe("Error code for categorization"),
+
+  /** Human-readable error message */
+  message: z.string().describe("Human-readable error message"),
+
+  /** Full stack trace if available */
+  stack: z
+    .string()
+    .nullable()
+    .optional()
+    .describe("Full stack trace if available"),
+
+  /** When the error occurred (ISO 8601) */
+  timestamp: z.string().datetime().describe("When the error occurred"),
+
+  /** Additional context about the error (tool name, file path, etc.) */
+  context: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .describe("Additional context about the error"),
+});
+
+export type ErrorInfo = z.infer<typeof ErrorInfoSchema>;
+
+// =============================================================================
+// Token Usage Schemas
+// =============================================================================
+
+/**
+ * Token usage information for a single AI call.
+ *
+ * @example
+ * ```typescript
+ * const usage: TokenUsage = {
+ *   inputTokens: 1500,
+ *   outputTokens: 500,
+ *   totalTokens: 2000,
+ *   cachedInputTokens: 1000,
+ *   cacheHitRatio: 0.67,
+ * };
+ * ```
+ */
+export const TokenUsageSchema = z.object({
+  /** Number of input tokens sent to the model */
+  inputTokens: z.number().describe("Number of input tokens sent to the model"),
+
+  /** Number of output tokens generated by the model */
+  outputTokens: z
+    .number()
+    .describe("Number of output tokens generated by the model"),
+
+  /** Total tokens (input + output) */
+  totalTokens: z.number().describe("Total tokens (input + output)"),
+
+  /** Number of input tokens served from cache (for prompt caching) */
+  cachedInputTokens: z
+    .number()
+    .nullable()
+    .optional()
+    .describe("Number of cached input tokens"),
+
+  /** Cache hit ratio (cachedInputTokens / inputTokens). Between 0 and 1. */
+  cacheHitRatio: z
+    .number()
+    .nullable()
+    .optional()
+    .describe("Cache hit ratio (0-1)"),
+});
+
+export type TokenUsage = z.infer<typeof TokenUsageSchema>;
+
+// =============================================================================
+// Tool Call Schemas
+// =============================================================================
+
+/**
+ * Tool call status enum.
+ */
+export const ToolCallStatusSchema = z.enum([
+  "pending", // Tool call is waiting for execution
+  "running", // Tool call is currently executing
+  "success", // Tool call completed successfully
+  "failed", // Tool call failed with an error
+  "cancelled", // Tool call was cancelled (e.g., user abort)
+  "denied", // Tool call was denied by user consent
+]);
+
+export type ToolCallStatus = z.infer<typeof ToolCallStatusSchema>;
+
+/**
+ * Individual tool call with full execution details.
+ * Each AI call can invoke multiple tools, and each tool call is tracked separately.
+ *
+ * @example
+ * ```typescript
+ * const toolCall: ToolCallInfo = {
+ *   id: "call_abc123",
+ *   toolName: "write_file",
+ *   status: "success",
+ *   input: {
+ *     file_path: "src/components/Login.tsx",
+ *     content: "import React from 'react'...",
+ *   },
+ *   output: "File written successfully",
+ *   timing: {
+ *     startedAt: "2024-01-15T10:30:01.000Z",
+ *     completedAt: "2024-01-15T10:30:02.000Z",
+ *     durationMs: 1000,
+ *   },
+ *   error: null,
+ *   consentRequired: true,
+ *   consentDecision: "accept-once",
+ * };
+ * ```
+ */
+export const ToolCallInfoSchema = z.object({
+  /** Unique identifier for this tool call (from AI SDK) */
+  id: z.string().describe("Unique identifier for this tool call"),
+
+  /** Name of the tool (e.g., "write_file", "read_file", "grep") */
+  toolName: z.string().describe("Name of the tool"),
+
+  /** Current status of the tool call */
+  status: ToolCallStatusSchema.describe("Current status of the tool call"),
+
+  /** Input arguments passed to the tool (JSON-serializable) */
+  input: z.unknown().describe("Input arguments passed to the tool"),
+
+  /** Output returned by the tool. Null if not completed or failed. */
+  output: z.unknown().nullable().describe("Output returned by the tool"),
+
+  /** Timing information for the tool execution */
+  timing: TimingSchema.describe("Timing information for the tool execution"),
+
+  /** Error information if the tool call failed */
+  error: ErrorInfoSchema.nullable()
+    .optional()
+    .describe("Error information if the tool call failed"),
+
+  /** Whether user consent was required for this tool */
+  consentRequired: z.boolean().describe("Whether user consent was required"),
+
+  /** User's consent decision if consent was required */
+  consentDecision: z
+    .enum(["accept-once", "accept-always", "decline"])
+    .nullable()
+    .optional()
+    .describe("User's consent decision"),
+
+  /** Index of the AI call (step) this tool belongs to */
+  aiCallIndex: z.number().describe("Index of the AI call this tool belongs to"),
+
+  /** Whether this is an MCP (Model Context Protocol) tool */
+  isMcpTool: z.boolean().optional().describe("Whether this is an MCP tool"),
+
+  /** MCP server name if this is an MCP tool */
+  mcpServerName: z
+    .string()
+    .nullable()
+    .optional()
+    .describe("MCP server name if applicable"),
+});
+
+export type ToolCallInfo = z.infer<typeof ToolCallInfoSchema>;
+
+// =============================================================================
+// AI Call Schemas
+// =============================================================================
+
+/**
+ * Reason why an AI call finished.
+ */
+export const AiCallFinishReasonSchema = z.enum([
+  "stop", // Model finished naturally
+  "tool-calls", // Model requested tool calls
+  "length", // Hit max tokens limit
+  "content-filter", // Content was filtered
+  "error", // An error occurred
+  "cancelled", // User cancelled the stream
+  "unknown", // Unknown reason
+]);
+
+export type AiCallFinishReason = z.infer<typeof AiCallFinishReasonSchema>;
+
+/**
+ * Individual AI call (step) within a message.
+ * A single assistant message can involve multiple AI calls when using tools
+ * (the model calls tools, receives results, then continues).
+ *
+ * @example
+ * ```typescript
+ * const aiCall: AiCallInfo = {
+ *   index: 0,
+ *   model: "claude-sonnet-4-20250514",
+ *   finishReason: "tool-calls",
+ *   timing: {
+ *     startedAt: "2024-01-15T10:30:00.000Z",
+ *     completedAt: "2024-01-15T10:30:02.000Z",
+ *     durationMs: 2000,
+ *     firstTokenAt: "2024-01-15T10:30:00.300Z",
+ *     timeToFirstTokenMs: 300,
+ *   },
+ *   tokenUsage: {
+ *     inputTokens: 1500,
+ *     outputTokens: 200,
+ *     totalTokens: 1700,
+ *   },
+ *   toolCallIds: ["call_abc123", "call_def456"],
+ *   textDeltaCount: 15,
+ *   error: null,
+ * };
+ * ```
+ */
+export const AiCallInfoSchema = z.object({
+  /** Zero-based index of this AI call within the message (step number) */
+  index: z
+    .number()
+    .describe("Zero-based index of this AI call within the message"),
+
+  /** Model used for this specific call (can differ between calls if model switching) */
+  model: z.string().describe("Model used for this call"),
+
+  /** Why the AI call finished */
+  finishReason: AiCallFinishReasonSchema.describe("Why the AI call finished"),
+
+  /** Timing information including time-to-first-token */
+  timing: StreamTimingSchema.describe("Timing information including TTFT"),
+
+  /** Token usage for this call */
+  tokenUsage: TokenUsageSchema.nullable()
+    .optional()
+    .describe("Token usage for this call"),
+
+  /** IDs of tool calls made during this AI call */
+  toolCallIds: z
+    .array(z.string())
+    .describe("IDs of tool calls made during this AI call"),
+
+  /** Number of text deltas received (useful for debugging streaming issues) */
+  textDeltaCount: z.number().describe("Number of text deltas received"),
+
+  /** Number of reasoning (thinking) deltas received */
+  reasoningDeltaCount: z
+    .number()
+    .optional()
+    .describe("Number of reasoning deltas received"),
+
+  /** Error information if this call failed */
+  error: ErrorInfoSchema.nullable()
+    .optional()
+    .describe("Error information if this call failed"),
+
+  /** Provider-specific request ID for debugging with the AI provider */
+  providerRequestId: z
+    .string()
+    .nullable()
+    .optional()
+    .describe("Provider-specific request ID"),
+});
+
+export type AiCallInfo = z.infer<typeof AiCallInfoSchema>;
+
+// =============================================================================
+// Message Schemas
+// =============================================================================
+
+/**
+ * Attachment information for user messages.
+ *
+ * @example
+ * ```typescript
+ * const attachment: AttachmentInfo = {
+ *   name: "screenshot.png",
+ *   type: "image/png",
+ *   attachmentType: "chat-context",
+ *   sizeBytes: 102400,
+ * };
+ * ```
+ */
+export const AttachmentInfoSchema = z.object({
+  /** Original filename */
+  name: z.string().describe("Original filename"),
+
+  /** MIME type of the attachment */
+  type: z.string().describe("MIME type of the attachment"),
+
+  /** How the attachment is used: uploaded to codebase or just for chat context */
+  attachmentType: z
+    .enum(["upload-to-codebase", "chat-context"])
+    .describe("How the attachment is used"),
+
+  /** Size in bytes (for monitoring large uploads) */
+  sizeBytes: z.number().optional().describe("Size in bytes"),
+});
+
+export type AttachmentInfo = z.infer<typeof AttachmentInfoSchema>;
+
+/**
+ * Component selection info for user messages with selected code.
+ *
+ * @example
+ * ```typescript
+ * const component: ComponentSelectionInfo = {
+ *   id: "comp_abc123",
+ *   name: "LoginForm",
+ *   relativePath: "src/components/LoginForm.tsx",
+ *   lineNumber: 15,
+ *   columnNumber: 3,
+ * };
+ * ```
+ */
+export const ComponentSelectionInfoSchema = z.object({
+  /** Component identifier */
+  id: z.string().describe("Component identifier"),
+
+  /** Component name */
+  name: z.string().describe("Component name"),
+
+  /** File path relative to app root */
+  relativePath: z.string().describe("File path relative to app root"),
+
+  /** Line number where the component starts */
+  lineNumber: z.number().describe("Line number where the component starts"),
+
+  /** Column number where the component starts */
+  columnNumber: z.number().describe("Column number where the component starts"),
+});
+
+export type ComponentSelectionInfo = z.infer<
+  typeof ComponentSelectionInfoSchema
+>;
+
+/**
+ * User message with input details.
+ *
+ * @example
+ * ```typescript
+ * const userMessage: UserMessageInfo = {
+ *   id: 1,
+ *   role: "user",
+ *   content: "Add a login form with email and password fields",
+ *   createdAt: "2024-01-15T10:30:00.000Z",
+ *   attachments: [],
+ *   selectedComponents: [],
+ * };
+ * ```
+ */
+export const UserMessageInfoSchema = z.object({
+  /** Message ID (database primary key) */
+  id: z.number().describe("Message ID"),
+
+  /** Role is always "user" for user messages */
+  role: z.literal("user").describe("Message role"),
+
+  /** The user's prompt text */
+  content: z.string().describe("The user's prompt text"),
+
+  /** When the message was created (ISO 8601) */
+  createdAt: z.string().datetime().describe("When the message was created"),
+
+  /** Attachments included with the message */
+  attachments: z
+    .array(AttachmentInfoSchema)
+    .optional()
+    .describe("Attachments included with the message"),
+
+  /** Components selected by the user in the UI */
+  selectedComponents: z
+    .array(ComponentSelectionInfoSchema)
+    .optional()
+    .describe("Components selected by the user"),
+});
+
+export type UserMessageInfo = z.infer<typeof UserMessageInfoSchema>;
+
+/**
+ * Assistant message with full AI call and tool call details.
+ * This is the main message type for debugging AI behavior.
+ *
+ * @example
+ * ```typescript
+ * const assistantMessage: AssistantMessageInfo = {
+ *   id: 2,
+ *   role: "assistant",
+ *   content: "I'll create a login form for you...",
+ *   createdAt: "2024-01-15T10:30:05.000Z",
+ *   model: "claude-sonnet-4-20250514",
+ *   requestId: "req_abc123",
+ *   approvalState: "approved",
+ *   sourceCommitHash: "abc123",
+ *   commitHash: "def456",
+ *   timing: {
+ *     startedAt: "2024-01-15T10:30:00.000Z",
+ *     completedAt: "2024-01-15T10:30:05.000Z",
+ *     durationMs: 5000,
+ *     firstTokenAt: "2024-01-15T10:30:00.500Z",
+ *     timeToFirstTokenMs: 500,
+ *   },
+ *   tokenUsage: {
+ *     inputTokens: 2000,
+ *     outputTokens: 800,
+ *     totalTokens: 2800,
+ *   },
+ *   aiCalls: [...],
+ *   toolCalls: [...],
+ *   errors: [],
+ * };
+ * ```
+ */
+export const AssistantMessageInfoSchema = z.object({
+  /** Message ID (database primary key) */
+  id: z.number().describe("Message ID"),
+
+  /** Role is always "assistant" for assistant messages */
+  role: z.literal("assistant").describe("Message role"),
+
+  /** The final response content (may include XML tool call representations) */
+  content: z.string().describe("The final response content"),
+
+  /** When the message was created (ISO 8601) */
+  createdAt: z.string().datetime().describe("When the message was created"),
+
+  /** Model used for this message (may be overridden per-call) */
+  model: z
+    .string()
+    .nullable()
+    .optional()
+    .describe("Model used for this message"),
+
+  /** Dyad request ID for correlation with backend logs */
+  requestId: z
+    .string()
+    .nullable()
+    .optional()
+    .describe("Dyad request ID for correlation"),
+
+  /** Approval state: approved, rejected, or null (pending) */
+  approvalState: z
+    .enum(["approved", "rejected"])
+    .nullable()
+    .optional()
+    .describe("Approval state of changes"),
+
+  /** Git commit hash of codebase when message was created */
+  sourceCommitHash: z
+    .string()
+    .nullable()
+    .optional()
+    .describe("Commit hash when message was created"),
+
+  /** Git commit hash created by this message's changes */
+  commitHash: z
+    .string()
+    .nullable()
+    .optional()
+    .describe("Commit hash created by this message"),
+
+  /** Overall timing for the entire message generation */
+  timing: StreamTimingSchema.describe("Overall timing for message generation"),
+
+  /** Aggregated token usage across all AI calls */
+  tokenUsage: TokenUsageSchema.nullable()
+    .optional()
+    .describe("Aggregated token usage"),
+
+  /**
+   * Individual AI calls (steps) for this message.
+   * In local-agent mode with tools, there can be many AI calls per message
+   * as the model calls tools and continues reasoning.
+   */
+  aiCalls: z
+    .array(AiCallInfoSchema)
+    .describe("Individual AI calls (steps) for this message"),
+
+  /**
+   * All tool calls made during this message.
+   * Use toolCall.aiCallIndex to correlate with specific AI calls.
+   */
+  toolCalls: z
+    .array(ToolCallInfoSchema)
+    .describe("All tool calls made during this message"),
+
+  /** Errors that occurred during message generation */
+  errors: z
+    .array(ErrorInfoSchema)
+    .optional()
+    .describe("Errors during message generation"),
+
+  /** Whether the message was cancelled by the user */
+  wasCancelled: z
+    .boolean()
+    .optional()
+    .describe("Whether the message was cancelled"),
+
+  /** Max step count reached (hit stepCountIs limit) */
+  maxStepsReached: z
+    .boolean()
+    .optional()
+    .describe("Whether max steps limit was reached"),
+});
+
+export type AssistantMessageInfo = z.infer<typeof AssistantMessageInfoSchema>;
+
+/**
+ * Union of user and assistant message types.
+ */
+export const MessageInfoSchema = z.discriminatedUnion("role", [
+  UserMessageInfoSchema,
+  AssistantMessageInfoSchema,
+]);
+
+export type MessageInfo = z.infer<typeof MessageInfoSchema>;
+
+// =============================================================================
+// App and Chat Schemas
+// =============================================================================
+
+/**
+ * App information for context.
+ *
+ * @example
+ * ```typescript
+ * const app: AppInfo = {
+ *   id: 1,
+ *   name: "my-saas-app",
+ *   path: "/Users/dev/projects/my-saas-app",
+ *   supabaseProjectId: "abc123",
+ *   themeId: "default",
+ * };
+ * ```
+ */
+export const AppInfoSchema = z.object({
+  /** App ID (database primary key) */
+  id: z.number().describe("App ID"),
+
+  /** Display name of the app */
+  name: z.string().describe("Display name of the app"),
+
+  /** Relative path to the app (within Dyad's apps directory) */
+  path: z.string().describe("Relative path to the app"),
+
+  /** Supabase project ID if connected */
+  supabaseProjectId: z
+    .string()
+    .nullable()
+    .optional()
+    .describe("Supabase project ID"),
+
+  /** Active theme ID */
+  themeId: z.string().nullable().optional().describe("Active theme ID"),
+});
+
+export type AppInfo = z.infer<typeof AppInfoSchema>;
+
+/**
+ * Chat information for context.
+ *
+ * @example
+ * ```typescript
+ * const chat: ChatInfo = {
+ *   id: 42,
+ *   title: "Add user authentication",
+ *   createdAt: "2024-01-15T09:00:00.000Z",
+ *   initialCommitHash: "abc123",
+ * };
+ * ```
+ */
+export const ChatInfoSchema = z.object({
+  /** Chat ID (database primary key) */
+  id: z.number().describe("Chat ID"),
+
+  /** Chat title (may be auto-generated or user-set) */
+  title: z.string().nullable().describe("Chat title"),
+
+  /** When the chat was created (ISO 8601) */
+  createdAt: z.string().datetime().describe("When the chat was created"),
+
+  /** Git commit hash at chat creation (baseline for changes) */
+  initialCommitHash: z
+    .string()
+    .nullable()
+    .optional()
+    .describe("Initial commit hash"),
+});
+
+export type ChatInfo = z.infer<typeof ChatInfoSchema>;
+
+// =============================================================================
+// Settings Snapshot Schema
+// =============================================================================
+
+/**
+ * Relevant settings captured at upload time for context.
+ * Excludes sensitive data like API keys.
+ *
+ * @example
+ * ```typescript
+ * const settings: SettingsSnapshot = {
+ *   chatMode: "local-agent",
+ *   selectedModel: "claude-sonnet-4-20250514",
+ *   enableDyadPro: true,
+ *   proLazyEditsMode: "v2",
+ *   smartContextMode: "balanced",
+ * };
+ * ```
+ */
+export const SettingsSnapshotSchema = z.object({
+  /** Chat mode used for this session */
+  chatMode: z
+    .enum(["build", "ask", "agent", "local-agent"])
+    .describe("Chat mode used"),
+
+  /** Selected model name */
+  selectedModel: z.string().describe("Selected model name"),
+
+  /** Whether Dyad Pro was enabled */
+  enableDyadPro: z
+    .boolean()
+    .optional()
+    .describe("Whether Dyad Pro was enabled"),
+
+  /** Lazy edits mode setting */
+  proLazyEditsMode: z
+    .enum(["off", "v1", "v2"])
+    .nullable()
+    .optional()
+    .describe("Lazy edits mode"),
+
+  /** Smart context mode setting */
+  smartContextMode: z
+    .enum(["balanced", "conservative", "deep"])
+    .nullable()
+    .optional()
+    .describe("Smart context mode"),
+
+  /** Whether auto-fix problems was enabled */
+  enableAutoFixProblems: z
+    .boolean()
+    .optional()
+    .describe("Whether auto-fix was enabled"),
+
+  /** Max chat turns in context setting */
+  maxChatTurnsInContext: z
+    .number()
+    .nullable()
+    .optional()
+    .describe("Max chat turns in context"),
+});
+
+export type SettingsSnapshot = z.infer<typeof SettingsSnapshotSchema>;
+
+// =============================================================================
+// Session Summary Schema
+// =============================================================================
+
+/**
+ * Summary statistics for the session.
+ *
+ * @example
+ * ```typescript
+ * const summary: SessionSummary = {
+ *   totalMessages: 10,
+ *   userMessageCount: 5,
+ *   assistantMessageCount: 5,
+ *   totalToolCalls: 25,
+ *   successfulToolCalls: 23,
+ *   failedToolCalls: 2,
+ *   totalAiCalls: 15,
+ *   totalDurationMs: 45000,
+ *   totalInputTokens: 15000,
+ *   totalOutputTokens: 5000,
+ *   totalTokens: 20000,
+ *   errorsCount: 2,
+ *   cancelledCount: 0,
+ * };
+ * ```
+ */
+export const SessionSummarySchema = z.object({
+  /** Total number of messages in the session */
+  totalMessages: z.number().describe("Total number of messages"),
+
+  /** Number of user messages */
+  userMessageCount: z.number().describe("Number of user messages"),
+
+  /** Number of assistant messages */
+  assistantMessageCount: z.number().describe("Number of assistant messages"),
+
+  /** Total number of tool calls across all messages */
+  totalToolCalls: z.number().describe("Total number of tool calls"),
+
+  /** Number of successful tool calls */
+  successfulToolCalls: z.number().describe("Number of successful tool calls"),
+
+  /** Number of failed tool calls */
+  failedToolCalls: z.number().describe("Number of failed tool calls"),
+
+  /** Total number of AI calls (steps) across all messages */
+  totalAiCalls: z.number().describe("Total number of AI calls"),
+
+  /** Total duration of all assistant messages in milliseconds */
+  totalDurationMs: z.number().describe("Total duration in milliseconds"),
+
+  /** Total input tokens across all messages */
+  totalInputTokens: z.number().describe("Total input tokens"),
+
+  /** Total output tokens across all messages */
+  totalOutputTokens: z.number().describe("Total output tokens"),
+
+  /** Total tokens (input + output) */
+  totalTokens: z.number().describe("Total tokens"),
+
+  /** Number of errors that occurred */
+  errorsCount: z.number().describe("Number of errors"),
+
+  /** Number of messages that were cancelled */
+  cancelledCount: z.number().describe("Number of cancelled messages"),
+});
+
+export type SessionSummary = z.infer<typeof SessionSummarySchema>;
+
+// =============================================================================
+// Client Information Schema
+// =============================================================================
+
+/**
+ * Client environment information for debugging.
+ *
+ * @example
+ * ```typescript
+ * const client: ClientInfo = {
+ *   dyadVersion: "1.2.3",
+ *   platform: "darwin",
+ *   architecture: "arm64",
+ *   nodeVersion: "20.10.0",
+ *   electronVersion: "28.0.0",
+ * };
+ * ```
+ */
+export const ClientInfoSchema = z.object({
+  /** Dyad application version */
+  dyadVersion: z.string().describe("Dyad application version"),
+
+  /** Operating system platform */
+  platform: z.string().describe("Operating system platform"),
+
+  /** CPU architecture */
+  architecture: z.string().describe("CPU architecture"),
+
+  /** Node.js version */
+  nodeVersion: z.string().nullable().optional().describe("Node.js version"),
+
+  /** Electron version */
+  electronVersion: z
+    .string()
+    .nullable()
+    .optional()
+    .describe("Electron version"),
+});
+
+export type ClientInfo = z.infer<typeof ClientInfoSchema>;
+
+// =============================================================================
+// Main Session Upload Payload Schema
+// =============================================================================
+
+/**
+ * Complete session upload payload.
+ * This is the main schema for uploading chat session data.
+ *
+ * @example Full payload
+ * ```typescript
+ * const payload: SessionUploadPayload = {
+ *   schemaVersion: "1.0.0",
+ *   sessionId: "session_abc123",
+ *   uploadedAt: "2024-01-15T12:00:00.000Z",
+ *   client: {
+ *     dyadVersion: "1.2.3",
+ *     platform: "darwin",
+ *     architecture: "arm64",
+ *   },
+ *   settings: {
+ *     chatMode: "local-agent",
+ *     selectedModel: "claude-sonnet-4-20250514",
+ *     enableDyadPro: true,
+ *   },
+ *   app: {
+ *     id: 1,
+ *     name: "my-app",
+ *     path: "/apps/my-app",
+ *   },
+ *   chat: {
+ *     id: 42,
+ *     title: "Add authentication",
+ *     createdAt: "2024-01-15T09:00:00.000Z",
+ *   },
+ *   messages: [
+ *     {
+ *       id: 1,
+ *       role: "user",
+ *       content: "Add login form",
+ *       createdAt: "2024-01-15T09:00:00.000Z",
+ *     },
+ *     {
+ *       id: 2,
+ *       role: "assistant",
+ *       content: "I'll create a login form...",
+ *       createdAt: "2024-01-15T09:00:05.000Z",
+ *       model: "claude-sonnet-4-20250514",
+ *       timing: {...},
+ *       aiCalls: [...],
+ *       toolCalls: [...],
+ *     },
+ *   ],
+ *   summary: {
+ *     totalMessages: 2,
+ *     userMessageCount: 1,
+ *     assistantMessageCount: 1,
+ *     totalToolCalls: 5,
+ *     successfulToolCalls: 5,
+ *     failedToolCalls: 0,
+ *     totalAiCalls: 3,
+ *     totalDurationMs: 5000,
+ *     totalInputTokens: 2000,
+ *     totalOutputTokens: 800,
+ *     totalTokens: 2800,
+ *     errorsCount: 0,
+ *     cancelledCount: 0,
+ *   },
+ * };
+ * ```
+ */
+export const SessionUploadPayloadSchema = z.object({
+  /** Schema version for backwards compatibility */
+  schemaVersion: z
+    .literal(SESSION_UPLOAD_SCHEMA_VERSION)
+    .describe("Schema version"),
+
+  /** Unique identifier for this upload session */
+  sessionId: z.string().describe("Unique identifier for this upload"),
+
+  /** When this payload was uploaded (ISO 8601) */
+  uploadedAt: z.string().datetime().describe("When this payload was uploaded"),
+
+  /** Client environment information */
+  client: ClientInfoSchema.describe("Client environment information"),
+
+  /** Relevant settings at time of upload */
+  settings: SettingsSnapshotSchema.describe(
+    "Relevant settings at time of upload",
+  ),
+
+  /** App information */
+  app: AppInfoSchema.describe("App information"),
+
+  /** Chat information */
+  chat: ChatInfoSchema.describe("Chat information"),
+
+  /** All messages in the chat, in chronological order */
+  messages: z
+    .array(MessageInfoSchema)
+    .describe("All messages in chronological order"),
+
+  /** Summary statistics for quick analysis */
+  summary: SessionSummarySchema.describe("Summary statistics"),
+});
+
+export type SessionUploadPayload = z.infer<typeof SessionUploadPayloadSchema>;
+
+// =============================================================================
+// IPC Contract
+// =============================================================================
+
+export const sessionUploadContracts = {
+  uploadSession: defineContract({
+    channel: "session:upload",
+    input: z.object({
+      url: z.string().describe("Signed URL to upload to"),
+      payload: SessionUploadPayloadSchema.describe("Session upload payload"),
+    }),
+    output: z.void(),
+  }),
+} as const;
+
+export const sessionUploadClient = createClient(sessionUploadContracts);

--- a/src/pro/main/ipc/handlers/local_agent/session_data_collector.ts
+++ b/src/pro/main/ipc/handlers/local_agent/session_data_collector.ts
@@ -306,7 +306,10 @@ export class SessionDataCollector {
     error?: Error | string,
   ): void {
     const toolCall = this.toolCalls.get(id);
-    if (toolCall) {
+    // Guard against double-ending: if already completed, don't overwrite
+    // This can happen when e.g. consent denial calls endToolCall, then the
+    // thrown error propagates to a catch block that also calls endToolCall
+    if (toolCall && !toolCall.completedAt) {
       toolCall.completedAt = new Date();
       toolCall.status = status;
       toolCall.output = output ?? null;

--- a/src/pro/main/ipc/handlers/local_agent/session_data_collector.ts
+++ b/src/pro/main/ipc/handlers/local_agent/session_data_collector.ts
@@ -1,0 +1,542 @@
+/**
+ * Session Data Collector
+ *
+ * Collects timing, AI calls, tool calls, and error data during local agent
+ * stream processing for later upload and analysis.
+ */
+
+import type {
+  AiCallInfo,
+  ToolCallInfo,
+  ErrorInfo,
+  StreamTiming,
+  TokenUsage,
+  AiCallFinishReason,
+  ToolCallStatus,
+  AssistantMessageInfo,
+} from "@/ipc/types/session_upload";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface AiCallData {
+  index: number;
+  model: string;
+  startedAt: Date;
+  completedAt: Date | null;
+  firstTokenAt: Date | null;
+  finishReason: AiCallFinishReason;
+  tokenUsage: TokenUsage | null;
+  toolCallIds: string[];
+  textDeltaCount: number;
+  reasoningDeltaCount: number;
+  error: ErrorInfo | null;
+  providerRequestId: string | null;
+}
+
+export interface ToolCallData {
+  id: string;
+  toolName: string;
+  status: ToolCallStatus;
+  input: unknown;
+  output: unknown;
+  startedAt: Date;
+  completedAt: Date | null;
+  error: ErrorInfo | null;
+  consentRequired: boolean;
+  consentDecision: "accept-once" | "accept-always" | "decline" | null;
+  aiCallIndex: number;
+  isMcpTool: boolean;
+  mcpServerName: string | null;
+}
+
+// =============================================================================
+// Session Data Collector
+// =============================================================================
+
+/**
+ * Collects all session data during local agent stream processing.
+ * Create one instance per assistant message generation.
+ *
+ * @example
+ * ```typescript
+ * const collector = new SessionDataCollector(messageId, model);
+ *
+ * // Start tracking
+ * collector.startMessage();
+ *
+ * // Track AI calls
+ * collector.startAiCall();
+ * collector.recordFirstToken();
+ * collector.recordTextDelta();
+ * collector.endAiCall("tool-calls", tokenUsage);
+ *
+ * // Track tool calls
+ * collector.startToolCall("call_123", "write_file", { file_path: "..." });
+ * collector.endToolCall("call_123", "success", "File written");
+ *
+ * // Finish and get data
+ * collector.endMessage(false);
+ * const data = collector.getAssistantMessageData(content);
+ * ```
+ */
+export class SessionDataCollector {
+  private messageId: number;
+  private model: string;
+  private requestId: string | null = null;
+
+  // Message-level timing
+  private messageStartedAt: Date | null = null;
+  private messageCompletedAt: Date | null = null;
+  private messageFirstTokenAt: Date | null = null;
+
+  // AI calls
+  private aiCalls: AiCallData[] = [];
+  private currentAiCall: AiCallData | null = null;
+
+  // Tool calls
+  private toolCalls: Map<string, ToolCallData> = new Map();
+
+  // Errors
+  private errors: ErrorInfo[] = [];
+
+  // Cancellation
+  private wasCancelled = false;
+  private maxStepsReached = false;
+
+  constructor(messageId: number, model: string, requestId?: string | null) {
+    this.messageId = messageId;
+    this.model = model;
+    this.requestId = requestId ?? null;
+  }
+
+  // ===========================================================================
+  // Message-level tracking
+  // ===========================================================================
+
+  /**
+   * Mark the start of message generation.
+   * Call this when beginning to process the assistant message.
+   */
+  startMessage(): void {
+    this.messageStartedAt = new Date();
+  }
+
+  /**
+   * Mark the end of message generation.
+   * @param wasCancelled Whether the message was cancelled by the user
+   * @param maxStepsReached Whether the max steps limit was reached
+   */
+  endMessage(wasCancelled = false, maxStepsReached = false): void {
+    this.messageCompletedAt = new Date();
+    this.wasCancelled = wasCancelled;
+    this.maxStepsReached = maxStepsReached;
+
+    // End any in-progress AI call
+    if (this.currentAiCall && !this.currentAiCall.completedAt) {
+      this.currentAiCall.completedAt = this.messageCompletedAt;
+      this.currentAiCall.finishReason = wasCancelled ? "cancelled" : "unknown";
+    }
+  }
+
+  // ===========================================================================
+  // AI Call tracking
+  // ===========================================================================
+
+  /**
+   * Start a new AI call (step).
+   * Call this at the beginning of each streamText call or step.
+   * @param model Optional model override for this call
+   */
+  startAiCall(model?: string): void {
+    // End previous AI call if not ended
+    if (this.currentAiCall && !this.currentAiCall.completedAt) {
+      this.currentAiCall.completedAt = new Date();
+    }
+
+    this.currentAiCall = {
+      index: this.aiCalls.length,
+      model: model ?? this.model,
+      startedAt: new Date(),
+      completedAt: null,
+      firstTokenAt: null,
+      finishReason: "unknown",
+      tokenUsage: null,
+      toolCallIds: [],
+      textDeltaCount: 0,
+      reasoningDeltaCount: 0,
+      error: null,
+      providerRequestId: null,
+    };
+    this.aiCalls.push(this.currentAiCall);
+  }
+
+  /**
+   * Record when the first token is received.
+   * Call this on the first text-delta or reasoning-delta.
+   */
+  recordFirstToken(): void {
+    const now = new Date();
+    if (this.currentAiCall && !this.currentAiCall.firstTokenAt) {
+      this.currentAiCall.firstTokenAt = now;
+    }
+    if (!this.messageFirstTokenAt) {
+      this.messageFirstTokenAt = now;
+    }
+  }
+
+  /**
+   * Record a text delta.
+   * Call this on each text-delta stream part.
+   */
+  recordTextDelta(): void {
+    if (this.currentAiCall) {
+      this.currentAiCall.textDeltaCount++;
+    }
+  }
+
+  /**
+   * Record a reasoning delta.
+   * Call this on each reasoning-delta stream part.
+   */
+  recordReasoningDelta(): void {
+    if (this.currentAiCall) {
+      this.currentAiCall.reasoningDeltaCount++;
+    }
+  }
+
+  /**
+   * End the current AI call.
+   * @param finishReason Why the AI call finished
+   * @param tokenUsage Token usage for this call
+   * @param providerRequestId Optional provider request ID
+   */
+  endAiCall(
+    finishReason: AiCallFinishReason,
+    tokenUsage?: TokenUsage | null,
+    providerRequestId?: string | null,
+  ): void {
+    if (this.currentAiCall) {
+      this.currentAiCall.completedAt = new Date();
+      this.currentAiCall.finishReason = finishReason;
+      this.currentAiCall.tokenUsage = tokenUsage ?? null;
+      this.currentAiCall.providerRequestId = providerRequestId ?? null;
+    }
+  }
+
+  /**
+   * Record an error for the current AI call.
+   */
+  recordAiCallError(error: Error | string, code = "AI_CALL_ERROR"): void {
+    const errorInfo = this.createErrorInfo(error, code);
+    if (this.currentAiCall) {
+      this.currentAiCall.error = errorInfo;
+      this.currentAiCall.finishReason = "error";
+    }
+    this.errors.push(errorInfo);
+  }
+
+  // ===========================================================================
+  // Tool Call tracking
+  // ===========================================================================
+
+  /**
+   * Start tracking a tool call.
+   * Call this when a tool call begins (tool-input-start or tool-call).
+   */
+  startToolCall(
+    id: string,
+    toolName: string,
+    input: unknown,
+    options?: {
+      isMcpTool?: boolean;
+      mcpServerName?: string | null;
+    },
+  ): void {
+    const toolCall: ToolCallData = {
+      id,
+      toolName,
+      status: "running",
+      input,
+      output: null,
+      startedAt: new Date(),
+      completedAt: null,
+      error: null,
+      consentRequired: false,
+      consentDecision: null,
+      aiCallIndex: this.currentAiCall?.index ?? 0,
+      isMcpTool: options?.isMcpTool ?? false,
+      mcpServerName: options?.mcpServerName ?? null,
+    };
+    this.toolCalls.set(id, toolCall);
+
+    // Track tool call ID in current AI call
+    if (this.currentAiCall) {
+      this.currentAiCall.toolCallIds.push(id);
+    }
+  }
+
+  /**
+   * Record consent information for a tool call.
+   */
+  recordToolConsent(
+    id: string,
+    required: boolean,
+    decision?: "accept-once" | "accept-always" | "decline" | null,
+  ): void {
+    const toolCall = this.toolCalls.get(id);
+    if (toolCall) {
+      toolCall.consentRequired = required;
+      toolCall.consentDecision = decision ?? null;
+      if (decision === "decline") {
+        toolCall.status = "denied";
+        toolCall.completedAt = new Date();
+      }
+    }
+  }
+
+  /**
+   * End a tool call with its result.
+   */
+  endToolCall(
+    id: string,
+    status: "success" | "failed" | "cancelled" | "denied",
+    output?: unknown,
+    error?: Error | string,
+  ): void {
+    const toolCall = this.toolCalls.get(id);
+    if (toolCall) {
+      toolCall.completedAt = new Date();
+      toolCall.status = status;
+      toolCall.output = output ?? null;
+      if (error) {
+        toolCall.error = this.createErrorInfo(error, "TOOL_EXECUTION_FAILED", {
+          toolName: toolCall.toolName,
+          toolCallId: id,
+        });
+        this.errors.push(toolCall.error);
+      }
+    }
+  }
+
+  /**
+   * Update tool call input (useful when input is streamed).
+   */
+  updateToolCallInput(id: string, input: unknown): void {
+    const toolCall = this.toolCalls.get(id);
+    if (toolCall) {
+      toolCall.input = input;
+    }
+  }
+
+  // ===========================================================================
+  // Error tracking
+  // ===========================================================================
+
+  /**
+   * Record a general error (not tied to a specific AI call or tool call).
+   */
+  recordError(
+    error: Error | string,
+    code = "UNKNOWN_ERROR",
+    context?: Record<string, unknown>,
+  ): void {
+    this.errors.push(this.createErrorInfo(error, code, context));
+  }
+
+  private createErrorInfo(
+    error: Error | string,
+    code: string,
+    context?: Record<string, unknown>,
+  ): ErrorInfo {
+    const message = error instanceof Error ? error.message : error;
+    const stack = error instanceof Error ? error.stack : null;
+    return {
+      code,
+      message,
+      stack: stack ?? null,
+      timestamp: new Date().toISOString(),
+      context,
+    };
+  }
+
+  // ===========================================================================
+  // Data export
+  // ===========================================================================
+
+  /**
+   * Get the collected data as an AssistantMessageInfo object.
+   * Call this after endMessage() to get the final data.
+   */
+  getAssistantMessageData(
+    content: string,
+    createdAt: Date,
+    additionalData?: {
+      approvalState?: "approved" | "rejected" | null;
+      sourceCommitHash?: string | null;
+      commitHash?: string | null;
+    },
+  ): AssistantMessageInfo {
+    const timing = this.getMessageTiming();
+    const tokenUsage = this.getAggregatedTokenUsage();
+
+    return {
+      id: this.messageId,
+      role: "assistant",
+      content,
+      createdAt: createdAt.toISOString(),
+      model: this.model,
+      requestId: this.requestId,
+      approvalState: additionalData?.approvalState ?? null,
+      sourceCommitHash: additionalData?.sourceCommitHash ?? null,
+      commitHash: additionalData?.commitHash ?? null,
+      timing,
+      tokenUsage,
+      aiCalls: this.getAiCallsInfo(),
+      toolCalls: this.getToolCallsInfo(),
+      errors: this.errors.length > 0 ? this.errors : undefined,
+      wasCancelled: this.wasCancelled || undefined,
+      maxStepsReached: this.maxStepsReached || undefined,
+    };
+  }
+
+  private getMessageTiming(): StreamTiming {
+    const startedAt = this.messageStartedAt ?? new Date();
+    const completedAt = this.messageCompletedAt;
+    const firstTokenAt = this.messageFirstTokenAt;
+
+    return {
+      startedAt: startedAt.toISOString(),
+      completedAt: completedAt?.toISOString() ?? null,
+      durationMs: completedAt
+        ? completedAt.getTime() - startedAt.getTime()
+        : null,
+      firstTokenAt: firstTokenAt?.toISOString() ?? null,
+      timeToFirstTokenMs: firstTokenAt
+        ? firstTokenAt.getTime() - startedAt.getTime()
+        : null,
+    };
+  }
+
+  private getAggregatedTokenUsage(): TokenUsage | null {
+    let totalInput = 0;
+    let totalOutput = 0;
+    let totalCached = 0;
+    let hasUsage = false;
+
+    for (const aiCall of this.aiCalls) {
+      if (aiCall.tokenUsage) {
+        hasUsage = true;
+        totalInput += aiCall.tokenUsage.inputTokens;
+        totalOutput += aiCall.tokenUsage.outputTokens;
+        totalCached += aiCall.tokenUsage.cachedInputTokens ?? 0;
+      }
+    }
+
+    if (!hasUsage) return null;
+
+    return {
+      inputTokens: totalInput,
+      outputTokens: totalOutput,
+      totalTokens: totalInput + totalOutput,
+      cachedInputTokens: totalCached > 0 ? totalCached : null,
+      cacheHitRatio: totalInput > 0 ? totalCached / totalInput : null,
+    };
+  }
+
+  private getAiCallsInfo(): AiCallInfo[] {
+    return this.aiCalls.map((call) => {
+      const durationMs = call.completedAt
+        ? call.completedAt.getTime() - call.startedAt.getTime()
+        : null;
+      const timeToFirstTokenMs = call.firstTokenAt
+        ? call.firstTokenAt.getTime() - call.startedAt.getTime()
+        : null;
+
+      return {
+        index: call.index,
+        model: call.model,
+        finishReason: call.finishReason,
+        timing: {
+          startedAt: call.startedAt.toISOString(),
+          completedAt: call.completedAt?.toISOString() ?? null,
+          durationMs,
+          firstTokenAt: call.firstTokenAt?.toISOString() ?? null,
+          timeToFirstTokenMs,
+        },
+        tokenUsage: call.tokenUsage,
+        toolCallIds: call.toolCallIds,
+        textDeltaCount: call.textDeltaCount,
+        reasoningDeltaCount: call.reasoningDeltaCount,
+        error: call.error ?? undefined,
+        providerRequestId: call.providerRequestId ?? undefined,
+      };
+    });
+  }
+
+  private getToolCallsInfo(): ToolCallInfo[] {
+    return Array.from(this.toolCalls.values()).map((call) => {
+      const durationMs = call.completedAt
+        ? call.completedAt.getTime() - call.startedAt.getTime()
+        : null;
+
+      return {
+        id: call.id,
+        toolName: call.toolName,
+        status: call.status,
+        input: call.input,
+        output: call.output,
+        timing: {
+          startedAt: call.startedAt.toISOString(),
+          completedAt: call.completedAt?.toISOString() ?? null,
+          durationMs,
+        },
+        error: call.error ?? undefined,
+        consentRequired: call.consentRequired,
+        consentDecision: call.consentDecision ?? undefined,
+        aiCallIndex: call.aiCallIndex,
+        isMcpTool: call.isMcpTool || undefined,
+        mcpServerName: call.mcpServerName ?? undefined,
+      };
+    });
+  }
+
+  // ===========================================================================
+  // Utility getters
+  // ===========================================================================
+
+  /** Get the current AI call index (step number) */
+  getCurrentAiCallIndex(): number {
+    return this.currentAiCall?.index ?? 0;
+  }
+
+  /** Check if there's an active AI call */
+  hasActiveAiCall(): boolean {
+    return this.currentAiCall !== null && !this.currentAiCall.completedAt;
+  }
+
+  /** Get total tool calls count */
+  getToolCallCount(): number {
+    return this.toolCalls.size;
+  }
+
+  /** Get successful tool calls count */
+  getSuccessfulToolCallCount(): number {
+    return Array.from(this.toolCalls.values()).filter(
+      (t) => t.status === "success",
+    ).length;
+  }
+
+  /** Get failed tool calls count */
+  getFailedToolCallCount(): number {
+    return Array.from(this.toolCalls.values()).filter(
+      (t) => t.status === "failed" || t.status === "denied",
+    ).length;
+  }
+
+  /** Get total errors count */
+  getErrorCount(): number {
+    return this.errors.length;
+  }
+}

--- a/src/pro/main/ipc/handlers/local_agent/tools/types.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/types.ts
@@ -7,6 +7,7 @@ import { IpcMainInvokeEvent } from "electron";
 import { jsonrepair } from "jsonrepair";
 import { AgentToolConsent } from "@/lib/schemas";
 import { AgentTodo } from "@/ipc/types";
+import type { SessionDataCollector } from "../session_data_collector";
 
 // ============================================================================
 // XML Escape Helpers
@@ -83,6 +84,11 @@ export interface AgentContext {
    * Call this when todos are updated to show them in the chat input area.
    */
   onUpdateTodos: (todos: Todo[]) => void;
+  /**
+   * Optional session data collector for tracking AI calls, tool calls, and timing.
+   * Used for session upload and debugging.
+   */
+  sessionDataCollector?: SessionDataCollector;
 }
 
 // ============================================================================


### PR DESCRIPTION
This adds a well-documented Zod schema and data collection infrastructure for uploading chat session data to better understand issues like errors, correlate logs with messages, and measure durations.

Key components:
- SessionUploadPayload schema with detailed JSDoc examples
- SessionDataCollector class to track AI calls, tool calls, timing
- Each message can have multiple AI calls (steps) with tool calls
- Tool call tracking includes consent, timing, and error details
- Token usage tracking per AI call with cache hit ratios
- Integration with local_agent_handler for automatic data collection

Schema includes:
- Session metadata (app, chat, settings, client info)
- Message history with user/assistant discrimination
- AI calls with timing, tokens, finish reasons
- Tool calls with inputs, outputs, timing, consent decisions
- Error tracking with stack traces and context
- Summary statistics for quick analysis

https://claude.ai/code/session_01BYDoF44At6YCmzvB8xEptJ
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2379">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a comprehensive session upload schema and a data collector to capture full chat session details (AI calls, tool calls, timing, tokens, errors) and upload them to a signed URL. Integrates with the local agent to automatically track steps and emit a lightweight session summary for debugging.

- **New Features**
  - Zod SessionUploadPayload v1.0.0 covering messages, AI/Tool calls, timing/TTFT, token usage (with cache ratios), errors, settings, client, app/chat, and summary.
  - SessionDataCollector wired into local_agent_handler to track AI call steps and tool calls (status, consent decisions, MCP metadata), record first-token timing and deltas, capture errors/cancellation, and emit chat:session-data.
  - New IPC contract session:upload with ipc.sessionUpload.uploadSession; upload_handlers PUTs JSON payloads to a signed URL.
  - Types and clients exported via ipc/types/index for reuse and validation.

- **Migration**
  - To upload sessions, listen for chat:session-data, build a SessionUploadPayload, then call ipc.sessionUpload.uploadSession({ url, payload }).
  - Ensure the signed URL accepts PUT with Content-Type: application/json.
  - Use SESSION_UPLOAD_SCHEMA_VERSION for versioning; no other changes required.

<sup>Written for commit a45b6977e0da232888a0cb696127a4a8f218e3e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to wiring new instrumentation into the `local_agent_handler` streaming loop and MCP tool execution paths; mistakes could affect chat streaming stability or performance, though changes are largely additive and guarded.
> 
> **Overview**
> Adds a new, versioned `SessionUploadPayload` Zod schema (messages, AI call steps, tool calls with consent, timing/TTFT, token usage, and errors) and exports its contracts/types/schemas via `ipc/types/index.ts`.
> 
> Introduces a new `session:upload` typed IPC contract/client and a corresponding main-process handler that `PUT`s the JSON payload to an HTTPS signed URL (and tightens signed-URL validation in the existing generic upload handler by using `new URL()` + protocol check).
> 
> Wires a new `SessionDataCollector` into `local_agent_handler` to track per-step finish reasons/token usage, first-token/delta counts, tool call lifecycle (including MCP consent/denial and errors), then emits a `chat:session-data` event with a lightweight summary after completion/cancellation/error.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c21b9ff4cb13a15b30d72832494a53021c305328. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->