### PR TITLE
Add @types/node-fetch dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -120,6 +120,7 @@
         "@types/glob": "^8.1.0",
         "@types/kill-port": "^2.0.3",
         "@types/node": "^22.14.0",
+        "@types/node-fetch": "^2.6.13",
         "@types/react": "^19.0.10",
         "@types/react-dom": "^19.0.4",
         "@typescript-eslint/eslint-plugin": "^5.62.0",
@@ -7546,6 +7547,17 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
       }
     },
     "node_modules/@types/pg": {

--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
     "@types/glob": "^8.1.0",
     "@types/kill-port": "^2.0.3",
     "@types/node": "^22.14.0",
+    "@types/node-fetch": "^2.6.13",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
     "@typescript-eslint/eslint-plugin": "^5.62.0",


### PR DESCRIPTION
## Summary
- Adds `@types/node-fetch` as a dev dependency for improved TypeScript type support

## Test plan
- All existing tests pass
- TypeScript compilation succeeds

#skip-bugbot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2437">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add @types/node-fetch (^2.6.13) as a dev dependency to provide TypeScript types for node-fetch. Improves type safety and editor autocomplete for code using fetch in Node.

<sup>Written for commit 43975a34f2a5b5675c47917721cf9eb8705ef80a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

