### PR TITLE
Add Missing Dyad Logo

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -96,14 +96,26 @@ const config: ForgeConfig = {
       isGitHubActions
         ? {
             windowsSign,
+            iconUrl:
+              "https://raw.githubusercontent.com/dyad-sh/dyad/refs/heads/main/assets/icon/logo.ico",
+            setupIcon: "./assets/icon/logo.ico",
           }
-        : {},
+        : {
+            iconUrl:
+              "https://raw.githubusercontent.com/dyad-sh/dyad/refs/heads/main/assets/icon/logo.ico",
+            setupIcon: "./assets/icon/logo.ico",
+          },
     ),
     new MakerZIP({}, ["darwin"]),
-    new MakerRpm({}),
+    new MakerRpm({
+      options: {
+        icon: "./assets/icon/logo.png",
+      },
+    }),
     new MakerDeb({
       options: {
         mimeType: ["x-scheme-handler/dyad"],
+        icon: "./assets/icon/logo.png",
       },
     }),
     new MakerAppImage({

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -97,12 +97,12 @@ const config: ForgeConfig = {
         ? {
             windowsSign,
             iconUrl:
-              "https://raw.githubusercontent.com/dyad-sh/dyad/refs/heads/main/assets/icon/logo.ico",
+              "https://raw.githubusercontent.com/dyad-sh/dyad/main/assets/icon/logo.ico",
             setupIcon: "./assets/icon/logo.ico",
           }
         : {
             iconUrl:
-              "https://raw.githubusercontent.com/dyad-sh/dyad/refs/heads/main/assets/icon/logo.ico",
+              "https://raw.githubusercontent.com/dyad-sh/dyad/main/assets/icon/logo.ico",
             setupIcon: "./assets/icon/logo.ico",
           },
     ),

--- a/src/main.ts
+++ b/src/main.ts
@@ -211,6 +211,7 @@ const createWindow = () => {
       preload: path.join(__dirname, "preload.js"),
       // transparent: true,
     },
+    icon: "./assets/icon/logo.png",
     // backgroundColor: "#00000001",
     // frame: false,
   });

--- a/src/main.ts
+++ b/src/main.ts
@@ -211,7 +211,7 @@ const createWindow = () => {
       preload: path.join(__dirname, "preload.js"),
       // transparent: true,
     },
-    icon: "./assets/icon/logo.png",
+    icon: path.join(app.getAppPath(), "assets/icon/logo.png"),
     // backgroundColor: "#00000001",
     // frame: false,
   });


### PR DESCRIPTION
Closes #585.

Currently, there are at least two places where an Electron logo appears instead of the Dyad logo:
- In the Windows control panel (see #585).
- On the taskbar (or equivalent) of some Linux desktop environments while running the app.

The Windows installer (`.Setup.exe`) also shows a generic icon instead of the Dyad logo when viewed in the file explorer.

This PR aims to fix all of the above. It's a relatively minor detail, but it's nice to have anyway.

The relevant documentation from Electron Forge is on this page:
https://www.electronforge.io/guides/create-and-add-icons#setting-the-app-icon

I've double-checked that this fixes the icons on Windows 10, XFCE and Cinnamon (on Linux Mint), and GNOME (on Fedora). I don't have a device that runs Windows 11.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2404">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace generic/Electron icons with the Dyad logo across Windows and Linux. Ensures correct branding in the Windows control panel, Linux taskbar, and the Windows installer.

- **Bug Fixes**
  - Set BrowserWindow icon to assets/icon/logo.png.
  - Configured Electron Forge makers:
    - Squirrel: iconUrl and setupIcon set to Dyad .ico for installer and control panel.
    - Deb/RPM: icon set to Dyad .png for desktop environments.
  - Verified on Windows 10, Linux Mint (XFCE, Cinnamon), and Fedora (GNOME).

<sup>Written for commit f350918828da4b7451bbd5a68bbbb59d8c968d2e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

