### PR TITLE
Disapaly a dialog to select a template before creating an app

### DIFF
--- a/e2e-tests/helpers/test_helper.ts
+++ b/e2e-tests/helpers/test_helper.ts
@@ -1604,6 +1604,12 @@ export const test = base.extend<{
       }
       const baseTmpDir = os.tmpdir();
       const userDataDir = path.join(baseTmpDir, `dyad-e2e-tests-${Date.now()}`);
+      // Disable the template selection dialog for all tests by default
+      fs.mkdirSync(userDataDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(userDataDir, "user-settings.json"),
+        JSON.stringify({ promptForTemplate: false }),
+      );
       if (electronConfig.preLaunchHook) {
         await electronConfig.preLaunchHook({ userDataDir });
       }

--- a/e2e-tests/select-template-dialog.spec.ts
+++ b/e2e-tests/select-template-dialog.spec.ts
@@ -1,0 +1,68 @@
+import { testWithConfig } from "./helpers/test_helper";
+import { expect } from "@playwright/test";
+import * as fs from "fs";
+import * as path from "path";
+
+const testWithTemplateDialog = testWithConfig({
+  preLaunchHook: async ({ userDataDir }) => {
+    // Enable the template selection dialog (overrides the default test fixture setting)
+    fs.writeFileSync(
+      path.join(userDataDir, "user-settings.json"),
+      JSON.stringify({ promptForTemplate: true }),
+    );
+  },
+});
+
+testWithTemplateDialog("select template dialog - cancel", async ({ po }) => {
+  await po.setUp();
+
+  const beforeSettings = po.recordSettings();
+
+  // Type a prompt and submit from home page
+  await po.getChatInput().fill("test prompt");
+  await po.page.getByRole("button", { name: "Send message" }).click();
+
+  // Template selection dialog should appear
+  await expect(
+    po.page.getByRole("heading", { name: "Select a Template" }),
+  ).toBeVisible();
+
+  // Cancel should dismiss the dialog without side effects
+  await po.page.getByRole("button", { name: "Cancel" }).click();
+  await expect(
+    po.page.getByRole("heading", { name: "Select a Template" }),
+  ).not.toBeVisible();
+
+  po.snapshotSettingsDelta(beforeSettings);
+});
+
+testWithTemplateDialog(
+  "select template dialog - continue with template",
+  async ({ po }) => {
+    await po.setUp();
+
+    const beforeSettings = po.recordSettings();
+
+    // Type a prompt and submit from home page
+    await po.getChatInput().fill("tc=edit-made-with-dyad");
+    await po.page.getByRole("button", { name: "Send message" }).click();
+
+    // Template selection dialog should appear
+    await expect(
+      po.page.getByRole("heading", { name: "Select a Template" }),
+    ).toBeVisible();
+
+    // Select Next.js template and check "Don't show again"
+    await po.page.getByRole("img", { name: "Next.js Template" }).click();
+    await po.page.getByText("Don't show me this again").click();
+
+    // Continue should dismiss dialog and proceed with app creation
+    await po.page.getByRole("button", { name: "Continue" }).click();
+    await expect(
+      po.page.getByRole("heading", { name: "Select a Template" }),
+    ).not.toBeVisible();
+
+    await po.waitForChatCompletion();
+    po.snapshotSettingsDelta(beforeSettings);
+  },
+);

--- a/e2e-tests/snapshots/select-template-dialog.spec.ts_select-template-dialog---continue-with-template-1.txt
+++ b/e2e-tests/snapshots/select-template-dialog.spec.ts_select-template-dialog---continue-with-template-1.txt
@@ -1,0 +1,4 @@
+- "promptForTemplate": true
++ "promptForTemplate": false
+- "selectedTemplateId": "react"
++ "selectedTemplateId": "next"

--- a/src/components/PromptForTemplateSwitch.tsx
+++ b/src/components/PromptForTemplateSwitch.tsx
@@ -1,0 +1,26 @@
+import { useSettings } from "@/hooks/useSettings";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+
+export function PromptForTemplateSwitch() {
+  const { settings, updateSettings } = useSettings();
+  const isEnabled = settings?.promptForTemplate !== false;
+
+  return (
+    <div className="flex items-center space-x-2">
+      <Switch
+        id="prompt-for-template"
+        aria-label="Prompt for template when creating new app"
+        checked={isEnabled}
+        onCheckedChange={(checked) => {
+          updateSettings({
+            promptForTemplate: checked,
+          });
+        }}
+      />
+      <Label htmlFor="prompt-for-template">
+        Prompt for template when creating new app
+      </Label>
+    </div>
+  );
+}

--- a/src/components/SelectTemplateDialog.tsx
+++ b/src/components/SelectTemplateDialog.tsx
@@ -1,0 +1,110 @@
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { TemplateCard } from "./TemplateCard";
+import { useTemplates } from "@/hooks/useTemplates";
+import { useSettings } from "@/hooks/useSettings";
+
+interface SelectTemplateDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (templateId: string) => void;
+}
+
+export function SelectTemplateDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+}: SelectTemplateDialogProps) {
+  const { templates } = useTemplates();
+  const { settings, updateSettings } = useSettings();
+  const [selectedId, setSelectedId] = useState<string>(
+    settings?.selectedTemplateId ?? "react",
+  );
+  const [dontShowAgain, setDontShowAgain] = useState(false);
+
+  // Build list: official templates + currently selected template if non-official
+  const officialTemplates = (templates ?? []).filter((t) => t.isOfficial);
+  const currentTemplateId = settings?.selectedTemplateId;
+  const currentIsInOfficialList = officialTemplates.some(
+    (t) => t.id === currentTemplateId,
+  );
+  const currentNonOfficialTemplate =
+    !currentIsInOfficialList && currentTemplateId
+      ? (templates ?? []).find((t) => t.id === currentTemplateId)
+      : null;
+
+  const displayTemplates = currentNonOfficialTemplate
+    ? [currentNonOfficialTemplate, ...officialTemplates]
+    : officialTemplates;
+
+  const handleConfirm = async () => {
+    if (dontShowAgain) {
+      await updateSettings({ promptForTemplate: false });
+    }
+    await updateSettings({ selectedTemplateId: selectedId });
+    onConfirm(selectedId);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-2xl max-h-[80vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Select a Template</DialogTitle>
+          <DialogDescription>
+            Choose a template for your new app. We're only showing official
+            templates here. Go to the Hub tab for community templates.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 py-4">
+          {displayTemplates.map((template) => (
+            <TemplateCard
+              key={template.id}
+              template={template}
+              isSelected={selectedId === template.id}
+              onSelect={setSelectedId}
+              onCreateApp={() => {}}
+              compact
+            />
+          ))}
+        </div>
+
+        <div className="flex items-center space-x-2">
+          <Checkbox
+            id="dont-show-again"
+            checked={dontShowAgain}
+            onCheckedChange={(checked) => setDontShowAgain(checked === true)}
+          />
+          <Label
+            htmlFor="dont-show-again"
+            className="text-sm text-muted-foreground"
+          >
+            Don't show me this again
+          </Label>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleConfirm}
+            className="bg-indigo-600 hover:bg-indigo-700 text-white"
+          >
+            Continue
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/SelectTemplateDialog.tsx
+++ b/src/components/SelectTemplateDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import {
   Dialog,
   DialogContent,
@@ -13,6 +13,7 @@ import { Label } from "@/components/ui/label";
 import { TemplateCard } from "./TemplateCard";
 import { useTemplates } from "@/hooks/useTemplates";
 import { useSettings } from "@/hooks/useSettings";
+import { DEFAULT_TEMPLATE_ID } from "@/shared/templates";
 
 interface SelectTemplateDialogProps {
   open: boolean;
@@ -28,9 +29,17 @@ export function SelectTemplateDialog({
   const { templates } = useTemplates();
   const { settings, updateSettings } = useSettings();
   const [selectedId, setSelectedId] = useState<string>(
-    settings?.selectedTemplateId ?? "react",
+    settings?.selectedTemplateId ?? DEFAULT_TEMPLATE_ID,
   );
   const [dontShowAgain, setDontShowAgain] = useState(false);
+
+  // Reset state when dialog opens
+  useEffect(() => {
+    if (open) {
+      setSelectedId(settings?.selectedTemplateId ?? DEFAULT_TEMPLATE_ID);
+      setDontShowAgain(false);
+    }
+  }, [open, settings?.selectedTemplateId]);
 
   // Build list: official templates + currently selected template if non-official
   const officialTemplates = (templates ?? []).filter((t) => t.isOfficial);
@@ -48,10 +57,12 @@ export function SelectTemplateDialog({
     : officialTemplates;
 
   const handleConfirm = async () => {
+    const updates: { selectedTemplateId: string; promptForTemplate?: boolean } =
+      { selectedTemplateId: selectedId };
     if (dontShowAgain) {
-      await updateSettings({ promptForTemplate: false });
+      updates.promptForTemplate = false;
     }
-    await updateSettings({ selectedTemplateId: selectedId });
+    await updateSettings(updates);
     onConfirm(selectedId);
   };
 
@@ -73,7 +84,6 @@ export function SelectTemplateDialog({
               template={template}
               isSelected={selectedId === template.id}
               onSelect={setSelectedId}
-              onCreateApp={() => {}}
               compact
             />
           ))}

--- a/src/components/TemplateCard.tsx
+++ b/src/components/TemplateCard.tsx
@@ -12,7 +12,7 @@ interface TemplateCardProps {
   template: Template;
   isSelected: boolean;
   onSelect: (templateId: string) => void;
-  onCreateApp: () => void;
+  onCreateApp?: () => void;
   compact?: boolean;
 }
 
@@ -141,7 +141,7 @@ export const TemplateCard: React.FC<TemplateCardProps> = ({
             </a>
           )}
 
-          {!compact && (
+          {!compact && onCreateApp && (
             <Button
               onClick={(e) => {
                 e.stopPropagation();

--- a/src/components/TemplateCard.tsx
+++ b/src/components/TemplateCard.tsx
@@ -13,6 +13,7 @@ interface TemplateCardProps {
   isSelected: boolean;
   onSelect: (templateId: string) => void;
   onCreateApp: () => void;
+  compact?: boolean;
 }
 
 export const TemplateCard: React.FC<TemplateCardProps> = ({
@@ -20,6 +21,7 @@ export const TemplateCard: React.FC<TemplateCardProps> = ({
   isSelected,
   onSelect,
   onCreateApp,
+  compact,
 }) => {
   const { settings, updateSettings } = useSettings();
   const [showConsentDialog, setShowConsentDialog] = useState(false);
@@ -82,7 +84,7 @@ export const TemplateCard: React.FC<TemplateCardProps> = ({
           <img
             src={template.imageUrl}
             alt={template.title}
-            className={`w-full h-52 object-cover transition-opacity duration-300 group-hover:opacity-80 ${
+            className={`w-full ${compact ? "h-24" : "h-52"} object-cover transition-opacity duration-300 group-hover:opacity-80 ${
               isSelected ? "opacity-75" : ""
             }`}
           />
@@ -95,7 +97,7 @@ export const TemplateCard: React.FC<TemplateCardProps> = ({
         <div className="p-4">
           <div className="flex justify-between items-center mb-1.5">
             <h2
-              className={`text-lg font-semibold ${
+              className={`${compact ? "text-base" : "text-lg"} font-semibold ${
                 isSelected
                   ? "text-blue-600 dark:text-blue-400"
                   : "text-gray-900 dark:text-white"
@@ -120,10 +122,12 @@ export const TemplateCard: React.FC<TemplateCardProps> = ({
               </span>
             )}
           </div>
-          <p className="text-sm text-gray-500 dark:text-gray-400 mb-3 h-10 overflow-y-auto">
+          <p
+            className={`text-sm text-gray-500 dark:text-gray-400 mb-3 ${compact ? "line-clamp-2" : "h-10 overflow-y-auto"}`}
+          >
             {template.description}
           </p>
-          {template.githubUrl && (
+          {template.githubUrl && !compact && (
             <a
               className={`inline-flex items-center text-sm font-medium transition-colors duration-200 ${
                 isSelected
@@ -137,19 +141,21 @@ export const TemplateCard: React.FC<TemplateCardProps> = ({
             </a>
           )}
 
-          <Button
-            onClick={(e) => {
-              e.stopPropagation();
-              onCreateApp();
-            }}
-            size="sm"
-            className={cn(
-              "w-full bg-indigo-600 hover:bg-indigo-700 text-white font-semibold mt-2",
-              settings?.selectedTemplateId !== template.id && "invisible",
-            )}
-          >
-            Create App
-          </Button>
+          {!compact && (
+            <Button
+              onClick={(e) => {
+                e.stopPropagation();
+                onCreateApp();
+              }}
+              size="sm"
+              className={cn(
+                "w-full bg-indigo-600 hover:bg-indigo-700 text-white font-semibold mt-2",
+                settings?.selectedTemplateId !== template.id && "invisible",
+              )}
+            >
+              Create App
+            </Button>
+          )}
         </div>
       </div>
 

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -304,6 +304,7 @@ export const UserSettingsSchema = z
     selectedChatMode: ChatModeSchema.optional(),
     defaultChatMode: ChatModeSchema.optional(),
     acceptedCommunityCode: z.boolean().optional(),
+    promptForTemplate: z.boolean().optional(),
     zoomLevel: ZoomLevelSchema.optional(),
     previewDeviceMode: DeviceModeSchema.optional(),
 

--- a/src/lib/settingsSearchIndex.ts
+++ b/src/lib/settingsSearchIndex.ts
@@ -32,6 +32,7 @@ export const SETTING_IDS = {
   supabase: "setting-supabase",
   neon: "setting-neon",
   nativeGit: "setting-native-git",
+  promptForTemplate: "setting-prompt-for-template",
   reset: "setting-reset",
 } as const;
 
@@ -135,6 +136,14 @@ export const SETTINGS_SEARCH_INDEX: SearchableSettingItem[] = [
     description:
       "Show a native notification when a chat response completes while the app is not focused",
     keywords: ["notification", "chat", "complete", "alert", "background"],
+    sectionId: SECTION_IDS.workflow,
+    sectionLabel: "Workflow",
+  },
+  {
+    id: SETTING_IDS.promptForTemplate,
+    label: "Prompt for Template",
+    description: "Show a template selection dialog when creating a new app",
+    keywords: ["template", "prompt", "dialog", "select", "new app", "create"],
     sectionId: SECTION_IDS.workflow,
     sectionLabel: "Workflow",
   },

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -41,6 +41,7 @@ const DEFAULT_SETTINGS: UserSettings = {
   // Enabled by default in 0.33.0-beta.1
   enableNativeGit: true,
   autoExpandPreviewPanel: true,
+  promptForTemplate: true,
   enableContextCompaction: true,
 };
 

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -178,14 +178,18 @@ export default function HomePage() {
     await proceedWithSubmit(options);
   };
 
-  const handleTemplateConfirm = async () => {
+  const handleTemplateConfirm = async (templateId: string) => {
     setShowTemplateDialog(false);
-    await proceedWithSubmit(pendingSubmitOptions);
+    await proceedWithSubmit(pendingSubmitOptions, templateId);
     setPendingSubmitOptions(undefined);
   };
 
-  const proceedWithSubmit = async (options?: HomeSubmitOptions) => {
+  const proceedWithSubmit = async (
+    options?: HomeSubmitOptions,
+    templateId?: string,
+  ) => {
     const attachments = options?.attachments || [];
+    const effectiveTemplateId = templateId ?? settings?.selectedTemplateId;
 
     try {
       setIsLoading(true);
@@ -193,10 +197,7 @@ export default function HomePage() {
       const result = await ipc.app.createApp({
         name: generateCuteAppName(),
       });
-      if (
-        settings?.selectedTemplateId &&
-        NEON_TEMPLATE_IDS.has(settings.selectedTemplateId)
-      ) {
+      if (effectiveTemplateId && NEON_TEMPLATE_IDS.has(effectiveTemplateId)) {
         await neonTemplateHook({
           appId: result.app.id,
           appName: result.app.name,

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -32,6 +32,7 @@ import { AgentToolsSettings } from "@/components/settings/AgentToolsSettings";
 import { ZoomSelector } from "@/components/ZoomSelector";
 import { DefaultChatModeSelector } from "@/components/DefaultChatModeSelector";
 import { ContextCompactionSwitch } from "@/components/ContextCompactionSwitch";
+import { PromptForTemplateSwitch } from "@/components/PromptForTemplateSwitch";
 import { useSetAtom } from "jotai";
 import { activeSettingsSectionAtom } from "@/atoms/viewAtoms";
 import { SECTION_IDS, SETTING_IDS } from "@/lib/settingsSearchIndex";
@@ -331,6 +332,14 @@ export function WorkflowSettings() {
 
       <div id={SETTING_IDS.defaultChatMode} className="mt-4">
         <DefaultChatModeSelector />
+      </div>
+
+      <div id={SETTING_IDS.promptForTemplate} className="space-y-1 mt-4">
+        <PromptForTemplateSwitch />
+        <div className="text-sm text-gray-500 dark:text-gray-400">
+          Show a template selection dialog when creating a new app from the home
+          page.
+        </div>
       </div>
 
       <div id={SETTING_IDS.autoApprove} className="space-y-1 mt-4">


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2564" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Display a template selection dialog before creating a new app so users can pick an official template, with an option to skip this prompt next time. Persists the chosen template and integrates the flow on the home page.

- New Features
  - Dialog opens on app creation; confirms selection and continues. Defaults to the previously selected template or the default template.
  - “Don’t show again” toggles settings.promptForTemplate (default true). Switch added under Settings > Workflow and indexed for search.
  - Shows official templates only; includes the current non‑official template if selected. Notes community templates are in the Hub.
  - TemplateCard adds a compact mode and hides “Create App” in the dialog. Settings updated to persist selectedTemplateId.

- Bug Fixes
  - Prevent stale selections by resetting dialog state on open, using DEFAULT_TEMPLATE_ID as fallback, and passing templateId to confirm.
  - Combine settings updates into a single call; make onCreateApp optional on TemplateCard; e2e: disable the dialog by default and add tests covering cancel/continue with settings snapshots.

<sup>Written for commit 9bdecc23ce3e3571d216781fe4b75eac48a69e30. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

