### PR TITLE
fix: deflake E2E tests (setup_flow, chat_history, Navigation)

### DIFF
--- a/e2e-tests/chat_history.spec.ts
+++ b/e2e-tests/chat_history.spec.ts
@@ -41,8 +41,10 @@ test("should open, navigate, and select from history menu", async ({ po }) => {
   await expect(firstItem).toContainText("First test message");
 
   // Navigate up again to wrap to last item (newest message)
+  // Wait briefly to ensure the previous navigation state has settled
+  await po.page.waitForTimeout(100);
   await po.page.keyboard.press("ArrowUp");
-  await expect(lastItem).toHaveClass(/bg-accent/);
+  await expect(lastItem).toHaveClass(/bg-accent/, { timeout: Timeout.MEDIUM });
 
   // Select with Enter (selects newest message)
   await po.page.keyboard.press("Enter");

--- a/e2e-tests/helpers/page-objects/components/Navigation.ts
+++ b/e2e-tests/helpers/page-objects/components/Navigation.ts
@@ -17,7 +17,9 @@ export class Navigation {
   }
 
   async goToAppsTab() {
-    await this.page.getByRole("link", { name: "Apps" }).click();
+    const appsLink = this.page.getByRole("link", { name: "Apps" });
+    await expect(appsLink).toBeVisible({ timeout: 60000 });
+    await appsLink.click();
     await expect(this.page.getByText("Build a new app")).toBeVisible();
   }
 

--- a/e2e-tests/setup_flow.spec.ts
+++ b/e2e-tests/setup_flow.spec.ts
@@ -40,6 +40,7 @@ testSetup.describe("Setup Flow", () => {
     // Start with Node.js not installed
     await po.setNodeMock(false);
     await po.page.reload();
+    await po.page.waitForLoadState("domcontentloaded");
 
     // Verify setup banner and install button are visible
     await expect(
@@ -47,7 +48,7 @@ testSetup.describe("Setup Flow", () => {
     ).toBeVisible();
     await expect(
       po.page.getByRole("button", { name: "Install Node.js Runtime" }),
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 10000 });
 
     // Manual configuration link should be visible
     await expect(

--- a/rules/e2e-testing.md
+++ b/rules/e2e-testing.md
@@ -101,7 +101,7 @@ When adding new test server URLs, update **both** the test fixtures (`e2e-tests/
 
 - **After `page.reload()`**: Always add `await page.waitForLoadState("domcontentloaded")` before interacting with elements. Without this, the page may not have re-rendered yet.
 - **Keyboard navigation events (ArrowUp/ArrowDown)**: Add `await page.waitForTimeout(100)` between sequential keyboard presses to let the UI state settle. Rapid keypresses can cause race conditions in menu navigation.
-- **Navigation to tabs**: Use `await expect(link).toBeVisible({ timeout: 60000 })` before clicking tab links (especially in `goToAppsTab()`). Electron sidebar links can take time to render during app initialization.
+- **Navigation to tabs**: Use `await expect(link).toBeVisible({ timeout: Timeout.EXTRA_LONG })` before clicking tab links (especially in `goToAppsTab()`). Electron sidebar links can take time to render during app initialization.
 - **Confirming flakiness**: Use `PLAYWRIGHT_RETRIES=0 PLAYWRIGHT_HTML_OPEN=never npm run e2e -- e2e-tests/<spec> --repeat-each=10` to reproduce flaky tests. `PLAYWRIGHT_RETRIES=0` is critical — CI defaults to 2 retries, hiding flakiness.
 
 ## E2E test fixtures with .dyad directories

--- a/rules/e2e-testing.md
+++ b/rules/e2e-testing.md
@@ -97,6 +97,13 @@ Each parallel Playwright worker gets its own fake LLM server on port `FAKE_LLM_B
 
 When adding new test server URLs, update **both** the test fixtures (`e2e-tests/helpers/fixtures.ts`) and the Electron app source that consumes them. The app reads `process.env.FAKE_LLM_PORT` to build its `TEST_SERVER_BASE` URL — if you hardcode a port in app source, parallel workers will all hit the same server.
 
+## Common flaky test patterns and fixes
+
+- **After `page.reload()`**: Always add `await page.waitForLoadState("domcontentloaded")` before interacting with elements. Without this, the page may not have re-rendered yet.
+- **Keyboard navigation events (ArrowUp/ArrowDown)**: Add `await page.waitForTimeout(100)` between sequential keyboard presses to let the UI state settle. Rapid keypresses can cause race conditions in menu navigation.
+- **Navigation to tabs**: Use `await expect(link).toBeVisible({ timeout: 60000 })` before clicking tab links (especially in `goToAppsTab()`). Electron sidebar links can take time to render during app initialization.
+- **Confirming flakiness**: Use `PLAYWRIGHT_RETRIES=0 PLAYWRIGHT_HTML_OPEN=never npm run e2e -- e2e-tests/<spec> --repeat-each=10` to reproduce flaky tests. `PLAYWRIGHT_RETRIES=0` is critical — CI defaults to 2 retries, hiding flakiness.
+
 ## E2E test fixtures with .dyad directories
 
 When adding E2E test fixtures that need a `.dyad` directory for testing:


### PR DESCRIPTION
- setup_flow.spec.ts: Wait for domcontentloaded after reload and increase timeout for "Install Node.js Runtime" button visibility check
- chat_history.spec.ts: Add small delay between keyboard navigation events and increase timeout on class assertion to prevent ArrowUp race condition
- Navigation.ts: Wait for "Apps" link to be visible before clicking in goToAppsTab() to prevent timeouts when sidebar loads slowly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2681" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
