### PR TITLE
use ai-bots env for draft-stale-prs

### DIFF
--- a/.github/workflows/draft-stale-prs.yml
+++ b/.github/workflows/draft-stale-prs.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   draft-stale-prs:
     runs-on: ubuntu-latest
+    environment: ai-bots
     steps:
       - uses: actions/github-script@v7
         with:


### PR DESCRIPTION
#skip-bb
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2614" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the draft-stale-prs GitHub Actions workflow to run in the ai-bots environment. This ensures it uses the correct environment-specific secrets and permissions.

<sup>Written for commit fca26d3da5cd061e05fc2835ec6e1247fa546125. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

