### PR TITLE
refactor(ci): simplify workflows by removing workflow_dispatch and using PAT for pushes

### DIFF
--- a/.github/workflows/bugbot-trigger.yml
+++ b/.github/workflows/bugbot-trigger.yml
@@ -3,60 +3,26 @@ name: BugBot Trigger
 on:
   pull_request_target:
     types: [opened, synchronize, ready_for_review, reopened]
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: "PR number to trigger BugBot on (used by pr-review-responder)"
-        required: true
-        type: string
 
 jobs:
   trigger-bugbot:
     environment: ai-bots
     # Only review code from regular contributors since bug bot has a capped # of PR reviews.
-    # For workflow_dispatch, we check skip tags below since the caller may not have validated them.
     if: |
-      github.event_name == 'workflow_dispatch' ||
-      ((github.event.pull_request.user.login == 'wwwillchen' ||
+      (github.event.pull_request.user.login == 'wwwillchen' ||
       github.event.pull_request.user.login == 'wwwillchen-bot' ||
       github.event.pull_request.user.login == 'azizmejri1' ||
       github.event.pull_request.user.login == 'princeaden1') &&
       !contains(github.event.pull_request.body, '#skip-bugbot') &&
-      !contains(github.event.pull_request.body, '#skip-bb'))
+      !contains(github.event.pull_request.body, '#skip-bb')
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     steps:
-      - name: Validate pr_number format
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          if ! [[ "${{ inputs.pr_number }}" =~ ^[0-9]+$ ]]; then
-            echo "::error::pr_number must be a numeric value"
-            exit 1
-          fi
-
-      - name: Check skip tags for workflow_dispatch
-        if: github.event_name == 'workflow_dispatch'
-        id: check-skip
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PR_BODY=$(gh pr view "${{ inputs.pr_number }}" --repo "${{ github.repository }}" --json body --jq '.body') || {
-            echo "::error::Failed to fetch PR body for skip tag check"
-            exit 1
-          }
-          if echo "$PR_BODY" | grep -qE '#skip-bugbot|#skip-bb'; then
-            echo "skip=true" >> $GITHUB_OUTPUT
-            echo "Skipping BugBot: PR contains skip tag"
-          else
-            echo "skip=false" >> $GITHUB_OUTPUT
-          fi
-
       - name: Comment @BugBot run
-        if: steps.check-skip.outputs.skip != 'true'
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         with:
           # Use a PAT from wwwillchen to post on their behalf
-          token: ${{ secrets.WWWILLCHEN_PR_RW_PAT }}
-          issue-number: ${{ github.event.pull_request.number || inputs.pr_number }}
+          token: ${{ secrets.PR_RW_GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
           body: "@BugBot run"

--- a/.github/workflows/bugbot-trigger.yml
+++ b/.github/workflows/bugbot-trigger.yml
@@ -23,6 +23,6 @@ jobs:
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         with:
           # Use a PAT from wwwillchen to post on their behalf
-          token: ${{ secrets.PR_RW_GITHUB_TOKEN }}
+          token: ${{ secrets.WWWILLCHEN_PR_RW_PAT }}
           issue-number: ${{ github.event.pull_request.number }}
           body: "@BugBot run"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,17 +6,9 @@ on:
       - main
   pull_request:
     types: [opened, synchronize, reopened, closed]
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: "PR number for CI re-run (used by pr-review-responder)"
-        required: true
-        type: string
 
 concurrency:
-  # Use PR number for pull_request/workflow_dispatch events to enable proper per-PR cancellation
-  # For workflow_dispatch, inputs.pr_number ensures different PRs don't cancel each other
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.pr_number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 defaults:
@@ -30,42 +22,20 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       should_run_tests: ${{ steps.check.outputs.should_run_tests }}
-      pr_head_ref: ${{ steps.pr-info.outputs.head_ref }}
-      pr_head_repo: ${{ steps.pr-info.outputs.head_repo }}
       build_os: ${{ steps.matrix.outputs.build_os }}
       e2e_os: ${{ steps.matrix.outputs.e2e_os }}
       e2e_shard: ${{ steps.matrix.outputs.e2e_shard }}
       e2e_shard_total: ${{ steps.matrix.outputs.e2e_shard_total }}
     steps:
-      - name: Get PR info for workflow_dispatch
-        if: github.event_name == 'workflow_dispatch' && inputs.pr_number != ''
-        id: pr-info
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PR_DATA=$(gh pr view "${{ inputs.pr_number }}" --repo "${{ github.repository }}" --json headRefName,headRepository,headRepositoryOwner) || {
-            echo "::error::Failed to fetch PR info for PR #${{ inputs.pr_number }}"
-            exit 1
-          }
-          echo "head_ref=$(echo "$PR_DATA" | jq -r '.headRefName')" >> $GITHUB_OUTPUT
-          echo "head_repo=$(echo "$PR_DATA" | jq -r '.headRepositoryOwner.login + "/" + .headRepository.name')" >> $GITHUB_OUTPUT
-
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          repository: ${{ steps.pr-info.outputs.head_repo || github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ steps.pr-info.outputs.head_ref || github.event.pull_request.head.ref || '' }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.ref || '' }}
           fetch-depth: 0
       - name: Check if only .claude files changed
         id: check
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            # Always run tests for manual workflow dispatch (e.g., from pr-review-responder)
-            echo "should_run_tests=true" >> $GITHUB_OUTPUT
-            echo "Running tests: manual workflow dispatch"
-            exit 0
-          fi
-
           if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
             # Always run tests on pushes to main
             echo "should_run_tests=true" >> $GITHUB_OUTPUT
@@ -114,8 +84,6 @@ jobs:
           AUTHOR=""
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             AUTHOR="${{ github.event.pull_request.user.login }}"
-          elif [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.pr_number }}" ]; then
-            AUTHOR=$(gh pr view "${{ inputs.pr_number }}" --repo "${{ github.repository }}" --json author --jq '.author.login') || true
           fi
           echo "Author: $AUTHOR"
           if [ "$AUTHOR" = "wwwillchen" ] || [ "$AUTHOR" = "wwwillchen-bot" ]; then
@@ -174,8 +142,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          repository: ${{ needs.check-changes.outputs.pr_head_repo || github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ needs.check-changes.outputs.pr_head_ref || github.event.pull_request.head.ref || '' }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.ref || '' }}
       - name: Initialize environment
         uses: actions/setup-node@v4
         with:
@@ -244,8 +212,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          repository: ${{ needs.check-changes.outputs.pr_head_repo || github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ needs.check-changes.outputs.pr_head_ref || github.event.pull_request.head.ref || '' }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.ref || '' }}
       - name: Initialize environment
         uses: actions/setup-node@v4
         with:
@@ -323,8 +291,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          repository: ${{ needs.check-changes.outputs.pr_head_repo || github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ needs.check-changes.outputs.pr_head_ref || github.event.pull_request.head.ref || '' }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.ref || '' }}
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
@@ -370,8 +338,6 @@ jobs:
         uses: actions/github-script@v7
         env:
           PLAYWRIGHT_RUN_ID: ${{ github.run_id }}
-          # Pass PR number for workflow_dispatch triggers (from pr-review-responder)
-          PR_NUMBER: ${{ inputs.pr_number }}
         with:
           script: |
             const { run } = require('./scripts/generate-playwright-summary.js');

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -5,15 +5,9 @@ name: Claude PR Review
 on:
   pull_request_target:
     types: [opened, synchronize, ready_for_review, reopened]
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: "PR number to review (used by pr-review-responder)"
-        required: true
-        type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.pr_number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
@@ -23,10 +17,8 @@ jobs:
     # Only review code from regular contributors since claude code has non-trivial costs.
     # It's also a safe-guard for preventing malicious PRs from doing bad things although we restrict
     # the permissions and tools allowed in this job.
-    # For workflow_dispatch, we trust the caller (pr-review-responder) has already validated.
     # https://github.com/anthropics/claude-code-action/blob/main/examples/pr-review-filtered-authors.yml
     if: |
-      github.event_name == 'workflow_dispatch' ||
       github.event.pull_request.user.login == 'wwwillchen' ||
       github.event.pull_request.user.login == 'wwwillchen-bot' ||
       github.event.pull_request.user.login == 'azizmejri1' ||
@@ -36,24 +28,11 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - name: Get PR info for workflow_dispatch
-        if: github.event_name == 'workflow_dispatch'
-        id: pr-info
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PR_DATA=$(gh pr view "${{ inputs.pr_number }}" --repo "${{ github.repository }}" --json headRefName,headRepository,headRepositoryOwner) || {
-            echo "::error::Failed to fetch PR info for PR #${{ inputs.pr_number }}"
-            exit 1
-          }
-          echo "head_ref=$(echo "$PR_DATA" | jq -r '.headRefName')" >> $GITHUB_OUTPUT
-          echo "head_repo=$(echo "$PR_DATA" | jq -r '.headRepositoryOwner.login + "/" + .headRepository.name')" >> $GITHUB_OUTPUT
-
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name || steps.pr-info.outputs.head_repo }}
-          ref: ${{ github.event.pull_request.head.ref || steps.pr-info.outputs.head_ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 1
 
       - name: PR Review
@@ -74,7 +53,7 @@ jobs:
           track_progress: false
 
           prompt: |
-            /dyad:multi-pr-review ${{ github.event.pull_request.number || inputs.pr_number }}
+            /dyad:multi-pr-review ${{ github.event.pull_request.number }}
 
           # Uses .claude/settings.json for permissions; only add MCP tool not in settings
           claude_args: |

--- a/.github/workflows/claude-rebase.yml
+++ b/.github/workflows/claude-rebase.yml
@@ -57,10 +57,15 @@ jobs:
           # (using GITHUB_REPOSITORY which is always the base repo in pull_request_target events).
           # Setting pushurl separately ensures git push still targets the fork,
           # because git uses pushurl over url when both are configured.
-          git remote set-url --push origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.event.pull_request.head.repo.full_name }}.git"
+          #
+          # We use PR_CONTENTS_RW_GITHUB_TOKEN (a PAT) instead of GITHUB_TOKEN so that
+          # the push creates real PR events (synchronize) that trigger downstream workflows
+          # like CI. Pushes made with GITHUB_TOKEN are silently ignored by GitHub to prevent
+          # infinite loops.
+          git remote set-url --push origin "https://x-access-token:${PR_CONTENTS_RW_GITHUB_TOKEN}@github.com/${{ github.event.pull_request.head.repo.full_name }}.git"
           echo "Configured pushurl to ${{ github.event.pull_request.head.repo.full_name }}"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_CONTENTS_RW_GITHUB_TOKEN: ${{ secrets.PR_CONTENTS_RW_GITHUB_TOKEN }}
 
       - name: Remove cc:rebase label and add cc:rebasing
         if: steps.check-author.outputs.should_continue == 'true'

--- a/.github/workflows/pr-review-responder.yml
+++ b/.github/workflows/pr-review-responder.yml
@@ -173,10 +173,15 @@ jobs:
           # (using GITHUB_REPOSITORY which is always the base repo in workflow_run events).
           # Setting pushurl separately ensures git push still targets the fork,
           # because git uses pushurl over url when both are configured.
-          git remote set-url --push origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ steps.pr-info.outputs.head_repo }}.git"
+          #
+          # We use PR_CONTENTS_RW_GITHUB_TOKEN (a PAT) instead of GITHUB_TOKEN so that
+          # the push creates real PR events (synchronize) that trigger downstream workflows
+          # like CI. Pushes made with GITHUB_TOKEN are silently ignored by GitHub to prevent
+          # infinite loops.
+          git remote set-url --push origin "https://x-access-token:${PR_CONTENTS_RW_GITHUB_TOKEN}@github.com/${{ steps.pr-info.outputs.head_repo }}.git"
           echo "Configured pushurl to ${{ steps.pr-info.outputs.head_repo }}"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_CONTENTS_RW_GITHUB_TOKEN: ${{ secrets.PR_CONTENTS_RW_GITHUB_TOKEN }}
 
       - name: Update labels to pending
         if: steps.pr-info.outputs.should_continue == 'true'
@@ -204,14 +209,15 @@ jobs:
             Now run the following command:
             /dyad:pr-fix ${{ steps.pr-info.outputs.pr_number }}
 
-      - name: Re-trigger workflows if commits were pushed
-        # Use always() to ensure commits get tested even if Claude Code fails partway through
+      - name: Check if commits were pushed
+        # Use always() to ensure we detect commits even if Claude Code fails partway through.
+        # The push itself (made with PR_CONTENTS_RW_GITHUB_TOKEN) triggers downstream workflows
+        # like CI, BugBot, and Claude PR Review naturally via pull_request synchronize events.
         if: steps.pr-info.outputs.should_continue == 'true' && always()
         id: retrigger
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Fetch using the PR's head ref to handle both fork and same-repo PRs correctly
           # Use the GitHub API to get the current head SHA, avoiding race conditions with git fetch
           PR_HEAD_SHA=$(gh pr view ${{ steps.pr-info.outputs.pr_number }} --repo ${{ github.repository }} --json headRefOid --jq '.headRefOid')
           if [ -z "$PR_HEAD_SHA" ]; then
@@ -222,34 +228,9 @@ jobs:
 
           if [ "${{ steps.before-claude.outputs.sha }}" != "$PR_HEAD_SHA" ]; then
             echo "Claude pushed new commits (before: ${{ steps.before-claude.outputs.sha }}, after: $PR_HEAD_SHA)"
-            echo "Re-triggering workflows via workflow_dispatch"
             echo "commits_pushed=true" >> $GITHUB_OUTPUT
-            # Use workflow_dispatch to trigger workflows - this works with GITHUB_TOKEN unlike PR events
-            # which are blocked to prevent infinite loops
-            #
-            # Note: We use the default branch (no --ref) instead of head_branch because for fork PRs,
-            # head_branch only exists in the fork repo, not the main repo. The workflows will checkout
-            # the correct PR code using the pr_number input.
-
-            # Trigger CI
-            gh workflow run ci.yml \
-              --repo ${{ github.repository }} \
-              -f pr_number=${{ steps.pr-info.outputs.pr_number }} \
-              || echo "::warning::Failed to trigger CI workflow"
-
-            # Trigger BugBot
-            gh workflow run bugbot-trigger.yml \
-              --repo ${{ github.repository }} \
-              -f pr_number=${{ steps.pr-info.outputs.pr_number }} \
-              || echo "::warning::Failed to trigger BugBot workflow"
-
-            # Trigger Claude PR Review
-            gh workflow run claude-pr-review.yml \
-              --repo ${{ github.repository }} \
-              -f pr_number=${{ steps.pr-info.outputs.pr_number }} \
-              || echo "::warning::Failed to trigger Claude PR Review workflow"
           else
-            echo "No new commits pushed, skipping workflow re-triggers"
+            echo "No new commits pushed"
             echo "commits_pushed=false" >> $GITHUB_OUTPUT
           fi
 


### PR DESCRIPTION
## Summary
- Remove `workflow_dispatch` inputs from CI, BugBot, and Claude PR Review workflows since pushes made with `PR_CONTENTS_RW_GITHUB_TOKEN` (a PAT) now naturally trigger downstream workflows via `pull_request synchronize` events
- Simplify checkout logic across all workflows by removing fork-resolution steps that were only needed for `workflow_dispatch`
- Remove manual workflow re-triggering in `pr-review-responder.yml` since PAT-based pushes handle this automatically

#skip-bugbot

## Test plan
- Verify CI workflows trigger correctly on PR push events from fork PRs
- Verify BugBot and Claude PR Review trigger on `pull_request_target` events
- Verify `pr-review-responder` pushes with PAT correctly trigger downstream workflows without manual `workflow_dispatch` calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2598" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streamlined GitHub Actions by removing workflow_dispatch paths and switching to PAT-based pushes so pull_request synchronize events naturally trigger CI, BugBot, and Claude review. This reduces custom logic and makes fork PRs behave consistently.

- **Refactors**
  - Removed workflow_dispatch and pr_number inputs from CI, BugBot, and Claude PR Review.
  - Checkout now uses pull_request head repo/ref; dropped fork-resolution logic.
  - Rebase and pr-review-responder push with PR_CONTENTS_RW_GITHUB_TOKEN to emit real synchronize events.
  - BugBot comment now uses WWWILLCHEN_PR_RW_PAT.
  - Simplified concurrency groups; removed manual re-triggers in pr-review-responder.

- **Migration**
  - Ensure secrets exist: PR_CONTENTS_RW_GITHUB_TOKEN (contents: read/write) and WWWILLCHEN_PR_RW_PAT.
  - Verify CI, BugBot, and Claude run on pull_request synchronize from fork PRs; no manual reruns needed.

<sup>Written for commit b8950ec974c1c8b4ae52f1ff200fa0edc4b296d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

