### PR TITLE
fix: skip package-lock.json in pr-push unless package.json changed

### DIFF
--- a/.claude/commands/dyad/pr-push.md
+++ b/.claude/commands/dyad/pr-push.md
@@ -28,6 +28,7 @@ Commit any uncommitted changes, run lint checks, fix any issues, and push the cu
    If there are uncommitted changes:
    - **When in doubt, `git add` the files.** Assume changed/untracked files are related to the current work unless they are egregiously unrelated (e.g., completely different feature area with no connection to the current changes).
    - Only exclude files that are clearly secrets or artifacts that should never be committed (e.g., `.env`, `.env.*`, `credentials.*`, `*.secret`, `*.key`, `*.pem`, `.DS_Store`, `node_modules/`, `*.log`).
+   - **Do NOT stage `package-lock.json` unless `package.json` has also been modified.** Changes to `package-lock.json` without a corresponding `package.json` change are spurious diffs (e.g., from running `npm install` locally) and should be excluded. If `package-lock.json` is dirty but `package.json` is not, run `git checkout -- package-lock.json` to discard the changes.
    - Stage and commit all relevant files with a descriptive commit message summarizing the changes.
    - Keep track of any files you ignored so you can report them at the end.
 


### PR DESCRIPTION
## Summary
- Update the `pr-push` command to never stage `package-lock.json` unless `package.json` has also been modified
- If `package-lock.json` is dirty but `package.json` is not, the lockfile changes are discarded via `git checkout`
- Prevents spurious lockfile diffs from polluting commits and PRs

## Test plan
- Run `/dyad:pr-push` with a dirty `package-lock.json` but no changes to `package.json` — verify the lockfile is not committed
- Run `/dyad:pr-push` with both `package.json` and `package-lock.json` modified — verify both are committed

#skip-bugbot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2585" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the pr-push command to skip staging package-lock.json unless package.json also changed. Prevents spurious lockfile diffs from local npm install and keeps commits and PRs clean.

<sup>Written for commit dce6ac590eb28b9b46857075ece299bc4528a715. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

