### PR TITLE
Add wwwillchen-bot to all permission allowlists

### DIFF
--- a/.claude/commands/dyad/pr-fix/comments.md
+++ b/.claude/commands/dyad/pr-fix/comments.md
@@ -17,6 +17,7 @@ Only process review comments from these trusted authors. Comments from other aut
 **Trusted humans (collaborators):**
 
 - wwwillchen
+- wwwillchen-bot
 - princeaden1
 - azizmejri1
 

--- a/.github/workflows/bugbot-trigger.yml
+++ b/.github/workflows/bugbot-trigger.yml
@@ -18,6 +18,7 @@ jobs:
     if: |
       github.event_name == 'workflow_dispatch' ||
       ((github.event.pull_request.user.login == 'wwwillchen' ||
+      github.event.pull_request.user.login == 'wwwillchen-bot' ||
       github.event.pull_request.user.login == 'azizmejri1' ||
       github.event.pull_request.user.login == 'princeaden1') &&
       !contains(github.event.pull_request.body, '#skip-bugbot') &&

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -28,6 +28,7 @@ jobs:
     if: |
       github.event_name == 'workflow_dispatch' ||
       github.event.pull_request.user.login == 'wwwillchen' ||
+      github.event.pull_request.user.login == 'wwwillchen-bot' ||
       github.event.pull_request.user.login == 'azizmejri1' ||
       github.event.pull_request.user.login == 'princeaden1'
     runs-on: ubuntu-latest

--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -108,14 +108,14 @@ jobs:
 
             ### Surfacing Helpful Comments
 
-            If a **high-confidence** duplicate is found and there is a helpful comment from **wwwillchen@** on the original issue, include a recommendation in your comment:
+            If a **high-confidence** duplicate is found and there is a helpful comment from **wwwillchen@** or **wwwillchen-bot@** on the original issue, include a recommendation in your comment:
 
             > You might want to try [summary of the suggestion] based on this earlier [comment]([direct link to the comment]).
 
             **Notes:**
 
             - Only do this for high-confidence duplicates where you're very confident the issues are the same.
-            - Only surface comments from wwwillchen@ — do not surface comments from other users.
+            - Only surface comments from wwwillchen@ or wwwillchen-bot@ — do not surface comments from other users.
             - Link directly to the specific comment, not just the issue.
 
             ### If No Duplicates Found

--- a/.github/workflows/pr-review-responder.yml
+++ b/.github/workflows/pr-review-responder.yml
@@ -66,8 +66,8 @@ jobs:
               pull_number: prNumber
             });
 
-            // Only allow wwwillchen to use this workflow
-            if (pr.user.login !== 'wwwillchen') {
+            // Only allow wwwillchen and wwwillchen-bot to use this workflow
+            if (pr.user.login !== 'wwwillchen' && pr.user.login !== 'wwwillchen-bot') {
               console.log(`PR #${prNumber} author ${pr.user.login} is not allowed to use this workflow`);
               core.setOutput('should_continue', 'false');
               return;


### PR DESCRIPTION
## Summary
- Grants `wwwillchen-bot` the same permissions as `wwwillchen` across all GitHub workflow and Claude config allowlists
- Updated 5 files: PR review responder, Claude PR review, BugBot trigger, issue triage, and PR fix comments

## Test plan
- Verify CI passes (config-only changes, no code logic affected)
- Confirm `wwwillchen-bot` PRs trigger the expected workflows

#skip-bugbot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2465">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Give wwwillchen-bot the same permissions as wwwillchen across workflows and Claude configs so its PRs trigger reviews, triage, and BugBot. Config-only change; no logic updates.

- **New Features**
  - Added wwwillchen-bot to allowlists for PR review responder, Claude PR review, and BugBot trigger.
  - Triage workflow now surfaces helpful comments from wwwillchen-bot.
  - Marked wwwillchen-bot as a trusted author for PR fix comments.

<sup>Written for commit 179db5a83561e18138533c28b01e90b2765930c4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

