### PR TITLE
Move remember-learnings to beginning of pr-push workflow

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -14,7 +14,7 @@ Slash commands are invoked with `/dyad:<command>`. Available commands:
 | `/dyad:pr-fix:comments` | Address unresolved PR review comments                          | `lint`, `pr-push`                   |
 | `/dyad:pr-fix:actions`  | Fix failing CI checks and GitHub Actions                       | `e2e-rebase`, `pr-push`             |
 | `/dyad:pr-rebase`       | Rebase the current branch                                      | `pr-push`                           |
-| `/dyad:pr-push`         | Push changes and create/update a PR                            | -                                   |
+| `/dyad:pr-push`         | Push changes and create/update a PR                            | `remember-learnings`                |
 | `/dyad:lint`            | Run all pre-commit checks (formatting, linting, type-checking) | -                                   |
 | `/dyad:e2e-rebase`      | Rebase E2E test snapshots                                      | -                                   |
 | `/dyad:deflake-e2e`     | Deflake flaky E2E tests                                        | -                                   |

--- a/.claude/commands/dyad/pr-push.md
+++ b/.claude/commands/dyad/pr-push.md
@@ -32,7 +32,22 @@ Commit any uncommitted changes, run lint checks, fix any issues, and push the cu
 
    If there are no uncommitted changes, proceed to the next step.
 
-3. **Run lint checks:**
+3. **Remember learnings:**
+
+   Run the `/remember-learnings` skill to capture any errors, snags, or insights from this session into `AGENTS.md`.
+
+   If `AGENTS.md` was modified by the skill, stage it and amend the latest commit to include the changes:
+
+   ```
+   git add AGENTS.md
+   git diff --cached --quiet AGENTS.md || git commit --amend --no-edit
+   ```
+
+   This ensures `AGENTS.md` is always included in the committed changes before lint/formatting runs.
+
+   **IMPORTANT:** Do NOT stop here. You MUST continue to step 4.
+
+4. **Run lint checks:**
 
    Run these commands to ensure the code passes all pre-commit checks:
 
@@ -42,9 +57,9 @@ Commit any uncommitted changes, run lint checks, fix any issues, and push the cu
 
    If there are errors that could not be auto-fixed, read the affected files and fix them manually, then re-run the checks until they pass.
 
-   **IMPORTANT:** Do NOT stop after lint passes. You MUST continue to step 4.
+   **IMPORTANT:** Do NOT stop after lint passes. You MUST continue to step 5.
 
-4. **Run tests:**
+5. **Run tests:**
 
    Run the test suite to ensure nothing is broken:
 
@@ -54,9 +69,9 @@ Commit any uncommitted changes, run lint checks, fix any issues, and push the cu
 
    If any tests fail, fix them before proceeding. Do NOT skip failing tests.
 
-   **IMPORTANT:** Do NOT stop after tests pass. You MUST continue to step 5.
+   **IMPORTANT:** Do NOT stop after tests pass. You MUST continue to step 6.
 
-5. **If lint made changes, amend the last commit:**
+6. **If lint made changes, amend the last commit:**
 
    If the lint checks made any changes, stage and amend them into the last commit:
 
@@ -65,19 +80,7 @@ Commit any uncommitted changes, run lint checks, fix any issues, and push the cu
    git commit --amend --no-edit
    ```
 
-   **IMPORTANT:** Do NOT stop here. You MUST continue to step 6.
-
-6. **Remember learnings:**
-
-   Run the `/remember-learnings` skill to capture any errors, snags, or insights from this session into `AGENTS.md`.
-
-   If `AGENTS.md` was modified by the skill, amend the latest commit to include the changes:
-
-   ```
-   git diff --cached --quiet AGENTS.md || git commit --amend --no-edit
-   ```
-
-   This conditional guard ensures the commit is only amended if `AGENTS.md` actually changed, avoiding unnecessary history rewrites.
+   **IMPORTANT:** Do NOT stop here. You MUST continue to step 7.
 
 7. **Push the branch (REQUIRED):**
 


### PR DESCRIPTION
## Summary
Reordered the `/dyad:pr-push` command workflow to run the `remember-learnings` skill before lint checks, rather than after. This ensures that learnings are captured early in the process and included in the final commit.

## Changes
- **Workflow reordering**: Moved the "Remember learnings" step from position 6 to position 3 (before lint checks)
  - This allows `AGENTS.md` changes to be captured before any formatting/linting modifications
  - Ensures learnings are part of the final amended commit rather than added after lint changes
  
- **Updated step numbering**: Renumbered all subsequent steps (lint checks, tests, and final push) to reflect the new order

- **Updated command metadata**: Added `remember-learnings` as a dependent skill in the pr-push command documentation

- **Simplified git logic**: Removed the conditional guard comment since the step now runs earlier in the process

## Rationale
By capturing learnings before lint checks, we ensure that:
1. All insights from the session are preserved in `AGENTS.md`
2. The file is included in the commit before any auto-formatting occurs
3. The final commit contains both learnings and properly formatted code
4. There's no risk of learnings being lost if lint makes significant changes

https://claude.ai/code/session_01KfNBDK6GsBNu2zD85UfA7V
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2485">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the remember-learnings step to run before linting in the /dyad:pr-push workflow so AGENTS.md updates are captured early and included in the commit. This prevents learnings from being lost and keeps the final commit consistent.

- **Refactors**
  - Run remember-learnings at step 3 (before lint/formatting); renumbered following steps.
  - Stage AGENTS.md and amend the last commit when changed, ensuring learnings land before lint changes.
  - Updated README and pr-push docs to reflect the new dependency and step order.

<sup>Written for commit d010420a889a8cbf896511199f926f066a62fd35. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that reorders the `pr-push` checklist; no runtime code, build, or security-sensitive logic is modified.
> 
> **Overview**
> Updates the `/dyad:pr-push` workflow to run `remember-learnings` *before* linting, with instructions to stage `AGENTS.md` and amend the latest commit so learnings are captured early.
> 
> Renumbers the remaining steps accordingly and updates `.claude/README.md` to list `remember-learnings` as a dependency for `/dyad:pr-push`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d010420a889a8cbf896511199f926f066a62fd35. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->