### PR TITLE
fix: allow node commands in CI and remove deprecated direct input

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -75,6 +75,8 @@
 
       "Bash(git:*)",
 
+      "Bash(node:*)",
+
       "Bash(gh api:*)",
       "Bash(gh pr view:*)",
       "Bash(gh pr list:*)",

--- a/.github/workflows/claude-deflake-e2e.yml
+++ b/.github/workflows/claude-deflake-e2e.yml
@@ -71,7 +71,6 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: --model claude-opus-4-6
-          direct: true
           prompt: |
             /dyad:deflake-e2e-recent-commits ${{ inputs.commit_count || '10' }}
       - name: Cleanup (self-hosted macOS)

--- a/rules/git-workflow.md
+++ b/rules/git-workflow.md
@@ -56,6 +56,10 @@ gh api graphql --input .claude/tmp/resolve_thread.json
 gh api repos/dyad-sh/dyad/issues/{PR_NUMBER}/labels -f "labels[]=label-name"
 ```
 
+## CI permission allowlist (claude-code-action)
+
+In CI, `claude-code-action@v1` runs without an interactive user. Any Bash command not explicitly listed in `.claude/settings.json`'s `permissions.allow` will be denied (the `PermissionRequest` hook's YELLOW score also results in denial since there's no user to approve). When adding new CI scripts or tools, ensure the corresponding `Bash(command:*)` pattern is in the allowlist. For example, `node .claude/*.js` scripts require `Bash(node:*)`.
+
 ## CI file access (claude-code-action)
 
 In CI, `claude-code-action` restricts file access to the repo working directory (e.g., `/home/runner/work/dyad/dyad`). Skills that save intermediate files (like PR diffs) must use `./filename` (current working directory), **never** `/tmp/`. Using `/tmp/` causes errors like: `cat in '/tmp/pr_*_diff.patch' was blocked. For security, Claude Code may only concatenate files from the allowed working directories`.


### PR DESCRIPTION
## Summary
- Add `Bash(node:*)` to `.claude/settings.json` permission allowlist so the deflake CI workflow can run node scripts (`gather-flaky-tests.js`, `create-pr.js`) — these were silently denied in CI since there's no interactive user to approve unlisted commands
- Remove deprecated `direct: true` input from `claude-code-action@v1` in the deflake workflow (was generating warnings)
- Document the CI permission allowlist behavior in `rules/git-workflow.md`

## Test plan
- [ ] Verify the deflake CI workflow can run successfully (trigger via workflow_dispatch)
- [ ] Confirm `direct` input warning no longer appears in CI logs

#skip-bugbot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2687" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
