### PR TITLE
Fix Azure DLL search paths in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,35 +51,39 @@ jobs:
         run: |
           winget install -e --id Microsoft.Azure.TrustedSigningClientTools --source winget --accept-source-agreements --accept-package-agreements
 
-          # Search multiple locations where winget might install the tools
-          $searchPaths = @(
-            "C:\Program Files",
-            "$env:LOCALAPPDATA",
-            "$env:LOCALAPPDATA\Microsoft\WinGet\Packages",
-            "C:\Users\runneradmin\AppData\Local\Microsoft\WinGet\Packages"
-          )
-
+          $known = Join-Path $env:LOCALAPPDATA "Microsoft\MicrosoftTrustedSigningClientTools\Azure.CodeSigning.Dlib.dll"
           $dllPath = $null
-          foreach ($searchPath in $searchPaths) {
-            if (Test-Path $searchPath) {
-              Write-Host "Searching in: $searchPath"
-              $found = Get-ChildItem -Path $searchPath -Recurse -Filter "Azure.CodeSigning.Dlib.dll" -ErrorAction SilentlyContinue |
-                      Where-Object { $_.FullName -like "*x64*" } |
-                      Select-Object -First 1 -ExpandProperty FullName
-              if ($found) {
-                $dllPath = $found
-                break
+
+          if (Test-Path $known) {
+            $dllPath = $known
+          } else {
+            $searchPaths = @(
+              (Join-Path $env:LOCALAPPDATA "Microsoft\MicrosoftTrustedSigningClientTools"),
+              "C:\Program Files",
+              "$env:LOCALAPPDATA",
+              "$env:LOCALAPPDATA\Microsoft\WinGet\Packages",
+              "C:\Users\runneradmin\AppData\Local\Microsoft\WinGet\Packages"
+            )
+
+            foreach ($searchPath in $searchPaths) {
+              if (Test-Path $searchPath) {
+                Write-Host "Searching in: $searchPath"
+                $found = Get-ChildItem -Path $searchPath -Recurse -Filter "Azure.CodeSigning.Dlib.dll" -ErrorAction SilentlyContinue |
+                  Sort-Object { $_.FullName -notlike "*x64*" } |
+                  Select-Object -First 1 -ExpandProperty FullName
+                if ($found) { $dllPath = $found; break }
               }
             }
           }
 
           if ($dllPath) {
-            echo "Found DLL at: $dllPath"
-            echo "AZURE_CODE_SIGNING_DLIB=$dllPath" >> $env:GITHUB_ENV
+            Write-Host "Found DLL at: $dllPath"
+            "AZURE_CODE_SIGNING_DLIB=$dllPath" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
           } else {
-            Write-Error "Could not find Azure.CodeSigning.Dlib.dll in any of the search paths"
+            Write-Error "Could not find Azure.CodeSigning.Dlib.dll"
             exit 1
           }
+
       - name: Create Azure signing metadata
         if: contains(matrix.os.name, 'windows')
         shell: powershell

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,22 +51,33 @@ jobs:
         run: |
           winget install -e --id Microsoft.Azure.TrustedSigningClientTools --source winget --accept-source-agreements --accept-package-agreements
 
-          # Find the DLL path
-          $dllPath = Get-ChildItem -Path "C:\Program Files" -Recurse -Filter "Azure.CodeSigning.Dlib.dll" -ErrorAction SilentlyContinue | 
-                    Where-Object { $_.FullName -like "*x64*" } |
-                    Select-Object -First 1 -ExpandProperty FullName
+          # Search multiple locations where winget might install the tools
+          $searchPaths = @(
+            "C:\Program Files",
+            "$env:LOCALAPPDATA",
+            "$env:LOCALAPPDATA\Microsoft\WinGet\Packages",
+            "C:\Users\runneradmin\AppData\Local\Microsoft\WinGet\Packages"
+          )
 
-          if (-not $dllPath) {
-            $dllPath = Get-ChildItem -Path "$env:LOCALAPPDATA" -Recurse -Filter "Azure.CodeSigning.Dlib.dll" -ErrorAction SilentlyContinue | 
+          $dllPath = $null
+          foreach ($searchPath in $searchPaths) {
+            if (Test-Path $searchPath) {
+              Write-Host "Searching in: $searchPath"
+              $found = Get-ChildItem -Path $searchPath -Recurse -Filter "Azure.CodeSigning.Dlib.dll" -ErrorAction SilentlyContinue |
                       Where-Object { $_.FullName -like "*x64*" } |
                       Select-Object -First 1 -ExpandProperty FullName
+              if ($found) {
+                $dllPath = $found
+                break
+              }
+            }
           }
 
           if ($dllPath) {
             echo "Found DLL at: $dllPath"
             echo "AZURE_CODE_SIGNING_DLIB=$dllPath" >> $env:GITHUB_ENV
           } else {
-            Write-Error "Could not find Azure.CodeSigning.Dlib.dll"
+            Write-Error "Could not find Azure.CodeSigning.Dlib.dll in any of the search paths"
             exit 1
           }
       - name: Create Azure signing metadata


### PR DESCRIPTION
## Summary
- Add additional search paths for Azure.CodeSigning.Dlib.dll in the Windows release workflow
- Search in WinGet packages directory and runner user profile where winget may install tools
- Add logging to show which paths are being searched for easier debugging

## Test plan
- Trigger the release workflow manually
- Verify the Windows build finds the Azure code signing DLL successfully

#skip-bugbot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2442">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures the Windows release workflow reliably finds Azure.CodeSigning.Dlib.dll to prevent signing failures on GitHub Actions runners.

- **Bug Fixes**
  - Prefer %LOCALAPPDATA%\Microsoft\MicrosoftTrustedSigningClientTools, then search: Program Files, %LOCALAPPDATA%, %LOCALAPPDATA%\Microsoft\WinGet\Packages, and C:\Users\runneradmin\AppData\Local\Microsoft\WinGet\Packages.
  - Log each path checked for easier debugging.
  - Set AZURE_CODE_SIGNING_DLIB when found; exit with a clear error if not.

<sup>Written for commit 0b868ec6f24a30b32e17ba4a03decf5d2674df18. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

