### PR TITLE
fix: allow non-write users to trigger closed issue comment handler

### DIFF
--- a/.github/workflows/closed-issue-comment.yml
+++ b/.github/workflows/closed-issue-comment.yml
@@ -25,6 +25,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # See: https://github.com/anthropics/claude-code-action/blob/v1/docs/security.md
           github_token: ${{ secrets.GITHUB_TOKEN }} # bypass OIDC
+          allowed_non_write_users: "*"
           claude_args: |
             --model sonnet --allowedTools "Bash(gh issue reopen:*), Bash(gh issue comment:*)"
           prompt: |


### PR DESCRIPTION
## Summary
- The `claude-code-action` requires write permissions on the triggering actor by default, but the closed issue comment workflow is designed to respond to **any** user commenting on a closed issue
- Added `allowed_non_write_users: '*'` to bypass this check — safe because the workflow's permissions are tightly scoped (`issues: write`, `contents: read`) and Claude is restricted to only `gh issue reopen` and `gh issue comment`

## Test plan
- Comment on a closed issue from a non-collaborator account and verify the workflow runs successfully instead of failing with "Actor does not have write permissions"

#skip-bugbot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2578" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow non-write users to trigger the closed-issue comment workflow by setting allowed_non_write_users: "*". This removes the write-permission block so any comment on a closed issue runs the workflow, while staying safe via scoped permissions and restricted tools (only gh issue reopen/comment).

<sup>Written for commit 211887fea46b0e48c3f4bf7eeacba6b3a3b74b53. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

