### PR TITLE
fix: use current branch when creating new chat instead of hardcoding main

### DIFF
--- a/src/ipc/handlers/chat_handlers.ts
+++ b/src/ipc/handlers/chat_handlers.ts
@@ -27,10 +27,9 @@ export function registerChatHandlers() {
 
     let initialCommitHash = null;
     try {
-      // Get the current git revision of main branch
+      // Get the current git revision of the currently checked-out branch
       initialCommitHash = await getCurrentCommitHash({
         path: getDyadAppPath(app.path),
-        ref: "main",
       });
     } catch (error) {
       logger.error("Error getting git revision:", error);


### PR DESCRIPTION
## Summary
- **Fixes #2396**: When creating a new chat (including "summarize to new chat"), the system was hardcoding `ref: "main"` when getting the `initialCommitHash`, causing issues when users work on feature branches
- Changed to use the default `"HEAD"` ref instead, so the chat correctly tracks the currently checked-out branch's commit
- This prevents merge conflicts and ensures changes are applied to the correct branch

## Test plan
1. Create a feature branch from main
2. Create a new chat while on the feature branch
3. Verify the new chat tracks the feature branch's commit, not main's commit
4. Test "summarize to new chat" functionality while on a feature branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2411">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, localized change that only affects which git ref is used to capture `initialCommitHash` during chat creation.
> 
> **Overview**
> When creating a new chat, the `initialCommitHash` is now resolved from the repo’s current `HEAD` rather than forcing `ref: "main"`, so chats created on feature branches track the correct starting commit.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 541b373218a04781d63dfdb05474b4f110d38ab0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
New chats now use the currently checked-out branch (HEAD) to resolve initialCommitHash instead of hardcoding main. This ensures chats track the correct branch and prevents merge conflicts. Fixes #2396.

<sup>Written for commit 541b373218a04781d63dfdb05474b4f110d38ab0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

