### PR TITLE
Add /remember-learnings skill to capture session insights

### DIFF
--- a/.claude/commands/dyad/pr-push.md
+++ b/.claude/commands/dyad/pr-push.md
@@ -65,9 +65,21 @@ Commit any uncommitted changes, run lint checks, fix any issues, and push the cu
    git commit --amend --no-edit
    ```
 
-   **IMPORTANT:** Do NOT stop here. You MUST continue to step 6 to push.
+   **IMPORTANT:** Do NOT stop here. You MUST continue to step 6.
 
-6. **Push the branch (REQUIRED):**
+6. **Remember learnings:**
+
+   Run the `/remember-learnings` skill to capture any errors, snags, or insights from this session into `AGENTS.md`.
+
+   If `AGENTS.md` was modified by the skill, amend the latest commit to include the changes:
+
+   ```
+   git diff --cached --quiet AGENTS.md || git commit --amend --no-edit
+   ```
+
+   This conditional guard ensures the commit is only amended if `AGENTS.md` actually changed, avoiding unnecessary history rewrites.
+
+7. **Push the branch (REQUIRED):**
 
    You MUST push the branch to GitHub. Do NOT skip this step or ask for confirmation.
 
@@ -83,7 +95,7 @@ Commit any uncommitted changes, run lint checks, fix any issues, and push the cu
 
    Note: `--force-with-lease` is used because the commit may have been amended. It's safer than `--force` as it will fail if someone else has pushed to the branch.
 
-7. **Create or update the PR (REQUIRED):**
+8. **Create or update the PR (REQUIRED):**
 
    **CRITICAL:** Do NOT tell the user to visit a URL to create a PR. You MUST create it automatically.
 
@@ -121,18 +133,6 @@ Commit any uncommitted changes, run lint checks, fix any issues, and push the cu
 
    ```
    gh pr edit --add-label "cc:request"
-   ```
-
-8. **Remember learnings:**
-
-   Run the `/remember-learnings` skill to capture any errors, snags, or insights from this session into `AGENTS.md`.
-
-   If `AGENTS.md` was modified by the skill, amend the latest commit to include it and force-push:
-
-   ```
-   git add AGENTS.md
-   git commit --amend --no-edit
-   git push --force-with-lease
    ```
 
 9. **Summarize the results:**

--- a/.claude/commands/dyad/pr-push.md
+++ b/.claude/commands/dyad/pr-push.md
@@ -123,11 +123,24 @@ Commit any uncommitted changes, run lint checks, fix any issues, and push the cu
    gh pr edit --add-label "cc:request"
    ```
 
-8. **Summarize the results:**
+8. **Remember learnings:**
+
+   Run the `/remember-learnings` skill to capture any errors, snags, or insights from this session into `AGENTS.md`.
+
+   If `AGENTS.md` was modified by the skill, amend the latest commit to include it and force-push:
+
+   ```
+   git add AGENTS.md
+   git commit --amend --no-edit
+   git push --force-with-lease
+   ```
+
+9. **Summarize the results:**
    - Report if a new feature branch was created (and its name)
    - Report any uncommitted changes that were committed in step 2
    - Report any files that were IGNORED and not committed (if any), explaining why they were skipped
    - Report any lint fixes that were applied
    - Confirm tests passed
    - Confirm the branch has been pushed
+   - Report any learnings added to `AGENTS.md`
    - **Include the PR URL** (either newly created or existing)

--- a/.claude/commands/remember-learnings.md
+++ b/.claude/commands/remember-learnings.md
@@ -6,10 +6,11 @@ Review the current session for errors, issues, snags, and hard-won knowledge, th
 
 ## File relationship
 
-- **`CLAUDE.md`** contains project-wide instructions, setup guides, and conventions for all contributors (human and agent). It is the authoritative source of truth and is manually curated.
-- **`AGENTS.md`** contains agent-specific operational knowledge — tips, gotchas, and hard-won insights that help agents avoid repeating mistakes. It supplements `CLAUDE.md` but should never duplicate it.
+> **NOTE:** `CLAUDE.md` is a symlink to `AGENTS.md`. They are the same file. **ALL EDITS MUST BE MADE TO `AGENTS.md`**, never to `CLAUDE.md` directly.
 
-Learnings should only go into `AGENTS.md`. If a learning is important enough to be a project-wide convention, flag it in the summary so a human can promote it to `CLAUDE.md`.
+- **`AGENTS.md`** contains agent-specific operational knowledge — tips, gotchas, and hard-won insights that help agents avoid repeating mistakes.
+
+Learnings should go into `AGENTS.md`. If a learning is important enough to be a project-wide convention, flag it in the summary so a human can promote it to the project documentation.
 
 ## Instructions
 
@@ -21,18 +22,18 @@ Learnings should only go into `AGENTS.md`. If a learning is important enough to 
    - **Workflow friction:** Steps that were done in the wrong order, missing prerequisites, commands that needed special flags
    - **Architecture insights:** Patterns that weren't obvious, file locations that were hard to find, implicit conventions not documented
 
-   Skip anything that is already well-documented in `CLAUDE.md` or `AGENTS.md`.
+   Skip anything that is already well-documented in `AGENTS.md`.
 
 2. **Read existing documentation:**
 
-   Read both `CLAUDE.md` and `AGENTS.md` at the repository root to understand what's already documented and avoid duplication.
+   Read `AGENTS.md` at the repository root to understand what's already documented and avoid duplication.
 
 3. **Draft concise, actionable additions:**
 
    For each learning, write a short bullet point or section that would help a future agent avoid the same issue. Follow these rules:
    - Be specific and actionable (e.g., "Run `npm run build` before E2E tests" not "remember to build first")
    - Include the actual error message or symptom when relevant so agents can recognize the situation
-   - Don't duplicate what's already in `AGENTS.md` or `CLAUDE.md`
+   - Don't duplicate what's already in `AGENTS.md`
    - Group related learnings under existing sections if appropriate, or create a new section
    - Keep it concise: each learning should be 1-3 lines max
    - **Limit to at most 5 learnings per session** — focus on the most impactful insights
@@ -45,7 +46,6 @@ Learnings should only go into `AGENTS.md`. If a learning is important enough to 
    If there are no new learnings worth recording (i.e., everything went smoothly or all issues are already documented), skip the edit and report that no updates were needed.
 
    **Maintenance:** When adding new learnings, review the existing `## Learnings` section and remove any entries that are:
-   - Now covered by `CLAUDE.md` (promoted to project-wide docs)
    - Obsolete due to codebase changes
    - Duplicated by or subsumed by a newer, more complete learning
 

--- a/.claude/commands/remember-learnings.md
+++ b/.claude/commands/remember-learnings.md
@@ -4,6 +4,13 @@ Review the current session for errors, issues, snags, and hard-won knowledge, th
 
 **IMPORTANT:** This skill MUST complete autonomously. Do NOT ask for user confirmation.
 
+## File relationship
+
+- **`CLAUDE.md`** contains project-wide instructions, setup guides, and conventions for all contributors (human and agent). It is the authoritative source of truth and is manually curated.
+- **`AGENTS.md`** contains agent-specific operational knowledge — tips, gotchas, and hard-won insights that help agents avoid repeating mistakes. It supplements `CLAUDE.md` but should never duplicate it.
+
+Learnings should only go into `AGENTS.md`. If a learning is important enough to be a project-wide convention, flag it in the summary so a human can promote it to `CLAUDE.md`.
+
 ## Instructions
 
 1. **Analyze the session for learnings:**
@@ -16,9 +23,9 @@ Review the current session for errors, issues, snags, and hard-won knowledge, th
 
    Skip anything that is already well-documented in `CLAUDE.md` or `AGENTS.md`.
 
-2. **Read the current AGENTS.md:**
+2. **Read existing documentation:**
 
-   Read `AGENTS.md` at the repository root to understand what's already documented.
+   Read both `CLAUDE.md` and `AGENTS.md` at the repository root to understand what's already documented and avoid duplication.
 
 3. **Draft concise, actionable additions:**
 
@@ -28,12 +35,19 @@ Review the current session for errors, issues, snags, and hard-won knowledge, th
    - Don't duplicate what's already in `AGENTS.md` or `CLAUDE.md`
    - Group related learnings under existing sections if appropriate, or create a new section
    - Keep it concise: each learning should be 1-3 lines max
+   - **Limit to at most 5 learnings per session** — focus on the most impactful insights
+   - If a new learning overlaps with or supersedes an existing one, consolidate them into a single entry rather than appending
 
 4. **Update AGENTS.md:**
 
    Edit `AGENTS.md` to incorporate the new learnings. Add a `## Learnings` section at the bottom if one doesn't exist, or append to the existing `## Learnings` section.
 
    If there are no new learnings worth recording (i.e., everything went smoothly or all issues are already documented), skip the edit and report that no updates were needed.
+
+   **Maintenance:** When adding new learnings, review the existing `## Learnings` section and remove any entries that are:
+   - Now covered by `CLAUDE.md` (promoted to project-wide docs)
+   - Obsolete due to codebase changes
+   - Duplicated by or subsumed by a newer, more complete learning
 
 5. **Stage the changes:**
 

--- a/.claude/commands/remember-learnings.md
+++ b/.claude/commands/remember-learnings.md
@@ -1,0 +1,48 @@
+# Remember Learnings
+
+Review the current session for errors, issues, snags, and hard-won knowledge, then update `AGENTS.md` with actionable learnings so future agent sessions run more smoothly.
+
+**IMPORTANT:** This skill MUST complete autonomously. Do NOT ask for user confirmation.
+
+## Instructions
+
+1. **Analyze the session for learnings:**
+
+   Review the entire conversation history and identify:
+   - **Errors encountered:** Build failures, lint errors, type errors, test failures, runtime errors
+   - **Snags and gotchas:** Things that took multiple attempts, unexpected behavior, tricky configurations
+   - **Workflow friction:** Steps that were done in the wrong order, missing prerequisites, commands that needed special flags
+   - **Architecture insights:** Patterns that weren't obvious, file locations that were hard to find, implicit conventions not documented
+
+   Skip anything that is already well-documented in `CLAUDE.md` or `AGENTS.md`.
+
+2. **Read the current AGENTS.md:**
+
+   Read `AGENTS.md` at the repository root to understand what's already documented.
+
+3. **Draft concise, actionable additions:**
+
+   For each learning, write a short bullet point or section that would help a future agent avoid the same issue. Follow these rules:
+   - Be specific and actionable (e.g., "Run `npm run build` before E2E tests" not "remember to build first")
+   - Include the actual error message or symptom when relevant so agents can recognize the situation
+   - Don't duplicate what's already in `AGENTS.md` or `CLAUDE.md`
+   - Group related learnings under existing sections if appropriate, or create a new section
+   - Keep it concise: each learning should be 1-3 lines max
+
+4. **Update AGENTS.md:**
+
+   Edit `AGENTS.md` to incorporate the new learnings. Add a `## Learnings` section at the bottom if one doesn't exist, or append to the existing `## Learnings` section.
+
+   If there are no new learnings worth recording (i.e., everything went smoothly or all issues are already documented), skip the edit and report that no updates were needed.
+
+5. **Stage the changes:**
+
+   If `AGENTS.md` was modified:
+
+   ```
+   git add AGENTS.md
+   ```
+
+6. **Summarize:**
+   - List the learnings that were added (or state that none were needed)
+   - Confirm whether `AGENTS.md` was staged for commit


### PR DESCRIPTION
## Summary
- Add `/remember-learnings` command that reviews session errors, snags, and insights, then updates `AGENTS.md` with actionable learnings for future agent sessions
- Integrate `/remember-learnings` as step 8 in `/dyad:pr-push` so learnings are automatically captured and included in every PR

## Test plan
- Run `/remember-learnings` manually in a session that encountered errors — verify it appends a `## Learnings` section to `AGENTS.md`
- Run `/dyad:pr-push` end-to-end — verify step 8 runs the skill and amends `AGENTS.md` into the commit

#skip-bugbot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2467">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a /remember-learnings skill to capture session errors and insights into AGENTS.md, with guardrails to keep entries concise and useful. Integrates it into /dyad:pr-push before push, amending the commit only when AGENTS.md changes.

- **New Features**
  - New /remember-learnings command: scans for errors/snags/workflow issues, writes 1–3 line bullets under ## Learnings in AGENTS.md; reads CLAUDE.md/AGENTS.md to avoid duplication; limits to 5 items, consolidates duplicates, and prunes obsolete entries.
  - /dyad:pr-push integration: added as step 6 (before push); conditionally amends the latest commit only if AGENTS.md changed; final summary reports any learnings added.

<sup>Written for commit 43b24b73843a17fa9948408d3ed5fc238a7e2784. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

