### PR TITLE
Fix Windows signing failure caused by UTF-8 BOM in metadata JSON

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Create Azure signing metadata
         if: contains(matrix.os.name, 'windows')
-        shell: powershell
+        shell: pwsh
         run: |
           @'
           {


### PR DESCRIPTION
## Summary
- Windows release builds fail during code signing because the Azure Trusted Signing DLL cannot parse the signing metadata JSON file
- The `signing-metadata.json` is written with a UTF-8 BOM (0xEF 0xBB 0xBF) by Windows PowerShell 5.1's `Out-File -Encoding utf8`, and .NET's `System.Text.Json` parser rejects the BOM as invalid JSON
- Fix: switch `shell: powershell` to `shell: pwsh` (PowerShell Core) which writes UTF-8 without BOM by default

## Test plan
- Re-run the release workflow and verify the Windows build completes signing successfully

#skip-bugbot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2446">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Windows release signing failures by switching the workflow to PowerShell Core (pwsh) so signing-metadata.json is written as UTF-8 without a BOM. This avoids the .NET System.Text.Json BOM error and lets Azure Trusted Signing parse the file successfully.

<sup>Written for commit b1967255ec4547681dd5650fe0c2154b7374f0ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

