### PR TITLE
Bump to v0.36 stable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dyad",
-  "version": "0.36.0-beta.1",
+  "version": "0.36.0",
   "description": "Free, local, open-source AI app builder",
   "keywords": [],
   "license": "MIT",


### PR DESCRIPTION
#skip-bb
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2532" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes Dyad from 0.36.0-beta.1 to 0.36.0 stable by updating the package.json version. No functional changes; prepares the v0.36 stable release.

<sup>Written for commit 5ef59bc985df7d0687b18859dc4796477da2ea52. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

