### PR TITLE
fix: use stable artifact name for Playwright HTML report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,9 +361,10 @@ jobs:
       - name: Upload HTML report
         uses: actions/upload-artifact@v4
         with:
-          name: html-report--attempt-${{ github.run_attempt }}
+          name: html-report
           path: playwright-report
           retention-days: 3
+          overwrite: true
 
       - name: Generate Playwright summary
         uses: actions/github-script@v7

--- a/.github/workflows/playwright-comment.yml
+++ b/.github/workflows/playwright-comment.yml
@@ -79,7 +79,7 @@ jobs:
         if: ${{ steps.pr.outputs.number != '' }}
         uses: actions/download-artifact@v4
         with:
-          name: html-report--attempt-${{ github.event.workflow_run.run_attempt }}
+          name: html-report
           path: playwright-report
           github-token: ${{ github.token }}
           repository: ${{ github.event.workflow_run.repository.full_name }}


### PR DESCRIPTION
## Summary
- Remove the `run_attempt` suffix from the `html-report` artifact name in CI and the downstream Playwright comment workflow
- Use `overwrite: true` so re-runs replace the previous artifact in place instead of creating a differently-named one that downstream workflows can't find
- Fixes the issue where re-running failed CI jobs produced `html-report--attempt-2.zip` but the comment workflow expected `html-report--attempt-1.zip`

## Test plan
- Re-run a failed CI workflow and verify the Playwright comment workflow can still find and download the HTML report artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2595" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use a stable artifact name for the Playwright HTML report and enable overwrite so re-runs replace the same artifact. This fixes the comment workflow failing to download the report after CI re-runs.

- **Bug Fixes**
  - CI uploads the report as "html-report" with overwrite: true.
  - Comment workflow downloads "html-report" instead of attempt-specific names.

<sup>Written for commit 96e5dcee43b5f03f602d31111afbe9860964b280. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that standardizes artifact naming and enables overwriting on reruns; main risk is misnaming would break the downstream report download.
> 
> **Overview**
> Makes the Playwright HTML report artifact name stable across CI reruns by removing the `run_attempt` suffix in `ci.yml` and updating `playwright-comment.yml` to download the fixed `html-report` artifact.
> 
> Enables `overwrite: true` on the uploaded HTML report so reruns replace the prior artifact instead of creating a new name that the comment workflow can’t find.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96e5dcee43b5f03f602d31111afbe9860964b280. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->