### PR TITLE
Make title bar more easy to drag / move MacOs controls to more standard

### DIFF
--- a/src/app/TitleBar.tsx
+++ b/src/app/TitleBar.tsx
@@ -78,10 +78,10 @@ export const TitleBar = () => {
 
   return (
     <>
-      <div className="@container z-11 w-full h-11 bg-(--sidebar) absolute top-0 left-0 app-region-drag flex items-center">
+      <div className="@container z-11 w-full h-11 pt-3 bg-(--sidebar) absolute top-0 left-0 app-region-drag flex items-center">
         <div className={`${showWindowControls ? "pl-2" : "pl-18"}`}></div>
 
-        <img src={logo} alt="Dyad Logo" className="w-6 h-6 mr-0.5" />
+        <img src={logo} alt="Dyad Logo" className="w-6 h-6 mr-0.5 ml-2" />
         <Button
           data-testid="title-bar-app-name-button"
           variant="outline"

--- a/src/main.ts
+++ b/src/main.ts
@@ -202,8 +202,8 @@ const createWindow = () => {
     titleBarStyle: "hidden",
     titleBarOverlay: false,
     trafficLightPosition: {
-      x: 10,
-      y: 8,
+      x: 13,
+      y: 13,
     },
     webPreferences: {
       nodeIntegration: false,


### PR DESCRIPTION
#skip-bb
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2660" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made the title bar easier to drag and aligned macOS window controls to a more standard position. Added top padding and slight logo offset; moved the traffic lights to x=13, y=13 for a more native look.

<sup>Written for commit 0acfcdd974fba70dd9ad025fb664397d2c4a2c86. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

