### PR TITLE
Add ts-expect-error for zod v4 type inference in registerTypedHandlers

### DIFF
--- a/src/ipc/handlers/base.ts
+++ b/src/ipc/handlers/base.ts
@@ -148,6 +148,7 @@ export function registerTypedHandlers<
   for (const [key, contract] of Object.entries(contracts)) {
     const handler = handlers[key as keyof typeof handlers];
     if (handler) {
+      // @ts-expect-error zod v4 type inference is not working correctly
       createTypedHandler(contract, handler);
     }
   }


### PR DESCRIPTION
## Summary
- Adds `@ts-expect-error` comment to suppress a zod v4 type inference issue in `registerTypedHandlers` (`src/ipc/handlers/base.ts`)
- The generic handler registration produces incorrect types with zod v4, requiring this suppression until the upstream issue is resolved

## Test plan
- [x] TypeScript type-checking passes (`npm run ts`)
- [x] All 661 unit tests pass
- [x] Lint checks pass

#skip-bugbot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2444">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppress a Zod v4 type inference error in registerTypedHandlers by adding @ts-expect-error in src/ipc/handlers/base.ts. This unblocks type-checking with no runtime changes until the upstream issue is fixed.

<sup>Written for commit 4b847c8611331b51afead606c85bdc52d017a1dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

