### PR TITLE
Add Moonshot AI's Kimi K2.5 model to OpenRouter options

### DIFF
--- a/src/ipc/shared/language_model_constants.ts
+++ b/src/ipc/shared/language_model_constants.ts
@@ -218,6 +218,16 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
     },
   ],
   openrouter: [
+    // https://openrouter.ai/moonshotai/kimi-k2.5
+    {
+      name: "moonshotai/kimi-k2.5",
+      displayName: "Kimi K2.5",
+      description: "Moonshot AI's latest and most capable model",
+      maxOutputTokens: 32_000,
+      contextWindow: 256_000,
+      temperature: 0,
+      dollarSigns: 2,
+    },
     {
       name: "qwen/qwen3-coder:free",
       displayName: "Qwen3 Coder (free)",

--- a/src/ipc/shared/language_model_constants.ts
+++ b/src/ipc/shared/language_model_constants.ts
@@ -225,7 +225,7 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
       description: "Moonshot AI's latest and most capable model",
       maxOutputTokens: 32_000,
       contextWindow: 256_000,
-      temperature: 0,
+      temperature: 1.0,
       dollarSigns: 2,
     },
     {


### PR DESCRIPTION
## Summary
Added support for Moonshot AI's latest Kimi K2.5 model through OpenRouter, expanding the available language model options for users.

## Changes
- Added `moonshotai/kimi-k2.5` model configuration to the OpenRouter model options
- Configured with the following specifications:
  - Display name: "Kimi K2.5"
  - Description: "Moonshot AI's latest and most capable model"
  - Context window: 256,000 tokens
  - Max output tokens: 32,000 tokens
  - Temperature: 0 (deterministic responses)
  - Pricing tier: 2 dollar signs (mid-range pricing)

## Details
The model is positioned as Moonshot AI's flagship offering and has been added at the top of the OpenRouter model list. It supports a large context window suitable for processing lengthy documents and conversations.

https://claude.ai/code/session_016BLQbf16FjY5b6u3vjGX5X
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2495">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added Moonshot AI’s Kimi K2.5 model to OpenRouter to expand model options and support very large contexts. It’s listed at the top of the OpenRouter models.

- **New Features**
  - Added moonshotai/kimi-k2.5 with display name “Kimi K2.5” and description.
  - Key specs: 256k context window, 32k max output tokens, temperature 1.0, pricing tier $$.

<sup>Written for commit 63271c151cea6b096d8a3afb7f5092b9b16f562f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single `MODEL_OPTIONS.openrouter` entry with metadata only, with no changes to request/selection logic. Any impact is limited to users selecting the new model (notably its token limits and non-zero temperature setting).
> 
> **Overview**
> Adds Moonshot AI’s `moonshotai/kimi-k2.5` to the `openrouter` model options, exposing it in the app’s selectable model list.
> 
> The new entry defines its display metadata plus limits/pricing (`256k` context, `32k` max output, `temperature: 1.0`, `dollarSigns: 2`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63271c151cea6b096d8a3afb7f5092b9b16f562f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->