### PR TITLE
Clarify ANTHROPIC_API_KEY not required for multi-pr-review skill

### DIFF
--- a/.claude/skills/multi-pr-review/SKILL.md
+++ b/.claude/skills/multi-pr-review/SKILL.md
@@ -104,8 +104,9 @@ references/
 
 Environment variables:
 
-- `ANTHROPIC_API_KEY` - Required for sub-agent API calls
 - `GITHUB_TOKEN` - Required for PR access and commenting
+
+Note: `ANTHROPIC_API_KEY` is **not required** - sub-agents spawned via the Task tool automatically have access to Anthropic.
 
 Optional tuning in `orchestrate_review.py`:
 


### PR DESCRIPTION
## Summary
- Removed ANTHROPIC_API_KEY from the required environment variables list
- Added clarification that sub-agents spawned via the Task tool automatically have access to Anthropic

#skip-bugbot

## Test plan
- Verify the documentation accurately reflects the current behavior of the multi-pr-review skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2386">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified that ANTHROPIC_API_KEY is not required for the multi-pr-review skill. Updated SKILL.md to note that sub-agents launched via the Task tool already have Anthropic access, so only GITHUB_TOKEN is needed.

<sup>Written for commit f5735d135face9923420ecfa08ebcbfab60796dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

