### PR TITLE
Update pr-push to add files more aggressively

### DIFF
--- a/.claude/commands/dyad/pr-push.md
+++ b/.claude/commands/dyad/pr-push.md
@@ -26,9 +26,10 @@ Commit any uncommitted changes, run lint checks, fix any issues, and push the cu
    Run `git status` to check for any uncommitted changes (staged, unstaged, or untracked files).
 
    If there are uncommitted changes:
-   - Identify files that should NOT be committed (e.g., `.env`, `.env.*`, `credentials.*`, `*.secret`, `*.key`, `*.pem`, `.DS_Store`, `node_modules/`, `*.log`, temporary files, or anything that looks like it contains secrets or personal configuration)
-   - Stage and commit all OTHER files with a descriptive commit message summarizing the changes
-   - Keep track of any files you ignored so you can report them at the end
+   - **When in doubt, `git add` the files.** Assume changed/untracked files are related to the current work unless they are egregiously unrelated (e.g., completely different feature area with no connection to the current changes).
+   - Only exclude files that are clearly secrets or artifacts that should never be committed (e.g., `.env`, `.env.*`, `credentials.*`, `*.secret`, `*.key`, `*.pem`, `.DS_Store`, `node_modules/`, `*.log`).
+   - Stage and commit all relevant files with a descriptive commit message summarizing the changes.
+   - Keep track of any files you ignored so you can report them at the end.
 
    If there are no uncommitted changes, proceed to the next step.
 

--- a/.claude/commands/dyad/pr-push.md
+++ b/.claude/commands/dyad/pr-push.md
@@ -87,6 +87,8 @@ Commit any uncommitted changes, run lint checks, fix any issues, and push the cu
 
    You MUST push the branch to GitHub. Do NOT skip this step or ask for confirmation.
 
+   **CRITICAL:** You MUST NEVER run `git pull --rebase` (or any `git pull`) from the fork repo. If you need to pull/rebase, ONLY pull from the upstream repo (`dyad-sh/dyad`). Pulling from a fork can overwrite local changes or introduce unexpected commits from the fork's history.
+
    First, determine the correct remote to push to:
 
    a. Check if the branch already tracks a remote:


### PR DESCRIPTION
## Summary
- Update pr-push skill to default to staging files when in doubt, rather than being overly cautious
- Narrow the exclusion list to only true secrets/artifacts (`.env`, keys, `node_modules`, etc.)
- Remove vague exclusion language about "temporary files" and "personal configuration"

#skip-bugbot

## Test plan
- Run `/dyad:pr-push` and verify the updated behavior stages files more aggressively

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2530" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make /dyad:pr-push stage and commit files more aggressively with a tight exclude list, while improving safety and reliability of the push flow. Blocks pushes to main, runs checks/tests, tracks tasks, and detects the right remote.

- **New Features**
  - Stage most changes by default; only exclude true secrets/artifacts (.env, keys, .DS_Store, node_modules, *.log).
  - Remove vague exclusions for “temporary files” or personal configs.
  - Prevent pushing on main/master; auto-create and switch to a feature branch when needed.
  - Inline checks: run fmt, lint --fix, type-check, and npm test; amend if tools change files.
  - Use TaskCreate/TaskUpdate to track progress and provide a clear summary.
  - Capture session learnings before lint; commit AGENTS.md updates when present.
  - Auto-detect the correct remote (handles forks), set upstream; push with --force-with-lease; never pull/rebase from a fork—only from upstream.
  - If no PR exists, create one and add cc:request for non-trivial changes.

<sup>Written for commit fc6933aeb2e26e743805e65b4e0e92462d8eb7c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

