### PR TITLE
fix: add retry logic to npm ci for Windows CI flakiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,17 @@ jobs:
       - name: Install npm 11.8.0
         run: npm install -g npm@11.8.0
       - name: Install node modules
-        run: npm ci --no-audit --no-fund --progress=false
+        run: |
+          for i in 1 2 3; do
+            if npm ci --no-audit --no-fund --progress=false; then
+              exit 0
+            fi
+            echo "npm ci attempt $i failed, retrying in 10s..."
+            sleep 10
+            rm -rf node_modules || true
+          done
+          echo "npm ci failed after 3 attempts"
+          exit 1
         env:
           # Required for @vscode/ripgrep to download binaries without hitting GitHub API rate limits
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -228,7 +238,17 @@ jobs:
       - name: Install npm 11.8.0
         run: npm install -g npm@11.8.0
       - name: Install node modules
-        run: npm ci --no-audit --no-fund --progress=false
+        run: |
+          for i in 1 2 3; do
+            if npm ci --no-audit --no-fund --progress=false; then
+              exit 0
+            fi
+            echo "npm ci attempt $i failed, retrying in 10s..."
+            sleep 10
+            rm -rf node_modules || true
+          done
+          echo "npm ci failed after 3 attempts"
+          exit 1
         env:
           # Required for @vscode/ripgrep to download binaries without hitting GitHub API rate limits
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,17 +153,7 @@ jobs:
       - name: Install npm 11.8.0
         run: npm install -g npm@11.8.0
       - name: Install node modules
-        run: |
-          for i in 1 2 3; do
-            if npm ci --no-audit --no-fund --progress=false; then
-              exit 0
-            fi
-            echo "npm ci attempt $i failed, retrying in 10s..."
-            sleep 10
-            rm -rf node_modules || true
-          done
-          echo "npm ci failed after 3 attempts"
-          exit 1
+        run: bash scripts/npm-ci-retry.sh
         env:
           # Required for @vscode/ripgrep to download binaries without hitting GitHub API rate limits
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -238,17 +228,7 @@ jobs:
       - name: Install npm 11.8.0
         run: npm install -g npm@11.8.0
       - name: Install node modules
-        run: |
-          for i in 1 2 3; do
-            if npm ci --no-audit --no-fund --progress=false; then
-              exit 0
-            fi
-            echo "npm ci attempt $i failed, retrying in 10s..."
-            sleep 10
-            rm -rf node_modules || true
-          done
-          echo "npm ci failed after 3 attempts"
-          exit 1
+        run: bash scripts/npm-ci-retry.sh
         env:
           # Required for @vscode/ripgrep to download binaries without hitting GitHub API rate limits
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/npm-ci-retry.sh
+++ b/scripts/npm-ci-retry.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# npm-ci-retry.sh
+# Retry npm ci up to 3 times to handle intermittent EBUSY/EPERM errors on Windows.
+# These errors are caused by file locking from antivirus or indexing services.
+
+set -e
+
+MAX_ATTEMPTS=3
+RETRY_DELAY=10
+
+for i in $(seq 1 $MAX_ATTEMPTS); do
+  if npm ci --no-audit --no-fund --progress=false; then
+    exit 0
+  fi
+  echo "npm ci attempt $i failed, retrying in ${RETRY_DELAY}s..."
+  sleep $RETRY_DELAY
+  rm -rf node_modules || true
+done
+
+echo "npm ci failed after $MAX_ATTEMPTS attempts"
+exit 1


### PR DESCRIPTION
## Summary
- Windows CI builds intermittently fail during `npm ci` with `EBUSY`/`EPERM` errors caused by file locking (antivirus, indexing services)
- Added a 3-attempt retry loop with 10s delay and `node_modules` cleanup between attempts
- Applied to both the `build` and `e2e-tests` jobs in the CI workflow

## Test plan
- [x] Lint passes
- [x] Type checks pass
- [x] Unit tests pass (810/810)
- Verify the next Windows CI run completes the `npm ci` step successfully

#skip-bugbot

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add retry logic to npm ci on Windows runners to handle intermittent EBUSY/EPERM file locks. This stabilizes the build and e2e-tests jobs.

- **Bug Fixes**
  - Retry npm ci up to 3 times with a 10s delay.
  - Clean node_modules between attempts.
  - Implemented via scripts/npm-ci-retry.sh and applied to both build and e2e-tests jobs.

<sup>Written for commit 79bc6ede3b90db4068369e59853144170547aaf0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2657" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
