### PR TITLE
Fix Windows Trusted Signing client tools installation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         if: contains(matrix.os.name, 'windows')
         shell: powershell
         run: |
-          winget install Microsoft.AzureTrustedSigning --accept-source-agreements --accept-package-agreements
+          winget install -e --id Microsoft.Azure.TrustedSigningClientTools --source winget --accept-source-agreements --accept-package-agreements
       - name: Create Azure signing metadata
         if: contains(matrix.os.name, 'windows')
         shell: powershell


### PR DESCRIPTION
## Summary
- Update winget command to use the correct package ID `Microsoft.Azure.TrustedSigningClientTools` for Azure Trusted Signing
- Add explicit `--source winget` and `-e --id` flags for more reliable package resolution

## Test plan
- Verify Windows release build workflow runs successfully with the updated package installation command

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2440">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line change to the Windows release workflow installer command; impact is limited to CI reliability for code-signing tool setup.
> 
> **Overview**
> Fixes the Windows release workflow’s Azure Trusted Signing setup by switching the `winget install` step to the correct package (`Microsoft.Azure.TrustedSigningClientTools`) and using explicit resolution flags (`-e --id` with `--source winget`) to avoid ambiguous installs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3cf9df7763a6ef52d5d32ac35601860da9af458. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->