### PR TITLE
Add custom templates feature with CRUD operations and library UI

### DIFF
--- a/drizzle/0025_lush_stark_industries.sql
+++ b/drizzle/0025_lush_stark_industries.sql
@@ -1,3 +1,13 @@
+CREATE TABLE `custom_templates` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`name` text NOT NULL,
+	`description` text,
+	`github_url` text NOT NULL,
+	`image_url` text,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`updated_at` integer DEFAULT (unixepoch()) NOT NULL
+);
+--> statement-breakpoint
 ALTER TABLE `chats` ADD `compacted_at` integer;--> statement-breakpoint
 ALTER TABLE `chats` ADD `compaction_backup_path` text;--> statement-breakpoint
 ALTER TABLE `chats` ADD `pending_compaction` integer;--> statement-breakpoint

--- a/drizzle/meta/0025_snapshot.json
+++ b/drizzle/meta/0025_snapshot.json
@@ -259,6 +259,67 @@
       "uniqueConstraints": {},
       "checkConstraints": {}
     },
+    "custom_templates": {
+      "name": "custom_templates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_url": {
+          "name": "github_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
     "custom_themes": {
       "name": "custom_themes",
       "columns": {

--- a/rules/database-drizzle.md
+++ b/rules/database-drizzle.md
@@ -19,3 +19,12 @@ When rebasing a branch that has drizzle migrations conflicting with upstream (e.
 3. Update `drizzle/meta/_journal.json` to include all migrations with correct indices
 4. Create/update the snapshot file (`drizzle/meta/00XX_snapshot.json`) with the new index, updating `prevId` to reference the previous snapshot's `id`
 5. If the PR had subsequent commits that deleted/modified its migration files, those changes become no-ops after renaming — just accept the deletion conflicts by staging the renamed files
+
+### Merging snapshot conflicts when both branches modify the same migration number
+
+When both HEAD and your branch create the same migration index (e.g., both create `0025_*.sql` with different changes):
+
+1. **Use HEAD's `id` and timestamp** in the snapshot and journal files (HEAD represents the merged state)
+2. **Merge the SQL migrations** by combining both sets of ALTER/CREATE statements into a single file named with HEAD's tag
+3. **Merge the snapshot JSON schema** by combining both sets of table/column changes into HEAD's snapshot file
+4. Example: If HEAD adds compaction columns and your branch adds `custom_templates` table, the merged `0025_lush_stark_industries.sql` should contain both the `CREATE TABLE custom_templates` and the `ALTER TABLE chats/messages` statements, and the snapshot should include both the new table and new columns

--- a/src/components/CreateCustomTemplateDialog.tsx
+++ b/src/components/CreateCustomTemplateDialog.tsx
@@ -1,0 +1,115 @@
+import React, { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Plus, Save } from "lucide-react";
+
+interface CreateCustomTemplateDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCreateTemplate: (params: {
+    name: string;
+    description?: string;
+    githubUrl: string;
+    imageUrl?: string;
+  }) => Promise<any>;
+}
+
+export function CreateCustomTemplateDialog({
+  open,
+  onOpenChange,
+  onCreateTemplate,
+}: CreateCustomTemplateDialogProps) {
+  const [draft, setDraft] = useState({
+    name: "",
+    description: "",
+    githubUrl: "",
+    imageUrl: "",
+  });
+
+  useEffect(() => {
+    if (!open) {
+      setDraft({ name: "", description: "", githubUrl: "", imageUrl: "" });
+    }
+  }, [open]);
+
+  const onSave = async () => {
+    if (!draft.name.trim() || !draft.githubUrl.trim()) return;
+
+    await onCreateTemplate({
+      name: draft.name.trim(),
+      description: draft.description.trim() || undefined,
+      githubUrl: draft.githubUrl.trim(),
+      imageUrl: draft.imageUrl.trim() || undefined,
+    });
+
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogTrigger
+        render={
+          <Button>
+            <Plus className="mr-2 h-4 w-4" /> New Template
+          </Button>
+        }
+      />
+      <DialogContent className="sm:max-w-[500px]">
+        <DialogHeader>
+          <DialogTitle>Create Custom Template</DialogTitle>
+          <DialogDescription>
+            Add a custom template from a GitHub repository.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          <Input
+            placeholder="Template name"
+            value={draft.name}
+            onChange={(e) => setDraft((d) => ({ ...d, name: e.target.value }))}
+          />
+          <Input
+            placeholder="Description (optional)"
+            value={draft.description}
+            onChange={(e) =>
+              setDraft((d) => ({ ...d, description: e.target.value }))
+            }
+          />
+          <Input
+            placeholder="GitHub URL (required)"
+            value={draft.githubUrl}
+            onChange={(e) =>
+              setDraft((d) => ({ ...d, githubUrl: e.target.value }))
+            }
+          />
+          <Input
+            placeholder="Image URL (optional)"
+            value={draft.imageUrl}
+            onChange={(e) =>
+              setDraft((d) => ({ ...d, imageUrl: e.target.value }))
+            }
+          />
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            onClick={onSave}
+            disabled={!draft.name.trim() || !draft.githubUrl.trim()}
+          >
+            <Save className="mr-2 h-4 w-4" /> Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/EditCustomTemplateDialog.tsx
+++ b/src/components/EditCustomTemplateDialog.tsx
@@ -1,0 +1,136 @@
+import React, { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Save, Edit2 } from "lucide-react";
+import type { CustomTemplate } from "@/ipc/types";
+
+interface EditCustomTemplateDialogProps {
+  template: CustomTemplate;
+  onUpdateTemplate: (params: {
+    id: number;
+    name?: string;
+    description?: string;
+    githubUrl?: string;
+    imageUrl?: string;
+  }) => Promise<any>;
+}
+
+export function EditCustomTemplateDialog({
+  template,
+  onUpdateTemplate,
+}: EditCustomTemplateDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState({
+    name: template.name,
+    description: template.description || "",
+    githubUrl: template.githubUrl,
+    imageUrl: template.imageUrl || "",
+  });
+
+  useEffect(() => {
+    if (open) {
+      setDraft({
+        name: template.name,
+        description: template.description || "",
+        githubUrl: template.githubUrl,
+        imageUrl: template.imageUrl || "",
+      });
+    }
+  }, [open, template]);
+
+  const onSave = async () => {
+    if (!draft.name.trim() || !draft.githubUrl.trim()) return;
+
+    await onUpdateTemplate({
+      id: template.id,
+      name: draft.name.trim(),
+      description: draft.description.trim() || undefined,
+      githubUrl: draft.githubUrl.trim(),
+      imageUrl: draft.imageUrl.trim() || undefined,
+    });
+
+    setOpen(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <DialogTrigger
+              render={
+                <Button size="icon" variant="ghost">
+                  <Edit2 className="h-4 w-4" />
+                </Button>
+              }
+            />
+          }
+        />
+        <TooltipContent>
+          <p>Edit template</p>
+        </TooltipContent>
+      </Tooltip>
+      <DialogContent className="sm:max-w-[500px]">
+        <DialogHeader>
+          <DialogTitle>Edit Custom Template</DialogTitle>
+          <DialogDescription>
+            Update your custom template settings.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          <Input
+            placeholder="Template name"
+            value={draft.name}
+            onChange={(e) => setDraft((d) => ({ ...d, name: e.target.value }))}
+          />
+          <Input
+            placeholder="Description (optional)"
+            value={draft.description}
+            onChange={(e) =>
+              setDraft((d) => ({ ...d, description: e.target.value }))
+            }
+          />
+          <Input
+            placeholder="GitHub URL (required)"
+            value={draft.githubUrl}
+            onChange={(e) =>
+              setDraft((d) => ({ ...d, githubUrl: e.target.value }))
+            }
+          />
+          <Input
+            placeholder="Image URL (optional)"
+            value={draft.imageUrl}
+            onChange={(e) =>
+              setDraft((d) => ({ ...d, imageUrl: e.target.value }))
+            }
+          />
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setOpen(false)}>
+            Cancel
+          </Button>
+          <Button
+            onClick={onSave}
+            disabled={!draft.name.trim() || !draft.githubUrl.trim()}
+          >
+            <Save className="mr-2 h-4 w-4" /> Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/LibraryList.tsx
+++ b/src/components/LibraryList.tsx
@@ -1,7 +1,7 @@
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
 import { Link, useRouterState } from "@tanstack/react-router";
-import { Palette, FileText } from "lucide-react";
+import { LayoutTemplate, Palette, FileText } from "lucide-react";
 
 type LibrarySection = {
   id: string;
@@ -11,6 +11,12 @@ type LibrarySection = {
 };
 
 const LIBRARY_SECTIONS: LibrarySection[] = [
+  {
+    id: "templates",
+    label: "Templates",
+    to: "/library/templates",
+    icon: LayoutTemplate,
+  },
   { id: "themes", label: "Themes", to: "/themes", icon: Palette },
   { id: "prompts", label: "Prompts", to: "/library", icon: FileText },
 ];

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -49,7 +49,7 @@ const items = [
   },
   {
     title: "Library",
-    to: "/themes",
+    to: "/library/templates",
     icon: BookOpen,
   },
   {
@@ -196,7 +196,12 @@ function AppIcons({
           {items.map((item) => {
             const isActive =
               (item.to === "/" && pathname === "/") ||
-              (item.to !== "/" && pathname.startsWith(item.to));
+              (item.to !== "/" &&
+                (pathname.startsWith(item.to) ||
+                  // Library icon should also be active on /themes and /library paths
+                  (item.title === "Library" &&
+                    (pathname.startsWith("/library") ||
+                      pathname.startsWith("/themes")))));
 
             return (
               <SidebarMenuItem key={item.title}>

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -262,6 +262,21 @@ export const mcpToolConsents = sqliteTable(
   (table) => [unique("uniq_mcp_consent").on(table.serverId, table.toolName)],
 );
 
+// --- Custom Templates table ---
+export const customTemplates = sqliteTable("custom_templates", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  name: text("name").notNull(),
+  description: text("description"),
+  githubUrl: text("github_url").notNull(),
+  imageUrl: text("image_url"),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .default(sql`(unixepoch())`),
+  updatedAt: integer("updated_at", { mode: "timestamp" })
+    .notNull()
+    .default(sql`(unixepoch())`),
+});
+
 // --- Custom Themes table ---
 export const customThemes = sqliteTable("custom_themes", {
   id: integer("id").primaryKey({ autoIncrement: true }),

--- a/src/hooks/useCustomTemplates.ts
+++ b/src/hooks/useCustomTemplates.ts
@@ -1,0 +1,79 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { ipc } from "@/ipc/types";
+import type {
+  CustomTemplate,
+  CreateCustomTemplateParams,
+  UpdateCustomTemplateParams,
+} from "@/ipc/types";
+import { queryKeys } from "@/lib/queryKeys";
+
+/**
+ * Hook to fetch all custom templates.
+ */
+export function useCustomTemplates() {
+  const query = useQuery({
+    queryKey: queryKeys.customTemplates.all,
+    queryFn: async (): Promise<CustomTemplate[]> => {
+      return ipc.template.getCustomTemplates();
+    },
+    meta: {
+      showErrorToast: true,
+    },
+  });
+
+  return {
+    customTemplates: query.data ?? [],
+    isLoading: query.isLoading,
+    error: query.error,
+    refetch: query.refetch,
+  };
+}
+
+export function useCreateCustomTemplate() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (
+      params: CreateCustomTemplateParams,
+    ): Promise<CustomTemplate> => {
+      return ipc.template.createCustomTemplate(params);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.customTemplates.all,
+      });
+    },
+  });
+}
+
+export function useUpdateCustomTemplate() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (
+      params: UpdateCustomTemplateParams,
+    ): Promise<CustomTemplate> => {
+      return ipc.template.updateCustomTemplate(params);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.customTemplates.all,
+      });
+    },
+  });
+}
+
+export function useDeleteCustomTemplate() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (id: number): Promise<void> => {
+      await ipc.template.deleteCustomTemplate({ id });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.customTemplates.all,
+      });
+    },
+  });
+}

--- a/src/ipc/handlers/base.ts
+++ b/src/ipc/handlers/base.ts
@@ -148,8 +148,13 @@ export function registerTypedHandlers<
   for (const [key, contract] of Object.entries(contracts)) {
     const handler = handlers[key as keyof typeof handlers];
     if (handler) {
-      // @ts-expect-error zod v4 type inference is not working correctly
-      createTypedHandler(contract, handler);
+      createTypedHandler(
+        contract as IpcContract<string, z.ZodType, z.ZodType>,
+        handler as (
+          event: IpcMainInvokeEvent,
+          input: unknown,
+        ) => Promise<unknown>,
+      );
     }
   }
 }

--- a/src/ipc/handlers/template_handlers.ts
+++ b/src/ipc/handlers/template_handlers.ts
@@ -3,6 +3,9 @@ import { getAllTemplates } from "../utils/template_utils";
 import { localTemplatesData } from "../../shared/templates";
 import { createTypedHandler } from "./base";
 import { templateContracts } from "../types/templates";
+import { db } from "@/db";
+import { customTemplates } from "@/db/schema";
+import { eq } from "drizzle-orm";
 
 const logger = log.scope("template_handlers");
 
@@ -16,4 +19,97 @@ export function registerTemplateHandlers() {
       return localTemplatesData;
     }
   });
+
+  // Custom template CRUD handlers
+  createTypedHandler(templateContracts.getCustomTemplates, async () => {
+    const rows = db.select().from(customTemplates).all();
+    return rows.map((r) => ({
+      id: r.id!,
+      name: r.name,
+      description: r.description,
+      githubUrl: r.githubUrl,
+      imageUrl: r.imageUrl,
+      createdAt: r.createdAt,
+      updatedAt: r.updatedAt,
+    }));
+  });
+
+  createTypedHandler(
+    templateContracts.createCustomTemplate,
+    async (_, params) => {
+      const { name, description, githubUrl, imageUrl } = params;
+      if (!name || !githubUrl) {
+        throw new Error("Name and GitHub URL are required");
+      }
+      const result = db
+        .insert(customTemplates)
+        .values({
+          name,
+          description,
+          githubUrl,
+          imageUrl,
+        })
+        .run();
+
+      const id = Number(result.lastInsertRowid);
+      const row = db
+        .select()
+        .from(customTemplates)
+        .where(eq(customTemplates.id, id))
+        .get();
+      if (!row) throw new Error("Failed to fetch created custom template");
+      return {
+        id: row.id!,
+        name: row.name,
+        description: row.description,
+        githubUrl: row.githubUrl,
+        imageUrl: row.imageUrl,
+        createdAt: row.createdAt,
+        updatedAt: row.updatedAt,
+      };
+    },
+  );
+
+  createTypedHandler(
+    templateContracts.updateCustomTemplate,
+    async (_, params) => {
+      const { id, name, description, githubUrl, imageUrl } = params;
+      if (!id) throw new Error("Custom template id is required");
+      const now = new Date();
+      const updateData: Record<string, any> = { updatedAt: now };
+      if (name !== undefined) updateData.name = name;
+      if (description !== undefined) updateData.description = description;
+      if (githubUrl !== undefined) updateData.githubUrl = githubUrl;
+      if (imageUrl !== undefined) updateData.imageUrl = imageUrl;
+      db.update(customTemplates)
+        .set(updateData)
+        .where(eq(customTemplates.id, id))
+        .run();
+
+      const row = db
+        .select()
+        .from(customTemplates)
+        .where(eq(customTemplates.id, id))
+        .get();
+      if (!row) throw new Error("Failed to fetch updated custom template");
+      return {
+        id: row.id!,
+        name: row.name,
+        description: row.description,
+        githubUrl: row.githubUrl,
+        imageUrl: row.imageUrl,
+        createdAt: row.createdAt,
+        updatedAt: row.updatedAt,
+      };
+    },
+  );
+
+  createTypedHandler(
+    templateContracts.deleteCustomTemplate,
+    async (_, params) => {
+      const { id } = params;
+      if (!id) throw new Error("Custom template id is required");
+      db.delete(customTemplates).where(eq(customTemplates.id, id)).run();
+    },
+  );
 }

--- a/src/ipc/types/index.ts
+++ b/src/ipc/types/index.ts
@@ -252,6 +252,10 @@ export type {
   SaveThemeImageParams,
   SaveThemeImageResult,
   CleanupThemeImagesParams,
+  CustomTemplate,
+  CreateCustomTemplateParams,
+  UpdateCustomTemplateParams,
+  DeleteCustomTemplateParams,
 } from "./templates";
 
 // Proposal types

--- a/src/ipc/types/templates.ts
+++ b/src/ipc/types/templates.ts
@@ -174,6 +174,53 @@ export type CleanupThemeImagesParams = z.infer<
 >;
 
 // =============================================================================
+// Custom Template Schemas
+// =============================================================================
+
+export const CustomTemplateSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  description: z.string().nullable(),
+  githubUrl: z.string(),
+  imageUrl: z.string().nullable(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+
+export type CustomTemplate = z.infer<typeof CustomTemplateSchema>;
+
+export const CreateCustomTemplateParamsSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+  githubUrl: z.string(),
+  imageUrl: z.string().optional(),
+});
+
+export type CreateCustomTemplateParams = z.infer<
+  typeof CreateCustomTemplateParamsSchema
+>;
+
+export const UpdateCustomTemplateParamsSchema = z.object({
+  id: z.number(),
+  name: z.string().optional(),
+  description: z.string().optional(),
+  githubUrl: z.string().optional(),
+  imageUrl: z.string().optional(),
+});
+
+export type UpdateCustomTemplateParams = z.infer<
+  typeof UpdateCustomTemplateParamsSchema
+>;
+
+export const DeleteCustomTemplateParamsSchema = z.object({
+  id: z.number(),
+});
+
+export type DeleteCustomTemplateParams = z.infer<
+  typeof DeleteCustomTemplateParamsSchema
+>;
+
+// =============================================================================
 // Template/Theme Contracts
 // =============================================================================
 
@@ -249,6 +296,31 @@ export const templateContracts = {
   cleanupThemeImages: defineContract({
     channel: "cleanup-theme-images",
     input: CleanupThemeImagesParamsSchema,
+    output: z.void(),
+  }),
+
+  // Custom template operations
+  getCustomTemplates: defineContract({
+    channel: "get-custom-templates",
+    input: z.void(),
+    output: z.array(CustomTemplateSchema),
+  }),
+
+  createCustomTemplate: defineContract({
+    channel: "create-custom-template",
+    input: CreateCustomTemplateParamsSchema,
+    output: CustomTemplateSchema,
+  }),
+
+  updateCustomTemplate: defineContract({
+    channel: "update-custom-template",
+    input: UpdateCustomTemplateParamsSchema,
+    output: CustomTemplateSchema,
+  }),
+
+  deleteCustomTemplate: defineContract({
+    channel: "delete-custom-template",
+    input: DeleteCustomTemplateParamsSchema,
     output: z.void(),
   }),
 } as const;

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -192,6 +192,13 @@ export const queryKeys = {
   },
 
   // ─────────────────────────────────────────────────────────────────────────────
+  // Custom Templates
+  // ─────────────────────────────────────────────────────────────────────────────
+  customTemplates: {
+    all: ["custom-templates"] as const,
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────────
   // Prompts
   // ─────────────────────────────────────────────────────────────────────────────
   prompts: {
@@ -344,6 +351,9 @@ export type AppQueryKey =
       (typeof queryKeys.customThemes)[keyof typeof queryKeys.customThemes]
     >
   | QueryKeyOf<(typeof queryKeys.templates)[keyof typeof queryKeys.templates]>
+  | QueryKeyOf<
+      (typeof queryKeys.customTemplates)[keyof typeof queryKeys.customTemplates]
+    >
   | QueryKeyOf<(typeof queryKeys.prompts)[keyof typeof queryKeys.prompts]>
   | QueryKeyOf<(typeof queryKeys.agentTools)[keyof typeof queryKeys.agentTools]>
   | QueryKeyOf<

--- a/src/pages/library-templates.tsx
+++ b/src/pages/library-templates.tsx
@@ -1,0 +1,289 @@
+import React, { useState } from "react";
+import { LayoutTemplate, ExternalLink } from "lucide-react";
+import { useSettings } from "@/hooks/useSettings";
+import { useTemplates } from "@/hooks/useTemplates";
+import {
+  useCustomTemplates,
+  useCreateCustomTemplate,
+  useUpdateCustomTemplate,
+  useDeleteCustomTemplate,
+} from "@/hooks/useCustomTemplates";
+import { TemplateCard } from "@/components/TemplateCard";
+import { CreateAppDialog } from "@/components/CreateAppDialog";
+import { NeonConnector } from "@/components/NeonConnector";
+import { CreateCustomTemplateDialog } from "@/components/CreateCustomTemplateDialog";
+import { EditCustomTemplateDialog } from "@/components/EditCustomTemplateDialog";
+import { DeleteConfirmationDialog } from "@/components/DeleteConfirmationDialog";
+import { Button } from "@/components/ui/button";
+import { showError } from "@/lib/toast";
+import { ipc } from "@/ipc/types";
+import { cn } from "@/lib/utils";
+import type { CustomTemplate } from "@/ipc/types";
+
+const CUSTOM_TEMPLATE_PREFIX = "custom-template:";
+
+export default function LibraryTemplatesPage() {
+  const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
+  const [isCreateTemplateDialogOpen, setIsCreateTemplateDialogOpen] =
+    useState(false);
+  const { templates } = useTemplates();
+  const { customTemplates, isLoading: isCustomLoading } = useCustomTemplates();
+  const createMutation = useCreateCustomTemplate();
+  const { settings, updateSettings } = useSettings();
+  const selectedTemplateId = settings?.selectedTemplateId;
+
+  // Only show official (built-in) templates
+  const builtInTemplates =
+    templates?.filter((template) => template.isOfficial) || [];
+
+  const handleTemplateSelect = (templateId: string) => {
+    updateSettings({ selectedTemplateId: templateId });
+  };
+
+  const handleCreateApp = () => {
+    setIsCreateDialogOpen(true);
+  };
+
+  const handleCreateCustomTemplate = async (params: {
+    name: string;
+    description?: string;
+    githubUrl: string;
+    imageUrl?: string;
+  }) => {
+    await createMutation.mutateAsync(params);
+  };
+
+  return (
+    <div className="min-h-screen px-8 py-6">
+      <div className="max-w-6xl mx-auto pb-12">
+        <div className="flex items-center justify-between mb-6">
+          <h1 className="text-3xl font-bold">
+            <LayoutTemplate className="inline-block h-8 w-8 mr-2" />
+            Templates
+          </h1>
+        </div>
+
+        {/* Built-in Templates Section */}
+        <section className="mb-12">
+          <h2 className="text-2xl font-bold mb-6">Built-in Templates</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            {builtInTemplates.map((template) => (
+              <TemplateCard
+                key={template.id}
+                template={template}
+                isSelected={template.id === selectedTemplateId}
+                onSelect={handleTemplateSelect}
+                onCreateApp={handleCreateApp}
+              />
+            ))}
+          </div>
+        </section>
+
+        {/* Integrations Section */}
+        <section className="mb-12">
+          <h2 className="text-2xl font-bold mb-6">Integrations</h2>
+          <div className="grid grid-cols-1 gap-6">
+            <NeonConnector />
+          </div>
+        </section>
+
+        {/* My Templates Section */}
+        <section className="mb-12">
+          <div className="flex items-center justify-between mb-6">
+            <h2 className="text-2xl font-bold">My Templates</h2>
+            <CreateCustomTemplateDialog
+              open={isCreateTemplateDialogOpen}
+              onOpenChange={setIsCreateTemplateDialogOpen}
+              onCreateTemplate={handleCreateCustomTemplate}
+            />
+          </div>
+          {isCustomLoading ? (
+            <div>Loading...</div>
+          ) : customTemplates.length === 0 ? (
+            <div className="text-muted-foreground">
+              No custom templates yet. Create one to get started.
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              {customTemplates.map((ct) => (
+                <CustomTemplateCard
+                  key={ct.id}
+                  customTemplate={ct}
+                  isSelected={
+                    selectedTemplateId === `${CUSTOM_TEMPLATE_PREFIX}${ct.id}`
+                  }
+                  onSelect={() =>
+                    handleTemplateSelect(`${CUSTOM_TEMPLATE_PREFIX}${ct.id}`)
+                  }
+                  onCreateApp={handleCreateApp}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+
+      <CreateAppDialog
+        open={isCreateDialogOpen}
+        onOpenChange={setIsCreateDialogOpen}
+        template={
+          // Try to find in built-in templates or construct from custom templates
+          templates?.find((t) => t.id === settings?.selectedTemplateId) ??
+          (() => {
+            if (
+              settings?.selectedTemplateId?.startsWith(CUSTOM_TEMPLATE_PREFIX)
+            ) {
+              const numericId = Number(
+                settings.selectedTemplateId.slice(
+                  CUSTOM_TEMPLATE_PREFIX.length,
+                ),
+              );
+              const ct = customTemplates.find((c) => c.id === numericId);
+              if (ct) {
+                return {
+                  id: `${CUSTOM_TEMPLATE_PREFIX}${ct.id}`,
+                  title: ct.name,
+                  description: ct.description || "",
+                  imageUrl: ct.imageUrl || "",
+                  githubUrl: ct.githubUrl,
+                  isOfficial: false,
+                };
+              }
+            }
+            return undefined;
+          })()
+        }
+      />
+    </div>
+  );
+}
+
+function CustomTemplateCard({
+  customTemplate,
+  isSelected,
+  onSelect,
+  onCreateApp,
+}: {
+  customTemplate: CustomTemplate;
+  isSelected: boolean;
+  onSelect: () => void;
+  onCreateApp: () => void;
+}) {
+  const updateMutation = useUpdateCustomTemplate();
+  const deleteMutation = useDeleteCustomTemplate();
+
+  const handleUpdate = async (params: {
+    id: number;
+    name?: string;
+    description?: string;
+    githubUrl?: string;
+    imageUrl?: string;
+  }) => {
+    await updateMutation.mutateAsync(params);
+  };
+
+  const handleDelete = async () => {
+    try {
+      await deleteMutation.mutateAsync(customTemplate.id);
+    } catch (error) {
+      showError(
+        `Failed to delete template: ${error instanceof Error ? error.message : "Unknown error"}`,
+      );
+    }
+  };
+
+  const handleGithubClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    ipc.system.openExternalUrl(customTemplate.githubUrl);
+  };
+
+  return (
+    <div
+      onClick={onSelect}
+      className={`
+        bg-white dark:bg-gray-800 rounded-xl shadow-sm overflow-hidden
+        transform transition-all duration-300 ease-in-out
+        cursor-pointer group relative
+        ${
+          isSelected
+            ? "ring-2 ring-blue-500 dark:ring-blue-400 shadow-xl"
+            : "hover:shadow-lg hover:-translate-y-1"
+        }
+      `}
+    >
+      {customTemplate.imageUrl && (
+        <div className="relative">
+          <img
+            src={customTemplate.imageUrl}
+            alt={customTemplate.name}
+            className={`w-full h-52 object-cover transition-opacity duration-300 group-hover:opacity-80 ${
+              isSelected ? "opacity-75" : ""
+            }`}
+          />
+          {isSelected && (
+            <span className="absolute top-3 right-3 bg-blue-600 text-white text-xs font-bold px-3 py-1.5 rounded-md shadow-lg">
+              Selected
+            </span>
+          )}
+        </div>
+      )}
+      {!customTemplate.imageUrl && isSelected && (
+        <div className="relative h-8">
+          <span className="absolute top-3 right-3 bg-blue-600 text-white text-xs font-bold px-3 py-1.5 rounded-md shadow-lg">
+            Selected
+          </span>
+        </div>
+      )}
+      <div className="p-4">
+        <div className="flex justify-between items-center mb-1.5">
+          <h2
+            className={`text-lg font-semibold ${
+              isSelected
+                ? "text-blue-600 dark:text-blue-400"
+                : "text-gray-900 dark:text-white"
+            }`}
+          >
+            {customTemplate.name}
+          </h2>
+          <div className="flex gap-1" onClick={(e) => e.stopPropagation()}>
+            <EditCustomTemplateDialog
+              template={customTemplate}
+              onUpdateTemplate={handleUpdate}
+            />
+            <DeleteConfirmationDialog
+              itemName={customTemplate.name}
+              itemType="Template"
+              onDelete={handleDelete}
+              isDeleting={deleteMutation.isPending}
+            />
+          </div>
+        </div>
+        {customTemplate.description && (
+          <p className="text-sm text-gray-500 dark:text-gray-400 mb-3 h-10 overflow-y-auto">
+            {customTemplate.description}
+          </p>
+        )}
+        <a
+          className="inline-flex items-center text-sm font-medium text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 transition-colors duration-200"
+          onClick={handleGithubClick}
+        >
+          View on GitHub <ExternalLink className="w-4 h-4 ml-1" />
+        </a>
+
+        <Button
+          onClick={(e) => {
+            e.stopPropagation();
+            onCreateApp();
+          }}
+          size="sm"
+          className={cn(
+            "w-full bg-indigo-600 hover:bg-indigo-700 text-white font-semibold mt-2",
+            !isSelected && "invisible",
+          )}
+        >
+          Create App
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/router.ts
+++ b/src/router.ts
@@ -7,11 +7,13 @@ import { providerSettingsRoute } from "./routes/settings/providers/$provider";
 import { appDetailsRoute } from "./routes/app-details";
 import { hubRoute } from "./routes/hub";
 import { libraryRoute } from "./routes/library";
+import { libraryTemplatesRoute } from "./routes/library-templates";
 import { themesRoute } from "./routes/themes";
 
 const routeTree = rootRoute.addChildren([
   homeRoute,
   hubRoute,
+  libraryTemplatesRoute,
   libraryRoute,
   themesRoute,
   chatRoute,

--- a/src/routes/library-templates.ts
+++ b/src/routes/library-templates.ts
@@ -1,0 +1,9 @@
+import { createRoute } from "@tanstack/react-router";
+import { rootRoute } from "./root";
+import LibraryTemplatesPage from "@/pages/library-templates";
+
+export const libraryTemplatesRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/library/templates",
+  component: LibraryTemplatesPage,
+});


### PR DESCRIPTION
## Summary
- Add database schema and drizzle migration for custom templates with fields for name, description, prompt, and Git URL
- Implement full CRUD IPC handlers for custom templates (create, read, update, delete, list)
- Add CreateCustomTemplateDialog, EditCustomTemplateDialog components and a dedicated library-templates page with route and sidebar navigation
- Add useCustomTemplates hook with TanStack Query integration and query keys

## Test plan
- Create a custom template and verify it appears in the library templates list
- Edit an existing custom template and verify changes persist
- Delete a custom template and verify it is removed from the list
- Verify sidebar navigation to the library templates page works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2453">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new persisted table plus new IPC CRUD surface area and changes template selection/routing, which could impact app creation flows if IDs or data shapes don’t match expectations.
> 
> **Overview**
> Adds **persisted custom templates** backed by a new `custom_templates` SQLite table (Drizzle migration + `schema.ts`) and wires them into template resolution via `custom-template:` IDs in `getTemplateOrThrow`.
> 
> Introduces end-to-end CRUD for custom templates: new IPC contracts/types, main-process handlers (`get/create/update/delete`), renderer React Query hooks (`useCustomTemplates` + mutations), and a new `/library/templates` page with create/edit/delete dialogs and “Create App” from a selected custom template.
> 
> Updates navigation and UI: Library sidebar/list now points to `/library/templates`, and the Hub page is simplified to a read-only **community templates** gallery with GitHub links.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41be1bacbed7a886ca7c31499b381c57723828c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Custom Templates with full CRUD and a Templates library page, so users can save GitHub-based templates and use them to create apps. Implements Linear issue 1770107173607 with DB persistence, IPC, hooks, routing, and navigation updates.

- **New Features**
  - Database: adds custom_templates table (name, description, github_url, image_url, timestamps) via Drizzle migration.
  - IPC: get/create/update/delete handlers; template utils support “custom-template:” IDs with DB lookup.
  - Hooks: useCustomTemplates with create/update/delete mutations and new query keys.
  - UI: new /library/templates page with Built-in and My Templates sections, create/edit/delete dialogs, and “Create App” for selected custom templates; Hub now shows only community templates with GitHub links.
  - Navigation: Library sidebar routes to /library/templates; router and LibraryList updated.

- **Migration**
  - Run Drizzle migrations to create the custom_templates table.
  - Library entry now routes to /library/templates; no other breaking changes.

<sup>Written for commit 60fcefefae20a348c33ddfdb56269ca228f8fda4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

