### PR TITLE
Add workflow to cancel Claude PR review after merge

### DIFF
--- a/.github/workflows/cancel-claude-pr-review-after-merge.yml
+++ b/.github/workflows/cancel-claude-pr-review-after-merge.yml
@@ -1,0 +1,73 @@
+name: Cancel Claude PR Review after merge
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cancel-claude-pr-review:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Cancel Claude PR Review workflows for merged PR branch
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pr = context.payload.pull_request;
+            // Use head SHA instead of branch name - works for both fork and non-fork PRs
+            // since workflow runs are registered to the base repo regardless
+            const headSha = pr.head.sha;
+
+            console.log(`Looking for Claude PR Review workflows to cancel for SHA: ${headSha}`);
+
+            // Use workflow file path instead of display name for reliable matching
+            const workflowFile = 'claude-pr-review.yml';
+
+            // Query all cancelable statuses: in_progress, queued, pending, waiting
+            const statuses = ['in_progress', 'queued', 'pending', 'waiting'];
+            const allRuns = [];
+
+            for (const status of statuses) {
+              try {
+                const { data } = await github.rest.actions.listWorkflowRuns({
+                  owner,
+                  repo,
+                  workflow_id: workflowFile,
+                  head_sha: headSha,
+                  status,
+                });
+                allRuns.push(...data.workflow_runs);
+              } catch (error) {
+                // Status may not be supported or no runs found
+                console.log(`No runs found for status '${status}': ${error.message}`);
+              }
+            }
+
+            if (allRuns.length === 0) {
+              console.log('No cancelable Claude PR Review workflows found for this SHA');
+              return;
+            }
+
+            // Deduplicate runs by ID (in case a run appears in multiple status queries)
+            const uniqueRuns = [...new Map(allRuns.map(run => [run.id, run])).values()];
+
+            console.log(`Found ${uniqueRuns.length} workflow run(s) to cancel`);
+
+            // Cancel each workflow run
+            for (const run of uniqueRuns) {
+              console.log(`Cancelling workflow run ${run.id} (status: ${run.status})`);
+              try {
+                await github.rest.actions.cancelWorkflowRun({
+                  owner,
+                  repo,
+                  run_id: run.id,
+                });
+                console.log(`Successfully cancelled workflow run ${run.id}`);
+              } catch (error) {
+                console.log(`Failed to cancel workflow run ${run.id}: ${error.message}`);
+              }
+            }


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions workflow that cancels in-progress/queued `claude-pr-review.yml` runs when a PR is merged
- Mirrors the existing `cancel-ci-after-merge.yml` pattern, targeting the Claude PR review workflow instead of CI
- Avoids wasting CI minutes on reviews for already-merged PRs

## Test plan
- Verify the workflow file is valid YAML and matches the structure of `cancel-ci-after-merge.yml`
- Merge a PR that has a running Claude PR review and confirm the review workflow is cancelled

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2609" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an isolated GitHub Actions workflow that only cancels in-progress/queued runs for a specific workflow on PR merge, with no application code or data changes.
> 
> **Overview**
> Adds a new `cancel-claude-pr-review-after-merge.yml` workflow that triggers when a PR is *closed and merged* and cancels any in-progress/queued `claude-pr-review.yml` runs associated with the PR’s head SHA.
> 
> The job queries multiple run statuses, deduplicates results, and issues `cancelWorkflowRun` calls with `actions: write` permission to avoid wasting runner time on already-merged PR reviews.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9faccb5308bd575e3ef638c6efb94818dc9964b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Actions workflow that cancels Claude PR review runs after a PR is merged to save CI minutes. Mirrors the existing cancel-ci-after-merge workflow but targets claude-pr-review.yml.

- **New Features**
  - New workflow triggers on merged PRs and cancels claude-pr-review.yml runs for the PR’s head SHA (in_progress/queued/pending/waiting) using file-path matching and dedup, including for forks.

<sup>Written for commit 9faccb5308bd575e3ef638c6efb94818dc9964b4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

