### PR TITLE
Fix Windows signtool error by removing invalid /debug flag

### DIFF
--- a/windowsSign.ts
+++ b/windowsSign.ts
@@ -5,7 +5,7 @@ export const windowsSign: WindowsSignOptions = {
   ...(process.env.SIGNTOOL_PATH
     ? { signToolPath: process.env.SIGNTOOL_PATH }
     : {}),
-  signWithParams: `/v /debug /dlib ${process.env.AZURE_CODE_SIGNING_DLIB} /dmdf ${process.env.AZURE_METADATA_JSON}`,
+  signWithParams: `/v /dlib ${process.env.AZURE_CODE_SIGNING_DLIB} /dmdf ${process.env.AZURE_METADATA_JSON}`,
   timestampServer: "http://timestamp.acs.microsoft.com",
   hashes: ["sha256" as HASHES],
 };


### PR DESCRIPTION
## Summary
- Removes the invalid `/debug` flag from signtool parameters in `windowsSign.ts`
- The `/debug` flag is not a supported signtool option and was causing Windows builds to fail with `SignTool Error: Invalid option: /debug`

## Test plan
- [ ] Verify Windows release build succeeds by running the Release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2443">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the invalid /debug flag from signtool params in windowsSign.ts to fix Windows build failures. This resolves “SignTool Error: Invalid option: /debug” during signing.

<sup>Written for commit e8d71407fdcf4a3171ee12e9fe9028b4cbc584fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line change to Windows code-signing flags that only affects signing invocation and should reduce build failures.
> 
> **Overview**
> Removes the unsupported `/debug` option from `windowsSign.ts` `signWithParams`, leaving only the verbose (`/v`) and Azure signing library/metadata parameters. This aims to prevent `signtool` from failing Windows builds due to an invalid flag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8d71407fdcf4a3171ee12e9fe9028b4cbc584fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->