### PR TITLE
Add "Start new chat" button to error box for Dyad Pro users

### DIFF
--- a/src/components/chat/ChatErrorBox.tsx
+++ b/src/components/chat/ChatErrorBox.tsx
@@ -4,18 +4,26 @@ import {
   X,
   ExternalLink as ExternalLinkIcon,
   CircleArrowUp,
+  MessageSquarePlus,
 } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 export function ChatErrorBox({
   onDismiss,
   error,
   isDyadProEnabled,
+  onStartNewChat,
 }: {
   onDismiss: () => void;
   error: string;
   isDyadProEnabled: boolean;
+  onStartNewChat?: () => void;
 }) {
   if (error.includes("doesn't have a free quota tier")) {
     return (
@@ -138,6 +146,22 @@ export function ChatErrorBox({
               Upgrade to Dyad Pro
             </ExternalLink>
           )}
+        {isDyadProEnabled && onStartNewChat && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={onStartNewChat}
+                className="cursor-pointer inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium shadow-sm focus:outline-none focus:ring-2 bg-blue-600 text-white hover:bg-blue-700 focus:ring-blue-500"
+              >
+                <span>Start new chat</span>
+                <MessageSquarePlus size={18} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>
+              Starting a new chat can fix some issues
+            </TooltipContent>
+          </Tooltip>
+        )}
         <ExternalLink href="https://www.dyad.sh/docs/faq">
           Read docs
         </ExternalLink>


### PR DESCRIPTION
## Summary
Added a "Start new chat" button to the ChatErrorBox component that appears for Dyad Pro enabled users. This provides a quick way to recover from certain chat errors by creating a fresh conversation.

## Key Changes
- **ChatErrorBox.tsx**: 
  - Added `MessageSquarePlus` icon import from lucide-react
  - Imported Tooltip components for better UX
  - Added `onStartNewChat` optional callback prop
  - Rendered a new "Start new chat" button with tooltip when Dyad Pro is enabled and callback is provided

- **ChatInput.tsx**:
  - Imported `useChats`, `useRouter`, and toast utilities
  - Added `handleNewChat` function that:
    - Creates a new chat via IPC
    - Updates the selected chat ID atom
    - Navigates to the new chat
    - Invalidates the chats cache
    - Shows error toast on failure
  - Passed `handleNewChat` to ChatErrorBox's `onStartNewChat` prop

## Implementation Details
- The button only appears when both `isDyadProEnabled` is true AND `onStartNewChat` callback is provided
- Includes a helpful tooltip: "Starting a new chat can fix some issues"
- Styled consistently with existing UI (blue-600 background, white text, hover effects)
- Gracefully handles errors during chat creation with user-facing toast notifications
- Falls back to home page navigation if appId is unavailable

https://claude.ai/code/session_016vbjv8b4hs5fG52yKHv4oZ
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2494">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Start new chat” button to the chat error box for Dyad Pro users to quickly recover from errors. Clicking it creates a fresh chat, navigates to it, refreshes the chat list, and handles failures gracefully.

- **New Features**
  - Button shows only when Dyad Pro is enabled and a callback is provided.
  - Creates a new chat via IPC, selects it, navigates to /chat, and invalidates the chats cache.
  - Includes a tooltip (“Starting a new chat can fix some issues”); shows a toast on failure and falls back to home if no appId.

<sup>Written for commit f71be0aa8c08cdd258bc59daa21939cf91528c62. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/UX change that wires an extra navigation/mutation path (IPC chat creation + query invalidation) behind an error-state button for Pro users.
> 
> **Overview**
> Adds a Pro-only recovery action in `ChatErrorBox`: a new **“Start new chat”** button (with tooltip) shown only when `isDyadProEnabled` and an `onStartNewChat` callback are provided.
> 
> Wires this action from `ChatInput` via a new `handleNewChat` flow that creates a chat over IPC, updates the selected chat atom, navigates to the new chat route, invalidates the chats cache, and shows a toast if creation fails (fallback navigation to `/` when no `appId`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f71be0aa8c08cdd258bc59daa21939cf91528c62. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->