### PR TITLE
Delete and recreate Playwright PR comment instead of updating

### DIFF
--- a/scripts/generate-playwright-summary.js
+++ b/scripts/generate-playwright-summary.js
@@ -459,20 +459,19 @@ async function run({ github, context, core }) {
       );
 
       if (botComment) {
-        await github.rest.issues.updateComment({
+        await github.rest.issues.deleteComment({
           owner: context.repo.owner,
           repo: context.repo.repo,
           comment_id: botComment.id,
-          body: comment,
-        });
-      } else {
-        await github.rest.issues.createComment({
-          owner: context.repo.owner,
-          repo: context.repo.repo,
-          issue_number: prNumber,
-          body: comment,
         });
       }
+
+      await github.rest.issues.createComment({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: prNumber,
+        body: comment,
+      });
     } catch (error) {
       // Handle permission errors gracefully (common for fork PRs)
       if (error.status === 403) {


### PR DESCRIPTION
## Summary
- Change the Playwright test results comment workflow to delete the existing bot comment and create a new one, rather than updating in place
- This ensures the comment always appears at the bottom of the PR conversation with the latest results

## Test plan
- Verify the workflow triggers correctly on CI completion
- Check that old Playwright comments are deleted and new ones are created at the bottom of the PR thread

#skip-bugbot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2491">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Change Playwright test results commenting to delete the previous bot comment and post a new one. This ensures the latest results always appear at the bottom of the PR thread.

<sup>Written for commit f066fac1aa3c3fa362a9161605901359128f72ff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

