### PR TITLE
Add /dyad:pr-push step to pr-fix skill

### DIFF
--- a/.claude/commands/dyad/pr-fix.md
+++ b/.claude/commands/dyad/pr-fix.md
@@ -24,7 +24,12 @@ This is a meta-skill that orchestrates two sub-skills to comprehensively fix PR 
    - Update snapshots if needed
    - Ensure all checks pass
 
-3. **Post Summary Comment:**
+3. **Run `/dyad:pr-push`** to commit and push all changes:
+   - This step is REQUIRED. Do NOT skip it or stop before it completes.
+   - It will commit changes, run lint/tests, and push to GitHub.
+   - Wait for it to finish and verify the push succeeded.
+
+4. **Post Summary Comment:**
    After both sub-skills complete, post a comment on the PR with a consolidated summary using `gh pr comment`. The comment should include:
    - A header indicating success (✅) or failure (❌)
    - Review comments addressed, resolved, or flagged

--- a/.github/workflows/pr-review-responder.yml
+++ b/.github/workflows/pr-review-responder.yml
@@ -198,15 +198,8 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: --model claude-opus-4-6
           prompt: |
-            You are orchestrating the /dyad:pr-fix skill. Your job is to run it end-to-end as a sub-agent with NO shortcuts.
+            Run the following skill end-to-end. Execute every step sequentially. Do not skip, summarize, or stop early.
 
-            Rules:
-            1. Execute every step of /dyad:pr-fix sequentially. Do not skip, summarize, or stop early.
-            2. The skill includes a "/dyad:pr-push" step. This step MUST be fully executed — not just mentioned or planned, but actually run to completion.
-            3. After "/dyad:pr-push" completes, verify its output to confirm success (e.g., a PR URL or push confirmation).
-            4. Do not consider the task complete until "/dyad:pr-push" has succeeded and you have confirmed its output.
-
-            Now run the following command:
             /dyad:pr-fix ${{ steps.pr-info.outputs.pr_number }}
 
       - name: Check if commits were pushed


### PR DESCRIPTION
## Summary
- The `/dyad:pr-fix` skill was missing a push step, so Claude would fix review comments and CI issues but never commit/push the changes back to the PR branch
- Added `/dyad:pr-push` as an explicit step 3 in the skill (between fix steps and summary comment)
- Simplified the workflow prompt in `pr-review-responder.yml` since the skill itself now handles the push

## Test plan
- [ ] Trigger the PR Review Responder workflow on a PR with `cc:request` label and verify that changes are actually pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2612" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/prompt-orchestration changes only; risk is limited to altering the automation flow if the new required `/dyad:pr-push` step behaves unexpectedly.
> 
> **Overview**
> Updates the `/dyad:pr-fix` orchestration to **explicitly run `/dyad:pr-push` as a required step** before posting the final PR summary comment, ensuring fixes are actually committed and pushed back to the PR branch.
> 
> Simplifies the `pr-review-responder.yml` Claude prompt by removing redundant detailed rules and relying on the updated skill to execute end-to-end without skipping the push.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 542b65bac4120de76a8759ce3cf3e2e021e4fb98. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a required /dyad:pr-push step to the /dyad:pr-fix skill so fixes are committed and pushed to the PR branch. Simplifies the pr-review-responder workflow now that pushing is handled by the skill.

- **Bug Fixes**
  - Added /dyad:pr-push as step 3 in pr-fix to commit, run lint/tests, and push to GitHub.
  - Simplified pr-review-responder.yml prompt to run pr-fix end-to-end without manual push checks.

<sup>Written for commit 542b65bac4120de76a8759ce3cf3e2e021e4fb98. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

