### PR TITLE
Fix Azure DLL path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,7 @@ jobs:
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          SIGNTOOL_PATH: ${{ vars.SIGNTOOL_PATH }}
 
   verify-assets:
     name: Verify Release Assets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,25 @@ jobs:
         shell: powershell
         run: |
           winget install -e --id Microsoft.Azure.TrustedSigningClientTools --source winget --accept-source-agreements --accept-package-agreements
+
+          # Find the DLL path
+          $dllPath = Get-ChildItem -Path "C:\Program Files" -Recurse -Filter "Azure.CodeSigning.Dlib.dll" -ErrorAction SilentlyContinue | 
+                    Where-Object { $_.FullName -like "*x64*" } |
+                    Select-Object -First 1 -ExpandProperty FullName
+
+          if (-not $dllPath) {
+            $dllPath = Get-ChildItem -Path "$env:LOCALAPPDATA" -Recurse -Filter "Azure.CodeSigning.Dlib.dll" -ErrorAction SilentlyContinue | 
+                      Where-Object { $_.FullName -like "*x64*" } |
+                      Select-Object -First 1 -ExpandProperty FullName
+          }
+
+          if ($dllPath) {
+            echo "Found DLL at: $dllPath"
+            echo "AZURE_CODE_SIGNING_DLIB=$dllPath" >> $env:GITHUB_ENV
+          } else {
+            Write-Error "Could not find Azure.CodeSigning.Dlib.dll"
+            exit 1
+          }
       - name: Create Azure signing metadata
         if: contains(matrix.os.name, 'windows')
         shell: powershell
@@ -94,7 +113,7 @@ jobs:
           max_attempts: 3
           command: ./node_modules/.bin/electron-forge publish
         env:
-          DEBUG: "@electron/*,electron-forge:*,electron-windows-installer:main"
+          DEBUG: "@electron/*,electron-forge:*,electron-windows-installer:main,electron-windows-sign"
           NODE_OPTIONS: "--max-old-space-size=4096"
           # SM_CODE_SIGNING_CERT_SHA1_HASH: ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -10,6 +10,8 @@ import { FusesPlugin } from "@electron-forge/plugin-fuses";
 import { FuseV1Options, FuseVersion } from "@electron/fuses";
 import { AutoUnpackNativesPlugin } from "@electron-forge/plugin-auto-unpack-natives";
 
+console.log("AZURE_CODE_SIGNING_DLIB", process.env.AZURE_CODE_SIGNING_DLIB);
+
 // Based on https://github.com/electron/forge/blob/6b2d547a7216c30fde1e1fddd1118eee5d872945/packages/plugin/vite/src/VitePlugin.ts#L124
 const ignore = (file: string) => {
   if (!file) return false;


### PR DESCRIPTION
#skip-bb

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Azure code signing on Windows by auto-detecting the Azure.CodeSigning.Dlib.dll path and exporting it for the build. Also exports SIGNTOOL_PATH and adds better debug output to diagnose signing issues.

- **Bug Fixes**
  - Search Program Files and LocalAppData for x64 Azure.CodeSigning.Dlib.dll and set AZURE_CODE_SIGNING_DLIB in the workflow; fail fast if not found.
  - Export SIGNTOOL_PATH from repo variables for signing tool discovery.
  - Extend DEBUG to include electron-windows-sign.
  - Log AZURE_CODE_SIGNING_DLIB in forge.config.ts for visibility during builds.

<sup>Written for commit bbaf06219896b34e6555f40a1d81457815a0166c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2441">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
