### PR TITLE
fix: add missing createdAt to mid-turn compaction test messages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,10 +128,6 @@ In the AI SDK's `streamText`, `step.usage.totalTokens` in `onStepFinish` is **pe
 
 In `prepareStep`, the AI SDK sets `stepNumber = steps.length`. The first call has `steps = []` so `stepNumber = 0`, the second call has one step so `stepNumber = 1`, etc. When writing tests that mock `prepareStep`, use 0-indexed step numbers to match real SDK behavior.
 
-### Compaction test mock messages need createdAt
-
-`buildChatMessageHistory` and `getMidTurnCompactionSummaryIds` call `createdAt.getTime()` on chat messages to detect mid-turn compaction summaries. Test messages created via `buildTestChat` must include `createdAt` on every message (including mock compaction summaries added by `performCompaction`). Missing `createdAt` causes a silent TypeError inside the async generator that manifests as `undefined` return values rather than an obvious error.
-
 ### Custom chat message indicators
 
 The `<dyad-status>` tag in chat messages renders as a collapsible status indicator box. Use it for system messages like compaction notifications:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,10 @@ In the AI SDK's `streamText`, `step.usage.totalTokens` in `onStepFinish` is **pe
 
 In `prepareStep`, the AI SDK sets `stepNumber = steps.length`. The first call has `steps = []` so `stepNumber = 0`, the second call has one step so `stepNumber = 1`, etc. When writing tests that mock `prepareStep`, use 0-indexed step numbers to match real SDK behavior.
 
+### Compaction test mock messages need createdAt
+
+`buildChatMessageHistory` and `getMidTurnCompactionSummaryIds` call `createdAt.getTime()` on chat messages to detect mid-turn compaction summaries. Test messages created via `buildTestChat` must include `createdAt` on every message (including mock compaction summaries added by `performCompaction`). Missing `createdAt` causes a silent TypeError inside the async generator that manifests as `undefined` return values rather than an obvious error.
+
 ### Custom chat message indicators
 
 The `<dyad-status>` tag in chat messages renders as a collapsible status indicator box. Use it for system messages like compaction notifications:

--- a/src/__tests__/local_agent_handler.test.ts
+++ b/src/__tests__/local_agent_handler.test.ts
@@ -452,12 +452,21 @@ describe("handleLocalAgentStream", () => {
       // Arrange
       const { event, getMessagesByChannel } = createFakeEvent();
       mockSettings = buildTestSettings({ enableDyadPro: true });
+      const t0 = new Date("2025-01-01T00:00:00Z");
+      const t1 = new Date("2025-01-01T00:01:00Z");
+      const t2 = new Date("2025-01-01T00:02:00Z");
+      const t3 = new Date("2025-01-01T00:03:00Z");
       mockChatData = buildTestChat({
         messages: [
-          { id: 1, role: "user", content: "old context user" },
-          { id: 2, role: "assistant", content: "old context assistant" },
-          { id: 3, role: "user", content: "current task" },
-          { id: 10, role: "assistant", content: "" }, // placeholder
+          { id: 1, role: "user", content: "old context user", createdAt: t0 },
+          {
+            id: 2,
+            role: "assistant",
+            content: "old context assistant",
+            createdAt: t1,
+          },
+          { id: 3, role: "user", content: "current task", createdAt: t2 },
+          { id: 10, role: "assistant", content: "", createdAt: t3 }, // placeholder
         ],
       });
 
@@ -480,6 +489,7 @@ describe("handleLocalAgentStream", () => {
               content:
                 '<dyad-compaction title="Conversation compacted" state="finished">mid-turn summary</dyad-compaction>',
               isCompactionSummary: true,
+              createdAt: new Date("2025-01-01T00:03:30Z"),
             },
           ],
         } as any;
@@ -607,12 +617,21 @@ describe("handleLocalAgentStream", () => {
       // Arrange
       const { event } = createFakeEvent();
       mockSettings = buildTestSettings({ enableDyadPro: true });
+      const t0 = new Date("2025-01-01T00:00:00Z");
+      const t1 = new Date("2025-01-01T00:01:00Z");
+      const t2 = new Date("2025-01-01T00:02:00Z");
+      const t3 = new Date("2025-01-01T00:03:00Z");
       mockChatData = buildTestChat({
         messages: [
-          { id: 1, role: "user", content: "old context user" },
-          { id: 2, role: "assistant", content: "old context assistant" },
-          { id: 3, role: "user", content: "current task" },
-          { id: 10, role: "assistant", content: "" }, // placeholder
+          { id: 1, role: "user", content: "old context user", createdAt: t0 },
+          {
+            id: 2,
+            role: "assistant",
+            content: "old context assistant",
+            createdAt: t1,
+          },
+          { id: 3, role: "user", content: "current task", createdAt: t2 },
+          { id: 10, role: "assistant", content: "", createdAt: t3 }, // placeholder
         ],
       });
 
@@ -635,6 +654,7 @@ describe("handleLocalAgentStream", () => {
               content:
                 '<dyad-compaction title="Conversation compacted" state="finished">mid-turn summary</dyad-compaction>',
               isCompactionSummary: true,
+              createdAt: new Date("2025-01-01T00:03:30Z"),
             },
           ],
         } as any;


### PR DESCRIPTION
## Summary
- Two mid-turn compaction tests in `local_agent_handler.test.ts` were failing because mock messages lacked `createdAt` fields
- `buildChatMessageHistory` and `getMidTurnCompactionSummaryIds` call `createdAt.getTime()` to detect mid-turn compaction summaries, causing a silent TypeError inside the async generator
- Added `createdAt` timestamps to all mock messages and compaction summary messages in both tests

## Test plan
- [x] `npm test` passes (786/786 tests)
- [x] Both previously-failing mid-turn compaction tests now pass
- [x] Lint, formatting, and type checks all pass

#skip-bugbot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2624" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix failing mid-turn compaction tests by adding createdAt timestamps to mocked chat and summary messages. This prevents a silent TypeError in the async generator and restores test reliability.

- **Bug Fixes**
  - Added createdAt to all test messages (including compaction summaries) so buildChatMessageHistory and getMidTurnCompactionSummaryIds can safely call createdAt.getTime().

<sup>Written for commit b8c82c8f91110a274eeff29d7e7a16e4df65eec5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

