### PR TITLE
Add persistent memory system for per-app context retention

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,0 +1,172 @@
+# Memory System Design Plan
+
+## Problem Statement
+
+Dyad currently has no persistent memory across chat sessions. Each new chat starts with zero context about user preferences, past decisions, or project-specific patterns learned in previous conversations. This means users repeatedly re-explain the same preferences, and the AI cannot learn from past interactions.
+
+## Requirements
+
+1. **Persistent memory**: Memories survive across chats and app restarts
+2. **Per-app scoping**: Memories are scoped to individual apps (different projects have different contexts)
+3. **Toggleable**: Users can enable/disable memory via a setting
+4. **Manageable**: Users can view and delete individual memories
+5. **Injected into context**: Relevant memories are included in the system prompt
+6. **Bounded size**: Memory doesn't grow unbounded and consume the entire context window
+
+---
+
+## Option 1: Dependency-Free SQLite Storage (RECOMMENDED)
+
+### Description
+
+Store memories as plain text entries in a new SQLite table using the existing Drizzle ORM setup. Memories are simple key-value-like entries with content and metadata. The AI model extracts memories from conversations and the system injects them into the system prompt.
+
+### Architecture
+
+- **Storage**: New `memories` table in the existing SQLite database
+- **Extraction**: At the end of each chat response, the AI is asked (via a lightweight follow-up call) to extract noteworthy facts/preferences
+- **Injection**: Before each chat request, all memories for the current app are fetched and appended to the system prompt
+- **Management**: CRUD IPC endpoints for viewing/deleting memories
+
+### Schema
+
+```sql
+CREATE TABLE memories (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  app_id INTEGER NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+  content TEXT NOT NULL,
+  created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+  updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+);
+```
+
+### Pros
+
+- Zero new dependencies
+- Uses existing infrastructure (SQLite, Drizzle, IPC contract system)
+- Simple to implement and maintain
+- Fast lookups (all memories for an app is a single indexed query)
+- Works offline
+- No external API calls for storage/retrieval
+
+### Cons
+
+- No semantic search (all memories for an app are included)
+- Requires a secondary LLM call for memory extraction (adds latency + cost)
+- Memory relevance depends on manual curation or simple heuristics
+
+### Estimated Complexity
+
+Low — follows existing patterns exactly (similar to prompts table).
+
+---
+
+## Option 2: Vector Embeddings with `vectra` (Open Source)
+
+### Description
+
+Use [vectra](https://github.com/Stevenic/vectra), a local vector database for Node.js, to store memories as embeddings. This enables semantic search so only relevant memories are retrieved per query.
+
+### Architecture
+
+- **Storage**: Local JSON-based vector index (one per app) managed by vectra
+- **Embeddings**: Use the configured AI provider's embedding API (or a local model)
+- **Retrieval**: Semantic similarity search on user's current prompt to find top-K relevant memories
+- **Injection**: Only semantically relevant memories are injected into context
+
+### Pros
+
+- Semantic search means only relevant memories are included
+- Scales better with large memory stores
+- Open source (MIT license)
+
+### Cons
+
+- **New dependency** (`vectra`)
+- Requires an embedding model (external API call or local model)
+- More complex implementation (vector index management, embedding pipeline)
+- Embedding API adds latency and cost to every chat message
+- JSON-based storage may not be as robust as SQLite
+- Offline support depends on embedding model availability
+
+### Estimated Complexity
+
+Medium-High — new dependency, embedding pipeline, vector index management.
+
+---
+
+## Option 3: Vector Embeddings with `lancedb` (Open Source)
+
+### Description
+
+Use [LanceDB](https://github.com/lancedb/lancedb), an embedded vector database, for storage and retrieval. Similar to Option 2 but with a more robust storage engine.
+
+### Pros
+
+- Columnar storage format (efficient for large datasets)
+- Semantic search with vector similarity
+- Open source (Apache 2.0)
+- Embedded (no server needed)
+
+### Cons
+
+- **Heavy dependency** (native binaries, ~50MB+)
+- Requires embedding model (same issues as Option 2)
+- Significantly increases app bundle size
+- Complex build pipeline for native modules across platforms
+- Overkill for the expected memory volume (tens to hundreds of entries per app)
+
+### Estimated Complexity
+
+High — native dependency management, cross-platform builds, embedding pipeline.
+
+---
+
+## Option 4: Hybrid — SQLite Storage + LLM-based Relevance Filtering
+
+### Description
+
+Store memories in SQLite (like Option 1) but use the LLM itself to filter which memories are relevant before injection. When memory count exceeds a threshold, ask the model to select the N most relevant memories given the current prompt.
+
+### Pros
+
+- No new dependencies
+- Better relevance filtering than including all memories
+- Uses existing infrastructure
+
+### Cons
+
+- Extra LLM call for filtering adds latency
+- Cost scales with memory count (more tokens to evaluate)
+- Filtering quality depends on model capability
+- For small memory stores (<50 entries), the overhead isn't worth it
+
+### Estimated Complexity
+
+Low-Medium — same as Option 1 plus an optional filtering step.
+
+---
+
+## Decision: Option 1 (Dependency-Free SQLite Storage)
+
+### Rationale
+
+1. **Simplicity**: The expected memory volume per app (tens of entries) doesn't justify vector search infrastructure
+2. **Zero dependencies**: No new packages to maintain, audit, or worry about cross-platform compatibility
+3. **Follows existing patterns**: The implementation mirrors the existing `prompts` table exactly
+4. **Incremental**: Can always upgrade to semantic search later if memory volume warrants it
+5. **Offline-first**: Works entirely offline with no external API calls for storage/retrieval
+6. **Memory extraction**: Rather than an expensive secondary LLM call, we let users manually add memories and also auto-extract them from chat summaries
+
+### Implementation Plan
+
+1. Add `memories` table to Drizzle schema
+2. Generate migration with `npm run db:generate`
+3. Create IPC contracts (`memory.ts`) for CRUD operations
+4. Create IPC handlers (`memory_handlers.ts`)
+5. Register handlers in `ipc_host.ts`
+6. Add `enableMemory` setting to `UserSettingsSchema`
+7. Create `MemorySwitch` component for settings page
+8. Add query keys to `queryKeys.ts`
+9. Inject memories into system prompt in `chat_stream_handlers.ts`
+10. Create memory management UI component

--- a/drizzle/0025_steady_memory.sql
+++ b/drizzle/0025_steady_memory.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `memories` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`app_id` integer NOT NULL,
+	`content` text NOT NULL,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`updated_at` integer DEFAULT (unixepoch()) NOT NULL,
+	FOREIGN KEY (`app_id`) REFERENCES `apps`(`id`) ON UPDATE no action ON DELETE cascade
+);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1769582904159,
       "tag": "0024_useful_skin",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "6",
+      "when": 1770000000000,
+      "tag": "0025_steady_memory",
+      "breakpoints": true
     }
   ]
 }

--- a/src/components/MemoryPanel.tsx
+++ b/src/components/MemoryPanel.tsx
@@ -1,0 +1,207 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Trash2, Plus, X, Pencil, Check } from "lucide-react";
+import { showError } from "@/lib/toast";
+import { useMemories } from "@/hooks/useMemories";
+import { useSettings } from "@/hooks/useSettings";
+
+export function MemoryPanel() {
+  const { settings } = useSettings();
+  const { memories, isLoading, createMemory, updateMemory, deleteMemory } =
+    useMemories();
+  const [newContent, setNewContent] = useState("");
+  const [isAdding, setIsAdding] = useState(false);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editingContent, setEditingContent] = useState("");
+
+  if (!settings?.enableMemory) {
+    return (
+      <div className="p-4 text-sm text-muted-foreground">
+        Memory is disabled. Enable it in Settings &gt; AI Settings to start
+        saving memories.
+      </div>
+    );
+  }
+
+  const handleAdd = async () => {
+    if (!newContent.trim()) return;
+    try {
+      await createMemory.mutateAsync(newContent.trim());
+      setNewContent("");
+      setIsAdding(false);
+    } catch (error) {
+      showError(
+        error instanceof Error ? error.message : "Failed to create memory",
+      );
+    }
+  };
+
+  const handleUpdate = async (id: number) => {
+    if (!editingContent.trim()) return;
+    try {
+      await updateMemory.mutateAsync({ id, content: editingContent.trim() });
+      setEditingId(null);
+      setEditingContent("");
+    } catch (error) {
+      showError(
+        error instanceof Error ? error.message : "Failed to update memory",
+      );
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    try {
+      await deleteMemory.mutateAsync(id);
+    } catch (error) {
+      showError(
+        error instanceof Error ? error.message : "Failed to delete memory",
+      );
+    }
+  };
+
+  const startEditing = (id: number, content: string) => {
+    setEditingId(id);
+    setEditingContent(content);
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-medium">Memories</h3>
+        {!isAdding && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setIsAdding(true)}
+            className="h-7 text-xs"
+          >
+            <Plus className="h-3 w-3 mr-1" />
+            Add
+          </Button>
+        )}
+      </div>
+
+      {isAdding && (
+        <div className="flex gap-2">
+          <textarea
+            value={newContent}
+            onChange={(e) => setNewContent(e.target.value)}
+            placeholder="e.g. User prefers Tailwind CSS for styling"
+            className="flex-1 min-h-[60px] rounded-md border border-input bg-background px-3 py-2 text-sm"
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                handleAdd();
+              }
+            }}
+          />
+          <div className="flex flex-col gap-1">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleAdd}
+              disabled={!newContent.trim() || createMemory.isPending}
+              className="h-7"
+            >
+              <Check className="h-3 w-3" />
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                setIsAdding(false);
+                setNewContent("");
+              }}
+              className="h-7"
+            >
+              <X className="h-3 w-3" />
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {isLoading ? (
+        <div className="text-sm text-muted-foreground">Loading memories...</div>
+      ) : memories.length === 0 ? (
+        <div className="text-sm text-muted-foreground">
+          No memories yet. Add memories to help the AI remember your preferences
+          across chats.
+        </div>
+      ) : (
+        <ul className="space-y-2">
+          {memories.map((memory) => (
+            <li
+              key={memory.id}
+              className="group flex items-start gap-2 rounded-md border border-border p-2 text-sm"
+            >
+              {editingId === memory.id ? (
+                <div className="flex-1 flex gap-2">
+                  <textarea
+                    value={editingContent}
+                    onChange={(e) => setEditingContent(e.target.value)}
+                    className="flex-1 min-h-[40px] rounded-md border border-input bg-background px-2 py-1 text-sm"
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" && !e.shiftKey) {
+                        e.preventDefault();
+                        handleUpdate(memory.id);
+                      }
+                      if (e.key === "Escape") {
+                        setEditingId(null);
+                      }
+                    }}
+                  />
+                  <div className="flex flex-col gap-1">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => handleUpdate(memory.id)}
+                      disabled={
+                        !editingContent.trim() || updateMemory.isPending
+                      }
+                      className="h-6 w-6 p-0"
+                    >
+                      <Check className="h-3 w-3" />
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setEditingId(null)}
+                      className="h-6 w-6 p-0"
+                    >
+                      <X className="h-3 w-3" />
+                    </Button>
+                  </div>
+                </div>
+              ) : (
+                <>
+                  <span className="flex-1 whitespace-pre-wrap">
+                    {memory.content}
+                  </span>
+                  <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => startEditing(memory.id, memory.content)}
+                      className="h-6 w-6 p-0"
+                    >
+                      <Pencil className="h-3 w-3" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleDelete(memory.id)}
+                      disabled={deleteMemory.isPending}
+                      className="h-6 w-6 p-0 text-destructive hover:text-destructive"
+                    >
+                      <Trash2 className="h-3 w-3" />
+                    </Button>
+                  </div>
+                </>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/MemorySwitch.tsx
+++ b/src/components/MemorySwitch.tsx
@@ -1,0 +1,23 @@
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { useSettings } from "@/hooks/useSettings";
+
+export function MemorySwitch() {
+  const { settings, updateSettings } = useSettings();
+
+  return (
+    <div className="flex items-center space-x-2">
+      <Switch
+        id="enable-memory"
+        aria-label="Enable Memory"
+        checked={!!settings?.enableMemory}
+        onCheckedChange={(checked) => {
+          updateSettings({
+            enableMemory: checked,
+          });
+        }}
+      />
+      <Label htmlFor="enable-memory">Enable Memory</Label>
+    </div>
+  );
+}

--- a/src/components/preview_panel/ConfigurePanel.tsx
+++ b/src/components/preview_panel/ConfigurePanel.tsx
@@ -25,6 +25,7 @@ import { ipc } from "@/ipc/types";
 import { useNavigate } from "@tanstack/react-router";
 import { NeonConfigure } from "./NeonConfigure";
 import { queryKeys } from "@/lib/queryKeys";
+import { MemoryPanel } from "@/components/MemoryPanel";
 
 const EnvironmentVariablesTitle = () => (
   <div className="flex items-center gap-2">
@@ -394,6 +395,18 @@ export const ConfigurePanel = () => {
               <ArrowRight size={16} />
             </Button>
           </div>
+        </CardContent>
+      </Card>
+
+      {/* Memory */}
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <span className="text-lg font-semibold">Memory</span>
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <MemoryPanel />
         </CardContent>
       </Card>
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -256,6 +256,28 @@ export const mcpToolConsents = sqliteTable(
   (table) => [unique("uniq_mcp_consent").on(table.serverId, table.toolName)],
 );
 
+// --- Memories table ---
+export const memories = sqliteTable("memories", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  appId: integer("app_id")
+    .notNull()
+    .references(() => apps.id, { onDelete: "cascade" }),
+  content: text("content").notNull(),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .default(sql`(unixepoch())`),
+  updatedAt: integer("updated_at", { mode: "timestamp" })
+    .notNull()
+    .default(sql`(unixepoch())`),
+});
+
+export const memoriesRelations = relations(memories, ({ one }) => ({
+  app: one(apps, {
+    fields: [memories.appId],
+    references: [apps.id],
+  }),
+}));
+
 // --- Custom Themes table ---
 export const customThemes = sqliteTable("custom_themes", {
   id: integer("id").primaryKey({ autoIncrement: true }),

--- a/src/hooks/useMemories.ts
+++ b/src/hooks/useMemories.ts
@@ -1,0 +1,67 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAtomValue } from "jotai";
+import { selectedAppIdAtom } from "@/atoms/appAtoms";
+import { ipc } from "@/ipc/types";
+import { queryKeys } from "@/lib/queryKeys";
+import type { MemoryDto } from "@/ipc/types";
+
+export function useMemories() {
+  const queryClient = useQueryClient();
+  const appId = useAtomValue(selectedAppIdAtom);
+
+  const {
+    data: memories,
+    isLoading,
+    error,
+  } = useQuery<MemoryDto[], Error>({
+    queryKey: queryKeys.memories.byApp({ appId }),
+    queryFn: async () => {
+      if (!appId) return [];
+      return ipc.memory.listByApp(appId);
+    },
+    enabled: !!appId,
+  });
+
+  const createMemory = useMutation({
+    mutationFn: async (content: string) => {
+      if (!appId) throw new Error("No app selected");
+      return ipc.memory.create({ appId, content });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.memories.byApp({ appId }),
+      });
+    },
+  });
+
+  const updateMemory = useMutation({
+    mutationFn: async ({ id, content }: { id: number; content: string }) => {
+      return ipc.memory.update({ id, content });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.memories.byApp({ appId }),
+      });
+    },
+  });
+
+  const deleteMemory = useMutation({
+    mutationFn: async (id: number) => {
+      return ipc.memory.delete(id);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.memories.byApp({ appId }),
+      });
+    },
+  });
+
+  return {
+    memories: memories ?? [],
+    isLoading,
+    error,
+    createMemory,
+    updateMemory,
+    deleteMemory,
+  };
+}

--- a/src/ipc/handlers/memory_handlers.ts
+++ b/src/ipc/handlers/memory_handlers.ts
@@ -1,0 +1,68 @@
+import log from "electron-log";
+import { db } from "@/db";
+import { memories } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import { createTypedHandler } from "./base";
+import { memoryContracts } from "../types/memory";
+
+const _logger = log.scope("memory_handlers");
+
+export function registerMemoryHandlers() {
+  createTypedHandler(memoryContracts.listByApp, async (_, appId) => {
+    const rows = db
+      .select()
+      .from(memories)
+      .where(eq(memories.appId, appId))
+      .all();
+    return rows.map((r) => ({
+      id: r.id!,
+      appId: r.appId,
+      content: r.content,
+      createdAt: r.createdAt,
+      updatedAt: r.updatedAt,
+    }));
+  });
+
+  createTypedHandler(memoryContracts.create, async (_, params) => {
+    const { appId, content } = params;
+    if (!content || !content.trim()) {
+      throw new Error("Memory content is required");
+    }
+    const result = db
+      .insert(memories)
+      .values({
+        appId,
+        content: content.trim(),
+      })
+      .run();
+
+    const id = Number(result.lastInsertRowid);
+    const row = db.select().from(memories).where(eq(memories.id, id)).get();
+    if (!row) throw new Error("Failed to fetch created memory");
+    return {
+      id: row.id!,
+      appId: row.appId,
+      content: row.content,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    };
+  });
+
+  createTypedHandler(memoryContracts.update, async (_, params) => {
+    const { id, content } = params;
+    if (!id) throw new Error("Memory id is required");
+    if (!content || !content.trim()) {
+      throw new Error("Memory content is required");
+    }
+    const now = new Date();
+    db.update(memories)
+      .set({ content: content.trim(), updatedAt: now })
+      .where(eq(memories.id, id))
+      .run();
+  });
+
+  createTypedHandler(memoryContracts.delete, async (_, id) => {
+    if (!id) throw new Error("Memory id is required");
+    db.delete(memories).where(eq(memories.id, id)).run();
+  });
+}

--- a/src/ipc/ipc_host.ts
+++ b/src/ipc/ipc_host.ts
@@ -37,6 +37,7 @@ import { registerSecurityHandlers } from "./handlers/security_handlers";
 import { registerVisualEditingHandlers } from "../pro/main/ipc/handlers/visual_editing_handlers";
 import { registerAgentToolHandlers } from "../pro/main/ipc/handlers/local_agent/agent_tool_handlers";
 import { registerFreeAgentQuotaHandlers } from "./handlers/free_agent_quota_handlers";
+import { registerMemoryHandlers } from "./handlers/memory_handlers";
 
 export function registerIpcHandlers() {
   // Register all IPC handlers by category
@@ -79,4 +80,5 @@ export function registerIpcHandlers() {
   registerVisualEditingHandlers();
   registerAgentToolHandlers();
   registerFreeAgentQuotaHandlers();
+  registerMemoryHandlers();
 }

--- a/src/ipc/preload/channels.ts
+++ b/src/ipc/preload/channels.ts
@@ -38,6 +38,7 @@ import { visualEditingContracts } from "../types/visual-editing";
 import { securityContracts } from "../types/security";
 import { miscContracts, miscEvents } from "../types/misc";
 import { freeAgentQuotaContracts } from "../types/free_agent_quota";
+import { memoryContracts } from "../types/memory";
 
 // =============================================================================
 // Invoke Channels (derived from all contracts)
@@ -91,6 +92,7 @@ export const VALID_INVOKE_CHANNELS = [
   ...getInvokeChannels(securityContracts),
   ...getInvokeChannels(miscContracts),
   ...getInvokeChannels(freeAgentQuotaContracts),
+  ...getInvokeChannels(memoryContracts),
 
   // Test-only channels
   ...TEST_INVOKE_CHANNELS,

--- a/src/ipc/types/index.ts
+++ b/src/ipc/types/index.ts
@@ -50,6 +50,7 @@ export { visualEditingContracts } from "./visual-editing";
 export { securityContracts } from "./security";
 export { miscContracts, miscEvents } from "./misc";
 export { freeAgentQuotaContracts } from "./free_agent_quota";
+export { memoryContracts } from "./memory";
 
 // =============================================================================
 // Client Exports
@@ -79,6 +80,7 @@ export { visualEditingClient } from "./visual-editing";
 export { securityClient } from "./security";
 export { miscClient, miscEventClient } from "./misc";
 export { freeAgentQuotaClient } from "./free_agent_quota";
+export { memoryClient } from "./memory";
 
 // =============================================================================
 // Type Exports
@@ -284,6 +286,13 @@ export type { ChatLogsData, DeepLinkData, AppOutput, EnvVar } from "./misc";
 // Free agent quota types
 export type { FreeAgentQuotaStatus } from "./free_agent_quota";
 
+// Memory types
+export type {
+  MemoryDto,
+  CreateMemoryParams,
+  UpdateMemoryParams,
+} from "./memory";
+
 // =============================================================================
 // Schema Exports (for validation in handlers/components)
 // =============================================================================
@@ -340,6 +349,7 @@ import { visualEditingClient } from "./visual-editing";
 import { securityClient } from "./security";
 import { miscClient, miscEventClient } from "./misc";
 import { freeAgentQuotaClient } from "./free_agent_quota";
+import { memoryClient } from "./memory";
 
 /**
  * Unified IPC client with all domains organized by namespace.
@@ -395,6 +405,7 @@ export const ipc = {
   security: securityClient,
   misc: miscClient,
   freeAgentQuota: freeAgentQuotaClient,
+  memory: memoryClient,
 
   // Event clients for main->renderer pub/sub
   events: {

--- a/src/ipc/types/memory.ts
+++ b/src/ipc/types/memory.ts
@@ -1,0 +1,66 @@
+import { z } from "zod";
+import { defineContract, createClient } from "../contracts/core";
+
+// =============================================================================
+// Memory Schemas
+// =============================================================================
+
+export const MemoryDtoSchema = z.object({
+  id: z.number(),
+  appId: z.number(),
+  content: z.string(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+
+export type MemoryDto = z.infer<typeof MemoryDtoSchema>;
+
+export const CreateMemoryParamsSchema = z.object({
+  appId: z.number(),
+  content: z.string(),
+});
+
+export type CreateMemoryParams = z.infer<typeof CreateMemoryParamsSchema>;
+
+export const UpdateMemoryParamsSchema = z.object({
+  id: z.number(),
+  content: z.string(),
+});
+
+export type UpdateMemoryParams = z.infer<typeof UpdateMemoryParamsSchema>;
+
+// =============================================================================
+// Memory Contracts
+// =============================================================================
+
+export const memoryContracts = {
+  listByApp: defineContract({
+    channel: "memories:list-by-app",
+    input: z.number(), // appId
+    output: z.array(MemoryDtoSchema),
+  }),
+
+  create: defineContract({
+    channel: "memories:create",
+    input: CreateMemoryParamsSchema,
+    output: MemoryDtoSchema,
+  }),
+
+  update: defineContract({
+    channel: "memories:update",
+    input: UpdateMemoryParamsSchema,
+    output: z.void(),
+  }),
+
+  delete: defineContract({
+    channel: "memories:delete",
+    input: z.number(), // id
+    output: z.void(),
+  }),
+} as const;
+
+// =============================================================================
+// Memory Client
+// =============================================================================
+
+export const memoryClient = createClient(memoryContracts);

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -247,6 +247,15 @@ export const queryKeys = {
     byApp: ({ appId }: { appId: number | null }) =>
       ["app-env-vars", appId] as const,
   },
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Memories
+  // ─────────────────────────────────────────────────────────────────────────────
+  memories: {
+    all: ["memories"] as const,
+    byApp: ({ appId }: { appId: number | null }) =>
+      ["memories", appId] as const,
+  },
 } as const;
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -302,6 +311,5 @@ export type AppQueryKey =
   | QueryKeyOf<(typeof queryKeys.mcp)[keyof typeof queryKeys.mcp]>
   | QueryKeyOf<(typeof queryKeys.supabase)[keyof typeof queryKeys.supabase]>
   | QueryKeyOf<(typeof queryKeys.neon)[keyof typeof queryKeys.neon]>
-  | QueryKeyOf<
-      (typeof queryKeys.appEnvVars)[keyof typeof queryKeys.appEnvVars]
-    >;
+  | QueryKeyOf<(typeof queryKeys.appEnvVars)[keyof typeof queryKeys.appEnvVars]>
+  | QueryKeyOf<(typeof queryKeys.memories)[keyof typeof queryKeys.memories]>;

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -321,6 +321,7 @@ export const UserSettingsSchema = z
       })
       .optional(),
     hideLocalAgentNewChatToast: z.boolean().optional(),
+    enableMemory: z.boolean().optional(),
   })
   // Allow unknown properties to pass through (e.g. future settings
   // that should be preserved if user downgrades to an older version)

--- a/src/lib/settingsSearchIndex.ts
+++ b/src/lib/settingsSearchIndex.ts
@@ -31,6 +31,7 @@ export const SETTING_IDS = {
   supabase: "setting-supabase",
   neon: "setting-neon",
   nativeGit: "setting-native-git",
+  memory: "setting-memory",
   reset: "setting-reset",
 } as const;
 
@@ -284,6 +285,24 @@ export const SETTINGS_SEARCH_INDEX: SearchableSettingItem[] = [
     keywords: ["git", "native", "experiment", "beta", "performance"],
     sectionId: SECTION_IDS.experiments,
     sectionLabel: "Experiments",
+  },
+
+  // Memory
+  {
+    id: SETTING_IDS.memory,
+    label: "Memory",
+    description:
+      "Enable persistent memory so the AI remembers preferences and context across chats",
+    keywords: [
+      "memory",
+      "remember",
+      "context",
+      "persistent",
+      "preferences",
+      "history",
+    ],
+    sectionId: SECTION_IDS.ai,
+    sectionLabel: "AI",
   },
 
   // Danger Zone

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -34,6 +34,7 @@ import { DefaultChatModeSelector } from "@/components/DefaultChatModeSelector";
 import { useSetAtom } from "jotai";
 import { activeSettingsSectionAtom } from "@/atoms/viewAtoms";
 import { SECTION_IDS, SETTING_IDS } from "@/lib/settingsSearchIndex";
+import { MemorySwitch } from "@/components/MemorySwitch";
 
 export default function SettingsPage() {
   const [isResetDialogOpen, setIsResetDialogOpen] = useState(false);
@@ -381,6 +382,14 @@ export function AISettings() {
 
       <div id={SETTING_IDS.maxChatTurns} className="mt-4">
         <MaxChatTurnsSelector />
+      </div>
+
+      <div id={SETTING_IDS.memory} className="space-y-1 mt-4">
+        <MemorySwitch />
+        <div className="text-sm text-gray-500 dark:text-gray-400">
+          When enabled, the AI will remember your preferences and project
+          context across chat sessions. Memories are stored per app.
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Implements a persistent memory system that allows the AI to remember user preferences and project context across chat sessions. Memories are scoped per app and can be manually managed through a new UI panel.

## Key Changes

- **Database Schema**: Added `memories` table to store per-app memory entries with timestamps
- **IPC Layer**: Created memory contracts and handlers for CRUD operations (`listByApp`, `create`, `update`, `delete`)
- **UI Components**: 
  - `MemoryPanel`: Displays, creates, edits, and deletes memories for the current app
  - `MemorySwitch`: Toggle to enable/disable memory feature in AI Settings
- **Settings Integration**: Added `enableMemory` boolean flag to user settings with search index entry
- **Context Injection**: Memories are automatically injected into the system prompt when enabled, appearing in both regular and read-only chat modes
- **Query Management**: Added memory query keys for React Query cache management

## Implementation Details

- **Storage**: Uses existing SQLite database with Drizzle ORM (no new dependencies)
- **Scoping**: Memories are tied to `app_id` and cascade-deleted when an app is removed
- **UI/UX**: 
  - Memory panel appears in the Configure tab under a new "Memory" card
  - Inline editing with keyboard shortcuts (Enter to save, Escape to cancel)
  - Hover-activated action buttons (edit/delete)
  - Disabled state when memory feature is turned off
- **Performance**: All memories for an app are fetched in a single indexed query and injected as a formatted list in the system prompt

## Design Decision

Chose dependency-free SQLite storage over vector embeddings (vectra/lancedb) because:
- Expected memory volume (tens of entries per app) doesn't justify semantic search complexity
- Simpler maintenance and offline-first operation
- Follows existing patterns (mirrors the `prompts` table structure)
- Can be upgraded to semantic search later if needed

https://claude.ai/code/session_012Yr3yrTX6vePg4TGDFP7qA
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2481">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new persistent data model plus IPC CRUD and injects stored content into the system prompt, which can affect AI behavior and token usage. Risk is mitigated by being gated behind `enableMemory` and scoped per app, but it touches the chat streaming path.
> 
> **Overview**
> Adds a **persistent per-app “memory” feature** backed by a new SQLite/Drizzle `memories` table and migration, plus typed IPC contracts/handlers for list/create/update/delete.
> 
> Introduces a new settings flag `enableMemory` (search-indexed) with a `MemorySwitch` toggle, and a `MemoryPanel` UI in the Configure panel to manually add/edit/delete memories.
> 
> When enabled, the chat stream handler now **fetches all memories for the active app and appends them to the system prompt** (including the Pro ask-mode read-only/local-agent prompt), so stored preferences/context influence future chats.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b1bc5404f89d149e06544a1870ecec31ce737a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a persistent per-app memory system to remember user preferences and project context across chats. When enabled, memories are injected into system prompts in both regular and read-only modes and can be managed from a new UI.

- **New Features**
  - Storage: new SQLite `memories` table with Drizzle migration and cascade delete.
  - IPC: list/create/update/delete contracts, handlers, whitelist registration, unified client, and React Query keys with `useMemories` hook.
  - UI: MemoryPanel in Configure tab for inline add/edit/delete, plus MemorySwitch in AI Settings with a searchable setting entry.
  - Prompt injection: app memories appended to system and read-only prompts when `enableMemory` is on.
  - No new dependencies.

<sup>Written for commit 3b1bc5404f89d149e06544a1870ecec31ce737a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

