### PR TITLE
Improve release workflow: use NuGet for Azure Trusted Signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,32 +51,13 @@ jobs:
         if: contains(matrix.os.name, 'windows')
         shell: powershell
         run: |
-          winget install -e --id Microsoft.Azure.TrustedSigningClientTools --source winget --accept-source-agreements --accept-package-agreements
+          # Install via NuGet instead of winget (winget is slow/unreliable in CI)
+          $installDir = "$env:RUNNER_TEMP\TrustedSigning"
+          nuget install Microsoft.Trusted.Signing.Client -Version 1.0.95 -OutputDirectory $installDir -Source https://api.nuget.org/v3/index.json
 
-          $known = Join-Path $env:LOCALAPPDATA "Microsoft\MicrosoftTrustedSigningClientTools\Azure.CodeSigning.Dlib.dll"
-          $dllPath = $null
-
-          if (Test-Path $known) {
-            $dllPath = $known
-          } else {
-            $searchPaths = @(
-              (Join-Path $env:LOCALAPPDATA "Microsoft\MicrosoftTrustedSigningClientTools"),
-              "C:\Program Files",
-              "$env:LOCALAPPDATA",
-              "$env:LOCALAPPDATA\Microsoft\WinGet\Packages",
-              "C:\Users\runneradmin\AppData\Local\Microsoft\WinGet\Packages"
-            )
-
-            foreach ($searchPath in $searchPaths) {
-              if (Test-Path $searchPath) {
-                Write-Host "Searching in: $searchPath"
-                $found = Get-ChildItem -Path $searchPath -Recurse -Filter "Azure.CodeSigning.Dlib.dll" -ErrorAction SilentlyContinue |
-                  Sort-Object { $_.FullName -notlike "*x64*" } |
-                  Select-Object -First 1 -ExpandProperty FullName
-                if ($found) { $dllPath = $found; break }
-              }
-            }
-          }
+          $dllPath = Get-ChildItem -Path $installDir -Recurse -Filter "Azure.CodeSigning.Dlib.dll" |
+            Where-Object { $_.FullName -match "x64" } |
+            Select-Object -First 1 -ExpandProperty FullName
 
           if ($dllPath) {
             Write-Host "Found DLL at: $dllPath"


### PR DESCRIPTION
## Summary
- Replace unreliable winget installation with NuGet installation for Azure Trusted Signing tools
- Simplify DLL discovery logic to use direct NuGet installation path
- Makes Windows signing step more robust and reliable

## Test plan
- Verify that the release workflow still builds successfully on Windows runners
- Confirm Azure Trusted Signing client is installed and used correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2661" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the Windows release workflow to use NuGet for Azure Trusted Signing and simplify DLL discovery to the NuGet install path. This reduces CI flakiness and makes the signing step more reliable.

- **Refactors**
  - Install Microsoft.Trusted.Signing.Client 1.0.95 to $RUNNER_TEMP\TrustedSigning from nuget.org.
  - Find Azure.CodeSigning.Dlib.dll (x64) by scanning the install directory only.

<sup>Written for commit 0dd327769005b7890b31d782bf07f66a4912406b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that alters how Windows signing dependencies are installed and discovered; risk is limited to potential release pipeline breakage if the NuGet package layout/version changes.
> 
> **Overview**
> Improves the Windows portion of the release workflow by installing Azure Trusted Signing tooling via `nuget` (pinned to `Microsoft.Trusted.Signing.Client` `1.0.95`) instead of `winget`.
> 
> Simplifies DLL discovery by searching only within the NuGet install directory for the x64 `Azure.CodeSigning.Dlib.dll`, then exporting `AZURE_CODE_SIGNING_DLIB` for subsequent signing steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0dd327769005b7890b31d782bf07f66a4912406b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->