### PR TITLE
Fix CI build by updating Node version specification in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
-          node-version: 20
+          node-version-file: package.json
       - name: Install npm 11.8.0
         run: npm install -g npm@11.8.0
       - run: npm ci
@@ -170,7 +170,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
-          node-version: 20
+          node-version-file: package.json
       - name: Verify all release assets are uploaded
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Updated node-version to node-version-file: package.json in release workflow
- Allows the CI build to use Node >= 24 as required by project dependencies
- Fixes the automated release build process

## Test plan
- The release workflow will be tested on the next release trigger
- Verify that the workflow can access the Node version from package.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2658" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failing release CI by reading the Node version from package.json instead of hardcoding v20, so the workflow uses Node 24+ and the release build runs again.

- **Bug Fixes**
  - Switched actions/setup-node to node-version-file: package.json in two release jobs.
  - Ensures CI uses the repo’s Node version (24+) and unblocks automated releases.

<sup>Written for commit f062289452ced8dbb62b47530ad0e98299d80a10. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that adjusts runtime version selection; low risk outside of potential CI environment differences if `package.json` engines is misconfigured.
> 
> **Overview**
> Updates the GitHub Release workflow to source the Node version from `package.json` (via `node-version-file`) instead of hardcoding `node-version: 20` for both the build matrix and the `verify-assets` job.
> 
> This aligns release CI with the repo’s declared Node engine requirement and avoids failures when dependencies require a newer Node than the previously pinned value.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f062289452ced8dbb62b47530ad0e98299d80a10. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->