### PR TITLE
Only enable Windows code signing in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,6 +156,7 @@ jobs:
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          WINDOWS_SIGN: ${{ contains(matrix.os.name, 'windows') && 'true' || '' }}
 
   verify-assets:
     name: Verify Release Assets

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -56,11 +56,18 @@ const ignore = (file: string) => {
 };
 
 const isEndToEndTestBuild = process.env.E2E_TEST_BUILD === "true";
-const isGitHubActions = process.env.GITHUB_ACTIONS === "true";
+const isWindowsSigningEnabled = process.env.WINDOWS_SIGN === "true";
+
+if (isWindowsSigningEnabled && !process.env.AZURE_CODE_SIGNING_DLIB) {
+  throw new Error(
+    "WINDOWS_SIGN is enabled but AZURE_CODE_SIGNING_DLIB is not set. " +
+      "Ensure Azure Trusted Signing tools are installed.",
+  );
+}
 
 const config: ForgeConfig = {
   packagerConfig: {
-    windowsSign: isGitHubActions ? windowsSign : undefined,
+    windowsSign: isWindowsSigningEnabled ? windowsSign : undefined,
     protocols: [
       {
         name: "Dyad",
@@ -93,7 +100,7 @@ const config: ForgeConfig = {
   makers: [
     new MakerSquirrel(
       // @ts-expect-error - incorrect types exported by MakerSquirrel
-      isGitHubActions
+      isWindowsSigningEnabled
         ? {
             windowsSign,
             iconUrl:


### PR DESCRIPTION
## Summary
- Add explicit `WINDOWS_SIGN` env var to the release workflow (set only for Windows builds)
- `forge.config.ts` now checks `WINDOWS_SIGN=true` to enable Windows code signing, instead of the generic `isGitHubActions` check
- If `WINDOWS_SIGN` is enabled but `AZURE_CODE_SIGNING_DLIB` is missing, the build **fails loudly** with a clear error message
- CI builds no longer attempt Windows code signing since they don't set `WINDOWS_SIGN`

## Test plan
- CI workflow should pass without attempting Windows code signing (no `WINDOWS_SIGN` env var)
- Release workflow Windows builds will set `WINDOWS_SIGN=true` and sign correctly
- If Azure signing tools fail to install in the release workflow, the build will fail explicitly instead of silently skipping signing

#skip-bugbot

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow/config gating change; main impact is release Windows builds may fail if `AZURE_CODE_SIGNING_DLIB` isn’t set when signing is enabled.
> 
> **Overview**
> Windows code signing is now **explicitly opt-in** via `WINDOWS_SIGN=true` instead of implicitly enabling whenever running on GitHub Actions.
> 
> The release workflow sets `WINDOWS_SIGN` only for the Windows matrix job, and `forge.config.ts` uses this flag to enable `windowsSign` for both `packagerConfig` and the Squirrel maker, failing fast with a clear error if signing is enabled but `AZURE_CODE_SIGNING_DLIB` is missing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 132029c13f0da8afde3f864dc58a1ebdaeddf28e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->