### PR TITLE
Fixing file attachement

### DIFF
--- a/src/components/chat/FileAttachmentDropdown.tsx
+++ b/src/components/chat/FileAttachmentDropdown.tsx
@@ -41,12 +41,8 @@ export function FileAttachmentDropdown({
   const menuItems = (
     <>
       <DropdownMenuItem
-        onClick={(e: React.MouseEvent) => {
-          // Prevent default so menu doesn't close in order to keep the hidden inputs in the DOM
-          // Manually close menu after file selection
-          e.preventDefault();
-          handleChatContextClick();
-        }}
+        closeOnClick={false}
+        onClick={handleChatContextClick}
         className="py-3 px-4"
         title="Example use case: screenshot of the app to point out a UI issue"
       >
@@ -55,12 +51,8 @@ export function FileAttachmentDropdown({
       </DropdownMenuItem>
 
       <DropdownMenuItem
-        onClick={(e: React.MouseEvent) => {
-          // Prevent default so menu doesn't close in order to keep the hidden inputs in the DOM
-          // Manually close menu after file selection
-          e.preventDefault();
-          handleUploadToCodebaseClick();
-        }}
+        closeOnClick={false}
+        onClick={handleUploadToCodebaseClick}
         className="py-3 px-4"
         title="Example use case: add an image to use for your app"
       >


### PR DESCRIPTION
The migration from Radix to Base UI broke file attachments because calling e.preventDefault() in the onClick handler does not stop Base UI menus from closing. Base UI relies on an internal closeOnClick mechanism instead. As a result, when the menu closed, the portaled hidden <input type="file"> elements were unmounted from the DOM before the user could select a file.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2541" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the file attachment menu so selecting “Attach chat context” or “Upload to codebase” no longer closes the dropdown too early. Uses closeOnClick={false} with direct onClick handlers to keep hidden inputs mounted and make file selection reliable.

<sup>Written for commit afe8de3b5de300b8c2254418aa9bbd87d818c0bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

