### PR TITLE
fix: trim whitespace from API keys and secrets in encrypt/decrypt

### DIFF
--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -250,21 +250,22 @@ export function writeSettings(settings: Partial<UserSettings>): void {
 }
 
 export function encrypt(data: string): Secret {
+  const trimmed = data.trim();
   if (safeStorage.isEncryptionAvailable() && !IS_TEST_BUILD) {
     return {
-      value: safeStorage.encryptString(data).toString("base64"),
+      value: safeStorage.encryptString(trimmed).toString("base64"),
       encryptionType: "electron-safe-storage",
     };
   }
   return {
-    value: data,
+    value: trimmed,
     encryptionType: "plaintext",
   };
 }
 
 export function decrypt(data: Secret): string {
   if (data.encryptionType === "electron-safe-storage") {
-    return safeStorage.decryptString(Buffer.from(data.value, "base64"));
+    return safeStorage.decryptString(Buffer.from(data.value, "base64")).trim();
   }
-  return data.value;
+  return data.value.trim();
 }


### PR DESCRIPTION
## Summary
- Trims whitespace from API keys and secrets during both encryption and decryption in `src/main/settings.ts`
- Prevents issues caused by accidental leading/trailing whitespace or newlines in API keys (e.g., from copy-paste)
- Adds comprehensive tests for the `encrypt`, `decrypt`, and `readSettings` whitespace trimming behavior

## Test plan
- [x] Unit tests added for `encrypt()` trimming whitespace before encrypting
- [x] Unit tests added for `decrypt()` trimming whitespace from both plaintext and electron-safe-storage secrets
- [x] Unit tests added for `readSettings()` trimming whitespace from decrypted API keys
- [x] All 784 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2518" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit d24002f59f18428d78ce55d11e82d4800425d3eb. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trim whitespace from API keys and secrets during encryption, decryption, and settings reads to prevent auth failures from copy‑pasted spaces or newlines. Ensures consistent storage and use of secrets across providers.

- **Bug Fixes**
  - encrypt(): trims input before encrypting or storing plaintext
  - decrypt(): trims decrypted strings for both electron-safe-storage and plaintext
  - readSettings(): trims whitespace from decrypted and plaintext secrets
  - Added unit tests for encrypt, decrypt, and readSettings trimming behavior

<sup>Written for commit d24002f59f18428d78ce55d11e82d4800425d3eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

