### PR TITLE
fix: configure upstream remote for cross-repo PR rebasing

### DIFF
--- a/.claude/commands/dyad/pr-rebase.md
+++ b/.claude/commands/dyad/pr-rebase.md
@@ -4,14 +4,18 @@ Rebase the current branch on the latest upstream changes, resolve conflicts, and
 
 ## Instructions
 
-1. **Determine the base branch:**
+1. **Determine the git remote setup:**
 
    ```
    git remote -v
    git branch -vv
    ```
 
-   Identify which remote and branch the current branch is tracking or should rebase onto (typically `main` or `master` from `upstream` or `origin`).
+   In GitHub Actions for cross-repo PRs:
+   - `origin` points to the **head repo** (fork) - this is where you push
+   - `upstream` points to the **base repo** - this is what you rebase onto
+
+   For same-repo PRs, `origin` points to the main repo and there may be no `upstream`.
 
 2. **Fetch the latest changes:**
 
@@ -21,11 +25,12 @@ Rebase the current branch on the latest upstream changes, resolve conflicts, and
 
 3. **Rebase onto the base branch:**
 
-   ```
-   git rebase <remote>/<base-branch>
-   ```
+   Use `upstream/main` if the `upstream` remote exists (cross-repo PR), otherwise use `origin/main`:
 
-   For example: `git rebase upstream/main`
+   ```
+   # Check if upstream remote exists
+   git remote get-url upstream 2>/dev/null && git rebase upstream/main || git rebase origin/main
+   ```
 
 4. **If there are merge conflicts:**
    - Identify the conflicting files from the rebase output

--- a/.github/workflows/claude-rebase.yml
+++ b/.github/workflows/claude-rebase.yml
@@ -36,6 +36,20 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
 
+      - name: Configure git remotes for cross-repo PR
+        if: steps.check-author.outputs.should_continue == 'true'
+        run: |
+          # Add upstream remote pointing to the base repo for rebasing
+          git remote add upstream https://github.com/${{ github.repository }}.git
+          git fetch upstream main
+
+          echo "Git remotes configured:"
+          echo "  origin -> ${{ github.event.pull_request.head.repo.full_name }} (head repo / fork)"
+          echo "  upstream -> ${{ github.repository }} (base repo)"
+          git remote -v
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Remove cc:rebase label and add cc:rebasing
         if: steps.check-author.outputs.should_continue == 'true'
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,3 +214,14 @@ Add `#skip-bugbot` to the PR description for trivial PRs that won't affect end-u
 - Linting or test setup changes
 - Documentation-only changes
 - CI/build configuration updates
+
+## Learnings
+
+### Cross-repo PR workflows (forks)
+
+When running GitHub Actions with `pull_request_target` on cross-repo PRs (from forks):
+
+- The checkout action sets `origin` to the **fork** (head repo), not the base repo
+- To rebase onto the base repo's main, you must add an `upstream` remote: `git remote add upstream https://github.com/<base-repo>.git`
+- Remote setup for cross-repo PRs: `origin` → fork (push here), `upstream` → base repo (rebase from here)
+- The `GITHUB_TOKEN` can push to the fork if the PR author enabled "Allow edits from maintainers"


### PR DESCRIPTION
## Summary
- Add workflow step to configure `upstream` remote pointing to base repo for cross-repo PRs
- Fetch `upstream/main` before Claude runs so rebase target is available
- Update pr-rebase skill to explicitly use `upstream/main` for cross-repo PRs (falling back to `origin/main` for same-repo PRs)

The claude-rebase workflow was failing because only `origin` (pointing to the fork) was configured. Claude would rebase onto `origin/main` which may be stale instead of the base repo's current main.

## Test plan
- Trigger the cc:rebase label on a cross-repo PR and verify it rebases onto the correct upstream/main

#skip-bugbot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2505">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cross-repo PR rebasing by adding an upstream remote to the base repo and rebasing onto upstream/main instead of a stale origin/main. This makes the claude-rebase workflow reliable for forks.

- **Bug Fixes**
  - Add upstream remote in workflow and fetch upstream/main.
  - Update pr-rebase command to prefer upstream/main, fallback to origin/main for same-repo PRs.
  - Document cross-repo remote setup and permissions in AGENTS.md.

<sup>Written for commit 52ea2741fa0397ee9e783c9a19b0d18cc54e388c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

