### PR TITLE
Fix release workflow publish command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,7 @@ jobs:
         run: ls -laR out/
 
       - name: Publish from dry-run
-        run: npm run publish -- --from-dry-run
+        run: ./node_modules/.bin/electron-forge publish --from-dry-run
         env:
           DEBUG: "@electron/*,electron-forge:*"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Update the release workflow dry-run publish step to invoke `electron-forge` directly.
- Avoid `npm run publish` script indirection in CI release publishing.

## Test plan
- npm run fmt
- npm run lint:fix
- npm run ts

#skip-bugbot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2711" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
