### PR TITLE
refactor: migrate hooks to React Query for data fetching

### DIFF
--- a/e2e-tests/favorite_app.spec.ts
+++ b/e2e-tests/favorite_app.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "./helpers/test_helper";
+import { test, Timeout } from "./helpers/test_helper";
 import { expect } from "@playwright/test";
 
 test.describe("Favorite App Tests", () => {
@@ -20,16 +20,22 @@ test.describe("Favorite App Tests", () => {
     const appItem = po.page.locator(`[data-testid="app-list-item-${appName}"]`);
     await expect(appItem).toBeVisible();
 
-    // Click the favorite button
+    // Click the favorite button — hover first like a real user would,
+    // then wait for the app to finish starting before the click resolves.
     const favoriteButton = appItem
       .locator("xpath=..")
       .locator('[data-testid="favorite-button"]');
     await expect(favoriteButton).toBeVisible();
+    await appItem.hover();
     await favoriteButton.click();
 
-    // Check that the star is filled (favorited)
+    // Check that the star is filled (favorited).
+    // Use a longer timeout because the addToFavorite IPC call may be waiting
+    // for the app startup lock to release.
     const star = favoriteButton.locator("svg");
-    await expect(star).toHaveClass(/(?:^|\s)fill-\[#6c55dc\]/);
+    await expect(star).toHaveClass(/(?:^|\s)fill-\[#6c55dc\]/, {
+      timeout: Timeout.MEDIUM,
+    });
   });
 
   test("Remove app from favorite", async ({ po }) => {
@@ -53,21 +59,27 @@ test.describe("Favorite App Tests", () => {
     const favoriteButton = appItem
       .locator("xpath=..")
       .locator('[data-testid="favorite-button"]');
+    await appItem.hover();
     await favoriteButton.click();
 
     // Check that the star is filled (favorited)
     const star = favoriteButton.locator("svg");
-    await expect(star).toHaveClass(/(?:^|\s)fill-\[#6c55dc\]/);
+    await expect(star).toHaveClass(/(?:^|\s)fill-\[#6c55dc\]/, {
+      timeout: Timeout.MEDIUM,
+    });
 
     // Now, remove from favorite
     const unfavoriteButton = appItem
       .locator("xpath=..")
       .locator('[data-testid="favorite-button"]');
     await expect(unfavoriteButton).toBeVisible();
+    await appItem.hover();
     await unfavoriteButton.click();
 
     // Check that the star is not filled (unfavorited)
     // Match fill-[#6c55dc] only at start or after whitespace (not as part of hover:fill-...)
-    await expect(star).not.toHaveClass(/(?:^|\s)fill-\[#6c55dc\]/);
+    await expect(star).not.toHaveClass(/(?:^|\s)fill-\[#6c55dc\]/, {
+      timeout: Timeout.MEDIUM,
+    });
   });
 });

--- a/src/app/TitleBar.tsx
+++ b/src/app/TitleBar.tsx
@@ -13,6 +13,7 @@ import { useEffect, useState } from "react";
 import { DyadProSuccessDialog } from "@/components/DyadProSuccessDialog";
 import { useTheme } from "@/contexts/ThemeContext";
 import { ipc } from "@/ipc/types";
+import { useSystemPlatform } from "@/hooks/useSystemPlatform";
 import { useUserBudgetInfo } from "@/hooks/useUserBudgetInfo";
 import type { UserBudgetInfo } from "@/ipc/types";
 import {
@@ -29,21 +30,8 @@ export const TitleBar = () => {
   const location = useLocation();
   const { settings, refreshSettings } = useSettings();
   const [isSuccessDialogOpen, setIsSuccessDialogOpen] = useState(false);
-  const [showWindowControls, setShowWindowControls] = useState(false);
-
-  useEffect(() => {
-    // Check if we're running on Windows
-    const checkPlatform = async () => {
-      try {
-        const platform = await ipc.system.getSystemPlatform();
-        setShowWindowControls(platform !== "darwin");
-      } catch (error) {
-        console.error("Failed to get platform info:", error);
-      }
-    };
-
-    checkPlatform();
-  }, []);
+  const platform = useSystemPlatform();
+  const showWindowControls = platform !== null && platform !== "darwin";
 
   const showDyadProSuccessDialog = () => {
     setIsSuccessDialogOpen(true);

--- a/src/atoms/appAtoms.ts
+++ b/src/atoms/appAtoms.ts
@@ -1,11 +1,9 @@
 import { atom } from "jotai";
 import type { App, Version, ConsoleEntry } from "@/ipc/types";
-import type { ListedApp } from "@/ipc/types/app";
 import type { UserSettings } from "@/lib/schemas";
 
 export const currentAppAtom = atom<App | null>(null);
 export const selectedAppIdAtom = atom<number | null>(null);
-export const appsListAtom = atom<ListedApp[]>([]);
 export const versionsListAtom = atom<Version[]>([]);
 export const previewModeAtom = atom<
   | "preview"

--- a/src/hooks/useAddAppToFavorite.ts
+++ b/src/hooks/useAddAppToFavorite.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { ipc } from "@/ipc/types";
+import type { ListedApp } from "@/ipc/types/app";
 import { showError, showSuccess } from "@/lib/toast";
 import { queryKeys } from "@/lib/queryKeys";
 
@@ -11,8 +12,12 @@ export function useAddAppToFavorite() {
       const result = await ipc.app.addToFavorite({ appId });
       return result.isFavorite;
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.apps.all });
+    onSuccess: (newIsFavorite, appId) => {
+      queryClient.setQueryData<ListedApp[]>(queryKeys.apps.all, (oldApps) =>
+        oldApps?.map((app) =>
+          app.id === appId ? { ...app, isFavorite: newIsFavorite } : app,
+        ),
+      );
       showSuccess("App favorite status updated");
     },
     onError: (error) => {

--- a/src/hooks/useAppVersion.ts
+++ b/src/hooks/useAppVersion.ts
@@ -1,20 +1,16 @@
-import { useState, useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { ipc } from "@/ipc/types";
+import { queryKeys } from "@/lib/queryKeys";
 
 export function useAppVersion() {
-  const [appVersion, setAppVersion] = useState<string | null>(null);
+  const { data } = useQuery({
+    queryKey: queryKeys.system.appVersion,
+    queryFn: async () => {
+      const result = await ipc.system.getAppVersion();
+      return result.version;
+    },
+    staleTime: Infinity, // App version never changes during a session
+  });
 
-  useEffect(() => {
-    const fetchVersion = async () => {
-      try {
-        const result = await ipc.system.getAppVersion();
-        setAppVersion(result.version);
-      } catch {
-        setAppVersion(null);
-      }
-    };
-    fetchVersion();
-  }, []);
-
-  return appVersion;
+  return data ?? null;
 }

--- a/src/hooks/useGithubRepos.ts
+++ b/src/hooks/useGithubRepos.ts
@@ -1,0 +1,18 @@
+import { useQuery } from "@tanstack/react-query";
+import { ipc } from "@/ipc/types";
+import { queryKeys } from "@/lib/queryKeys";
+
+export function useGithubRepos({ enabled }: { enabled: boolean }) {
+  const { data, isLoading, error } = useQuery({
+    queryKey: queryKeys.github.repos,
+    queryFn: () => ipc.github.listRepos(),
+    enabled,
+    meta: { showErrorToast: true },
+  });
+
+  return {
+    repos: data ?? [],
+    loading: isLoading,
+    error,
+  };
+}

--- a/src/hooks/useLoadApps.ts
+++ b/src/hooks/useLoadApps.ts
@@ -1,12 +1,8 @@
-import { useEffect } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useAtom } from "jotai";
-import { appsListAtom } from "@/atoms/appAtoms";
 import { ipc } from "@/ipc/types";
 import { queryKeys } from "@/lib/queryKeys";
 
 export function useLoadApps() {
-  const [, setApps] = useAtom(appsListAtom);
   const queryClient = useQueryClient();
 
   const { data, isLoading, error } = useQuery({
@@ -16,13 +12,6 @@ export function useLoadApps() {
       return appListResponse.apps;
     },
   });
-
-  // Sync to Jotai atom for backward compatibility
-  useEffect(() => {
-    if (data !== undefined) {
-      setApps(data);
-    }
-  }, [data, setApps]);
 
   const refreshApps = () => {
     return queryClient.invalidateQueries({ queryKey: queryKeys.apps.all });

--- a/src/hooks/useSystemPlatform.ts
+++ b/src/hooks/useSystemPlatform.ts
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+import { ipc } from "@/ipc/types";
+import { queryKeys } from "@/lib/queryKeys";
+
+export function useSystemPlatform() {
+  const { data } = useQuery({
+    queryKey: queryKeys.system.platform,
+    queryFn: () => ipc.system.getSystemPlatform(),
+    staleTime: Infinity, // Platform never changes during a session
+  });
+
+  return data ?? null;
+}

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -16,6 +16,24 @@
 
 export const queryKeys = {
   // ─────────────────────────────────────────────────────────────────────────────
+  // System
+  // ─────────────────────────────────────────────────────────────────────────────
+  system: {
+    all: ["system"] as const,
+    appVersion: ["system", "appVersion"] as const,
+    platform: ["system", "platform"] as const,
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Settings
+  // ─────────────────────────────────────────────────────────────────────────────
+  settings: {
+    all: ["settings"] as const,
+    user: ["settings", "user"] as const,
+    envVars: ["settings", "envVars"] as const,
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────────
   // Apps
   // ─────────────────────────────────────────────────────────────────────────────
   apps: {
@@ -112,6 +130,20 @@ export const queryKeys = {
   files: {
     search: ({ appId, query }: { appId: number | null; query: string }) =>
       ["search-app-files", appId, query] as const,
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // App Files
+  // ─────────────────────────────────────────────────────────────────────────────
+  appFiles: {
+    all: ["app-files"] as const,
+    content: ({
+      appId,
+      filePath,
+    }: {
+      appId: number | null;
+      filePath: string | null;
+    }) => ["app-files", "content", appId, filePath] as const,
   },
 
   // ─────────────────────────────────────────────────────────────────────────────
@@ -247,6 +279,14 @@ export const queryKeys = {
   },
 
   // ─────────────────────────────────────────────────────────────────────────────
+  // GitHub
+  // ─────────────────────────────────────────────────────────────────────────────
+  github: {
+    all: ["github"] as const,
+    repos: ["github", "repos"] as const,
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────────
   // Neon
   // ─────────────────────────────────────────────────────────────────────────────
   neon: {
@@ -276,6 +316,8 @@ export type QueryKeyOf<T> = T extends readonly unknown[]
 
 /** All possible query keys (useful for typing queryClient operations) */
 export type AppQueryKey =
+  | QueryKeyOf<(typeof queryKeys.system)[keyof typeof queryKeys.system]>
+  | QueryKeyOf<(typeof queryKeys.settings)[keyof typeof queryKeys.settings]>
   | QueryKeyOf<(typeof queryKeys.apps)[keyof typeof queryKeys.apps]>
   | QueryKeyOf<(typeof queryKeys.chats)[keyof typeof queryKeys.chats]>
   | QueryKeyOf<(typeof queryKeys.plans)[keyof typeof queryKeys.plans]>
@@ -290,6 +332,7 @@ export type AppQueryKey =
       (typeof queryKeys.contextPaths)[keyof typeof queryKeys.contextPaths]
     >
   | QueryKeyOf<(typeof queryKeys.tokenCount)[keyof typeof queryKeys.tokenCount]>
+  | QueryKeyOf<(typeof queryKeys.appFiles)[keyof typeof queryKeys.appFiles]>
   | QueryKeyOf<(typeof queryKeys.files)[keyof typeof queryKeys.files]>
   | QueryKeyOf<(typeof queryKeys.appName)[keyof typeof queryKeys.appName]>
   | QueryKeyOf<
@@ -316,6 +359,7 @@ export type AppQueryKey =
     >
   | QueryKeyOf<(typeof queryKeys.mcp)[keyof typeof queryKeys.mcp]>
   | QueryKeyOf<(typeof queryKeys.supabase)[keyof typeof queryKeys.supabase]>
+  | QueryKeyOf<(typeof queryKeys.github)[keyof typeof queryKeys.github]>
   | QueryKeyOf<(typeof queryKeys.neon)[keyof typeof queryKeys.neon]>
   | QueryKeyOf<
       (typeof queryKeys.appEnvVars)[keyof typeof queryKeys.appEnvVars]

--- a/src/pages/app-details.tsx
+++ b/src/pages/app-details.tsx
@@ -1,7 +1,7 @@
 import { useNavigate, useRouter, useSearch } from "@tanstack/react-router";
 import { normalizePath } from "../../shared/normalizePath";
-import { useAtom, useSetAtom } from "jotai";
-import { appsListAtom, selectedAppIdAtom } from "@/atoms/appAtoms";
+import { useSetAtom } from "jotai";
+import { selectedAppIdAtom } from "@/atoms/appAtoms";
 import { ipc } from "@/ipc/types";
 import { useLoadApps } from "@/hooks/useLoadApps";
 import { useState } from "react";
@@ -49,8 +49,7 @@ export default function AppDetailsPage() {
   const navigate = useNavigate();
   const router = useRouter();
   const search = useSearch({ from: "/app-details" as const });
-  const [appsList] = useAtom(appsListAtom);
-  const { refreshApps } = useLoadApps();
+  const { apps: appsList, refreshApps } = useLoadApps();
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [isRenameDialogOpen, setIsRenameDialogOpen] = useState(false);


### PR DESCRIPTION
## Summary
- Replaced manual `useState`/`useEffect` data fetching patterns with React Query's `useQuery` and `useMutation` in `useSettings`, `useLoadAppFile`, `useLoadApps`, `useAppVersion`, and related hooks
- Added centralized query keys for `system`, `settings`, `appFiles`, and `github` domains in `queryKeys.ts`
- Added new `useGithubRepos` and `useSystemPlatform` hooks using React Query
- Simplified `TitleBar` and `ImportAppDialog` to use the updated hook interfaces

## Test plan
- All 784 unit tests pass
- Verify settings load correctly on app startup
- Verify file loading works in the code viewer
- Verify app list loads and refreshes properly
- Verify title bar shows correct app version

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2536" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core loading paths (settings, app list, file reads) and caching/invalidations, so regressions could show up as stale data or missing refreshes; changes are mostly refactors with minimal behavioral intent.
> 
> **Overview**
> **Migrates several app/system/settings data flows from local state/Jotai-driven fetching to React Query.** `useLoadApps`, `useLoadAppFile`, `useAppVersion`, and `useSettings` now use `useQuery`/`useMutation` with cache updates and refresh via query invalidation, and app favorites (`useAddAppToFavorite`) update the React Query apps cache instead of an `appsListAtom` (which is removed).
> 
> Adds new React Query-powered hooks (`useSystemPlatform`, `useGithubRepos`) and extends `queryKeys` with `system`, `settings`, `appFiles`, and `github` domains; UI callers (`TitleBar`, `ImportAppDialog`, `app-details`) are adjusted to consume the new hooks. E2E favorite-app tests are hardened by hovering before clicks and using a longer assertion timeout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c82dfca589d0186d25cec33a2453fc5b3f28520b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated core data fetching to React Query to standardize caching, loading, and error handling. Cleaned up UI and tests, removed the apps Jotai atom, and made refresh flows consistent via query invalidation.

- **Refactors**
  - Replaced manual state/effect with useQuery/useMutation in useSettings, useLoadApps, useLoadAppFile, and useAppVersion.
  - Centralized query keys for system, settings, appFiles, and github in queryKeys.ts.
  - Removed appsListAtom; apps now read/write via React Query. Kept Jotai sync for settings and env vars.
  - Simplified TitleBar (uses useSystemPlatform), ImportAppDialog (uses useGithubRepos), and app-details (reads apps from useLoadApps).
  - Updated useAddAppToFavorite to update the React Query cache.
  - Reduced flakiness in favorite app e2e tests by hovering before clicks and using a medium timeout.

- **New Features**
  - Added useGithubRepos and useSystemPlatform hooks with session-level caching.

<sup>Written for commit c82dfca589d0186d25cec33a2453fc5b3f28520b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

