### PR TITLE
Fix github token for closed-issue-comment.yml

### DIFF
--- a/.github/workflows/closed-issue-comment.yml
+++ b/.github/workflows/closed-issue-comment.yml
@@ -23,6 +23,8 @@ jobs:
           COMMENT_BODY: ${{ github.event.comment.body }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # See: https://github.com/anthropics/claude-code-action/blob/v1/docs/security.md
+          github_token: ${{ secrets.GITHUB_TOKEN }} # bypass OIDC
           claude_args: |
             --model sonnet --allowedTools "Bash(gh issue reopen:*), Bash(gh issue comment:*)"
           prompt: |


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2473">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that adjusts how the GitHub token is provided to `anthropics/claude-code-action` to avoid OIDC permission issues. Main risk is unintended token/permissions behavior in the `closed-issue-comment` automation.
> 
> **Overview**
> Fixes the `closed-issue-comment` GitHub Actions workflow by explicitly passing `github_token: ${{ secrets.GITHUB_TOKEN }}` to `anthropics/claude-code-action@v1` (with a reference to the action’s security docs), bypassing OIDC.
> 
> This ensures the action can reliably run `gh issue reopen`/`gh issue comment` on closed-issue comments without token permission failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 64b36211889abe42a210182c11267b4d30854a59. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix auth in closed-issue-comment.yml by passing github_token: ${{ secrets.GITHUB_TOKEN }} to claude-code-action. This bypasses OIDC and prevents permission errors when reopening or commenting on issues.

<sup>Written for commit 64b36211889abe42a210182c11267b4d30854a59. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

