### PR TITLE
Update Claude PR Review workflow configuration

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -24,6 +24,7 @@ jobs:
       github.event.pull_request.user.login == 'azizmejri1' ||
       github.event.pull_request.user.login == 'princeaden1'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary
- Update claude-pr-review.yml with latest configuration
- Adjust settings for improved PR review automation

## Changes
- Modified `.github/workflows/claude-pr-review.yml` with updated configuration

## Test plan
- Workflow configuration has been validated by lint checks
- No breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2640" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that limits job runtime; low risk beyond possibly timing out unusually long review runs.
> 
> **Overview**
> Adds a 30-minute `timeout-minutes` to the `claude-review` job in `.github/workflows/claude-pr-review.yml` to prevent the automated PR review workflow from running indefinitely.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75736d6b53a2104d2fe2a030dc0101aabc72f6c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set a 30-minute timeout for the Claude PR Review GitHub Actions job to prevent runaway runs and improve reliability. Added timeout-minutes: 30 to .github/workflows/claude-pr-review.yml; no functional changes to triggers or permissions.

<sup>Written for commit 75736d6b53a2104d2fe2a030dc0101aabc72f6c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

