### PR TITLE
chore: add skills symlink

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/.claude/skills/fix-issue/scripts/goldens/details_summary_input.md
+++ b/.claude/skills/fix-issue/scripts/goldens/details_summary_input.md
@@ -4,6 +4,7 @@
 <summary>Click to expand logs</summary>
 
 Error log content here:
+
 ```
 ERROR: Something went wrong
 Stack trace follows

--- a/.claude/skills/fix-issue/scripts/goldens/details_summary_output.md
+++ b/.claude/skills/fix-issue/scripts/goldens/details_summary_output.md
@@ -1,19 +1,17 @@
 # Bug Report
 
-
 Click to expand logs
 
 Error log content here:
+
 ```
 ERROR: Something went wrong
 Stack trace follows
 ```
 
-
 ## More Info
 
 Additional context.
-
 
 Open by default
 This is expanded by default.

--- a/.claude/skills/fix-issue/scripts/goldens/excessive_whitespace_input.md
+++ b/.claude/skills/fix-issue/scripts/goldens/excessive_whitespace_input.md
@@ -1,12 +1,6 @@
 # Issue Title
 
-
-
-
 Too many blank lines above.
-
-
-
 
 And here too.
 

--- a/.claude/skills/fix-issue/scripts/goldens/excessive_whitespace_output.md
+++ b/.claude/skills/fix-issue/scripts/goldens/excessive_whitespace_output.md
@@ -1,8 +1,6 @@
 # Issue Title
 
-
 Too many blank lines above.
-
 
 And here too.
 

--- a/.claude/skills/fix-issue/scripts/goldens/html_comments_output.md
+++ b/.claude/skills/fix-issue/scripts/goldens/html_comments_output.md
@@ -1,8 +1,6 @@
 # Bug Report
 
-
 There's a bug in the login flow.
-
 
 ## Steps to Reproduce
 

--- a/.claude/skills/fix-issue/scripts/goldens/invisible_chars_output.md
+++ b/.claude/skills/fix-issue/scripts/goldens/invisible_chars_output.md
@@ -2,7 +2,7 @@
 
 This text has zero-width spaces hidden in it.
 
-And some other invisible characters like  and  and .
+And some other invisible characters like and and .
 
 ## Description
 

--- a/.claude/skills/fix-issue/scripts/goldens/mixed_input.md
+++ b/.claude/skills/fix-issue/scripts/goldens/mixed_input.md
@@ -4,8 +4,6 @@
 
 This​ issue has multiple problems.
 
-
-
 <details>
 <summary>Stack trace</summary>
 

--- a/.claude/skills/fix-issue/scripts/goldens/mixed_output.md
+++ b/.claude/skills/fix-issue/scripts/goldens/mixed_output.md
@@ -1,8 +1,6 @@
 # Complex Issue
 
-
 This issue has multiple problems.
-
 
 Stack trace
 
@@ -12,9 +10,7 @@ Error at line 42
   at bar()
 ```
 
-
 ## Steps to Reproduce
-
 
 1. Do thing A
 2. Do thing B


### PR DESCRIPTION
## Summary
- add local `.agents/skills` symlink for skill tool access in workspace

## Test plan
- npm run fmt
- npm run lint:fix
- npm run ts
- npm test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2690" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
