### PR TITLE
Add icons and distinct colors to chat mode selectors

### DIFF
--- a/src/components/ChatModeSelector.tsx
+++ b/src/components/ChatModeSelector.tsx
@@ -20,6 +20,37 @@ import { toast } from "sonner";
 import { LocalAgentNewChatToast } from "./LocalAgentNewChatToast";
 import { useAtomValue } from "jotai";
 import { chatMessagesByIdAtom } from "@/atoms/chatAtoms";
+import { Hammer, MessageCircle, Plug, Sparkles } from "lucide-react";
+
+export function getModeIcon(mode: ChatMode) {
+  switch (mode) {
+    case "build":
+      return Hammer;
+    case "ask":
+      return MessageCircle;
+    case "agent":
+      return Plug;
+    case "local-agent":
+      return Sparkles;
+    default:
+      return Hammer;
+  }
+}
+
+export function getModeColorClasses(mode: ChatMode) {
+  switch (mode) {
+    case "build":
+      return "bg-emerald-500/10 hover:bg-emerald-500/20 focus:bg-emerald-500/20 text-emerald-600 border-emerald-500/20 dark:bg-emerald-500/20 dark:hover:bg-emerald-500/30 dark:focus:bg-emerald-500/30 dark:text-emerald-400";
+    case "ask":
+      return "bg-blue-500/10 hover:bg-blue-500/20 focus:bg-blue-500/20 text-blue-600 border-blue-500/20 dark:bg-blue-500/20 dark:hover:bg-blue-500/30 dark:focus:bg-blue-500/30 dark:text-blue-400";
+    case "agent":
+      return "bg-purple-500/10 hover:bg-purple-500/20 focus:bg-purple-500/20 text-purple-600 border-purple-500/20 dark:bg-purple-500/20 dark:hover:bg-purple-500/30 dark:focus:bg-purple-500/30 dark:text-purple-400";
+    case "local-agent":
+      return "bg-background hover:bg-muted/50 focus:bg-muted/50";
+    default:
+      return "bg-background hover:bg-muted/50 focus:bg-muted/50";
+  }
+}
 
 function NewBadge() {
   return (
@@ -88,6 +119,8 @@ export function ChatModeSelector() {
   };
   const isMac = detectIsMac();
 
+  const ModeIcon = getModeIcon(selectedMode);
+
   return (
     <Select value={selectedMode} onValueChange={handleModeChange}>
       <Tooltip>
@@ -95,13 +128,12 @@ export function ChatModeSelector() {
           <MiniSelectTrigger
             data-testid="chat-mode-selector"
             className={cn(
-              "h-6 w-fit px-1.5 py-0 text-xs-sm font-medium shadow-none gap-0.5",
-              selectedMode === "build" || selectedMode === "local-agent"
-                ? "bg-background hover:bg-muted/50 focus:bg-muted/50"
-                : "bg-primary/10 hover:bg-primary/20 focus:bg-primary/20 text-primary border-primary/20 dark:bg-primary/20 dark:hover:bg-primary/30 dark:focus:bg-primary/30",
+              "h-6 w-fit px-1.5 py-0 text-xs-sm font-medium shadow-none gap-1",
+              getModeColorClasses(selectedMode),
             )}
             size="sm"
           >
+            <ModeIcon className="h-3.5 w-3.5" />
             <SelectValue>{getModeDisplayName(selectedMode)}</SelectValue>
           </MiniSelectTrigger>
         </TooltipTrigger>
@@ -117,41 +149,53 @@ export function ChatModeSelector() {
       <SelectContent align="start" onCloseAutoFocus={(e) => e.preventDefault()}>
         {isProEnabled && (
           <SelectItem value="local-agent">
-            <div className="flex flex-col items-start">
-              <div className="flex items-center gap-1.5">
-                <span className="font-medium">Agent v2</span>
-                <NewBadge />
+            <div className="flex items-start gap-2">
+              <Sparkles className="h-4 w-4 mt-0.5 shrink-0" />
+              <div className="flex flex-col items-start">
+                <div className="flex items-center gap-1.5">
+                  <span className="font-medium">Agent v2</span>
+                  <NewBadge />
+                </div>
+                <span className="text-xs text-muted-foreground">
+                  Better at bigger tasks and debugging
+                </span>
               </div>
-              <span className="text-xs text-muted-foreground">
-                Better at bigger tasks and debugging
-              </span>
             </div>
           </SelectItem>
         )}
         <SelectItem value="build">
-          <div className="flex flex-col items-start">
-            <span className="font-medium">Build</span>
-            <span className="text-xs text-muted-foreground">
-              Generate and edit code
-            </span>
+          <div className="flex items-start gap-2">
+            <Hammer className="h-4 w-4 mt-0.5 shrink-0 text-emerald-600 dark:text-emerald-400" />
+            <div className="flex flex-col items-start">
+              <span className="font-medium">Build</span>
+              <span className="text-xs text-muted-foreground">
+                Generate and edit code
+              </span>
+            </div>
           </div>
         </SelectItem>
         <SelectItem value="ask">
-          <div className="flex flex-col items-start">
-            <span className="font-medium">Ask</span>
-            <span className="text-xs text-muted-foreground">
-              Ask questions about the app
-            </span>
+          <div className="flex items-start gap-2">
+            <MessageCircle className="h-4 w-4 mt-0.5 shrink-0 text-blue-600 dark:text-blue-400" />
+            <div className="flex flex-col items-start">
+              <span className="font-medium">Ask</span>
+              <span className="text-xs text-muted-foreground">
+                Ask questions about the app
+              </span>
+            </div>
           </div>
         </SelectItem>
         <SelectItem value="agent">
-          <div className="flex flex-col items-start">
-            <div className="flex items-center gap-1.5">
-              <span className="font-medium">Build with MCP</span>
+          <div className="flex items-start gap-2">
+            <Plug className="h-4 w-4 mt-0.5 shrink-0 text-purple-600 dark:text-purple-400" />
+            <div className="flex flex-col items-start">
+              <div className="flex items-center gap-1.5">
+                <span className="font-medium">Build with MCP</span>
+              </div>
+              <span className="text-xs text-muted-foreground">
+                Like Build, but can use tools (MCP) to generate code
+              </span>
             </div>
-            <span className="text-xs text-muted-foreground">
-              Like Build, but can use tools (MCP) to generate code
-            </span>
           </div>
         </SelectItem>
       </SelectContent>

--- a/src/components/DefaultChatModeSelector.tsx
+++ b/src/components/DefaultChatModeSelector.tsx
@@ -8,6 +8,8 @@ import {
 } from "@/components/ui/select";
 import type { ChatMode } from "@/lib/schemas";
 import { isDyadProEnabled, getEffectiveDefaultChatMode } from "@/lib/schemas";
+import { getModeIcon } from "./ChatModeSelector";
+import { Hammer, Plug, Sparkles } from "lucide-react";
 
 export function DefaultChatModeSelector() {
   const { settings, updateSettings } = useSettings();
@@ -50,34 +52,49 @@ export function DefaultChatModeSelector() {
           value={effectiveDefault}
           onValueChange={handleDefaultChatModeChange}
         >
-          <SelectTrigger className="w-40" id="default-chat-mode">
-            <SelectValue>{getModeDisplayName(effectiveDefault)}</SelectValue>
+          <SelectTrigger className="w-44" id="default-chat-mode">
+            <div className="flex items-center gap-2">
+              {(() => {
+                const Icon = getModeIcon(effectiveDefault);
+                return <Icon className="h-4 w-4" />;
+              })()}
+              <SelectValue>{getModeDisplayName(effectiveDefault)}</SelectValue>
+            </div>
           </SelectTrigger>
           <SelectContent>
             {isProEnabled && (
               <SelectItem value="local-agent">
-                <div className="flex flex-col items-start">
-                  <span className="font-medium">Agent</span>
-                  <span className="text-xs text-muted-foreground">
-                    Better at bigger tasks
-                  </span>
+                <div className="flex items-start gap-2">
+                  <Sparkles className="h-4 w-4 mt-0.5 shrink-0" />
+                  <div className="flex flex-col items-start">
+                    <span className="font-medium">Agent</span>
+                    <span className="text-xs text-muted-foreground">
+                      Better at bigger tasks
+                    </span>
+                  </div>
                 </div>
               </SelectItem>
             )}
             <SelectItem value="build">
-              <div className="flex flex-col items-start">
-                <span className="font-medium">Build</span>
-                <span className="text-xs text-muted-foreground">
-                  Generate and edit code
-                </span>
+              <div className="flex items-start gap-2">
+                <Hammer className="h-4 w-4 mt-0.5 shrink-0 text-emerald-600 dark:text-emerald-400" />
+                <div className="flex flex-col items-start">
+                  <span className="font-medium">Build</span>
+                  <span className="text-xs text-muted-foreground">
+                    Generate and edit code
+                  </span>
+                </div>
               </div>
             </SelectItem>
             <SelectItem value="agent">
-              <div className="flex flex-col items-start">
-                <span className="font-medium">Build with MCP</span>
-                <span className="text-xs text-muted-foreground">
-                  Build with tools (MCP)
-                </span>
+              <div className="flex items-start gap-2">
+                <Plug className="h-4 w-4 mt-0.5 shrink-0 text-purple-600 dark:text-purple-400" />
+                <div className="flex flex-col items-start">
+                  <span className="font-medium">Build with MCP</span>
+                  <span className="text-xs text-muted-foreground">
+                    Build with tools (MCP)
+                  </span>
+                </div>
               </div>
             </SelectItem>
           </SelectContent>


### PR DESCRIPTION
- Add icons for each chat mode: Hammer (Build), MessageCircle (Ask), Plug (Agent/MCP), Sparkles (Agent v2/local-agent)
- Add distinct background/text colors for non-local-agent modes:
  - Build: emerald green
  - Ask: blue
  - Agent (MCP): purple
  - Local-agent: keeps default neutral styling
- Export getModeIcon and getModeColorClasses for reuse
- Update both ChatModeSelector and DefaultChatModeSelector components

https://claude.ai/code/session_01PRTrV9KRLMDedcTCZtG1XD

#skip-bb
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2380">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds icons and color-coded styling to chat mode selectors so modes are easy to scan at a glance. Local-agent stays neutral; Build (emerald), Ask (blue), Agent/MCP (purple).

- **New Features**
  - Icons per mode in ChatModeSelector and DefaultChatModeSelector: Hammer (Build), MessageCircle (Ask), Plug (Agent/MCP), Sparkles (Local-agent).
  - Mode-specific background/text colors for non-local-agent modes; Default selector trigger widened to fit icon + label.

- **Refactors**
  - Exported getModeIcon and getModeColorClasses for reuse across selectors.

<sup>Written for commit 98f510cacb267830ffe9a1f64385b99f626075ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

