### PR TITLE
Disable Windows code signing on local builds

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -58,7 +58,7 @@ const isGitHubActions = process.env.GITHUB_ACTIONS === "true";
 
 const config: ForgeConfig = {
   packagerConfig: {
-    windowsSign: isGitHubActions ? undefined : windowsSign,
+    windowsSign: isGitHubActions ? windowsSign : undefined,
     protocols: [
       {
         name: "Dyad",
@@ -90,12 +90,12 @@ const config: ForgeConfig = {
   },
   makers: [
     new MakerSquirrel(
+      // @ts-expect-error - incorrect types exported by MakerSquirrel
       isGitHubActions
-        ? {}
-        : {
-            // @ts-expect-error - incorrect types exported by MakerSquirrel
+        ? {
             windowsSign,
-          },
+          }
+        : {},
     ),
     new MakerZIP({}, ["darwin"]),
     new MakerRpm({}),

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -54,10 +54,11 @@ const ignore = (file: string) => {
 };
 
 const isEndToEndTestBuild = process.env.E2E_TEST_BUILD === "true";
+const isGitHubActions = process.env.GITHUB_ACTIONS === "true";
 
 const config: ForgeConfig = {
   packagerConfig: {
-    windowsSign,
+    windowsSign: isGitHubActions ? undefined : windowsSign,
     protocols: [
       {
         name: "Dyad",
@@ -88,10 +89,14 @@ const config: ForgeConfig = {
     force: true,
   },
   makers: [
-    new MakerSquirrel({
-      // @ts-expect-error - incorrect types exported by MakerSquirrel
-      windowsSign,
-    }),
+    new MakerSquirrel(
+      isGitHubActions
+        ? {}
+        : {
+            // @ts-expect-error - incorrect types exported by MakerSquirrel
+            windowsSign,
+          },
+    ),
     new MakerZIP({}, ["darwin"]),
     new MakerRpm({}),
     new MakerDeb({


### PR DESCRIPTION
## Summary
- Add `isGitHubActions` environment variable check to conditionally disable Windows code signing
- Disable `windowsSign` in `packagerConfig` when running on GitHub Actions
- Pass empty config to `MakerSquirrel` instead of signing config on GitHub Actions

## Test plan
- Verify the build succeeds on GitHub Actions without Windows signing errors
- Verify local builds with Windows signing still work when not on GitHub Actions

#skip-bugbot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2438">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Windows code signing on GitHub Actions and skip it for local builds. Added an isGitHubActions env check to set packagerConfig.windowsSign and pass windowsSign to MakerSquirrel only when running in CI.

<sup>Written for commit 259bc98373fa92668745c503eecc6413528d1172. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

