### PR TITLE
ci: use 2 e2e shards for self-hosted Mac mini runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,8 +117,8 @@ jobs:
           if [ "${{ steps.author-check.outputs.is_privileged }}" = "true" ]; then
             echo 'build_os=[{"name":"macos","image":"[\"self-hosted\",\"macOS\",\"ARM64\"]"}]' >> $GITHUB_OUTPUT
             echo 'e2e_os=[{"name":"macos","image":"[\"self-hosted\",\"macOS\",\"ARM64\"]"}]' >> $GITHUB_OUTPUT
-            echo 'e2e_shard=[1]' >> $GITHUB_OUTPUT
-            echo 'e2e_shard_total=[1]' >> $GITHUB_OUTPUT
+            echo 'e2e_shard=[1,2]' >> $GITHUB_OUTPUT
+            echo 'e2e_shard_total=[2]' >> $GITHUB_OUTPUT
           else
             echo 'build_os=[{"name":"windows","image":"[\"windows-latest\"]"},{"name":"macos","image":"[\"macos-latest\"]"}]' >> $GITHUB_OUTPUT
             echo 'e2e_os=[{"name":"windows","image":"[\"windows-latest\"]"},{"name":"macos","image":"[\"macos-latest\"]"}]' >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- Update CI workflow to use 2 E2E test shards instead of 1 for self-hosted Mac mini runners (privileged authors)
- This improves E2E test parallelism on self-hosted infrastructure

## Test plan
- CI should run with 2 shards on self-hosted runners for privileged authors
- Non-privileged authors still get 4 shards on GitHub-hosted runners (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2606" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run E2E tests in 2 shards on self-hosted Mac mini (macOS ARM64) runners for privileged authors to improve parallelism and speed up CI. Non-privileged authors remain on GitHub-hosted runners with 4 shards; other CI settings are unchanged.

<sup>Written for commit 972f36eb853a620a3f08ac2089d725768177beb7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change; main impact is CI execution behavior (more parallel shards) and potential shard/merge configuration issues if assumptions about 1 shard were relied on.
> 
> **Overview**
> In `.github/workflows/ci.yml`, increases **self-hosted privileged-author** Playwright E2E parallelism by changing the matrix from `1/1` to `2` shards (`e2e_shard=[1,2]`, `e2e_shard_total=[2]`).
> 
> GitHub-hosted macOS/Windows runs remain at `4` shards, and build/job wiring is otherwise unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 972f36eb853a620a3f08ac2089d725768177beb7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->