### PR TITLE
Relax shell injection checks in permission hooks

### DIFF
--- a/.claude/hooks/tests/good_commands.txt
+++ b/.claude/hooks/tests/good_commands.txt
@@ -765,6 +765,16 @@ gh api repos/$(gh repo view --json nameWithOwner -q .nameWithOwner)/pulls/2524/c
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner) && gh api "repos/${REPO}/pulls/2524/comments" --paginate | jq -r '.[].body' 2>/dev/null | head -200
 
 # =============================================================================
+# SAFE $(cat ...) SUBCOMMAND PATTERNS (passthrough - cat is read-only)
+# =============================================================================
+
+# Loading GraphQL query from file into gh api graphql argument
+gh api graphql -F owner=dyad-sh -F repo=dyad -F pr=2284 -f query="$(cat /tmp/pr_threads_query.graphql)" > /tmp/all_threads.json
+# Note: $(cat ...) is recognized as safe (read-only command) and neutralized before
+# shell injection checking. The > redirect doesn't match any injection pattern either
+# (only >( process substitution does). This command passes as a passthrough.
+
+# =============================================================================
 # GH ISSUE COMMANDS WITH SHELL METACHARACTERS (allowed - common workflow patterns)
 # =============================================================================
 

--- a/.claude/hooks/tests/python_good_commands.txt
+++ b/.claude/hooks/tests/python_good_commands.txt
@@ -96,3 +96,9 @@ python -W ignore -X dev .claude/script.py
 python -- .claude/script.py
 python3 -- .claude/script.py
 python -u -- .claude/script.py
+
+# =============================================================================
+# PIPES TO SAFE COMMANDS
+# =============================================================================
+
+python .claude/script.py | cat

--- a/.claude/hooks/tests/python_passthrough_commands.txt
+++ b/.claude/hooks/tests/python_passthrough_commands.txt
@@ -56,3 +56,7 @@ python3 -m pytest ./tests
 # Pytest with options and paths
 python -m pytest -v tests/
 python3 -m pytest --tb=short tests/unit/
+
+# Pytest with pipes and redirects (common for test output formatting)
+python -m pytest .claude/hooks/tests/test_gh_permission_hook.py -v 2>&1
+python -m pytest .claude/hooks/tests/test_gh_permission_hook.py -v 2>&1 | tail -60

--- a/.claude/hooks/tests/python_security_blocked_commands.txt
+++ b/.claude/hooks/tests/python_security_blocked_commands.txt
@@ -19,7 +19,7 @@ python .claude/script.py || malicious_command
 python3 .claude/script.py || rm -rf /
 
 # Pipe to another command
-python .claude/script.py | cat
+# Note: python .claude/script.py | cat moved to good_commands (cat is safe)
 python3 .claude/script.py | sh
 
 # Background + another command


### PR DESCRIPTION
## Summary
- Add `$(cat ...)` as a safe command substitution pattern in the gh permission hook, allowing commands like `gh api graphql -f query="$(cat /tmp/query.graphql)" > /tmp/output.json` to passthrough instead of being blocked
- Add safe pipe and redirect handling to the python permission hook, allowing pytest commands with `2>&1 | tail` output formatting patterns
- Move `| cat` from blocked to allowed in python hook tests since `cat` is a safe read-only command

#skip-bugbot

## Test plan
- [x] All gh permission hook tests pass (572 good commands, 406 bad commands)
- [x] All python permission hook tests pass (good, bad, passthrough, security-blocked)
- [x] npm test passes (803 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2653" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Relaxed shell injection checks in GH and Python permission hooks to allow common read-only patterns like $(cat ...), pipes to safe tools, and simple redirects. This reduces false blocks while keeping unsafe substitutions and pipelines guarded.

- **Bug Fixes**
  - GH hook: treat $(cat ...) as a safe command substitution and neutralize it before checks.
  - Python hook: allow pipes to common text tools (e.g., tail, grep, cat) and redirects like 2>&1 and >/dev/null.
  - Tests: move python `| cat` to allowed; add cases for gh `$(cat ...)` and pytest `2>&1 | tail`.

<sup>Written for commit b1695c6e09bdc58288197ae2ab79745947fcca59. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

