### PR TITLE
fix(e2e): use correct page object sub-components in createGitConflict helper

### DIFF
--- a/e2e-tests/git_collaboration.spec.ts
+++ b/e2e-tests/git_collaboration.spec.ts
@@ -9,7 +9,7 @@ async function createGitConflict(po: PageObject) {
   await po.setUp({ disableNativeGit: false, autoApprove: true });
   await po.sendPrompt("tc=basic");
 
-  await po.getTitleBarAppNameButton().click();
+  await po.appManagement.getTitleBarAppNameButton().click();
   await po.githubConnector.connect();
 
   const repoName = "test-git-conflict-" + Date.now();
@@ -19,7 +19,7 @@ async function createGitConflict(po: PageObject) {
     timeout: Timeout.MEDIUM,
   });
 
-  const appPath = await po.getCurrentAppPath();
+  const appPath = await po.appManagement.getCurrentAppPath();
   if (!appPath) throw new Error("App path not found");
 
   // Setup conflict
@@ -53,8 +53,8 @@ async function createGitConflict(po: PageObject) {
   });
 
   // 4. Try to merge feature into main via UI
-  await po.goToChatTab();
-  await po.getTitleBarAppNameButton().click(); // Open Publish Panel
+  await po.navigation.goToChatTab();
+  await po.appManagement.getTitleBarAppNameButton().click(); // Open Publish Panel
 
   // Open branches accordion
   const branchesCard = po.page.getByTestId("branches-header");

--- a/rules/e2e-testing.md
+++ b/rules/e2e-testing.md
@@ -24,6 +24,24 @@ To get additional debug logs when a test is failing, use:
 DEBUG=pw:browser PLAYWRIGHT_HTML_OPEN=never npm run e2e
 ```
 
+## PageObject sub-component pattern
+
+The `PageObject` (aliased as `po` in tests) delegates most methods to sub-component page objects. Don't call methods directly on `po` unless they are explicitly defined on `PageObject` itself:
+
+```ts
+// Wrong: methods don't exist on po directly
+await po.getTitleBarAppNameButton().click();
+await po.getCurrentAppPath();
+await po.goToChatTab();
+
+// Correct: use the appropriate sub-component
+await po.appManagement.getTitleBarAppNameButton().click();
+await po.appManagement.getCurrentAppPath();
+await po.navigation.goToChatTab();
+```
+
+Key sub-components: `po.appManagement`, `po.navigation`, `po.chatActions`, `po.previewPanel`, `po.codeEditor`, `po.githubConnector`, `po.toastNotifications`, `po.settings`, `po.securityReview`, `po.modelPicker`.
+
 ## Base UI Radio component selection in Playwright
 
 Base UI Radio components render a hidden native `<input type="radio">` with `aria-hidden="true"`. Both `getByRole('radio', { name: '...' })` and `getByLabel('...')` find this hidden input but can't click it (element is outside viewport). Use `getByText` to click the visible label text instead.


### PR DESCRIPTION
## Summary
- Fixed 4 TypeScript errors in `e2e-tests/git_collaboration.spec.ts` where the `createGitConflict` helper called `getTitleBarAppNameButton()`, `getCurrentAppPath()`, and `goToChatTab()` directly on `po` instead of through `po.appManagement` and `po.navigation`
- Added PageObject sub-component pattern documentation to `rules/e2e-testing.md`

## Test plan
- `npm run ts` passes with zero errors
- All 784 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2604" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> E2E test refactor plus documentation only; no production logic changes, with minimal risk beyond potential test behavior differences if selectors were misrouted.
> 
> **Overview**
> Updates `createGitConflict` in `e2e-tests/git_collaboration.spec.ts` to call UI helpers through the correct `PageObject` sub-components (e.g., `po.appManagement.*`, `po.navigation.*`) instead of nonexistent top-level `po` methods, resolving TypeScript errors.
> 
> Adds documentation to `rules/e2e-testing.md` describing the `PageObject` sub-component pattern and listing the primary sub-components to use in E2E tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c053dacf656833ad274881e97337f8a97c97f1ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed TypeScript errors in the createGitConflict e2e helper by using the correct PageObject sub-components (po.appManagement and po.navigation). Added docs in e2e-testing.md explaining the PageObject sub-component pattern to prevent calling methods directly on po.

<sup>Written for commit c053dacf656833ad274881e97337f8a97c97f1ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

