### PR TITLE
Add automated PR merge workflow based on test results

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,232 @@
+name: Auto Merge
+
+on:
+  workflow_run:
+    workflows: ["Playwright Report Comment"]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR and decide whether to merge
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const run = context.payload.workflow_run;
+
+            // --- Find the PR associated with this workflow run ---
+            const sha = run.head_sha;
+            const headBranch = run.head_branch;
+            const headRepoOwner = run.head_repository?.owner?.login;
+
+            core.info(`Looking up PR for sha=${sha}, branch=${headBranch}`);
+
+            let pr;
+
+            // Method 1: listPullRequestsAssociatedWithCommit
+            const res = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner, repo, commit_sha: sha,
+            });
+            pr = res.data?.find(p => p.state === 'open');
+
+            // Method 2: Fallback for fork PRs
+            if (!pr && headRepoOwner && headBranch) {
+              core.info(`Fallback: searching for PRs with head=${headRepoOwner}:${headBranch}`);
+              const pullsRes = await github.rest.pulls.list({
+                owner, repo, state: 'open',
+                head: `${headRepoOwner}:${headBranch}`,
+              });
+              pr = pullsRes.data?.[0];
+            }
+
+            if (!pr) {
+              core.info('No open PR found for this workflow run.');
+              core.setOutput('should_merge', 'false');
+              return;
+            }
+
+            const prNumber = pr.number;
+            core.info(`Found PR #${prNumber}`);
+
+            // --- Check for merge-when-ready label ---
+            const hasLabel = pr.labels.some(l => l.name === 'merge-when-ready');
+            if (!hasLabel) {
+              core.info(`PR #${prNumber} does not have the "merge-when-ready" label. Skipping.`);
+              core.setOutput('should_merge', 'false');
+              return;
+            }
+            core.info(`PR #${prNumber} has "merge-when-ready" label.`);
+
+            // --- Check for "changes requested" reviews ---
+            const { data: reviews } = await github.rest.pulls.listReviews({
+              owner, repo, pull_number: prNumber,
+            });
+
+            // Build a map of latest review state per reviewer
+            const latestReviewByUser = new Map();
+            for (const review of reviews) {
+              if (review.state === 'APPROVED' || review.state === 'CHANGES_REQUESTED' || review.state === 'DISMISSED') {
+                latestReviewByUser.set(review.user.login, review.state);
+              }
+            }
+
+            const hasChangesRequested = [...latestReviewByUser.values()].some(
+              state => state === 'CHANGES_REQUESTED'
+            );
+            if (hasChangesRequested) {
+              core.info(`PR #${prNumber} has unresolved "changes requested" reviews. Skipping merge.`);
+              core.setOutput('should_merge', 'false');
+              return;
+            }
+
+            // --- Parse the Playwright comment for test failures ---
+            const { data: comments } = await github.rest.issues.listComments({
+              owner, repo, issue_number: prNumber,
+            });
+
+            const playwrightComment = comments.find(
+              c => c.user?.type === 'Bot' && c.body?.includes('🎭 Playwright Test Results')
+            );
+
+            if (!playwrightComment) {
+              core.info('No Playwright comment found. Skipping merge (tests may not have run).');
+              core.setOutput('should_merge', 'false');
+              return;
+            }
+
+            const body = playwrightComment.body;
+
+            // Check for missing shards warning - this indicates CI infrastructure issues
+            if (body.includes('⚠️ WARNING: Missing Test Shards')) {
+              core.info('Playwright report has missing test shards. Skipping merge.');
+              core.setOutput('should_merge', 'false');
+              return;
+            }
+
+            // If all tests passed, we can merge
+            if (body.includes('✅ All tests passed')) {
+              core.info('All Playwright tests passed!');
+              core.setOutput('should_merge', 'true');
+              core.setOutput('pr_number', String(prNumber));
+              return;
+            }
+
+            // Tests failed - parse failure count and check if related to changes
+            if (!body.includes('❌ Some tests failed')) {
+              core.info('Could not determine Playwright test status. Skipping merge.');
+              core.setOutput('should_merge', 'false');
+              return;
+            }
+
+            // Extract total failed count from summary line: "**Summary: X passed, Y failed**"
+            const summaryMatch = body.match(/\*\*Summary:\s*\d+\s*passed,\s*(\d+)\s*failed\*\*/);
+            const totalFailed = summaryMatch ? parseInt(summaryMatch[1], 10) : 999;
+            core.info(`Total failed tests: ${totalFailed}`);
+
+            if (totalFailed >= 5) {
+              core.info(`Too many failures (${totalFailed} >= 5). Skipping merge.`);
+              core.setOutput('should_merge', 'false');
+              return;
+            }
+
+            // Extract failed test names from the comment
+            // Format: "- `spec_name.spec.ts > Suite > Test Name`"
+            const failedTestNames = [];
+            const testNameRegex = /^- `([^`]+)`$/gm;
+            let match;
+            // Only look at the "Failed Tests" section
+            const failedSection = body.split('### Failed Tests')[1]?.split('### 📋')[0] || '';
+            while ((match = testNameRegex.exec(failedSection)) !== null) {
+              failedTestNames.push(match[1]);
+            }
+            core.info(`Failed test names: ${JSON.stringify(failedTestNames)}`);
+
+            // Get changed files in the PR
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner, repo, pull_number: prNumber, per_page: 300,
+            });
+            const changedFiles = files.map(f => f.filename);
+            core.info(`Changed files (${changedFiles.length}): ${changedFiles.slice(0, 20).join(', ')}${changedFiles.length > 20 ? '...' : ''}`);
+
+            // Extract meaningful identifiers from changed files for matching
+            // e.g., "src/components/ChatView.tsx" -> ["chatview", "chat-view", "chat_view"]
+            function getFileIdentifiers(filepath) {
+              const basename = filepath.split('/').pop().replace(/\.[^.]+$/, '');
+              const identifiers = new Set();
+              // Original name (lowercased)
+              identifiers.add(basename.toLowerCase());
+              // Split camelCase/PascalCase into parts
+              const parts = basename.replace(/([a-z])([A-Z])/g, '$1 $2').toLowerCase().split(/[\s_-]+/);
+              for (const part of parts) {
+                if (part.length > 2) identifiers.add(part);
+              }
+              return identifiers;
+            }
+
+            // Collect identifiers from all changed files (excluding test/config files)
+            const changedIdentifiers = new Set();
+            for (const file of changedFiles) {
+              // Skip test files, config files, and workflow files from matching
+              if (file.includes('.spec.') || file.includes('.test.') ||
+                  file.includes('.github/') || file.includes('.claude/')) {
+                continue;
+              }
+              for (const id of getFileIdentifiers(file)) {
+                changedIdentifiers.add(id);
+              }
+            }
+            core.info(`Changed file identifiers: ${JSON.stringify([...changedIdentifiers])}`);
+
+            // Check if any failed test is related to changed files
+            let hasRelatedFailure = false;
+            for (const testName of failedTestNames) {
+              const testLower = testName.toLowerCase();
+              for (const identifier of changedIdentifiers) {
+                if (testLower.includes(identifier)) {
+                  core.info(`Failed test "${testName}" appears related to changed identifier "${identifier}"`);
+                  hasRelatedFailure = true;
+                  break;
+                }
+              }
+              if (hasRelatedFailure) break;
+            }
+
+            if (hasRelatedFailure) {
+              core.info('Some failing tests appear related to the PR changes. Skipping merge.');
+              core.setOutput('should_merge', 'false');
+              return;
+            }
+
+            core.info(`${totalFailed} unrelated test failure(s) detected. Proceeding with merge.`);
+            core.setOutput('should_merge', 'true');
+            core.setOutput('pr_number', String(prNumber));
+
+      - name: Squash merge the PR
+        if: steps.check.outputs.should_merge == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = parseInt('${{ steps.check.outputs.pr_number }}', 10);
+            const { owner, repo } = context.repo;
+
+            core.info(`Squash merging PR #${prNumber}...`);
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner, repo, pull_number: prNumber,
+            });
+
+            await github.rest.pulls.merge({
+              owner, repo, pull_number: prNumber,
+              merge_method: 'squash',
+              commit_title: `${pr.title} (#${prNumber})`,
+            });
+
+            core.info(`PR #${prNumber} has been squash merged.`);

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Check PR and decide whether to merge
         id: check
@@ -73,8 +74,11 @@ jobs:
             // Build a map of latest review state per reviewer
             const latestReviewByUser = new Map();
             for (const review of reviews) {
-              if (review.state === 'APPROVED' || review.state === 'CHANGES_REQUESTED' || review.state === 'DISMISSED') {
+              if (!review.user) continue;
+              if (review.state === 'APPROVED' || review.state === 'CHANGES_REQUESTED') {
                 latestReviewByUser.set(review.user.login, review.state);
+              } else if (review.state === 'DISMISSED') {
+                latestReviewByUser.delete(review.user.login);
               }
             }
 
@@ -88,16 +92,26 @@ jobs:
             }
 
             // --- Parse the Playwright comment for test failures ---
-            const { data: comments } = await github.rest.issues.listComments({
-              owner, repo, issue_number: prNumber,
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: prNumber, per_page: 100,
             });
 
             const playwrightComment = comments.find(
-              c => c.user?.type === 'Bot' && c.body?.includes('🎭 Playwright Test Results')
+              c => c.user?.login === 'github-actions[bot]' && c.body?.includes('🎭 Playwright Test Results')
             );
 
             if (!playwrightComment) {
               core.info('No Playwright comment found. Skipping merge (tests may not have run).');
+              core.setOutput('should_merge', 'false');
+              return;
+            }
+
+            // --- Validate that the Playwright comment is for the current PR head ---
+            const { data: currentPr } = await github.rest.pulls.get({
+              owner, repo, pull_number: prNumber,
+            });
+            if (currentPr.head.sha !== sha) {
+              core.info(`PR head (${currentPr.head.sha}) differs from workflow run SHA (${sha}). Skipping.`);
               core.setOutput('should_merge', 'false');
               return;
             }
@@ -128,7 +142,12 @@ jobs:
 
             // Extract total failed count from summary line: "**Summary: X passed, Y failed**"
             const summaryMatch = body.match(/\*\*Summary:\s*\d+\s*passed,\s*(\d+)\s*failed\*\*/);
-            const totalFailed = summaryMatch ? parseInt(summaryMatch[1], 10) : 999;
+            if (!summaryMatch) {
+              core.info('Could not parse failure count from Playwright comment. Skipping merge.');
+              core.setOutput('should_merge', 'false');
+              return;
+            }
+            const totalFailed = parseInt(summaryMatch[1], 10);
             core.info(`Total failed tests: ${totalFailed}`);
 
             if (totalFailed >= 5) {
@@ -140,10 +159,11 @@ jobs:
             // Extract failed test names from the comment
             // Format: "- `spec_name.spec.ts > Suite > Test Name`"
             const failedTestNames = [];
-            const testNameRegex = /^- `([^`]+)`$/gm;
+            const testNameRegex = /^- `([^`]+)`/gm;
             let match;
-            // Only look at the "Failed Tests" section
-            const failedSection = body.split('### Failed Tests')[1]?.split('### 📋')[0] || '';
+            // Only look at the "Failed Tests" section, stopping at the next ### heading
+            const afterFailedTests = body.split('### Failed Tests')[1] || '';
+            const failedSection = afterFailedTests.split(/\n###\s/)[0] || '';
             while ((match = testNameRegex.exec(failedSection)) !== null) {
               failedTestNames.push(match[1]);
             }
@@ -166,7 +186,7 @@ jobs:
               // Split camelCase/PascalCase into parts
               const parts = basename.replace(/([a-z])([A-Z])/g, '$1 $2').toLowerCase().split(/[\s_-]+/);
               for (const part of parts) {
-                if (part.length > 2) identifiers.add(part);
+                if (part.length >= 5) identifiers.add(part);
               }
               return identifiers;
             }
@@ -212,16 +232,47 @@ jobs:
       - name: Squash merge the PR
         if: steps.check.outputs.should_merge == 'true'
         uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.check.outputs.pr_number }}
         with:
           script: |
-            const prNumber = parseInt('${{ steps.check.outputs.pr_number }}', 10);
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
             const { owner, repo } = context.repo;
 
             core.info(`Squash merging PR #${prNumber}...`);
 
+            // Re-validate PR state before merging to avoid race conditions
             const { data: pr } = await github.rest.pulls.get({
               owner, repo, pull_number: prNumber,
             });
+
+            if (pr.state !== 'open') {
+              core.info(`PR #${prNumber} is no longer open (state: ${pr.state}). Skipping merge.`);
+              return;
+            }
+
+            if (!pr.labels.some(l => l.name === 'merge-when-ready')) {
+              core.info(`PR #${prNumber} no longer has "merge-when-ready" label. Skipping merge.`);
+              return;
+            }
+
+            // Re-check for changes requested reviews
+            const { data: reviews } = await github.rest.pulls.listReviews({
+              owner, repo, pull_number: prNumber,
+            });
+            const latestReviewByUser = new Map();
+            for (const review of reviews) {
+              if (!review.user) continue;
+              if (review.state === 'APPROVED' || review.state === 'CHANGES_REQUESTED') {
+                latestReviewByUser.set(review.user.login, review.state);
+              } else if (review.state === 'DISMISSED') {
+                latestReviewByUser.delete(review.user.login);
+              }
+            }
+            if ([...latestReviewByUser.values()].some(s => s === 'CHANGES_REQUESTED')) {
+              core.info(`PR #${prNumber} now has "changes requested" reviews. Skipping merge.`);
+              return;
+            }
 
             await github.rest.pulls.merge({
               owner, repo, pull_number: prNumber,


### PR DESCRIPTION
## Summary
Introduces an automated merge workflow that intelligently merges pull requests labeled with `merge-when-ready` based on Playwright test results and code change analysis.

## Key Changes
- **New GitHub Actions workflow** (`auto-merge.yml`): Triggered after Playwright test reports are generated
- **Smart PR detection**: Finds associated PRs using commit SHA with fallback support for fork PRs
- **Comprehensive merge criteria**:
  - PR must have `merge-when-ready` label
  - No "changes requested" reviews
  - Playwright tests must pass or have minimal unrelated failures
  - Detects and skips merge if test infrastructure issues exist (missing shards)
- **Intelligent failure analysis**: 
  - Allows up to 4 test failures if unrelated to PR changes
  - Matches failed test names against changed files using identifier extraction
  - Skips merge if failures appear related to code changes
- **Automatic squash merge**: Merges qualifying PRs with clean commit history

## Implementation Details
- Uses GitHub Script action for complex logic without external dependencies
- Extracts file identifiers from changed files (handles camelCase, snake_case, kebab-case)
- Parses Playwright test report comments to extract failure counts and test names
- Provides detailed logging for debugging and audit trail
- Handles edge cases like fork PRs and missing test reports gracefully

https://claude.ai/code/session_01PvwXgEEusFdWZW2T3vy9Cc
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2486">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Actions workflow that auto-squash-merges PRs labeled "merge-when-ready" based on Playwright test results and change impact. This reduces manual merges while keeping risky changes out.

- **New Features**
  - Adds auto-merge.yml triggered after the "Playwright Report Comment" workflow completes.
  - Merges PRs with the "merge-when-ready" label when safe: no "changes requested", tests all pass or fewer than 5 unrelated failures, and no missing shards.
  - Checks if failures are related by matching failed test names to identifiers from changed files (ignores tests/config/workflow files).
  - Finds the correct PR via commit SHA with a fork fallback, then performs a squash merge with detailed logs.

- **Migration**
  - Apply the "merge-when-ready" label when a PR is ready for auto-merge.
  - Ensure the Playwright report workflow is named "Playwright Report Comment".

<sup>Written for commit 2fe70ffcef3ba221182b5caa0a73fd3bd8b4998b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new GitHub Actions workflow with `contents`/`pull-requests` write permissions that can automatically squash-merge PRs, so mis-parsing Playwright comments or incorrect PR association could merge changes unintentionally.
> 
> **Overview**
> Introduces a new `Auto Merge` GitHub Actions workflow (`.github/workflows/auto-merge.yml`) that runs after the `Playwright Report Comment` workflow succeeds and can **auto squash-merge** PRs.
> 
> The workflow locates the PR for the triggering SHA (with a fork-safe fallback), requires the `merge-when-ready` label, blocks merges when any reviewer has an outstanding *changes requested*, and parses the Playwright summary comment to merge only when tests fully pass or when fewer than 5 failures appear unrelated to the PR’s changed files (and skips on missing-shard warnings).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d6658b90f507618c1b90405df1d46373677c21c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->