### PR TITLE
fix: configure push remote for fork PRs in claude-rebase workflow

### DIFF
--- a/.github/workflows/claude-rebase.yml
+++ b/.github/workflows/claude-rebase.yml
@@ -50,6 +50,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Configure push remote for fork PRs
+        if: steps.check-author.outputs.should_continue == 'true'
+        run: |
+          # claude-code-action overwrites origin's fetch URL to point to dyad-sh/dyad
+          # (using GITHUB_REPOSITORY which is always the base repo in pull_request_target events).
+          # Setting pushurl separately ensures git push still targets the fork,
+          # because git uses pushurl over url when both are configured.
+          git remote set-url --push origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.event.pull_request.head.repo.full_name }}.git"
+          echo "Configured pushurl to ${{ github.event.pull_request.head.repo.full_name }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Remove cc:rebase label and add cc:rebasing
         if: steps.check-author.outputs.should_continue == 'true'
         run: |

--- a/rules/git-workflow.md
+++ b/rules/git-workflow.md
@@ -23,6 +23,7 @@ When running GitHub Actions with `pull_request_target` on cross-repo PRs (from f
 - To rebase onto the base repo's main, you must add an `upstream` remote: `git remote add upstream https://github.com/<base-repo>.git`
 - Remote setup for cross-repo PRs: `origin` → fork (push here), `upstream` → base repo (rebase from here)
 - The `GITHUB_TOKEN` can push to the fork if the PR author enabled "Allow edits from maintainers"
+- **`claude-code-action` overwrites origin's fetch URL** to point to the base repo (using `GITHUB_REPOSITORY`). Any workflow that needs to push to the fork must set `pushurl` separately via `git remote set-url --push origin <fork-url>`, because git uses `pushurl` over `url` when both are configured. See `pr-review-responder.yml` and `claude-rebase.yml` for examples.
 
 ## Adding labels to PRs
 


### PR DESCRIPTION
## Summary
- `claude-code-action` overwrites origin's fetch URL to point to the base repo (`dyad-sh/dyad`), causing the rebase workflow to push to upstream instead of the fork
- Added a `Configure push remote for fork PRs` step (matching `pr-review-responder.yml`) that sets `pushurl` on origin to point to the fork repo
- Added a learning to `rules/git-workflow.md` documenting this `claude-code-action` behavior

## Test plan
- Apply `cc:rebase` label to a fork PR and verify the rebase pushes to the fork, not the base repo

#skip-bugbot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2583" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure claude-rebase pushes to the contributor’s fork instead of the base repo by setting a push-only remote for fork PRs. Also documents this claude-code-action behavior in git workflow rules.

- **Bug Fixes**
  - Add a “Configure push remote for fork PRs” step to claude-rebase.yml that sets origin’s pushurl to the PR head repo using GITHUB_TOKEN, so pushes go to the fork even if claude-code-action rewrites origin’s fetch URL; matches pr-review-responder.yml.

<sup>Written for commit dbd6a1082657c8a162b137682e1f3c30df697e94. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

