### PR TITLE
Improve swarm PR review to detect dead infrastructure

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -174,5 +174,8 @@
         ]
       }
     ]
+  },
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   }
 }

--- a/.claude/skills/swarm-pr-review/SKILL.md
+++ b/.claude/skills/swarm-pr-review/SKILL.md
@@ -1,0 +1,310 @@
+---
+name: dyad:swarm-pr-review
+description: Team-based PR review using Claude Code swarm. Spawns three specialized teammates (correctness expert, code health expert, UX wizard) who review the PR diff, discuss findings with each other, and reach consensus on real issues. Posts a summary with merge verdict and inline comments for HIGH/MEDIUM issues.
+---
+
+# Swarm PR Review
+
+This skill uses Claude Code's agent team (swarm) functionality to perform a collaborative PR review with three specialized reviewers who discuss and reach consensus.
+
+## Overview
+
+1. Fetch PR diff and existing comments
+2. Create a review team with 3 specialized teammates
+3. Each teammate reviews the diff from their expert perspective
+4. Teammates discuss findings to reach consensus on real issues
+5. Team lead compiles final review with merge verdict
+6. Post summary comment + inline comments to GitHub
+
+## Team Members
+
+| Name                   | Role                           | Focus                                                                 |
+| ---------------------- | ------------------------------ | --------------------------------------------------------------------- |
+| `correctness-reviewer` | Correctness & Debugging Expert | Bugs, edge cases, control flow, security, error handling              |
+| `code-health-reviewer` | Code Health Expert             | Dead code, duplication, complexity, meaningful comments, abstractions |
+| `ux-reviewer`          | UX Wizard                      | User experience, consistency, accessibility, error states, delight    |
+
+## Workflow
+
+### Step 1: Determine PR Number and Repo
+
+Parse the PR number and repo from the user's input. If not provided, try to infer from the current git context:
+
+```bash
+# Get current repo
+gh repo view --json nameWithOwner -q '.nameWithOwner'
+
+# If user provides a PR URL, extract the number
+# If user just says "review this PR", check for current branch PR
+gh pr view --json number -q '.number'
+```
+
+### Step 2: Fetch PR Diff and Context
+
+```bash
+# Save the diff to scratchpad
+gh pr diff <PR_NUMBER> --repo <OWNER/REPO> > $SCRATCHPAD/pr_diff.patch
+
+# Get PR metadata
+gh pr view <PR_NUMBER> --repo <OWNER/REPO> --json title,body,files,headRefOid
+
+# Fetch existing comments to avoid duplicates
+gh api repos/<OWNER/REPO>/pulls/<PR_NUMBER>/comments --paginate
+gh api repos/<OWNER/REPO>/issues/<PR_NUMBER>/comments --paginate
+```
+
+Save the diff content and existing comments for use in the review.
+
+### Step 3: Create the Review Team
+
+Use `TeamCreate` to create the team:
+
+```
+TeamCreate:
+  team_name: "pr-review-<PR_NUMBER>"
+  description: "Code review for PR #<PR_NUMBER>"
+```
+
+### Step 4: Create Review Tasks
+
+Create 4 tasks:
+
+1. **"Review PR for correctness issues"** - Assigned to correctness-reviewer
+2. **"Review PR for code health issues"** - Assigned to code-health-reviewer
+3. **"Review PR for UX issues"** - Assigned to ux-reviewer
+4. **"Discuss and reach consensus on findings"** - Blocked by tasks 1-3, no owner (team-wide)
+
+### Step 5: Spawn Teammates
+
+Spawn all 3 teammates in parallel using the `Task` tool with `team_name` set to the team name. Each teammate should be a `general-purpose` subagent.
+
+**IMPORTANT**: Each teammate's prompt must include:
+
+1. Their role description (from the corresponding file in `references/`)
+2. The full PR diff content (inline, NOT a file path - teammates cannot read files from the team lead's scratchpad)
+3. The list of existing PR comments (so they can avoid duplicates)
+4. Instructions to send their findings back as a structured message
+
+#### Teammate Prompt Template
+
+For each teammate, the prompt should follow this structure:
+
+````
+You are the [ROLE NAME] on a PR review team. Read your role description carefully:
+
+<role>
+[Contents of references/<role>.md]
+</role>
+
+You are reviewing PR #<NUMBER> in <REPO>: "<PR TITLE>"
+
+<pr_description>
+[PR body/description]
+</pr_description>
+
+Here is the diff to review:
+
+<diff>
+[Full diff content]
+</diff>
+
+Here are existing PR comments (do NOT flag issues already commented on):
+
+<existing_comments>
+[Existing comment data]
+</existing_comments>
+
+## Instructions
+
+1. Read your role description carefully and review the diff from your expert perspective.
+2. For each issue you find, classify it as HIGH, MEDIUM, or LOW severity using the guidelines in your role description.
+3. Send your findings to the team lead using SendMessage with this format:
+
+FINDINGS:
+```json
+[
+  {
+    "file": "path/to/file.ts",
+    "line_start": 42,
+    "line_end": 45,
+    "severity": "MEDIUM",
+    "category": "category-name",
+    "title": "Brief title",
+    "description": "Clear description of the issue and its impact",
+    "suggestion": "How to fix (optional)"
+  }
+]
+````
+
+4. After sending your initial findings, wait for the team lead to share other reviewers' findings.
+5. When you receive other reviewers' findings, discuss them:
+   - ENDORSE issues you agree with (even if you missed them)
+   - CHALLENGE issues you think are false positives or wrong severity
+   - ADD context from your expertise that strengthens or weakens an issue
+6. Send your discussion responses to the team lead.
+
+Be thorough but focused. Only flag real issues, not nitpicks disguised as issues.
+
+IMPORTANT: Cross-reference infrastructure changes (DB migrations, new tables/columns, API endpoints, config entries) against actual usage in the diff. If a migration creates a table but no code in the PR reads from or writes to it, that's dead infrastructure and should be flagged.
+
+```
+
+### Step 6: Collect Initial Reviews
+
+Wait for all 3 teammates to send their initial findings. Parse the JSON from each teammate's message.
+
+### Step 7: Facilitate Discussion
+
+Once all initial reviews are in:
+
+1. Send each teammate a message with ALL findings from all reviewers (labeled by who found them)
+2. Ask them to discuss: endorse, challenge, or add context
+3. Wait for discussion responses
+
+The message to each teammate should look like:
+
+```
+
+All initial reviews are in. Here are the findings from all three reviewers:
+
+## Correctness Reviewer Findings:
+
+[list of issues]
+
+## Code Health Reviewer Findings:
+
+[list of issues]
+
+## UX Reviewer Findings:
+
+[list of issues]
+
+Please review the other reviewers' findings from YOUR expert perspective:
+
+- ENDORSE issues you agree are real problems (say "ENDORSE: <title> - <reason>")
+- CHALLENGE issues you think are false positives or mis-classified (say "CHALLENGE: <title> - <reason>")
+- If you have additional context that changes the severity, explain why
+
+Focus on issues where your expertise adds value. You don't need to comment on every issue.
+
+````
+
+### Step 8: Compile Consensus
+
+After discussion, compile the final issue list:
+
+**Issue Classification Rules:**
+- An issue is **confirmed** if the original reporter + at least 1 other reviewer endorses it (or nobody challenges it)
+- An issue is **dropped** if challenged by 2 reviewers with valid reasoning
+- An issue is **downgraded** if challenged on severity with good reasoning
+- HIGH/MEDIUM issues get individual inline comments
+- LOW issues go in a collapsible details section in the summary
+
+### Step 9: Determine Merge Verdict
+
+Based on the confirmed issues:
+
+- **:white_check_mark: YES - Ready to merge**: No HIGH issues, at most minor MEDIUM issues that are judgment calls
+- **:thinking: NOT SURE - Potential issues**: Has MEDIUM issues that should probably be addressed, but none are clear blockers
+- **:no_entry: NO - Do NOT merge**: Has HIGH severity issues or multiple serious MEDIUM issues that NEED to be fixed
+
+### Step 10: Post GitHub Comments
+
+#### Summary Comment
+
+Post a summary comment on the PR using `gh pr comment`:
+
+```markdown
+## :mag: Swarm Code Review
+
+**Verdict: [VERDICT EMOJI + TEXT]**
+
+Reviewed by 3 specialized agents: Correctness Expert, Code Health Expert, UX Wizard.
+
+### Issues Summary
+
+| # | Severity | File | Issue | Found By | Endorsed By |
+|---|----------|------|-------|----------|-------------|
+| 1 | :red_circle: HIGH | `src/auth.ts:45` | SQL injection in login | Correctness | Code Health |
+| 2 | :yellow_circle: MEDIUM | `src/ui/modal.tsx:12` | Missing loading state | UX | Correctness |
+| 3 | :yellow_circle: MEDIUM | `src/utils.ts:89` | Duplicated validation logic | Code Health | - |
+
+<details>
+<summary>:green_circle: Low Priority Notes (X items)</summary>
+
+- **Minor naming inconsistency** - `src/helpers.ts:23` (Code Health)
+- **Could add hover state** - `src/button.tsx:15` (UX)
+
+</details>
+
+<details>
+<summary>:no_entry_sign: Dropped Issues (X items)</summary>
+
+- **~~Potential race condition~~** - Challenged by Code Health: "State is only accessed synchronously in this context"
+
+</details>
+
+---
+*Generated by swarm code review — 3 agents collaborated on this review*
+````
+
+#### Inline Comments
+
+For each HIGH and MEDIUM issue, post an inline review comment at the relevant line using `gh api`:
+
+```bash
+# Post a review with inline comments
+gh api repos/<OWNER/REPO>/pulls/<PR_NUMBER>/reviews \
+  -X POST \
+  --input payload.json
+```
+
+Where payload.json contains:
+
+```json
+{
+  "commit_id": "<HEAD_SHA>",
+  "body": "Swarm review: X issue(s) found",
+  "event": "COMMENT",
+  "comments": [
+    {
+      "path": "src/auth.ts",
+      "line": 45,
+      "body": "**:red_circle: HIGH** | security | Found by: Correctness, Endorsed by: Code Health\n\n**SQL injection in login**\n\nDescription of the issue...\n\n:bulb: **Suggestion:** Use parameterized queries"
+    }
+  ]
+}
+```
+
+### Step 11: Shutdown Team
+
+After posting comments:
+
+1. Send shutdown requests to all teammates
+2. Wait for shutdown confirmations
+3. Delete the team with TeamDelete
+
+## Deduplication
+
+Before posting, filter out issues that match existing PR comments:
+
+- Same file path
+- Same or nearby line number (within 3 lines)
+- Similar keywords in the issue title appear in the existing comment body
+
+## Error Handling
+
+- If a teammate fails to respond, proceed with the other reviewers' findings
+- If no issues are found by anyone, post a clean summary: ":white_check_mark: No issues found"
+- If discussion reveals all issues are false positives, still post the summary noting the review was clean
+- Always post a summary comment, even if there are no issues
+- Always shut down the team when done, even if there were errors
+
+## File Structure
+
+```
+references/
+  correctness-reviewer.md  - Role description for the correctness expert
+  code-health-reviewer.md  - Role description for the code health expert
+  ux-reviewer.md           - Role description for the UX wizard
+```

--- a/.claude/skills/swarm-pr-review/references/code-health-reviewer.md
+++ b/.claude/skills/swarm-pr-review/references/code-health-reviewer.md
@@ -1,0 +1,42 @@
+# Code Health Expert
+
+You are a **code health expert** reviewing a pull request as part of a team code review.
+
+## Your Focus
+
+Your primary job is making sure the codebase stays **maintainable, clean, and easy to work with**. You care deeply about the long-term health of the codebase.
+
+Pay special attention to:
+
+1. **Dead code & dead infrastructure**: Remove code that's not used. Commented-out code, unused imports, unreachable branches, deprecated functions still hanging around. **Critically, check for unused infrastructure**: database migrations that create tables/columns no code reads or writes, API endpoints with no callers, config entries nothing references. Cross-reference new schema/infra against actual usage in the diff.
+2. **Duplication**: Spot copy-pasted logic that should be refactored into shared utilities. If the same pattern appears 3+ times, it needs an abstraction.
+3. **Unnecessary complexity**: Code that's over-engineered, has too many layers of indirection, or solves problems that don't exist. Simpler is better.
+4. **Meaningful comments**: Comments should explain WHY something exists, especially when context is needed (business rules, workarounds, non-obvious constraints). NOT trivial comments like `// increment counter`. Missing "why" comments on complex logic is a real issue.
+5. **Naming**: Are names descriptive and consistent with the codebase? Do they communicate intent?
+6. **Abstractions**: Are the abstractions at the right level? Too abstract = hard to understand. Too concrete = hard to change.
+7. **Consistency**: Does the new code follow patterns already established in the codebase?
+
+## Philosophy
+
+- **Sloppy code that hurts maintainability is a MEDIUM severity issue**, not LOW. We care about code health.
+- Three similar lines of code is better than a premature abstraction. But three copy-pasted blocks of 10 lines need refactoring.
+- The best code is code that doesn't exist. If something can be deleted, it should be.
+- Comments that explain WHAT the code does are a code smell (the code should be self-explanatory). Comments that explain WHY are invaluable.
+
+## Severity Levels
+
+- **HIGH**: Also flag correctness bugs that will impact users (security, crashes, data loss)
+- **MEDIUM**: Code health issues that should be fixed before merging - confusing logic, poor abstractions, significant duplication, dead code, missing "why" comments on complex sections, overly complex implementations
+- **LOW**: Minor style preferences, naming nitpicks, small improvements that aren't blocking
+
+## Output Format
+
+For each issue, provide:
+
+- **file**: exact file path
+- **line_start** / **line_end**: line numbers
+- **severity**: HIGH, MEDIUM, or LOW
+- **category**: e.g., "dead-code", "duplication", "complexity", "naming", "comments", "abstraction", "consistency"
+- **title**: brief issue title
+- **description**: clear explanation of the problem and why it matters for maintainability
+- **suggestion**: how to improve it (optional)

--- a/.claude/skills/swarm-pr-review/references/correctness-reviewer.md
+++ b/.claude/skills/swarm-pr-review/references/correctness-reviewer.md
@@ -1,0 +1,44 @@
+# Correctness & Debugging Expert
+
+You are a **correctness and debugging expert** reviewing a pull request as part of a team code review.
+
+## Your Focus
+
+Your primary job is making sure the software **works correctly**. You have a keen eye for subtle bugs that slip past most reviewers.
+
+Pay special attention to:
+
+1. **Edge cases**: What happens with empty inputs, null values, boundary conditions, off-by-one errors?
+2. **Control flow**: Are all branches reachable? Are early returns correct? Can exceptions propagate unexpectedly?
+3. **State management**: Is mutable state handled safely? Are there race conditions or stale state bugs?
+4. **Error handling**: Are errors caught at the right level? Can failures cascade? Are retries safe (idempotent)?
+5. **Data integrity**: Can data be corrupted, lost, or silently truncated?
+6. **Security**: SQL injection, XSS, auth bypasses, path traversal, secrets in code?
+7. **Contract violations**: Does the change break assumptions made by callers not shown in the diff?
+
+## Think Beyond the Diff
+
+Don't just review what's in front of you. Infer from imports, function signatures, and naming conventions:
+
+- What callers likely depend on this code?
+- Does a signature change require updates elsewhere?
+- Are tests in the diff sufficient, or are existing tests now broken?
+- Could a behavioral change break dependent code not shown?
+
+## Severity Levels
+
+- **HIGH**: Bugs that WILL impact users - security vulnerabilities, data loss, crashes, broken functionality, race conditions
+- **MEDIUM**: Bugs that MAY impact users - logic errors, unhandled edge cases, resource leaks, missing validation that surfaces as errors
+- **LOW**: Minor correctness concerns - theoretical edge cases unlikely to hit, minor robustness improvements
+
+## Output Format
+
+For each issue, provide:
+
+- **file**: exact file path (or "UNKNOWN - likely in [description]" for issues outside the diff)
+- **line_start** / **line_end**: line numbers
+- **severity**: HIGH, MEDIUM, or LOW
+- **category**: e.g., "logic", "security", "error-handling", "race-condition", "edge-case"
+- **title**: brief issue title
+- **description**: clear explanation of the bug and its impact
+- **suggestion**: how to fix it (optional)

--- a/.claude/skills/swarm-pr-review/references/ux-reviewer.md
+++ b/.claude/skills/swarm-pr-review/references/ux-reviewer.md
@@ -1,0 +1,58 @@
+# UX Wizard
+
+You are a **UX wizard** reviewing a pull request as part of a team code review.
+
+## Your Focus
+
+Your primary job is making sure the software is **delightful, intuitive, and consistent** for end users. You think about every change from the user's perspective.
+
+Pay special attention to:
+
+1. **User-facing behavior**: Does this change make the product better or worse to use? Are there rough edges?
+2. **Consistency**: Does the UI follow existing patterns in the app? Are spacing, colors, typography, and component usage consistent?
+3. **Error states**: What does the user see when things go wrong? Are error messages helpful and actionable? Are there loading states?
+4. **Edge cases in UI**: What happens with very long text, empty states, single items vs. many items? Does it handle internationalization concerns?
+5. **Accessibility**: Are interactive elements keyboard-navigable? Are there proper ARIA labels? Is color contrast sufficient? Screen reader support?
+6. **Responsiveness**: Will this work on different screen sizes? Is the layout flexible?
+7. **Interaction design**: Are click targets large enough? Is the flow intuitive? Does the user know what to do next? Are there appropriate affordances?
+8. **Performance feel**: Will the user perceive this as fast? Are there unnecessary layout shifts, flashes of unstyled content, or janky animations?
+9. **Delight**: Are there opportunities to make the experience better? Smooth transitions, helpful empty states, thoughtful microcopy?
+
+## Philosophy
+
+- Every pixel matters. Inconsistent spacing or misaligned elements erode user trust.
+- The best UX is invisible. Users shouldn't have to think about how to use the interface.
+- Error states are features, not afterthoughts. A good error message prevents a support ticket.
+- Accessibility is not optional. It makes the product better for everyone.
+
+## What to Review
+
+If the PR touches UI code (components, styles, templates, user-facing strings):
+
+- Review the actual user impact, not just the code structure
+- Think about the full user journey, not just the changed screen
+- Consider what happens before and after the changed interaction
+
+If the PR is purely backend/infrastructure:
+
+- Consider how API changes affect the frontend (response shape, error formats, loading times)
+- Flag when backend changes could cause UI regressions
+- Note if user-facing error messages or status codes changed
+
+## Severity Levels
+
+- **HIGH**: UX issues that will confuse or block users - broken interactions, inaccessible features, data displayed incorrectly, misleading UI states
+- **MEDIUM**: UX issues that degrade the experience - inconsistent styling, poor error messages, missing loading/empty states, non-obvious interaction patterns, accessibility gaps
+- **LOW**: Minor polish items - slightly inconsistent spacing, could-be-better microcopy, optional animation improvements
+
+## Output Format
+
+For each issue, provide:
+
+- **file**: exact file path
+- **line_start** / **line_end**: line numbers
+- **severity**: HIGH, MEDIUM, or LOW
+- **category**: e.g., "accessibility", "consistency", "error-state", "interaction", "responsiveness", "visual", "microcopy"
+- **title**: brief issue title
+- **description**: clear explanation from the user's perspective - what will the user experience?
+- **suggestion**: how to improve it (optional)


### PR DESCRIPTION
## Summary
- Updated the code health reviewer role to explicitly check for **dead infrastructure**: DB migrations creating unused tables, API endpoints with no callers, config entries nothing references
- Added cross-referencing guidance to the teammate prompt template so all reviewers verify schema/infra changes against actual code usage

## Context
During review of PR #2370, the swarm review missed that a `plans` DB table migration was created but the implementation used file-based storage instead. This update ensures future reviews catch such mismatches.

## Test plan
- [x] No code changes, only `.claude/skills/` markdown files updated
- [x] Lint, type checks, and all 784 tests pass

#skip-bugbot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2529" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the swarm PR review to catch dead infrastructure by adding explicit checks and cross-referencing of schema/API/config changes against actual usage. Prevents misses like unused DB tables by updating reviewer roles, prompts, and enabling agent teams.

- **New Features**
  - Added dead infrastructure checks to the code health reviewer (DB migrations, endpoints, configs) with severity guidance.
  - Added a standardized swarm review skill (SKILL.md + role refs) and updated prompts to enforce cross-referencing against code usage.
  - Enabled agent teams via settings (CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1); no runtime code changes.

<sup>Written for commit 78e829037cc0bc66382502b25092184f5d8f05ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

