### PR TITLE
Update language model constants with latest configurations

### DIFF
--- a/src/ipc/shared/language_model_constants.ts
+++ b/src/ipc/shared/language_model_constants.ts
@@ -113,6 +113,17 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
   // https://docs.anthropic.com/en/docs/about-claude/models/all-models#model-comparison-table
   anthropic: [
     {
+      name: "claude-opus-4-6",
+      displayName: "Claude Opus 4.6",
+      description:
+        "Anthropic's best model for coding (note: this model is very expensive!)",
+      // Set to 32k since context window is 1M tokens
+      maxOutputTokens: 32_000,
+      contextWindow: 1_000_000,
+      temperature: 0,
+      dollarSigns: 6,
+    },
+    {
       name: "claude-opus-4-5",
       displayName: "Claude Opus 4.5",
       description:
@@ -218,6 +229,16 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
     },
   ],
   openrouter: [
+    {
+      name: "openrouter/free",
+      displayName: "Free (OpenRouter)",
+      description:
+        "Uses one of the free OpenRouter models (data may be used for training)",
+      maxOutputTokens: 32_000,
+      contextWindow: 200_000,
+      temperature: 0,
+      dollarSigns: 0,
+    },
     // https://openrouter.ai/moonshotai/kimi-k2.5
     {
       name: "moonshotai/kimi-k2.5",
@@ -229,27 +250,18 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
       dollarSigns: 2,
     },
     {
-      name: "qwen/qwen3-coder:free",
-      displayName: "Qwen3 Coder (free)",
-      description: "Use for free (data may be used for training)",
-      maxOutputTokens: 32_000,
-      contextWindow: 262_000,
-      temperature: 0,
-      dollarSigns: 0,
-    },
-    {
-      name: "mistralai/devstral-2512:free",
-      displayName: "Devstral 2 (free)",
-      description: "Use for free (data may be used for training)",
+      name: "z-ai/glm-5",
+      displayName: "GLM 5",
+      description: "Z-AI's best coding model",
       maxOutputTokens: 32_000,
       contextWindow: 200_000,
-      temperature: 0,
-      dollarSigns: 0,
+      temperature: 0.7,
+      dollarSigns: 2,
     },
     {
       name: "z-ai/glm-4.7",
       displayName: "GLM 4.7",
-      description: "Z-AI's best coding model",
+      description: "Z-AI's coding model",
       maxOutputTokens: 32_000,
       contextWindow: 200_000,
       temperature: 0.7,
@@ -270,16 +282,6 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
       description: "Strong cost-effective model with optional thinking",
       maxOutputTokens: 32_000,
       contextWindow: 128_000,
-      temperature: 0,
-      dollarSigns: 2,
-    },
-    // https://openrouter.ai/moonshotai/kimi-k2
-    {
-      name: "moonshotai/kimi-k2-0905",
-      displayName: "Kimi K2",
-      description: "Powerful cost-effective model (updated to 0905)",
-      maxOutputTokens: 32_000,
-      contextWindow: 256_000,
       temperature: 0,
       dollarSigns: 2,
     },
@@ -477,7 +479,9 @@ export const TURBO_MODELS: LanguageModel[] = [
 ];
 
 export const FREE_OPENROUTER_MODEL_NAMES = MODEL_OPTIONS.openrouter
-  .filter((model) => model.name.endsWith(":free"))
+  .filter(
+    (model) => model.name.endsWith(":free") || model.name.endsWith("/free"),
+  )
   .map((model) => model.name);
 
 export const PROVIDER_TO_ENV_VAR: Record<string, string> = {


### PR DESCRIPTION
## Summary
- Update language model constants with latest model configurations and pricing
- Add support for new model versions across multiple providers
- Improve model descriptions and configuration parameters

## Test plan
- Verify that the application loads with all model configurations
- Test model selection in the UI
- Confirm no TypeScript or lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily updates configuration/constants for model selection; main behavioral change is the expanded free-model name matching which could alter which OpenRouter models are used in fallback.
> 
> **Overview**
> Adds the new Anthropic model `claude-opus-4-6` (with updated token limits/pricing metadata) to the selectable model options.
> 
> Refreshes OpenRouter model options by introducing a generic `openrouter/free` entry, adding `z-ai/glm-5`, tweaking `glm-4.7` description, and removing older explicit free-model entries and `moonshotai/kimi-k2-0905`. Updates `FREE_OPENROUTER_MODEL_NAMES` to treat both `:free` and `/free` model names as free, which changes which models can be selected in the auto free fallback.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d192033357d87355a9d414269a19a348c3faef6d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated language model constants with the latest configs and pricing to keep model selection current. Adds new models and improves free model detection for OpenRouter.

- **New Features**
  - Added Claude Opus 4.6 (1M context, 32k max output).
  - Added OpenRouter “free” model and Z‑AI GLM 5; updated GLM 4.7 description.
  - Updated context windows, temperatures, and pricing; removed deprecated free entries and Kimi K2 0905.

- **Bug Fixes**
  - Free model detection now supports names ending with “/free” (not just “:free”).

<sup>Written for commit d192033357d87355a9d414269a19a348c3faef6d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

