### PR TITLE
Add mid-stream auto-compaction for local-agent mode

### DIFF
--- a/src/__tests__/compaction_utils.test.ts
+++ b/src/__tests__/compaction_utils.test.ts
@@ -1,0 +1,404 @@
+import { describe, it, expect } from "vitest";
+import type { ModelMessage } from "ai";
+import {
+  estimateModelMessagesTokens,
+  shouldCompact,
+  partitionMessagesForCompaction,
+  buildCompactionPrompt,
+  buildCompactedMessages,
+} from "@/pro/main/ipc/handlers/local_agent/compaction_utils";
+
+describe("compaction_utils", () => {
+  describe("estimateModelMessagesTokens", () => {
+    it("estimates tokens for string content messages", () => {
+      const messages: ModelMessage[] = [
+        { role: "user", content: "Hello world" }, // 11 chars -> 3 tokens + 4 overhead
+        { role: "assistant", content: "Hi there" }, // 8 chars -> 2 tokens + 4 overhead
+      ];
+      const result = estimateModelMessagesTokens(messages);
+      // (ceil(11/4) + 4) + (ceil(8/4) + 4) = (3+4) + (2+4) = 13
+      expect(result).toBe(13);
+    });
+
+    it("estimates tokens for text parts", () => {
+      const messages: ModelMessage[] = [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "Hello" },
+            { type: "text", text: "World" },
+          ],
+        },
+      ];
+      const result = estimateModelMessagesTokens(messages);
+      // ceil(5/4) + ceil(5/4) + 4 = 2 + 2 + 4 = 8
+      expect(result).toBe(8);
+    });
+
+    it("estimates tokens for image parts", () => {
+      const messages: ModelMessage[] = [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "Look at this:" },
+            { type: "image", image: new URL("https://example.com/img.png") },
+          ],
+        },
+      ];
+      const result = estimateModelMessagesTokens(messages);
+      // ceil(13/4) + 1000 + 4 = 4 + 1000 + 4 = 1008
+      expect(result).toBe(1008);
+    });
+
+    it("estimates tokens for tool-call parts", () => {
+      const messages: ModelMessage[] = [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "call1",
+              toolName: "read_file",
+              input: { path: "/src/index.ts" },
+            },
+          ],
+        },
+      ];
+      const result = estimateModelMessagesTokens(messages);
+      const inputStr = JSON.stringify({ path: "/src/index.ts" });
+      // ceil(inputStr.length / 4) + 20 overhead + 4 role overhead
+      expect(result).toBe(Math.ceil(inputStr.length / 4) + 20 + 4);
+    });
+
+    it("estimates tokens for tool-result parts", () => {
+      const messages: ModelMessage[] = [
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "call1",
+              toolName: "read_file",
+              output: {
+                type: "text" as const,
+                value: "file contents here",
+              },
+            },
+          ],
+        },
+      ];
+      const result = estimateModelMessagesTokens(messages);
+      const outputStr = JSON.stringify({
+        type: "text",
+        value: "file contents here",
+      });
+      expect(result).toBe(Math.ceil(outputStr.length / 4) + 20 + 4);
+    });
+
+    it("estimates tokens for reasoning parts", () => {
+      const messages: ModelMessage[] = [
+        {
+          role: "assistant",
+          content: [{ type: "reasoning", text: "Let me think about this..." }],
+        },
+      ];
+      const result = estimateModelMessagesTokens(messages);
+      // ceil(26/4) + 4 = 7 + 4 = 11
+      expect(result).toBe(11);
+    });
+
+    it("handles empty messages array", () => {
+      expect(estimateModelMessagesTokens([])).toBe(0);
+    });
+
+    it("handles mixed content types in a single message", () => {
+      const messages: ModelMessage[] = [
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "I will read the file" },
+            {
+              type: "tool-call",
+              toolCallId: "call1",
+              toolName: "read",
+              input: { path: "a.ts" },
+            },
+          ],
+        },
+      ];
+      const result = estimateModelMessagesTokens(messages);
+      const textTokens = Math.ceil(20 / 4);
+      const toolTokens =
+        Math.ceil(JSON.stringify({ path: "a.ts" }).length / 4) + 20;
+      expect(result).toBe(textTokens + toolTokens + 4);
+    });
+  });
+
+  describe("shouldCompact", () => {
+    it("returns false when under threshold", () => {
+      const messages: ModelMessage[] = [
+        { role: "user", content: "Short message" },
+      ];
+      expect(shouldCompact({ messages, contextWindow: 128000 })).toBe(false);
+    });
+
+    it("returns true when at or above threshold", () => {
+      // Create a message large enough to exceed 75% of a small context window
+      const longContent = "x".repeat(400); // 100 tokens
+      const messages: ModelMessage[] = [{ role: "user", content: longContent }];
+      // 100 + 4 overhead = 104 tokens, context window of 128 * 0.75 = 96
+      expect(shouldCompact({ messages, contextWindow: 128 })).toBe(true);
+    });
+
+    it("respects custom threshold", () => {
+      const longContent = "x".repeat(400); // 100 tokens
+      const messages: ModelMessage[] = [{ role: "user", content: longContent }];
+      // 104 tokens total, context window 200, threshold 0.5 = 100
+      expect(
+        shouldCompact({ messages, contextWindow: 200, threshold: 0.5 }),
+      ).toBe(true);
+      // threshold 0.6 = 120
+      expect(
+        shouldCompact({ messages, contextWindow: 200, threshold: 0.6 }),
+      ).toBe(false);
+    });
+  });
+
+  describe("partitionMessagesForCompaction", () => {
+    function makeMessages(count: number): ModelMessage[] {
+      const msgs: ModelMessage[] = [];
+      for (let i = 0; i < count; i++) {
+        if (i === 0) {
+          msgs.push({ role: "user", content: `User message ${i}` });
+        } else if (i % 3 === 0) {
+          msgs.push({
+            role: "tool",
+            content: [
+              {
+                type: "tool-result",
+                toolCallId: `call${i}`,
+                toolName: "test",
+                output: { type: "text" as const, value: `Result ${i}` },
+              },
+            ],
+          });
+        } else if (i % 2 === 0) {
+          msgs.push({
+            role: "assistant",
+            content: [
+              {
+                type: "tool-call",
+                toolCallId: `call${i + 1}`,
+                toolName: "test",
+                input: { step: i },
+              },
+            ],
+          });
+        } else {
+          msgs.push({ role: "assistant", content: `Response ${i}` });
+        }
+      }
+      return msgs;
+    }
+
+    it("returns empty toCompact when too few messages", () => {
+      const messages = makeMessages(5);
+      const { toCompact, toPreserve } = partitionMessagesForCompaction(
+        messages,
+        10,
+      );
+      expect(toCompact).toHaveLength(0);
+      expect(toPreserve).toEqual(messages);
+    });
+
+    it("preserves the first user message", () => {
+      const messages = makeMessages(20);
+      const { toPreserve } = partitionMessagesForCompaction(messages, 10);
+      expect(toPreserve[0]).toEqual(messages[0]);
+    });
+
+    it("preserves the last N messages", () => {
+      const messages = makeMessages(20);
+      const { toPreserve } = partitionMessagesForCompaction(messages, 10);
+      // First message + last 10 = 11 preserved (but first message is from original position 0,
+      // which is before the split, so it gets moved)
+      const lastTen = messages.slice(-10);
+      // The preserved set should end with the last 10 messages
+      expect(toPreserve.slice(-10)).toEqual(lastTen);
+    });
+
+    it("does not split tool-call / tool-result pairs", () => {
+      // Construct messages where a tool-result is at the split boundary
+      const messages: ModelMessage[] = [
+        { role: "user", content: "Do something" },
+        { role: "assistant", content: "Step 1" },
+        { role: "assistant", content: "Step 2" },
+        { role: "assistant", content: "Step 3" },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "call1",
+              toolName: "read",
+              input: {},
+            },
+          ],
+        },
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "call1",
+              toolName: "read",
+              output: { type: "text" as const, value: "result" },
+            },
+          ],
+        },
+        { role: "assistant", content: "Step 5" },
+        { role: "assistant", content: "Step 6" },
+        { role: "assistant", content: "Step 7" },
+        { role: "assistant", content: "Step 8" },
+        { role: "assistant", content: "Step 9" },
+        { role: "assistant", content: "Step 10" },
+      ];
+
+      // With preserveRecentCount=7, split would be at index 5 (the tool-result)
+      // It should adjust backward to keep the tool-call + tool-result together
+      const { toCompact, toPreserve } = partitionMessagesForCompaction(
+        messages,
+        7,
+      );
+
+      // The tool-result message should NOT be in toCompact
+      for (const msg of toCompact) {
+        expect(msg.role).not.toBe("tool");
+      }
+
+      // Both the tool-call and tool-result should be in toPreserve
+      const hasToolCall = toPreserve.some(
+        (m) =>
+          m.role === "assistant" &&
+          Array.isArray(m.content) &&
+          m.content.some((p) => p.type === "tool-call"),
+      );
+      const hasToolResult = toPreserve.some((m) => m.role === "tool");
+      expect(hasToolCall).toBe(true);
+      expect(hasToolResult).toBe(true);
+    });
+
+    it("compacts messages between first and preserved window", () => {
+      const messages = makeMessages(25);
+      const { toCompact, toPreserve } = partitionMessagesForCompaction(
+        messages,
+        10,
+      );
+
+      expect(toCompact.length).toBeGreaterThan(0);
+      // Total should equal original (minus first message which moved to preserve)
+      expect(toCompact.length + toPreserve.length).toBe(messages.length);
+    });
+  });
+
+  describe("buildCompactionPrompt", () => {
+    it("serializes string content messages", () => {
+      const messages: ModelMessage[] = [
+        { role: "assistant", content: "I'll help you" },
+        { role: "user", content: "Thanks" },
+      ];
+      const result = buildCompactionPrompt(messages);
+      expect(result).toHaveLength(1);
+      expect(result[0].role).toBe("user");
+      expect(result[0].content).toContain("[ASSISTANT]: I'll help you");
+      expect(result[0].content).toContain("[USER]: Thanks");
+    });
+
+    it("serializes tool-call parts", () => {
+      const messages: ModelMessage[] = [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "call1",
+              toolName: "read_file",
+              input: { path: "/src/index.ts" },
+            },
+          ],
+        },
+      ];
+      const result = buildCompactionPrompt(messages);
+      expect(result[0].content).toContain("[Tool Call: read_file(");
+      expect(result[0].content).toContain("/src/index.ts");
+    });
+
+    it("truncates large tool results", () => {
+      const longResult = "x".repeat(3000);
+      const messages: ModelMessage[] = [
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "call1",
+              toolName: "read_file",
+              output: { type: "text" as const, value: longResult },
+            },
+          ],
+        },
+      ];
+      const result = buildCompactionPrompt(messages);
+      const content = result[0].content as string;
+      expect(content).toContain("... (truncated)");
+      // Should be much shorter than the original 3000 chars
+      expect(content.length).toBeLessThan(3000);
+    });
+
+    it("handles image parts", () => {
+      const messages: ModelMessage[] = [
+        {
+          role: "user",
+          content: [
+            { type: "image", image: new URL("https://example.com/img.png") },
+          ],
+        },
+      ];
+      const result = buildCompactionPrompt(messages);
+      expect(result[0].content).toContain("[Image]");
+    });
+  });
+
+  describe("buildCompactedMessages", () => {
+    it("returns summary message followed by preserved messages", () => {
+      const toPreserve: ModelMessage[] = [
+        { role: "user", content: "Original task" },
+        { role: "assistant", content: "Working on it" },
+      ];
+      const result = buildCompactedMessages(
+        "Summary of earlier work",
+        toPreserve,
+      );
+
+      expect(result).toHaveLength(3);
+      expect(result[0].role).toBe("user");
+      expect(result[0].content).toContain("[Conversation Summary");
+      expect(result[0].content).toContain("Summary of earlier work");
+      expect(result[1]).toEqual(toPreserve[0]);
+      expect(result[2]).toEqual(toPreserve[1]);
+    });
+
+    it("works with empty preserve set", () => {
+      const result = buildCompactedMessages("Summary", []);
+      expect(result).toHaveLength(1);
+      expect(result[0].role).toBe("user");
+    });
+
+    it("includes the context prefix in summary", () => {
+      const result = buildCompactedMessages("test summary", []);
+      expect(result[0].content).toContain(
+        "[Conversation Summary — use for context, focus on recent messages for current task]",
+      );
+    });
+  });
+});

--- a/src/__tests__/local_agent_handler.test.ts
+++ b/src/__tests__/local_agent_handler.test.ts
@@ -209,6 +209,7 @@ let mockStreamResult: ReturnType<typeof createFakeStream> | null = null;
 
 vi.mock("ai", () => ({
   streamText: vi.fn(() => mockStreamResult),
+  generateText: vi.fn(async () => ({ text: "Compaction summary" })),
   stepCountIs: vi.fn((n: number) => ({ steps: n })),
   hasToolCall: vi.fn((toolName: string) => ({ toolName })),
 }));
@@ -225,6 +226,7 @@ vi.mock("@/ipc/utils/get_model_client", () => ({
 vi.mock("@/ipc/utils/token_utils", () => ({
   getMaxTokens: vi.fn(async () => 4096),
   getTemperature: vi.fn(async () => 0.7),
+  getContextWindowForModel: vi.fn(async () => 128000),
 }));
 
 vi.mock("@/ipc/utils/provider_options", () => ({

--- a/src/ipc/handlers/base.ts
+++ b/src/ipc/handlers/base.ts
@@ -148,7 +148,6 @@ export function registerTypedHandlers<
   for (const [key, contract] of Object.entries(contracts)) {
     const handler = handlers[key as keyof typeof handlers];
     if (handler) {
-      // @ts-expect-error zod v4 type inference is not working correctly
       createTypedHandler(contract, handler);
     }
   }

--- a/src/ipc/types/agent.ts
+++ b/src/ipc/types/agent.ts
@@ -185,6 +185,17 @@ export const agentEvents = {
     channel: "agent-tool:problems-update",
     payload: AgentProblemsUpdateSchema,
   }),
+
+  /**
+   * Emitted when the agent compacts its conversation history.
+   */
+  compactionStatus: defineEvent({
+    channel: "agent-tool:compaction-status",
+    payload: z.object({
+      chatId: z.number(),
+      status: z.enum(["compacting", "compacted"]),
+    }),
+  }),
 } as const;
 
 // =============================================================================

--- a/src/ipc/utils/token_utils.ts
+++ b/src/ipc/utils/token_utils.ts
@@ -24,6 +24,13 @@ export async function getContextWindow() {
   return modelOption?.contextWindow || DEFAULT_CONTEXT_WINDOW;
 }
 
+export async function getContextWindowForModel(
+  model: LargeLanguageModel,
+): Promise<number> {
+  const modelOption = await findLanguageModel(model);
+  return modelOption?.contextWindow || DEFAULT_CONTEXT_WINDOW;
+}
+
 export async function getMaxTokens(
   model: LargeLanguageModel,
 ): Promise<number | undefined> {

--- a/src/pro/main/ipc/handlers/local_agent/compaction_utils.ts
+++ b/src/pro/main/ipc/handlers/local_agent/compaction_utils.ts
@@ -1,0 +1,232 @@
+/**
+ * Core compaction logic for mid-stream context window management.
+ *
+ * Pure/testable functions that estimate token usage, decide when to compact,
+ * partition messages, and build compacted message arrays.
+ */
+
+import type { ModelMessage } from "ai";
+
+/**
+ * Estimate tokens for a string (4 chars per token heuristic).
+ */
+function estimateStringTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+/**
+ * Estimate the total token count for an array of ModelMessages.
+ *
+ * Walks each message and estimates tokens by content type:
+ * - String content: 4 chars/token
+ * - TextPart[]: concatenate .text fields
+ * - ToolCallPart: JSON.stringify(input) + 20 token overhead
+ * - ToolResultPart: JSON.stringify(output) + 20 token overhead
+ * - ImagePart: flat 1000 tokens per image
+ * - ~4 tokens/message for role/structure overhead
+ */
+export function estimateModelMessagesTokens(messages: ModelMessage[]): number {
+  let total = 0;
+
+  for (const msg of messages) {
+    // Role/structure overhead per message
+    total += 4;
+
+    if (typeof msg.content === "string") {
+      total += estimateStringTokens(msg.content);
+      continue;
+    }
+
+    if (!Array.isArray(msg.content)) {
+      continue;
+    }
+
+    for (const part of msg.content) {
+      switch (part.type) {
+        case "text":
+          total += estimateStringTokens(part.text);
+          break;
+        case "image":
+          total += 1000;
+          break;
+        case "file":
+          // Estimate based on data size if string, otherwise flat cost
+          if (typeof part.data === "string") {
+            total += estimateStringTokens(part.data);
+          } else {
+            total += 500;
+          }
+          break;
+        case "tool-call":
+          total += estimateStringTokens(JSON.stringify(part.input)) + 20;
+          break;
+        case "tool-result":
+          total += estimateStringTokens(JSON.stringify(part.output)) + 20;
+          break;
+        case "reasoning":
+          total += estimateStringTokens(part.text);
+          break;
+        default:
+          // Unknown part type, small overhead
+          total += 10;
+          break;
+      }
+    }
+  }
+
+  return total;
+}
+
+/**
+ * Returns true when estimated tokens >= contextWindow * threshold.
+ */
+export function shouldCompact(params: {
+  messages: ModelMessage[];
+  contextWindow: number;
+  threshold?: number;
+}): boolean {
+  const { messages, contextWindow, threshold = 0.75 } = params;
+  const estimated = estimateModelMessagesTokens(messages);
+  return estimated >= contextWindow * threshold;
+}
+
+/**
+ * Splits messages into two groups: those to compact (summarize) and those to preserve.
+ *
+ * Rules:
+ * - Always preserves the first user message (original intent)
+ * - Keeps the last `preserveRecentCount` messages intact
+ * - Never splits a tool-call / tool-result pair across the boundary
+ * - If fewer messages than preserveRecentCount + 1, nothing to compact
+ */
+export function partitionMessagesForCompaction(
+  messages: ModelMessage[],
+  preserveRecentCount = 10,
+): { toCompact: ModelMessage[]; toPreserve: ModelMessage[] } {
+  // Need at least preserveRecentCount + 1 (for the first user message) + 1 more to compact
+  if (messages.length <= preserveRecentCount + 1) {
+    return { toCompact: [], toPreserve: messages };
+  }
+
+  // Start with a split point that preserves the last N messages
+  let splitIndex = messages.length - preserveRecentCount;
+
+  // Adjust split point to avoid breaking tool-call / tool-result pairs.
+  // A tool-result message (role: "tool") should stay with the preceding assistant
+  // message that contains the tool-call. Walk the boundary backwards if needed.
+  while (splitIndex > 1 && isToolResultMessage(messages[splitIndex])) {
+    splitIndex--;
+  }
+
+  // If we pushed splitIndex too far back, there's nothing meaningful to compact
+  if (splitIndex <= 1) {
+    return { toCompact: [], toPreserve: messages };
+  }
+
+  // Always preserve the first user message in the toPreserve set
+  const firstUserMessage = messages[0];
+  const toCompact = messages.slice(1, splitIndex);
+  const toPreserve = [firstUserMessage, ...messages.slice(splitIndex)];
+
+  return { toCompact, toPreserve };
+}
+
+/**
+ * Checks if a message is a tool-result message (role: "tool").
+ */
+function isToolResultMessage(msg: ModelMessage): boolean {
+  return msg.role === "tool";
+}
+
+/**
+ * Serializes compactable messages into a text representation for the summarizer.
+ * Large tool results (>2000 chars) are truncated.
+ */
+export function buildCompactionPrompt(
+  toCompact: ModelMessage[],
+): ModelMessage[] {
+  const MAX_TOOL_RESULT_LENGTH = 2000;
+
+  const lines: string[] = [];
+
+  for (const msg of toCompact) {
+    const role = msg.role.toUpperCase();
+
+    if (typeof msg.content === "string") {
+      lines.push(`[${role}]: ${msg.content}`);
+      continue;
+    }
+
+    if (!Array.isArray(msg.content)) {
+      lines.push(`[${role}]: (empty)`);
+      continue;
+    }
+
+    const parts: string[] = [];
+    for (const part of msg.content) {
+      switch (part.type) {
+        case "text":
+          parts.push(part.text);
+          break;
+        case "tool-call":
+          parts.push(
+            `[Tool Call: ${part.toolName}(${truncate(JSON.stringify(part.input), MAX_TOOL_RESULT_LENGTH)})]`,
+          );
+          break;
+        case "tool-result": {
+          const resultStr = JSON.stringify(part.output);
+          parts.push(
+            `[Tool Result for ${part.toolName}: ${truncate(resultStr, MAX_TOOL_RESULT_LENGTH)}]`,
+          );
+          break;
+        }
+        case "image":
+          parts.push("[Image]");
+          break;
+        case "file":
+          parts.push("[File]");
+          break;
+        case "reasoning":
+          parts.push(
+            `[Reasoning: ${truncate(part.text, MAX_TOOL_RESULT_LENGTH)}]`,
+          );
+          break;
+        default:
+          parts.push(`[${part.type}]`);
+          break;
+      }
+    }
+
+    lines.push(`[${role}]: ${parts.join("\n")}`);
+  }
+
+  return [
+    {
+      role: "user",
+      content: lines.join("\n\n"),
+    },
+  ];
+}
+
+/**
+ * Returns [summaryUserMessage, ...toPreserve] where the summary is a user message
+ * prefixed with context about it being a summary.
+ */
+export function buildCompactedMessages(
+  summary: string,
+  toPreserve: ModelMessage[],
+): ModelMessage[] {
+  const summaryMessage: ModelMessage = {
+    role: "user",
+    content: `[Conversation Summary — use for context, focus on recent messages for current task]\n\n${summary}`,
+  };
+
+  return [summaryMessage, ...toPreserve];
+}
+
+function truncate(text: string, maxLength: number): string {
+  if (text.length <= maxLength) {
+    return text;
+  }
+  return text.slice(0, maxLength) + "... (truncated)";
+}

--- a/src/prompts/compaction_system_prompt.ts
+++ b/src/prompts/compaction_system_prompt.ts
@@ -1,0 +1,17 @@
+export const COMPACTION_SYSTEM_PROMPT = `You are a conversation summarizer for an AI coding assistant. Your task is to create a concise summary of the conversation history that will replace the original messages to save context window space.
+
+Capture the following in your summary:
+
+1. **Task Objective**: What the user originally asked for and the overall goal.
+2. **Decisions Made**: Key architectural or implementation decisions, including alternatives that were considered and rejected.
+3. **Files Modified**: List files that were created, modified, or read, with brief descriptions of what changed.
+4. **Current State**: What has been accomplished so far and the state of the work.
+5. **Open Issues**: Any errors encountered, unresolved problems, or remaining work.
+
+Guidelines:
+- Be concise but preserve critical details that the assistant will need to continue working.
+- Prioritize information about the most recent actions and decisions.
+- Include exact file paths and function/variable names when relevant.
+- Omit verbose tool outputs, stack traces, and file contents — summarize their key findings instead.
+- Target under 2000 tokens.
+- Write in plain text, not markdown.`;


### PR DESCRIPTION
## Summary
- Adds automatic context compaction during local-agent tool loops when estimated token usage reaches ~75% of the model's context window
- Older messages are summarized via a fast LLM call and replaced with a compact summary, allowing the agent to continue without hitting context limits
- Includes compaction status events (`compacting`/`compacted`) sent to the UI, graceful degradation on failure, and re-compaction tracking to avoid loops

## Test plan
- [x] Unit tests for all compaction utility functions (23 tests in `compaction_utils.test.ts`)
- [x] Updated existing `local_agent_handler.test.ts` mocks for new dependencies
- [x] All 684 unit tests pass
- [ ] Manual test: open a local-agent chat with a small context window model, give a task requiring many tool calls, verify compaction triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2452">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the local-agent streaming loop to rewrite message history mid-run via an extra `generateText` summarization call, which can affect tool-loop behavior and context fidelity if token estimation/partitioning is off or the summarizer fails.
> 
> **Overview**
> Adds **automatic mid-stream context compaction** to local-agent tool loops: when estimated token usage crosses ~75% of the model context window, older messages are summarized and replaced with a single `[Conversation Summary …]` message while preserving the first user prompt and the most recent messages (without splitting tool-call/tool-result pairs).
> 
> Introduces new compaction utilities (`estimateModelMessagesTokens`, `shouldCompact`, prompt building, and message partitioning), a dedicated `COMPACTION_SYSTEM_PROMPT`, and a new IPC event `agent-tool:compaction-status` (`compacting`/`compacted`) emitted around the summarization step. Adds `getContextWindowForModel` and updates tests/mocks accordingly, plus a small cleanup removing a `@ts-expect-error` in IPC handler registration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea4bf7345ed083473908ea6dcd1722ceb3b824c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds mid-stream auto-compaction to local-agent mode to keep long tool runs within the model’s context window. When estimated tokens hit ~75% of the window, older history is summarized and replaced so the agent can continue.

- **New Features**
  - Token-aware trigger in prepareStep using the selected model’s context window.
  - Compaction preserves the first user message and the last N messages; never splits tool-call/tool-result pairs.
  - Fast summarization via generateText with a dedicated system prompt; avoids repeat compaction loops and degrades gracefully on failure.
  - New UI events: compactionStatus ("compacting" / "compacted"); added utilities and tests for token estimation and partitioning.

- **Migration**
  - Optional: handle the "agent-tool:compaction-status" event to show compaction state in the UI. No changes required for existing behavior.

<sup>Written for commit ea4bf7345ed083473908ea6dcd1722ceb3b824c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

