### PR TITLE
add Stats for displaying line changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dyad",
-  "version": "0.37.0",
+  "version": "0.36.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dyad",
-      "version": "0.37.0",
+      "version": "0.36.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/amazon-bedrock": "^4.0.46",
@@ -20,7 +20,7 @@
         "@ai-sdk/provider-utils": "^4.0.13",
         "@ai-sdk/xai": "^3.0.46",
         "@babel/parser": "^7.28.5",
-        "@base-ui/react": "^1.2.0",
+        "@base-ui/react": "^1.1.0",
         "@biomejs/biome": "^1.9.4",
         "@dyad-sh/supabase-management-js": "v1.0.1",
         "@flakiness/playwright": "^1.0.0",
@@ -57,7 +57,6 @@
         "geist": "^1.3.1",
         "glob": "^11.0.2",
         "html-to-image": "^1.11.13",
-        "i18next": "^25.8.0",
         "isomorphic-git": "^1.30.1",
         "jotai": "^2.12.2",
         "jsonrepair": "^3.13.1",
@@ -71,7 +70,6 @@
         "posthog-js": "^1.236.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-i18next": "^16.5.4",
         "react-konva": "^19.2.1",
         "react-markdown": "^10.1.0",
         "react-resizable-panels": "^2.1.7",
@@ -139,7 +137,7 @@
         "vitest": "^3.1.1"
       },
       "engines": {
-        "node": ">=24"
+        "node": ">=20"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -662,9 +660,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -716,15 +714,16 @@
       }
     },
     "node_modules/@base-ui/react": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.2.0.tgz",
-      "integrity": "sha512-O6aEQHcm+QyGTFY28xuwRD3SEJGZOBDpyjN2WvpfWYFVhg+3zfXPysAILqtM0C1kWC82MccOE/v1j+GHXE4qIw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.1.0.tgz",
+      "integrity": "sha512-ikcJRNj1mOiF2HZ5jQHrXoVoHcNHdBU5ejJljcBl+VTLoYXR6FidjTN86GjO6hyshi6TZFuNvv0dEOgaOFv6Lw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6",
-        "@base-ui/utils": "0.2.5",
+        "@babel/runtime": "^7.28.4",
+        "@base-ui/utils": "0.2.4",
         "@floating-ui/react-dom": "^2.1.6",
         "@floating-ui/utils": "^0.2.10",
+        "reselect": "^5.1.1",
         "tabbable": "^6.4.0",
         "use-sync-external-store": "^1.6.0"
       },
@@ -747,12 +746,12 @@
       }
     },
     "node_modules/@base-ui/utils": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.5.tgz",
-      "integrity": "sha512-oYC7w0gp76RI5MxprlGLV0wze0SErZaRl3AAkeP3OnNB/UBMb6RqNf6ZSIlxOc9Qp68Ab3C2VOcJQyRs7Xc7Vw==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.4.tgz",
+      "integrity": "sha512-smZwpMhjO29v+jrZusBSc5T+IJ3vBb9cjIiBjtKcvWmRj9Z4DWGVR3efr1eHR56/bqY5a4qyY9ElkOY5ljo3ng==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6",
+        "@babel/runtime": "^7.28.4",
         "@floating-ui/utils": "^0.2.10",
         "reselect": "^5.1.1",
         "use-sync-external-store": "^1.6.0"
@@ -14501,15 +14500,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/html-parse-stringify": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
-      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
-      "license": "MIT",
-      "dependencies": {
-        "void-elements": "3.1.0"
-      }
-    },
     "node_modules/html-to-image": {
       "version": "1.11.13",
       "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
@@ -14657,37 +14647,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
-      }
-    },
-    "node_modules/i18next": {
-      "version": "25.8.0",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.8.0.tgz",
-      "integrity": "sha512-urrg4HMFFMQZ2bbKRK7IZ8/CTE7D8H4JRlAwqA2ZwDRFfdd0K/4cdbNNLgfn9mo+I/h9wJu61qJzH7jCFAhUZQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://locize.com"
-        },
-        {
-          "type": "individual",
-          "url": "https://locize.com/i18next.html"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.4"
-      },
-      "peerDependencies": {
-        "typescript": "^5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/iconv-lite": {
@@ -19762,33 +19721,6 @@
         "react": ">=16.13.1"
       }
     },
-    "node_modules/react-i18next": {
-      "version": "16.5.4",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.5.4.tgz",
-      "integrity": "sha512-6yj+dcfMncEC21QPhOTsW8mOSO+pzFmT6uvU7XXdvM/Cp38zJkmTeMeKmTrmCMD5ToT79FmiE/mRWiYWcJYW4g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "html-parse-stringify": "^3.0.1",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "peerDependencies": {
-        "i18next": ">= 25.6.2",
-        "react": ">= 16.8.0",
-        "typescript": "^5"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        },
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -22837,7 +22769,7 @@
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -23957,15 +23889,6 @@
         "jsdom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/void-elements": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
-      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/watchpack": {

--- a/src/components/chat/DyadCardPrimitives.tsx
+++ b/src/components/chat/DyadCardPrimitives.tsx
@@ -343,6 +343,54 @@ export function DyadFilePath({ path }: DyadFilePathProps) {
   );
 }
 
+// -- DyadDiffStats --
+
+interface DyadDiffStatsProps {
+  addedLines?: number;
+  removedLines?: number;
+  totalLines?: number;
+}
+
+/**
+ * Inline line-count badge for file change cards.
+ * Shows "+X / -Y" for search-replace diffs, or "N lines" for full file writes.
+ */
+export function DyadDiffStats({
+  addedLines,
+  removedLines,
+  totalLines,
+}: DyadDiffStatsProps) {
+  if (addedLines != null || removedLines != null) {
+    return (
+      <span className="inline-flex items-center gap-1 text-[11px] font-medium shrink-0">
+        {addedLines != null && (
+          <span className="text-green-600 dark:text-green-400">
+            +{addedLines}
+          </span>
+        )}
+        {addedLines != null && removedLines != null && (
+          <span className="text-muted-foreground">/</span>
+        )}
+        {removedLines != null && (
+          <span className="text-red-600 dark:text-red-400">
+            -{removedLines}
+          </span>
+        )}
+      </span>
+    );
+  }
+
+  if (totalLines != null && totalLines > 0) {
+    return (
+      <span className="text-[11px] font-medium text-muted-foreground shrink-0">
+        {totalLines} {totalLines === 1 ? "line" : "lines"}
+      </span>
+    );
+  }
+
+  return null;
+}
+
 // -- DyadDescription --
 
 interface DyadDescriptionProps {

--- a/src/components/chat/DyadCardPrimitives.tsx
+++ b/src/components/chat/DyadCardPrimitives.tsx
@@ -360,18 +360,21 @@ export function DyadDiffStats({
   removedLines,
   totalLines,
 }: DyadDiffStatsProps) {
-  if (addedLines != null || removedLines != null) {
+  const showAdded = addedLines != null && addedLines > 0;
+  const showRemoved = removedLines != null && removedLines > 0;
+
+  if (showAdded || showRemoved) {
     return (
       <span className="inline-flex items-center gap-1 text-[11px] font-medium shrink-0">
-        {addedLines != null && (
+        {showAdded && (
           <span className="text-green-600 dark:text-green-400">
             +{addedLines}
           </span>
         )}
-        {addedLines != null && removedLines != null && (
+        {showAdded && showRemoved && (
           <span className="text-muted-foreground">/</span>
         )}
-        {removedLines != null && (
+        {showRemoved && (
           <span className="text-red-600 dark:text-red-400">
             -{removedLines}
           </span>

--- a/src/components/chat/DyadEdit.tsx
+++ b/src/components/chat/DyadEdit.tsx
@@ -38,8 +38,9 @@ export const DyadEdit: React.FC<DyadEditProps> = ({
 
   const lineCount = useMemo(() => {
     const content = String(children ?? "");
-    if (!content.trim()) return 0;
-    return content.split("\n").length;
+    if (content === "") return 0;
+    const count = content.split("\n").length;
+    return content.endsWith("\n") ? count - 1 : count;
   }, [children]);
 
   const fileName = path ? path.split("/").pop() : "";

--- a/src/components/chat/DyadEdit.tsx
+++ b/src/components/chat/DyadEdit.tsx
@@ -1,6 +1,6 @@
 import type React from "react";
 import type { ReactNode } from "react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Zap } from "lucide-react";
 import { CodeHighlight } from "./CodeHighlight";
 import { CustomTagState } from "./stateTypes";
@@ -12,6 +12,7 @@ import {
   DyadStateIndicator,
   DyadDescription,
   DyadCardContent,
+  DyadDiffStats,
 } from "./DyadCardPrimitives";
 
 interface DyadEditProps {
@@ -34,6 +35,12 @@ export const DyadEdit: React.FC<DyadEditProps> = ({
   const state = node?.properties?.state as CustomTagState;
   const inProgress = state === "pending";
   const aborted = state === "aborted";
+
+  const lineCount = useMemo(() => {
+    const content = String(children ?? "");
+    if (!content.trim()) return 0;
+    return content.split("\n").length;
+  }, [children]);
 
   const fileName = path ? path.split("/").pop() : "";
 
@@ -64,6 +71,9 @@ export const DyadEdit: React.FC<DyadEditProps> = ({
           <DyadStateIndicator state="aborted" abortedLabel="Did not finish" />
         )}
         <div className="ml-auto flex items-center gap-1">
+          {!inProgress && lineCount > 0 && (
+            <DyadDiffStats totalLines={lineCount} />
+          )}
           <DyadBadge color="sky">Turbo Edit</DyadBadge>
           <DyadExpandIcon isExpanded={isContentVisible} />
         </div>

--- a/src/components/chat/DyadSearchReplace.tsx
+++ b/src/components/chat/DyadSearchReplace.tsx
@@ -14,6 +14,7 @@ import {
   DyadFilePath,
   DyadDescription,
   DyadCardContent,
+  DyadDiffStats,
 } from "./DyadCardPrimitives";
 
 interface DyadSearchReplaceProps {
@@ -42,6 +43,16 @@ export const DyadSearchReplace: React.FC<DyadSearchReplaceProps> = ({
     [children],
   );
 
+  const { addedLines, removedLines } = useMemo(() => {
+    let added = 0;
+    let removed = 0;
+    for (const b of blocks) {
+      removed += b.searchContent.split("\n").length;
+      added += b.replaceContent.split("\n").length;
+    }
+    return { addedLines: added, removedLines: removed };
+  }, [blocks]);
+
   const fileName = path ? path.split("/").pop() : "";
 
   return (
@@ -68,7 +79,13 @@ export const DyadSearchReplace: React.FC<DyadSearchReplaceProps> = ({
         {aborted && (
           <DyadStateIndicator state="aborted" abortedLabel="Did not finish" />
         )}
-        <div className="ml-auto">
+        <div className="ml-auto flex items-center gap-1.5">
+          {blocks.length > 0 && (
+            <DyadDiffStats
+              addedLines={addedLines}
+              removedLines={removedLines}
+            />
+          )}
           <DyadExpandIcon isExpanded={isContentVisible} />
         </div>
       </DyadCardHeader>

--- a/src/components/chat/DyadSearchReplace.tsx
+++ b/src/components/chat/DyadSearchReplace.tsx
@@ -44,11 +44,16 @@ export const DyadSearchReplace: React.FC<DyadSearchReplaceProps> = ({
   );
 
   const { addedLines, removedLines } = useMemo(() => {
+    const countLines = (content: string) => {
+      if (content === "") return 0;
+      const count = content.split("\n").length;
+      return content.endsWith("\n") ? count - 1 : count;
+    };
     let added = 0;
     let removed = 0;
     for (const b of blocks) {
-      removed += b.searchContent.split("\n").length;
-      added += b.replaceContent.split("\n").length;
+      removed += countLines(b.searchContent);
+      added += countLines(b.replaceContent);
     }
     return { addedLines: added, removedLines: removed };
   }, [blocks]);
@@ -80,7 +85,7 @@ export const DyadSearchReplace: React.FC<DyadSearchReplaceProps> = ({
           <DyadStateIndicator state="aborted" abortedLabel="Did not finish" />
         )}
         <div className="ml-auto flex items-center gap-1.5">
-          {blocks.length > 0 && (
+          {!inProgress && blocks.length > 0 && (
             <DyadDiffStats
               addedLines={addedLines}
               removedLines={removedLines}

--- a/src/components/chat/DyadWrite.tsx
+++ b/src/components/chat/DyadWrite.tsx
@@ -52,8 +52,9 @@ export const DyadWrite: React.FC<DyadWriteProps> = ({
 
   const lineCount = useMemo(() => {
     const content = String(children ?? "");
-    if (!content.trim()) return 0;
-    return content.split("\n").length;
+    if (content === "") return 0;
+    const count = content.split("\n").length;
+    return content.endsWith("\n") ? count - 1 : count;
   }, [children]);
 
   const fileName = path ? path.split("/").pop() : "";

--- a/src/components/chat/DyadWrite.tsx
+++ b/src/components/chat/DyadWrite.tsx
@@ -1,6 +1,6 @@
 import type React from "react";
 import type { ReactNode } from "react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Pencil, Edit, X } from "lucide-react";
 import { CodeHighlight } from "./CodeHighlight";
 import { CustomTagState } from "./stateTypes";
@@ -14,6 +14,7 @@ import {
   DyadStateIndicator,
   DyadDescription,
   DyadCardContent,
+  DyadDiffStats,
 } from "./DyadCardPrimitives";
 
 interface DyadWriteProps {
@@ -49,6 +50,12 @@ export const DyadWrite: React.FC<DyadWriteProps> = ({
     setIsContentVisible(true);
   };
 
+  const lineCount = useMemo(() => {
+    const content = String(children ?? "");
+    if (!content.trim()) return 0;
+    return content.split("\n").length;
+  }, [children]);
+
   const fileName = path ? path.split("/").pop() : "";
 
   return (
@@ -78,6 +85,9 @@ export const DyadWrite: React.FC<DyadWriteProps> = ({
           <DyadStateIndicator state="aborted" abortedLabel="Did not finish" />
         )}
         <div className="ml-auto flex items-center gap-1">
+          {!inProgress && lineCount > 0 && (
+            <DyadDiffStats totalLines={lineCount} />
+          )}
           {!inProgress && (
             <>
               {isEditing ? (


### PR DESCRIPTION
closes #2330
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2548" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add inline line-change stats to file change cards so users can see additions, removals, or total lines at a glance. Implements #2330.

- New Features
  - Added DyadDiffStats component that shows “+X/-Y” for diffs or “N lines” for full writes.
  - Integrated into Search/Replace to sum added/removed lines across blocks.
  - Integrated into Write and Edit to show total lines once processing completes (memoized for performance).

<sup>Written for commit 632ed51a096f0882314f483d680da07d34b55c03. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

