### PR TITLE
ci: pass GITHUB_TOKEN as GH_TOKEN in deflake e2e workflow

### DIFF
--- a/.github/workflows/claude-deflake-e2e.yml
+++ b/.github/workflows/claude-deflake-e2e.yml
@@ -66,12 +66,12 @@ jobs:
       - name: Deflake E2E tests
         uses: anthropics/claude-code-action@v1
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CLAUDE_CODE_MAX_OUTPUT_TOKENS: 48000
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: --model claude-opus-4-6
-          direct: true
           prompt: |
             /dyad:deflake-e2e-recent-commits ${{ inputs.commit_count || '10' }}
       - name: Cleanup (self-hosted macOS)


### PR DESCRIPTION
## Summary
- Added `GH_TOKEN` env var from `secrets.GITHUB_TOKEN` to the `Deflake E2E tests` action step in `.github/workflows/claude-deflake-e2e.yml`.
- Removed `direct: true` from the `anthropics/claude-code-action` input list.

## Test plan
- `npm run fmt`
- `npm run lint:fix`
- `npm run ts`
- `npm test`