### PR TITLE
Allow POST to /issues/{id}/labels in gh permission hook

### DIFF
--- a/.claude/hooks/gh-permission-hook.py
+++ b/.claude/hooks/gh-permission-hook.py
@@ -27,6 +27,7 @@ ALLOWED (auto-approved):
    - PATCH to /pulls/{id} (PR title/body updates)
    - PATCH to /issues/comments/{id} (issue comment updates)
    - PATCH to /pulls/comments/{id} (PR comment updates)
+   - POST to /issues/{id}/labels (add labels to issues)
 
 5. gh api graphql - queries and specific mutations:
    - All GraphQL queries (read-only)
@@ -455,6 +456,11 @@ def check_gh_api_command(cmd: str) -> Optional[dict]:
         if re.search(r'/pulls/\d+$', endpoint):
             if method == "PATCH":
                 return make_allow_decision("PR update auto-approved")
+
+        # Allow adding labels to issues (repos/.../issues/.../labels)
+        if re.search(r'/issues/\d+/labels$', endpoint):
+            if method in [None, "POST"]:
+                return make_allow_decision("Issue label addition auto-approved")
 
     # Now check if method is destructive (after checking allowed endpoints)
     if method:

--- a/.claude/hooks/tests/good_commands.txt
+++ b/.claude/hooks/tests/good_commands.txt
@@ -559,6 +559,13 @@ gh api repos/owner/repo/issues/1/comments -f body='Working on this'
 gh api repos/owner/repo/issues/999/comments --field body='Fixed in latest commit'
 gh api /repos/owner/repo/issues/123/comments -f body='See PR #456'
 
+# Add labels to issues (POST to /issues/{id}/labels)
+gh api repos/owner/repo/issues/123/labels -f "labels[]=bug"
+gh api repos/owner/repo/issues/123/labels --method POST -f "labels[]=cc:request"
+gh api repos/dyad-sh/dyad/issues/2488/labels --method POST -f "labels[]=cc:request" 2>&1
+gh api /repos/owner/repo/issues/456/labels -f "labels[]=enhancement"
+gh api -X POST repos/owner/repo/issues/789/labels -f "labels[]=bug" -f "labels[]=urgent"
+
 # Update issue comments (PATCH to /issues/comments/{id})
 gh api repos/owner/repo/issues/comments/123 --method PATCH -f body='Updated comment'
 gh api repos/owner/repo/issues/comments/456 -X PATCH -f body='Fixed typo'


### PR DESCRIPTION
## Summary
- Added `/issues/{id}/labels` as an allowed POST endpoint in `gh-permission-hook.py`, enabling automated label management (e.g., adding `cc:request` labels to issues/PRs)
- Added 5 test cases to `good_commands.txt` covering the new endpoint
- All 921 hook tests pass

## Test plan
- [x] Hook unit tests pass (`python3 .claude/hooks/tests/test_gh_permission_hook.py` — 921/921)
- [x] Vitest suite passes (661/661)

#skip-bugbot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2490">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow POST to /issues/{id}/labels in gh-permission-hook so automation can add labels (e.g., cc:request) without manual approval. Added five allowed-command tests covering the new endpoint.

<sup>Written for commit ffceaef93ca64b2944523244a187bbd418d9743a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

