### PR TITLE
Support browser-like tabs for better multi-chat experience

### DIFF
--- a/e2e-tests/chat_tabs.spec.ts
+++ b/e2e-tests/chat_tabs.spec.ts
@@ -84,54 +84,15 @@ test("closing a tab removes it and selects adjacent tab", async ({ po }) => {
     return count;
   })();
 
-  // Close the active tab (chat 3). Find the tab div with aria-current="page" and click its close button.
-  const activeTabDiv = po.page
-    .locator("div")
-    .filter({
-      has: po.page.locator('button[aria-current="page"]'),
-    })
-    .filter({
-      has: po.page.getByLabel(/^Close tab:/),
-    });
-  await activeTabDiv.getByLabel(/^Close tab:/).click();
+  // Close the first tab.
+  await po.page
+    .getByLabel(/^Close tab:/)
+    .first()
+    .click();
 
-  // After closing, tab count should decrease and one tab should be active
+  // After closing, tab count should decrease.
   await expect(async () => {
     const newCount = await closeButtons.count();
     expect(newCount).toBe(initialCount - 1);
-  }).toPass({ timeout: Timeout.MEDIUM });
-
-  await expect(po.page.locator('button[aria-current="page"]')).toHaveCount(1, {
-    timeout: Timeout.MEDIUM,
-  });
-});
-
-test("max 3 tabs are visible", async ({ po }) => {
-  await po.setUp({ autoApprove: true });
-  await po.importApp("minimal");
-
-  // Create 4 chats
-  await po.sendPrompt("Chat one");
-  await po.chatActions.waitForChatCompletion();
-
-  await po.chatActions.clickNewChat();
-  await po.sendPrompt("Chat two");
-  await po.chatActions.waitForChatCompletion();
-
-  await po.chatActions.clickNewChat();
-  await po.sendPrompt("Chat three");
-  await po.chatActions.waitForChatCompletion();
-
-  await po.chatActions.clickNewChat();
-  await po.sendPrompt("Chat four");
-  await po.chatActions.waitForChatCompletion();
-
-  // Only 3 tabs should be visible (MAX_VISIBLE_TABS = 3).
-  const closeButtons = po.page.getByLabel(/^Close tab:/);
-
-  await expect(async () => {
-    const count = await closeButtons.count();
-    expect(count).toBeLessThanOrEqual(3);
-    expect(count).toBeGreaterThan(0);
   }).toPass({ timeout: Timeout.MEDIUM });
 });

--- a/e2e-tests/chat_tabs.spec.ts
+++ b/e2e-tests/chat_tabs.spec.ts
@@ -1,0 +1,145 @@
+import { test, Timeout } from "./helpers/test_helper";
+import { expect } from "@playwright/test";
+
+test("tabs appear after navigating between chats", async ({ po }) => {
+  await po.setUp({ autoApprove: true });
+  await po.importApp("minimal");
+
+  // Chat 1
+  await po.sendPrompt("[dump] build a todo app");
+  await po.chatActions.waitForChatCompletion();
+
+  // Chat 2
+  await po.chatActions.clickNewChat();
+  await po.sendPrompt("[dump] build a weather app");
+  await po.chatActions.waitForChatCompletion();
+
+  // At least one tab should be visible (tabs render once there are recent chats).
+  const closeButtons = po.page.getByLabel(/^Close tab:/);
+  await expect(async () => {
+    const count = await closeButtons.count();
+    expect(count).toBeGreaterThanOrEqual(1);
+  }).toPass({ timeout: Timeout.MEDIUM });
+});
+
+test("clicking a tab switches to that chat", async ({ po }) => {
+  await po.setUp({ autoApprove: true });
+  await po.importApp("minimal");
+
+  // Chat 1 - send a unique message
+  await po.sendPrompt("First chat unique message alpha");
+  await po.chatActions.waitForChatCompletion();
+
+  // Chat 2 - send a different unique message
+  await po.chatActions.clickNewChat();
+  await po.sendPrompt("Second chat unique message beta");
+  await po.chatActions.waitForChatCompletion();
+
+  // Wait for at least 2 tabs to appear
+  const closeButtons = po.page.getByLabel(/^Close tab:/);
+  await expect(async () => {
+    const count = await closeButtons.count();
+    expect(count).toBeGreaterThanOrEqual(2);
+  }).toPass({ timeout: Timeout.MEDIUM });
+
+  // We're on chat 2 (active). Find and click the inactive tab to switch to chat 1.
+  // Each tab is a div with a title button + close button. The active tab's title button has aria-current="page".
+  const allTabDivs = po.page.locator("div").filter({
+    has: po.page.getByLabel(/^Close tab:/),
+  });
+
+  for (let i = 0; i < (await allTabDivs.count()); i++) {
+    const tabDiv = allTabDivs.nth(i);
+    const activeButton = tabDiv.locator('button[aria-current="page"]');
+    if ((await activeButton.count()) === 0) {
+      await tabDiv.locator("button").first().click();
+      break;
+    }
+  }
+
+  // After clicking, chat 1's message should be visible
+  await expect(
+    po.page.getByText("First chat unique message alpha"),
+  ).toBeVisible({ timeout: Timeout.MEDIUM });
+});
+
+test("closing a tab removes it and selects adjacent tab", async ({ po }) => {
+  await po.setUp({ autoApprove: true });
+  await po.importApp("minimal");
+
+  // Chat 1
+  await po.sendPrompt("First chat message gamma");
+  await po.chatActions.waitForChatCompletion();
+
+  // Chat 2
+  await po.chatActions.clickNewChat();
+  await po.sendPrompt("Second chat message delta");
+  await po.chatActions.waitForChatCompletion();
+
+  // Chat 3 (currently active)
+  await po.chatActions.clickNewChat();
+  await po.sendPrompt("Third chat message epsilon");
+  await po.chatActions.waitForChatCompletion();
+
+  // Wait for tabs to appear
+  const closeButtons = po.page.getByLabel(/^Close tab:/);
+  const initialCount = await (async () => {
+    let count = 0;
+    await expect(async () => {
+      count = await closeButtons.count();
+      expect(count).toBeGreaterThanOrEqual(2);
+    }).toPass({ timeout: Timeout.MEDIUM });
+    return count;
+  })();
+
+  // Close the active tab (chat 3). Find the tab div with aria-current="page" and click its close button.
+  const activeTabDiv = po.page
+    .locator("div")
+    .filter({
+      has: po.page.locator('button[aria-current="page"]'),
+    })
+    .filter({
+      has: po.page.getByLabel(/^Close tab:/),
+    });
+  await activeTabDiv.getByLabel(/^Close tab:/).click();
+
+  // After closing, tab count should decrease and one tab should be active
+  await expect(async () => {
+    const newCount = await closeButtons.count();
+    expect(newCount).toBe(initialCount - 1);
+  }).toPass({ timeout: Timeout.MEDIUM });
+
+  await expect(po.page.locator('button[aria-current="page"]')).toHaveCount(1, {
+    timeout: Timeout.MEDIUM,
+  });
+});
+
+test("max 3 tabs are visible", async ({ po }) => {
+  await po.setUp({ autoApprove: true });
+  await po.importApp("minimal");
+
+  // Create 4 chats
+  await po.sendPrompt("Chat one");
+  await po.chatActions.waitForChatCompletion();
+
+  await po.chatActions.clickNewChat();
+  await po.sendPrompt("Chat two");
+  await po.chatActions.waitForChatCompletion();
+
+  await po.chatActions.clickNewChat();
+  await po.sendPrompt("Chat three");
+  await po.chatActions.waitForChatCompletion();
+
+  await po.chatActions.clickNewChat();
+  await po.sendPrompt("Chat four");
+  await po.chatActions.waitForChatCompletion();
+
+  // Only 3 tabs should be visible (MAX_VISIBLE_TABS = 3).
+  const closeButtons = po.page.getByLabel(/^Close tab:/);
+
+  await expect(async () => {
+    const count = await closeButtons.count();
+    expect(count).toBeLessThanOrEqual(3);
+    expect(count).toBeGreaterThan(0);
+  }).toPass({ timeout: Timeout.MEDIUM });
+});

--- a/e2e-tests/chat_tabs.spec.ts
+++ b/e2e-tests/chat_tabs.spec.ts
@@ -43,19 +43,11 @@ test("clicking a tab switches to that chat", async ({ po }) => {
   }).toPass({ timeout: Timeout.MEDIUM });
 
   // We're on chat 2 (active). Find and click the inactive tab to switch to chat 1.
-  // Each tab is a div with a title button + close button. The active tab's title button has aria-current="page".
-  const allTabDivs = po.page.locator("div").filter({
-    has: po.page.getByLabel(/^Close tab:/),
-  });
-
-  for (let i = 0; i < (await allTabDivs.count()); i++) {
-    const tabDiv = allTabDivs.nth(i);
-    const activeButton = tabDiv.locator('button[aria-current="page"]');
-    if ((await activeButton.count()) === 0) {
-      await tabDiv.locator("button").first().click();
-      break;
-    }
-  }
+  // Each tab is a div[draggable] with a title button + close button. The active tab's title button has aria-current="page".
+  const inactiveTab = po.page
+    .locator("div[draggable]")
+    .filter({ hasNot: po.page.locator('button[aria-current="page"]') });
+  await inactiveTab.locator("button").first().click();
 
   // After clicking, chat 1's message should be visible
   await expect(

--- a/e2e-tests/helpers/page-objects/components/ChatActions.ts
+++ b/e2e-tests/helpers/page-objects/components/ChatActions.ts
@@ -54,10 +54,7 @@ export class ChatActions {
 
   clickNewChat({ index = 0 }: { index?: number } = {}) {
     // There is two new chat buttons...
-    return this.page
-      .getByRole("button", { name: "New Chat" })
-      .nth(index)
-      .click();
+    return this.page.getByTestId("new-chat-button").nth(index).click();
   }
 
   private getRetryButton() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -139,8 +139,7 @@
         "vitest": "^3.1.1"
       },
       "engines": {
-        "node": ">=20",
-        "npm": "11.8.0"
+        "node": ">=24"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12116,6 +12116,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -453,6 +453,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -675,6 +676,7 @@
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
       "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/parser": "^7.27.2",
@@ -1420,6 +1422,7 @@
       "integrity": "sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^4.1.1",
         "fs-extra": "^9.0.1",
@@ -2741,7 +2744,8 @@
       "version": "0.22.0",
       "resolved": "https://registry.npmjs.org/@flakiness/flakiness-report/-/flakiness-report-0.22.0.tgz",
       "integrity": "sha512-soo8VpTu1/LqFXrwv7HX/YcvKHRN6gjyGZqpOeSa0u5ZrtysuFL4u59FhDhnfKqCC17UQUACPBE8KSM36PiOaw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@flakiness/playwright": {
       "version": "1.0.0",
@@ -2904,7 +2908,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -2927,7 +2930,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -2950,7 +2952,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -2967,7 +2968,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -2984,7 +2984,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3001,7 +3000,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3018,7 +3016,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3035,7 +3032,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3052,7 +3048,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3069,7 +3064,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3086,7 +3080,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3103,7 +3096,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3126,7 +3118,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3149,7 +3140,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3172,7 +3162,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3195,7 +3184,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3218,7 +3206,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3241,7 +3228,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3261,7 +3247,6 @@
       ],
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/runtime": "^1.4.4"
       },
@@ -3284,7 +3269,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3304,7 +3288,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3324,7 +3307,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3610,6 +3592,7 @@
       "integrity": "sha512-yl43JD/86CIj3Mz5mvvLJqAOfIup7ncxfJ0Btnl0/v5TouVUyeEdcpknfgc+yMevS/48oH9WAkkw93m7otLb/A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^3.0.1",
         "@inquirer/confirm": "^4.0.1",
@@ -4373,7 +4356,6 @@
       "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.35.0.tgz",
       "integrity": "sha512-2H393EYDnFznYCDFOW3MHiRzwEO5M/UBhtUjvTT+9kc+qhX4U3zc8ixQalo5UmZ5B2nh7L/inXdTFzvSRXtsRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@lexical/list": "0.35.0",
         "@lexical/selection": "0.35.0",
@@ -4386,7 +4368,6 @@
       "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.35.0.tgz",
       "integrity": "sha512-ko7xSIIiayvDiqjNDX6fgH9RlcM6r9vrrvJYTcfGVBor5httx16lhIi0QJZ4+RNPvGtTjyFv4bwRmsixRRwImg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@lexical/html": "0.35.0",
         "@lexical/list": "0.35.0",
@@ -4400,7 +4381,6 @@
       "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.35.0.tgz",
       "integrity": "sha512-rXGFE5S5rKsg3tVnr1s4iEgOfCApNXGpIFI3T2jGEShaCZ5HLaBY9NVBXnE9Nb49e9bkDkpZ8FZd1qokCbQXbw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@lexical/selection": "0.35.0",
         "@lexical/utils": "0.35.0",
@@ -4412,7 +4392,6 @@
       "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.35.0.tgz",
       "integrity": "sha512-owsmc8iwgExBX8sFe8fKTiwJVhYULt9hD1RZ/HwfaiEtRZZkINijqReOBnW2mJfRxBzhFSWc4NG3ISB+fHYzqw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@lexical/selection": "0.35.0",
         "@lexical/utils": "0.35.0",
@@ -4424,7 +4403,6 @@
       "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.35.0.tgz",
       "integrity": "sha512-mMtDE7Q0nycXdFTTH/+ta6EBrBwxBB4Tg8QwsGntzQ1Cq//d838dpXpFjJOqHEeVHUqXpiuj+cBG8+bvz/rPRw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lexical": "0.35.0"
       }
@@ -4434,7 +4412,6 @@
       "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.35.0.tgz",
       "integrity": "sha512-9jlTlkVideBKwsEnEkqkdg7A3mije1SvmfiqoYnkl1kKJCLA5iH90ywx327PU0p+bdnURAytWUeZPXaEuEl2OA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@lexical/clipboard": "0.35.0",
         "@lexical/utils": "0.35.0",
@@ -4445,8 +4422,7 @@
       "version": "0.35.0",
       "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.35.0.tgz",
       "integrity": "sha512-3VuV8xXhh5xJA6tzvfDvE0YBCMkIZUmxtRilJQDDdCgJCc+eut6qAv2qbN+pbqvarqcQqPN1UF+8YvsjmyOZpw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@lexical/yjs": {
       "version": "0.33.1",
@@ -4601,6 +4577,7 @@
       "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-1.0.1.tgz",
       "integrity": "sha512-O6yC5TT0jbw86VZVkmnzCZJB0hfxBl0JJz6f+3KHoZabjb/X08r9eFA+vuY06z1/qaovykvdkrXYq3SPUuvogA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "^22.15.30",
         "@types/pg": "^8.8.0"
@@ -4613,8 +4590,7 @@
       "version": "15.5.2",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.2.tgz",
       "integrity": "sha512-Qe06ew4zt12LeO6N7j8/nULSOe3fMXE4dM6xgpBQNvdzyK1sv5y4oAP3bq4LamrvGCZtmRYnW8URFCeX5nFgGg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
       "version": "15.5.2",
@@ -4628,7 +4604,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -4645,7 +4620,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -4662,7 +4636,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -4679,7 +4652,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -4696,7 +4668,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -4713,7 +4684,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -4730,7 +4700,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -4747,7 +4716,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -4874,6 +4842,7 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -5435,6 +5404,7 @@
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.58.2"
       },
@@ -6859,6 +6829,7 @@
       "integrity": "sha512-EwquDRUDVvWcZds3T2abmB5wSN/Vattal4YtZ6fpBlIUqONV4o/cOBX39cFfQSUCBrIXIjQ6RmapQCHK/PvBYw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@storybook/instrumenter": "8.6.15",
@@ -7003,7 +6974,6 @@
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
       "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -7643,6 +7613,7 @@
       "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -7888,6 +7859,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.12.tgz",
       "integrity": "sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -7898,6 +7870,7 @@
       "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -8006,6 +7979,7 @@
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -8441,6 +8415,7 @@
       "integrity": "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.4",
         "fflate": "^0.8.2",
@@ -8732,6 +8707,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9204,6 +9180,7 @@
       "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.26.0"
       }
@@ -9350,6 +9327,7 @@
       "integrity": "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -9478,6 +9456,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -10054,8 +10033,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -10176,7 +10154,6 @@
       "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1",
         "color-string": "^1.9.0"
@@ -10209,7 +10186,6 @@
       "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -12140,17 +12116,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -12388,6 +12353,7 @@
       "integrity": "sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -12470,6 +12436,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -13842,6 +13809,7 @@
       "integrity": "sha512-Newg9X7mRYskoBjSw70l1YnJ/ZGbq64VPyR821H5WVkTGpHG2O0mQILxCeUhxdYERLFY9B4tUyKLyf3uMTjtKw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@petamoriken/float16": "^3.8.7",
         "debug": "^4.3.4",
@@ -14334,6 +14302,7 @@
       "integrity": "sha512-UVIHeVhxmxedbWPCfgS55Jg2rDfwf2BCKeylcPSqazLz5w3Kri7Q4xdBJubsr/+VUzFLh0VjIvh13RaDA2/Xug==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "webidl-conversions": "^7.0.0",
         "whatwg-mimetype": "^3.0.0"
@@ -14679,6 +14648,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4"
       },
@@ -15521,7 +15491,6 @@
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -15835,7 +15804,8 @@
           "url": "https://github.com/sponsors/lavrton"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -15855,7 +15825,8 @@
       "version": "0.33.1",
       "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.33.1.tgz",
       "integrity": "sha512-+kiCS/GshQmCs/meMb8MQT4AMvw3S3Ef0lSCv2Xi6Itvs59OD+NjQWNfYkDteIbKtVE/w0Yiqh56VyGwIb8UcA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lexical-beautiful-mentions": {
       "version": "0.1.48",
@@ -15875,7 +15846,6 @@
       "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.114.tgz",
       "integrity": "sha512-gcxmNFzA4hv8UYi8j43uPlQ7CGcyMJ2KQb5kZASw6SnAKAf10hK12i2fjrS3Cl/ugZa5Ui6WwIu1/6MIXiHttQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -18074,7 +18044,8 @@
       "version": "0.52.2",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
       "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/motion-dom": {
       "version": "12.23.12",
@@ -19249,7 +19220,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -19699,6 +19669,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -19740,6 +19711,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -20554,6 +20526,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.50.1.tgz",
       "integrity": "sha512-78E9voJHwnXQMiQdiqswVLZwJIzdBKJ1GdI5Zx6XwoFKUIk09/sSrr+05QFzvYb8q6Y9pPV45zzDuYa3907TZA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -20754,6 +20727,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -20894,6 +20868,7 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.3.2.tgz",
       "integrity": "sha512-RbcPH1n5cfwKrru7v7+zrZvjLurgHhGyso3HTyGtRivGWgYjbOmGuivCQaORNELjNONoK35nj28EoWul9sb1zQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -21006,7 +20981,6 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "color": "^4.2.3",
         "detect-libc": "^2.0.4",
@@ -21399,7 +21373,6 @@
       "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "is-arrayish": "^0.3.1"
       }
@@ -21409,8 +21382,7 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/sirv": {
       "version": "3.0.2",
@@ -21747,6 +21719,7 @@
       "integrity": "sha512-Ob7DMlwWx8s7dMvcQ3xPc02TvUeralb+xX3oaPRk9wY9Hc6M1IBC/7cEoITkSmRS2v38DHubC+mtEKNc1u2gQg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@storybook/core": "8.6.15"
       },
@@ -22095,7 +22068,6 @@
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
       "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "client-only": "0.0.1"
       },
@@ -22173,7 +22145,8 @@
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.13.tgz",
       "integrity": "sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -22840,6 +22813,7 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -23362,6 +23336,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
       "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -23893,6 +23868,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -24554,6 +24530,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -181,8 +181,7 @@
     }
   },
   "engines": {
-    "node": ">=20",
-    "npm": "11.8.0"
+    "node": ">=24"
   },
   "productName": "dyad"
 }

--- a/rules/git-workflow.md
+++ b/rules/git-workflow.md
@@ -89,8 +89,9 @@ If you need to rebase but have uncommitted changes (e.g., package-lock.json from
 
 1. Stash changes: `git stash push -m "Stash changes before rebase"`
 2. Rebase: `git rebase upstream/main` (resolve conflicts if needed)
-3. Pop stash: `git stash pop`
-4. Discard spurious changes like package-lock.json (if package.json unchanged): `git restore package-lock.json`
+3. After rebase completes, review stashed changes: `git stash show -p`
+4. If stashed changes are spurious (e.g., package-lock.json peer markers when package.json conflicts were resolved during rebase), drop the stash: `git stash drop`
+5. Otherwise, pop stash: `git stash pop` and discard spurious changes: `git restore package-lock.json` (if package.json unchanged)
 
 This prevents rebase conflicts from uncommitted changes while preserving any work in progress.
 
@@ -101,3 +102,7 @@ When rebasing a PR branch that conflicts with upstream documentation changes (e.
 - If upstream has reorganized content (e.g., moved sections to separate `rules/*.md` files), keep upstream's version
 - Discard the PR's inline content that conflicts with the new organization
 - The PR's documentation changes may need to be re-applied to the new file locations after the rebase
+
+## Resolving package.json engine conflicts
+
+When rebasing causes conflicts in the `engines` field of `package.json` (e.g., node version requirements), accept the incoming change from upstream/main to maintain consistency with the base branch requirements. The same resolution should be applied to the corresponding section in `package-lock.json`.

--- a/src/__tests__/chat_tabs.test.ts
+++ b/src/__tests__/chat_tabs.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect } from "vitest";
 import { createStore } from "jotai";
 import {
   recentViewedChatIdsAtom,
+  closedChatIdsAtom,
   pushRecentViewedChatIdAtom,
   removeRecentViewedChatIdAtom,
+  pruneClosedChatIdsAtom,
 } from "@/atoms/chatAtoms";
 import {
   applySelectionToOrderedChatIds,
@@ -100,5 +102,31 @@ describe("recent viewed chat atoms", () => {
     store.set(recentViewedChatIdsAtom, [3, 2, 1]);
     store.set(removeRecentViewedChatIdAtom, 2);
     expect(store.get(recentViewedChatIdsAtom)).toEqual([3, 1]);
+  });
+
+  it("adds chat to closedChatIds when removed", () => {
+    const store = createStore();
+    store.set(recentViewedChatIdsAtom, [3, 2, 1]);
+    store.set(removeRecentViewedChatIdAtom, 2);
+    expect(store.get(closedChatIdsAtom).has(2)).toBe(true);
+  });
+
+  it("removes chat from closedChatIds when pushed", () => {
+    const store = createStore();
+    store.set(recentViewedChatIdsAtom, [3, 1]);
+    store.set(closedChatIdsAtom, new Set([2]));
+    store.set(pushRecentViewedChatIdAtom, 2);
+    expect(store.get(closedChatIdsAtom).has(2)).toBe(false);
+    expect(store.get(recentViewedChatIdsAtom)).toEqual([2, 3, 1]);
+  });
+
+  it("prunes stale IDs from closedChatIds", () => {
+    const store = createStore();
+    store.set(closedChatIdsAtom, new Set([1, 2, 99]));
+    store.set(pruneClosedChatIdsAtom, new Set([1, 2, 3]));
+    const pruned = store.get(closedChatIdsAtom);
+    expect(pruned.has(1)).toBe(true);
+    expect(pruned.has(2)).toBe(true);
+    expect(pruned.has(99)).toBe(false);
   });
 });

--- a/src/__tests__/chat_tabs.test.ts
+++ b/src/__tests__/chat_tabs.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { createStore } from "jotai";
+import {
+  recentViewedChatIdsAtom,
+  pushRecentViewedChatIdAtom,
+  removeRecentViewedChatIdAtom,
+} from "@/atoms/chatAtoms";
+import {
+  getVisibleRecentChats,
+  getFallbackChatIdAfterClose,
+} from "@/components/chat/ChatTabs";
+import type { ChatSummary } from "@/lib/schemas";
+
+function chat(id: number): ChatSummary {
+  return {
+    id,
+    appId: 1,
+    title: `Chat ${id}`,
+    createdAt: new Date(),
+  };
+}
+
+describe("ChatTabs helpers", () => {
+  it("returns at most 3 tabs in MRU order", () => {
+    const chats = [chat(1), chat(2), chat(3), chat(4)];
+    const visible = getVisibleRecentChats([4, 2, 3, 1], chats);
+    expect(visible.map((c) => c.id)).toEqual([4, 2, 3]);
+  });
+
+  it("skips stale chat ids that no longer exist", () => {
+    const chats = [chat(1), chat(3)];
+    const visible = getVisibleRecentChats([3, 999, 1], chats);
+    expect(visible.map((c) => c.id)).toEqual([3, 1]);
+  });
+
+  it("selects right-adjacent tab when closing active middle tab", () => {
+    const fallback = getFallbackChatIdAfterClose(
+      [chat(1), chat(2), chat(3)],
+      2,
+    );
+    expect(fallback).toBe(3);
+  });
+
+  it("selects previous tab when closing active rightmost tab", () => {
+    const fallback = getFallbackChatIdAfterClose(
+      [chat(1), chat(2), chat(3)],
+      3,
+    );
+    expect(fallback).toBe(2);
+  });
+});
+
+describe("recent viewed chat atoms", () => {
+  it("moves selected chat to front and dedupes", () => {
+    const store = createStore();
+    store.set(recentViewedChatIdsAtom, [1, 2, 3]);
+    store.set(pushRecentViewedChatIdAtom, 2);
+    expect(store.get(recentViewedChatIdsAtom)).toEqual([2, 1, 3]);
+  });
+
+  it("removes closed tab from tab state only", () => {
+    const store = createStore();
+    store.set(recentViewedChatIdsAtom, [3, 2, 1]);
+    store.set(removeRecentViewedChatIdAtom, 2);
+    expect(store.get(recentViewedChatIdsAtom)).toEqual([3, 1]);
+  });
+});

--- a/src/app/TitleBar.tsx
+++ b/src/app/TitleBar.tsx
@@ -1,4 +1,4 @@
-import { useAtom } from "jotai";
+import { useAtom, useAtomValue } from "jotai";
 import { selectedAppIdAtom } from "@/atoms/appAtoms";
 import { useLoadApps } from "@/hooks/useLoadApps";
 import { useRouter } from "@tanstack/react-router";
@@ -22,6 +22,8 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { ChatActivityButton } from "@/components/chat/ChatActivity";
+import { ChatTabs } from "@/components/chat/ChatTabs";
+import { selectedChatIdAtom } from "@/atoms/chatAtoms";
 import { MoreVertical, Cog, Trash2 } from "lucide-react";
 import {
   DropdownMenu,
@@ -36,6 +38,7 @@ import { useTranslation } from "react-i18next";
 
 export const TitleBar = () => {
   const [selectedAppId] = useAtom(selectedAppIdAtom);
+  const selectedChatId = useAtomValue(selectedChatIdAtom);
   const { apps } = useLoadApps();
   const { navigate } = useRouter();
   const { settings, refreshSettings } = useSettings();
@@ -93,8 +96,9 @@ export const TitleBar = () => {
         </Button>
         {isDyadPro && <DyadProButton isDyadProEnabled={isDyadProEnabled} />}
 
-        {/* Spacer to push window controls to the right */}
-        <div className="flex-1" />
+        <div className="flex-1 min-w-0 overflow-hidden no-app-region-drag">
+          <ChatTabs appId={selectedAppId} selectedChatId={selectedChatId} />
+        </div>
 
         <TitleBarActions />
 

--- a/src/app/TitleBar.tsx
+++ b/src/app/TitleBar.tsx
@@ -97,7 +97,7 @@ export const TitleBar = () => {
         {isDyadPro && <DyadProButton isDyadProEnabled={isDyadProEnabled} />}
 
         <div className="flex-1 min-w-0 overflow-hidden no-app-region-drag">
-          <ChatTabs appId={selectedAppId} selectedChatId={selectedChatId} />
+          <ChatTabs selectedChatId={selectedChatId} />
         </div>
 
         <TitleBarActions />

--- a/src/atoms/chatAtoms.ts
+++ b/src/atoms/chatAtoms.ts
@@ -21,7 +21,14 @@ export const closedChatIdsAtom = atom<Set<number>>(new Set<number>());
 export const setRecentViewedChatIdsAtom = atom(
   null,
   (_get, set, chatIds: number[]) => {
-    set(recentViewedChatIdsAtom, chatIds);
+    if (chatIds.length > MAX_RECENT_VIEWED_CHAT_IDS) {
+      set(
+        recentViewedChatIdsAtom,
+        chatIds.slice(0, MAX_RECENT_VIEWED_CHAT_IDS),
+      );
+    } else {
+      set(recentViewedChatIdsAtom, chatIds);
+    }
   },
 );
 const MAX_RECENT_VIEWED_CHAT_IDS = 100;

--- a/src/atoms/chatAtoms.ts
+++ b/src/atoms/chatAtoms.ts
@@ -53,6 +53,25 @@ export const removeRecentViewedChatIdAtom = atom(
     set(closedChatIdsAtom, newClosedIds);
   },
 );
+// Prune closed chat IDs that no longer exist in the chats list
+export const pruneClosedChatIdsAtom = atom(
+  null,
+  (get, set, validChatIds: Set<number>) => {
+    const closedIds = get(closedChatIdsAtom);
+    let changed = false;
+    const pruned = new Set<number>();
+    for (const id of closedIds) {
+      if (validChatIds.has(id)) {
+        pruned.add(id);
+      } else {
+        changed = true;
+      }
+    }
+    if (changed) {
+      set(closedChatIdsAtom, pruned);
+    }
+  },
+);
 // Remove a chat ID from all tracking (used when chat is deleted)
 export const removeChatIdFromAllTrackingAtom = atom(
   null,

--- a/src/atoms/chatAtoms.ts
+++ b/src/atoms/chatAtoms.ts
@@ -18,6 +18,7 @@ export const recentStreamChatIdsAtom = atom<Set<number>>(new Set<number>());
 export const recentViewedChatIdsAtom = atom<number[]>([]);
 // Track explicitly closed tabs - these should not reappear in the tab bar
 export const closedChatIdsAtom = atom<Set<number>>(new Set<number>());
+const MAX_RECENT_VIEWED_CHAT_IDS = 100;
 export const setRecentViewedChatIdsAtom = atom(
   null,
   (_get, set, chatIds: number[]) => {
@@ -31,7 +32,6 @@ export const setRecentViewedChatIdsAtom = atom(
     }
   },
 );
-const MAX_RECENT_VIEWED_CHAT_IDS = 100;
 // Add a chat ID to the recent list only if it's not already present.
 // Unlike pushRecentViewedChatIdAtom, this does NOT move existing IDs to the front,
 // preserving the current tab order for chats already tracked.

--- a/src/atoms/chatAtoms.ts
+++ b/src/atoms/chatAtoms.ts
@@ -32,6 +32,28 @@ export const setRecentViewedChatIdsAtom = atom(
   },
 );
 const MAX_RECENT_VIEWED_CHAT_IDS = 100;
+// Add a chat ID to the recent list only if it's not already present.
+// Unlike pushRecentViewedChatIdAtom, this does NOT move existing IDs to the front,
+// preserving the current tab order for chats already tracked.
+export const ensureRecentViewedChatIdAtom = atom(
+  null,
+  (get, set, chatId: number) => {
+    const currentIds = get(recentViewedChatIdsAtom);
+    if (currentIds.includes(chatId)) return;
+    const nextIds = [chatId, ...currentIds];
+    if (nextIds.length > MAX_RECENT_VIEWED_CHAT_IDS) {
+      nextIds.length = MAX_RECENT_VIEWED_CHAT_IDS;
+    }
+    set(recentViewedChatIdsAtom, nextIds);
+    // Remove from closed set when explicitly selected
+    const closedIds = get(closedChatIdsAtom);
+    if (closedIds.has(chatId)) {
+      const newClosedIds = new Set(closedIds);
+      newClosedIds.delete(chatId);
+      set(closedChatIdsAtom, newClosedIds);
+    }
+  },
+);
 export const pushRecentViewedChatIdAtom = atom(
   null,
   (get, set, chatId: number) => {

--- a/src/atoms/chatAtoms.ts
+++ b/src/atoms/chatAtoms.ts
@@ -15,6 +15,24 @@ export const homeChatInputValueAtom = atom<string>("");
 // Used for scrolling to the bottom of the chat messages (per chat)
 export const chatStreamCountByIdAtom = atom<Map<number, number>>(new Map());
 export const recentStreamChatIdsAtom = atom<Set<number>>(new Set<number>());
+export const recentViewedChatIdsAtom = atom<number[]>([]);
+export const pushRecentViewedChatIdAtom = atom(
+  null,
+  (get, set, chatId: number) => {
+    const nextIds = get(recentViewedChatIdsAtom).filter((id) => id !== chatId);
+    nextIds.unshift(chatId);
+    set(recentViewedChatIdsAtom, nextIds);
+  },
+);
+export const removeRecentViewedChatIdAtom = atom(
+  null,
+  (get, set, chatId: number) => {
+    set(
+      recentViewedChatIdsAtom,
+      get(recentViewedChatIdsAtom).filter((id) => id !== chatId),
+    );
+  },
+);
 
 export const attachmentsAtom = atom<FileAttachment[]>([]);
 

--- a/src/atoms/chatAtoms.ts
+++ b/src/atoms/chatAtoms.ts
@@ -24,11 +24,15 @@ export const setRecentViewedChatIdsAtom = atom(
     set(recentViewedChatIdsAtom, chatIds);
   },
 );
+const MAX_RECENT_VIEWED_CHAT_IDS = 100;
 export const pushRecentViewedChatIdAtom = atom(
   null,
   (get, set, chatId: number) => {
     const nextIds = get(recentViewedChatIdsAtom).filter((id) => id !== chatId);
     nextIds.unshift(chatId);
+    if (nextIds.length > MAX_RECENT_VIEWED_CHAT_IDS) {
+      nextIds.length = MAX_RECENT_VIEWED_CHAT_IDS;
+    }
     set(recentViewedChatIdsAtom, nextIds);
     // Remove from closed set when explicitly selected
     const closedIds = get(closedChatIdsAtom);

--- a/src/atoms/chatAtoms.ts
+++ b/src/atoms/chatAtoms.ts
@@ -16,6 +16,12 @@ export const homeChatInputValueAtom = atom<string>("");
 export const chatStreamCountByIdAtom = atom<Map<number, number>>(new Map());
 export const recentStreamChatIdsAtom = atom<Set<number>>(new Set<number>());
 export const recentViewedChatIdsAtom = atom<number[]>([]);
+export const setRecentViewedChatIdsAtom = atom(
+  null,
+  (_get, set, chatIds: number[]) => {
+    set(recentViewedChatIdsAtom, chatIds);
+  },
+);
 export const pushRecentViewedChatIdAtom = atom(
   null,
   (get, set, chatId: number) => {

--- a/src/components/ChatList.tsx
+++ b/src/components/ChatList.tsx
@@ -190,6 +190,7 @@ export function ChatList({ show }: { show?: boolean }) {
               onClick={handleNewChat}
               variant="outline"
               className="flex items-center justify-start gap-2 mx-2 py-3"
+              data-testid="new-chat-button"
             >
               <PlusCircle size={16} />
               <span>{t("newChat")}</span>

--- a/src/components/ChatList.tsx
+++ b/src/components/ChatList.tsx
@@ -8,6 +8,7 @@ import { useAtom, useSetAtom } from "jotai";
 import {
   selectedChatIdAtom,
   removeChatIdFromAllTrackingAtom,
+  pushRecentViewedChatIdAtom,
 } from "@/atoms/chatAtoms";
 import { selectedAppIdAtom } from "@/atoms/appAtoms";
 import { dropdownOpenAtom } from "@/atoms/uiAtoms";
@@ -66,17 +67,24 @@ export function ChatList({ show }: { show?: boolean }) {
   const removeChatIdFromAllTracking = useSetAtom(
     removeChatIdFromAllTrackingAtom,
   );
+  const pushRecentViewedChatId = useSetAtom(pushRecentViewedChatIdAtom);
 
-  // Update selectedChatId when route changes
+  // Update selectedChatId when route changes and ensure chat appears in tabs
   useEffect(() => {
     if (isChatRoute) {
       const id = routerState.location.search.id;
       const chatId = Number(id);
       if (Number.isFinite(chatId) && chatId > 0) {
         setSelectedChatId(chatId);
+        pushRecentViewedChatId(chatId);
       }
     }
-  }, [isChatRoute, routerState.location.search, setSelectedChatId]);
+  }, [
+    isChatRoute,
+    routerState.location.search,
+    setSelectedChatId,
+    pushRecentViewedChatId,
+  ]);
 
   if (!show) {
     return;

--- a/src/components/ChatList.tsx
+++ b/src/components/ChatList.tsx
@@ -4,8 +4,11 @@ import { useNavigate, useRouterState } from "@tanstack/react-router";
 
 import { formatDistanceToNow } from "date-fns";
 import { PlusCircle, MoreVertical, Trash2, Edit3, Search } from "lucide-react";
-import { useAtom } from "jotai";
-import { selectedChatIdAtom } from "@/atoms/chatAtoms";
+import { useAtom, useSetAtom } from "jotai";
+import {
+  selectedChatIdAtom,
+  removeChatIdFromAllTrackingAtom,
+} from "@/atoms/chatAtoms";
 import { selectedAppIdAtom } from "@/atoms/appAtoms";
 import { dropdownOpenAtom } from "@/atoms/uiAtoms";
 import { ipc } from "@/ipc/types";
@@ -60,6 +63,9 @@ export function ChatList({ show }: { show?: boolean }) {
   // search dialog state
   const [isSearchDialogOpen, setIsSearchDialogOpen] = useState(false);
   const { selectChat } = useSelectChat();
+  const removeChatIdFromAllTracking = useSetAtom(
+    removeChatIdFromAllTrackingAtom,
+  );
 
   // Update selectedChatId when route changes
   useEffect(() => {
@@ -129,6 +135,9 @@ export function ChatList({ show }: { show?: boolean }) {
     try {
       await ipc.chat.deleteChat(chatId);
       showSuccess(t("chatDeleted"));
+
+      // Remove from tab tracking to prevent stale IDs
+      removeChatIdFromAllTracking(chatId);
 
       // If the deleted chat was selected, navigate to home
       if (selectedChatId === chatId) {

--- a/src/components/ChatList.tsx
+++ b/src/components/ChatList.tsx
@@ -112,12 +112,8 @@ export function ChatList({ show }: { show?: boolean }) {
           updateSettings({ selectedChatMode: effectiveDefaultMode });
         }
 
-        // Navigate to the new chat
-        setSelectedChatId(chatId);
-        navigate({
-          to: "/chat",
-          search: { id: chatId },
-        });
+        // Navigate to the new chat (use selectChat so it appears at front of tab bar)
+        selectChat({ chatId, appId: selectedAppId });
 
         // Refresh the chat list
         await invalidateChats();

--- a/src/components/ChatList.tsx
+++ b/src/components/ChatList.tsx
@@ -147,10 +147,10 @@ export function ChatList({ show }: { show?: boolean }) {
       // Remove from tab tracking to prevent stale IDs
       removeChatIdFromAllTracking(chatId);
 
-      // If the deleted chat was selected, navigate to home
+      // If the deleted chat was selected, navigate to home (matches tab-close behavior)
       if (selectedChatId === chatId) {
         setSelectedChatId(null);
-        navigate({ to: "/chat" });
+        navigate({ to: "/" });
       }
 
       // Refresh the chat list

--- a/src/components/ChatList.tsx
+++ b/src/components/ChatList.tsx
@@ -65,9 +65,9 @@ export function ChatList({ show }: { show?: boolean }) {
   useEffect(() => {
     if (isChatRoute) {
       const id = routerState.location.search.id;
-      if (id) {
-        console.log("Setting selected chat id to", id);
-        setSelectedChatId(id);
+      const chatId = Number(id);
+      if (Number.isFinite(chatId) && chatId > 0) {
+        setSelectedChatId(chatId);
       }
     }
   }, [isChatRoute, routerState.location.search, setSelectedChatId]);

--- a/src/components/CreateAppDialog.tsx
+++ b/src/components/CreateAppDialog.tsx
@@ -13,11 +13,8 @@ import {
 } from "@/components/ui/dialog";
 import { useCreateApp } from "@/hooks/useCreateApp";
 import { useCheckName } from "@/hooks/useCheckName";
-import { useSetAtom } from "jotai";
-import { selectedAppIdAtom } from "@/atoms/appAtoms";
 import { NEON_TEMPLATE_IDS, Template } from "@/shared/templates";
-
-import { useRouter } from "@tanstack/react-router";
+import { useSelectChat } from "@/hooks/useSelectChat";
 
 import { Loader2 } from "lucide-react";
 import { neonTemplateHook } from "@/client_logic/template_hook";
@@ -35,12 +32,11 @@ export function CreateAppDialog({
   template,
 }: CreateAppDialogProps) {
   const { t } = useTranslation(["home", "common"]);
-  const setSelectedAppId = useSetAtom(selectedAppIdAtom);
   const [appName, setAppName] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { createApp } = useCreateApp();
   const { data: nameCheckResult } = useCheckName(appName);
-  const router = useRouter();
+  const { selectChat } = useSelectChat();
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
@@ -61,12 +57,8 @@ export function CreateAppDialog({
           appName: result.app.name,
         });
       }
-      setSelectedAppId(result.app.id);
-      // Navigate to the new app's first chat
-      router.navigate({
-        to: "/chat",
-        search: { id: result.chatId },
-      });
+      // Selecting the new chat seeds recent tab order immediately.
+      selectChat({ chatId: result.chatId, appId: result.app.id });
       setAppName("");
       onOpenChange(false);
     } catch (error) {

--- a/src/components/chat/ChatHeader.tsx
+++ b/src/components/chat/ChatHeader.tsx
@@ -194,6 +194,7 @@ export function ChatHeader({
             onClick={handleNewChat}
             variant="ghost"
             className="hidden @2xs:flex items-center justify-start gap-2 mx-2 py-3"
+            data-testid="new-chat-button"
           >
             <PlusCircle size={16} />
             <span>{t("newChat")}</span>

--- a/src/components/chat/ChatHeader.tsx
+++ b/src/components/chat/ChatHeader.tsx
@@ -89,8 +89,8 @@ export function ChatHeader({
     if (appId) {
       try {
         const chatId = await ipc.chat.createChat(appId);
-        selectChat({ chatId, appId });
         await invalidateChats();
+        selectChat({ chatId, appId });
       } catch (error) {
         showError(t("failedCreateChat", { error: (error as any).toString() }));
       }

--- a/src/components/chat/ChatHeader.tsx
+++ b/src/components/chat/ChatHeader.tsx
@@ -20,6 +20,7 @@ import {
 import { ipc } from "@/ipc/types";
 import { useRouter } from "@tanstack/react-router";
 import { selectedChatIdAtom } from "@/atoms/chatAtoms";
+import { useSelectChat } from "@/hooks/useSelectChat";
 import { useChats } from "@/hooks/useChats";
 import { showError, showSuccess } from "@/lib/toast";
 import { useEffect } from "react";
@@ -48,8 +49,9 @@ export function ChatHeader({
   const appId = useAtomValue(selectedAppIdAtom);
   const { versions, loading: versionsLoading } = useVersions(appId);
   const { navigate } = useRouter();
-  const [selectedChatId, setSelectedChatId] = useAtom(selectedChatIdAtom);
+  const [selectedChatId] = useAtom(selectedChatIdAtom);
   const { invalidateChats } = useChats(appId);
+  const { selectChat } = useSelectChat();
   const { isStreaming } = useStreamChat();
   const isAnyCheckoutVersionInProgress = useAtomValue(
     isAnyCheckoutVersionInProgressAtom,
@@ -87,11 +89,7 @@ export function ChatHeader({
     if (appId) {
       try {
         const chatId = await ipc.chat.createChat(appId);
-        setSelectedChatId(chatId);
-        navigate({
-          to: "/chat",
-          search: { id: chatId },
-        });
+        selectChat({ chatId, appId });
         await invalidateChats();
       } catch (error) {
         showError(t("failedCreateChat", { error: (error as any).toString() }));

--- a/src/components/chat/ChatTabs.tsx
+++ b/src/components/chat/ChatTabs.tsx
@@ -495,7 +495,7 @@ export function ChatTabs({ selectedChatId }: ChatTabsProps) {
                   <button
                     type="button"
                     onClick={() => handleTabClick(chat)}
-                    className="min-w-0 flex-1 text-left"
+                    className="min-w-0 flex-1 text-left rounded-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                     aria-current={isActive ? "page" : undefined}
                   >
                     <div className="min-w-0">
@@ -512,10 +512,10 @@ export function ChatTabs({ selectedChatId }: ChatTabsProps) {
                       handleCloseTab(chat.id);
                     }}
                     className={cn(
-                      "flex h-6 w-6 items-center justify-center rounded-sm transition-colors",
+                      "flex h-6 w-6 items-center justify-center rounded-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
                       isActive
                         ? "opacity-80 hover:bg-muted"
-                        : "opacity-0 group-hover:opacity-80 hover:bg-background/50",
+                        : "opacity-0 group-hover:opacity-80 hover:bg-background/50 focus-visible:opacity-80",
                     )}
                     aria-label={t("closeChatTab", { title })}
                   >
@@ -547,7 +547,7 @@ export function ChatTabs({ selectedChatId }: ChatTabsProps) {
             <DropdownMenuTrigger
               className="flex h-7 w-8 items-center justify-center rounded-md border border-transparent bg-muted/50 text-muted-foreground hover:bg-muted"
               aria-label={t("openOverflowTabs", {
-                count: overflowTabsForMenu.length,
+                count: overflowTabs.length,
               })}
             >
               <MoreHorizontal size={14} />
@@ -594,7 +594,7 @@ export function ChatTabs({ selectedChatId }: ChatTabsProps) {
                         event.stopPropagation();
                         handleCloseTab(chat.id);
                       }}
-                      className="flex h-6 w-6 items-center justify-center rounded-sm text-muted-foreground hover:bg-muted"
+                      className="flex h-6 w-6 items-center justify-center rounded-sm text-muted-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                       aria-label={t("closeChatTab", { title })}
                     >
                       <X size={12} />

--- a/src/components/chat/ChatTabs.tsx
+++ b/src/components/chat/ChatTabs.tsx
@@ -367,6 +367,7 @@ export function ChatTabs({ selectedChatId }: ChatTabsProps) {
     const fallbackChatId = getFallbackChatIdAfterClose(orderedChats, chatId);
 
     removeRecentViewedChatId(chatId);
+    clearNotification(chatId);
 
     if (!closedTab || selectedChatId !== chatId) {
       return;
@@ -413,6 +414,13 @@ export function ChatTabs({ selectedChatId }: ChatTabsProps) {
                   render={
                     <div
                       draggable
+                      onAuxClick={(event) => {
+                        // Middle-click (button 1) to close tab
+                        if (event.button === 1) {
+                          event.preventDefault();
+                          handleCloseTab(chat.id);
+                        }
+                      }}
                       onDragStart={(event) => {
                         event.dataTransfer.effectAllowed = "move";
                         event.dataTransfer.setData(
@@ -504,7 +512,7 @@ export function ChatTabs({ selectedChatId }: ChatTabsProps) {
                       handleCloseTab(chat.id);
                     }}
                     className={cn(
-                      "rounded-sm p-0.5 transition-colors",
+                      "flex h-6 w-6 items-center justify-center rounded-sm transition-colors",
                       isActive
                         ? "opacity-80 hover:bg-muted"
                         : "opacity-0 group-hover:opacity-80 hover:bg-background/50",
@@ -556,6 +564,12 @@ export function ChatTabs({ selectedChatId }: ChatTabsProps) {
                   <DropdownMenuItem
                     key={chat.id}
                     onClick={() => handleTabClick(chat, true)}
+                    onAuxClick={(event) => {
+                      if (event.button === 1) {
+                        event.preventDefault();
+                        handleCloseTab(chat.id);
+                      }
+                    }}
                     className="flex items-center gap-2"
                   >
                     {inProgress && (

--- a/src/components/chat/ChatTabs.tsx
+++ b/src/components/chat/ChatTabs.tsx
@@ -499,7 +499,7 @@ export function ChatTabs({ selectedChatId }: ChatTabsProps) {
                     aria-current={isActive ? "page" : undefined}
                   >
                     <div className="min-w-0">
-                      <div className="truncate text-[10px] leading-3 font-bold">
+                      <div className="truncate text-xs leading-3.5 font-bold">
                         {appName}
                       </div>
                       <div className="truncate text-xs leading-4">{title}</div>
@@ -583,7 +583,7 @@ export function ChatTabs({ selectedChatId }: ChatTabsProps) {
                       </span>
                     )}
                     <div className="min-w-0 flex-1">
-                      <div className="truncate text-[10px] leading-3 font-bold">
+                      <div className="truncate text-xs leading-3.5 font-bold">
                         {appName}
                       </div>
                       <div className="truncate text-xs leading-4">{title}</div>
@@ -594,7 +594,7 @@ export function ChatTabs({ selectedChatId }: ChatTabsProps) {
                         event.stopPropagation();
                         handleCloseTab(chat.id);
                       }}
-                      className="rounded-sm p-0.5 text-muted-foreground hover:bg-muted"
+                      className="flex h-6 w-6 items-center justify-center rounded-sm text-muted-foreground hover:bg-muted"
                       aria-label={t("closeChatTab", { title })}
                     >
                       <X size={12} />

--- a/src/components/chat/ChatTabs.tsx
+++ b/src/components/chat/ChatTabs.tsx
@@ -233,6 +233,9 @@ export function ChatTabs({ selectedChatId }: ChatTabsProps) {
     [overflowTabs],
   );
 
+  // Re-run when orderedChats becomes non-empty so the ResizeObserver attaches
+  // after the container div renders (it returns null when there are no chats).
+  const hasChats = orderedChats.length > 0;
   useEffect(() => {
     const node = containerRef.current;
     if (!node) return;
@@ -260,7 +263,7 @@ export function ChatTabs({ selectedChatId }: ChatTabsProps) {
       window.cancelAnimationFrame(frameId);
       observer.disconnect();
     };
-  }, []);
+  }, [hasChats]);
 
   // Detect streaming → finished transitions for non-active tabs to show a
   // notification dot.
@@ -603,5 +606,5 @@ function isSameIdOrder(left: number[], right: number[]): boolean {
 
 function getChatTitleExcerpt(title: string, maxLength = 140): string {
   if (title.length <= maxLength) return title;
-  return `${title.slice(0, maxLength - 1)}...`;
+  return `${title.slice(0, maxLength - 3)}...`;
 }

--- a/src/components/chat/ChatTabs.tsx
+++ b/src/components/chat/ChatTabs.tsx
@@ -477,8 +477,8 @@ export function ChatTabs({ selectedChatId }: ChatTabsProps) {
                   {inProgress && (
                     <span
                       className="flex items-center text-purple-600"
-                      aria-label="Chat in progress"
-                      title="Chat in progress"
+                      aria-label={t("chatInProgress")}
+                      title={t("chatInProgress")}
                     >
                       <Loader2 size={12} className="animate-spin" />
                     </span>
@@ -486,8 +486,8 @@ export function ChatTabs({ selectedChatId }: ChatTabsProps) {
                   {hasNotification && (
                     <span
                       className="flex items-center"
-                      aria-label="New activity"
-                      title="New activity"
+                      aria-label={t("newActivity")}
+                      title={t("newActivity")}
                     >
                       <span className="h-2 w-2 rounded-full bg-blue-500" />
                     </span>
@@ -573,12 +573,20 @@ export function ChatTabs({ selectedChatId }: ChatTabsProps) {
                     className="flex items-center gap-2"
                   >
                     {inProgress && (
-                      <span className="flex items-center text-purple-600">
+                      <span
+                        className="flex items-center text-purple-600"
+                        aria-label={t("chatInProgress")}
+                        title={t("chatInProgress")}
+                      >
                         <Loader2 size={12} className="animate-spin" />
                       </span>
                     )}
                     {hasNotification && (
-                      <span className="flex items-center">
+                      <span
+                        className="flex items-center"
+                        aria-label={t("newActivity")}
+                        title={t("newActivity")}
+                      >
                         <span className="h-2 w-2 rounded-full bg-blue-500" />
                       </span>
                     )}

--- a/src/components/chat/ChatTabs.tsx
+++ b/src/components/chat/ChatTabs.tsx
@@ -1,0 +1,144 @@
+import { useEffect, useMemo } from "react";
+import { useAtomValue, useSetAtom } from "jotai";
+import { X } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type { ChatSummary } from "@/lib/schemas";
+import { useChats } from "@/hooks/useChats";
+import { useSelectChat } from "@/hooks/useSelectChat";
+import {
+  recentViewedChatIdsAtom,
+  removeRecentViewedChatIdAtom,
+  pushRecentViewedChatIdAtom,
+} from "@/atoms/chatAtoms";
+import { cn } from "@/lib/utils";
+
+const MAX_VISIBLE_TABS = 3;
+
+export function getVisibleRecentChats(
+  recentViewedChatIds: number[],
+  chats: ChatSummary[],
+  limit = MAX_VISIBLE_TABS,
+): ChatSummary[] {
+  if (recentViewedChatIds.length === 0 || chats.length === 0 || limit <= 0) {
+    return [];
+  }
+
+  const chatsById = new Map(chats.map((chat) => [chat.id, chat]));
+  const visibleTabs: ChatSummary[] = [];
+
+  for (const chatId of recentViewedChatIds) {
+    const chat = chatsById.get(chatId);
+    if (!chat) continue;
+    visibleTabs.push(chat);
+    if (visibleTabs.length >= limit) break;
+  }
+
+  return visibleTabs;
+}
+
+export function getFallbackChatIdAfterClose(
+  tabs: ChatSummary[],
+  closedChatId: number,
+): number | null {
+  const closedIndex = tabs.findIndex((tab) => tab.id === closedChatId);
+  if (closedIndex === -1) return null;
+
+  const remainingTabs = tabs.filter((tab) => tab.id !== closedChatId);
+  if (remainingTabs.length === 0) return null;
+
+  const fallbackIndex = Math.min(closedIndex, remainingTabs.length - 1);
+  return remainingTabs[fallbackIndex]?.id ?? null;
+}
+
+interface ChatTabsProps {
+  appId: number | null;
+  selectedChatId: number | null;
+}
+
+export function ChatTabs({ appId, selectedChatId }: ChatTabsProps) {
+  const { t } = useTranslation("chat");
+  const { chats } = useChats(appId);
+  const recentViewedChatIds = useAtomValue(recentViewedChatIdsAtom);
+  const removeRecentViewedChatId = useSetAtom(removeRecentViewedChatIdAtom);
+  const pushRecentViewedChatId = useSetAtom(pushRecentViewedChatIdAtom);
+  const { selectChat } = useSelectChat();
+
+  useEffect(() => {
+    if (selectedChatId !== null) {
+      pushRecentViewedChatId(selectedChatId);
+    }
+  }, [selectedChatId, pushRecentViewedChatId]);
+
+  const tabs = useMemo(
+    () => getVisibleRecentChats(recentViewedChatIds, chats),
+    [recentViewedChatIds, chats],
+  );
+
+  const handleTabClick = (chat: ChatSummary) => {
+    selectChat({ chatId: chat.id, appId: chat.appId });
+  };
+
+  const handleCloseTab = (chatId: number) => {
+    const closedTab = tabs.find((tab) => tab.id === chatId);
+    const fallbackChatId = getFallbackChatIdAfterClose(tabs, chatId);
+
+    removeRecentViewedChatId(chatId);
+
+    if (!closedTab || selectedChatId !== chatId || fallbackChatId === null) {
+      return;
+    }
+
+    const fallbackTab = tabs.find((tab) => tab.id === fallbackChatId);
+    if (!fallbackTab) return;
+
+    selectChat({ chatId: fallbackTab.id, appId: fallbackTab.appId });
+  };
+
+  if (tabs.length === 0) return null;
+
+  return (
+    <div className="flex items-center gap-1 overflow-x-auto px-2 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+      {tabs.map((chat) => {
+        const isActive = selectedChatId === chat.id;
+        const title = chat.title?.trim() || t("newChat");
+
+        return (
+          <div
+            key={chat.id}
+            className={cn(
+              "group flex h-7 max-w-44 min-w-0 items-center gap-1 rounded-md border px-2.5 text-xs transition-colors",
+              isActive
+                ? "bg-background text-foreground shadow-sm border-border"
+                : "bg-muted/50 text-muted-foreground hover:bg-muted border-transparent",
+            )}
+          >
+            <button
+              type="button"
+              onClick={() => handleTabClick(chat)}
+              className="min-w-0 flex-1 truncate text-left"
+              aria-current={isActive ? "page" : undefined}
+            >
+              {title}
+            </button>
+            <button
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation();
+                handleCloseTab(chat.id);
+              }}
+              className={cn(
+                "rounded-sm p-0.5 transition-colors",
+                isActive
+                  ? "opacity-80 hover:bg-muted"
+                  : "opacity-0 group-hover:opacity-80 hover:bg-background/50",
+              )}
+              aria-label={t("closeChatTab", { title })}
+            >
+              <X size={12} />
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/hooks/useCreateApp.ts
+++ b/src/hooks/useCreateApp.ts
@@ -18,6 +18,9 @@ export function useCreateApp() {
     onSuccess: () => {
       // Invalidate apps list to trigger refetch
       queryClient.invalidateQueries({ queryKey: queryKeys.apps.all });
+      // Creating an app also creates the first chat, so refresh the chat list
+      // so ChatTabs can see it immediately.
+      queryClient.invalidateQueries({ queryKey: queryKeys.chats.all });
     },
     onError: (error) => {
       showError(error);

--- a/src/hooks/useSelectChat.ts
+++ b/src/hooks/useSelectChat.ts
@@ -13,10 +13,20 @@ export function useSelectChat() {
   const navigate = useNavigate();
 
   return {
-    selectChat: ({ chatId, appId }: { chatId: number; appId: number }) => {
+    selectChat: ({
+      chatId,
+      appId,
+      preserveTabOrder = false,
+    }: {
+      chatId: number;
+      appId: number;
+      preserveTabOrder?: boolean;
+    }) => {
       setSelectedChatId(chatId);
       setSelectedAppId(appId);
-      pushRecentViewedChatId(chatId);
+      if (!preserveTabOrder) {
+        pushRecentViewedChatId(chatId);
+      }
       navigate({
         to: "/chat",
         search: { id: chatId },

--- a/src/hooks/useSelectChat.ts
+++ b/src/hooks/useSelectChat.ts
@@ -1,17 +1,22 @@
 import { useSetAtom } from "jotai";
-import { selectedChatIdAtom } from "@/atoms/chatAtoms";
+import {
+  selectedChatIdAtom,
+  pushRecentViewedChatIdAtom,
+} from "@/atoms/chatAtoms";
 import { selectedAppIdAtom } from "@/atoms/appAtoms";
 import { useNavigate } from "@tanstack/react-router";
 
 export function useSelectChat() {
   const setSelectedChatId = useSetAtom(selectedChatIdAtom);
   const setSelectedAppId = useSetAtom(selectedAppIdAtom);
+  const pushRecentViewedChatId = useSetAtom(pushRecentViewedChatIdAtom);
   const navigate = useNavigate();
 
   return {
     selectChat: ({ chatId, appId }: { chatId: number; appId: number }) => {
       setSelectedChatId(chatId);
       setSelectedAppId(appId);
+      pushRecentViewedChatId(chatId);
       navigate({
         to: "/chat",
         search: { id: chatId },

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -2,6 +2,7 @@
   "newChat": "New Chat",
   "recentChats": "Recent Chats",
   "searchChats": "Search chats",
+  "closeChatTab": "Close tab: {{title}}",
   "loadingChats": "Loading chats...",
   "noChatsFound": "No chats found",
   "renameChat": "Rename Chat",

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -3,6 +3,7 @@
   "recentChats": "Recent Chats",
   "searchChats": "Search chats",
   "closeChatTab": "Close tab: {{title}}",
+  "openOverflowTabs": "Open more tabs ({{count}})",
   "loadingChats": "Loading chats...",
   "noChatsFound": "No chats found",
   "renameChat": "Rename Chat",

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -3,6 +3,8 @@
   "recentChats": "Recent Chats",
   "searchChats": "Search chats",
   "closeChatTab": "Close tab: {{title}}",
+  "chatInProgress": "Chat in progress",
+  "newActivity": "New activity",
   "openOverflowTabs": "Open more tabs ({{count}})",
   "loadingChats": "Loading chats...",
   "noChatsFound": "No chats found",

--- a/src/i18n/locales/pt-BR/chat.json
+++ b/src/i18n/locales/pt-BR/chat.json
@@ -2,6 +2,8 @@
   "newChat": "Novo Chat",
   "recentChats": "Chats Recentes",
   "searchChats": "Pesquisar chats",
+  "closeChatTab": "Fechar aba: {{title}}",
+  "openOverflowTabs": "Abrir mais abas ({{count}})",
   "loadingChats": "Carregando chats...",
   "noChatsFound": "Nenhum chat encontrado",
   "renameChat": "Renomear Chat",

--- a/src/i18n/locales/pt-BR/chat.json
+++ b/src/i18n/locales/pt-BR/chat.json
@@ -3,6 +3,8 @@
   "recentChats": "Chats Recentes",
   "searchChats": "Pesquisar chats",
   "closeChatTab": "Fechar aba: {{title}}",
+  "chatInProgress": "Chat em andamento",
+  "newActivity": "Nova atividade",
   "openOverflowTabs": "Abrir mais abas ({{count}})",
   "loadingChats": "Carregando chats...",
   "noChatsFound": "Nenhum chat encontrado",

--- a/src/i18n/locales/zh-CN/chat.json
+++ b/src/i18n/locales/zh-CN/chat.json
@@ -2,6 +2,8 @@
   "newChat": "新建聊天",
   "recentChats": "最近的聊天",
   "searchChats": "搜索聊天",
+  "closeChatTab": "关闭标签页：{{title}}",
+  "openOverflowTabs": "打开更多标签页（{{count}}）",
   "loadingChats": "正在加载聊天...",
   "noChatsFound": "未找到聊天",
   "renameChat": "重命名聊天",

--- a/src/i18n/locales/zh-CN/chat.json
+++ b/src/i18n/locales/zh-CN/chat.json
@@ -3,6 +3,8 @@
   "recentChats": "最近的聊天",
   "searchChats": "搜索聊天",
   "closeChatTab": "关闭标签页：{{title}}",
+  "chatInProgress": "聊天进行中",
+  "newActivity": "新活动",
   "openOverflowTabs": "打开更多标签页（{{count}}）",
   "loadingChats": "正在加载聊天...",
   "noChatsFound": "未找到聊天",

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -2,7 +2,6 @@ import { useTranslation } from "react-i18next";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useAtom, useSetAtom } from "jotai";
 import { homeChatInputValueAtom } from "../atoms/chatAtoms";
-import { selectedAppIdAtom } from "@/atoms/appAtoms";
 import { ipc } from "@/ipc/types";
 import { generateCuteAppName } from "@/lib/utils";
 import { useLoadApps } from "@/hooks/useLoadApps";
@@ -55,7 +54,6 @@ export default function HomePage() {
   const [inputValue, setInputValue] = useAtom(homeChatInputValueAtom);
   const navigate = useNavigate();
   const search = useSearch({ from: "/" });
-  const setSelectedAppId = useSetAtom(selectedAppIdAtom);
   const { refreshApps } = useLoadApps();
   const { settings, updateSettings, envVars } = useSettings();
   const { isQuotaExceeded, isLoading: isQuotaLoading } = useFreeAgentQuota();
@@ -203,7 +201,6 @@ export default function HomePage() {
       );
 
       setInputValue("");
-      setSelectedAppId(result.app.id);
       setIsPreviewOpen(false);
       await refreshApps(); // Ensure refreshApps is awaited if it's async
       await invalidateAppQuery(queryClient, { appId: result.app.id });


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2619" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new cross-cutting chat navigation UI and new tab-state atoms that affect chat selection/creation/deletion flows; risk is mainly UX/state regressions and e2e flakiness rather than security.
> 
> **Overview**
> **Adds browser-like chat tabs in the title bar.** Introduces `ChatTabs` with draggable visible tabs, an overflow menu, per-tab close (incl. middle-click), streaming-in-progress indicator, and “new activity” dot, plus i18n strings for accessible labels.
> 
> **Persists and coordinates tab state across navigation.** Adds `recentViewedChatIds`/`closedChatIds` atoms and helpers to keep MRU ordering, prevent explicitly closed tabs from reappearing, prune stale IDs, and choose an adjacent fallback chat when closing the active tab (navigating home if none).
> 
> **Updates chat creation/selection flows and tests.** Refactors `useSelectChat` to optionally preserve tab order; updates Home/CreateApp/ChatHeader/ChatList to use it and invalidate chat queries so new chats appear in tabs immediately; adds stable `new-chat-button` test IDs, new unit tests for tab helpers/atoms, and new Playwright e2e coverage for tab render/switch/close behavior.
> 
> **Build tooling/doc tweaks.** Bumps Node engine requirement to `>=24` and updates `rules/git-workflow.md` guidance for engine conflict resolution and stash handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 982cef98ff0d3c1552097a91f59196fd07d47602. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds browser-like tabs to the chat title bar for fast multi-chat navigation. Refines tab behavior, accessibility, and creation/deletion flows so tabs stay accurate, responsive, and preserve tab order.

- **New Features**
  - ChatTabs in TitleBar: MRU ordering; drag-to-reorder (visible tabs); overflow dropdown with live count; streaming spinner; post-stream notification dot; middle-click close; WCAG 24x24 close targets; tooltips; accessible labels and focus-visible rings; i18n labels for “Chat in progress” and “New activity” (en, pt-BR, zh-CN); unit + e2e tests (incl. closed-tab state).
  - Persistent tab state via Jotai: recentViewedChatIds (cap 100) and closedChatIds so explicitly closed tabs don’t reappear; ensureRecentViewedChatId to keep tab order on route changes; Node engine bumped to >=24.

- **Bug Fixes**
  - Close/selection: adjacent-tab fallback; closing the last tab navigates home; selecting a closed tab re-opens it; clear notifications on close; guard unknown/stale IDs; resolve selection loop; prune stale closed IDs; deleting the selected chat also navigates home.
  - Flows/accessibility: new-chat in ChatHeader uses correct invalidate/select order so tabs render immediately; route changes use ensureRecentViewedChatId to preserve order; overflow ARIA label uses actual overflow count; ResizeObserver attaches with async loads; title truncation respects max length; stable e2e selectors via new-chat-button; fixed CI npm sync via encoding; updated git workflow docs on stash review and engine conflicts; internal refactor with removeFromClosedSet helper to reduce duplication.

<sup>Written for commit 982cef98ff0d3c1552097a91f59196fd07d47602. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

