### PR TITLE
Bump to v0.36 beta 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dyad",
-  "version": "0.36.0",
+  "version": "0.36.0-beta.2",
   "description": "Free, local, open-source AI app builder",
   "keywords": [],
   "license": "MIT",


### PR DESCRIPTION
#skip-bb
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2543" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update package.json version to 0.36.0-beta.2 to prepare the v0.36 beta 2 release and enable prerelease distribution.

<sup>Written for commit 76afb00bf78fc4407be138baec8d6d554bd45000. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

