### PR TITLE
fix: use PAT for label-rebase-prs to trigger rebase workflow

### DIFF
--- a/.github/workflows/label-rebase-prs.yml
+++ b/.github/workflows/label-rebase-prs.yml
@@ -8,16 +8,14 @@ concurrency:
   group: label-rebase-prs
   cancel-in-progress: true
 
-permissions:
-  pull-requests: write
-  issues: write
-
 jobs:
   label-conflicting-prs:
+    environment: ai-bots
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.PR_RW_GITHUB_TOKEN }}
           script: |
             const allowedAuthors = ['wwwillchen', 'wwwillchen-bot'];
 

--- a/rules/git-workflow.md
+++ b/rules/git-workflow.md
@@ -25,6 +25,10 @@ When running GitHub Actions with `pull_request_target` on cross-repo PRs (from f
 - The `GITHUB_TOKEN` can push to the fork if the PR author enabled "Allow edits from maintainers"
 - **`claude-code-action` overwrites origin's fetch URL** to point to the base repo (using `GITHUB_REPOSITORY`). Any workflow that needs to push to the fork must set `pushurl` separately via `git remote set-url --push origin <fork-url>`, because git uses `pushurl` over `url` when both are configured. See `pr-review-responder.yml` and `claude-rebase.yml` for examples.
 
+## GITHUB_TOKEN and workflow chaining
+
+Actions performed using the default `GITHUB_TOKEN` (including labels added by `github-actions[bot]` via `actions/github-script`) do **not** trigger `pull_request_target` or other workflow events. This is a GitHub limitation to prevent infinite loops. If one workflow adds a label that should trigger another workflow (e.g., `label-rebase-prs.yml` adds `cc:rebase` to trigger `claude-rebase.yml`), the label-adding step must use a **PAT** or **GitHub App token** (e.g., `PR_RW_GITHUB_TOKEN`) instead of `GITHUB_TOKEN`.
+
 ## Adding labels to PRs
 
 `gh pr edit --add-label` fails with a GraphQL "Projects (classic)" deprecation error on repos that had classic projects. Use the REST API instead:


### PR DESCRIPTION
## Summary
- Labels added by `GITHUB_TOKEN` don't trigger `pull_request_target` events (GitHub limitation to prevent loops)
- `label-rebase-prs.yml` was adding `cc:rebase` via the default token, so `claude-rebase.yml` never fired
- Switch to `GITHUB_PR_RW_TOKEN` (fine-grained PAT with PR read/write) so label events trigger the rebase workflow
- Added `environment: ai-bots` to access the secret
- Documented the `GITHUB_TOKEN` workflow chaining gotcha in `rules/git-workflow.md`

## Test plan
- Add `GITHUB_PR_RW_TOKEN` as a fine-grained PAT secret in the `ai-bots` environment (needs `Pull requests: Read and write` permission on `dyad-sh/dyad`)
- Push to `main` while a conflicting PR exists from an allowed author — verify `cc:rebase` label is added AND `claude-rebase.yml` triggers

#skip-bugbot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2596" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch label-rebase-prs to use a fine-grained PAT (PR_RW_GITHUB_TOKEN) so adding cc:rebase triggers the claude-rebase pull_request_target workflow. Document the GITHUB_TOKEN workflow-chaining limitation and load the token from the ai-bots environment.

- **Migration**
  - Add PR_RW_GITHUB_TOKEN as an environment secret in ai-bots (fine-grained PAT with Pull requests: Read and write on dyad-sh/dyad).

<sup>Written for commit 2ff7d85a011aa53cff631f6490795ca4148f9f1c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

