### PR TITLE
Use claude_args to set opus-4-6 model in CI workflows

### DIFF
--- a/.github/workflows/pr-review-responder.yml
+++ b/.github/workflows/pr-review-responder.yml
@@ -182,6 +182,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: --model claude-opus-4-6
           prompt: |
             /dyad:pr-fix ${{ steps.pr-info.outputs.pr_number }}
 


### PR DESCRIPTION
## Summary
- Add `claude_args: --model claude-opus-4-6` to the pr-review-responder workflow so it uses Opus 4.6

#skip-bugbot

## Test plan
- Verify the workflow YAML is valid
- Confirm both CI workflows specify `claude-opus-4-6` via `claude_args`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2531" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the pr-review-responder GitHub Actions workflow to use Claude Opus 4.6 by adding claude_args: --model claude-opus-4-6, so PR review runs on the intended model.

<sup>Written for commit f7bb9047549c88d41888e49dd98cf6ae865966ea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

