### PR TITLE
feat: add workflow to draft stale PRs after 7 days of inactivity

### DIFF
--- a/.github/workflows/draft-stale-prs.yml
+++ b/.github/workflows/draft-stale-prs.yml
@@ -1,0 +1,118 @@
+name: Draft stale PRs
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # daily at midnight UTC
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+
+jobs:
+  draft-stale-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const sevenDaysAgo = new Date();
+            sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              sort: 'updated',
+              direction: 'asc',
+            });
+
+            for (const pr of prs) {
+              if (pr.draft) {
+                continue;
+              }
+
+              // Skip PRs updated recently (quick filter before detailed check)
+              if (new Date(pr.updated_at) >= sevenDaysAgo) {
+                continue;
+              }
+
+              try {
+                // Check the latest commit date on the PR branch
+                const commits = await github.rest.pulls.listCommits({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pr.number,
+                  per_page: 1,
+                });
+                const lastCommitDate = commits.data.length > 0
+                  ? new Date(commits.data[commits.data.length - 1].commit.committer.date)
+                  : new Date(0);
+
+                // Check comments (issue comments + review comments)
+                const comments = await github.rest.issues.listComments({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  per_page: 1,
+                  sort: 'created',
+                  direction: 'desc',
+                });
+                const lastCommentDate = comments.data.length > 0
+                  ? new Date(comments.data[0].created_at)
+                  : new Date(0);
+
+                const reviewComments = await github.rest.pulls.listReviewComments({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pr.number,
+                  per_page: 1,
+                  sort: 'created',
+                  direction: 'desc',
+                });
+                const lastReviewCommentDate = reviewComments.data.length > 0
+                  ? new Date(reviewComments.data[0].created_at)
+                  : new Date(0);
+
+                // Check timeline events for re-opens
+                const events = await github.paginate(github.rest.issues.listEvents, {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                });
+                const lastReopenDate = events
+                  .filter(e => e.event === 'reopened')
+                  .reduce((latest, e) => {
+                    const d = new Date(e.created_at);
+                    return d > latest ? d : latest;
+                  }, new Date(0));
+
+                const lastActivity = new Date(Math.max(
+                  lastCommitDate.getTime(),
+                  lastCommentDate.getTime(),
+                  lastReviewCommentDate.getTime(),
+                  lastReopenDate.getTime(),
+                ));
+
+                if (lastActivity < sevenDaysAgo) {
+                  // Convert to draft using GraphQL (REST API doesn't support this)
+                  await github.graphql(`
+                    mutation($pullRequestId: ID!) {
+                      convertPullRequestToDraft(input: { pullRequestId: $pullRequestId }) {
+                        pullRequest { id }
+                      }
+                    }
+                  `, { pullRequestId: pr.node_id });
+
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: pr.number,
+                    body: "We flipped this PR to draft since there hasn't been any work in the last 7 days. Please mark it as ready for review when ready!",
+                  });
+
+                  console.log(`Converted PR #${pr.number} to draft: ${pr.title} (last activity: ${lastActivity.toISOString()})`);
+                }
+              } catch (error) {
+                console.log(`Failed to process PR #${pr.number}: ${error.message}`);
+              }
+            }

--- a/.github/workflows/draft-stale-prs.yml
+++ b/.github/workflows/draft-stale-prs.yml
@@ -66,7 +66,9 @@ jobs:
                   : new Date(0);
 
                 // Check timeline events for re-opens and ready_for_review
-                const events = await github.paginate(github.rest.issues.listEvents, {
+                // Note: must use listEventsForTimeline (not listEvents) because
+                // ready_for_review is only available through the Timeline Events API.
+                const events = await github.paginate(github.rest.issues.listEventsForTimeline, {
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: pr.number,

--- a/.github/workflows/draft-stale-prs.yml
+++ b/.github/workflows/draft-stale-prs.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   pull-requests: write
+  issues: write
 
 jobs:
   draft-stale-prs:
@@ -37,28 +38,27 @@ jobs:
               }
 
               try {
-                // Check the latest commit date on the PR branch
-                const commits = await github.rest.pulls.listCommits({
+                // Check the latest commit date using the PR head SHA
+                const headCommit = await github.rest.git.getCommit({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  pull_number: pr.number,
-                  per_page: 1,
+                  commit_sha: pr.head.sha,
                 });
-                const lastCommitDate = commits.data.length > 0
-                  ? new Date(commits.data[commits.data.length - 1].commit.committer.date)
-                  : new Date(0);
+                const lastCommitDate = new Date(headCommit.data.committer.date);
 
                 // Check comments (issue comments + review comments)
-                const comments = await github.rest.issues.listComments({
+                // Note: issues.listComments doesn't support sort/direction params,
+                // returns in ascending order. Fetch all and filter out bot comments.
+                const allComments = await github.paginate(github.rest.issues.listComments, {
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: pr.number,
-                  per_page: 1,
-                  sort: 'created',
-                  direction: 'desc',
                 });
-                const lastCommentDate = comments.data.length > 0
-                  ? new Date(comments.data[0].created_at)
+                const humanComments = allComments.filter(
+                  c => !c.user?.login?.endsWith('[bot]')
+                );
+                const lastCommentDate = humanComments.length > 0
+                  ? new Date(humanComments[humanComments.length - 1].created_at)
                   : new Date(0);
 
                 const reviewComments = await github.rest.pulls.listReviewComments({
@@ -73,24 +73,37 @@ jobs:
                   ? new Date(reviewComments.data[0].created_at)
                   : new Date(0);
 
-                // Check timeline events for re-opens
-                const events = await github.paginate(github.rest.issues.listEvents, {
+                // Check timeline events for re-opens and ready_for_review
+                // Use non-paginated call to avoid excessive API usage
+                const events = await github.rest.issues.listEvents({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: pr.number,
+                  per_page: 100,
                 });
-                const lastReopenDate = events
-                  .filter(e => e.event === 'reopened')
+                const lastReopenOrReadyDate = events.data
+                  .filter(e => e.event === 'reopened' || e.event === 'ready_for_review')
                   .reduce((latest, e) => {
                     const d = new Date(e.created_at);
                     return d > latest ? d : latest;
                   }, new Date(0));
 
+                // Check review submissions (approvals, request-changes, dismissals)
+                const reviews = await github.paginate(github.rest.pulls.listReviews, {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pr.number,
+                });
+                const lastReviewDate = reviews.length > 0
+                  ? new Date(reviews[reviews.length - 1].submitted_at)
+                  : new Date(0);
+
                 const lastActivity = new Date(Math.max(
                   lastCommitDate.getTime(),
                   lastCommentDate.getTime(),
                   lastReviewCommentDate.getTime(),
-                  lastReopenDate.getTime(),
+                  lastReopenOrReadyDate.getTime(),
+                  lastReviewDate.getTime(),
                 ));
 
                 if (lastActivity < sevenDaysAgo) {

--- a/.github/workflows/draft-stale-prs.yml
+++ b/.github/workflows/draft-stale-prs.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  contents: read
   pull-requests: write
   issues: write
 
@@ -19,23 +20,17 @@ jobs:
             const sevenDaysAgo = new Date();
             sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
 
-            const prs = await github.paginate(github.rest.pulls.list, {
+            const allPrs = await github.paginate(github.rest.pulls.list, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
               sort: 'updated',
               direction: 'asc',
             });
+            // Pre-filter to non-draft, stale PRs and cap to avoid rate limit exhaustion
+            const prs = allPrs.filter(pr => !pr.draft && new Date(pr.updated_at) < sevenDaysAgo).slice(0, 30);
 
             for (const pr of prs) {
-              if (pr.draft) {
-                continue;
-              }
-
-              // Skip PRs updated recently (quick filter before detailed check)
-              if (new Date(pr.updated_at) >= sevenDaysAgo) {
-                continue;
-              }
 
               try {
                 // Check the latest commit date using the PR head SHA
@@ -61,27 +56,23 @@ jobs:
                   ? new Date(humanComments[humanComments.length - 1].created_at)
                   : new Date(0);
 
-                const reviewComments = await github.rest.pulls.listReviewComments({
+                const allReviewComments = await github.paginate(github.rest.pulls.listReviewComments, {
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   pull_number: pr.number,
-                  per_page: 1,
-                  sort: 'created',
-                  direction: 'desc',
                 });
-                const lastReviewCommentDate = reviewComments.data.length > 0
-                  ? new Date(reviewComments.data[0].created_at)
+                const lastReviewCommentDate = allReviewComments.length > 0
+                  ? new Date(allReviewComments[allReviewComments.length - 1].created_at)
                   : new Date(0);
 
                 // Check timeline events for re-opens and ready_for_review
-                // Use non-paginated call to avoid excessive API usage
-                const events = await github.rest.issues.listEvents({
+                const events = await github.paginate(github.rest.issues.listEvents, {
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: pr.number,
                   per_page: 100,
                 });
-                const lastReopenOrReadyDate = events.data
+                const lastReopenOrReadyDate = events
                   .filter(e => e.event === 'reopened' || e.event === 'ready_for_review')
                   .reduce((latest, e) => {
                     const d = new Date(e.created_at);
@@ -126,6 +117,9 @@ jobs:
                   console.log(`Converted PR #${pr.number} to draft: ${pr.title} (last activity: ${lastActivity.toISOString()})`);
                 }
               } catch (error) {
-                console.log(`Failed to process PR #${pr.number}: ${error.message}`);
+                core.warning(`Failed to process PR #${pr.number}: ${error.message}`);
+                if (error.status === 403 || error.status === 429) {
+                  throw error;
+                }
               }
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dyad",
-  "version": "0.36.0-beta.2",
+  "version": "0.36.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dyad",
-      "version": "0.36.0-beta.2",
+      "version": "0.36.0",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/amazon-bedrock": "^4.0.46",


### PR DESCRIPTION
## Summary
- Adds a new daily GitHub Actions workflow (`draft-stale-prs.yml`) that automatically converts open PRs to draft state when there has been no activity for 7 days
- Checks four activity signals: last commit push, issue comments, review comments, and reopen events
- Leaves a comment explaining why the PR was converted to draft

## Test plan
- [ ] Trigger the workflow manually via `workflow_dispatch` and verify it runs without errors
- [ ] Verify it skips PRs that are already in draft state
- [ ] Verify it correctly identifies stale PRs with no activity in 7 days

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2586" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an automated GitHub Actions job that mutates PR state and posts comments; incorrect activity detection or permission/rate-limit issues could draft active PRs or cause workflow noise.
> 
> **Overview**
> Adds a new scheduled/manual GitHub Actions workflow `draft-stale-prs.yml` that scans open PRs and **converts non-draft PRs to draft** when there has been no detected activity for 7 days.
> 
> “Activity” is computed as the latest of head commit time, non-bot issue comments, review comments, timeline reopen/`ready_for_review` events, and review submissions; if stale, the workflow drafts the PR via GraphQL and leaves an explanatory comment (with basic error handling and a 30-PR processing cap to reduce rate-limit risk).
> 
> Bumps the project version in `package-lock.json` from `0.36.0-beta.2` to `0.36.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55cce4bd08d584e3378ae0194dbe95e66bce92ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->