### PR TITLE
Fix attachment upload instructions for local agent mode

### DIFF
--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -534,6 +534,11 @@ ${componentSnippet}
           mentionedAppNames,
           updatedChat.app.id, // Exclude current app
         );
+        const willUseLocalAgentStream =
+          settings.selectedChatMode === "local-agent" ||
+          (settings.selectedChatMode === "ask" &&
+            isDyadProEnabled(settings) &&
+            !mentionedAppsCodebases.length);
 
         const isDeepContextEnabled =
           isEngineEnabled &&
@@ -725,7 +730,20 @@ ${componentSnippet}
         // Usually, AI models will want to use the image as reference to generate code (e.g. UI mockups) anyways, so
         // it's not that critical to include the image analysis instructions.
         if (hasUploadedAttachments) {
-          systemPrompt += `
+          if (willUseLocalAgentStream) {
+            systemPrompt += `
+
+When files are attached to this conversation, upload them to the codebase using the \`write_file\` tool.
+Use the attachment ID (e.g., DYAD_ATTACHMENT_0) as the content, and it will be automatically resolved to the actual file content.
+
+Example for file with id of DYAD_ATTACHMENT_0:
+\`\`\`
+write_file(path="src/components/Button.jsx", content="DYAD_ATTACHMENT_0", description="Upload file to codebase")
+\`\`\`
+
+`;
+          } else {
+            systemPrompt += `
   
 When files are attached to this conversation, upload them to the codebase using this exact format:
 
@@ -739,6 +757,7 @@ DYAD_ATTACHMENT_0
 </dyad-write>
 
   `;
+          }
         } else if (hasImageAttachments) {
           systemPrompt += `
 
@@ -819,11 +838,7 @@ This conversation includes one or more image attachments. When the user uploads 
             }
             // Save aiMessagesJson for modes that use handleLocalAgentStream
             // (which reads from DB and needs structured image content)
-            const willUseLocalAgentStream =
-              settings.selectedChatMode === "local-agent" ||
-              (settings.selectedChatMode === "ask" &&
-                isDyadProEnabled(settings) &&
-                !mentionedAppsCodebases.length);
+
             if (willUseLocalAgentStream) {
               // Insert into DB (with size guard)
               const userAiMessagesJson = getAiMessagesJsonIfWithinLimit([

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -535,10 +535,10 @@ ${componentSnippet}
           updatedChat.app.id, // Exclude current app
         );
         const willUseLocalAgentStream =
-          settings.selectedChatMode === "local-agent" ||
-          (settings.selectedChatMode === "ask" &&
-            isDyadProEnabled(settings) &&
-            !mentionedAppsCodebases.length);
+          (settings.selectedChatMode === "local-agent" ||
+            (settings.selectedChatMode === "ask" &&
+              isDyadProEnabled(settings))) &&
+          !mentionedAppsCodebases.length;
 
         const isDeepContextEnabled =
           isEngineEnabled &&


### PR DESCRIPTION
Fixes #2395 

## Summary
- Use `write_file` tool format instead of `dyad-write` XML tags when local agent stream mode is active
- The local agent uses tools rather than XML-based commands, so attachments need compatible upload instructions
- Refactored `willUseLocalAgentStream` check to be computed once and reused

## Test plan
- Test uploading file attachments while in local agent mode
- Verify the system prompt contains `write_file` tool instructions instead of `dyad-write` XML tags
- Verify regular (non-local-agent) mode still uses the XML-based instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2412">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts system-prompt attachment upload instructions and reuses a single `willUseLocalAgentStream` flag; could affect how models handle uploads in local-agent/Pro ask mode.
> 
> **Overview**
> Fixes attachment-upload prompting when streaming via the local agent by switching from `dyad-write` XML tag instructions to `write_file` tool-call instructions for conversations that will use `handleLocalAgentStream`.
> 
> Also refactors the `willUseLocalAgentStream` condition to be computed once (based on chat mode/Pro ask mode and absence of mentioned-app codebases) and reused for both system-prompt construction and `aiMessagesJson` persistence.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60dd66e4548c5d10ace43739aea7765958284739. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->