### PR TITLE
Create sub-agents which are supervised for claude workflows

### DIFF
--- a/.github/workflows/claude-rebase.yml
+++ b/.github/workflows/claude-rebase.yml
@@ -76,6 +76,15 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
+            You are orchestrating the /dyad:pr-rebase skill. Your job is to run it end-to-end as a sub-agent with NO shortcuts.
+
+            Rules:
+            1. Execute every step of /dyad:pr-rebase sequentially. Do not skip, summarize, or stop early.
+            2. The skill includes a "/dyad:pr-push" step. This step MUST be fully executed — not just mentioned or planned, but actually run to completion.
+            3. After "/dyad:pr-push" completes, verify its output to confirm success (e.g., a PR URL or push confirmation).
+            4. Do not consider the task complete until "/dyad:pr-push" has succeeded and you have confirmed its output.
+
+            Now run the following command:          
             /dyad:pr-rebase ${{ steps.check-author.outputs.pr_number }}
 
       - name: Update labels on success

--- a/.github/workflows/pr-review-responder.yml
+++ b/.github/workflows/pr-review-responder.yml
@@ -193,6 +193,15 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: --model claude-opus-4-6
           prompt: |
+            You are orchestrating the /dyad:pr-fix skill. Your job is to run it end-to-end as a sub-agent with NO shortcuts.
+
+            Rules:
+            1. Execute every step of /dyad:pr-fix sequentially. Do not skip, summarize, or stop early.
+            2. The skill includes a "/dyad:pr-push" step. This step MUST be fully executed — not just mentioned or planned, but actually run to completion.
+            3. After "/dyad:pr-push" completes, verify its output to confirm success (e.g., a PR URL or push confirmation).
+            4. Do not consider the task complete until "/dyad:pr-push" has succeeded and you have confirmed its output.
+
+            Now run the following command:
             /dyad:pr-fix ${{ steps.pr-info.outputs.pr_number }}
 
       - name: Re-trigger workflows if commits were pushed


### PR DESCRIPTION
#skip-bb
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2597" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds supervised sub-agent execution to the Claude rebase and PR review responder workflows to run /dyad skills end-to-end and verify pushes before completion. This improves reliability and prevents workflows from stopping early.

- **New Features**
  - Enforces sequential execution for /dyad:pr-rebase and /dyad:pr-fix with no shortcuts.
  - Requires /dyad:pr-push to run and validates its output (e.g., PR URL or push confirmation) before marking the job complete.

<sup>Written for commit f44355f1cb4eacc4db1521d38a8a22a4c6fdbeff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

