### PR TITLE
Add SessionStart hook for npm install

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -152,6 +152,17 @@
         ]
       }
     ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npm install",
+            "timeout": 60
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -158,7 +158,7 @@
           {
             "type": "command",
             "command": "npm install",
-            "timeout": 60
+            "timeout": 60000
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Adds a `SessionStart` hook to `.claude/settings.json` that runs `npm install` automatically when a Claude Code session starts
- Ensures dependencies are always up to date at the beginning of each session
- Uses a 60-second timeout

## Test plan
- [ ] Start a new Claude Code session and verify `npm install` runs automatically
- [ ] Verify the hook doesn't block session startup if it completes within 60s

#skip-bugbot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2458">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a SessionStart hook to .claude/settings.json to run npm install when a Claude Code session starts. This keeps dependencies current and uses a 60s timeout so startup isn’t blocked.

<sup>Written for commit 2aadae530a416479306117a2f758532634d0c817. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

