### PR TITLE
Add per-chat settings for chat mode and selected model

### DIFF
--- a/drizzle/0026_fluffy_iron_monger.sql
+++ b/drizzle/0026_fluffy_iron_monger.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `chats` ADD `chat_mode` text;--> statement-breakpoint
+ALTER TABLE `chats` ADD `selected_model` text;

--- a/drizzle/meta/0026_snapshot.json
+++ b/drizzle/meta/0026_snapshot.json
@@ -1,0 +1,905 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "940b74df-efa5-44b9-b5ad-0714db095931",
+  "prevId": "8aa6589b-2eb5-4d16-98a1-6354539472c4",
+  "tables": {
+    "apps": {
+      "name": "apps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "github_org": {
+          "name": "github_org",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_repo": {
+          "name": "github_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_branch": {
+          "name": "github_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supabase_project_id": {
+          "name": "supabase_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supabase_parent_project_id": {
+          "name": "supabase_parent_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supabase_organization_slug": {
+          "name": "supabase_organization_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_project_id": {
+          "name": "neon_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_development_branch_id": {
+          "name": "neon_development_branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_preview_branch_id": {
+          "name": "neon_preview_branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vercel_project_id": {
+          "name": "vercel_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vercel_project_name": {
+          "name": "vercel_project_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vercel_team_id": {
+          "name": "vercel_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vercel_deployment_url": {
+          "name": "vercel_deployment_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "install_command": {
+          "name": "install_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_command": {
+          "name": "start_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chat_context": {
+          "name": "chat_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "theme_id": {
+          "name": "theme_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chats": {
+      "name": "chats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "initial_commit_hash": {
+          "name": "initial_commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chat_mode": {
+          "name": "chat_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "compacted_at": {
+          "name": "compacted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "compaction_backup_path": {
+          "name": "compaction_backup_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pending_compaction": {
+          "name": "pending_compaction",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chats_app_id_apps_id_fk": {
+          "name": "chats_app_id_apps_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_themes": {
+      "name": "custom_themes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "language_model_providers": {
+      "name": "language_model_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_base_url": {
+          "name": "api_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "env_var_name": {
+          "name": "env_var_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "language_models": {
+      "name": "language_models",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_name": {
+          "name": "api_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "builtin_provider_id": {
+          "name": "builtin_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "custom_provider_id": {
+          "name": "custom_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_output_tokens": {
+          "name": "max_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "language_models_custom_provider_id_language_model_providers_id_fk": {
+          "name": "language_models_custom_provider_id_language_model_providers_id_fk",
+          "tableFrom": "language_models",
+          "tableTo": "language_model_providers",
+          "columnsFrom": [
+            "custom_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "env_json": {
+          "name": "env_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "headers_json": {
+          "name": "headers_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_tool_consents": {
+      "name": "mcp_tool_consents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consent": {
+          "name": "consent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ask'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "uniq_mcp_consent": {
+          "name": "uniq_mcp_consent",
+          "columns": [
+            "server_id",
+            "tool_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "mcp_tool_consents_server_id_mcp_servers_id_fk": {
+          "name": "mcp_tool_consents_server_id_mcp_servers_id_fk",
+          "tableFrom": "mcp_tool_consents",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "approval_state": {
+          "name": "approval_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_commit_hash": {
+          "name": "source_commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "commit_hash": {
+          "name": "commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_tokens_used": {
+          "name": "max_tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ai_messages_json": {
+          "name": "ai_messages_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "using_free_agent_mode_quota": {
+          "name": "using_free_agent_mode_quota",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_compaction_summary": {
+          "name": "is_compaction_summary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_chat_id_chats_id_fk": {
+          "name": "messages_chat_id_chats_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompts": {
+      "name": "prompts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "versions": {
+      "name": "versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "commit_hash": {
+          "name": "commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "neon_db_timestamp": {
+          "name": "neon_db_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "versions_app_commit_unique": {
+          "name": "versions_app_commit_unique",
+          "columns": [
+            "app_id",
+            "commit_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "versions_app_id_apps_id_fk": {
+          "name": "versions_app_id_apps_id_fk",
+          "tableFrom": "versions",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1770256089560,
       "tag": "0025_lush_stark_industries",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "6",
+      "when": 1770418911136,
+      "tag": "0026_fluffy_iron_monger",
+      "breakpoints": true
     }
   ]
 }

--- a/e2e-tests/per_chat_settings.spec.ts
+++ b/e2e-tests/per_chat_settings.spec.ts
@@ -1,0 +1,58 @@
+import { test } from "./helpers/test_helper";
+import { expect } from "@playwright/test";
+
+test("per-chat settings - mode is isolated between chats", async ({ po }) => {
+  await po.setUpDyadPro({ autoApprove: true, localAgent: true });
+  await po.importApp("minimal");
+
+  // First chat: switch to Ask mode
+  await po.selectChatMode("ask");
+
+  // Verify Chat #1 shows Ask mode
+  await expect(po.page.getByTestId("chat-mode-selector")).toContainText("Ask");
+
+  // Send a message in Ask mode to ensure the mode is persisted
+  await po.sendPrompt("tc=local-agent/ask-read-file");
+  await po.waitForChatCompletion();
+
+  // Create a new chat
+  await po.clickNewChat();
+
+  // Change Chat #2 to Agent mode
+  await po.selectChatMode("local-agent");
+  await expect(po.page.getByTestId("chat-mode-selector")).toContainText(
+    "Agent",
+  );
+
+  // Send a message in Chat #2 to ensure it's saved
+  await po.sendPrompt("tc=local-agent/simple-response");
+  await po.waitForChatCompletion();
+
+  // Use the chat activity panel to navigate between chats
+  await po.clickChatActivityButton();
+
+  // Find and click Chat #1 (should be at index 1 since Chat #2 is most recent)
+  const chat1ItemInList = po.page
+    .locator('[data-testid^="chat-activity-list-item-"]')
+    .filter({ hasText: "Chat #1" });
+  await expect(chat1ItemInList).toBeVisible();
+  await chat1ItemInList.click();
+
+  // Chat #1 should still be in Ask mode (not affected by Chat #2's mode change)
+  await expect(po.page.getByTestId("chat-mode-selector")).toContainText("Ask");
+
+  // Go back to Chat #2 through activity panel
+  await po.clickChatActivityButton();
+
+  // Find and click Chat #2 (now Chat #1 is most recent, so Chat #2 should be at a different index)
+  const chat2ItemInList = po.page
+    .locator('[data-testid^="chat-activity-list-item-"]')
+    .filter({ hasText: "Chat #2" });
+  await expect(chat2ItemInList).toBeVisible();
+  await chat2ItemInList.click();
+
+  // Chat #2 should still be in Agent mode (persisted its own setting)
+  await expect(po.page.getByTestId("chat-mode-selector")).toContainText(
+    "Agent",
+  );
+});

--- a/rules/git-workflow.md
+++ b/rules/git-workflow.md
@@ -98,9 +98,11 @@ If you need to rebase but have uncommitted changes (e.g., package-lock.json from
 This prevents rebase conflicts from uncommitted changes while preserving any work in progress.
 
 **If stash pop creates a conflict in package-lock.json:** The file will be marked as unmerged. To resolve:
+
 ```bash
 git reset HEAD package-lock.json && git checkout -- package-lock.json && git stash drop
 ```
+
 This resets package-lock.json to the rebased HEAD (discarding the stashed version) and drops the stash.
 
 ## Resolving documentation rebase conflicts

--- a/rules/git-workflow.md
+++ b/rules/git-workflow.md
@@ -97,6 +97,12 @@ If you need to rebase but have uncommitted changes (e.g., package-lock.json from
 
 This prevents rebase conflicts from uncommitted changes while preserving any work in progress.
 
+**If stash pop creates a conflict in package-lock.json:** The file will be marked as unmerged. To resolve:
+```bash
+git reset HEAD package-lock.json && git checkout -- package-lock.json && git stash drop
+```
+This resets package-lock.json to the rebased HEAD (discarding the stashed version) and drops the stash.
+
 ## Resolving documentation rebase conflicts
 
 When rebasing a PR branch that conflicts with upstream documentation changes (e.g., AGENTS.md):

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -69,6 +69,16 @@ export const chats = sqliteTable("chats", {
     .references(() => apps.id, { onDelete: "cascade" }),
   title: text("title"),
   initialCommitHash: text("initial_commit_hash"),
+  // Per-chat settings: chat mode (build, ask, agent, local-agent, plan)
+  chatMode: text("chat_mode", {
+    enum: ["build", "ask", "agent", "local-agent", "plan"],
+  }),
+  // Per-chat settings: selected model (JSON with name, provider, customModelId)
+  selectedModel: text("selected_model", { mode: "json" }).$type<{
+    name: string;
+    provider: string;
+    customModelId?: number;
+  } | null>(),
   createdAt: integer("created_at", { mode: "timestamp" })
     .notNull()
     .default(sql`(unixepoch())`),

--- a/src/hooks/useChatSettings.ts
+++ b/src/hooks/useChatSettings.ts
@@ -1,0 +1,84 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { queryKeys } from "@/lib/queryKeys";
+import { ipc } from "@/ipc/types";
+import type { ChatMode, LargeLanguageModel } from "@/lib/schemas";
+import { useSettings } from "./useSettings";
+
+/**
+ * Hook to get and update per-chat settings (mode and model).
+ * Falls back to global user settings if no per-chat settings are set.
+ */
+export function useChatSettings(chatId: number | null) {
+  const queryClient = useQueryClient();
+  const { settings } = useSettings();
+
+  const { data: chatSettings, isLoading } = useQuery({
+    queryKey: queryKeys.chats.settings({ chatId }),
+    queryFn: async () => {
+      if (chatId === null) {
+        return null;
+      }
+      return ipc.chat.getChatSettings(chatId);
+    },
+    enabled: chatId !== null,
+  });
+
+  const updateChatSettingsMutation = useMutation({
+    mutationFn: async (params: {
+      chatMode?: ChatMode;
+      selectedModel?: LargeLanguageModel;
+    }) => {
+      if (chatId === null) {
+        throw new Error("Cannot update settings without a chat ID");
+      }
+      return ipc.chat.updateChatSettings({
+        chatId,
+        ...params,
+      });
+    },
+    onSuccess: () => {
+      // Invalidate the chat settings query to refetch
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.chats.settings({ chatId }),
+      });
+      // Also invalidate token count since model change affects context window
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.tokenCount.all,
+      });
+    },
+  });
+
+  // Effective settings: per-chat if set, otherwise fall back to global
+  const effectiveChatMode: ChatMode =
+    chatSettings?.chatMode ?? settings?.selectedChatMode ?? "build";
+  const effectiveModel: LargeLanguageModel = chatSettings?.selectedModel ??
+    settings?.selectedModel ?? {
+      name: "auto",
+      provider: "auto",
+    };
+
+  return {
+    // Raw per-chat settings (null means not set)
+    chatSettings,
+    isLoading,
+
+    // Effective settings (with fallback to global)
+    effectiveChatMode,
+    effectiveModel,
+
+    // Check if using global settings (no per-chat override)
+    isUsingGlobalSettings: {
+      chatMode: chatSettings?.chatMode === null,
+      model: chatSettings?.selectedModel === null,
+    },
+
+    // Update functions
+    updateChatMode: (chatMode: ChatMode) => {
+      updateChatSettingsMutation.mutate({ chatMode });
+    },
+    updateSelectedModel: (selectedModel: LargeLanguageModel) => {
+      updateChatSettingsMutation.mutate({ selectedModel });
+    },
+    isUpdating: updateChatSettingsMutation.isPending,
+  };
+}

--- a/src/ipc/handlers/chat_handlers.ts
+++ b/src/ipc/handlers/chat_handlers.ts
@@ -172,5 +172,40 @@ export function registerChatHandlers() {
     return uniqueChats;
   });
 
+  createTypedHandler(chatContracts.getChatSettings, async (_, chatId) => {
+    const chat = await db.query.chats.findFirst({
+      where: eq(chats.id, chatId),
+      columns: {
+        chatMode: true,
+        selectedModel: true,
+      },
+    });
+
+    if (!chat) {
+      throw new Error("Chat not found");
+    }
+
+    return {
+      chatMode: chat.chatMode ?? null,
+      selectedModel: chat.selectedModel ?? null,
+    };
+  });
+
+  createTypedHandler(chatContracts.updateChatSettings, async (_, params) => {
+    const { chatId, chatMode, selectedModel } = params;
+
+    // Build the update object dynamically
+    const updates: Record<string, unknown> = {};
+
+    if (chatMode !== undefined) {
+      updates.chatMode = chatMode;
+    }
+    if (selectedModel !== undefined) {
+      updates.selectedModel = selectedModel;
+    }
+
+    await db.update(chats).set(updates).where(eq(chats.id, chatId));
+  });
+
   logger.debug("Registered chat IPC handlers");
 }

--- a/src/ipc/handlers/chat_handlers.ts
+++ b/src/ipc/handlers/chat_handlers.ts
@@ -2,6 +2,7 @@ import { db } from "../../db";
 import { apps, chats, messages } from "../../db/schema";
 import { desc, eq, and, like } from "drizzle-orm";
 import type { ChatSearchResult, ChatSummary } from "../../lib/schemas";
+import { migrateStoredChatMode } from "../../lib/schemas";
 
 import log from "electron-log";
 import { getDyadAppPath } from "../../paths/paths";
@@ -72,6 +73,8 @@ export function registerChatHandlers() {
     return {
       ...chat,
       title: chat.title ?? "",
+      // Migrate deprecated "agent" to "build" for chat mode
+      chatMode: chat.chatMode ? migrateStoredChatMode(chat.chatMode) : null,
       messages: chat.messages.map((m) => ({
         ...m,
         role: m.role as "user" | "assistant",
@@ -186,7 +189,9 @@ export function registerChatHandlers() {
     }
 
     return {
-      chatMode: chat.chatMode ?? null,
+      chatMode: chat.chatMode
+        ? (migrateStoredChatMode(chat.chatMode) ?? null)
+        : null,
       selectedModel: chat.selectedModel ?? null,
     };
   });

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -18,6 +18,7 @@ import { db } from "../../db";
 import { chats, messages } from "../../db/schema";
 import { and, eq, isNull } from "drizzle-orm";
 import type { SmartContextMode } from "../../lib/schemas";
+import { migrateStoredChatMode } from "../../lib/schemas";
 import {
   constructSystemPrompt,
   readAiRules,
@@ -262,8 +263,10 @@ export function registerChatStreamHandlers() {
       const globalSettings = readSettings();
       const settings = {
         ...globalSettings,
-        // Per-chat mode overrides global if set
-        selectedChatMode: chat.chatMode ?? globalSettings.selectedChatMode,
+        // Per-chat mode overrides global if set (migrate deprecated "agent" to "build")
+        selectedChatMode: chat.chatMode
+          ? migrateStoredChatMode(chat.chatMode)
+          : globalSettings.selectedChatMode,
         // Per-chat model overrides global if set
         selectedModel: chat.selectedModel ?? globalSettings.selectedModel,
       };

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -243,7 +243,7 @@ export function registerChatStreamHandlers() {
       // Notify renderer that stream is starting
       safeSend(event.sender, "chat:stream:start", { chatId: req.chatId });
 
-      // Get the chat to check for existing messages
+      // Get the chat to check for existing messages and per-chat settings
       const chat = await db.query.chats.findFirst({
         where: eq(chats.id, req.chatId),
         with: {
@@ -257,6 +257,16 @@ export function registerChatStreamHandlers() {
       if (!chat) {
         throw new Error(`Chat not found: ${req.chatId}`);
       }
+
+      // Read global settings and merge with per-chat settings
+      const globalSettings = readSettings();
+      const settings = {
+        ...globalSettings,
+        // Per-chat mode overrides global if set
+        selectedChatMode: chat.chatMode ?? globalSettings.selectedChatMode,
+        // Per-chat model overrides global if set
+        selectedModel: chat.selectedModel ?? globalSettings.selectedModel,
+      };
 
       // Handle redo option: remove the most recent messages if needed
       if (req.redo) {
@@ -457,7 +467,6 @@ ${componentSnippet}
         })
         .returning({ id: messages.id });
       const userMessageId = insertedUserMessage.id;
-      const settings = readSettings();
       // Only Dyad Pro requests have request ids.
       if (settings.enableDyadPro) {
         // Generate requestId early so it can be saved with the message
@@ -1589,7 +1598,7 @@ ${problemReport.problems
           .update(messages)
           .set({ content: fullResponse })
           .where(eq(messages.id, placeholderAssistantMessage.id));
-        const settings = readSettings();
+        // Use per-chat aware settings (already defined earlier in this function)
         if (
           settings.autoApproveChanges &&
           settings.selectedChatMode !== "ask"

--- a/src/ipc/types/chat.ts
+++ b/src/ipc/types/chat.ts
@@ -5,6 +5,7 @@ import {
   createClient,
   createStreamClient,
 } from "../contracts/core";
+import { ChatModeSchema, LargeLanguageModelSchema } from "../../lib/schemas";
 
 // =============================================================================
 // Chat Schemas
@@ -38,9 +39,35 @@ export const ChatSchema = z.object({
   messages: z.array(MessageSchema),
   initialCommitHash: z.string().nullable().optional(),
   dbTimestamp: z.string().nullable().optional(),
+  // Per-chat settings
+  chatMode: ChatModeSchema.nullable().optional(),
+  selectedModel: LargeLanguageModelSchema.nullable().optional(),
 });
 
 export type Chat = z.infer<typeof ChatSchema>;
+
+/**
+ * Schema for updating chat settings (mode and/or model).
+ */
+export const UpdateChatSettingsParamsSchema = z.object({
+  chatId: z.number(),
+  chatMode: ChatModeSchema.optional(),
+  selectedModel: LargeLanguageModelSchema.optional(),
+});
+
+export type UpdateChatSettingsParams = z.infer<
+  typeof UpdateChatSettingsParamsSchema
+>;
+
+/**
+ * Schema for chat settings result.
+ */
+export const ChatSettingsSchema = z.object({
+  chatMode: ChatModeSchema.nullable(),
+  selectedModel: LargeLanguageModelSchema.nullable(),
+});
+
+export type ChatSettings = z.infer<typeof ChatSettingsSchema>;
 
 /**
  * Schema for component selection (used in chat context).
@@ -231,6 +258,18 @@ export const chatContracts = {
     channel: "chat:count-tokens",
     input: TokenCountParamsSchema,
     output: TokenCountResultSchema,
+  }),
+
+  getChatSettings: defineContract({
+    channel: "chat:get-settings",
+    input: z.number(), // chatId
+    output: ChatSettingsSchema,
+  }),
+
+  updateChatSettings: defineContract({
+    channel: "chat:update-settings",
+    input: UpdateChatSettingsParamsSchema,
+    output: z.void(),
   }),
 
   cancelStream: defineContract({

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -52,6 +52,8 @@ export const queryKeys = {
     list: ({ appId }: { appId: number | null }) => ["chats", appId] as const,
     search: ({ appId, query }: { appId: number | null; query: string }) =>
       ["chats", "search", appId, query] as const,
+    settings: ({ chatId }: { chatId: number | null }) =>
+      ["chats", "settings", chatId] as const,
   },
 
   // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes: #1844
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2544" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per‑chat settings for chat mode and selected model so each chat can have its own configuration, with global settings used as fallback. Streaming and UI now respect these per‑chat overrides.

- **New Features**
  - Store per-chat chat_mode and selected_model on the chats table.
  - Added useChatSettings hook with global fallback and update mutations.
  - Updated ChatModeSelector and ModelPicker to read/write per-chat when a chat is selected.
  - New IPC: chat:get-settings and chat:update-settings; stream handler merges per-chat with global settings.
  - Added e2e test verifying mode/model isolation between chats.

- **Migration**
  - Run Drizzle migrations to add chat_mode and selected_model.
  - Existing chats continue using global settings until a per-chat override is saved.

<sup>Written for commit 4658c55d7eb2c7250817cbbd814273ec637fb444. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

