### PR TITLE
ci: skip tests when only .claude/ or rules/ files changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,16 +94,16 @@ jobs:
           echo "Changed files:"
           echo "$CHANGED_FILES"
 
-          # Check if all changed files are in .claude directory
-          NON_CLAUDE_FILES=$(echo "$CHANGED_FILES" | grep -v "^\.claude/" || true)
+          # Check if all changed files are in config-only directories (.claude, rules)
+          NON_CONFIG_FILES=$(echo "$CHANGED_FILES" | grep -v "^\.claude/" | grep -v "^rules/" || true)
 
-          if [ -z "$NON_CLAUDE_FILES" ]; then
+          if [ -z "$NON_CONFIG_FILES" ]; then
             echo "should_run_tests=false" >> $GITHUB_OUTPUT
-            echo "Skipping tests: all changed files are in .claude/"
+            echo "Skipping tests: all changed files are in .claude/ or rules/"
           else
             echo "should_run_tests=true" >> $GITHUB_OUTPUT
-            echo "Running tests: found non-.claude files:"
-            echo "$NON_CLAUDE_FILES"
+            echo "Running tests: found files outside .claude/ and rules/:"
+            echo "$NON_CONFIG_FILES"
           fi
 
       - name: Detect privileged author

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dyad",
-  "version": "0.36.0-beta.2",
+  "version": "0.36.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dyad",
-      "version": "0.36.0-beta.2",
+      "version": "0.36.0",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/amazon-bedrock": "^4.0.46",


### PR DESCRIPTION
## Summary
- Broadens the CI `check-changes` step to also skip tests when all changed files are in `rules/` (in addition to `.claude/`)
- PRs that only modify agent rules or Claude config no longer trigger the full build + E2E test suite

## Test plan
- Open a PR that only changes files in `rules/` — CI should skip tests
- Open a PR that only changes files in `.claude/` — CI should still skip tests (existing behavior)
- Open a PR that changes both `rules/` and source files — CI should run tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2584" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update CI to skip tests when all changed files are in .claude/ or rules/, so config/rule-only PRs don’t run the full build and E2E suite. Also updates package-lock.json to version 0.36.0.

<sup>Written for commit a29ca0ab88f5293b2c88ee2e96b270902f69623c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that adjusts when tests run; main risk is accidentally skipping tests if path filters are too broad or mis-handle edge cases.
> 
> **Overview**
> Broadens the CI change-detection logic so the `build` and `e2e-tests` jobs are skipped when a PR only touches configuration directories (`.claude/` *or* `rules/`), and updates logging/variable naming to reflect the new scope.
> 
> Updates `package-lock.json` to bump the project version from `0.36.0-beta.2` to `0.36.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a29ca0ab88f5293b2c88ee2e96b270902f69623c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->