### PR TITLE
Debug OSX release issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,7 +146,7 @@ jobs:
           max_attempts: 3
           command: ./node_modules/.bin/electron-forge publish
         env:
-          DEBUG: "@electron/*,electron-forge:*,electron-windows-installer:main,electron-windows-sign"
+          DEBUG: "@electron/*,electron-forge:*,electron-osx-sign*,electron-notarize*,electron-windows-installer:main,electron-windows-sign"
           NODE_OPTIONS: "--max-old-space-size=4096"
           # SM_CODE_SIGNING_CERT_SHA1_HASH: ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -78,9 +78,12 @@ const config: ForgeConfig = {
 
     osxSign: isEndToEndTestBuild
       ? undefined
-      : {
+      : ({
           identity: process.env.APPLE_TEAM_ID,
-        },
+          // Surface the actual signing error instead of silently continuing
+          // (@electron/packager defaults continueOnError to true, which masks failures)
+          continueOnError: false,
+        } as Record<string, unknown>),
     osxNotarize: isEndToEndTestBuild
       ? undefined
       : {


### PR DESCRIPTION
#skip-bb
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2521" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve macOS release debugging by enabling detailed signing/notarization logs and failing fast on signing errors. This prevents silent passes and surfaces real issues in CI.

- **Bug Fixes**
  - Added electron-osx-sign* and electron-notarize* to DEBUG in the release workflow to capture detailed logs.
  - Set osxSign continueOnError to false (using APPLE_TEAM_ID identity) so CI fails on actual signing errors.

<sup>Written for commit 069bc57f27651c99dda7e32cd75bd37da80ed107. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

