### PR TITLE
Disable preEmbedProvisioningProfile not needed for non-Mac app store …

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -83,6 +83,9 @@ const config: ForgeConfig = {
           // Surface the actual signing error instead of silently continuing
           // (@electron/packager defaults continueOnError to true, which masks failures)
           continueOnError: false,
+          // Skip provisioning profile search (not needed for Developer ID distribution,
+          // and the cwd scan crashes on broken symlinks like CLAUDE.md)
+          preEmbedProvisioningProfile: false,
         } as Record<string, unknown>),
     osxNotarize: isEndToEndTestBuild
       ? undefined


### PR DESCRIPTION
…builds

https://github.com/dyad-sh/dyad/actions/runs/21731969067/job/62688473027

#skip-bb

logs:

```
   > Name: Developer ID Application: William Chen (***) 
   > Hash: 90560E040ED522CFE1B4FA8068B4FFDECD6E193F
  2026-02-05T23:16:18.906Z electron-osx-sign Found 1 identity.
  2026-02-05T23:16:18.906Z electron-osx-sign Pre-sign operation enabled for provisioning profile: 
   * Disable by setting `pre-embed-provisioning-profile` to `false`.
  2026-02-05T23:16:18.907Z electron-osx-sign No `provisioning-profile` passed in arguments, will find in current working directory and in user library...
  ✖ Finalizing package [FAILED: ENOENT: no such file or directory, stat '/Users/runner/work/dyad/dyad/CLAUDE.md']
  ✖ Packaging for x64 on darwin [FAILED: ENOENT: no such file or directory, stat '/Users/runner/work/dyad/dyad/CLAUDE.md']
  ✖ Packaging application [FAILED: ENOENT: no such file or directory, stat '/Users/runner/work/dyad/dyad/CLAUDE.md']
  ✖ Running package command [FAILED: ENOENT: no such file or directory, stat '/Users/runner/work/dyad/dyad/CLAUDE.md']
  ✖ Running make command [FAILED: ENOENT: no such file or directory, stat '/Users/runner/work/dyad/dyad/CLAUDE.md']
  25h
  An unhandled rejection has occurred inside Forge:
  Error: ENOENT: no such file or directory, stat '/Users/runner/work/dyad/dyad/CLAUDE.md'
  2026-02-05T23:16:18.910Z electron-forge:plugin:vite handling process exit with: { cleanup: true }
  2026-02-05T23:16:18.910Z electron-forge:plugin:vite handling process exit with: { cleanup: true }
  2026-02-05T23:16:18.910Z electron-forge:plugin:vite handling process exit with: { cleanup: true }
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2522" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable provisioning profile pre-embed search for Developer ID (non–Mac App Store) builds to prevent CI crashes from scanning the working directory. This fixes the ENOENT error caused by a broken symlink (CLAUDE.md) and lets macOS packaging complete.

- **Bug Fixes**
  - Set preEmbedProvisioningProfile to false in electron-osx-sign.
  - Skips unnecessary provisioning profile scan that triggered the CLAUDE.md ENOENT.

<sup>Written for commit bfdf8680977154c8db22ea608eda034a0ede24be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

