### PR TITLE
Fix e2e tests & playwright comment job

### DIFF
--- a/e2e-tests/select_component.spec.ts
+++ b/e2e-tests/select_component.spec.ts
@@ -124,6 +124,7 @@ testSkipIfWindows("upgrade app to select component", async ({ po }) => {
   await po.clickOpenInChatButton();
   // There should be another version from the upgrade being committed.
   await expect(po.page.getByText("Version 2")).toBeVisible();
+  await po.clickRestart();
 
   await po.clickPreviewPickElement();
 
@@ -141,7 +142,7 @@ testSkipIfWindows("select component next.js", async ({ po }) => {
   await po.setUp();
 
   await po.goToHubAndSelectTemplate("Next.js Template");
-
+  await po.selectChatMode("build");
   await po.sendPrompt("tc=basic");
   await po.clickTogglePreviewPanel();
   await po.clickPreviewPickElement();

--- a/e2e-tests/snapshots/template-create-nextjs.spec.ts_create-next-js-app-1.txt
+++ b/e2e-tests/snapshots/template-create-nextjs.spec.ts_create-next-js-app-1.txt
@@ -1,4 +1,2 @@
-- "selectedChatMode": "build"
-+ "selectedChatMode": "local-agent"
 - "selectedTemplateId": "react"
 + "selectedTemplateId": "next"

--- a/e2e-tests/template-create-nextjs.spec.ts
+++ b/e2e-tests/template-create-nextjs.spec.ts
@@ -5,6 +5,7 @@ test("create next.js app", async ({ po }) => {
   await po.setUp();
   const beforeSettings = po.recordSettings();
   await po.goToHubAndSelectTemplate("Next.js Template");
+  await po.selectChatMode("build");
   po.snapshotSettingsDelta(beforeSettings);
 
   // Create an app

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,7 +7,7 @@ const config: PlaywrightTestConfig = {
   testDir: "./e2e-tests",
   workers: 1,
   retries: process.env.CI ? 2 : 0,
-  timeout: process.env.CI ? 180_000 : 45_000,
+  timeout: process.env.CI ? 180_000 : 75_000,
   // Use a custom snapshot path template because Playwright's default
   // is platform-specific which isn't necessary for Dyad e2e tests
   // which should be platform agnostic (we don't do screenshots; only textual diffs).


### PR DESCRIPTION
#skip-bb
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2392">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failing Next.js e2e tests by selecting the correct chat mode and restarting after upgrades, and improves the Playwright PR comment with clearer run/update commands. Also increases local test timeout to reduce flaky failures.

- **Bug Fixes**
  - Selects “build” chat mode in Next.js tests.
  - Adds restart after upgrade in select component test.
  - Updates snapshot to expect the “next” template ID.
  - Raises local timeout to 75s to reduce flakes.

- **New Features**
  - Playwright PR comment now includes copy-paste commands to run and update snapshots for each failed test.
  - Uses -g "pattern" with proper escaping; groups many commands in a collapsible section.

<sup>Written for commit 5124cf2f3e8aa80e9de63b412ff0b6aeeff81eb5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

