### PR TITLE
Fix E2E tests

### DIFF
--- a/e2e-tests/context_compaction.spec.ts
+++ b/e2e-tests/context_compaction.spec.ts
@@ -32,6 +32,6 @@ testSkipIfWindows(
     await po.sendPrompt("[dump] hi");
     await po.snapshotServerDump("all-messages");
     // Snapshot the messages to capture the compaction summary + second response
-    await po.snapshotMessages();
+    await po.snapshotMessages({ replaceDumpPath: true });
   },
 );

--- a/e2e-tests/snapshots/approve.spec.ts_write-to-index-approve-check-preview-2.aria.yml
+++ b/e2e-tests/snapshots/approve.spec.ts_write-to-index-approve-check-preview-2.aria.yml
@@ -2,11 +2,17 @@
 - paragraph: OK, I'm going to do some writing now...
 - img
 - text: Index.tsx
+- button "Edit":
+  - img
 - img
 - text: "src/pages/Index.tsx Summary: write-description"
 - paragraph: And it's done!
+- button "Copy":
+  - img
 - img
-- text: Approved
+- text: test-model
+- img
+- text: less than a minute ago
 - button "Undo":
   - img
 - button "Retry":

--- a/e2e-tests/snapshots/context_compaction.spec.ts_local-agent---context-compaction-triggers-and-shows-summary-1.aria.yml
+++ b/e2e-tests/snapshots/context_compaction.spec.ts_local-agent---context-compaction-triggers-and-shows-summary-1.aria.yml
@@ -56,7 +56,7 @@
 - button "Copy Request ID":
   - img
 - paragraph: "[dump] hi"
-- paragraph: /\[\[dyad-dump-path=\/Users\/will\/Documents\/GitHub\/dyad-zero\/testing\/fake-llm-server\/dist\/generated\/\d+\.json\]\]/
+- paragraph: "[[dyad-dump-path=*]]"
 - button "Copy":
   - img
 - img


### PR DESCRIPTION
#skip-bb
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2520" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilized E2E tests by making dump-path scrubbing opt-in and updating snapshots to match the current UI. This prevents flaky assertions and avoids DOM mutations that could break React.

- **Bug Fixes**
  - snapshotMessages now scrubs dynamic paths only when replaceDumpPath is true.
  - context_compaction test passes replaceDumpPath: true and snapshots use "[[dyad-dump-path=*]]".
  - Updated approve snapshot for new UI elements (Edit/Copy buttons, model label) and timestamp text.

<sup>Written for commit 6639aea41d508d3277d3896e872faf044875a553. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

