### PR TITLE
Add actions:write permission to pr-review-responder workflow

### DIFF
--- a/.github/workflows/pr-review-responder.yml
+++ b/.github/workflows/pr-review-responder.yml
@@ -19,6 +19,7 @@ jobs:
     environment: ai-bots
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: write
       pull-requests: write
     steps:


### PR DESCRIPTION
## Summary
- The `pr-review-responder` workflow uses `gh workflow run` to re-trigger CI, BugBot, and Claude PR Review after Claude Code pushes commits
- The `GITHUB_TOKEN` was missing the `actions: write` permission, causing those workflow dispatch calls to silently fail
- Adds the missing permission to fix workflow re-triggering

## Test plan
- Verify that when `pr-review-responder` runs and Claude pushes commits, the CI, BugBot, and Claude PR Review workflows are triggered successfully
- Check the workflow run logs to confirm `gh workflow run` no longer produces permission errors

#skip-bugbot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2475">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added actions:write permission to the pr-review-responder workflow so GITHUB_TOKEN can dispatch CI, BugBot, and Claude PR Review after Claude Code pushes commits. Fixes silent failures where gh workflow run lacked permissions and didn’t re-trigger workflows.

<sup>Written for commit 91cffceae19d8c1eea2138d48fd76e42449963a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

