### PR TITLE
Add product principles guidance to PR fix skills

### DIFF
--- a/.claude/skills/pr-fix/SKILL.md
+++ b/.claude/skills/pr-fix/SKILL.md
@@ -15,6 +15,10 @@ Address all outstanding issues on a GitHub Pull Request by handling both review 
 
 **You MUST use the TaskCreate and TaskUpdate tools to track your progress.** At the start, create tasks for each step below. Mark each task as `in_progress` when you start it and `completed` when you finish. This ensures you complete ALL steps.
 
+## Product Principles
+
+When making decisions about review comments, consult `rules/product-principles.md`. Use these principles to resolve ambiguous or subjective feedback autonomously. Only flag issues for human attention when the product principles do not provide enough guidance to make a decision.
+
 ## Instructions
 
 This is a meta-skill that orchestrates two sub-skills to comprehensively fix PR issues.
@@ -22,7 +26,8 @@ This is a meta-skill that orchestrates two sub-skills to comprehensively fix PR 
 1. **Run `/dyad:pr-fix:comments`** to handle all unresolved review comments:
    - Address valid code review concerns
    - Resolve invalid concerns with explanations
-   - Flag ambiguous issues for human attention
+   - Use product principles to resolve ambiguous feedback autonomously
+   - Only flag issues for human attention when product principles are insufficient to decide
 
 2. **Run `/dyad:pr-fix:actions`** to handle failing CI checks:
    - Fix failing tests (unit and E2E)


### PR DESCRIPTION
## Summary
- Updates pr-fix-comments skill to leverage product principles for resolving ambiguous feedback
- Introduces 'Resolved by product principles' category to reduce human review burden
- Adds guidance for citing principles in replies and flagging when insufficient
- Enhances pr-fix meta-skill documentation on product principles usage

## Test plan
1. Verify that the updated skill documentation is accessible and clear
2. Review the new guidance on consulting rules/product-principles.md
3. Confirm the categorization options are correctly documented
4. Check that the reply examples include proper principle citations

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2674" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
