### PR TITLE
Add workflow to close stale PRs older than 2 months

### DIFF
--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -27,7 +27,10 @@ jobs:
             });
 
             for (const pr of prs) {
-              if (new Date(pr.created_at) < twoMonthsAgo) {
+              if (new Date(pr.created_at) >= twoMonthsAgo) {
+                break;
+              }
+              try {
                 await github.rest.issues.createComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
@@ -43,5 +46,7 @@ jobs:
                 });
 
                 console.log(`Closed PR #${pr.number}: ${pr.title}`);
+              } catch (error) {
+                console.log(`Failed to close PR #${pr.number}: ${error.message}`);
               }
             }

--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -1,0 +1,47 @@
+name: Close stale PRs
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # daily at midnight UTC
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+
+jobs:
+  close-stale-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const twoMonthsAgo = new Date();
+            twoMonthsAgo.setMonth(twoMonthsAgo.getMonth() - 2);
+
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              sort: 'created',
+              direction: 'asc',
+            });
+
+            for (const pr of prs) {
+              if (new Date(pr.created_at) < twoMonthsAgo) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  body: "Hi! We're closing this PR since it's been more than 2 months. Feel free to open a new PR if you'd like to continue. Thanks.",
+                });
+
+                await github.rest.pulls.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pr.number,
+                  state: 'closed',
+                });
+
+                console.log(`Closed PR #${pr.number}: ${pr.title}`);
+              }
+            }


### PR DESCRIPTION
## Summary
- Adds a new GitHub Action (`close-stale-prs.yml`) that runs daily at midnight UTC
- Automatically closes open PRs that were created more than 2 months ago
- Leaves a friendly comment before closing each stale PR

## Test plan
- Verify the workflow YAML is valid by checking the Actions tab after merge
- Can be manually triggered via `workflow_dispatch` to test behavior

#skip-bugbot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2474">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a scheduled GitHub Action to automatically close open PRs older than 2 months and post a comment, keeping the backlog tidy. Runs daily at midnight UTC.

- **New Features**
  - Adds .github/workflows/close-stale-prs.yml using actions/github-script@v7
  - Requires pull-requests: write permission
  - Supports manual runs via workflow_dispatch
  - Logs closed PRs to workflow output

<sup>Written for commit 6687ed758e6104e8cde06895a021b121283aea71. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

