### PR TITLE
Add cc:rebase label-triggered workflow for PR rebasing

### DIFF
--- a/.github/workflows/claude-rebase.yml
+++ b/.github/workflows/claude-rebase.yml
@@ -1,0 +1,67 @@
+name: Claude Rebase
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+jobs:
+  rebase:
+    environment: ai-bots
+    if: github.event.label.name == 'cc:rebase'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Check PR author
+        id: check-author
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const allowedUsers = ['wwwillchen', 'wwwillchen-bot', 'azizmejri1', 'princeaden1'];
+            if (!allowedUsers.includes(pr.user.login)) {
+              console.log(`PR author ${pr.user.login} is not allowed to use this workflow`);
+              core.setOutput('should_continue', 'false');
+              return;
+            }
+            core.setOutput('should_continue', 'true');
+            core.setOutput('pr_number', pr.number);
+
+      - name: Checkout repository
+        if: steps.check-author.outputs.should_continue == 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+
+      - name: Remove cc:rebase label and add cc:rebasing
+        if: steps.check-author.outputs.should_continue == 'true'
+        run: |
+          gh pr edit ${{ steps.check-author.outputs.pr_number }} --repo ${{ github.repository }} --remove-label "cc:rebase" --add-label "cc:rebasing"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run PR Rebase
+        if: steps.check-author.outputs.should_continue == 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: |
+            /dyad:pr-rebase ${{ steps.check-author.outputs.pr_number }}
+
+      - name: Update labels on success
+        if: steps.check-author.outputs.should_continue == 'true' && success()
+        run: |
+          gh pr edit ${{ steps.check-author.outputs.pr_number }} --repo ${{ github.repository }} --remove-label "cc:rebasing"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update labels on failure
+        if: steps.check-author.outputs.should_continue == 'true' && failure()
+        run: |
+          gh pr edit ${{ steps.check-author.outputs.pr_number }} --repo ${{ github.repository }} --remove-label "cc:rebasing" --add-label "cc:rebase-failed"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds a GitHub workflow that triggers when the `cc:rebase` label is added to a PR
- Runs Claude Code with `/dyad:pr-rebase` to automatically rebase the PR branch
- Only allows trusted maintainers (wwwillchen, wwwillchen-bot, azizmejri1, princeaden1)
- Swaps `cc:rebase` → `cc:rebasing` while running, removes on success or adds `cc:rebase-failed` on failure

## Test plan
- [ ] Add `cc:rebase` label to a PR and verify the workflow triggers
- [ ] Verify the workflow correctly runs `/dyad:pr-rebase`
- [ ] Verify label transitions work correctly

#skip-bugbot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2504">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a label-triggered workflow to auto-rebase PRs and show status via labels. Only trusted maintainers can trigger it.

- **New Features**
  - Triggers on cc:rebase and runs /dyad:pr-rebase via anthropics/claude-code-action@v1.
  - Limits use to these authors: wwwillchen, wwwillchen-bot, azizmejri1, princeaden1.
  - Label flow: cc:rebase → cc:rebasing; removes on success; adds cc:rebase-failed on failure.

<sup>Written for commit 24d7909963a41752f0e9dd68bf13c8820a59d8b9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

