### PR TITLE
Replace button title attributes with shadcn Tooltip components

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,3 +167,20 @@ Add `#skip-bugbot` to the PR description for trivial PRs that won't affect end-u
 - Linting or test setup changes
 - Documentation-only changes
 - CI/build configuration updates
+
+## Learnings
+
+### TooltipTrigger render prop (Base UI)
+
+- `TooltipTrigger` from `@base-ui/react/tooltip` (wrapped in `src/components/ui/tooltip.tsx`) renders a `<button>` by default. Wrapping another button-like element (`<button>`, `<Button>`, `<DropdownMenuTrigger>`, `<PopoverTrigger>`, `<MiniSelectTrigger>`, `<ToggleGroupItem>`) inside it creates invalid nested `<button>` HTML. Use the `render` prop instead:
+
+  ```tsx
+  // Wrong: nested buttons
+  <TooltipTrigger><Button onClick={fn}>Click</Button></TooltipTrigger>
+
+  // Correct: render prop merges into a single element
+  <TooltipTrigger render={<Button onClick={fn} />}>Click</TooltipTrigger>
+  ```
+
+- Wrapping `ToggleGroupItem` in `TooltipTrigger` without `render` also breaks `:first-child`/`:last-child` CSS selectors for rounded corners on the group.
+- For drag handles and resize rails, prefer the native `title` attribute over `Tooltip` — tooltips appear immediately on hover and interfere with drag interactions, while `title` has a built-in delay.

--- a/e2e-tests/snapshots/local_agent_advanced.spec.ts_local-agent---mcp-tool-call-1.aria.yml
+++ b/e2e-tests/snapshots/local_agent_advanced.spec.ts_local-agent---mcp-tool-call-1.aria.yml
@@ -14,7 +14,7 @@
 - text: claude-opus-4-5
 - img
 - text: less than a minute ago
-- button "Request ID":
+- button "Copy Request ID":
   - img
 - paragraph: tc=local-agent/mcp-calculator
 - paragraph: I'll calculate the sum of 5 and 3 using the calculator.
@@ -36,7 +36,7 @@
 - text: claude-opus-4-5
 - img
 - text: less than a minute ago
-- button "Request ID":
+- button "Copy Request ID":
   - img
 - button "Undo":
   - img

--- a/e2e-tests/snapshots/local_agent_ask.spec.ts_local-agent-ask-mode-1.aria.yml
+++ b/e2e-tests/snapshots/local_agent_ask.spec.ts_local-agent-ask-mode-1.aria.yml
@@ -6,7 +6,7 @@
 - img
 - text: file1.txt
 - paragraph: More EOM
-- button:
+- button "Copy":
   - img
 - img
 - text: Approved
@@ -14,20 +14,20 @@
 - text: claude-opus-4-5
 - img
 - text: less than a minute ago
-- button "Request ID":
+- button "Copy Request ID":
   - img
 - paragraph: tc=local-agent/ask-read-file
 - paragraph: Let me read the file to explain its contents.
 - img
 - text: App.tsx Read src/App.tsx
 - paragraph: This is a simple React component that renders a div with the text 'Minimal imported app'. The component is exported as the default export.
-- button:
+- button "Copy":
   - img
 - img
 - text: claude-opus-4-5
 - img
 - text: less than a minute ago
-- button "Request ID":
+- button "Copy Request ID":
   - img
 - button "Undo":
   - img

--- a/e2e-tests/snapshots/local_agent_basic.spec.ts_local-agent---parallel-tool-calls-1.aria.yml
+++ b/e2e-tests/snapshots/local_agent_basic.spec.ts_local-agent---parallel-tool-calls-1.aria.yml
@@ -6,11 +6,15 @@
 - img
 - text: file1.txt
 - paragraph: More EOM
-- button:
+- button "Copy":
   - img
 - img
+- text: Approved
+- img
+- text: claude-opus-4-5
+- img
 - text: less than a minute ago
-- button "Request ID":
+- button "Copy Request ID":
   - img
 - paragraph: tc=local-agent/parallel-tools
 - paragraph: I'll create two files for you in parallel.
@@ -27,11 +31,15 @@
 - img
 - text: "src/utils/string.ts Summary: Create string utilities"
 - paragraph: Task completed.
-- button:
+- button "Copy":
   - img
 - img
+- text: claude-opus-4-5
+- img
 - text: less than a minute ago
-- button "Request ID":
+- button "Copy Request ID":
+  - img
+- button "Undo":
   - img
 - button "Retry":
   - img

--- a/e2e-tests/snapshots/local_agent_basic.spec.ts_local-agent---read-then-edit-1.aria.yml
+++ b/e2e-tests/snapshots/local_agent_basic.spec.ts_local-agent---read-then-edit-1.aria.yml
@@ -6,7 +6,7 @@
 - img
 - text: file1.txt
 - paragraph: More EOM
-- button:
+- button "Copy":
   - img
 - img
 - text: Approved
@@ -14,7 +14,7 @@
 - text: claude-opus-4-5
 - img
 - text: less than a minute ago
-- button "Request ID":
+- button "Copy Request ID":
   - img
 - paragraph: tc=local-agent/read-then-edit
 - paragraph: Let me first read the current file contents to understand what we're working with.
@@ -26,13 +26,13 @@
 - img
 - text: src/App.tsx
 - paragraph: Done! I've updated the title from 'Minimal imported app' to 'UPDATED imported app'. The change has been applied successfully.
-- button:
+- button "Copy":
   - img
 - img
 - text: claude-opus-4-5
 - img
 - text: less than a minute ago
-- button "Request ID":
+- button "Copy Request ID":
   - img
 - button "Undo":
   - img

--- a/e2e-tests/snapshots/local_agent_code_search.spec.ts_local-agent---code-search-1.aria.yml
+++ b/e2e-tests/snapshots/local_agent_code_search.spec.ts_local-agent---code-search-1.aria.yml
@@ -6,13 +6,15 @@
 - img
 - text: file1.txt
 - paragraph: More EOM
-- button:
+- button "Copy":
   - img
+- img
+- text: Approved
 - img
 - text: claude-opus-4-5
 - img
 - text: less than a minute ago
-- button "Request ID":
+- button "Copy Request ID":
   - img
 - paragraph: tc=local-agent/code-search
 - paragraph: I'll search for files related to React components in the codebase.
@@ -20,13 +22,13 @@
   - img
   - img
 - paragraph: I found the relevant files! The main React component is in src/App.tsx which handles the app rendering.
-- button:
+- button "Copy":
   - img
 - img
 - text: claude-opus-4-5
 - img
 - text: less than a minute ago
-- button "Request ID":
+- button "Copy Request ID":
   - img
 - button "Undo":
   - img

--- a/e2e-tests/snapshots/local_agent_consent.spec.ts_local-agent---add-dependency-consent-allow-once-1.aria.yml
+++ b/e2e-tests/snapshots/local_agent_consent.spec.ts_local-agent---add-dependency-consent-allow-once-1.aria.yml
@@ -6,22 +6,30 @@
 - img
 - text: file1.txt
 - paragraph: More EOM
-- button:
+- button "Copy":
   - img
 - img
+- text: Approved
+- img
+- text: claude-opus-4-5
+- img
 - text: less than a minute ago
-- button "Request ID":
+- button "Copy Request ID":
   - img
 - paragraph: tc=local-agent/add-dependency
 - paragraph: I'll add a dependency to your project.
 - img
 - text: Do you want to install these packages? @dyad-sh/supabase-management-js Make sure these packages are what you want.
 - paragraph: Dependency added done.
-- button:
+- button "Copy":
   - img
 - img
+- text: claude-opus-4-5
+- img
 - text: less than a minute ago
-- button "Request ID":
+- button "Copy Request ID":
+  - img
+- button "Undo":
   - img
 - button "Retry":
   - img

--- a/e2e-tests/snapshots/local_agent_consent.spec.ts_local-agent---add-dependency-consent-always-allow-1.aria.yml
+++ b/e2e-tests/snapshots/local_agent_consent.spec.ts_local-agent---add-dependency-consent-always-allow-1.aria.yml
@@ -6,22 +6,30 @@
 - img
 - text: file1.txt
 - paragraph: More EOM
-- button:
+- button "Copy":
   - img
 - img
+- text: Approved
+- img
+- text: claude-opus-4-5
+- img
 - text: less than a minute ago
-- button "Request ID":
+- button "Copy Request ID":
   - img
 - paragraph: tc=local-agent/add-dependency
 - paragraph: I'll add a dependency to your project.
 - img
 - text: Do you want to install these packages? @dyad-sh/supabase-management-js Make sure these packages are what you want.
 - paragraph: Dependency added done.
-- button:
+- button "Copy":
   - img
 - img
+- text: claude-opus-4-5
+- img
 - text: less than a minute ago
-- button "Request ID":
+- button "Copy Request ID":
+  - img
+- button "Undo":
   - img
 - button "Retry":
   - img

--- a/e2e-tests/snapshots/local_agent_consent.spec.ts_local-agent---add-dependency-consent-decline-1.aria.yml
+++ b/e2e-tests/snapshots/local_agent_consent.spec.ts_local-agent---add-dependency-consent-decline-1.aria.yml
@@ -6,11 +6,15 @@
 - img
 - text: file1.txt
 - paragraph: More EOM
-- button:
+- button "Copy":
   - img
 - img
+- text: Approved
+- img
+- text: claude-opus-4-5
+- img
 - text: less than a minute ago
-- button "Request ID":
+- button "Copy Request ID":
   - img
 - paragraph: tc=local-agent/add-dependency
 - paragraph: I'll add a dependency to your project.
@@ -24,11 +28,15 @@
 - button "Fix with AI":
   - img
 - paragraph: Dependency added done.
-- button:
+- button "Copy":
   - img
 - img
+- text: claude-opus-4-5
+- img
 - text: less than a minute ago
-- button "Request ID":
+- button "Copy Request ID":
+  - img
+- button "Undo":
   - img
 - button "Retry":
   - img

--- a/e2e-tests/snapshots/local_agent_file_upload.spec.ts_local-agent---upload-file-to-codebase-1.aria.yml
+++ b/e2e-tests/snapshots/local_agent_file_upload.spec.ts_local-agent---upload-file-to-codebase-1.aria.yml
@@ -6,13 +6,15 @@
 - img
 - text: file1.txt
 - paragraph: More EOM
-- button:
+- button "Copy":
   - img
+- img
+- text: Approved
 - img
 - text: claude-opus-4-5
 - img
 - text: less than a minute ago
-- button "Request ID":
+- button "Copy Request ID":
   - img
 - paragraph: tc=local-agent/upload-to-codebase
 - paragraph: "Attachments:"
@@ -25,13 +27,13 @@
 - img
 - text: "assets/uploaded-file.png Summary: Upload file to codebase"
 - paragraph: I've successfully uploaded your file to assets/uploaded-file.png in the codebase.
-- button:
+- button "Copy":
   - img
 - img
 - text: claude-opus-4-5
 - img
 - text: less than a minute ago
-- button "Request ID":
+- button "Copy Request ID":
   - img
 - button "Undo":
   - img

--- a/e2e-tests/snapshots/local_agent_grep.spec.ts_local-agent---grep-search-1.aria.yml
+++ b/e2e-tests/snapshots/local_agent_grep.spec.ts_local-agent---grep-search-1.aria.yml
@@ -6,31 +6,43 @@
 - img
 - text: file1.txt
 - paragraph: More EOM
-- button:
+- button "Copy":
   - img
+- img
+- text: Approved
 - img
 - text: claude-opus-4-5
 - img
 - text: less than a minute ago
-- button "Request ID":
+- button "Copy Request ID":
   - img
 - paragraph: tc=local-agent/grep-search
 - paragraph: I'll search for 'createRoot' in the codebase to find where the React app is initialized.
 - img
 - text: GREP"createRoot"(2 matches)
 - img
+- text: log
+- button "Copy":
+  - img
+- text: log
+- code: "src/main.tsx:1: import { createRoot } from \"react-dom/client\"; src/main.tsx:4: createRoot(document.getElementById(\"root\")!).render(<App />);"
 - paragraph: Now I'll search specifically in .tsx files for 'App' to find component references.
 - img
 - text: GREP"App" in *.tsx(4 matches)
 - img
+- text: log
+- button "Copy":
+  - img
+- text: log
+- code: "src/main.tsx:2: import App from \"./App.tsx\"; src/main.tsx:4: createRoot(document.getElementById(\"root\")!).render(<App />); src/App.tsx:1: const App = () => <div>Minimal imported app</div>; src/App.tsx:3: export default App;"
 - paragraph: I found the matches! The React app is initialized in src/main.tsx using createRoot, and the App component is defined in src/App.tsx and imported in src/main.tsx.
-- button:
+- button "Copy":
   - img
 - img
 - text: claude-opus-4-5
 - img
 - text: less than a minute ago
-- button "Request ID":
+- button "Copy Request ID":
   - img
 - button "Undo":
   - img

--- a/e2e-tests/snapshots/local_agent_read_logs.spec.ts_local-agent---read-logs-with-filters-1.aria.yml
+++ b/e2e-tests/snapshots/local_agent_read_logs.spec.ts_local-agent---read-logs-with-filters-1.aria.yml
@@ -6,18 +6,20 @@
 - img
 - text: file1.txt
 - paragraph: More EOM
-- button:
+- button "Copy":
   - img
+- img
+- text: Approved
 - img
 - text: claude-opus-4-5
 - img
 - text: less than a minute ago
-- button "Request ID":
+- button "Copy Request ID":
   - img
 - paragraph: tc=local-agent/read-logs
 - paragraph: Let me check the recent console logs to see what's happening in the application.
 - img
-- text: /LOGSReading \d+ logs/
+- text: LOGSReading 8 logs
 - img
 - paragraph: Now let me filter for only error logs to identify any issues.
 - img
@@ -28,13 +30,13 @@
 - text: "LOGSReading 0 logs (type: client)"
 - img
 - paragraph: I've reviewed the console logs. The application appears to be running normally with no critical errors detected.
-- button:
+- button "Copy":
   - img
 - img
 - text: claude-opus-4-5
 - img
 - text: less than a minute ago
-- button "Request ID":
+- button "Copy Request ID":
   - img
 - button "Undo":
   - img

--- a/e2e-tests/snapshots/local_agent_search_replace.spec.ts_local-agent---search-replace-edit-1.aria.yml
+++ b/e2e-tests/snapshots/local_agent_search_replace.spec.ts_local-agent---search-replace-edit-1.aria.yml
@@ -6,7 +6,7 @@
 - img
 - text: file1.txt
 - paragraph: More EOM
-- button:
+- button "Copy":
   - img
 - img
 - text: Approved
@@ -14,7 +14,7 @@
 - text: claude-opus-4-5
 - img
 - text: less than a minute ago
-- button "Request ID":
+- button "Copy Request ID":
   - img
 - paragraph: tc=local-agent/search-replace
 - paragraph: Let me first read the file to see its contents.
@@ -26,13 +26,13 @@
 - img
 - text: src/App.tsx
 - paragraph: Done! I've updated the message using search_replace. The edit was applied successfully.
-- button:
+- button "Copy":
   - img
 - img
 - text: claude-opus-4-5
 - img
 - text: less than a minute ago
-- button "Request ID":
+- button "Copy Request ID":
   - img
 - button "Undo":
   - img

--- a/e2e-tests/snapshots/local_agent_summarize.spec.ts_local-agent---summarize-to-new-chat-works-1.aria.yml
+++ b/e2e-tests/snapshots/local_agent_summarize.spec.ts_local-agent---summarize-to-new-chat-works-1.aria.yml
@@ -6,13 +6,13 @@
 - img
 - text: file1.txt
 - paragraph: More EOM
-- button:
+- button "Copy":
   - img
 - img
 - text: claude-opus-4-5
 - img
 - text: less than a minute ago
-- button "Request ID":
+- button "Copy Request ID":
   - img
 - button "Undo":
   - img

--- a/e2e-tests/snapshots/smart_context_balanced.spec.ts_smart-context-balanced---simple-1.aria.yml
+++ b/e2e-tests/snapshots/smart_context_balanced.spec.ts_smart-context-balanced---simple-1.aria.yml
@@ -1,12 +1,16 @@
 - paragraph: "[dump]"
 - paragraph: "[[dyad-dump-path=*]]"
-- button:
+- button "Copy":
   - img
 - img
 - text: Approved
 - img
+- text: auto
+- img
 - text: less than a minute ago
-- button "Request ID":
+- button "Copy Request ID":
+  - img
+- button "Undo":
   - img
 - button "Retry":
   - img

--- a/e2e-tests/snapshots/smart_context_deep.spec.ts_smart-context-deep---read-write-read-1.aria.yml
+++ b/e2e-tests/snapshots/smart_context_deep.spec.ts_smart-context-deep---read-write-read-1.aria.yml
@@ -3,13 +3,15 @@
 - img
 - text: Index.tsx Read src/pages/Index.tsx
 - paragraph: Done.
-- button:
+- button "Copy":
   - img
 - img
 - text: Approved
 - img
+- text: auto
+- img
 - text: less than a minute ago
-- button "Request ID":
+- button "Copy Request ID":
   - img
 - paragraph: tc=update-index-1
 - paragraph: First read
@@ -19,38 +21,46 @@
   - img
 - img
 - text: "src/pages/Index.tsx Summary: replace file"
-- button:
+- button "Copy":
   - img
 - img
 - text: Approved
 - img
+- text: auto
+- img
 - text: less than a minute ago
 - img
 - text: wrote 1 file(s)
-- button "Request ID":
+- button "Copy Request ID":
   - img
 - paragraph: tc=read-index
 - paragraph: "Read the index page:"
 - img
 - text: Index.tsx Read src/pages/Index.tsx
 - paragraph: Done.
-- button:
+- button "Copy":
   - img
 - img
 - text: Approved
 - img
+- text: auto
+- img
 - text: less than a minute ago
-- button "Request ID":
+- button "Copy Request ID":
   - img
 - paragraph: "[dump]"
 - paragraph: "[[dyad-dump-path=*]]"
-- button:
+- button "Copy":
   - img
 - img
 - text: Approved
 - img
+- text: auto
+- img
 - text: less than a minute ago
-- button "Request ID":
+- button "Copy Request ID":
+  - img
+- button "Undo":
   - img
 - button "Retry":
   - img

--- a/e2e-tests/snapshots/turbo_edits_v2.spec.ts_turbo-edits-v2---search-replace-approve-1.aria.yml
+++ b/e2e-tests/snapshots/turbo_edits_v2.spec.ts_turbo-edits-v2---search-replace-approve-1.aria.yml
@@ -5,11 +5,15 @@
 - img
 - text: src/pages/Index.tsx
 - paragraph: End of turbo edit
-- button:
+- button "Copy":
   - img
 - img
+- text: auto
+- img
 - text: less than a minute ago
-- button "Request ID":
+- button "Copy Request ID":
+  - img
+- button "Undo":
   - img
 - button "Retry":
   - img

--- a/e2e-tests/snapshots/turbo_edits_v2.spec.ts_turbo-edits-v2---search-replace-fallback-1.aria.yml
+++ b/e2e-tests/snapshots/turbo_edits_v2.spec.ts_turbo-edits-v2---search-replace-fallback-1.aria.yml
@@ -9,17 +9,31 @@
 - text: Warning Could not apply Turbo Edits properly for some of the files; re-generating code......
 - img
 - img
+- text: Index.tsx Read src/pages/Index.tsx
+- img
+- text: Search & Replace Index.tsx
+- img
+- text: src/pages/Index.tsx
+- paragraph: "[[dyad-dump-path=*]]"
+- img
+- text: Warning Could not apply Turbo Edits properly for some of the files; re-generating code......
+- img
+- img
 - text: Index.tsx
 - button "Edit":
   - img
 - img
 - text: "src/pages/Index.tsx Summary: Rewrite file."
 - paragraph: "[[dyad-dump-path=*]]"
-- button:
+- button "Copy":
   - img
 - img
+- text: auto
+- img
 - text: less than a minute ago
-- button "Request ID":
+- button "Copy Request ID":
+  - img
+- button "Undo":
   - img
 - button "Retry":
   - img

--- a/package-lock.json
+++ b/package-lock.json
@@ -437,6 +437,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1404,6 +1405,7 @@
       "integrity": "sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^4.1.1",
         "fs-extra": "^9.0.1",
@@ -2254,7 +2256,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2271,7 +2272,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2288,7 +2288,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2305,7 +2304,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2322,7 +2320,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2339,7 +2336,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2356,7 +2352,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2373,7 +2368,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2390,7 +2384,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2407,7 +2400,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2424,7 +2416,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2441,7 +2432,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2458,7 +2448,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2475,7 +2464,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2492,7 +2480,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2509,7 +2496,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2526,7 +2512,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2543,7 +2528,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2560,7 +2544,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2577,7 +2560,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2594,7 +2576,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2611,7 +2592,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2628,7 +2608,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2645,7 +2624,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2662,7 +2640,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2679,7 +2656,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2857,7 +2833,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -2880,7 +2855,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -2903,7 +2877,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -2920,7 +2893,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -2937,7 +2909,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -2954,7 +2925,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -2971,7 +2941,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -2988,7 +2957,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3005,7 +2973,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3022,7 +2989,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3039,7 +3005,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3056,7 +3021,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3079,7 +3043,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3102,7 +3065,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3125,7 +3087,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3148,7 +3109,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3171,7 +3131,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3194,7 +3153,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3214,7 +3172,6 @@
       ],
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/runtime": "^1.4.4"
       },
@@ -3237,7 +3194,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3257,7 +3213,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3277,7 +3232,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3563,6 +3517,7 @@
       "integrity": "sha512-yl43JD/86CIj3Mz5mvvLJqAOfIup7ncxfJ0Btnl0/v5TouVUyeEdcpknfgc+yMevS/48oH9WAkkw93m7otLb/A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^3.0.1",
         "@inquirer/confirm": "^4.0.1",
@@ -4204,7 +4159,6 @@
       "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.35.0.tgz",
       "integrity": "sha512-2H393EYDnFznYCDFOW3MHiRzwEO5M/UBhtUjvTT+9kc+qhX4U3zc8ixQalo5UmZ5B2nh7L/inXdTFzvSRXtsRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@lexical/list": "0.35.0",
         "@lexical/selection": "0.35.0",
@@ -4217,7 +4171,6 @@
       "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.35.0.tgz",
       "integrity": "sha512-ko7xSIIiayvDiqjNDX6fgH9RlcM6r9vrrvJYTcfGVBor5httx16lhIi0QJZ4+RNPvGtTjyFv4bwRmsixRRwImg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@lexical/html": "0.35.0",
         "@lexical/list": "0.35.0",
@@ -4231,7 +4184,6 @@
       "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.35.0.tgz",
       "integrity": "sha512-rXGFE5S5rKsg3tVnr1s4iEgOfCApNXGpIFI3T2jGEShaCZ5HLaBY9NVBXnE9Nb49e9bkDkpZ8FZd1qokCbQXbw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@lexical/selection": "0.35.0",
         "@lexical/utils": "0.35.0",
@@ -4243,7 +4195,6 @@
       "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.35.0.tgz",
       "integrity": "sha512-owsmc8iwgExBX8sFe8fKTiwJVhYULt9hD1RZ/HwfaiEtRZZkINijqReOBnW2mJfRxBzhFSWc4NG3ISB+fHYzqw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@lexical/selection": "0.35.0",
         "@lexical/utils": "0.35.0",
@@ -4255,7 +4206,6 @@
       "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.35.0.tgz",
       "integrity": "sha512-mMtDE7Q0nycXdFTTH/+ta6EBrBwxBB4Tg8QwsGntzQ1Cq//d838dpXpFjJOqHEeVHUqXpiuj+cBG8+bvz/rPRw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lexical": "0.35.0"
       }
@@ -4265,7 +4215,6 @@
       "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.35.0.tgz",
       "integrity": "sha512-9jlTlkVideBKwsEnEkqkdg7A3mije1SvmfiqoYnkl1kKJCLA5iH90ywx327PU0p+bdnURAytWUeZPXaEuEl2OA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@lexical/clipboard": "0.35.0",
         "@lexical/utils": "0.35.0",
@@ -4276,8 +4225,7 @@
       "version": "0.35.0",
       "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.35.0.tgz",
       "integrity": "sha512-3VuV8xXhh5xJA6tzvfDvE0YBCMkIZUmxtRilJQDDdCgJCc+eut6qAv2qbN+pbqvarqcQqPN1UF+8YvsjmyOZpw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@lexical/yjs": {
       "version": "0.33.1",
@@ -4414,6 +4362,7 @@
       "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-1.0.1.tgz",
       "integrity": "sha512-O6yC5TT0jbw86VZVkmnzCZJB0hfxBl0JJz6f+3KHoZabjb/X08r9eFA+vuY06z1/qaovykvdkrXYq3SPUuvogA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "^22.15.30",
         "@types/pg": "^8.8.0"
@@ -4426,8 +4375,7 @@
       "version": "15.5.2",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.2.tgz",
       "integrity": "sha512-Qe06ew4zt12LeO6N7j8/nULSOe3fMXE4dM6xgpBQNvdzyK1sv5y4oAP3bq4LamrvGCZtmRYnW8URFCeX5nFgGg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
       "version": "15.5.2",
@@ -4441,7 +4389,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -4458,7 +4405,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -4475,7 +4421,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -4492,7 +4437,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -4509,7 +4453,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -4526,7 +4469,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -4543,7 +4485,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -4560,7 +4501,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -4687,6 +4627,7 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -5248,6 +5189,7 @@
       "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.55.0"
       },
@@ -6104,7 +6046,6 @@
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
       "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -6639,8 +6580,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -6689,6 +6629,7 @@
       "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -6920,6 +6861,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.12.tgz",
       "integrity": "sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -6930,6 +6872,7 @@
       "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -7031,6 +6974,7 @@
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -7466,6 +7410,7 @@
       "integrity": "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.4",
         "fflate": "^0.8.2",
@@ -7757,6 +7702,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7977,7 +7923,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -8230,6 +8175,7 @@
       "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.26.0"
       }
@@ -8306,6 +8252,7 @@
       "integrity": "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -8428,6 +8375,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -8989,8 +8937,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -9111,7 +9058,6 @@
       "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1",
         "color-string": "^1.9.0"
@@ -9144,7 +9090,6 @@
       "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -9724,8 +9669,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
@@ -11349,6 +11293,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -12721,6 +12666,7 @@
       "integrity": "sha512-Newg9X7mRYskoBjSw70l1YnJ/ZGbq64VPyR821H5WVkTGpHG2O0mQILxCeUhxdYERLFY9B4tUyKLyf3uMTjtKw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@petamoriken/float16": "^3.8.7",
         "debug": "^4.3.4",
@@ -13213,6 +13159,7 @@
       "integrity": "sha512-UVIHeVhxmxedbWPCfgS55Jg2rDfwf2BCKeylcPSqazLz5w3Kri7Q4xdBJubsr/+VUzFLh0VjIvh13RaDA2/Xug==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "webidl-conversions": "^7.0.0",
         "whatwg-mimetype": "^3.0.0"
@@ -14295,7 +14242,6 @@
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -14599,7 +14545,8 @@
           "url": "https://github.com/sponsors/lavrton"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -14619,7 +14566,8 @@
       "version": "0.33.1",
       "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.33.1.tgz",
       "integrity": "sha512-+kiCS/GshQmCs/meMb8MQT4AMvw3S3Ef0lSCv2Xi6Itvs59OD+NjQWNfYkDteIbKtVE/w0Yiqh56VyGwIb8UcA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lexical-beautiful-mentions": {
       "version": "0.1.48",
@@ -14639,7 +14587,6 @@
       "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.114.tgz",
       "integrity": "sha512-gcxmNFzA4hv8UYi8j43uPlQ7CGcyMJ2KQb5kZASw6SnAKAf10hK12i2fjrS3Cl/ugZa5Ui6WwIu1/6MIXiHttQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -15410,7 +15357,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -16812,7 +16758,8 @@
       "version": "0.52.2",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
       "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/motion-dom": {
       "version": "12.23.12",
@@ -17956,7 +17903,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -18143,7 +18089,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -18159,7 +18104,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -18398,6 +18342,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18407,6 +18352,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -18435,8 +18381,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-konva": {
       "version": "19.2.1",
@@ -19168,6 +19113,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.50.1.tgz",
       "integrity": "sha512-78E9voJHwnXQMiQdiqswVLZwJIzdBKJ1GdI5Zx6XwoFKUIk09/sSrr+05QFzvYb8q6Y9pPV45zzDuYa3907TZA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -19356,6 +19302,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -19496,6 +19443,7 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.3.2.tgz",
       "integrity": "sha512-RbcPH1n5cfwKrru7v7+zrZvjLurgHhGyso3HTyGtRivGWgYjbOmGuivCQaORNELjNONoK35nj28EoWul9sb1zQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -19608,7 +19556,6 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "color": "^4.2.3",
         "detect-libc": "^2.0.4",
@@ -20001,7 +19948,6 @@
       "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "is-arrayish": "^0.3.1"
       }
@@ -20011,8 +19957,7 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/sirv": {
       "version": "3.0.2",
@@ -20651,7 +20596,6 @@
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
       "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "client-only": "0.0.1"
       },
@@ -20729,7 +20673,8 @@
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.13.tgz",
       "integrity": "sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -21386,6 +21331,7 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -21880,6 +21826,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
       "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -22411,6 +22358,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -23019,6 +22967,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/components/ChatModeSelector.tsx
+++ b/src/components/ChatModeSelector.tsx
@@ -5,6 +5,11 @@ import {
   SelectItem,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
 import { useSettings } from "@/hooks/useSettings";
 import { useFreeAgentQuota } from "@/hooks/useFreeAgentQuota";
 import type { ChatMode } from "@/lib/schemas";
@@ -91,19 +96,25 @@ export function ChatModeSelector() {
       value={selectedMode}
       onValueChange={(v) => v && handleModeChange(v)}
     >
-      <MiniSelectTrigger
-        data-testid="chat-mode-selector"
-        title={`Open mode menu (${isMac ? "⌘ + ." : "Ctrl + ."} to toggle)`}
-        className={cn(
-          "h-6 w-fit px-1.5 py-0 text-xs-sm font-medium shadow-none gap-0.5",
-          selectedMode === "build" || selectedMode === "local-agent"
-            ? "bg-background hover:bg-muted/50 focus:bg-muted/50"
-            : "bg-primary/10 hover:bg-primary/20 focus:bg-primary/20 text-primary border-primary/20 dark:bg-primary/20 dark:hover:bg-primary/30 dark:focus:bg-primary/30",
-        )}
-        size="sm"
-      >
-        <SelectValue>{getModeDisplayName(selectedMode)}</SelectValue>
-      </MiniSelectTrigger>
+      <Tooltip>
+        <TooltipTrigger>
+          <MiniSelectTrigger
+            data-testid="chat-mode-selector"
+            className={cn(
+              "h-6 w-fit px-1.5 py-0 text-xs-sm font-medium shadow-none gap-0.5",
+              selectedMode === "build" || selectedMode === "local-agent"
+                ? "bg-background hover:bg-muted/50 focus:bg-muted/50"
+                : "bg-primary/10 hover:bg-primary/20 focus:bg-primary/20 text-primary border-primary/20 dark:bg-primary/20 dark:hover:bg-primary/30 dark:focus:bg-primary/30",
+            )}
+            size="sm"
+          >
+            <SelectValue>{getModeDisplayName(selectedMode)}</SelectValue>
+          </MiniSelectTrigger>
+        </TooltipTrigger>
+        <TooltipContent>
+          {`Open mode menu (${isMac ? "\u2318 + ." : "Ctrl + ."} to toggle)`}
+        </TooltipContent>
+      </Tooltip>
       <SelectContent align="start">
         {isProEnabled && (
           <SelectItem value="local-agent">

--- a/src/components/ChatModeSelector.tsx
+++ b/src/components/ChatModeSelector.tsx
@@ -97,19 +97,21 @@ export function ChatModeSelector() {
       onValueChange={(v) => v && handleModeChange(v)}
     >
       <Tooltip>
-        <TooltipTrigger>
-          <MiniSelectTrigger
-            data-testid="chat-mode-selector"
-            className={cn(
-              "h-6 w-fit px-1.5 py-0 text-xs-sm font-medium shadow-none gap-0.5",
-              selectedMode === "build" || selectedMode === "local-agent"
-                ? "bg-background hover:bg-muted/50 focus:bg-muted/50"
-                : "bg-primary/10 hover:bg-primary/20 focus:bg-primary/20 text-primary border-primary/20 dark:bg-primary/20 dark:hover:bg-primary/30 dark:focus:bg-primary/30",
-            )}
-            size="sm"
-          >
-            <SelectValue>{getModeDisplayName(selectedMode)}</SelectValue>
-          </MiniSelectTrigger>
+        <TooltipTrigger
+          render={
+            <MiniSelectTrigger
+              data-testid="chat-mode-selector"
+              className={cn(
+                "h-6 w-fit px-1.5 py-0 text-xs-sm font-medium shadow-none gap-0.5",
+                selectedMode === "build" || selectedMode === "local-agent"
+                  ? "bg-background hover:bg-muted/50 focus:bg-muted/50"
+                  : "bg-primary/10 hover:bg-primary/20 focus:bg-primary/20 text-primary border-primary/20 dark:bg-primary/20 dark:hover:bg-primary/30 dark:focus:bg-primary/30",
+              )}
+              size="sm"
+            />
+          }
+        >
+          <SelectValue>{getModeDisplayName(selectedMode)}</SelectValue>
         </TooltipTrigger>
         <TooltipContent>
           {`Open mode menu (${isMac ? "\u2318 + ." : "Ctrl + ."} to toggle)`}

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -172,15 +172,17 @@ export function ChatPanel({
               {showScrollButton && (
                 <div className="absolute bottom-6 left-1/2 -translate-x-1/2 z-10">
                   <Tooltip>
-                    <TooltipTrigger>
-                      <Button
-                        onClick={handleScrollButtonClick}
-                        size="icon"
-                        className="rounded-full shadow-lg hover:shadow-xl transition-all border border-border/50 backdrop-blur-sm bg-background/95 hover:bg-accent"
-                        variant="outline"
-                      >
-                        <ArrowDown className="h-4 w-4" />
-                      </Button>
+                    <TooltipTrigger
+                      render={
+                        <Button
+                          onClick={handleScrollButtonClick}
+                          size="icon"
+                          className="rounded-full shadow-lg hover:shadow-xl transition-all border border-border/50 backdrop-blur-sm bg-background/95 hover:bg-accent"
+                          variant="outline"
+                        />
+                      }
+                    >
+                      <ArrowDown className="h-4 w-4" />
                     </TooltipTrigger>
                     <TooltipContent>Scroll to bottom</TooltipContent>
                   </Tooltip>

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -14,6 +14,11 @@ import { VersionPane } from "./chat/VersionPane";
 import { ChatError } from "./chat/ChatError";
 import { FreeAgentQuotaBanner } from "./chat/FreeAgentQuotaBanner";
 import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
 import { ArrowDown } from "lucide-react";
 import { useSettings } from "@/hooks/useSettings";
 import { useFreeAgentQuota } from "@/hooks/useFreeAgentQuota";
@@ -166,15 +171,19 @@ export function ChatPanel({
               {/* Scroll to bottom button */}
               {showScrollButton && (
                 <div className="absolute bottom-6 left-1/2 -translate-x-1/2 z-10">
-                  <Button
-                    onClick={handleScrollButtonClick}
-                    size="icon"
-                    className="rounded-full shadow-lg hover:shadow-xl transition-all border border-border/50 backdrop-blur-sm bg-background/95 hover:bg-accent"
-                    variant="outline"
-                    title={"Scroll to bottom"}
-                  >
-                    <ArrowDown className="h-4 w-4" />
-                  </Button>
+                  <Tooltip>
+                    <TooltipTrigger>
+                      <Button
+                        onClick={handleScrollButtonClick}
+                        size="icon"
+                        className="rounded-full shadow-lg hover:shadow-xl transition-all border border-border/50 backdrop-blur-sm bg-background/95 hover:bg-accent"
+                        variant="outline"
+                      >
+                        <ArrowDown className="h-4 w-4" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Scroll to bottom</TooltipContent>
+                  </Tooltip>
                 </div>
               )}
             </div>

--- a/src/components/CopyErrorMessage.tsx
+++ b/src/components/CopyErrorMessage.tsx
@@ -1,5 +1,10 @@
 import { Copy, Check } from "lucide-react";
 import { useState } from "react";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
 
 interface CopyErrorMessageProps {
   errorMessage: string;
@@ -24,26 +29,32 @@ export const CopyErrorMessage = ({
   };
 
   return (
-    <button
-      onClick={handleCopy}
-      className={`flex items-center gap-1 px-2 py-1 rounded text-xs transition-colors ${
-        isCopied
-          ? "bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300"
-          : "bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600"
-      } ${className}`}
-      title={isCopied ? "Copied!" : "Copy error message"}
-    >
-      {isCopied ? (
-        <>
-          <Check size={14} />
-          <span>Copied</span>
-        </>
-      ) : (
-        <>
-          <Copy size={14} />
-          <span>Copy</span>
-        </>
-      )}
-    </button>
+    <Tooltip>
+      <TooltipTrigger>
+        <button
+          onClick={handleCopy}
+          className={`flex items-center gap-1 px-2 py-1 rounded text-xs transition-colors ${
+            isCopied
+              ? "bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300"
+              : "bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600"
+          } ${className}`}
+        >
+          {isCopied ? (
+            <>
+              <Check size={14} />
+              <span>Copied</span>
+            </>
+          ) : (
+            <>
+              <Copy size={14} />
+              <span>Copy</span>
+            </>
+          )}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>
+        {isCopied ? "Copied!" : "Copy error message"}
+      </TooltipContent>
+    </Tooltip>
   );
 };

--- a/src/components/CopyErrorMessage.tsx
+++ b/src/components/CopyErrorMessage.tsx
@@ -30,27 +30,29 @@ export const CopyErrorMessage = ({
 
   return (
     <Tooltip>
-      <TooltipTrigger>
-        <button
-          onClick={handleCopy}
-          className={`flex items-center gap-1 px-2 py-1 rounded text-xs transition-colors ${
-            isCopied
-              ? "bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300"
-              : "bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600"
-          } ${className}`}
-        >
-          {isCopied ? (
-            <>
-              <Check size={14} />
-              <span>Copied</span>
-            </>
-          ) : (
-            <>
-              <Copy size={14} />
-              <span>Copy</span>
-            </>
-          )}
-        </button>
+      <TooltipTrigger
+        render={
+          <button
+            onClick={handleCopy}
+            className={`flex items-center gap-1 px-2 py-1 rounded text-xs transition-colors ${
+              isCopied
+                ? "bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300"
+                : "bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600"
+            } ${className}`}
+          />
+        }
+      >
+        {isCopied ? (
+          <>
+            <Check size={14} />
+            <span>Copied</span>
+          </>
+        ) : (
+          <>
+            <Copy size={14} />
+            <span>Copy</span>
+          </>
+        )}
       </TooltipTrigger>
       <TooltipContent>
         {isCopied ? "Copied!" : "Copy error message"}

--- a/src/components/CustomErrorToast.tsx
+++ b/src/components/CustomErrorToast.tsx
@@ -1,6 +1,11 @@
 import React from "react";
 import { toast } from "sonner";
 import { X, Copy, Check } from "lucide-react";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
 
 interface CustomErrorToastProps {
   message: string;
@@ -41,30 +46,38 @@ export function CustomErrorToast({
 
               {/* Action buttons */}
               <div className="flex items-center space-x-1.5 ml-auto">
-                <button
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    handleCopy();
-                  }}
-                  className="p-1.5 text-red-500 hover:text-red-700 hover:bg-red-100/70 rounded-lg transition-all duration-150"
-                  title="Copy to clipboard"
-                >
-                  {copied ? (
-                    <Check className="w-4 h-4 text-green-500" />
-                  ) : (
-                    <Copy className="w-4 h-4" />
-                  )}
-                </button>
-                <button
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    handleClose();
-                  }}
-                  className="p-1.5 text-red-500 hover:text-red-700 hover:bg-red-100/70 rounded-lg transition-all duration-150"
-                  title="Close"
-                >
-                  <X className="w-4 h-4" />
-                </button>
+                <Tooltip>
+                  <TooltipTrigger>
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleCopy();
+                      }}
+                      className="p-1.5 text-red-500 hover:text-red-700 hover:bg-red-100/70 rounded-lg transition-all duration-150"
+                    >
+                      {copied ? (
+                        <Check className="w-4 h-4 text-green-500" />
+                      ) : (
+                        <Copy className="w-4 h-4" />
+                      )}
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>Copy to clipboard</TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger>
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleClose();
+                      }}
+                      className="p-1.5 text-red-500 hover:text-red-700 hover:bg-red-100/70 rounded-lg transition-all duration-150"
+                    >
+                      <X className="w-4 h-4" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>Close</TooltipContent>
+                </Tooltip>
               </div>
             </div>
             <div>

--- a/src/components/GithubBranchManager.tsx
+++ b/src/components/GithubBranchManager.tsx
@@ -35,6 +35,11 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
+import {
   Dialog,
   DialogContent,
   DialogDescription,
@@ -414,14 +419,20 @@ export function GithubBranchManager({
         </Select>
 
         <DropdownMenu>
-          <DropdownMenuTrigger
-            className={cn(buttonVariants({ variant: "outline", size: "icon" }))}
-            title="Branch actions"
-            aria-label="Branch actions"
-            data-testid="branch-actions-menu-trigger"
-          >
-            <EllipsisVertical className="h-4 w-4" />
-          </DropdownMenuTrigger>
+          <Tooltip>
+            <TooltipTrigger>
+              <DropdownMenuTrigger
+                className={cn(
+                  buttonVariants({ variant: "outline", size: "icon" }),
+                )}
+                aria-label="Branch actions"
+                data-testid="branch-actions-menu-trigger"
+              >
+                <EllipsisVertical className="h-4 w-4" />
+              </DropdownMenuTrigger>
+            </TooltipTrigger>
+            <TooltipContent>Branch actions</TooltipContent>
+          </Tooltip>
           <DropdownMenuContent align="end">
             <DropdownMenuItem
               onClick={() => setShowCreateDialog(true)}

--- a/src/components/GithubBranchManager.tsx
+++ b/src/components/GithubBranchManager.tsx
@@ -420,16 +420,18 @@ export function GithubBranchManager({
 
         <DropdownMenu>
           <Tooltip>
-            <TooltipTrigger>
-              <DropdownMenuTrigger
-                className={cn(
-                  buttonVariants({ variant: "outline", size: "icon" }),
-                )}
-                aria-label="Branch actions"
-                data-testid="branch-actions-menu-trigger"
-              >
-                <EllipsisVertical className="h-4 w-4" />
-              </DropdownMenuTrigger>
+            <TooltipTrigger
+              render={
+                <DropdownMenuTrigger
+                  className={cn(
+                    buttonVariants({ variant: "outline", size: "icon" }),
+                  )}
+                  aria-label="Branch actions"
+                  data-testid="branch-actions-menu-trigger"
+                />
+              }
+            >
+              <EllipsisVertical className="h-4 w-4" />
             </TooltipTrigger>
             <TooltipContent>Branch actions</TooltipContent>
           </Tooltip>

--- a/src/components/ProModeSelector.tsx
+++ b/src/components/ProModeSelector.tsx
@@ -63,11 +63,13 @@ export function ProModeSelector() {
   return (
     <Popover>
       <Tooltip>
-        <TooltipTrigger>
-          <PopoverTrigger className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-primary/50 bg-background shadow-sm hover:bg-primary/10 h-8 px-1.5 gap-1.5 shadow-primary/10 hover:shadow-md hover:shadow-primary/15">
-            <Sparkles className="h-4 w-4 text-primary" />
-            <span className="text-primary font-medium text-xs-sm">Pro</span>
-          </PopoverTrigger>
+        <TooltipTrigger
+          render={
+            <PopoverTrigger className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-primary/50 bg-background shadow-sm hover:bg-primary/10 h-8 px-1.5 gap-1.5 shadow-primary/10 hover:shadow-md hover:shadow-primary/15" />
+          }
+        >
+          <Sparkles className="h-4 w-4 text-primary" />
+          <span className="text-primary font-medium text-xs-sm">Pro</span>
         </TooltipTrigger>
         <TooltipContent>Configure Dyad Pro settings</TooltipContent>
       </Tooltip>
@@ -213,46 +215,52 @@ function TurboEditsSelector({
         data-testid="turbo-edits-selector"
       >
         <Tooltip>
-          <TooltipTrigger>
-            <Button
-              variant={currentValue === "off" ? "default" : "ghost"}
-              size="sm"
-              onClick={() => onValueChange("off")}
-              disabled={!isTogglable}
-              className="rounded-r-none border-r border-input h-8 px-3 text-xs flex-shrink-0"
-            >
-              Off
-            </Button>
+          <TooltipTrigger
+            render={
+              <Button
+                variant={currentValue === "off" ? "default" : "ghost"}
+                size="sm"
+                onClick={() => onValueChange("off")}
+                disabled={!isTogglable}
+                className="rounded-r-none border-r border-input h-8 px-3 text-xs flex-shrink-0"
+              />
+            }
+          >
+            Off
           </TooltipTrigger>
           <TooltipContent>Disable Turbo Edits</TooltipContent>
         </Tooltip>
         <Tooltip>
-          <TooltipTrigger>
-            <Button
-              variant={currentValue === "v1" ? "default" : "ghost"}
-              size="sm"
-              onClick={() => onValueChange("v1")}
-              disabled={!isTogglable}
-              className="rounded-none border-r border-input h-8 px-3 text-xs flex-shrink-0"
-            >
-              Classic
-            </Button>
+          <TooltipTrigger
+            render={
+              <Button
+                variant={currentValue === "v1" ? "default" : "ghost"}
+                size="sm"
+                onClick={() => onValueChange("v1")}
+                disabled={!isTogglable}
+                className="rounded-none border-r border-input h-8 px-3 text-xs flex-shrink-0"
+              />
+            }
+          >
+            Classic
           </TooltipTrigger>
           <TooltipContent>
             Uses a smaller model to complete edits
           </TooltipContent>
         </Tooltip>
         <Tooltip>
-          <TooltipTrigger>
-            <Button
-              variant={currentValue === "v2" ? "default" : "ghost"}
-              size="sm"
-              onClick={() => onValueChange("v2")}
-              disabled={!isTogglable}
-              className="rounded-l-none h-8 px-3 text-xs flex-shrink-0"
-            >
-              Search & replace
-            </Button>
+          <TooltipTrigger
+            render={
+              <Button
+                variant={currentValue === "v2" ? "default" : "ghost"}
+                size="sm"
+                onClick={() => onValueChange("v2")}
+                disabled={!isTogglable}
+                className="rounded-l-none h-8 px-3 text-xs flex-shrink-0"
+              />
+            }
+          >
+            Search & replace
           </TooltipTrigger>
           <TooltipContent>
             Find and replaces specific text blocks
@@ -306,46 +314,52 @@ function SmartContextSelector({
         data-testid="smart-context-selector"
       >
         <Tooltip>
-          <TooltipTrigger>
-            <Button
-              variant={currentValue === "off" ? "default" : "ghost"}
-              size="sm"
-              onClick={() => onValueChange("off")}
-              disabled={!isTogglable}
-              className="rounded-r-none border-r border-input h-8 px-3 text-xs flex-shrink-0"
-            >
-              Off
-            </Button>
+          <TooltipTrigger
+            render={
+              <Button
+                variant={currentValue === "off" ? "default" : "ghost"}
+                size="sm"
+                onClick={() => onValueChange("off")}
+                disabled={!isTogglable}
+                className="rounded-r-none border-r border-input h-8 px-3 text-xs flex-shrink-0"
+              />
+            }
+          >
+            Off
           </TooltipTrigger>
           <TooltipContent>Disable Smart Context</TooltipContent>
         </Tooltip>
         <Tooltip>
-          <TooltipTrigger>
-            <Button
-              variant={currentValue === "balanced" ? "default" : "ghost"}
-              size="sm"
-              onClick={() => onValueChange("balanced")}
-              disabled={!isTogglable}
-              className="rounded-none border-r border-input h-8 px-3 text-xs flex-shrink-0"
-            >
-              Balanced
-            </Button>
+          <TooltipTrigger
+            render={
+              <Button
+                variant={currentValue === "balanced" ? "default" : "ghost"}
+                size="sm"
+                onClick={() => onValueChange("balanced")}
+                disabled={!isTogglable}
+                className="rounded-none border-r border-input h-8 px-3 text-xs flex-shrink-0"
+              />
+            }
+          >
+            Balanced
           </TooltipTrigger>
           <TooltipContent>
             Selects most relevant files with balanced context size
           </TooltipContent>
         </Tooltip>
         <Tooltip>
-          <TooltipTrigger>
-            <Button
-              variant={currentValue === "deep" ? "default" : "ghost"}
-              size="sm"
-              onClick={() => onValueChange("deep")}
-              disabled={!isTogglable}
-              className="rounded-l-none h-8 px-3 text-xs flex-shrink-0"
-            >
-              Deep
-            </Button>
+          <TooltipTrigger
+            render={
+              <Button
+                variant={currentValue === "deep" ? "default" : "ghost"}
+                size="sm"
+                onClick={() => onValueChange("deep")}
+                disabled={!isTogglable}
+                className="rounded-l-none h-8 px-3 text-xs flex-shrink-0"
+              />
+            }
+          >
+            Deep
           </TooltipTrigger>
           <TooltipContent>
             Experimental: Keeps full conversation history for maximum context

--- a/src/components/ProModeSelector.tsx
+++ b/src/components/ProModeSelector.tsx
@@ -7,6 +7,11 @@ import {
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { Sparkles, Info } from "lucide-react";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
 import { useSettings } from "@/hooks/useSettings";
 import { ipc } from "@/ipc/types";
 import { hasDyadProKey, type UserSettings } from "@/lib/schemas";
@@ -57,13 +62,15 @@ export function ProModeSelector() {
 
   return (
     <Popover>
-      <PopoverTrigger
-        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-primary/50 bg-background shadow-sm hover:bg-primary/10 h-8 px-1.5 gap-1.5 shadow-primary/10 hover:shadow-md hover:shadow-primary/15"
-        title="Configure Dyad Pro settings"
-      >
-        <Sparkles className="h-4 w-4 text-primary" />
-        <span className="text-primary font-medium text-xs-sm">Pro</span>
-      </PopoverTrigger>
+      <Tooltip>
+        <TooltipTrigger>
+          <PopoverTrigger className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-primary/50 bg-background shadow-sm hover:bg-primary/10 h-8 px-1.5 gap-1.5 shadow-primary/10 hover:shadow-md hover:shadow-primary/15">
+            <Sparkles className="h-4 w-4 text-primary" />
+            <span className="text-primary font-medium text-xs-sm">Pro</span>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent>Configure Dyad Pro settings</TooltipContent>
+      </Tooltip>
       <PopoverContent className="w-80 border-primary/20">
         <div className="space-y-4">
           <div className="space-y-1">
@@ -205,36 +212,52 @@ function TurboEditsSelector({
         className="inline-flex rounded-md border border-input"
         data-testid="turbo-edits-selector"
       >
-        <Button
-          variant={currentValue === "off" ? "default" : "ghost"}
-          size="sm"
-          onClick={() => onValueChange("off")}
-          disabled={!isTogglable}
-          className="rounded-r-none border-r border-input h-8 px-3 text-xs flex-shrink-0"
-          title="Disable Turbo Edits"
-        >
-          Off
-        </Button>
-        <Button
-          variant={currentValue === "v1" ? "default" : "ghost"}
-          size="sm"
-          onClick={() => onValueChange("v1")}
-          disabled={!isTogglable}
-          className="rounded-none border-r border-input h-8 px-3 text-xs flex-shrink-0"
-          title="Uses a smaller model to complete edits"
-        >
-          Classic
-        </Button>
-        <Button
-          variant={currentValue === "v2" ? "default" : "ghost"}
-          size="sm"
-          onClick={() => onValueChange("v2")}
-          disabled={!isTogglable}
-          className="rounded-l-none h-8 px-3 text-xs flex-shrink-0"
-          title="Find and replaces specific text blocks"
-        >
-          Search & replace
-        </Button>
+        <Tooltip>
+          <TooltipTrigger>
+            <Button
+              variant={currentValue === "off" ? "default" : "ghost"}
+              size="sm"
+              onClick={() => onValueChange("off")}
+              disabled={!isTogglable}
+              className="rounded-r-none border-r border-input h-8 px-3 text-xs flex-shrink-0"
+            >
+              Off
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Disable Turbo Edits</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger>
+            <Button
+              variant={currentValue === "v1" ? "default" : "ghost"}
+              size="sm"
+              onClick={() => onValueChange("v1")}
+              disabled={!isTogglable}
+              className="rounded-none border-r border-input h-8 px-3 text-xs flex-shrink-0"
+            >
+              Classic
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            Uses a smaller model to complete edits
+          </TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger>
+            <Button
+              variant={currentValue === "v2" ? "default" : "ghost"}
+              size="sm"
+              onClick={() => onValueChange("v2")}
+              disabled={!isTogglable}
+              className="rounded-l-none h-8 px-3 text-xs flex-shrink-0"
+            >
+              Search & replace
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            Find and replaces specific text blocks
+          </TooltipContent>
+        </Tooltip>
       </div>
     </div>
   );
@@ -282,36 +305,53 @@ function SmartContextSelector({
         className="inline-flex rounded-md border border-input"
         data-testid="smart-context-selector"
       >
-        <Button
-          variant={currentValue === "off" ? "default" : "ghost"}
-          size="sm"
-          onClick={() => onValueChange("off")}
-          disabled={!isTogglable}
-          className="rounded-r-none border-r border-input h-8 px-3 text-xs flex-shrink-0"
-          title="Disable Smart Context"
-        >
-          Off
-        </Button>
-        <Button
-          variant={currentValue === "balanced" ? "default" : "ghost"}
-          size="sm"
-          onClick={() => onValueChange("balanced")}
-          disabled={!isTogglable}
-          className="rounded-none border-r border-input h-8 px-3 text-xs flex-shrink-0"
-          title="Selects most relevant files with balanced context size"
-        >
-          Balanced
-        </Button>
-        <Button
-          variant={currentValue === "deep" ? "default" : "ghost"}
-          size="sm"
-          onClick={() => onValueChange("deep")}
-          disabled={!isTogglable}
-          className="rounded-l-none h-8 px-3 text-xs flex-shrink-0"
-          title="Experimental: Keeps full conversation history for maximum context and cache-optimized to control costs"
-        >
-          Deep
-        </Button>
+        <Tooltip>
+          <TooltipTrigger>
+            <Button
+              variant={currentValue === "off" ? "default" : "ghost"}
+              size="sm"
+              onClick={() => onValueChange("off")}
+              disabled={!isTogglable}
+              className="rounded-r-none border-r border-input h-8 px-3 text-xs flex-shrink-0"
+            >
+              Off
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Disable Smart Context</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger>
+            <Button
+              variant={currentValue === "balanced" ? "default" : "ghost"}
+              size="sm"
+              onClick={() => onValueChange("balanced")}
+              disabled={!isTogglable}
+              className="rounded-none border-r border-input h-8 px-3 text-xs flex-shrink-0"
+            >
+              Balanced
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            Selects most relevant files with balanced context size
+          </TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger>
+            <Button
+              variant={currentValue === "deep" ? "default" : "ghost"}
+              size="sm"
+              onClick={() => onValueChange("deep")}
+              disabled={!isTogglable}
+              className="rounded-l-none h-8 px-3 text-xs flex-shrink-0"
+            >
+              Deep
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            Experimental: Keeps full conversation history for maximum context
+            and cache-optimized to control costs
+          </TooltipContent>
+        </Tooltip>
       </div>
     </div>
   );

--- a/src/components/ProviderSettings.tsx
+++ b/src/components/ProviderSettings.tsx
@@ -18,6 +18,11 @@ import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
+import {
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,
@@ -123,26 +128,34 @@ export function ProviderSettingsGrid() {
                       className="flex items-center justify-end"
                       onClick={(e) => e.stopPropagation()}
                     >
-                      <Button
-                        data-testid="edit-custom-provider"
-                        variant="ghost"
-                        size="sm"
-                        className="h-8 w-8 p-0 hover:bg-muted rounded-md"
-                        title="Edit Provider"
-                        onClick={() => handleEditProvider(provider)}
-                      >
-                        <Edit className="h-4 w-4" />
-                      </Button>
-                      <Button
-                        data-testid="delete-custom-provider"
-                        variant="ghost"
-                        size="sm"
-                        className="h-8 w-8 p-0 text-destructive hover:text-destructive hover:bg-destructive/10 rounded-md"
-                        title="Delete Provider"
-                        onClick={() => setProviderToDelete(provider.id)}
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
+                      <Tooltip>
+                        <TooltipTrigger>
+                          <Button
+                            data-testid="edit-custom-provider"
+                            variant="ghost"
+                            size="sm"
+                            className="h-8 w-8 p-0 hover:bg-muted rounded-md"
+                            onClick={() => handleEditProvider(provider)}
+                          >
+                            <Edit className="h-4 w-4" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>Edit Provider</TooltipContent>
+                      </Tooltip>
+                      <Tooltip>
+                        <TooltipTrigger>
+                          <Button
+                            data-testid="delete-custom-provider"
+                            variant="ghost"
+                            size="sm"
+                            className="h-8 w-8 p-0 text-destructive hover:text-destructive hover:bg-destructive/10 rounded-md"
+                            onClick={() => setProviderToDelete(provider.id)}
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>Delete Provider</TooltipContent>
+                      </Tooltip>
                     </div>
                   )}
                   <CardTitle className="text-lg font-medium mb-2">

--- a/src/components/ProviderSettings.tsx
+++ b/src/components/ProviderSettings.tsx
@@ -129,30 +129,34 @@ export function ProviderSettingsGrid() {
                       onClick={(e) => e.stopPropagation()}
                     >
                       <Tooltip>
-                        <TooltipTrigger>
-                          <Button
-                            data-testid="edit-custom-provider"
-                            variant="ghost"
-                            size="sm"
-                            className="h-8 w-8 p-0 hover:bg-muted rounded-md"
-                            onClick={() => handleEditProvider(provider)}
-                          >
-                            <Edit className="h-4 w-4" />
-                          </Button>
+                        <TooltipTrigger
+                          render={
+                            <Button
+                              data-testid="edit-custom-provider"
+                              variant="ghost"
+                              size="sm"
+                              className="h-8 w-8 p-0 hover:bg-muted rounded-md"
+                              onClick={() => handleEditProvider(provider)}
+                            />
+                          }
+                        >
+                          <Edit className="h-4 w-4" />
                         </TooltipTrigger>
                         <TooltipContent>Edit Provider</TooltipContent>
                       </Tooltip>
                       <Tooltip>
-                        <TooltipTrigger>
-                          <Button
-                            data-testid="delete-custom-provider"
-                            variant="ghost"
-                            size="sm"
-                            className="h-8 w-8 p-0 text-destructive hover:text-destructive hover:bg-destructive/10 rounded-md"
-                            onClick={() => setProviderToDelete(provider.id)}
-                          >
-                            <Trash2 className="h-4 w-4" />
-                          </Button>
+                        <TooltipTrigger
+                          render={
+                            <Button
+                              data-testid="delete-custom-provider"
+                              variant="ghost"
+                              size="sm"
+                              className="h-8 w-8 p-0 text-destructive hover:text-destructive hover:bg-destructive/10 rounded-md"
+                              onClick={() => setProviderToDelete(provider.id)}
+                            />
+                          }
+                        >
+                          <Trash2 className="h-4 w-4" />
                         </TooltipTrigger>
                         <TooltipContent>Delete Provider</TooltipContent>
                       </Tooltip>

--- a/src/components/SupabaseConnector.tsx
+++ b/src/components/SupabaseConnector.tsx
@@ -38,6 +38,11 @@ import connectSupabaseDark from "../../assets/supabase/connect-supabase-dark.svg
 import connectSupabaseLight from "../../assets/supabase/connect-supabase-light.svg";
 
 import { ExternalLink, Plus, RefreshCw, Trash2 } from "lucide-react";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
 import { useTheme } from "@/contexts/ThemeContext";
 import { isSupabaseConnected } from "@/lib/schemas";
 
@@ -268,17 +273,21 @@ export function SupabaseConnector({ appId }: { appId: number }) {
           <CardTitle className="flex items-center justify-between">
             Supabase Projects
             <div className="flex items-center gap-2">
-              <Button
-                variant="outline"
-                size="icon"
-                onClick={() => refetchProjects()}
-                disabled={isFetchingProjects}
-                title="Refresh projects"
-              >
-                <RefreshCw
-                  className={`h-4 w-4 ${isFetchingProjects ? "animate-spin" : ""}`}
-                />
-              </Button>
+              <Tooltip>
+                <TooltipTrigger>
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    onClick={() => refetchProjects()}
+                    disabled={isFetchingProjects}
+                  >
+                    <RefreshCw
+                      className={`h-4 w-4 ${isFetchingProjects ? "animate-spin" : ""}`}
+                    />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Refresh projects</TooltipContent>
+              </Tooltip>
               <Button
                 variant="outline"
                 size="sm"
@@ -333,18 +342,22 @@ export function SupabaseConnector({ appId }: { appId: number }) {
                           </span>
                         )}
                       </div>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="h-7 px-2 text-muted-foreground hover:text-destructive shrink-0"
-                        onClick={() =>
-                          handleDeleteOrganization(org.organizationSlug)
-                        }
-                        title="Disconnect organization"
-                      >
-                        <Trash2 className="h-3.5 w-3.5 mr-1" />
-                        <span className="text-xs">Disconnect</span>
-                      </Button>
+                      <Tooltip>
+                        <TooltipTrigger>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-7 px-2 text-muted-foreground hover:text-destructive shrink-0"
+                            onClick={() =>
+                              handleDeleteOrganization(org.organizationSlug)
+                            }
+                          >
+                            <Trash2 className="h-3.5 w-3.5 mr-1" />
+                            <span className="text-xs">Disconnect</span>
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>Disconnect organization</TooltipContent>
+                      </Tooltip>
                     </div>
                   ))}
                 </div>

--- a/src/components/SupabaseConnector.tsx
+++ b/src/components/SupabaseConnector.tsx
@@ -274,17 +274,19 @@ export function SupabaseConnector({ appId }: { appId: number }) {
             Supabase Projects
             <div className="flex items-center gap-2">
               <Tooltip>
-                <TooltipTrigger>
-                  <Button
-                    variant="outline"
-                    size="icon"
-                    onClick={() => refetchProjects()}
-                    disabled={isFetchingProjects}
-                  >
-                    <RefreshCw
-                      className={`h-4 w-4 ${isFetchingProjects ? "animate-spin" : ""}`}
+                <TooltipTrigger
+                  render={
+                    <Button
+                      variant="outline"
+                      size="icon"
+                      onClick={() => refetchProjects()}
+                      disabled={isFetchingProjects}
                     />
-                  </Button>
+                  }
+                >
+                  <RefreshCw
+                    className={`h-4 w-4 ${isFetchingProjects ? "animate-spin" : ""}`}
+                  />
                 </TooltipTrigger>
                 <TooltipContent>Refresh projects</TooltipContent>
               </Tooltip>
@@ -343,18 +345,20 @@ export function SupabaseConnector({ appId }: { appId: number }) {
                         )}
                       </div>
                       <Tooltip>
-                        <TooltipTrigger>
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            className="h-7 px-2 text-muted-foreground hover:text-destructive shrink-0"
-                            onClick={() =>
-                              handleDeleteOrganization(org.organizationSlug)
-                            }
-                          >
-                            <Trash2 className="h-3.5 w-3.5 mr-1" />
-                            <span className="text-xs">Disconnect</span>
-                          </Button>
+                        <TooltipTrigger
+                          render={
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="h-7 px-2 text-muted-foreground hover:text-destructive shrink-0"
+                              onClick={() =>
+                                handleDeleteOrganization(org.organizationSlug)
+                              }
+                            />
+                          }
+                        >
+                          <Trash2 className="h-3.5 w-3.5 mr-1" />
+                          <span className="text-xs">Disconnect</span>
                         </TooltipTrigger>
                         <TooltipContent>Disconnect organization</TooltipContent>
                       </Tooltip>

--- a/src/components/SupabaseIntegration.tsx
+++ b/src/components/SupabaseIntegration.tsx
@@ -126,16 +126,20 @@ export function SupabaseIntegration() {
               )}
             </div>
             <Tooltip>
-              <TooltipTrigger>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-7 px-2 text-muted-foreground hover:text-destructive shrink-0"
-                  onClick={() => handleDeleteOrganization(org.organizationSlug)}
-                >
-                  <Trash2 className="h-3.5 w-3.5 mr-1" />
-                  <span className="text-xs">Disconnect</span>
-                </Button>
+              <TooltipTrigger
+                render={
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 px-2 text-muted-foreground hover:text-destructive shrink-0"
+                    onClick={() =>
+                      handleDeleteOrganization(org.organizationSlug)
+                    }
+                  />
+                }
+              >
+                <Trash2 className="h-3.5 w-3.5 mr-1" />
+                <span className="text-xs">Disconnect</span>
               </TooltipTrigger>
               <TooltipContent>Disconnect organization</TooltipContent>
             </Tooltip>

--- a/src/components/SupabaseIntegration.tsx
+++ b/src/components/SupabaseIntegration.tsx
@@ -5,6 +5,11 @@ import { Label } from "@/components/ui/label";
 // We might need a Supabase icon here, but for now, let's use a generic one or text.
 // import { Supabase } from "lucide-react"; // Placeholder
 import { DatabaseZap, Trash2 } from "lucide-react"; // Using DatabaseZap as a placeholder
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
 import { useSettings } from "@/hooks/useSettings";
 import { useSupabase } from "@/hooks/useSupabase";
 import { showSuccess, showError } from "@/lib/toast";
@@ -120,16 +125,20 @@ export function SupabaseIntegration() {
                 </span>
               )}
             </div>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-7 px-2 text-muted-foreground hover:text-destructive shrink-0"
-              onClick={() => handleDeleteOrganization(org.organizationSlug)}
-              title="Disconnect organization"
-            >
-              <Trash2 className="h-3.5 w-3.5 mr-1" />
-              <span className="text-xs">Disconnect</span>
-            </Button>
+            <Tooltip>
+              <TooltipTrigger>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 px-2 text-muted-foreground hover:text-destructive shrink-0"
+                  onClick={() => handleDeleteOrganization(org.organizationSlug)}
+                >
+                  <Trash2 className="h-3.5 w-3.5 mr-1" />
+                  <span className="text-xs">Disconnect</span>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Disconnect organization</TooltipContent>
+            </Tooltip>
           </div>
         ))}
       </div>

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -436,16 +436,18 @@ export function ChatInput({ chatId }: { chatId?: number }) {
             selectedComponents.length > 0 && (
               <div className="border-b border-border p-3 bg-muted/30">
                 <Tooltip>
-                  <TooltipTrigger>
-                    <button
-                      onClick={() => {
-                        ipc.system.openExternalUrl("https://dyad.sh/pro");
-                      }}
-                      className="flex items-center gap-2 text-sm text-muted-foreground hover:text-primary transition-colors cursor-pointer"
-                    >
-                      <Lock size={16} />
-                      <span className="font-medium">Visual editor (Pro)</span>
-                    </button>
+                  <TooltipTrigger
+                    render={
+                      <button
+                        onClick={() => {
+                          ipc.system.openExternalUrl("https://dyad.sh/pro");
+                        }}
+                        className="flex items-center gap-2 text-sm text-muted-foreground hover:text-primary transition-colors cursor-pointer"
+                      />
+                    }
+                  >
+                    <Lock size={16} />
+                    <span className="font-medium">Visual editor (Pro)</span>
                   </TooltipTrigger>
                   <TooltipContent>
                     Visual editing lets you make UI changes without AI and is a
@@ -480,29 +482,33 @@ export function ChatInput({ chatId }: { chatId?: number }) {
 
             {isStreaming ? (
               <Tooltip>
-                <TooltipTrigger>
-                  <button
-                    onClick={handleCancel}
-                    className="px-2 py-2 mt-1 mr-1 hover:bg-(--background-darkest) text-(--sidebar-accent-fg) rounded-lg"
-                  >
-                    <StopCircleIcon size={20} />
-                  </button>
+                <TooltipTrigger
+                  render={
+                    <button
+                      onClick={handleCancel}
+                      className="px-2 py-2 mt-1 mr-1 hover:bg-(--background-darkest) text-(--sidebar-accent-fg) rounded-lg"
+                    />
+                  }
+                >
+                  <StopCircleIcon size={20} />
                 </TooltipTrigger>
                 <TooltipContent>Cancel generation</TooltipContent>
               </Tooltip>
             ) : (
               <Tooltip>
-                <TooltipTrigger>
-                  <button
-                    onClick={handleSubmit}
-                    disabled={
-                      (!inputValue.trim() && attachments.length === 0) ||
-                      disableSendButton
-                    }
-                    className="px-2 py-2 mt-1 mr-1 hover:bg-(--background-darkest) text-(--sidebar-accent-fg) rounded-lg disabled:opacity-50"
-                  >
-                    <SendHorizontalIcon size={20} />
-                  </button>
+                <TooltipTrigger
+                  render={
+                    <button
+                      onClick={handleSubmit}
+                      disabled={
+                        (!inputValue.trim() && attachments.length === 0) ||
+                        disableSendButton
+                      }
+                      className="px-2 py-2 mt-1 mr-1 hover:bg-(--background-darkest) text-(--sidebar-accent-fg) rounded-lg disabled:opacity-50"
+                    />
+                  }
+                >
+                  <SendHorizontalIcon size={20} />
                 </TooltipTrigger>
                 <TooltipContent>Send message</TooltipContent>
               </Tooltip>
@@ -540,15 +546,17 @@ function SuggestionButton({
   const { isStreaming } = useStreamChat();
   return (
     <Tooltip>
-      <TooltipTrigger>
-        <Button
-          disabled={isStreaming}
-          variant="outline"
-          size="sm"
-          onClick={onClick}
-        >
-          {children}
-        </Button>
+      <TooltipTrigger
+        render={
+          <Button
+            disabled={isStreaming}
+            variant="outline"
+            size="sm"
+            onClick={onClick}
+          />
+        }
+      >
+        {children}
       </TooltipTrigger>
       <TooltipContent>{tooltipText}</TooltipContent>
     </Tooltip>

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -76,6 +76,11 @@ import { useUserBudgetInfo } from "@/hooks/useUserBudgetInfo";
 import { useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "@/lib/queryKeys";
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
   ContextLimitBanner,
   shouldShowContextLimitBanner,
 } from "./ContextLimitBanner";
@@ -430,16 +435,23 @@ export function ChatInput({ chatId }: { chatId?: number }) {
           ) : (
             selectedComponents.length > 0 && (
               <div className="border-b border-border p-3 bg-muted/30">
-                <button
-                  onClick={() => {
-                    ipc.system.openExternalUrl("https://dyad.sh/pro");
-                  }}
-                  className="flex items-center gap-2 text-sm text-muted-foreground hover:text-primary transition-colors cursor-pointer"
-                  title="Visual editing lets you make UI changes without AI and is a Pro-only feature"
-                >
-                  <Lock size={16} />
-                  <span className="font-medium">Visual editor (Pro)</span>
-                </button>
+                <Tooltip>
+                  <TooltipTrigger>
+                    <button
+                      onClick={() => {
+                        ipc.system.openExternalUrl("https://dyad.sh/pro");
+                      }}
+                      className="flex items-center gap-2 text-sm text-muted-foreground hover:text-primary transition-colors cursor-pointer"
+                    >
+                      <Lock size={16} />
+                      <span className="font-medium">Visual editor (Pro)</span>
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    Visual editing lets you make UI changes without AI and is a
+                    Pro-only feature
+                  </TooltipContent>
+                </Tooltip>
               </div>
             )
           )}
@@ -467,25 +479,33 @@ export function ChatInput({ chatId }: { chatId?: number }) {
             />
 
             {isStreaming ? (
-              <button
-                onClick={handleCancel}
-                className="px-2 py-2 mt-1 mr-1 hover:bg-(--background-darkest) text-(--sidebar-accent-fg) rounded-lg"
-                title="Cancel generation"
-              >
-                <StopCircleIcon size={20} />
-              </button>
+              <Tooltip>
+                <TooltipTrigger>
+                  <button
+                    onClick={handleCancel}
+                    className="px-2 py-2 mt-1 mr-1 hover:bg-(--background-darkest) text-(--sidebar-accent-fg) rounded-lg"
+                  >
+                    <StopCircleIcon size={20} />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>Cancel generation</TooltipContent>
+              </Tooltip>
             ) : (
-              <button
-                onClick={handleSubmit}
-                disabled={
-                  (!inputValue.trim() && attachments.length === 0) ||
-                  disableSendButton
-                }
-                className="px-2 py-2 mt-1 mr-1 hover:bg-(--background-darkest) text-(--sidebar-accent-fg) rounded-lg disabled:opacity-50"
-                title="Send message"
-              >
-                <SendHorizontalIcon size={20} />
-              </button>
+              <Tooltip>
+                <TooltipTrigger>
+                  <button
+                    onClick={handleSubmit}
+                    disabled={
+                      (!inputValue.trim() && attachments.length === 0) ||
+                      disableSendButton
+                    }
+                    className="px-2 py-2 mt-1 mr-1 hover:bg-(--background-darkest) text-(--sidebar-accent-fg) rounded-lg disabled:opacity-50"
+                  >
+                    <SendHorizontalIcon size={20} />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>Send message</TooltipContent>
+              </Tooltip>
             )}
           </div>
           <div className="pl-2 pr-1 flex items-center justify-between pb-2">
@@ -519,15 +539,19 @@ function SuggestionButton({
 }) {
   const { isStreaming } = useStreamChat();
   return (
-    <Button
-      disabled={isStreaming}
-      variant="outline"
-      size="sm"
-      onClick={onClick}
-      title={tooltipText}
-    >
-      {children}
-    </Button>
+    <Tooltip>
+      <TooltipTrigger>
+        <Button
+          disabled={isStreaming}
+          variant="outline"
+          size="sm"
+          onClick={onClick}
+        >
+          {children}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{tooltipText}</TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -486,6 +486,7 @@ export function ChatInput({ chatId }: { chatId?: number }) {
                   render={
                     <button
                       onClick={handleCancel}
+                      aria-label="Cancel generation"
                       className="px-2 py-2 mt-1 mr-1 hover:bg-(--background-darkest) text-(--sidebar-accent-fg) rounded-lg"
                     />
                   }
@@ -504,6 +505,7 @@ export function ChatInput({ chatId }: { chatId?: number }) {
                         (!inputValue.trim() && attachments.length === 0) ||
                         disableSendButton
                       }
+                      aria-label="Send message"
                       className="px-2 py-2 mt-1 mr-1 hover:bg-(--background-darkest) text-(--sidebar-accent-fg) rounded-lg disabled:opacity-50"
                     />
                   }

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -128,19 +128,21 @@ const ChatMessage = ({ message, isLastMessage }: ChatMessageProps) => {
                 message.content &&
                 !isStreaming && (
                   <Tooltip>
-                    <TooltipTrigger>
-                      <button
-                        data-testid="copy-message-button"
-                        onClick={handleCopyFormatted}
-                        className="flex items-center space-x-1 px-2 py-1 text-xs text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 rounded transition-colors duration-200 cursor-pointer"
-                      >
-                        {copied ? (
-                          <Check className="h-4 w-4 text-green-500" />
-                        ) : (
-                          <Copy className="h-4 w-4" />
-                        )}
-                        <span className="hidden sm:inline"></span>
-                      </button>
+                    <TooltipTrigger
+                      render={
+                        <button
+                          data-testid="copy-message-button"
+                          onClick={handleCopyFormatted}
+                          className="flex items-center space-x-1 px-2 py-1 text-xs text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 rounded transition-colors duration-200 cursor-pointer"
+                        />
+                      }
+                    >
+                      {copied ? (
+                        <Check className="h-4 w-4 text-green-500" />
+                      ) : (
+                        <Copy className="h-4 w-4" />
+                      )}
+                      <span className="hidden sm:inline"></span>
                     </TooltipTrigger>
                     <TooltipContent>
                       {copied ? "Copied!" : "Copy"}
@@ -199,37 +201,39 @@ const ChatMessage = ({ message, isLastMessage }: ChatMessageProps) => {
             )}
             {message.requestId && (
               <Tooltip>
-                <TooltipTrigger>
-                  <button
-                    onClick={() => {
-                      if (!message.requestId) return;
-                      navigator.clipboard
-                        .writeText(message.requestId)
-                        .then(() => {
-                          setCopiedRequestId(true);
-                          if (copiedRequestIdTimeoutRef.current) {
-                            clearTimeout(copiedRequestIdTimeoutRef.current);
-                          }
-                          copiedRequestIdTimeoutRef.current = setTimeout(
-                            () => setCopiedRequestId(false),
-                            2000,
-                          );
-                        })
-                        .catch(() => {
-                          // noop
-                        });
-                    }}
-                    className="flex items-center space-x-1 px-1 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-800 rounded transition-colors duration-200 cursor-pointer"
-                  >
-                    {copiedRequestId ? (
-                      <Check className="h-3 w-3 text-green-500" />
-                    ) : (
-                      <Copy className="h-3 w-3" />
-                    )}
-                    <span className="text-xs">
-                      {copiedRequestId ? "Copied" : "Request ID"}
-                    </span>
-                  </button>
+                <TooltipTrigger
+                  render={
+                    <button
+                      onClick={() => {
+                        if (!message.requestId) return;
+                        navigator.clipboard
+                          .writeText(message.requestId)
+                          .then(() => {
+                            setCopiedRequestId(true);
+                            if (copiedRequestIdTimeoutRef.current) {
+                              clearTimeout(copiedRequestIdTimeoutRef.current);
+                            }
+                            copiedRequestIdTimeoutRef.current = setTimeout(
+                              () => setCopiedRequestId(false),
+                              2000,
+                            );
+                          })
+                          .catch(() => {
+                            // noop
+                          });
+                      }}
+                      className="flex items-center space-x-1 px-1 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-800 rounded transition-colors duration-200 cursor-pointer"
+                    />
+                  }
+                >
+                  {copiedRequestId ? (
+                    <Check className="h-3 w-3 text-green-500" />
+                  ) : (
+                    <Copy className="h-3 w-3" />
+                  )}
+                  <span className="text-xs">
+                    {copiedRequestId ? "Copied" : "Request ID"}
+                  </span>
                 </TooltipTrigger>
                 <TooltipContent>
                   {copiedRequestId

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -133,6 +133,7 @@ const ChatMessage = ({ message, isLastMessage }: ChatMessageProps) => {
                         <button
                           data-testid="copy-message-button"
                           onClick={handleCopyFormatted}
+                          aria-label="Copy"
                           className="flex items-center space-x-1 px-2 py-1 text-xs text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 rounded transition-colors duration-200 cursor-pointer"
                         />
                       }
@@ -222,6 +223,7 @@ const ChatMessage = ({ message, isLastMessage }: ChatMessageProps) => {
                             // noop
                           });
                       }}
+                      aria-label="Copy Request ID"
                       className="flex items-center space-x-1 px-1 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-800 rounded transition-colors duration-200 cursor-pointer"
                     />
                   }

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -21,6 +21,11 @@ import { useAtomValue } from "jotai";
 import { selectedAppIdAtom } from "@/atoms/appAtoms";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
 
 interface ChatMessageProps {
   message: Message;
@@ -122,19 +127,25 @@ const ChatMessage = ({ message, isLastMessage }: ChatMessageProps) => {
               {message.role === "assistant" &&
                 message.content &&
                 !isStreaming && (
-                  <button
-                    data-testid="copy-message-button"
-                    onClick={handleCopyFormatted}
-                    title={copied ? "Copied!" : "Copy"}
-                    className="flex items-center space-x-1 px-2 py-1 text-xs text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 rounded transition-colors duration-200 cursor-pointer"
-                  >
-                    {copied ? (
-                      <Check className="h-4 w-4 text-green-500" />
-                    ) : (
-                      <Copy className="h-4 w-4" />
-                    )}
-                    <span className="hidden sm:inline"></span>
-                  </button>
+                  <Tooltip>
+                    <TooltipTrigger>
+                      <button
+                        data-testid="copy-message-button"
+                        onClick={handleCopyFormatted}
+                        className="flex items-center space-x-1 px-2 py-1 text-xs text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 rounded transition-colors duration-200 cursor-pointer"
+                      >
+                        {copied ? (
+                          <Check className="h-4 w-4 text-green-500" />
+                        ) : (
+                          <Copy className="h-4 w-4" />
+                        )}
+                        <span className="hidden sm:inline"></span>
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {copied ? "Copied!" : "Copy"}
+                    </TooltipContent>
+                  </Tooltip>
                 )}
               <div className="flex flex-wrap gap-2">
                 {message.approvalState && (
@@ -187,41 +198,45 @@ const ChatMessage = ({ message, isLastMessage }: ChatMessageProps) => {
               </div>
             )}
             {message.requestId && (
-              <button
-                onClick={() => {
-                  if (!message.requestId) return;
-                  navigator.clipboard
-                    .writeText(message.requestId)
-                    .then(() => {
-                      setCopiedRequestId(true);
-                      if (copiedRequestIdTimeoutRef.current) {
-                        clearTimeout(copiedRequestIdTimeoutRef.current);
-                      }
-                      copiedRequestIdTimeoutRef.current = setTimeout(
-                        () => setCopiedRequestId(false),
-                        2000,
-                      );
-                    })
-                    .catch(() => {
-                      // noop
-                    });
-                }}
-                title={
-                  copiedRequestId
+              <Tooltip>
+                <TooltipTrigger>
+                  <button
+                    onClick={() => {
+                      if (!message.requestId) return;
+                      navigator.clipboard
+                        .writeText(message.requestId)
+                        .then(() => {
+                          setCopiedRequestId(true);
+                          if (copiedRequestIdTimeoutRef.current) {
+                            clearTimeout(copiedRequestIdTimeoutRef.current);
+                          }
+                          copiedRequestIdTimeoutRef.current = setTimeout(
+                            () => setCopiedRequestId(false),
+                            2000,
+                          );
+                        })
+                        .catch(() => {
+                          // noop
+                        });
+                    }}
+                    className="flex items-center space-x-1 px-1 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-800 rounded transition-colors duration-200 cursor-pointer"
+                  >
+                    {copiedRequestId ? (
+                      <Check className="h-3 w-3 text-green-500" />
+                    ) : (
+                      <Copy className="h-3 w-3" />
+                    )}
+                    <span className="text-xs">
+                      {copiedRequestId ? "Copied" : "Request ID"}
+                    </span>
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {copiedRequestId
                     ? "Copied!"
-                    : `Copy Request ID: ${message.requestId.slice(0, 8)}...`
-                }
-                className="flex items-center space-x-1 px-1 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-800 rounded transition-colors duration-200 cursor-pointer"
-              >
-                {copiedRequestId ? (
-                  <Check className="h-3 w-3 text-green-500" />
-                ) : (
-                  <Copy className="h-3 w-3" />
-                )}
-                <span className="text-xs">
-                  {copiedRequestId ? "Copied" : "Request ID"}
-                </span>
-              </button>
+                    : `Copy Request ID: ${message.requestId.slice(0, 8)}...`}
+                </TooltipContent>
+              </Tooltip>
             )}
             {isLastMessage && message.totalTokens && (
               <div

--- a/src/components/chat/ContextLimitBanner.tsx
+++ b/src/components/chat/ContextLimitBanner.tsx
@@ -58,16 +58,18 @@ export function ContextLimitBanner({
         <span>{message}</span>
       </span>
       <Tooltip>
-        <TooltipTrigger>
-          <Button
-            onClick={handleSummarize}
-            variant="outline"
-            size="sm"
-            className="h-6 px-2 text-xs border-amber-500/40 bg-amber-500/5 text-amber-600 dark:text-amber-500 hover:bg-amber-500/20 hover:border-amber-500/60"
-          >
-            Summarize
-            <ArrowRight className="h-3 w-3 ml-1" />
-          </Button>
+        <TooltipTrigger
+          render={
+            <Button
+              onClick={handleSummarize}
+              variant="outline"
+              size="sm"
+              className="h-6 px-2 text-xs border-amber-500/40 bg-amber-500/5 text-amber-600 dark:text-amber-500 hover:bg-amber-500/20 hover:border-amber-500/60"
+            />
+          }
+        >
+          Summarize
+          <ArrowRight className="h-3 w-3 ml-1" />
         </TooltipTrigger>
         <TooltipContent>Summarize to new chat</TooltipContent>
       </Tooltip>

--- a/src/components/chat/ContextLimitBanner.tsx
+++ b/src/components/chat/ContextLimitBanner.tsx
@@ -1,5 +1,10 @@
 import { AlertTriangle, ArrowRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useSummarizeInNewChat } from "./SummarizeInNewChatButton";
 
 const CONTEXT_LIMIT_THRESHOLD = 40_000;
@@ -52,16 +57,20 @@ export function ContextLimitBanner({
         <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
         <span>{message}</span>
       </span>
-      <Button
-        onClick={handleSummarize}
-        variant="outline"
-        size="sm"
-        className="h-6 px-2 text-xs border-amber-500/40 bg-amber-500/5 text-amber-600 dark:text-amber-500 hover:bg-amber-500/20 hover:border-amber-500/60"
-        title="Summarize to new chat"
-      >
-        Summarize
-        <ArrowRight className="h-3 w-3 ml-1" />
-      </Button>
+      <Tooltip>
+        <TooltipTrigger>
+          <Button
+            onClick={handleSummarize}
+            variant="outline"
+            size="sm"
+            className="h-6 px-2 text-xs border-amber-500/40 bg-amber-500/5 text-amber-600 dark:text-amber-500 hover:bg-amber-500/20 hover:border-amber-500/60"
+          >
+            Summarize
+            <ArrowRight className="h-3 w-3 ml-1" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>Summarize to new chat</TooltipContent>
+      </Tooltip>
     </div>
   );
 }

--- a/src/components/chat/HomeChatInput.tsx
+++ b/src/components/chat/HomeChatInput.tsx
@@ -1,4 +1,9 @@
 import { SendIcon, StopCircleIcon } from "lucide-react";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
 
 import { useSettings } from "@/hooks/useSettings";
 import { homeChatInputValueAtom } from "@/atoms/chatAtoms"; // Use a different atom for home input
@@ -101,21 +106,31 @@ export function HomeChatInput({
             />
 
             {isStreaming ? (
-              <button
-                className="px-2 py-2 mt-1 mr-1 text-(--sidebar-accent-fg) rounded-lg opacity-50 cursor-not-allowed" // Indicate disabled state
-                title="Cancel generation (unavailable here)"
-              >
-                <StopCircleIcon size={20} />
-              </button>
+              <Tooltip>
+                <TooltipTrigger>
+                  <button
+                    className="px-2 py-2 mt-1 mr-1 text-(--sidebar-accent-fg) rounded-lg opacity-50 cursor-not-allowed" // Indicate disabled state
+                  >
+                    <StopCircleIcon size={20} />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  Cancel generation (unavailable here)
+                </TooltipContent>
+              </Tooltip>
             ) : (
-              <button
-                onClick={handleCustomSubmit}
-                disabled={!inputValue.trim() && attachments.length === 0}
-                className="px-2 py-2 mt-1 mr-1 hover:bg-(--background-darkest) text-(--sidebar-accent-fg) rounded-lg disabled:opacity-50"
-                title="Send message"
-              >
-                <SendIcon size={20} />
-              </button>
+              <Tooltip>
+                <TooltipTrigger>
+                  <button
+                    onClick={handleCustomSubmit}
+                    disabled={!inputValue.trim() && attachments.length === 0}
+                    className="px-2 py-2 mt-1 mr-1 hover:bg-(--background-darkest) text-(--sidebar-accent-fg) rounded-lg disabled:opacity-50"
+                  >
+                    <SendIcon size={20} />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>Send message</TooltipContent>
+              </Tooltip>
             )}
           </div>
           <div className="pl-2 pr-1 flex items-center justify-between pb-2">

--- a/src/components/chat/HomeChatInput.tsx
+++ b/src/components/chat/HomeChatInput.tsx
@@ -107,12 +107,12 @@ export function HomeChatInput({
 
             {isStreaming ? (
               <Tooltip>
-                <TooltipTrigger>
-                  <button
-                    className="px-2 py-2 mt-1 mr-1 text-(--sidebar-accent-fg) rounded-lg opacity-50 cursor-not-allowed" // Indicate disabled state
-                  >
-                    <StopCircleIcon size={20} />
-                  </button>
+                <TooltipTrigger
+                  render={
+                    <button className="px-2 py-2 mt-1 mr-1 text-(--sidebar-accent-fg) rounded-lg opacity-50 cursor-not-allowed" />
+                  }
+                >
+                  <StopCircleIcon size={20} />
                 </TooltipTrigger>
                 <TooltipContent>
                   Cancel generation (unavailable here)
@@ -120,14 +120,16 @@ export function HomeChatInput({
               </Tooltip>
             ) : (
               <Tooltip>
-                <TooltipTrigger>
-                  <button
-                    onClick={handleCustomSubmit}
-                    disabled={!inputValue.trim() && attachments.length === 0}
-                    className="px-2 py-2 mt-1 mr-1 hover:bg-(--background-darkest) text-(--sidebar-accent-fg) rounded-lg disabled:opacity-50"
-                  >
-                    <SendIcon size={20} />
-                  </button>
+                <TooltipTrigger
+                  render={
+                    <button
+                      onClick={handleCustomSubmit}
+                      disabled={!inputValue.trim() && attachments.length === 0}
+                      className="px-2 py-2 mt-1 mr-1 hover:bg-(--background-darkest) text-(--sidebar-accent-fg) rounded-lg disabled:opacity-50"
+                    />
+                  }
+                >
+                  <SendIcon size={20} />
                 </TooltipTrigger>
                 <TooltipContent>Send message</TooltipContent>
               </Tooltip>

--- a/src/components/chat/HomeChatInput.tsx
+++ b/src/components/chat/HomeChatInput.tsx
@@ -109,7 +109,10 @@ export function HomeChatInput({
               <Tooltip>
                 <TooltipTrigger
                   render={
-                    <button className="px-2 py-2 mt-1 mr-1 text-(--sidebar-accent-fg) rounded-lg opacity-50 cursor-not-allowed" />
+                    <button
+                      aria-label="Cancel generation (unavailable here)"
+                      className="px-2 py-2 mt-1 mr-1 text-(--sidebar-accent-fg) rounded-lg opacity-50 cursor-not-allowed"
+                    />
                   }
                 >
                   <StopCircleIcon size={20} />
@@ -125,6 +128,7 @@ export function HomeChatInput({
                     <button
                       onClick={handleCustomSubmit}
                       disabled={!inputValue.trim() && attachments.length === 0}
+                      aria-label="Send message"
                       className="px-2 py-2 mt-1 mr-1 hover:bg-(--background-darkest) text-(--sidebar-accent-fg) rounded-lg disabled:opacity-50"
                     />
                   }

--- a/src/components/chat/SelectedComponentDisplay.tsx
+++ b/src/components/chat/SelectedComponentDisplay.tsx
@@ -105,6 +105,7 @@ export function SelectedComponentsDisplay() {
                 render={
                   <button
                     onClick={() => handleRemoveComponent(index)}
+                    aria-label="Deselect component"
                     className="ml-2 flex-shrink-0 rounded-full p-0.5 hover:bg-indigo-600/20"
                   />
                 }

--- a/src/components/chat/SelectedComponentDisplay.tsx
+++ b/src/components/chat/SelectedComponentDisplay.tsx
@@ -5,6 +5,11 @@ import {
 } from "@/atoms/previewAtoms";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { Code2, X } from "lucide-react";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
 
 export function SelectedComponentsDisplay() {
   const [selectedComponents, setSelectedComponents] = useAtom(
@@ -57,13 +62,17 @@ export function SelectedComponentsDisplay() {
         <span className="text-xs font-medium text-muted-foreground">
           Selected Components ({selectedComponents.length})
         </span>
-        <button
-          onClick={handleClearAll}
-          className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-          title="Clear all selected components"
-        >
-          Clear all
-        </button>
+        <Tooltip>
+          <TooltipTrigger>
+            <button
+              onClick={handleClearAll}
+              className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              Clear all
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Clear all selected components</TooltipContent>
+        </Tooltip>
       </div>
       {selectedComponents.map((selectedComponent, index) => (
         <div key={selectedComponent.id} className="mb-1 last:mb-0">
@@ -89,13 +98,20 @@ export function SelectedComponentsDisplay() {
                 </span>
               </div>
             </div>
-            <button
-              onClick={() => handleRemoveComponent(index)}
-              className="ml-2 flex-shrink-0 rounded-full p-0.5 hover:bg-indigo-600/20"
-              title="Deselect component"
-            >
-              <X size={18} className="text-indigo-600 dark:text-indigo-400" />
-            </button>
+            <Tooltip>
+              <TooltipTrigger>
+                <button
+                  onClick={() => handleRemoveComponent(index)}
+                  className="ml-2 flex-shrink-0 rounded-full p-0.5 hover:bg-indigo-600/20"
+                >
+                  <X
+                    size={18}
+                    className="text-indigo-600 dark:text-indigo-400"
+                  />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Deselect component</TooltipContent>
+            </Tooltip>
           </div>
         </div>
       ))}

--- a/src/components/chat/SelectedComponentDisplay.tsx
+++ b/src/components/chat/SelectedComponentDisplay.tsx
@@ -63,13 +63,15 @@ export function SelectedComponentsDisplay() {
           Selected Components ({selectedComponents.length})
         </span>
         <Tooltip>
-          <TooltipTrigger>
-            <button
-              onClick={handleClearAll}
-              className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-            >
-              Clear all
-            </button>
+          <TooltipTrigger
+            render={
+              <button
+                onClick={handleClearAll}
+                className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+              />
+            }
+          >
+            Clear all
           </TooltipTrigger>
           <TooltipContent>Clear all selected components</TooltipContent>
         </Tooltip>
@@ -99,16 +101,15 @@ export function SelectedComponentsDisplay() {
               </div>
             </div>
             <Tooltip>
-              <TooltipTrigger>
-                <button
-                  onClick={() => handleRemoveComponent(index)}
-                  className="ml-2 flex-shrink-0 rounded-full p-0.5 hover:bg-indigo-600/20"
-                >
-                  <X
-                    size={18}
-                    className="text-indigo-600 dark:text-indigo-400"
+              <TooltipTrigger
+                render={
+                  <button
+                    onClick={() => handleRemoveComponent(index)}
+                    className="ml-2 flex-shrink-0 rounded-full p-0.5 hover:bg-indigo-600/20"
                   />
-                </button>
+                }
+              >
+                <X size={18} className="text-indigo-600 dark:text-indigo-400" />
               </TooltipTrigger>
               <TooltipContent>Deselect component</TooltipContent>
             </Tooltip>

--- a/src/components/preview_panel/ActionHeader.tsx
+++ b/src/components/preview_panel/ActionHeader.tsx
@@ -24,6 +24,11 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
 import { showError, showSuccess } from "@/lib/toast";
 import { useMutation } from "@tanstack/react-query";
 import { useCheckProblems } from "@/hooks/useCheckProblems";
@@ -170,19 +175,23 @@ export const ActionHeader = () => {
     badge?: React.ReactNode,
   ) => {
     return (
-      <button
-        data-testid={testId}
-        ref={ref}
-        className="no-app-region-drag cursor-pointer relative flex items-center gap-0.5 px-2 py-0.5 rounded-md text-xs font-medium z-10 hover:bg-[var(--background)] flex-col"
-        onClick={() => selectPanel(mode)}
-        title={isCompact ? text : undefined}
-      >
-        {icon}
-        <span>
-          {!isCompact && <span>{text}</span>}
-          {badge}
-        </span>
-      </button>
+      <Tooltip>
+        <TooltipTrigger>
+          <button
+            data-testid={testId}
+            ref={ref}
+            className="no-app-region-drag cursor-pointer relative flex items-center gap-0.5 px-2 py-0.5 rounded-md text-xs font-medium z-10 hover:bg-[var(--background)] flex-col"
+            onClick={() => selectPanel(mode)}
+          >
+            {icon}
+            <span>
+              {!isCompact && <span>{text}</span>}
+              {badge}
+            </span>
+          </button>
+        </TooltipTrigger>
+        {isCompact && <TooltipContent>{text}</TooltipContent>}
+      </Tooltip>
     );
   };
   const iconSize = 15;
@@ -255,13 +264,17 @@ export const ActionHeader = () => {
       <div className="flex items-center gap-1">
         <ChatActivityButton />
         <DropdownMenu>
-          <DropdownMenuTrigger
-            data-testid="preview-more-options-button"
-            className="no-app-region-drag flex items-center justify-center p-1.5 rounded-md text-sm hover:bg-[var(--background-darkest)] transition-colors"
-            title="More options"
-          >
-            <MoreVertical size={16} />
-          </DropdownMenuTrigger>
+          <Tooltip>
+            <TooltipTrigger>
+              <DropdownMenuTrigger
+                data-testid="preview-more-options-button"
+                className="no-app-region-drag flex items-center justify-center p-1.5 rounded-md text-sm hover:bg-[var(--background-darkest)] transition-colors"
+              >
+                <MoreVertical size={16} />
+              </DropdownMenuTrigger>
+            </TooltipTrigger>
+            <TooltipContent>More options</TooltipContent>
+          </Tooltip>
           <DropdownMenuContent align="end" className="w-60">
             <DropdownMenuItem onClick={onCleanRestart}>
               <Cog size={16} />

--- a/src/components/preview_panel/ActionHeader.tsx
+++ b/src/components/preview_panel/ActionHeader.tsx
@@ -176,19 +176,21 @@ export const ActionHeader = () => {
   ) => {
     return (
       <Tooltip>
-        <TooltipTrigger>
-          <button
-            data-testid={testId}
-            ref={ref}
-            className="no-app-region-drag cursor-pointer relative flex items-center gap-0.5 px-2 py-0.5 rounded-md text-xs font-medium z-10 hover:bg-[var(--background)] flex-col"
-            onClick={() => selectPanel(mode)}
-          >
-            {icon}
-            <span>
-              {!isCompact && <span>{text}</span>}
-              {badge}
-            </span>
-          </button>
+        <TooltipTrigger
+          render={
+            <button
+              data-testid={testId}
+              ref={ref}
+              className="no-app-region-drag cursor-pointer relative flex items-center gap-0.5 px-2 py-0.5 rounded-md text-xs font-medium z-10 hover:bg-[var(--background)] flex-col"
+              onClick={() => selectPanel(mode)}
+            />
+          }
+        >
+          {icon}
+          <span>
+            {!isCompact && <span>{text}</span>}
+            {badge}
+          </span>
         </TooltipTrigger>
         {isCompact && <TooltipContent>{text}</TooltipContent>}
       </Tooltip>
@@ -265,13 +267,15 @@ export const ActionHeader = () => {
         <ChatActivityButton />
         <DropdownMenu>
           <Tooltip>
-            <TooltipTrigger>
-              <DropdownMenuTrigger
-                data-testid="preview-more-options-button"
-                className="no-app-region-drag flex items-center justify-center p-1.5 rounded-md text-sm hover:bg-[var(--background-darkest)] transition-colors"
-              >
-                <MoreVertical size={16} />
-              </DropdownMenuTrigger>
+            <TooltipTrigger
+              render={
+                <DropdownMenuTrigger
+                  data-testid="preview-more-options-button"
+                  className="no-app-region-drag flex items-center justify-center p-1.5 rounded-md text-sm hover:bg-[var(--background-darkest)] transition-colors"
+                />
+              }
+            >
+              <MoreVertical size={16} />
             </TooltipTrigger>
             <TooltipContent>More options</TooltipContent>
           </Tooltip>

--- a/src/components/preview_panel/AnnotatorToolbar.tsx
+++ b/src/components/preview_panel/AnnotatorToolbar.tsx
@@ -52,55 +52,61 @@ export const AnnotatorToolbar = ({
       {/* Tool Selection Buttons */}
       <div className="flex space-x-1">
         <Tooltip>
-          <TooltipTrigger>
-            <button
-              onClick={() => onToolChange("select")}
-              aria-label="Select"
-              className={cn(
-                "p-1 rounded transition-colors duration-200",
-                tool === "select"
-                  ? "bg-purple-500 text-white hover:bg-purple-600 dark:bg-purple-600 dark:hover:bg-purple-700"
-                  : " text-purple-700 hover:bg-purple-200  dark:text-purple-300 dark:hover:bg-purple-900",
-              )}
-            >
-              <MousePointer2 size={16} />
-            </button>
+          <TooltipTrigger
+            render={
+              <button
+                onClick={() => onToolChange("select")}
+                aria-label="Select"
+                className={cn(
+                  "p-1 rounded transition-colors duration-200",
+                  tool === "select"
+                    ? "bg-purple-500 text-white hover:bg-purple-600 dark:bg-purple-600 dark:hover:bg-purple-700"
+                    : " text-purple-700 hover:bg-purple-200  dark:text-purple-300 dark:hover:bg-purple-900",
+                )}
+              />
+            }
+          >
+            <MousePointer2 size={16} />
           </TooltipTrigger>
           <TooltipContent>Select</TooltipContent>
         </Tooltip>
 
         <Tooltip>
-          <TooltipTrigger>
-            <button
-              onClick={() => onToolChange("draw")}
-              aria-label="Draw"
-              className={cn(
-                "p-1 rounded transition-colors duration-200",
-                tool === "draw"
-                  ? "bg-purple-500 text-white hover:bg-purple-600 dark:bg-purple-600 dark:hover:bg-purple-700"
-                  : " text-purple-700 hover:bg-purple-200  dark:text-purple-300 dark:hover:bg-purple-900",
-              )}
-            >
-              <Pencil size={16} />
-            </button>
+          <TooltipTrigger
+            render={
+              <button
+                onClick={() => onToolChange("draw")}
+                aria-label="Draw"
+                className={cn(
+                  "p-1 rounded transition-colors duration-200",
+                  tool === "draw"
+                    ? "bg-purple-500 text-white hover:bg-purple-600 dark:bg-purple-600 dark:hover:bg-purple-700"
+                    : " text-purple-700 hover:bg-purple-200  dark:text-purple-300 dark:hover:bg-purple-900",
+                )}
+              />
+            }
+          >
+            <Pencil size={16} />
           </TooltipTrigger>
           <TooltipContent>Draw</TooltipContent>
         </Tooltip>
 
         <Tooltip>
-          <TooltipTrigger>
-            <button
-              onClick={() => onToolChange("text")}
-              aria-label="Text"
-              className={cn(
-                "p-1 rounded transition-colors duration-200",
-                tool === "text"
-                  ? "bg-purple-500 text-white hover:bg-purple-600 dark:bg-purple-600 dark:hover:bg-purple-700"
-                  : "text-purple-700 hover:bg-purple-200  dark:text-purple-300 dark:hover:bg-purple-900",
-              )}
-            >
-              <Type size={16} />
-            </button>
+          <TooltipTrigger
+            render={
+              <button
+                onClick={() => onToolChange("text")}
+                aria-label="Text"
+                className={cn(
+                  "p-1 rounded transition-colors duration-200",
+                  tool === "text"
+                    ? "bg-purple-500 text-white hover:bg-purple-600 dark:bg-purple-600 dark:hover:bg-purple-700"
+                    : "text-purple-700 hover:bg-purple-200  dark:text-purple-300 dark:hover:bg-purple-900",
+                )}
+              />
+            }
+          >
+            <Type size={16} />
           </TooltipTrigger>
           <TooltipContent>Text</TooltipContent>
         </Tooltip>
@@ -117,15 +123,17 @@ export const AnnotatorToolbar = ({
         <div className="w-px bg-gray-200 dark:bg-gray-700 h-4" />
 
         <Tooltip>
-          <TooltipTrigger>
-            <button
-              onClick={onDelete}
-              aria-label="Delete"
-              className="p-1 rounded transition-colors duration-200 text-purple-700 hover:bg-purple-200  dark:text-purple-300 dark:hover:bg-purple-900 disabled:opacity-50 disabled:cursor-not-allowed"
-              disabled={!selectedId}
-            >
-              <Trash2 size={16} />
-            </button>
+          <TooltipTrigger
+            render={
+              <button
+                onClick={onDelete}
+                aria-label="Delete"
+                className="p-1 rounded transition-colors duration-200 text-purple-700 hover:bg-purple-200  dark:text-purple-300 dark:hover:bg-purple-900 disabled:opacity-50 disabled:cursor-not-allowed"
+                disabled={!selectedId}
+              />
+            }
+          >
+            <Trash2 size={16} />
           </TooltipTrigger>
           <TooltipContent>Delete Selected</TooltipContent>
         </Tooltip>
@@ -133,29 +141,33 @@ export const AnnotatorToolbar = ({
         <div className="w-px bg-gray-200 dark:bg-gray-700 h-4" />
 
         <Tooltip>
-          <TooltipTrigger>
-            <button
-              onClick={onUndo}
-              aria-label="Undo"
-              className="p-1 rounded transition-colors duration-200 text-purple-700 hover:bg-purple-200  dark:text-purple-300 dark:hover:bg-purple-900 disabled:opacity-50 disabled:cursor-not-allowed"
-              disabled={historyStep === 0}
-            >
-              <Undo size={16} />
-            </button>
+          <TooltipTrigger
+            render={
+              <button
+                onClick={onUndo}
+                aria-label="Undo"
+                className="p-1 rounded transition-colors duration-200 text-purple-700 hover:bg-purple-200  dark:text-purple-300 dark:hover:bg-purple-900 disabled:opacity-50 disabled:cursor-not-allowed"
+                disabled={historyStep === 0}
+              />
+            }
+          >
+            <Undo size={16} />
           </TooltipTrigger>
           <TooltipContent>Undo</TooltipContent>
         </Tooltip>
 
         <Tooltip>
-          <TooltipTrigger>
-            <button
-              onClick={onRedo}
-              aria-label="Redo"
-              className="p-1 rounded transition-colors duration-200 text-purple-700 hover:bg-purple-200  dark:text-purple-300 dark:hover:bg-purple-900 disabled:opacity-50 disabled:cursor-not-allowed"
-              disabled={historyStep === historyLength - 1}
-            >
-              <Redo size={16} />
-            </button>
+          <TooltipTrigger
+            render={
+              <button
+                onClick={onRedo}
+                aria-label="Redo"
+                className="p-1 rounded transition-colors duration-200 text-purple-700 hover:bg-purple-200  dark:text-purple-300 dark:hover:bg-purple-900 disabled:opacity-50 disabled:cursor-not-allowed"
+                disabled={historyStep === historyLength - 1}
+              />
+            }
+          >
+            <Redo size={16} />
           </TooltipTrigger>
           <TooltipContent>Redo</TooltipContent>
         </Tooltip>
@@ -163,27 +175,31 @@ export const AnnotatorToolbar = ({
         <div className="w-px bg-gray-200 dark:bg-gray-700 h-4" />
 
         <Tooltip>
-          <TooltipTrigger>
-            <button
-              onClick={onSubmit}
-              aria-label="Add to Chat"
-              className="p-1 rounded transition-colors duration-200 text-purple-700 hover:bg-purple-200 dark:text-purple-300 dark:hover:bg-purple-900 disabled:opacity-50 disabled:cursor-not-allowed"
-              disabled={!hasSubmitHandler}
-            >
-              <Check size={16} />
-            </button>
+          <TooltipTrigger
+            render={
+              <button
+                onClick={onSubmit}
+                aria-label="Add to Chat"
+                className="p-1 rounded transition-colors duration-200 text-purple-700 hover:bg-purple-200 dark:text-purple-300 dark:hover:bg-purple-900 disabled:opacity-50 disabled:cursor-not-allowed"
+                disabled={!hasSubmitHandler}
+              />
+            }
+          >
+            <Check size={16} />
           </TooltipTrigger>
           <TooltipContent>Add to Chat</TooltipContent>
         </Tooltip>
         <Tooltip>
-          <TooltipTrigger>
-            <button
-              onClick={onDeactivate}
-              aria-label="Close Annotator"
-              className="p-1 rounded transition-colors duration-200 text-purple-700 hover:bg-purple-200 dark:text-purple-300 dark:hover:bg-purple-900"
-            >
-              <X size={16} />
-            </button>
+          <TooltipTrigger
+            render={
+              <button
+                onClick={onDeactivate}
+                aria-label="Close Annotator"
+                className="p-1 rounded transition-colors duration-200 text-purple-700 hover:bg-purple-200 dark:text-purple-300 dark:hover:bg-purple-900"
+              />
+            }
+          >
+            <X size={16} />
           </TooltipTrigger>
           <TooltipContent>Close Annotator</TooltipContent>
         </Tooltip>

--- a/src/components/preview_panel/AnnotatorToolbar.tsx
+++ b/src/components/preview_panel/AnnotatorToolbar.tsx
@@ -10,6 +10,11 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { ToolbarColorPicker } from "./ToolbarColorPicker";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
 
 interface AnnotatorToolbarProps {
   tool: "select" | "draw" | "text";
@@ -46,108 +51,142 @@ export const AnnotatorToolbar = ({
     <div className="flex items-center justify-center p-2 border-b space-x-2">
       {/* Tool Selection Buttons */}
       <div className="flex space-x-1">
-        <button
-          onClick={() => onToolChange("select")}
-          aria-label="Select"
-          title="Select"
-          className={cn(
-            "p-1 rounded transition-colors duration-200",
-            tool === "select"
-              ? "bg-purple-500 text-white hover:bg-purple-600 dark:bg-purple-600 dark:hover:bg-purple-700"
-              : " text-purple-700 hover:bg-purple-200  dark:text-purple-300 dark:hover:bg-purple-900",
-          )}
-        >
-          <MousePointer2 size={16} />
-        </button>
+        <Tooltip>
+          <TooltipTrigger>
+            <button
+              onClick={() => onToolChange("select")}
+              aria-label="Select"
+              className={cn(
+                "p-1 rounded transition-colors duration-200",
+                tool === "select"
+                  ? "bg-purple-500 text-white hover:bg-purple-600 dark:bg-purple-600 dark:hover:bg-purple-700"
+                  : " text-purple-700 hover:bg-purple-200  dark:text-purple-300 dark:hover:bg-purple-900",
+              )}
+            >
+              <MousePointer2 size={16} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Select</TooltipContent>
+        </Tooltip>
 
-        <button
-          onClick={() => onToolChange("draw")}
-          aria-label="Draw"
-          title="Draw"
-          className={cn(
-            "p-1 rounded transition-colors duration-200",
-            tool === "draw"
-              ? "bg-purple-500 text-white hover:bg-purple-600 dark:bg-purple-600 dark:hover:bg-purple-700"
-              : " text-purple-700 hover:bg-purple-200  dark:text-purple-300 dark:hover:bg-purple-900",
-          )}
-        >
-          <Pencil size={16} />
-        </button>
+        <Tooltip>
+          <TooltipTrigger>
+            <button
+              onClick={() => onToolChange("draw")}
+              aria-label="Draw"
+              className={cn(
+                "p-1 rounded transition-colors duration-200",
+                tool === "draw"
+                  ? "bg-purple-500 text-white hover:bg-purple-600 dark:bg-purple-600 dark:hover:bg-purple-700"
+                  : " text-purple-700 hover:bg-purple-200  dark:text-purple-300 dark:hover:bg-purple-900",
+              )}
+            >
+              <Pencil size={16} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Draw</TooltipContent>
+        </Tooltip>
 
-        <button
-          onClick={() => onToolChange("text")}
-          aria-label="Text"
-          title="Text"
-          className={cn(
-            "p-1 rounded transition-colors duration-200",
-            tool === "text"
-              ? "bg-purple-500 text-white hover:bg-purple-600 dark:bg-purple-600 dark:hover:bg-purple-700"
-              : "text-purple-700 hover:bg-purple-200  dark:text-purple-300 dark:hover:bg-purple-900",
-          )}
-        >
-          <Type size={16} />
-        </button>
+        <Tooltip>
+          <TooltipTrigger>
+            <button
+              onClick={() => onToolChange("text")}
+              aria-label="Text"
+              className={cn(
+                "p-1 rounded transition-colors duration-200",
+                tool === "text"
+                  ? "bg-purple-500 text-white hover:bg-purple-600 dark:bg-purple-600 dark:hover:bg-purple-700"
+                  : "text-purple-700 hover:bg-purple-200  dark:text-purple-300 dark:hover:bg-purple-900",
+              )}
+            >
+              <Type size={16} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Text</TooltipContent>
+        </Tooltip>
 
-        <div
-          className="p-1 rounded transition-colors duration-200 hover:bg-purple-200 dark:hover:bg-purple-900"
-          title="Color"
-        >
-          <ToolbarColorPicker color={color} onChange={onColorChange} />
-        </div>
-
-        <div className="w-px bg-gray-200 dark:bg-gray-700 h-4" />
-
-        <button
-          onClick={onDelete}
-          aria-label="Delete"
-          title="Delete Selected"
-          className="p-1 rounded transition-colors duration-200 text-purple-700 hover:bg-purple-200  dark:text-purple-300 dark:hover:bg-purple-900 disabled:opacity-50 disabled:cursor-not-allowed"
-          disabled={!selectedId}
-        >
-          <Trash2 size={16} />
-        </button>
-
-        <div className="w-px bg-gray-200 dark:bg-gray-700 h-4" />
-
-        <button
-          onClick={onUndo}
-          aria-label="Undo"
-          title="Undo"
-          className="p-1 rounded transition-colors duration-200 text-purple-700 hover:bg-purple-200  dark:text-purple-300 dark:hover:bg-purple-900 disabled:opacity-50 disabled:cursor-not-allowed"
-          disabled={historyStep === 0}
-        >
-          <Undo size={16} />
-        </button>
-
-        <button
-          onClick={onRedo}
-          aria-label="Redo"
-          title="Redo"
-          className="p-1 rounded transition-colors duration-200 text-purple-700 hover:bg-purple-200  dark:text-purple-300 dark:hover:bg-purple-900 disabled:opacity-50 disabled:cursor-not-allowed"
-          disabled={historyStep === historyLength - 1}
-        >
-          <Redo size={16} />
-        </button>
+        <Tooltip>
+          <TooltipTrigger>
+            <div className="p-1 rounded transition-colors duration-200 hover:bg-purple-200 dark:hover:bg-purple-900">
+              <ToolbarColorPicker color={color} onChange={onColorChange} />
+            </div>
+          </TooltipTrigger>
+          <TooltipContent>Color</TooltipContent>
+        </Tooltip>
 
         <div className="w-px bg-gray-200 dark:bg-gray-700 h-4" />
 
-        <button
-          onClick={onSubmit}
-          aria-label="Add to Chat"
-          title="Add to Chat"
-          className="p-1 rounded transition-colors duration-200 text-purple-700 hover:bg-purple-200 dark:text-purple-300 dark:hover:bg-purple-900 disabled:opacity-50 disabled:cursor-not-allowed"
-          disabled={!hasSubmitHandler}
-        >
-          <Check size={16} />
-        </button>
-        <button
-          onClick={onDeactivate}
-          aria-label="Close Annotator"
-          title="Close Annotator"
-          className="p-1 rounded transition-colors duration-200 text-purple-700 hover:bg-purple-200 dark:text-purple-300 dark:hover:bg-purple-900"
-        >
-          <X size={16} />
-        </button>
+        <Tooltip>
+          <TooltipTrigger>
+            <button
+              onClick={onDelete}
+              aria-label="Delete"
+              className="p-1 rounded transition-colors duration-200 text-purple-700 hover:bg-purple-200  dark:text-purple-300 dark:hover:bg-purple-900 disabled:opacity-50 disabled:cursor-not-allowed"
+              disabled={!selectedId}
+            >
+              <Trash2 size={16} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Delete Selected</TooltipContent>
+        </Tooltip>
+
+        <div className="w-px bg-gray-200 dark:bg-gray-700 h-4" />
+
+        <Tooltip>
+          <TooltipTrigger>
+            <button
+              onClick={onUndo}
+              aria-label="Undo"
+              className="p-1 rounded transition-colors duration-200 text-purple-700 hover:bg-purple-200  dark:text-purple-300 dark:hover:bg-purple-900 disabled:opacity-50 disabled:cursor-not-allowed"
+              disabled={historyStep === 0}
+            >
+              <Undo size={16} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Undo</TooltipContent>
+        </Tooltip>
+
+        <Tooltip>
+          <TooltipTrigger>
+            <button
+              onClick={onRedo}
+              aria-label="Redo"
+              className="p-1 rounded transition-colors duration-200 text-purple-700 hover:bg-purple-200  dark:text-purple-300 dark:hover:bg-purple-900 disabled:opacity-50 disabled:cursor-not-allowed"
+              disabled={historyStep === historyLength - 1}
+            >
+              <Redo size={16} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Redo</TooltipContent>
+        </Tooltip>
+
+        <div className="w-px bg-gray-200 dark:bg-gray-700 h-4" />
+
+        <Tooltip>
+          <TooltipTrigger>
+            <button
+              onClick={onSubmit}
+              aria-label="Add to Chat"
+              className="p-1 rounded transition-colors duration-200 text-purple-700 hover:bg-purple-200 dark:text-purple-300 dark:hover:bg-purple-900 disabled:opacity-50 disabled:cursor-not-allowed"
+              disabled={!hasSubmitHandler}
+            >
+              <Check size={16} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Add to Chat</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger>
+            <button
+              onClick={onDeactivate}
+              aria-label="Close Annotator"
+              className="p-1 rounded transition-colors duration-200 text-purple-700 hover:bg-purple-200 dark:text-purple-300 dark:hover:bg-purple-900"
+            >
+              <X size={16} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Close Annotator</TooltipContent>
+        </Tooltip>
       </div>
     </div>
   );

--- a/src/components/preview_panel/CodeView.tsx
+++ b/src/components/preview_panel/CodeView.tsx
@@ -65,31 +65,31 @@ export const CodeView = ({ loading, app }: CodeViewProps) => {
         {/* Toolbar */}
         <div className="flex items-center p-2 border-b space-x-2">
           <Tooltip>
-            <TooltipTrigger>
-              <button
-                onClick={() => refreshApp()}
-                className="p-1 rounded hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed"
-                disabled={loading || !app.id}
-              >
-                <RefreshCw size={16} />
-              </button>
+            <TooltipTrigger
+              render={
+                <button
+                  onClick={() => refreshApp()}
+                  className="p-1 rounded hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed"
+                  disabled={loading || !app.id}
+                />
+              }
+            >
+              <RefreshCw size={16} />
             </TooltipTrigger>
             <TooltipContent>Refresh Files</TooltipContent>
           </Tooltip>
           <div className="text-sm text-gray-500">{app.files.length} files</div>
           <div className="flex-1" />
           <Tooltip>
-            <TooltipTrigger>
-              <button
-                onClick={() => setIsFullscreen((value) => !value)}
-                className="p-1 rounded hover:bg-gray-200"
-              >
-                {isFullscreen ? (
-                  <Minimize2 size={16} />
-                ) : (
-                  <Maximize2 size={16} />
-                )}
-              </button>
+            <TooltipTrigger
+              render={
+                <button
+                  onClick={() => setIsFullscreen((value) => !value)}
+                  className="p-1 rounded hover:bg-gray-200"
+                />
+              }
+            >
+              {isFullscreen ? <Minimize2 size={16} /> : <Maximize2 size={16} />}
             </TooltipTrigger>
             <TooltipContent>
               {isFullscreen ? "Exit full screen" : "Enter full screen"}

--- a/src/components/preview_panel/CodeView.tsx
+++ b/src/components/preview_panel/CodeView.tsx
@@ -3,6 +3,11 @@ import { FileTree } from "./FileTree";
 import { useEffect, useState } from "react";
 import { useLoadApp } from "@/hooks/useLoadApp";
 import { RefreshCw, Maximize2, Minimize2 } from "lucide-react";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
 import { useAtomValue } from "jotai";
 import { selectedFileAtom } from "@/atoms/viewAtoms";
 
@@ -59,23 +64,37 @@ export const CodeView = ({ loading, app }: CodeViewProps) => {
       >
         {/* Toolbar */}
         <div className="flex items-center p-2 border-b space-x-2">
-          <button
-            onClick={() => refreshApp()}
-            className="p-1 rounded hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed"
-            disabled={loading || !app.id}
-            title="Refresh Files"
-          >
-            <RefreshCw size={16} />
-          </button>
+          <Tooltip>
+            <TooltipTrigger>
+              <button
+                onClick={() => refreshApp()}
+                className="p-1 rounded hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed"
+                disabled={loading || !app.id}
+              >
+                <RefreshCw size={16} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Refresh Files</TooltipContent>
+          </Tooltip>
           <div className="text-sm text-gray-500">{app.files.length} files</div>
           <div className="flex-1" />
-          <button
-            onClick={() => setIsFullscreen((value) => !value)}
-            className="p-1 rounded hover:bg-gray-200"
-            title={isFullscreen ? "Exit full screen" : "Enter full screen"}
-          >
-            {isFullscreen ? <Minimize2 size={16} /> : <Maximize2 size={16} />}
-          </button>
+          <Tooltip>
+            <TooltipTrigger>
+              <button
+                onClick={() => setIsFullscreen((value) => !value)}
+                className="p-1 rounded hover:bg-gray-200"
+              >
+                {isFullscreen ? (
+                  <Minimize2 size={16} />
+                ) : (
+                  <Maximize2 size={16} />
+                )}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>
+              {isFullscreen ? "Exit full screen" : "Enter full screen"}
+            </TooltipContent>
+          </Tooltip>
         </div>
 
         {/* Content */}

--- a/src/components/preview_panel/ConsoleEntry.tsx
+++ b/src/components/preview_panel/ConsoleEntry.tsx
@@ -7,6 +7,11 @@ import {
 } from "lucide-react";
 import { useSetAtom } from "jotai";
 import { chatInputValueAtom } from "@/atoms/chatAtoms";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
 
 interface ConsoleEntryProps {
   type: "server" | "client" | "edge-function" | "network-requests";
@@ -120,14 +125,18 @@ export const ConsoleEntryComponent = (props: ConsoleEntryProps) => {
           )}
         </span>
       </div>
-      <button
-        onClick={handleSendToChat}
-        title="Send to chat"
-        className="absolute top-1 right-1 opacity-0 group-hover:opacity-100 transition-opacity p-1 hover:bg-gray-200 dark:hover:bg-gray-700 rounded"
-        data-testid="send-to-chat"
-      >
-        <MessageSquare size={12} className="text-gray-500" />
-      </button>
+      <Tooltip>
+        <TooltipTrigger>
+          <button
+            onClick={handleSendToChat}
+            className="absolute top-1 right-1 opacity-0 group-hover:opacity-100 transition-opacity p-1 hover:bg-gray-200 dark:hover:bg-gray-700 rounded"
+            data-testid="send-to-chat"
+          >
+            <MessageSquare size={12} className="text-gray-500" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>Send to chat</TooltipContent>
+      </Tooltip>
     </div>
   );
 };

--- a/src/components/preview_panel/ConsoleEntry.tsx
+++ b/src/components/preview_panel/ConsoleEntry.tsx
@@ -126,14 +126,16 @@ export const ConsoleEntryComponent = (props: ConsoleEntryProps) => {
         </span>
       </div>
       <Tooltip>
-        <TooltipTrigger>
-          <button
-            onClick={handleSendToChat}
-            className="absolute top-1 right-1 opacity-0 group-hover:opacity-100 transition-opacity p-1 hover:bg-gray-200 dark:hover:bg-gray-700 rounded"
-            data-testid="send-to-chat"
-          >
-            <MessageSquare size={12} className="text-gray-500" />
-          </button>
+        <TooltipTrigger
+          render={
+            <button
+              onClick={handleSendToChat}
+              className="absolute top-1 right-1 opacity-0 group-hover:opacity-100 transition-opacity p-1 hover:bg-gray-200 dark:hover:bg-gray-700 rounded"
+              data-testid="send-to-chat"
+            />
+          }
+        >
+          <MessageSquare size={12} className="text-gray-500" />
         </TooltipTrigger>
         <TooltipContent>Send to chat</TooltipContent>
       </Tooltip>

--- a/src/components/preview_panel/ConsoleFilters.tsx
+++ b/src/components/preview_panel/ConsoleFilters.tsx
@@ -115,14 +115,16 @@ export const ConsoleFilters = ({
 
       {/* Clear logs button */}
       <Tooltip>
-        <TooltipTrigger>
-          <button
-            onClick={onClearLogs}
-            className="p-1 border border-border rounded bg-transparent hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
-            data-testid="clear-logs-button"
-          >
-            <Trash2 size={14} />
-          </button>
+        <TooltipTrigger
+          render={
+            <button
+              onClick={onClearLogs}
+              className="p-1 border border-border rounded bg-transparent hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+              data-testid="clear-logs-button"
+            />
+          }
+        >
+          <Trash2 size={14} />
         </TooltipTrigger>
         <TooltipContent>Clear logs</TooltipContent>
       </Tooltip>

--- a/src/components/preview_panel/ConsoleFilters.tsx
+++ b/src/components/preview_panel/ConsoleFilters.tsx
@@ -1,4 +1,9 @@
 import { Filter, X, Trash2 } from "lucide-react";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
 
 interface ConsoleFiltersProps {
   levelFilter: "all" | "info" | "warn" | "error";
@@ -109,14 +114,18 @@ export const ConsoleFilters = ({
       )}
 
       {/* Clear logs button */}
-      <button
-        onClick={onClearLogs}
-        className="p-1 border border-border rounded bg-transparent hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
-        data-testid="clear-logs-button"
-        title="Clear logs"
-      >
-        <Trash2 size={14} />
-      </button>
+      <Tooltip>
+        <TooltipTrigger>
+          <button
+            onClick={onClearLogs}
+            className="p-1 border border-border rounded bg-transparent hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+            data-testid="clear-logs-button"
+          >
+            <Trash2 size={14} />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>Clear logs</TooltipContent>
+      </Tooltip>
 
       <div className="ml-auto text-xs text-gray-500">{totalLogs} logs</div>
     </div>

--- a/src/components/preview_panel/DraggableTextInput.tsx
+++ b/src/components/preview_panel/DraggableTextInput.tsx
@@ -1,5 +1,10 @@
 import React, { useState, useRef, useEffect } from "react";
 import { X } from "lucide-react";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
 
 interface DraggableTextInputProps {
   input: {
@@ -101,35 +106,39 @@ export const DraggableTextInput = ({
     >
       <div className="relative">
         {/* Drag Handle */}
-        <div
-          className="absolute left-2 top-1/2 -translate-y-1/2 cursor-move p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors z-10"
-          onMouseDown={(e) => {
-            setIsDragging(true);
-            dragOffset.current = {
-              x: e.clientX - input.x,
-              y: e.clientY - input.y,
-            };
-            e.preventDefault();
-            e.stopPropagation();
-          }}
-          title="Drag to move"
-        >
-          {/* Grip dots icon - smaller and more subtle */}
-          <svg
-            width="8"
-            height="12"
-            viewBox="0 0 8 12"
-            fill="currentColor"
-            className="text-gray-400 dark:text-gray-500"
-          >
-            <circle cx="2" cy="2" r="1" />
-            <circle cx="6" cy="2" r="1" />
-            <circle cx="2" cy="6" r="1" />
-            <circle cx="6" cy="6" r="1" />
-            <circle cx="2" cy="10" r="1" />
-            <circle cx="6" cy="10" r="1" />
-          </svg>
-        </div>
+        <Tooltip>
+          <TooltipTrigger>
+            <div
+              className="absolute left-2 top-1/2 -translate-y-1/2 cursor-move p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors z-10"
+              onMouseDown={(e) => {
+                setIsDragging(true);
+                dragOffset.current = {
+                  x: e.clientX - input.x,
+                  y: e.clientY - input.y,
+                };
+                e.preventDefault();
+                e.stopPropagation();
+              }}
+            >
+              {/* Grip dots icon - smaller and more subtle */}
+              <svg
+                width="8"
+                height="12"
+                viewBox="0 0 8 12"
+                fill="currentColor"
+                className="text-gray-400 dark:text-gray-500"
+              >
+                <circle cx="2" cy="2" r="1" />
+                <circle cx="6" cy="2" r="1" />
+                <circle cx="2" cy="6" r="1" />
+                <circle cx="6" cy="6" r="1" />
+                <circle cx="2" cy="10" r="1" />
+                <circle cx="6" cy="10" r="1" />
+              </svg>
+            </div>
+          </TooltipTrigger>
+          <TooltipContent>Drag to move</TooltipContent>
+        </Tooltip>
 
         <span
           ref={(e) => {
@@ -158,18 +167,22 @@ export const DraggableTextInput = ({
         />
 
         {/* Close Button - Rightmost */}
-        <button
-          className="absolute right-2 top-1/2 -translate-y-1/2 p-1 hover:bg-red-100 dark:hover:bg-red-900/30 rounded transition-colors z-10 group"
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            onRemove(input.id);
-          }}
-          title="Remove text input"
-          type="button"
-        >
-          <X className="w-3 h-3 text-gray-400 dark:text-gray-500 group-hover:text-red-600 dark:group-hover:text-red-400" />
-        </button>
+        <Tooltip>
+          <TooltipTrigger>
+            <button
+              className="absolute right-2 top-1/2 -translate-y-1/2 p-1 hover:bg-red-100 dark:hover:bg-red-900/30 rounded transition-colors z-10 group"
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                onRemove(input.id);
+              }}
+              type="button"
+            >
+              <X className="w-3 h-3 text-gray-400 dark:text-gray-500 group-hover:text-red-600 dark:group-hover:text-red-400" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Remove text input</TooltipContent>
+        </Tooltip>
       </div>
     </div>
   );

--- a/src/components/preview_panel/DraggableTextInput.tsx
+++ b/src/components/preview_panel/DraggableTextInput.tsx
@@ -106,39 +106,35 @@ export const DraggableTextInput = ({
     >
       <div className="relative">
         {/* Drag Handle */}
-        <Tooltip>
-          <TooltipTrigger>
-            <div
-              className="absolute left-2 top-1/2 -translate-y-1/2 cursor-move p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors z-10"
-              onMouseDown={(e) => {
-                setIsDragging(true);
-                dragOffset.current = {
-                  x: e.clientX - input.x,
-                  y: e.clientY - input.y,
-                };
-                e.preventDefault();
-                e.stopPropagation();
-              }}
-            >
-              {/* Grip dots icon - smaller and more subtle */}
-              <svg
-                width="8"
-                height="12"
-                viewBox="0 0 8 12"
-                fill="currentColor"
-                className="text-gray-400 dark:text-gray-500"
-              >
-                <circle cx="2" cy="2" r="1" />
-                <circle cx="6" cy="2" r="1" />
-                <circle cx="2" cy="6" r="1" />
-                <circle cx="6" cy="6" r="1" />
-                <circle cx="2" cy="10" r="1" />
-                <circle cx="6" cy="10" r="1" />
-              </svg>
-            </div>
-          </TooltipTrigger>
-          <TooltipContent>Drag to move</TooltipContent>
-        </Tooltip>
+        <div
+          className="absolute left-2 top-1/2 -translate-y-1/2 cursor-move p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors z-10"
+          onMouseDown={(e) => {
+            setIsDragging(true);
+            dragOffset.current = {
+              x: e.clientX - input.x,
+              y: e.clientY - input.y,
+            };
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+          title="Drag to move"
+        >
+          {/* Grip dots icon - smaller and more subtle */}
+          <svg
+            width="8"
+            height="12"
+            viewBox="0 0 8 12"
+            fill="currentColor"
+            className="text-gray-400 dark:text-gray-500"
+          >
+            <circle cx="2" cy="2" r="1" />
+            <circle cx="6" cy="2" r="1" />
+            <circle cx="2" cy="6" r="1" />
+            <circle cx="6" cy="6" r="1" />
+            <circle cx="2" cy="10" r="1" />
+            <circle cx="6" cy="10" r="1" />
+          </svg>
+        </div>
 
         <span
           ref={(e) => {
@@ -168,18 +164,20 @@ export const DraggableTextInput = ({
 
         {/* Close Button - Rightmost */}
         <Tooltip>
-          <TooltipTrigger>
-            <button
-              className="absolute right-2 top-1/2 -translate-y-1/2 p-1 hover:bg-red-100 dark:hover:bg-red-900/30 rounded transition-colors z-10 group"
-              onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                onRemove(input.id);
-              }}
-              type="button"
-            >
-              <X className="w-3 h-3 text-gray-400 dark:text-gray-500 group-hover:text-red-600 dark:group-hover:text-red-400" />
-            </button>
+          <TooltipTrigger
+            render={
+              <button
+                className="absolute right-2 top-1/2 -translate-y-1/2 p-1 hover:bg-red-100 dark:hover:bg-red-900/30 rounded transition-colors z-10 group"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  onRemove(input.id);
+                }}
+                type="button"
+              />
+            }
+          >
+            <X className="w-3 h-3 text-gray-400 dark:text-gray-500 group-hover:text-red-600 dark:group-hover:text-red-400" />
           </TooltipTrigger>
           <TooltipContent>Remove text input</TooltipContent>
         </Tooltip>

--- a/src/components/preview_panel/FileEditor.tsx
+++ b/src/components/preview_panel/FileEditor.tsx
@@ -12,6 +12,11 @@ import { useSettings } from "@/hooks/useSettings";
 import { useCheckProblems } from "@/hooks/useCheckProblems";
 import { getLanguage } from "@/utils/get_language";
 import { queryKeys } from "@/lib/queryKeys";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
 
 interface FileEditorProps {
   appId: number | null;
@@ -53,17 +58,23 @@ const Breadcrumb: React.FC<BreadcrumbProps> = ({
           ))}
         </div>
         <div className="flex items-center gap-2 flex-shrink-0 ml-2">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={onSave}
-            disabled={!hasUnsavedChanges || isSaving}
-            className="h-6 w-6 p-0"
-            data-testid="save-file-button"
-            title={hasUnsavedChanges ? "Save changes" : "No unsaved changes"}
-          >
-            <Save size={12} />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={onSave}
+                disabled={!hasUnsavedChanges || isSaving}
+                className="h-6 w-6 p-0"
+                data-testid="save-file-button"
+              >
+                <Save size={12} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              {hasUnsavedChanges ? "Save changes" : "No unsaved changes"}
+            </TooltipContent>
+          </Tooltip>
           {hasUnsavedChanges && (
             <Circle
               size={8}

--- a/src/components/preview_panel/FileEditor.tsx
+++ b/src/components/preview_panel/FileEditor.tsx
@@ -59,17 +59,19 @@ const Breadcrumb: React.FC<BreadcrumbProps> = ({
         </div>
         <div className="flex items-center gap-2 flex-shrink-0 ml-2">
           <Tooltip>
-            <TooltipTrigger>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={onSave}
-                disabled={!hasUnsavedChanges || isSaving}
-                className="h-6 w-6 p-0"
-                data-testid="save-file-button"
-              >
-                <Save size={12} />
-              </Button>
+            <TooltipTrigger
+              render={
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={onSave}
+                  disabled={!hasUnsavedChanges || isSaving}
+                  className="h-6 w-6 p-0"
+                  data-testid="save-file-button"
+                />
+              }
+            >
+              <Save size={12} />
             </TooltipTrigger>
             <TooltipContent>
               {hasUnsavedChanges ? "Save changes" : "No unsaved changes"}

--- a/src/components/preview_panel/PreviewIframe.tsx
+++ b/src/components/preview_panel/PreviewIframe.tsx
@@ -995,39 +995,45 @@ export const PreviewIframe = ({ loading }: { loading: boolean }) => {
           {/* Navigation Buttons */}
           <div className="flex space-x-1">
             <Tooltip>
-              <TooltipTrigger>
-                <button
-                  onClick={() => setIsChatPanelHidden(!isChatPanelHidden)}
-                  className="p-1 rounded transition-colors duration-200 hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300"
-                  data-testid="preview-toggle-chat-panel-button"
-                >
-                  {isChatPanelHidden ? (
-                    <Maximize2 size={16} />
-                  ) : (
-                    <Minimize2 size={16} />
-                  )}
-                </button>
+              <TooltipTrigger
+                render={
+                  <button
+                    onClick={() => setIsChatPanelHidden(!isChatPanelHidden)}
+                    className="p-1 rounded transition-colors duration-200 hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300"
+                    data-testid="preview-toggle-chat-panel-button"
+                  />
+                }
+              >
+                {isChatPanelHidden ? (
+                  <Maximize2 size={16} />
+                ) : (
+                  <Minimize2 size={16} />
+                )}
               </TooltipTrigger>
               <TooltipContent>
                 {isChatPanelHidden ? "Show chat" : "Hide chat"}
               </TooltipContent>
             </Tooltip>
             <Tooltip>
-              <TooltipTrigger>
-                <button
-                  onClick={handleActivateComponentSelector}
-                  className={`p-1 rounded transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed ${
-                    isPicking
-                      ? "bg-purple-500 text-white hover:bg-purple-600 dark:bg-purple-600 dark:hover:bg-purple-700"
-                      : " text-purple-700 hover:bg-purple-200  dark:text-purple-300 dark:hover:bg-purple-900"
-                  }`}
-                  disabled={
-                    loading || !selectedAppId || !isComponentSelectorInitialized
-                  }
-                  data-testid="preview-pick-element-button"
-                >
-                  <MousePointerClick size={16} />
-                </button>
+              <TooltipTrigger
+                render={
+                  <button
+                    onClick={handleActivateComponentSelector}
+                    className={`p-1 rounded transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed ${
+                      isPicking
+                        ? "bg-purple-500 text-white hover:bg-purple-600 dark:bg-purple-600 dark:hover:bg-purple-700"
+                        : " text-purple-700 hover:bg-purple-200  dark:text-purple-300 dark:hover:bg-purple-900"
+                    }`}
+                    disabled={
+                      loading ||
+                      !selectedAppId ||
+                      !isComponentSelectorInitialized
+                    }
+                    data-testid="preview-pick-element-button"
+                  />
+                }
+              >
+                <MousePointerClick size={16} />
               </TooltipTrigger>
               <TooltipContent>
                 {isPicking
@@ -1036,24 +1042,26 @@ export const PreviewIframe = ({ loading }: { loading: boolean }) => {
               </TooltipContent>
             </Tooltip>
             <Tooltip>
-              <TooltipTrigger>
-                <button
-                  onClick={handleAnnotatorClick}
-                  className={`p-1 rounded transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed ${
-                    annotatorMode
-                      ? "bg-purple-500 text-white hover:bg-purple-600 dark:bg-purple-600 dark:hover:bg-purple-700"
-                      : " text-purple-700 hover:bg-purple-200  dark:text-purple-300 dark:hover:bg-purple-900"
-                  }`}
-                  disabled={
-                    loading ||
-                    !selectedAppId ||
-                    isPicking ||
-                    !isComponentSelectorInitialized
-                  }
-                  data-testid="preview-annotator-button"
-                >
-                  <Pen size={16} />
-                </button>
+              <TooltipTrigger
+                render={
+                  <button
+                    onClick={handleAnnotatorClick}
+                    className={`p-1 rounded transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed ${
+                      annotatorMode
+                        ? "bg-purple-500 text-white hover:bg-purple-600 dark:bg-purple-600 dark:hover:bg-purple-700"
+                        : " text-purple-700 hover:bg-purple-200  dark:text-purple-300 dark:hover:bg-purple-900"
+                    }`}
+                    disabled={
+                      loading ||
+                      !selectedAppId ||
+                      isPicking ||
+                      !isComponentSelectorInitialized
+                    }
+                    data-testid="preview-annotator-button"
+                  />
+                }
+              >
+                <Pen size={16} />
               </TooltipTrigger>
               <TooltipContent>
                 {annotatorMode ? "Annotator mode active" : "Activate annotator"}
@@ -1126,14 +1134,16 @@ export const PreviewIframe = ({ loading }: { loading: boolean }) => {
           {/* Action Buttons */}
           <div className="flex space-x-1">
             <Tooltip>
-              <TooltipTrigger>
-                <button
-                  onClick={onRestart}
-                  className="flex items-center space-x-1 px-3 py-1 rounded-md text-sm hover:bg-[var(--background-darkest)] transition-colors"
-                >
-                  <Power size={16} />
-                  <span>Restart</span>
-                </button>
+              <TooltipTrigger
+                render={
+                  <button
+                    onClick={onRestart}
+                    className="flex items-center space-x-1 px-3 py-1 rounded-md text-sm hover:bg-[var(--background-darkest)] transition-colors"
+                  />
+                }
+              >
+                <Power size={16} />
+                <span>Restart</span>
               </TooltipTrigger>
               <TooltipContent>Restart App</TooltipContent>
             </Tooltip>
@@ -1152,23 +1162,25 @@ export const PreviewIframe = ({ loading }: { loading: boolean }) => {
             {/* Device Mode Button */}
             <Popover open={isDevicePopoverOpen} modal={false}>
               <Tooltip>
-                <TooltipTrigger>
-                  <PopoverTrigger
-                    data-testid="device-mode-button"
-                    onClick={() => {
-                      // Toggle popover open/close
-                      if (isDevicePopoverOpen)
-                        updateSettings({ previewDeviceMode: "desktop" });
-                      setIsDevicePopoverOpen(!isDevicePopoverOpen);
-                    }}
-                    className={cn(
-                      "p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 dark:text-gray-300",
-                      deviceMode !== "desktop" &&
-                        "bg-gray-200 dark:bg-gray-700",
-                    )}
-                  >
-                    <MonitorSmartphone size={16} />
-                  </PopoverTrigger>
+                <TooltipTrigger
+                  render={
+                    <PopoverTrigger
+                      data-testid="device-mode-button"
+                      onClick={() => {
+                        // Toggle popover open/close
+                        if (isDevicePopoverOpen)
+                          updateSettings({ previewDeviceMode: "desktop" });
+                        setIsDevicePopoverOpen(!isDevicePopoverOpen);
+                      }}
+                      className={cn(
+                        "p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 dark:text-gray-300",
+                        deviceMode !== "desktop" &&
+                          "bg-gray-200 dark:bg-gray-700",
+                      )}
+                    />
+                  }
+                >
+                  <MonitorSmartphone size={16} />
                 </TooltipTrigger>
                 <TooltipContent>Device Mode</TooltipContent>
               </Tooltip>
@@ -1188,29 +1200,41 @@ export const PreviewIframe = ({ loading }: { loading: boolean }) => {
                   variant="outline"
                 >
                   <Tooltip>
-                    <TooltipTrigger>
-                      <ToggleGroupItem
-                        value="desktop"
-                        aria-label="Desktop view"
-                      >
-                        <Monitor size={16} />
-                      </ToggleGroupItem>
+                    <TooltipTrigger
+                      render={
+                        <ToggleGroupItem
+                          value="desktop"
+                          aria-label="Desktop view"
+                        />
+                      }
+                    >
+                      <Monitor size={16} />
                     </TooltipTrigger>
                     <TooltipContent>Desktop</TooltipContent>
                   </Tooltip>
                   <Tooltip>
-                    <TooltipTrigger>
-                      <ToggleGroupItem value="tablet" aria-label="Tablet view">
-                        <Tablet size={16} className="scale-x-130" />
-                      </ToggleGroupItem>
+                    <TooltipTrigger
+                      render={
+                        <ToggleGroupItem
+                          value="tablet"
+                          aria-label="Tablet view"
+                        />
+                      }
+                    >
+                      <Tablet size={16} className="scale-x-130" />
                     </TooltipTrigger>
                     <TooltipContent>Tablet</TooltipContent>
                   </Tooltip>
                   <Tooltip>
-                    <TooltipTrigger>
-                      <ToggleGroupItem value="mobile" aria-label="Mobile view">
-                        <Smartphone size={16} />
-                      </ToggleGroupItem>
+                    <TooltipTrigger
+                      render={
+                        <ToggleGroupItem
+                          value="mobile"
+                          aria-label="Mobile view"
+                        />
+                      }
+                    >
+                      <Smartphone size={16} />
                     </TooltipTrigger>
                     <TooltipContent>Mobile</TooltipContent>
                   </Tooltip>

--- a/src/components/preview_panel/PreviewIframe.tsx
+++ b/src/components/preview_panel/PreviewIframe.tsx
@@ -57,6 +57,11 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
 import { useRunApp } from "@/hooks/useRunApp";
 import { useSettings } from "@/hooks/useSettings";
 import { useShortcut } from "@/hooks/useShortcut";
@@ -989,57 +994,71 @@ export const PreviewIframe = ({ loading }: { loading: boolean }) => {
         <div className="flex items-center p-2 border-b space-x-2">
           {/* Navigation Buttons */}
           <div className="flex space-x-1">
-            <button
-              onClick={() => setIsChatPanelHidden(!isChatPanelHidden)}
-              className="p-1 rounded transition-colors duration-200 hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300"
-              data-testid="preview-toggle-chat-panel-button"
-              title={isChatPanelHidden ? "Show chat" : "Hide chat"}
-            >
-              {isChatPanelHidden ? (
-                <Maximize2 size={16} />
-              ) : (
-                <Minimize2 size={16} />
-              )}
-            </button>
-            <button
-              onClick={handleActivateComponentSelector}
-              className={`p-1 rounded transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed ${
-                isPicking
-                  ? "bg-purple-500 text-white hover:bg-purple-600 dark:bg-purple-600 dark:hover:bg-purple-700"
-                  : " text-purple-700 hover:bg-purple-200  dark:text-purple-300 dark:hover:bg-purple-900"
-              }`}
-              disabled={
-                loading || !selectedAppId || !isComponentSelectorInitialized
-              }
-              data-testid="preview-pick-element-button"
-              title={
-                isPicking
+            <Tooltip>
+              <TooltipTrigger>
+                <button
+                  onClick={() => setIsChatPanelHidden(!isChatPanelHidden)}
+                  className="p-1 rounded transition-colors duration-200 hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300"
+                  data-testid="preview-toggle-chat-panel-button"
+                >
+                  {isChatPanelHidden ? (
+                    <Maximize2 size={16} />
+                  ) : (
+                    <Minimize2 size={16} />
+                  )}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>
+                {isChatPanelHidden ? "Show chat" : "Hide chat"}
+              </TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger>
+                <button
+                  onClick={handleActivateComponentSelector}
+                  className={`p-1 rounded transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed ${
+                    isPicking
+                      ? "bg-purple-500 text-white hover:bg-purple-600 dark:bg-purple-600 dark:hover:bg-purple-700"
+                      : " text-purple-700 hover:bg-purple-200  dark:text-purple-300 dark:hover:bg-purple-900"
+                  }`}
+                  disabled={
+                    loading || !selectedAppId || !isComponentSelectorInitialized
+                  }
+                  data-testid="preview-pick-element-button"
+                >
+                  <MousePointerClick size={16} />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>
+                {isPicking
                   ? "Deactivate component selector"
-                  : `Select component (${isMac ? "⌘ + ⇧ + C" : "Ctrl + ⇧ + C"})`
-              }
-            >
-              <MousePointerClick size={16} />
-            </button>
-            <button
-              onClick={handleAnnotatorClick}
-              className={`p-1 rounded transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed ${
-                annotatorMode
-                  ? "bg-purple-500 text-white hover:bg-purple-600 dark:bg-purple-600 dark:hover:bg-purple-700"
-                  : " text-purple-700 hover:bg-purple-200  dark:text-purple-300 dark:hover:bg-purple-900"
-              }`}
-              disabled={
-                loading ||
-                !selectedAppId ||
-                isPicking ||
-                !isComponentSelectorInitialized
-              }
-              data-testid="preview-annotator-button"
-              title={
-                annotatorMode ? "Annotator mode active" : "Activate annotator"
-              }
-            >
-              <Pen size={16} />
-            </button>
+                  : `Select component (${isMac ? "⌘ + ⇧ + C" : "Ctrl + ⇧ + C"})`}
+              </TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger>
+                <button
+                  onClick={handleAnnotatorClick}
+                  className={`p-1 rounded transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed ${
+                    annotatorMode
+                      ? "bg-purple-500 text-white hover:bg-purple-600 dark:bg-purple-600 dark:hover:bg-purple-700"
+                      : " text-purple-700 hover:bg-purple-200  dark:text-purple-300 dark:hover:bg-purple-900"
+                  }`}
+                  disabled={
+                    loading ||
+                    !selectedAppId ||
+                    isPicking ||
+                    !isComponentSelectorInitialized
+                  }
+                  data-testid="preview-annotator-button"
+                >
+                  <Pen size={16} />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>
+                {annotatorMode ? "Annotator mode active" : "Activate annotator"}
+              </TooltipContent>
+            </Tooltip>
             <button
               className="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed dark:text-gray-300"
               disabled={!canGoBack || loading || !selectedAppId}
@@ -1106,14 +1125,18 @@ export const PreviewIframe = ({ loading }: { loading: boolean }) => {
 
           {/* Action Buttons */}
           <div className="flex space-x-1">
-            <button
-              onClick={onRestart}
-              className="flex items-center space-x-1 px-3 py-1 rounded-md text-sm hover:bg-[var(--background-darkest)] transition-colors"
-              title="Restart App"
-            >
-              <Power size={16} />
-              <span>Restart</span>
-            </button>
+            <Tooltip>
+              <TooltipTrigger>
+                <button
+                  onClick={onRestart}
+                  className="flex items-center space-x-1 px-3 py-1 rounded-md text-sm hover:bg-[var(--background-darkest)] transition-colors"
+                >
+                  <Power size={16} />
+                  <span>Restart</span>
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Restart App</TooltipContent>
+            </Tooltip>
             <button
               data-testid="preview-open-browser-button"
               onClick={() => {
@@ -1128,22 +1151,27 @@ export const PreviewIframe = ({ loading }: { loading: boolean }) => {
 
             {/* Device Mode Button */}
             <Popover open={isDevicePopoverOpen} modal={false}>
-              <PopoverTrigger
-                data-testid="device-mode-button"
-                onClick={() => {
-                  // Toggle popover open/close
-                  if (isDevicePopoverOpen)
-                    updateSettings({ previewDeviceMode: "desktop" });
-                  setIsDevicePopoverOpen(!isDevicePopoverOpen);
-                }}
-                className={cn(
-                  "p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 dark:text-gray-300",
-                  deviceMode !== "desktop" && "bg-gray-200 dark:bg-gray-700",
-                )}
-                title="Device Mode"
-              >
-                <MonitorSmartphone size={16} />
-              </PopoverTrigger>
+              <Tooltip>
+                <TooltipTrigger>
+                  <PopoverTrigger
+                    data-testid="device-mode-button"
+                    onClick={() => {
+                      // Toggle popover open/close
+                      if (isDevicePopoverOpen)
+                        updateSettings({ previewDeviceMode: "desktop" });
+                      setIsDevicePopoverOpen(!isDevicePopoverOpen);
+                    }}
+                    className={cn(
+                      "p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 dark:text-gray-300",
+                      deviceMode !== "desktop" &&
+                        "bg-gray-200 dark:bg-gray-700",
+                    )}
+                  >
+                    <MonitorSmartphone size={16} />
+                  </PopoverTrigger>
+                </TooltipTrigger>
+                <TooltipContent>Device Mode</TooltipContent>
+              </Tooltip>
               <PopoverContent className="w-auto p-2">
                 <ToggleGroup
                   value={[deviceMode]}
@@ -1159,27 +1187,33 @@ export const PreviewIframe = ({ loading }: { loading: boolean }) => {
                   }}
                   variant="outline"
                 >
-                  <ToggleGroupItem
-                    value="desktop"
-                    aria-label="Desktop view"
-                    title="Desktop"
-                  >
-                    <Monitor size={16} />
-                  </ToggleGroupItem>
-                  <ToggleGroupItem
-                    value="tablet"
-                    aria-label="Tablet view"
-                    title="Tablet"
-                  >
-                    <Tablet size={16} className="scale-x-130" />
-                  </ToggleGroupItem>
-                  <ToggleGroupItem
-                    value="mobile"
-                    aria-label="Mobile view"
-                    title="Mobile"
-                  >
-                    <Smartphone size={16} />
-                  </ToggleGroupItem>
+                  <Tooltip>
+                    <TooltipTrigger>
+                      <ToggleGroupItem
+                        value="desktop"
+                        aria-label="Desktop view"
+                      >
+                        <Monitor size={16} />
+                      </ToggleGroupItem>
+                    </TooltipTrigger>
+                    <TooltipContent>Desktop</TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger>
+                      <ToggleGroupItem value="tablet" aria-label="Tablet view">
+                        <Tablet size={16} className="scale-x-130" />
+                      </ToggleGroupItem>
+                    </TooltipTrigger>
+                    <TooltipContent>Tablet</TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger>
+                      <ToggleGroupItem value="mobile" aria-label="Mobile view">
+                        <Smartphone size={16} />
+                      </ToggleGroupItem>
+                    </TooltipTrigger>
+                    <TooltipContent>Mobile</TooltipContent>
+                  </Tooltip>
                 </ToggleGroup>
               </PopoverContent>
             </Popover>

--- a/src/components/preview_panel/VisualEditingToolbar.tsx
+++ b/src/components/preview_panel/VisualEditingToolbar.tsx
@@ -320,14 +320,16 @@ export function VisualEditingToolbar({
       }}
     >
       <Tooltip>
-        <TooltipTrigger>
-          <button
-            onClick={handleDeselectComponent}
-            className="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 text-[#7f22fe] dark:text-gray-200"
-            aria-label="Deselect Component"
-          >
-            <X size={16} />
-          </button>
+        <TooltipTrigger
+          render={
+            <button
+              onClick={handleDeselectComponent}
+              className="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 text-[#7f22fe] dark:text-gray-200"
+              aria-label="Deselect Component"
+            />
+          }
+        >
+          <X size={16} />
         </TooltipTrigger>
         <TooltipContent>Deselect Component</TooltipContent>
       </Tooltip>

--- a/src/components/preview_panel/VisualEditingToolbar.tsx
+++ b/src/components/preview_panel/VisualEditingToolbar.tsx
@@ -1,4 +1,9 @@
 import { useState, useEffect } from "react";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
 import { X, Move, Square, Palette, Type } from "lucide-react";
 import { Label } from "@/components/ui/label";
 import { ComponentSelection } from "@/ipc/types";
@@ -314,14 +319,18 @@ export function VisualEditingToolbar({
         left: `${toolbarLeft}px`,
       }}
     >
-      <button
-        onClick={handleDeselectComponent}
-        className="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 text-[#7f22fe] dark:text-gray-200"
-        aria-label="Deselect Component"
-        title="Deselect Component"
-      >
-        <X size={16} />
-      </button>
+      <Tooltip>
+        <TooltipTrigger>
+          <button
+            onClick={handleDeselectComponent}
+            className="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 text-[#7f22fe] dark:text-gray-200"
+            aria-label="Deselect Component"
+          >
+            <X size={16} />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>Deselect Component</TooltipContent>
+      </Tooltip>
 
       {isDynamic ? (
         <div className="flex items-center px-2 py-1 text-yellow-800 dark:text-yellow-200 rounded text-xs font-medium">

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -259,23 +259,27 @@ function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
   const { toggleSidebar } = useSidebar();
 
   return (
-    <button
-      data-sidebar="rail"
-      data-slot="sidebar-rail"
-      aria-label="Toggle Sidebar"
-      tabIndex={-1}
-      onClick={toggleSidebar}
-      title="Toggle Sidebar"
-      className={cn(
-        "hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] sm:flex",
-        "in-data-[side=left][data-state=collapsed]_&]:cursor-e-resize in-data-[side=right][data-state=collapsed]_&]:cursor-w-resize",
-        "hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full",
-        "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
-        "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
-        className,
-      )}
-      {...props}
-    />
+    <Tooltip>
+      <TooltipTrigger>
+        <button
+          data-sidebar="rail"
+          data-slot="sidebar-rail"
+          aria-label="Toggle Sidebar"
+          tabIndex={-1}
+          onClick={toggleSidebar}
+          className={cn(
+            "hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] sm:flex",
+            "in-data-[side=left][data-state=collapsed]_&]:cursor-e-resize in-data-[side=right][data-state=collapsed]_&]:cursor-w-resize",
+            "hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full",
+            "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
+            "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
+            className,
+          )}
+          {...props}
+        />
+      </TooltipTrigger>
+      <TooltipContent>Toggle Sidebar</TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -259,27 +259,23 @@ function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
   const { toggleSidebar } = useSidebar();
 
   return (
-    <Tooltip>
-      <TooltipTrigger>
-        <button
-          data-sidebar="rail"
-          data-slot="sidebar-rail"
-          aria-label="Toggle Sidebar"
-          tabIndex={-1}
-          onClick={toggleSidebar}
-          className={cn(
-            "hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] sm:flex",
-            "in-data-[side=left][data-state=collapsed]_&]:cursor-e-resize in-data-[side=right][data-state=collapsed]_&]:cursor-w-resize",
-            "hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full",
-            "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
-            "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
-            className,
-          )}
-          {...props}
-        />
-      </TooltipTrigger>
-      <TooltipContent>Toggle Sidebar</TooltipContent>
-    </Tooltip>
+    <button
+      data-sidebar="rail"
+      data-slot="sidebar-rail"
+      aria-label="Toggle Sidebar"
+      tabIndex={-1}
+      onClick={toggleSidebar}
+      title="Toggle Sidebar"
+      className={cn(
+        "hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] sm:flex",
+        "in-data-[side=left][data-state=collapsed]_&]:cursor-e-resize in-data-[side=right][data-state=collapsed]_&]:cursor-w-resize",
+        "hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full",
+        "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
+        "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
+        className,
+      )}
+      {...props}
+    />
   );
 }
 
@@ -517,7 +513,7 @@ function SidebarMenuButton<T extends React.ElementType = "button">({
 
   return (
     <Tooltip>
-      <TooltipTrigger>{button}</TooltipTrigger>
+      <TooltipTrigger render={button} />
       <TooltipContent
         side="right"
         align="center"

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -18,11 +18,7 @@ function TooltipProvider({
 }
 
 function Tooltip({ ...props }: TooltipPrimitive.Root.Props) {
-  return (
-    <TooltipProvider>
-      <TooltipPrimitive.Root data-slot="tooltip" {...props} />
-    </TooltipProvider>
-  );
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
 }
 
 function TooltipTrigger({ ...props }: TooltipPrimitive.Trigger.Props) {
@@ -32,7 +28,7 @@ function TooltipTrigger({ ...props }: TooltipPrimitive.Trigger.Props) {
 function TooltipContent({
   className,
   side = "top",
-  sideOffset = 0,
+  sideOffset = 4,
   align = "center",
   alignOffset = 0,
   children,
@@ -54,13 +50,13 @@ function TooltipContent({
         <TooltipPrimitive.Popup
           data-slot="tooltip-content"
           className={cn(
-            "bg-primary text-primary-foreground data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit rounded-md px-3 py-1.5 text-xs text-balance origin-(--transform-origin)",
+            "data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 rounded-md px-3 py-1.5 text-xs data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 bg-foreground text-background z-50 w-fit max-w-xs origin-(--transform-origin)",
             className,
           )}
           {...props}
         >
           {children}
-          <TooltipPrimitive.Arrow className="bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+          <TooltipPrimitive.Arrow className="size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 bg-foreground fill-foreground z-50 data-[side=bottom]:top-1 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5" />
         </TooltipPrimitive.Popup>
       </TooltipPrimitive.Positioner>
     </TooltipPrimitive.Portal>

--- a/src/pages/app-details.tsx
+++ b/src/pages/app-details.tsx
@@ -18,6 +18,11 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
 import { Input } from "@/components/ui/input";
 import {
   Dialog,
@@ -357,17 +362,21 @@ export default function AppDetailsPage() {
               Path
             </span>
             <div className="flex items-center gap-1">
-              <Button
-                variant="ghost"
-                size="icon"
-                className="ml-[-8px] p-0.5 h-auto cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
-                onClick={() => {
-                  ipc.system.showItemInFolder(currentAppPath);
-                }}
-                title="Show in folder"
-              >
-                <Folder className="h-3.5 w-3.5" />
-              </Button>
+              <Tooltip>
+                <TooltipTrigger>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="ml-[-8px] p-0.5 h-auto cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+                    onClick={() => {
+                      ipc.system.showItemInFolder(currentAppPath);
+                    }}
+                  >
+                    <Folder className="h-3.5 w-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Show in folder</TooltipContent>
+              </Tooltip>
               <span className="text-sm break-all">{currentAppPath}</span>
             </div>
           </div>

--- a/src/pages/app-details.tsx
+++ b/src/pages/app-details.tsx
@@ -363,17 +363,19 @@ export default function AppDetailsPage() {
             </span>
             <div className="flex items-center gap-1">
               <Tooltip>
-                <TooltipTrigger>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="ml-[-8px] p-0.5 h-auto cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
-                    onClick={() => {
-                      ipc.system.showItemInFolder(currentAppPath);
-                    }}
-                  >
-                    <Folder className="h-3.5 w-3.5" />
-                  </Button>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="ml-[-8px] p-0.5 h-auto cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+                      onClick={() => {
+                        ipc.system.showItemInFolder(currentAppPath);
+                      }}
+                    />
+                  }
+                >
+                  <Folder className="h-3.5 w-3.5" />
                 </TooltipTrigger>
                 <TooltipContent>Show in folder</TooltipContent>
               </Tooltip>


### PR DESCRIPTION
## Summary
- Replace native HTML `title` attributes on button elements across 25 files with proper `<Tooltip>` / `<TooltipTrigger>` / `<TooltipContent>` components from the existing UI library
- Native browser tooltips are delayed and unstyled; the shadcn tooltips provide a consistent, polished tooltip experience with animations and proper positioning
- Only button/interactive elements were converted; `title` on non-interactive elements like `<span>` (text overflow), `<iframe>`, and component props were intentionally left as-is

## Test plan
- [x] TypeScript type check passes (`npm run ts`)
- [x] Lint passes (`npm run lint`)
- [x] Formatting passes (`npm run fmt`)
- [x] All 661 unit tests pass (`npm test`)
- [ ] Manual: hover over icon buttons throughout the app (chat input, preview toolbar, annotator, settings) to verify styled tooltips appear instead of browser-native ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2470">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily UI/UX refactoring of hover tooltips with minimal behavioral impact; main risk is small layout/accessibility regressions from the updated tooltip styling/positioning.
> 
> **Overview**
> Replaces native `title` tooltips on many interactive controls (chat, preview/annotator toolbars, settings/connectors, branch manager, etc.) with the app’s `Tooltip` components, using `TooltipTrigger`’s `render` prop to avoid invalid nested `<button>` markup.
> 
> Updates the tooltip implementation (`src/components/ui/tooltip.tsx`) to remove the implicit provider wrapper, tweak default positioning (`sideOffset`), and restyle tooltip/arrow classes; adjusts E2E aria snapshots accordingly and documents the `TooltipTrigger render` pitfall in `AGENTS.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8055379edcec73b53ca54ee82b9f4fb4a2f92c63. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced native title tooltips on interactive buttons with shadcn Tooltip for consistent, styled, and responsive tooltips across the app. Improves usability and visual polish without changing button behavior.

- **Refactors**
  - Converted titles to Tooltip/TooltipTrigger/TooltipContent across ~25 files, using TooltipTrigger’s render prop to avoid nested button HTML.
  - Kept native title for drag handles and resize rails, and left titles on non-interactive elements (e.g., span, iframe, component props).
  - Updated tooltip defaults (sideOffset 4) and removed the implicit provider; added aria-labels to icon-only buttons; fixed ToggleGroupItem corner styles and preserved ref forwarding where needed.

<sup>Written for commit 8055379edcec73b53ca54ee82b9f4fb4a2f92c63. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->