### PR TITLE
Switch CI PR review to swarm-pr-review and fix /tmp file access

### DIFF
--- a/.claude/skills/multi-pr-review/SKILL.md
+++ b/.claude/skills/multi-pr-review/SKILL.md
@@ -22,9 +22,11 @@ This skill creates three independent sub-agents to review code changes, then agg
 
 ### Step 1: Fetch PR Diff
 
+**IMPORTANT:** Always save files to the current working directory (e.g. `./pr_diff.patch`), never to `/tmp/` or other directories outside the repo. In CI, only the repo working directory is accessible.
+
 ```bash
-# Get changed files from PR
-gh pr diff <PR_NUMBER> --repo <OWNER/REPO> > pr_diff.patch
+# Get changed files from PR (save to current working directory, NOT /tmp/)
+gh pr diff <PR_NUMBER> --repo <OWNER/REPO> > ./pr_diff.patch
 
 # Or get list of changed files
 gh pr view <PR_NUMBER> --repo <OWNER/REPO> --json files -q '.files[].path'
@@ -38,7 +40,7 @@ Execute the orchestrator script:
 python3 scripts/orchestrate_review.py \
   --pr-number <PR_NUMBER> \
   --repo <OWNER/REPO> \
-  --diff-file pr_diff.patch
+  --diff-file ./pr_diff.patch
 ```
 
 The orchestrator:
@@ -177,7 +179,7 @@ To disable extended thinking (faster but less thorough):
 python3 scripts/orchestrate_review.py \
   --pr-number <PR_NUMBER> \
   --repo <OWNER/REPO> \
-  --diff-file pr_diff.patch \
+  --diff-file ./pr_diff.patch \
   --no-thinking
 ```
 
@@ -187,6 +189,6 @@ To customize thinking budget:
 python3 scripts/orchestrate_review.py \
   --pr-number <PR_NUMBER> \
   --repo <OWNER/REPO> \
-  --diff-file pr_diff.patch \
+  --diff-file ./pr_diff.patch \
   --thinking-budget 50000
 ```

--- a/.claude/skills/swarm-pr-review/SKILL.md
+++ b/.claude/skills/swarm-pr-review/SKILL.md
@@ -41,9 +41,11 @@ gh pr view --json number -q '.number'
 
 ### Step 2: Fetch PR Diff and Context
 
+**IMPORTANT:** Always save files to the current working directory (e.g. `./pr_diff.patch`), never to `/tmp/` or other directories outside the repo. In CI, only the repo working directory is accessible.
+
 ```bash
-# Save the diff to scratchpad
-gh pr diff <PR_NUMBER> --repo <OWNER/REPO> > $SCRATCHPAD/pr_diff.patch
+# Save the diff to current working directory (NOT /tmp/ or $SCRATCHPAD)
+gh pr diff <PR_NUMBER> --repo <OWNER/REPO> > ./pr_diff.patch
 
 # Get PR metadata
 gh pr view <PR_NUMBER> --repo <OWNER/REPO> --json title,body,files,headRefOid

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -53,7 +53,7 @@ jobs:
           track_progress: false
 
           prompt: |
-            /dyad:multi-pr-review ${{ github.event.pull_request.number }}
+            /dyad:swarm-pr-review ${{ github.event.pull_request.number }}
 
           # Uses .claude/settings.json for permissions; only add MCP tool not in settings
           claude_args: |

--- a/rules/git-workflow.md
+++ b/rules/git-workflow.md
@@ -37,6 +37,10 @@ Actions performed using the default `GITHUB_TOKEN` (including labels added by `g
 gh api repos/dyad-sh/dyad/issues/{PR_NUMBER}/labels -f "labels[]=label-name"
 ```
 
+## CI file access (claude-code-action)
+
+In CI, `claude-code-action` restricts file access to the repo working directory (e.g., `/home/runner/work/dyad/dyad`). Skills that save intermediate files (like PR diffs) must use `./filename` (current working directory), **never** `/tmp/`. Using `/tmp/` causes errors like: `cat in '/tmp/pr_*_diff.patch' was blocked. For security, Claude Code may only concatenate files from the allowed working directories`.
+
 ## Rebase conflict resolution tips
 
 - **Before rebasing:** If `npm install` modified `package-lock.json` (common in CI/local), discard changes with `git restore package-lock.json` to avoid "unstaged changes" errors


### PR DESCRIPTION
## Summary
- Switch `claude-pr-review` workflow from `multi-pr-review` to `swarm-pr-review` skill
- Add warnings in both skill SKILL.md files to save intermediate files to the working directory (`./pr_diff.patch`) instead of `/tmp/`, which is blocked by `claude-code-action` security sandboxing in CI
- Document the CI file access restriction in `rules/git-workflow.md`

Fixes the `cat in '/tmp/pr_*_diff.patch' was blocked` error: https://github.com/dyad-sh/dyad/actions/runs/21896099089?pr=2524

#skip-bugbot

## Test plan
- [ ] Verify PR review workflow triggers on a new PR and doesn't hit the `/tmp/` file access error
- [ ] Confirm the swarm-pr-review skill posts a review summary comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2623" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched the CI PR review workflow to use swarm-pr-review and fixed the /tmp file access block in claude-code-action. Updated skill docs and git workflow rules to save PR diffs in the repo working directory (e.g., ./pr_diff.patch) instead of /tmp, resolving the “cat in '/tmp/pr_*_diff.patch' was blocked” error.

<sup>Written for commit 449c7b02b4bacad12a659177d1f6a4db949fc7ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

