### PR TITLE
Update closed-issue-comment workflow to use claude-code-action

### DIFF
--- a/.github/workflows/closed-issue-comment.yml
+++ b/.github/workflows/closed-issue-comment.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      - uses: anthropics/claude-code-base-action@v1
+      - uses: anthropics/claude-code-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
@@ -23,8 +23,8 @@ jobs:
           COMMENT_BODY: ${{ github.event.comment.body }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          model: claude-sonnet-4-20250514
-          allowed_tools: "Bash(gh issue reopen:*), Bash(gh issue comment:*)"
+          claude_args: |
+            --model sonnet --allowedTools "Bash(gh issue reopen:*), Bash(gh issue comment:*)"
           prompt: |
             # Closed Issue Comment Handler
 


### PR DESCRIPTION
## Summary
- Migrate from `anthropics/claude-code-base-action@v1` to `anthropics/claude-code-action@v1`
- Switch from top-level `model`/`allowed_tools` params to `claude_args` format

## Test plan
- Verify the workflow triggers correctly on comments to closed issues
- Confirm the Claude Code action runs with the correct model and allowed tools

#skip-bugbot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2471">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the closed-issue-comment GitHub Actions workflow to use anthropics/claude-code-action and pass config via claude_args. No behavior change; the workflow still handles comments on closed issues.

- **Refactors**
  - Replace anthropics/claude-code-base-action@v1 with anthropics/claude-code-action@v1.
  - Move model/allowed_tools into claude_args: --model sonnet and allowedTools "Bash(gh issue reopen:*), Bash(gh issue comment:*)".

<sup>Written for commit 67e76b9b098c65902c4d9fe4b5aadb9b06fb8c1f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

