### PR TITLE
Add ci2 runner to nightly cleanup workflow

### DIFF
--- a/.github/workflows/nightly-runner-cleanup.yml
+++ b/.github/workflows/nightly-runner-cleanup.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   cleanup:
     strategy:
+      fail-fast: false
       matrix:
         runner: [ci1, ci2]
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/nightly-runner-cleanup.yml
+++ b/.github/workflows/nightly-runner-cleanup.yml
@@ -12,25 +12,15 @@ on:
 
 jobs:
   cleanup:
-    runs-on: [self-hosted, macOS, ARM64]
+    strategy:
+      matrix:
+        runner: [ci1, ci2]
+    runs-on: ${{ matrix.runner }}
     steps:
-      - name: Guard — run only on ci1 or ci2
-        id: guard
-        run: |
-          if [ "$RUNNER_NAME" = "ci1" ] || [ "$RUNNER_NAME" = "ci2" ]; then
-            echo "run_cleanup=true" >> "$GITHUB_OUTPUT"
-            echo "Running cleanup on runner: $RUNNER_NAME"
-          else
-            echo "run_cleanup=false" >> "$GITHUB_OUTPUT"
-            echo "Skipping cleanup: runner is '$RUNNER_NAME', expected ci1 or ci2"
-          fi
-
       - name: Checkout (for cleanup script)
-        if: steps.guard.outputs.run_cleanup == 'true'
         uses: actions/checkout@v4
 
       - name: Nightly disk cleanup
-        if: steps.guard.outputs.run_cleanup == 'true'
         env:
           CI_NIGHTLY_CLEANUP: "1"
         run: bash scripts/ci-cleanup-macos.sh

--- a/.github/workflows/nightly-runner-cleanup.yml
+++ b/.github/workflows/nightly-runner-cleanup.yml
@@ -1,4 +1,4 @@
-# Nightly disk cleanup for self-hosted macOS CI runners (e.g. ci1).
+# Nightly disk cleanup for self-hosted macOS CI runners (ci1, ci2).
 # Runs at 4:00 AM PST to prevent disk exhaustion from CI workloads.
 # Safe to run manually via workflow_dispatch for testing.
 
@@ -14,15 +14,15 @@ jobs:
   cleanup:
     runs-on: [self-hosted, macOS, ARM64]
     steps:
-      - name: Guard — run only on ci1
+      - name: Guard — run only on ci1 or ci2
         id: guard
         run: |
-          if [ "$RUNNER_NAME" = "ci1" ]; then
+          if [ "$RUNNER_NAME" = "ci1" ] || [ "$RUNNER_NAME" = "ci2" ]; then
             echo "run_cleanup=true" >> "$GITHUB_OUTPUT"
             echo "Running cleanup on runner: $RUNNER_NAME"
           else
             echo "run_cleanup=false" >> "$GITHUB_OUTPUT"
-            echo "Skipping cleanup: runner is '$RUNNER_NAME', expected ci1"
+            echo "Skipping cleanup: runner is '$RUNNER_NAME', expected ci1 or ci2"
           fi
 
       - name: Checkout (for cleanup script)


### PR DESCRIPTION
## Summary
- Extend the nightly disk cleanup workflow to run on both ci1 and ci2 self-hosted macOS runners
- Update the guard step to accept ci2 as a valid runner name

## Test plan
- Verify the workflow file syntax is correct
- The nightly cleanup will run on both ci1 and ci2 runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2645" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend the nightly disk cleanup to run on both ci1 and ci2 using a strategy matrix with fail-fast: false so each runner executes independently. Removed the guard step and related conditions, and updated comments to reflect both runners.

<sup>Written for commit d1a2a3d4d8d1392960aabf536afb152a9db89698. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI workflow change that only affects scheduled cleanup execution on self-hosted runners; main risk is increased load or unexpected cleanup behavior now running on `ci2` as well.
> 
> **Overview**
> Expands the nightly macOS runner disk cleanup workflow to run on both self-hosted runners `ci1` and `ci2` by switching the job to a matrix strategy and targeting `runs-on: ${{ matrix.runner }}`.
> 
> Removes the previous runner-name guard and conditional step execution so the cleanup script always runs for each matrix runner invocation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1a2a3d4d8d1392960aabf536afb152a9db89698. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->