### PR TITLE
Auto-discover Windows SDK SignTool path in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,24 @@ jobs:
             exit 1
           }
 
+      - name: Find Windows 11 SDK SignTool
+        if: contains(matrix.os.name, 'windows')
+        shell: powershell
+        run: |
+          $sdkPath = "C:\Program Files (x86)\Windows Kits\10\bin"
+          $signTool = Get-ChildItem -Path $sdkPath -Recurse -Filter "signtool.exe" |
+            Where-Object { $_.FullName -match "\\x64\\" } |
+            Sort-Object { [version]($_.FullName -replace '.*\\(\d+\.\d+\.\d+\.\d+)\\.*', '$1') } -Descending |
+            Select-Object -First 1
+
+          if ($signTool) {
+            Write-Host "Found SignTool at: $($signTool.FullName)"
+            "SIGNTOOL_PATH=$($signTool.FullName)" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          } else {
+            Write-Error "Could not find x64 signtool.exe"
+            exit 1
+          }
+
       - name: Create Azure signing metadata
         if: contains(matrix.os.name, 'windows')
         shell: powershell
@@ -138,7 +156,6 @@ jobs:
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          SIGNTOOL_PATH: ${{ vars.SIGNTOOL_PATH }}
 
   verify-assets:
     name: Verify Release Assets

--- a/windowsSign.ts
+++ b/windowsSign.ts
@@ -5,7 +5,7 @@ export const windowsSign: WindowsSignOptions = {
   ...(process.env.SIGNTOOL_PATH
     ? { signToolPath: process.env.SIGNTOOL_PATH }
     : {}),
-  signWithParams: `/v /dlib ${process.env.AZURE_CODE_SIGNING_DLIB} /dmdf ${process.env.AZURE_METADATA_JSON}`,
+  signWithParams: `/v /debug /dlib ${process.env.AZURE_CODE_SIGNING_DLIB} /dmdf ${process.env.AZURE_METADATA_JSON}`,
   timestampServer: "http://timestamp.acs.microsoft.com",
   hashes: ["sha256" as HASHES],
 };


### PR DESCRIPTION
## Summary
- Auto-discover signtool.exe from Windows SDK instead of relying on `SIGNTOOL_PATH` repository variable
- Add `/debug` flag to signtool for better diagnostics during signing failures
- Remove `SIGNTOOL_PATH` env var from the electron-builder step since it's now set dynamically

#skip-bugbot

## Test plan
- Verify the release workflow runs successfully on Windows runners
- Check that signtool.exe is found from the Windows SDK directory
- Confirm signing output includes debug information

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2445">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically discover the Windows SDK SignTool in the release workflow and set its path via GITHUB_ENV, removing the need for the SIGNTOOL_PATH repo variable. Adds /debug to SignTool for clearer diagnostics during signing.

- **Refactors**
  - Auto-find x64 signtool.exe from the Windows SDK and export SIGNTOOL_PATH dynamically.
  - Add /debug to signWithParams for better logging.
  - Remove SIGNTOOL_PATH from the electron-builder step.

<sup>Written for commit e667e794ac6b4c13bf34ab2943182fd22de26da0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

