### PR TITLE
Update pr-push skill to detect correct remote for pushing

### DIFF
--- a/.claude/commands/dyad/pr-push.md
+++ b/.claude/commands/dyad/pr-push.md
@@ -71,11 +71,39 @@ Commit any uncommitted changes, run lint checks, fix any issues, and push the cu
 
    You MUST push the branch to GitHub. Do NOT skip this step or ask for confirmation.
 
+   First, determine the correct remote to push to:
+
+   a. Check if the branch already tracks a remote:
+
+   ```
+   git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null
+   ```
+
+   If this succeeds (e.g., returns `origin/my-branch` or `someuser/my-branch`), the branch already has an upstream. Just push:
+
    ```
    git push --force-with-lease
    ```
 
-   If the branch has no upstream, set one:
+   b. If there is NO upstream, check if a PR already exists and determine which remote it was opened from:
+
+   ```
+   gh pr view --json headRepositoryOwner,headRepository --jq '"git@github.com:" + .headRepositoryOwner.login + "/" + .headRepository.name + ".git"'
+   ```
+
+   Then find which local remote matches that URL:
+
+   ```
+   git remote -v
+   ```
+
+   Match the PR's repository URL to a local remote name. Push to that remote:
+
+   ```
+   git push --force-with-lease -u <matched-remote> HEAD
+   ```
+
+   c. If no PR exists and there is no upstream, fall back to `origin`:
 
    ```
    git push --force-with-lease -u origin HEAD


### PR DESCRIPTION
## Summary
- Updated the pr-push skill's push step to detect the correct remote instead of always defaulting to `origin`
- When no upstream is set, the skill now checks the PR's head repository owner to find the matching local remote
- This handles cases where pushing to another user's fork (e.g. when fixing someone else's PR)

## Test plan
- Test by running `/dyad:pr-push` on a branch that was checked out from another user's fork PR
- Verify it pushes to the correct remote (not always `origin`)

#skip-bugbot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2469">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update pr-push to auto-detect and push to the correct remote instead of always using origin. This fixes pushes for branches from forks and PRs opened from another user’s repo.

- **New Features**
  - Use the branch’s upstream if set; otherwise match the PR’s head repo to a local remote by owner/repo (works for SSH/HTTPS/token URLs).
  - If no upstream and no PR/match, push to origin; if origin is denied, try upstream (per workflow).
  - Push with --force-with-lease and set -u when establishing the upstream; surface gh pr view errors instead of silently falling back.

<sup>Written for commit e24e347cc7ddc3cb68343100d696d775c75cffe6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

