### PR TITLE
Show file path in refactor button tooltip

### DIFF
--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -598,9 +598,9 @@ function RefactorFileButton({ path }: { path: string }) {
   return (
     <SuggestionButton
       onClick={onClick}
-      tooltipText="Refactor the file to improve maintainability"
+      tooltipText={`Refactor the file to improve maintainability: \n${path}`}
     >
-      <span className="max-w-[180px] overflow-hidden whitespace-nowrap text-ellipsis">
+      <span className="max-w-[200px] overflow-hidden whitespace-nowrap text-ellipsis">
         Refactor {path.split("/").slice(-2).join("/")}
       </span>
     </SuggestionButton>


### PR DESCRIPTION
Closes #1272.

Currently, the refactor suggestion button doesn't show the full path of the file that it's going to refactor. This PR adds the file path in the tooltip so that the user can see the path if they hover over the button. 

I also took the liberty to make the button slightly wider by 20px. This means that the button will typically show ~2-4 more characters than it does currently, which I think makes it a bit easier at a glance to infer which file the AI will refactor without needing to hover. For example, if the suggestion is to refactor `src/components/big-file.tsx`, this might make the difference of having the button show "Refactor components/big-fil..." instead of "Refactor components/big...".
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2511" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added the full file path to the refactor button tooltip for clarity. Widened the button from 180px to 200px to show a few more characters in the label.

<sup>Written for commit c8824c43fa66506ba6ced69b0c6675c4978ecaf9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

