### PR TITLE
Prompt the user for attachement type after dragging the file

### DIFF
--- a/e2e-tests/attach_image.spec.ts
+++ b/e2e-tests/attach_image.spec.ts
@@ -156,7 +156,7 @@ test("attach image via drag - chat", async ({ po }) => {
 
   // Choose "Attach as chat context" in the attachment type dialog
   const chatContextButton = po.page.getByRole("button", {
-    name: "Attach as chat context",
+    name: "Attach file as chat context",
   });
   await expect(chatContextButton).toBeVisible();
   await chatContextButton.click();

--- a/e2e-tests/attach_image.spec.ts
+++ b/e2e-tests/attach_image.spec.ts
@@ -154,6 +154,13 @@ test("attach image via drag - chat", async ({ po }) => {
     });
   }, fileBase64);
 
+  // Choose "Attach as chat context" in the attachment type dialog
+  const chatContextButton = po.page.getByRole("button", {
+    name: "Attach as chat context",
+  });
+  await expect(chatContextButton).toBeVisible();
+  await chatContextButton.click();
+
   // submit and verify
   await po.sendPrompt("[dump]");
   // Note: this should match EXACTLY the server dump from the previous test.

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -148,7 +148,7 @@ export function ChatInput({ chatId }: { chatId?: number }) {
   const {
     attachments,
     isDraggingOver,
-    pendingDroppedFiles,
+    pendingFiles,
     handleFileSelect,
     removeAttachment,
     handleDragOver,
@@ -156,8 +156,8 @@ export function ChatInput({ chatId }: { chatId?: number }) {
     handleDrop,
     clearAttachments,
     handlePaste,
-    confirmDroppedFiles,
-    cancelDroppedFiles,
+    confirmPendingFiles,
+    cancelPendingFiles,
   } = useAttachments();
 
   // Use the hook to fetch the proposal
@@ -558,11 +558,11 @@ export function ChatInput({ chatId }: { chatId?: number }) {
           {/* Use the DragDropOverlay component */}
           <DragDropOverlay isDraggingOver={isDraggingOver} />
 
-          {/* Dialog for choosing attachment type on drag & drop */}
+          {/* Dialog for choosing attachment type */}
           <FileAttachmentTypeDialog
-            pendingFiles={pendingDroppedFiles}
-            onConfirm={confirmDroppedFiles}
-            onCancel={cancelDroppedFiles}
+            pendingFiles={pendingFiles}
+            onConfirm={confirmPendingFiles}
+            onCancel={cancelPendingFiles}
           />
 
           <div className="flex items-start space-x-2 ">

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -55,6 +55,7 @@ import { useVersions } from "@/hooks/useVersions";
 import { useAttachments } from "@/hooks/useAttachments";
 import { AttachmentsList } from "./AttachmentsList";
 import { DragDropOverlay } from "./DragDropOverlay";
+import { FileAttachmentTypeDialog } from "./FileAttachmentTypeDialog";
 import { showExtraFilesToast, showInfo } from "@/lib/toast";
 import { useSummarizeInNewChat } from "./SummarizeInNewChatButton";
 import { ChatInputControls } from "../ChatInputControls";
@@ -147,6 +148,7 @@ export function ChatInput({ chatId }: { chatId?: number }) {
   const {
     attachments,
     isDraggingOver,
+    pendingDroppedFiles,
     handleFileSelect,
     removeAttachment,
     handleDragOver,
@@ -154,6 +156,8 @@ export function ChatInput({ chatId }: { chatId?: number }) {
     handleDrop,
     clearAttachments,
     handlePaste,
+    confirmDroppedFiles,
+    cancelDroppedFiles,
   } = useAttachments();
 
   // Use the hook to fetch the proposal
@@ -553,6 +557,13 @@ export function ChatInput({ chatId }: { chatId?: number }) {
 
           {/* Use the DragDropOverlay component */}
           <DragDropOverlay isDraggingOver={isDraggingOver} />
+
+          {/* Dialog for choosing attachment type on drag & drop */}
+          <FileAttachmentTypeDialog
+            pendingFiles={pendingDroppedFiles}
+            onConfirm={confirmDroppedFiles}
+            onCancel={cancelDroppedFiles}
+          />
 
           <div className="flex items-start space-x-2 ">
             <LexicalChatInput

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -245,7 +245,8 @@ export function ChatInput({ chatId }: { chatId?: number }) {
     if (
       (!inputValue.trim() && attachments.length === 0) ||
       isStreaming ||
-      !chatId
+      !chatId ||
+      pendingFiles
     ) {
       return;
     }

--- a/src/components/chat/FileAttachmentTypeDialog.tsx
+++ b/src/components/chat/FileAttachmentTypeDialog.tsx
@@ -6,6 +6,7 @@ import {
   DialogTitle,
   DialogDescription,
 } from "@/components/ui/dialog";
+import { useTranslation } from "react-i18next";
 
 interface FileAttachmentTypeDialogProps {
   pendingFiles: File[] | null;
@@ -18,6 +19,7 @@ export function FileAttachmentTypeDialog({
   onConfirm,
   onCancel,
 }: FileAttachmentTypeDialogProps) {
+  const { t } = useTranslation("chat");
   const isOpen = !!pendingFiles && pendingFiles.length > 0;
   const fileCount = pendingFiles?.length ?? 0;
 
@@ -31,16 +33,20 @@ export function FileAttachmentTypeDialog({
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>
-            How would you like to attach{" "}
-            {fileCount === 1 ? "this file" : `these ${fileCount} files`}?
+            {fileCount === 1
+              ? t("attachmentTypeDialog.titleSingular")
+              : t("attachmentTypeDialog.titlePlural", { count: fileCount })}
           </DialogTitle>
           <DialogDescription>
-            Choose how the {fileCount === 1 ? "file" : "files"} should be used.
+            {fileCount === 1
+              ? t("attachmentTypeDialog.descriptionSingular")
+              : t("attachmentTypeDialog.descriptionPlural")}
           </DialogDescription>
         </DialogHeader>
         <div className="flex flex-col gap-2">
           <button
-            className="flex items-start gap-3 rounded-lg border border-border p-4 text-left hover:bg-muted/50 transition-colors"
+            type="button"
+            className="flex items-start gap-3 rounded-lg border border-border p-4 text-left hover:bg-muted/50 transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
             onClick={() => onConfirm("chat-context")}
           >
             <MessageSquare
@@ -48,21 +54,26 @@ export function FileAttachmentTypeDialog({
               className="mt-0.5 text-green-500 flex-shrink-0"
             />
             <div>
-              <div className="font-medium text-sm">Attach as chat context</div>
+              <div className="font-medium text-sm">
+                {t("attachFileContext")}
+              </div>
               <div className="text-xs text-muted-foreground mt-0.5">
-                Provide context for the AI (e.g. screenshots, references)
+                {t("attachFileContextExample")}
               </div>
             </div>
           </button>
           <button
-            className="flex items-start gap-3 rounded-lg border border-border p-4 text-left hover:bg-muted/50 transition-colors"
+            type="button"
+            className="flex items-start gap-3 rounded-lg border border-border p-4 text-left hover:bg-muted/50 transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
             onClick={() => onConfirm("upload-to-codebase")}
           >
             <Upload size={20} className="mt-0.5 text-blue-500 flex-shrink-0" />
             <div>
-              <div className="font-medium text-sm">Upload to codebase</div>
+              <div className="font-medium text-sm">
+                {t("uploadFileCodebase")}
+              </div>
               <div className="text-xs text-muted-foreground mt-0.5">
-                Add files to your project (e.g. images, assets)
+                {t("uploadFileCodebaseExample")}
               </div>
             </div>
           </button>

--- a/src/components/chat/FileAttachmentTypeDialog.tsx
+++ b/src/components/chat/FileAttachmentTypeDialog.tsx
@@ -1,0 +1,73 @@
+import { MessageSquare, Upload } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+
+interface FileAttachmentTypeDialogProps {
+  pendingFiles: File[] | null;
+  onConfirm: (type: "chat-context" | "upload-to-codebase") => void;
+  onCancel: () => void;
+}
+
+export function FileAttachmentTypeDialog({
+  pendingFiles,
+  onConfirm,
+  onCancel,
+}: FileAttachmentTypeDialogProps) {
+  const isOpen = !!pendingFiles && pendingFiles.length > 0;
+  const fileCount = pendingFiles?.length ?? 0;
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) onCancel();
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            How would you like to attach{" "}
+            {fileCount === 1 ? "this file" : `these ${fileCount} files`}?
+          </DialogTitle>
+          <DialogDescription>
+            Choose how the {fileCount === 1 ? "file" : "files"} should be used.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-2">
+          <button
+            className="flex items-start gap-3 rounded-lg border border-border p-4 text-left hover:bg-muted/50 transition-colors"
+            onClick={() => onConfirm("chat-context")}
+          >
+            <MessageSquare
+              size={20}
+              className="mt-0.5 text-green-500 flex-shrink-0"
+            />
+            <div>
+              <div className="font-medium text-sm">Attach as chat context</div>
+              <div className="text-xs text-muted-foreground mt-0.5">
+                Provide context for the AI (e.g. screenshots, references)
+              </div>
+            </div>
+          </button>
+          <button
+            className="flex items-start gap-3 rounded-lg border border-border p-4 text-left hover:bg-muted/50 transition-colors"
+            onClick={() => onConfirm("upload-to-codebase")}
+          >
+            <Upload size={20} className="mt-0.5 text-blue-500 flex-shrink-0" />
+            <div>
+              <div className="font-medium text-sm">Upload to codebase</div>
+              <div className="text-xs text-muted-foreground mt-0.5">
+                Add files to your project (e.g. images, assets)
+              </div>
+            </div>
+          </button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/chat/HomeChatInput.tsx
+++ b/src/components/chat/HomeChatInput.tsx
@@ -12,6 +12,7 @@ import { useStreamChat } from "@/hooks/useStreamChat";
 import { useAttachments } from "@/hooks/useAttachments";
 import { AttachmentsList } from "./AttachmentsList";
 import { DragDropOverlay } from "./DragDropOverlay";
+import { FileAttachmentTypeDialog } from "./FileAttachmentTypeDialog";
 import { usePostHog } from "posthog-js/react";
 import { HomeSubmitOptions } from "@/pages/home";
 import { ChatInputControls } from "../ChatInputControls";
@@ -44,6 +45,7 @@ export function HomeChatInput({
   const {
     attachments,
     isDraggingOver,
+    pendingDroppedFiles,
     handleFileSelect,
     removeAttachment,
     handleDragOver,
@@ -51,6 +53,8 @@ export function HomeChatInput({
     handleDrop,
     clearAttachments,
     handlePaste,
+    confirmDroppedFiles,
+    cancelDroppedFiles,
   } = useAttachments();
 
   // Custom submit function that wraps the provided onSubmit
@@ -92,6 +96,13 @@ export function HomeChatInput({
 
           {/* Drag and drop overlay */}
           <DragDropOverlay isDraggingOver={isDraggingOver} />
+
+          {/* Dialog for choosing attachment type on drag & drop */}
+          <FileAttachmentTypeDialog
+            pendingFiles={pendingDroppedFiles}
+            onConfirm={confirmDroppedFiles}
+            onCancel={cancelDroppedFiles}
+          />
 
           <div className="flex items-start space-x-2 ">
             <LexicalChatInput

--- a/src/components/chat/HomeChatInput.tsx
+++ b/src/components/chat/HomeChatInput.tsx
@@ -45,7 +45,7 @@ export function HomeChatInput({
   const {
     attachments,
     isDraggingOver,
-    pendingDroppedFiles,
+    pendingFiles,
     handleFileSelect,
     removeAttachment,
     handleDragOver,
@@ -53,8 +53,8 @@ export function HomeChatInput({
     handleDrop,
     clearAttachments,
     handlePaste,
-    confirmDroppedFiles,
-    cancelDroppedFiles,
+    confirmPendingFiles,
+    cancelPendingFiles,
   } = useAttachments();
 
   // Custom submit function that wraps the provided onSubmit
@@ -97,11 +97,11 @@ export function HomeChatInput({
           {/* Drag and drop overlay */}
           <DragDropOverlay isDraggingOver={isDraggingOver} />
 
-          {/* Dialog for choosing attachment type on drag & drop */}
+          {/* Dialog for choosing attachment type */}
           <FileAttachmentTypeDialog
-            pendingFiles={pendingDroppedFiles}
-            onConfirm={confirmDroppedFiles}
-            onCancel={cancelDroppedFiles}
+            pendingFiles={pendingFiles}
+            onConfirm={confirmPendingFiles}
+            onCancel={cancelPendingFiles}
           />
 
           <div className="flex items-start space-x-2 ">

--- a/src/components/chat/HomeChatInput.tsx
+++ b/src/components/chat/HomeChatInput.tsx
@@ -59,7 +59,11 @@ export function HomeChatInput({
 
   // Custom submit function that wraps the provided onSubmit
   const handleCustomSubmit = () => {
-    if ((!inputValue.trim() && attachments.length === 0) || isStreaming) {
+    if (
+      (!inputValue.trim() && attachments.length === 0) ||
+      isStreaming ||
+      pendingFiles
+    ) {
       return;
     }
 

--- a/src/hooks/useAttachments.ts
+++ b/src/hooks/useAttachments.ts
@@ -68,28 +68,6 @@ export function useAttachments() {
     }
   };
 
-  const confirmPendingFiles = useCallback(
-    (type: "chat-context" | "upload-to-codebase") => {
-      if (pendingFiles) {
-        const fileAttachments: FileAttachment[] = pendingFiles.map((file) => ({
-          file,
-          type,
-        }));
-        setAttachments((prev) => [...prev, ...fileAttachments]);
-        setPendingFiles(null);
-      }
-    },
-    [pendingFiles, setAttachments],
-  );
-
-  const cancelPendingFiles = useCallback(() => {
-    setPendingFiles(null);
-  }, []);
-
-  const clearAttachments = () => {
-    setAttachments([]);
-  };
-
   const addAttachments = (
     files: File[],
     type: "chat-context" | "upload-to-codebase" = "chat-context",
@@ -99,6 +77,25 @@ export function useAttachments() {
       type,
     }));
     setAttachments((attachments) => [...attachments, ...fileAttachments]);
+  };
+
+  const confirmPendingFiles = useCallback(
+    (type: "chat-context" | "upload-to-codebase") => {
+      if (pendingFiles) {
+        addAttachments(pendingFiles, type);
+        setPendingFiles(null);
+      }
+    },
+    [pendingFiles, addAttachments],
+  );
+
+  const cancelPendingFiles = useCallback(() => {
+    setPendingFiles(null);
+  }, []);
+
+  const clearAttachments = () => {
+    setAttachments([]);
+    setPendingFiles(null);
   };
 
   const handlePaste = async (e: React.ClipboardEvent) => {

--- a/src/hooks/useAttachments.ts
+++ b/src/hooks/useAttachments.ts
@@ -47,7 +47,9 @@ export function useAttachments() {
 
   const handleDragOver = (e: React.DragEvent) => {
     e.preventDefault();
-    setIsDraggingOver(true);
+    if (!pendingFiles) {
+      setIsDraggingOver(true);
+    }
   };
 
   const handleDragLeave = () => {
@@ -57,6 +59,8 @@ export function useAttachments() {
   const handleDrop = (e: React.DragEvent) => {
     e.preventDefault();
     setIsDraggingOver(false);
+
+    if (pendingFiles) return;
 
     if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
       const files = Array.from(e.dataTransfer.files);
@@ -98,6 +102,8 @@ export function useAttachments() {
   };
 
   const handlePaste = async (e: React.ClipboardEvent) => {
+    if (pendingFiles) return;
+
     const clipboardData = e.clipboardData;
     if (!clipboardData) return;
 

--- a/src/hooks/useAttachments.ts
+++ b/src/hooks/useAttachments.ts
@@ -7,9 +7,7 @@ export function useAttachments() {
   const [attachments, setAttachments] = useAtom(attachmentsAtom);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [isDraggingOver, setIsDraggingOver] = useState(false);
-  const [pendingDroppedFiles, setPendingDroppedFiles] = useState<File[] | null>(
-    null,
-  );
+  const [pendingFiles, setPendingFiles] = useState<File[] | null>(null);
 
   const handleAttachmentClick = () => {
     fileInputRef.current?.click();
@@ -62,28 +60,26 @@ export function useAttachments() {
 
     if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
       const files = Array.from(e.dataTransfer.files);
-      setPendingDroppedFiles(files);
+      setPendingFiles(files);
     }
   };
 
-  const confirmDroppedFiles = useCallback(
+  const confirmPendingFiles = useCallback(
     (type: "chat-context" | "upload-to-codebase") => {
-      if (pendingDroppedFiles) {
-        const fileAttachments: FileAttachment[] = pendingDroppedFiles.map(
-          (file) => ({
-            file,
-            type,
-          }),
-        );
+      if (pendingFiles) {
+        const fileAttachments: FileAttachment[] = pendingFiles.map((file) => ({
+          file,
+          type,
+        }));
         setAttachments((prev) => [...prev, ...fileAttachments]);
-        setPendingDroppedFiles(null);
+        setPendingFiles(null);
       }
     },
-    [pendingDroppedFiles, setAttachments],
+    [pendingFiles, setAttachments],
   );
 
-  const cancelDroppedFiles = useCallback(() => {
-    setPendingDroppedFiles(null);
+  const cancelPendingFiles = useCallback(() => {
+    setPendingFiles(null);
   }, []);
 
   const clearAttachments = () => {
@@ -134,9 +130,7 @@ export function useAttachments() {
       }
 
       if (imageFiles.length > 0) {
-        addAttachments(imageFiles, "chat-context");
-        // Show a brief toast or indication that image was pasted
-        console.log(`Pasted ${imageFiles.length} image(s) from clipboard`);
+        setPendingFiles(imageFiles);
       }
     }
   };
@@ -145,7 +139,7 @@ export function useAttachments() {
     attachments,
     fileInputRef,
     isDraggingOver,
-    pendingDroppedFiles,
+    pendingFiles,
     handleAttachmentClick,
     handleFileChange,
     handleFileSelect,
@@ -156,7 +150,7 @@ export function useAttachments() {
     clearAttachments,
     handlePaste,
     addAttachments,
-    confirmDroppedFiles,
-    cancelDroppedFiles,
+    confirmPendingFiles,
+    cancelPendingFiles,
   };
 }

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -126,6 +126,12 @@
   "uploadFileCodebase": "Upload file to codebase",
   "uploadFileCodebaseExample": "Example use case: add an image to use for your app",
   "dropFilesToAttach": "Drop files to attach",
+  "attachmentTypeDialog": {
+    "titleSingular": "How would you like to attach this file?",
+    "titlePlural": "How would you like to attach these {{count}} files?",
+    "descriptionSingular": "Choose how the file should be used.",
+    "descriptionPlural": "Choose how the files should be used."
+  },
   "selectedComponents": "Selected Components ({{count}})",
   "clearAllComponents": "Clear all selected components",
   "deselectComponent": "Deselect component",

--- a/src/i18n/locales/pt-BR/chat.json
+++ b/src/i18n/locales/pt-BR/chat.json
@@ -126,6 +126,12 @@
   "uploadFileCodebase": "Enviar arquivo para a base de código",
   "uploadFileCodebaseExample": "Exemplo de uso: adicionar uma imagem para usar no seu app",
   "dropFilesToAttach": "Solte os arquivos para anexar",
+  "attachmentTypeDialog": {
+    "titleSingular": "Como você gostaria de anexar este arquivo?",
+    "titlePlural": "Como você gostaria de anexar estes {{count}} arquivos?",
+    "descriptionSingular": "Escolha como o arquivo deve ser usado.",
+    "descriptionPlural": "Escolha como os arquivos devem ser usados."
+  },
   "selectedComponents": "Componentes Selecionados ({{count}})",
   "clearAllComponents": "Limpar todos os componentes selecionados",
   "deselectComponent": "Desmarcar componente",

--- a/src/i18n/locales/zh-CN/chat.json
+++ b/src/i18n/locales/zh-CN/chat.json
@@ -126,6 +126,12 @@
   "uploadFileCodebase": "上传文件到代码库",
   "uploadFileCodebaseExample": "示例用途：添加图片供应用使用",
   "dropFilesToAttach": "拖放文件以附加",
+  "attachmentTypeDialog": {
+    "titleSingular": "您想如何附加此文件？",
+    "titlePlural": "您想如何附加这 {{count}} 个文件？",
+    "descriptionSingular": "选择文件的使用方式。",
+    "descriptionPlural": "选择文件的使用方式。"
+  },
   "selectedComponents": "已选择的组件 ({{count}})",
   "clearAllComponents": "清除所有已选择的组件",
   "deselectComponent": "取消选择组件",


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2563" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a dialog after dragging or pasting files into chat to choose how to attach them—as chat context or upload to codebase. This makes intent explicit and blocks submit, drop, and paste until you choose.

- **New Features**
  - Added FileAttachmentTypeDialog; integrated in ChatInput and HomeChatInput. i18n (en, pt-BR, zh-CN) with singular/plural titles and descriptions.
  - Updated useAttachments with pendingFiles and confirm/cancel. Drag/paste set pendingFiles; prevent attaching while pending; clearAttachments also clears pendingFiles; submit blocked when dialog is open.
  - Fixed e2e to select “Attach file as chat context”; dialog buttons use type="button" with focus-visible ring.

- **Refactors**
  - confirmPendingFiles reuses addAttachments to deduplicate logic.

<sup>Written for commit b625847b5ed5f82bea4616db27b87b16b5b33613. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

