### PR TITLE
Cancel CI runs when PR is merged

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, closed]
+    types: [opened, synchronize, reopened, closed]
 
 concurrency:
   # Use PR number for pull_request events to enable cancellation when PR is merged
@@ -18,12 +18,8 @@ defaults:
 
 jobs:
   check-changes:
-    # Skip if:
-    # - This is a closed PR event (we only listen to 'closed' to trigger cancellation of in-progress runs)
-    # - This is a draft PR (run when marked ready for review via ready_for_review event)
-    if: >-
-      github.event.action != 'closed' &&
-      (github.event_name != 'pull_request' || github.event.pull_request.draft != true)
+    # Skip closed PR events (we only listen to 'closed' to trigger cancellation of in-progress runs)
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     outputs:
       should_run_tests: ${{ steps.check.outputs.should_run_tests }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,11 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review, closed]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Use PR number for pull_request events to enable cancellation when PR is merged
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 defaults:
@@ -17,6 +18,12 @@ defaults:
 
 jobs:
   check-changes:
+    # Skip if:
+    # - This is a closed PR event (we only listen to 'closed' to trigger cancellation of in-progress runs)
+    # - This is a draft PR (run when marked ready for review via ready_for_review event)
+    if: >-
+      github.event.action != 'closed' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft != true)
     runs-on: ubuntu-latest
     outputs:
       should_run_tests: ${{ steps.check.outputs.should_run_tests }}


### PR DESCRIPTION
- Add ready_for_review and closed event types to pull_request trigger
- Update concurrency group to use PR number for proper cancellation
- Add condition to skip draft PRs and closed events
- When a PR is merged, the closed event triggers cancellation of in-progress runs

https://claude.ai/code/session_0131m7Y5ac6ztV6iPCiW6zMU

#skip-bb
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2383">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update CI to cancel in-progress runs when a PR is merged and use per-PR concurrency for accurate cancellation. Draft PRs now run; only closed events are skipped.

- **Refactors**
  - Listen to closed in the pull_request trigger.
  - Use PR number in the concurrency group for proper cancellation.
  - Add a job condition to skip closed events only.

<sup>Written for commit fe1d8903f8730bbf6ed93dbdfc8a9f0b804b9912. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

