### PR TITLE
Use PR_RW_GITHUB_TOKEN for draft-stale-prs workflow

### DIFF
--- a/.github/workflows/draft-stale-prs.yml
+++ b/.github/workflows/draft-stale-prs.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
       - uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.PR_RW_GITHUB_TOKEN }}
           script: |
             const sevenDaysAgo = new Date();
             sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);


### PR DESCRIPTION
## Summary
- The `draft-stale-prs` workflow was failing with "Resource not accessible by integration" when trying to convert fork PRs to draft via the GraphQL `convertPullRequestToDraft` mutation
- The default `GITHUB_TOKEN` lacks the necessary cross-repo permissions for this operation
- Switch to the `PR_RW_GITHUB_TOKEN` secret which has the required permissions

#skip-bugbot

## Test plan
- Trigger the workflow manually via `workflow_dispatch` and verify fork PRs are successfully converted to draft without "Resource not accessible by integration" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2608" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the draft-stale-prs workflow by using PR_RW_GITHUB_TOKEN so fork PRs can be converted to draft without permission errors.

- **Bug Fixes**
  - Set actions/github-script github-token to secrets.PR_RW_GITHUB_TOKEN to allow convertPullRequestToDraft on fork PRs.

<sup>Written for commit d3779f5f98a94625077188bc5d55660719cd49e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

