### PR TITLE
Deprecate "agent" chat mode, migrate to "build" on read

### DIFF
--- a/rules/adding-settings.md
+++ b/rules/adding-settings.md
@@ -2,8 +2,17 @@
 
 When adding a new toggle/setting to the Settings page:
 
-1. Add the field to `UserSettingsSchema` in `src/lib/schemas.ts`
+1. Add the field to `UserSettingsSchema` **and** `StoredUserSettingsSchema` in `src/lib/schemas.ts`
 2. Add the default value in `DEFAULT_SETTINGS` in `src/main/settings.ts`
 3. Add a `SETTING_IDS` entry and search index entry in `src/lib/settingsSearchIndex.ts`
 4. Create a switch component (e.g., `src/components/MySwitch.tsx`) - follow `AutoApproveSwitch.tsx` as a template
 5. Import and add the switch to the relevant section in `src/pages/settings.tsx`
+
+## Schema split: Stored vs Active
+
+Settings has two schemas:
+
+- **`StoredUserSettingsSchema`** — includes deprecated fields (e.g., `"agent"` chat mode). Used for reading/writing the JSON file on disk so old settings files still parse.
+- **`UserSettingsSchema`** — active fields only (no deprecated values). Used at runtime throughout the app.
+
+`readSettings()` parses with `StoredUserSettingsSchema`, migrates deprecated values (e.g., `"agent"` → `"build"`), and returns `UserSettings`. When deprecating a field or enum value, add the migration in `readSettings()` and keep the old value in `StoredUserSettingsSchema` only.

--- a/src/__tests__/readSettings.test.ts
+++ b/src/__tests__/readSettings.test.ts
@@ -116,6 +116,32 @@ describe("readSettings", () => {
       expect(result.releaseChannel).toBe("stable");
     });
 
+    it("should migrate selectedChatMode 'agent' to 'build'", () => {
+      const mockFileContent = {
+        selectedChatMode: "agent",
+      };
+
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readFileSync.mockReturnValue(JSON.stringify(mockFileContent));
+
+      const result = readSettings();
+
+      expect(result.selectedChatMode).toBe("build");
+    });
+
+    it("should migrate defaultChatMode 'agent' to 'build'", () => {
+      const mockFileContent = {
+        defaultChatMode: "agent",
+      };
+
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readFileSync.mockReturnValue(JSON.stringify(mockFileContent));
+
+      const result = readSettings();
+
+      expect(result.defaultChatMode).toBe("build");
+    });
+
     it("should decrypt encrypted provider API keys", () => {
       const mockFileContent = {
         providerSettings: {

--- a/src/components/ChatInputControls.tsx
+++ b/src/components/ChatInputControls.tsx
@@ -17,12 +17,11 @@ export function ChatInputControls({
 
   // Show MCP tools picker when:
   // 1. The enableMcpServersForBuildMode experiment is on AND
-  // 2. Mode is "agent" (backwards compatibility) OR
-  //    mode is "build" AND there are enabled MCP servers
+  // 2. Mode is "build" AND there are enabled MCP servers
   const showMcpToolsPicker =
     !!settings?.enableMcpServersForBuildMode &&
-    (settings?.selectedChatMode === "agent" ||
-      (settings?.selectedChatMode === "build" && enabledMcpServersCount > 0));
+    settings?.selectedChatMode === "build" &&
+    enabledMcpServersCount > 0;
 
   return (
     <div className="flex items-center">

--- a/src/components/ChatModeSelector.tsx
+++ b/src/components/ChatModeSelector.tsx
@@ -40,9 +40,7 @@ export function ChatModeSelector() {
   const chatId = routerState.location.search.id as number | undefined;
   const currentChatMessages = chatId ? (messagesById.get(chatId) ?? []) : [];
 
-  // Treat "agent" mode as "build" for UI purposes (backwards compatibility)
-  const rawSelectedMode = settings?.selectedChatMode || "build";
-  const selectedMode = rawSelectedMode === "agent" ? "build" : rawSelectedMode;
+  const selectedMode = settings?.selectedChatMode || "build";
   const isProEnabled = settings ? isDyadProEnabled(settings) : false;
   const { messagesRemaining, isQuotaExceeded } = useFreeAgentQuota();
   const { servers } = useMcp();
@@ -83,7 +81,6 @@ export function ChatModeSelector() {
   const getModeDisplayName = (mode: ChatMode) => {
     switch (mode) {
       case "build":
-      case "agent": // backwards compatibility - treat as build
         return "Build";
       case "ask":
         return "Ask";
@@ -100,7 +97,6 @@ export function ChatModeSelector() {
   const getModeIcon = (mode: ChatMode) => {
     switch (mode) {
       case "build":
-      case "agent":
         return <Hammer size={14} />;
       case "ask":
         return <MessageCircle size={14} />;

--- a/src/components/DefaultChatModeSelector.tsx
+++ b/src/components/DefaultChatModeSelector.tsx
@@ -38,7 +38,6 @@ export function DefaultChatModeSelector() {
   const getModeDisplayName = (mode: ChatMode) => {
     switch (mode) {
       case "build":
-      case "agent": // backwards compatibility - treat as build
         return "Build";
       case "local-agent":
         return isProEnabled ? "Agent" : "Basic Agent";

--- a/src/hooks/useChatModeToggle.ts
+++ b/src/hooks/useChatModeToggle.ts
@@ -20,17 +20,12 @@ export function useChatModeToggle() {
     [isMac],
   );
 
-  // Function to toggle between chat modes (skipping deprecated "agent" mode)
   const toggleChatMode = useCallback(() => {
     if (!settings || !settings.selectedChatMode) return;
 
     const currentMode = settings.selectedChatMode;
-    // Filter out deprecated "agent" mode from toggle cycle
-    const modes = ChatModeSchema.options.filter((m) => m !== "agent");
-    // If current mode is "agent", treat it as "build" for indexing
-    const effectiveCurrentMode =
-      currentMode === "agent" ? "build" : currentMode;
-    const currentIndex = modes.indexOf(effectiveCurrentMode);
+    const modes = ChatModeSchema.options;
+    const currentIndex = modes.indexOf(currentMode);
     const newMode = modes[(currentIndex + 1) % modes.length];
 
     updateSettings({ selectedChatMode: newMode });

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -685,10 +685,7 @@ ${componentSnippet}
 
         let systemPrompt = constructSystemPrompt({
           aiRules,
-          chatMode:
-            settings.selectedChatMode === "agent"
-              ? "build"
-              : settings.selectedChatMode,
+          chatMode: settings.selectedChatMode,
           enableTurboEditsV2: isTurboEditsV2Enabled(settings),
           themePrompt,
           basicAgentMode: isBasicAgentMode(settings),
@@ -1204,18 +1201,15 @@ This conversation includes one or more image attachments. When the user uploads 
 
         // Use MCP agent code path if:
         // 1. The enableMcpServersForBuildMode experiment is on AND
-        // 2. Mode is explicitly "agent" (backwards compatibility for existing settings)
-        //    OR mode is "build" AND there are enabled MCP servers
+        // 2. Mode is "build" AND there are enabled MCP servers
         if (
           settings.enableMcpServersForBuildMode &&
-          (settings.selectedChatMode === "agent" ||
-            settings.selectedChatMode === "build")
+          settings.selectedChatMode === "build"
         ) {
           const tools = await getMcpTools(event);
           const hasEnabledMcpServers = Object.keys(tools).length > 0;
 
-          // Only run MCP agent path if mode is "agent" OR if build mode has enabled MCP servers
-          if (settings.selectedChatMode === "agent" || hasEnabledMcpServers) {
+          if (hasEnabledMcpServers) {
             const { fullStream } = await simpleStreamText({
               chatMessages: limitedHistoryChatMessages,
               modelClient,
@@ -1232,7 +1226,7 @@ This conversation includes one or more image attachments. When the user uploads 
                 aiRules: await readAiRules(
                   getDyadAppPath(updatedChat.app.path),
                 ),
-                chatMode: "agent",
+                chatMode: "build",
                 enableTurboEditsV2: false,
               }),
               files: files,

--- a/src/ipc/handlers/token_count_handlers.ts
+++ b/src/ipc/handlers/token_count_handlers.ts
@@ -68,7 +68,6 @@ export function registerTokenCountHandlers() {
       let systemPrompt = constructSystemPrompt({
         aiRules: await readAiRules(getDyadAppPath(chat.app.path)),
         chatMode:
-          settings.selectedChatMode === "agent" ||
           settings.selectedChatMode === "local-agent"
             ? "build"
             : settings.selectedChatMode,

--- a/src/prompts/system_prompt.ts
+++ b/src/prompts/system_prompt.ts
@@ -453,58 +453,6 @@ IF YOU USE ANY OF THESE TAGS, YOU WILL BE FIRED.
 
 Remember: Your goal is to be a knowledgeable, helpful companion in the user's learning and development journey, providing clear conceptual explanations and practical guidance through detailed descriptions rather than code production.`;
 
-const AGENT_MODE_SYSTEM_PROMPT = `
-You are an AI App Builder Agent. Your role is to analyze app development requests and gather all necessary information before the actual coding phase begins.
-
-## Core Mission
-Determine what tools, APIs, data, or external resources are needed to build the requested application. Prepare everything needed for successful app development without writing any code yourself.
-
-## Tool Usage Decision Framework
-
-### Use Tools When The App Needs:
-- **External APIs or services** (payment processing, authentication, maps, social media, etc.)
-- **Real-time data** (weather, stock prices, news, current events)
-- **Third-party integrations** (Firebase, Supabase, cloud services)
-- **Current framework/library documentation** or best practices
-
-### Use Tools To Research:
-- Available APIs and their documentation
-- Authentication methods and implementation approaches  
-- Database options and setup requirements
-- UI/UX frameworks and component libraries
-- Deployment platforms and requirements
-- Performance optimization strategies
-- Security best practices for the app type
-
-### When Tools Are NOT Needed
-If the app request is straightforward and can be built with standard web technologies without external dependencies, respond with:
-
-**"Ok, looks like I don't need any tools, I can start building."**
-
-This applies to simple apps like:
-- Basic calculators or converters
-- Simple games (tic-tac-toe, memory games)
-- Static information displays
-- Basic form interfaces
-- Simple data visualization with static data
-
-## Critical Constraints
-
-- ABSOLUTELY NO CODE GENERATION
-- **Never write HTML, CSS, JavaScript, TypeScript, or any programming code**
-- **Do not create component examples or code snippets**  
-- **Do not provide implementation details or syntax**
-- **Do not use <dyad-write>, <dyad-edit>, <dyad-add-dependency> OR ANY OTHER <dyad-*> tags**
-- Your job ends with information gathering and requirement analysis
-- All actual development happens in the next phase
-
-## Output Structure
-
-When tools are used, provide a brief human-readable summary of the information gathered from the tools.
-
-When tools are not used, simply state: **"Ok, looks like I don't need any tools, I can start building."**
-`;
-
 export const constructSystemPrompt = ({
   aiRules,
   chatMode = "build",
@@ -514,7 +462,7 @@ export const constructSystemPrompt = ({
   basicAgentMode,
 }: {
   aiRules: string | undefined;
-  chatMode?: "build" | "ask" | "agent" | "local-agent" | "plan";
+  chatMode?: "build" | "ask" | "local-agent" | "plan";
   enableTurboEditsV2: boolean;
   themePrompt?: string;
   /** If true, use read-only mode for local-agent (ask mode with tools) */
@@ -554,12 +502,9 @@ export const getSystemPromptForChatMode = ({
   chatMode,
   enableTurboEditsV2,
 }: {
-  chatMode: "build" | "ask" | "agent";
+  chatMode: "build" | "ask";
   enableTurboEditsV2: boolean;
 }) => {
-  if (chatMode === "agent") {
-    return AGENT_MODE_SYSTEM_PROMPT;
-  }
   if (chatMode === "ask") {
     return ASK_MODE_SYSTEM_PROMPT;
   }


### PR DESCRIPTION
## Summary
- Split `UserSettingsSchema` into `StoredUserSettingsSchema` (disk format, includes deprecated fields) and `UserSettingsSchema` (runtime, active fields only)
- Split `ChatModeSchema` into `StoredChatModeSchema` (includes `"agent"`) and `ChatModeSchema` (excludes `"agent"`)
- `readSettings()` now parses with `StoredUserSettingsSchema` and migrates `"agent"` → `"build"` for both `selectedChatMode` and `defaultChatMode`
- Removed all runtime `"agent"` backwards-compatibility checks from UI components, IPC handlers, and system prompt construction
- Removed dead `AGENT_MODE_SYSTEM_PROMPT` constant
- Added migration tests for `"agent"` → `"build"` in `readSettings.test.ts`
- Updated `rules/adding-settings.md` with schema split documentation

## Test plan
- [x] `npm run ts` passes (no type errors)
- [x] All 812 unit tests pass
- [x] Settings files with `"agent"` chat mode are migrated to `"build"` on read (covered by new tests)

#skip-bugbot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2677" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
