### PR TITLE
Add CI cleanup script for self-hosted macOS runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,9 @@ jobs:
             scaffold/
             testing/fake-llm-server/
           retention-days: 1
+      - name: Cleanup (self-hosted macOS)
+        if: always() && contains(matrix.os.image, 'self-hosted')
+        run: bash scripts/ci-cleanup-macos.sh
 
   e2e-tests:
     needs: [check-changes, build]
@@ -276,6 +279,9 @@ jobs:
           name: blob-report-${{ matrix.os.name }}-shard-${{ matrix.shard }}
           path: blob-report
           retention-days: 1
+      - name: Cleanup (self-hosted macOS)
+        if: always() && contains(matrix.os.image, 'self-hosted')
+        run: bash scripts/ci-cleanup-macos.sh
 
   merge-reports:
     # Merge reports after playwright-tests, even if some shards have failed

--- a/.github/workflows/claude-deflake-e2e.yml
+++ b/.github/workflows/claude-deflake-e2e.yml
@@ -72,3 +72,6 @@ jobs:
           direct: true
           prompt: |
             /dyad:deflake-e2e-recent-commits ${{ inputs.commit_count || '10' }}
+      - name: Cleanup (self-hosted macOS)
+        if: always()
+        run: bash scripts/ci-cleanup-macos.sh

--- a/scripts/ci-cleanup-macos.sh
+++ b/scripts/ci-cleanup-macos.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# ci-cleanup-macos.sh — Frees disk space on self-hosted macOS CI runners.
+#
+# Intended to run as a post-job step in GitHub Actions workflows that use
+# self-hosted macOS ARM64 runners. Safe to run multiple times (idempotent).
+#
+# What it cleans:
+#   1. Build outputs           (out/, out-macos.tar)
+#   2. Blob reports            (blob-report/)
+#   3. Cloned template repos   (nextjs-template/)
+#   4. Old Playwright browsers (keeps only the current version)
+#   5. npm cache artifacts     (_cacache, _logs)
+#   6. Old runner diagnostics  (_diag/*.log older than 7 days)
+
+set -euo pipefail
+
+echo "=== CI Cleanup (macOS self-hosted) ==="
+df -h / | tail -1 | awk '{print "Disk before cleanup: "$4" available ("$5" used)"}'
+
+bytes_before=$(df -k / | tail -1 | awk '{print $4}')
+
+# ---------------------------------------------------------------------------
+# 1. Build outputs in the workspace
+# ---------------------------------------------------------------------------
+for f in out out-macos.tar; do
+  if [ -e "$f" ]; then
+    echo "Removing build output: $f"
+    rm -rf "$f"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# 2. Blob reports / playwright reports
+# ---------------------------------------------------------------------------
+for d in blob-report all-blob-reports playwright-report test-results; do
+  if [ -d "$d" ]; then
+    echo "Removing test artifacts: $d/"
+    rm -rf "$d"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# 3. Cloned template repos (re-cloned every run)
+# ---------------------------------------------------------------------------
+if [ -d "nextjs-template" ]; then
+  echo "Removing cloned nextjs-template/"
+  rm -rf nextjs-template
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Old Playwright browser versions
+#    Playwright stores browsers under ~/Library/Caches/ms-playwright.
+#    Keep only the version that matches the current project's playwright.
+# ---------------------------------------------------------------------------
+PW_CACHE="${HOME}/Library/Caches/ms-playwright"
+if [ -d "$PW_CACHE" ]; then
+  # Detect the expected chromium revision from the installed playwright
+  CURRENT_CHROMIUM=""
+  if command -v npx &>/dev/null && [ -f "node_modules/.package-lock.json" ] || [ -d "node_modules/playwright-core" ]; then
+    CURRENT_CHROMIUM=$(npx playwright --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)
+  fi
+
+  removed_browsers=0
+  for browser_dir in "$PW_CACHE"/chromium-*; do
+    [ -d "$browser_dir" ] || continue
+    dir_name=$(basename "$browser_dir")
+    if [ -n "$CURRENT_CHROMIUM" ] && echo "$dir_name" | grep -q "$CURRENT_CHROMIUM"; then
+      echo "Keeping current browser: $dir_name"
+    else
+      # Remove browser dirs older than 1 day (stale from previous runs)
+      if [ "$(find "$browser_dir" -maxdepth 0 -mtime +0 -print 2>/dev/null)" ]; then
+        echo "Removing old browser: $dir_name"
+        rm -rf "$browser_dir"
+        removed_browsers=$((removed_browsers + 1))
+      fi
+    fi
+  done
+
+  # Also clean up old non-chromium browsers (firefox, webkit) if present
+  for browser_dir in "$PW_CACHE"/firefox-* "$PW_CACHE"/webkit-*; do
+    [ -d "$browser_dir" ] || continue
+    echo "Removing unused browser: $(basename "$browser_dir")"
+    rm -rf "$browser_dir"
+    removed_browsers=$((removed_browsers + 1))
+  done
+
+  if [ "$removed_browsers" -gt 0 ]; then
+    echo "Removed $removed_browsers old browser installation(s)"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 5. npm cache bloat (_cacache, _logs inside ~/.npm)
+# ---------------------------------------------------------------------------
+NPM_CACHE="${HOME}/.npm"
+if [ -d "$NPM_CACHE/_cacache" ]; then
+  cache_size=$(du -sh "$NPM_CACHE/_cacache" 2>/dev/null | cut -f1 || echo "?")
+  echo "Pruning npm cache (${cache_size})..."
+  npm cache clean --force 2>/dev/null || true
+fi
+if [ -d "$NPM_CACHE/_logs" ]; then
+  echo "Removing npm logs"
+  rm -rf "$NPM_CACHE/_logs"
+fi
+
+# ---------------------------------------------------------------------------
+# 6. Runner diagnostic logs older than 7 days
+# ---------------------------------------------------------------------------
+RUNNER_DIR="${RUNNER_DIR:-${HOME}/actions-runner}"
+if [ -d "$RUNNER_DIR/_diag" ]; then
+  old_logs=$(find "$RUNNER_DIR/_diag" -name '*.log' -mtime +7 2>/dev/null | wc -l | tr -d ' ')
+  if [ "$old_logs" -gt 0 ]; then
+    echo "Removing $old_logs old runner diagnostic log(s)"
+    find "$RUNNER_DIR/_diag" -name '*.log' -mtime +7 -delete 2>/dev/null || true
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+bytes_after=$(df -k / | tail -1 | awk '{print $4}')
+freed_kb=$((bytes_after - bytes_before))
+if [ "$freed_kb" -gt 1024 ]; then
+  freed_mb=$((freed_kb / 1024))
+  echo "Freed ~${freed_mb} MB"
+else
+  echo "Freed ~${freed_kb} KB"
+fi
+
+df -h / | tail -1 | awk '{print "Disk after cleanup:  "$4" available ("$5" used)"}'
+echo "=== Cleanup complete ==="

--- a/scripts/ci-cleanup-macos.sh
+++ b/scripts/ci-cleanup-macos.sh
@@ -56,8 +56,8 @@ PW_CACHE="${HOME}/Library/Caches/ms-playwright"
 if [ -d "$PW_CACHE" ]; then
   # Detect the expected chromium revision from the installed playwright
   CURRENT_CHROMIUM=""
-  if command -v npx &>/dev/null && [ -f "node_modules/.package-lock.json" ] || [ -d "node_modules/playwright-core" ]; then
-    CURRENT_CHROMIUM=$(npx playwright --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)
+  if command -v node &>/dev/null && { [ -f "node_modules/.package-lock.json" ] || [ -d "node_modules/playwright-core" ]; }; then
+    CURRENT_CHROMIUM=$(node -e "const b=require('./node_modules/playwright-core/browsers.json').browsers.find(x=>x.name==='chromium'); console.log(b.revision)" 2>/dev/null || true)
   fi
 
   removed_browsers=0
@@ -95,8 +95,8 @@ fi
 NPM_CACHE="${HOME}/.npm"
 if [ -d "$NPM_CACHE/_cacache" ]; then
   cache_size=$(du -sh "$NPM_CACHE/_cacache" 2>/dev/null | cut -f1 || echo "?")
-  echo "Pruning npm cache (${cache_size})..."
-  npm cache clean --force 2>/dev/null || true
+  echo "Clearing npm cache (${cache_size})..."
+  rm -rf "$NPM_CACHE/_cacache"
 fi
 if [ -d "$NPM_CACHE/_logs" ]; then
   echo "Removing npm logs"


### PR DESCRIPTION
## Summary
- Adds `scripts/ci-cleanup-macos.sh` that cleans up build outputs, test artifacts, old Playwright browsers, npm cache, and stale runner diagnostic logs after each CI job
- Integrates the cleanup as an `if: always()` post-job step in `ci.yml` (build + e2e-tests jobs) and `claude-deflake-e2e.yml`
- Prevents disk space exhaustion on Mac Mini self-hosted runners (see [failed job](https://github.com/dyad-sh/dyad/actions/runs/21882508263/job/63168659300))

## Test plan
- [ ] Verify cleanup step runs on self-hosted macOS runners after build job
- [ ] Verify cleanup step runs on self-hosted macOS runners after e2e-tests job
- [ ] Verify cleanup step runs after deflake workflow
- [ ] Verify cleanup is skipped on GitHub-hosted runners (guarded by `contains(matrix.os.image, 'self-hosted')`)
- [ ] Verify the script is idempotent (safe to run when artifacts don't exist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2617" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a macOS CI cleanup script that runs after each job on self-hosted Mac Minis to free disk space and prevent failures from exhaustion.

- **New Features**
  - Added scripts/ci-cleanup-macos.sh to remove build outputs, test artifacts, old Playwright browsers (keeps current via chromium revision from browsers.json), npm cache/logs (rm -rf _cacache), and runner diagnostics older than 7 days; safe to run multiple times with a corrected Node check.
  - Integrated as an if: always() post-job step in ci.yml (build and e2e-tests, guarded to self-hosted) and claude-deflake-e2e.yml.

<sup>Written for commit 756485ea0c30b9ba26800c168f182b3688bef6cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change; main risk is over-aggressive cleanup (caches/artifacts) causing longer reruns or unexpected deletions on self-hosted runners.
> 
> **Overview**
> Adds a new `scripts/ci-cleanup-macos.sh` post-job script to reclaim disk space on self-hosted macOS runners by deleting workspace build/test artifacts, pruning old Playwright browser installs, clearing npm cache/logs, and removing stale runner diagnostic logs.
> 
> Integrates the cleanup as an `if: always()` step after `build` and `e2e-tests` in `ci.yml` (guarded to self-hosted macOS) and after the deflake job in `claude-deflake-e2e.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 756485ea0c30b9ba26800c168f182b3688bef6cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->