### PR TITLE
Persist todos across chat turns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Detailed rules and learnings are in the `rules/` directory. Read the relevant fi
 | File                                                                 | Read when...                                                                                     |
 | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
 | [rules/electron-ipc.md](rules/electron-ipc.md)                       | Adding/modifying IPC endpoints, handlers, React Query hooks, or renderer-to-main communication   |
+| [rules/local-agent-tools.md](rules/local-agent-tools.md)             | Adding/modifying local agent tools, tool flags (`modifiesState`), or read-only/plan-only guards  |
 | [rules/e2e-testing.md](rules/e2e-testing.md)                         | Writing or debugging E2E tests (Playwright, Base UI radio clicks, Lexical editor, test fixtures) |
 | [rules/git-workflow.md](rules/git-workflow.md)                       | Pushing branches, creating PRs, or dealing with fork/upstream remotes                            |
 | [rules/base-ui-components.md](rules/base-ui-components.md)           | Using TooltipTrigger, ToggleGroupItem, or other Base UI wrapper components                       |

--- a/e2e-tests/context_compaction.spec.ts
+++ b/e2e-tests/context_compaction.spec.ts
@@ -31,6 +31,11 @@ testSkipIfWindows(
 
     await po.sendPrompt("[dump] hi");
     await po.snapshotServerDump("all-messages");
+    // Wait for all message content (including file card buttons) to fully render
+    // before snapshotting to avoid flaky aria text mismatches.
+    await expect(po.page.getByRole("button", { name: "Retry" })).toBeVisible({
+      timeout: Timeout.MEDIUM,
+    });
     // Snapshot the messages to capture the compaction summary + second response
     await po.snapshotMessages({ replaceDumpPath: true });
   },
@@ -61,6 +66,11 @@ testSkipIfWindows(
 
     await po.sendPrompt("[dump] hi");
     await po.snapshotServerDump("all-messages");
+    // Wait for all message content (including file card buttons) to fully render
+    // before snapshotting to avoid flaky aria text mismatches.
+    await expect(po.page.getByRole("button", { name: "Retry" })).toBeVisible({
+      timeout: Timeout.MEDIUM,
+    });
     // Snapshot the messages to capture the compaction summary + second response
     await po.snapshotMessages({ replaceDumpPath: true });
   },

--- a/e2e-tests/fixtures/engine/local-agent/persistent-todos-resume.ts
+++ b/e2e-tests/fixtures/engine/local-agent/persistent-todos-resume.ts
@@ -1,0 +1,88 @@
+import type { LocalAgentFixture } from "../../../../testing/fake-llm-server/localAgentTypes";
+
+/**
+ * Fixture that tests persistent todos across turns (turn 2 of 2).
+ *
+ * This runs after persistent-todos.ts which left 2 incomplete todos on disk:
+ *   - todo-2: "Add error handling" (pending)
+ *   - todo-3: "Write tests" (pending)
+ *
+ * The handler loads these from .dyad/todos/<chatId>.json and injects a
+ * synthetic "[System] You have unfinished todos..." user message before
+ * this prompt. The agent then picks up the remaining work and completes
+ * all todos.
+ */
+export const fixture: LocalAgentFixture = {
+  description: "Turn 2: Resume and complete persisted todos from previous turn",
+  turns: [
+    {
+      text: "I see there are unfinished todos from last time. Let me continue.",
+      toolCalls: [
+        {
+          name: "update_todos",
+          args: {
+            merge: true,
+            todos: [
+              {
+                id: "todo-2",
+                status: "in_progress",
+              },
+            ],
+          },
+        },
+      ],
+    },
+    {
+      text: "Adding error handling to the utility module.",
+      toolCalls: [
+        {
+          name: "write_file",
+          args: {
+            path: "src/lib/utils.ts",
+            content:
+              'export function formatDate(d: Date): string {\n  return d.toISOString();\n}\n\nexport function safeParseJSON(str: string): unknown {\n  try {\n    return JSON.parse(str);\n  } catch {\n    return null;\n  }\n}\n',
+            description: "Add error handling utility",
+          },
+        },
+      ],
+    },
+    {
+      text: "Now writing the tests.",
+      toolCalls: [
+        {
+          name: "write_file",
+          args: {
+            path: "src/lib/utils.test.ts",
+            content:
+              'import { formatDate, safeParseJSON } from "./utils";\n\ntest("formatDate returns ISO string", () => {\n  const d = new Date("2024-01-01");\n  expect(formatDate(d)).toBe("2024-01-01T00:00:00.000Z");\n});\n\ntest("safeParseJSON parses valid JSON", () => {\n  expect(safeParseJSON(\'{"a":1}\')).toEqual({ a: 1 });\n});\n\ntest("safeParseJSON returns null for invalid JSON", () => {\n  expect(safeParseJSON("not json")).toBeNull();\n});\n',
+            description: "Write tests for utility module",
+          },
+        },
+      ],
+    },
+    {
+      text: "Marking all remaining tasks as done.",
+      toolCalls: [
+        {
+          name: "update_todos",
+          args: {
+            merge: true,
+            todos: [
+              {
+                id: "todo-2",
+                status: "completed",
+              },
+              {
+                id: "todo-3",
+                status: "completed",
+              },
+            ],
+          },
+        },
+      ],
+    },
+    {
+      text: "All tasks from the previous turn are now complete! I created the utility module, added error handling, and wrote the tests.",
+    },
+  ],
+};

--- a/e2e-tests/fixtures/engine/local-agent/persistent-todos.ts
+++ b/e2e-tests/fixtures/engine/local-agent/persistent-todos.ts
@@ -1,0 +1,101 @@
+import type { LocalAgentFixture } from "../../../../testing/fake-llm-server/localAgentTypes";
+
+/**
+ * Fixture that tests persistent todos across turns (turn 1 of 2).
+ *
+ * Pass 1: Agent creates 3 todos, completes only 1, writes a file, then emits
+ *         text. The outer loop detects incomplete todos and sends a reminder.
+ *
+ * Pass 2: After receiving the todo reminder, agent acknowledges but does NOT
+ *         complete the remaining todos (simulating running out of context/time).
+ *
+ * After both passes, 2 incomplete todos remain and are persisted to disk.
+ * The follow-up test (persistent-todos-resume) sends a second prompt to verify
+ * that the handler loads the persisted todos and injects a synthetic message.
+ */
+export const fixture: LocalAgentFixture = {
+  description:
+    "Turn 1: Create todos, partially complete, leave rest for next turn",
+  passes: [
+    {
+      // First pass: Create todos and partially complete them
+      turns: [
+        {
+          text: "I'll create a task list to track the work.",
+          toolCalls: [
+            {
+              name: "update_todos",
+              args: {
+                merge: false,
+                todos: [
+                  {
+                    id: "todo-1",
+                    content: "Create utility module",
+                    status: "in_progress",
+                  },
+                  {
+                    id: "todo-2",
+                    content: "Add error handling",
+                    status: "pending",
+                  },
+                  {
+                    id: "todo-3",
+                    content: "Write tests",
+                    status: "pending",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        {
+          text: "Let me create the utility module first.",
+          toolCalls: [
+            {
+              name: "write_file",
+              args: {
+                path: "src/lib/utils.ts",
+                content:
+                  'export function formatDate(d: Date): string {\n  return d.toISOString();\n}\n',
+                description: "Create utility module",
+              },
+            },
+          ],
+        },
+        {
+          text: "Marking the first task as done.",
+          toolCalls: [
+            {
+              name: "update_todos",
+              args: {
+                merge: true,
+                todos: [
+                  {
+                    id: "todo-1",
+                    status: "completed",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        {
+          // Text-only response triggers the outer loop check.
+          // Since there are still incomplete todos, it will inject a reminder.
+          text: "I've completed the utility module. I'll continue with the remaining tasks.",
+        },
+      ],
+    },
+    {
+      // Second pass (after todo reminder): acknowledge but don't complete.
+      // This simulates running out of budget/context. The outer loop won't
+      // fire again (maxTodoFollowUpLoops = 1), so the incomplete todos
+      // persist to disk for the next turn.
+      turns: [
+        {
+          text: "I see there are remaining tasks. I'll pick these up in the next turn.",
+        },
+      ],
+    },
+  ],
+};

--- a/e2e-tests/local_agent_persistent_todos.spec.ts
+++ b/e2e-tests/local_agent_persistent_todos.spec.ts
@@ -1,0 +1,51 @@
+import { testSkipIfWindows } from "./helpers/test_helper";
+
+/**
+ * E2E test for persistent todos across turns.
+ *
+ * This tests that when an agent creates a todo list but doesn't complete
+ * all items by the end of a turn, the incomplete todos are:
+ * 1. Persisted to disk (.dyad/todos/<chatId>.json)
+ * 2. Loaded at the start of the next turn
+ * 3. Injected as a synthetic "[System]" message so the LLM is aware of them
+ * 4. Completed by the agent in the subsequent turn
+ *
+ * Turn 1 (persistent-todos fixture):
+ *   - Creates 3 todos, completes 1, leaves 2 incomplete
+ *   - Followup loop fires once but doesn't complete remaining todos
+ *   - Incomplete todos are saved to disk
+ *
+ * Turn 2 (persistent-todos-resume fixture):
+ *   - Handler loads persisted todos and injects synthetic message
+ *   - Agent picks up remaining work and completes all todos
+ *   - Todos file is cleaned up (all completed)
+ */
+testSkipIfWindows(
+  "local-agent - persistent todos across turns",
+  async ({ po }) => {
+    await po.setUpDyadPro({ localAgent: true });
+    await po.importApp("minimal");
+    await po.chatActions.selectLocalAgentMode();
+
+    // Turn 1: Creates incomplete todos that get persisted to disk
+    await po.sendPrompt("tc=local-agent/persistent-todos");
+
+    // Turn 2: Handler loads persisted todos, injects synthetic message,
+    // and the agent completes the remaining work
+    await po.sendPrompt("tc=local-agent/persistent-todos-resume");
+
+    // Snapshot the final messages to verify:
+    // 1. Turn 1 created todos and partially completed them
+    // 2. Turn 2 resumed from persisted todos and completed them
+    await po.snapshotMessages();
+
+    // Verify files were created/updated across both turns
+    await po.snapshotAppFiles({
+      name: "after-persistent-todos",
+      files: [
+        "src/lib/utils.ts", // Created in turn 1, updated in turn 2
+        "src/lib/utils.test.ts", // Created in turn 2
+      ],
+    });
+  },
+);

--- a/e2e-tests/snapshots/context_compaction.spec.ts_local-agent---context-compaction-can-run-mid-turn-1.aria.yml
+++ b/e2e-tests/snapshots/context_compaction.spec.ts_local-agent---context-compaction-can-run-mid-turn-1.aria.yml
@@ -15,6 +15,8 @@
 - text: claude-opus-4-5
 - img
 - text: less than a minute ago
+- img
+- text: (1 files changed)
 - button "Copy Request ID":
   - img
   - text: ""
@@ -68,7 +70,7 @@
 - paragraph: This tool call will trigger compaction.
 - img
 - text: Read src/App.tsx
-- button "Conversation compacted":
+- button "Conversation compacted" [expanded]:
   - img
   - text: ""
   - img
@@ -102,8 +104,6 @@
 - text: claude-opus-4-5
 - img
 - text: less than a minute ago
-- img
-- text: (1 files changed)
 - button "Copy Request ID":
   - img
   - text: ""

--- a/e2e-tests/snapshots/context_compaction.spec.ts_local-agent---context-compaction-triggers-and-shows-summary-1.aria.yml
+++ b/e2e-tests/snapshots/context_compaction.spec.ts_local-agent---context-compaction-triggers-and-shows-summary-1.aria.yml
@@ -1,5 +1,11 @@
 - paragraph: /Generate an AI_RULES\.md file for this app\. Describe the tech stack in 5-\d+ bullet points and describe clear rules about what libraries to use for what\./
-- button "file1.txt file1.txt Edit"
+- button "file1.txt file1.txt Edit":
+  - img
+  - text: ""
+  - button "Edit":
+    - img
+    - text: ""
+  - img
 - paragraph: More EOM
 - button "Copy":
   - img
@@ -9,8 +15,11 @@
 - text: claude-opus-4-5
 - img
 - text: less than a minute ago
+- img
+- text: (1 files changed)
 - button "Copy Request ID":
   - img
+  - text: ""
 - paragraph: tc=local-agent/compaction-trigger
 - paragraph: I've completed the initial analysis of the codebase. Here are the findings.
 - button "Copy":
@@ -23,8 +32,10 @@
 - text: less than a minute ago
 - button "Copy Request ID":
   - img
-- button "Conversation compacted":
+  - text: ""
+- button "Conversation compacted" [expanded]:
   - img
+  - text: ""
   - img
 - heading "Key Decisions Made" [level=2]
 - list:
@@ -46,10 +57,9 @@
 - text: claude-opus-4-5
 - img
 - text: less than a minute ago
-- img
-- text: (1 files changed)
 - button "Copy Request ID":
   - img
+  - text: ""
 - paragraph: "[dump] hi"
 - paragraph: "[[dyad-dump-path=*]]"
 - button "Copy":
@@ -60,7 +70,10 @@
 - text: less than a minute ago
 - button "Copy Request ID":
   - img
+  - text: ""
 - button "Undo":
   - img
+  - text: ""
 - button "Retry":
   - img
+  - text: ""

--- a/e2e-tests/snapshots/context_manage.spec.ts_manage-context---exclude-paths-with-smart-context-2.aria.yml
+++ b/e2e-tests/snapshots/context_manage.spec.ts_manage-context---exclude-paths-with-smart-context-2.aria.yml
@@ -21,10 +21,6 @@
       - img
   - textbox "node_modules/**/*"
   - button "Add"
-  - button "src/components/**"
-  - text: /2 files, ~\d+ tokens/
-  - button:
-    - img
   - button "exclude/exclude.ts"
   - text: /1 files, ~\d+ tokens/
   - button:
@@ -46,3 +42,4 @@
     - img
   - button "Close":
     - img
+    - text: ""

--- a/e2e-tests/snapshots/local_agent_ask.spec.ts_local-agent-ask-mode-1.txt
+++ b/e2e-tests/snapshots/local_agent_ask.spec.ts_local-agent-ask-mode-1.txt
@@ -279,58 +279,6 @@
       {
         "type": "function",
         "function": {
-          "name": "update_todos",
-          "description": "\n### When to Use This Tool\n\nUse proactively for:\n1. Complex multi-step tasks (3+ distinct steps)\n2. Non-trivial tasks requiring careful planning\n3. User explicitly requests todo list\n4. User provides multiple tasks (numbered/comma-separated)\n5. After completing tasks - mark complete with merge=true and add follow-ups\n6. When starting new tasks - mark as in_progress (ideally only one at a time)\n\n### When NOT to Use\n\nSkip for:\n1. Single, straightforward tasks\n2. Trivial tasks with no organizational benefit\n3. Tasks completable in < 3 trivial steps\n4. Purely conversational/informational requests\n5. Todo items should NOT include operational actions done in service of higher-level tasks.\n\nNEVER INCLUDE THESE IN TODOS: linting; testing; searching or examining the codebase.\n\n### Examples\n\n<example>\nUser: Add dark mode toggle to settings\nAssistant:\n- *Creates todo list:*\n1. Add state management [in_progress]\n2. Implement styles\n3. Create toggle component\n4. Update components\n- [Immediately begins working on todo 1 in the same tool call batch]\n<reasoning>\nMulti-step feature with dependencies.\n</reasoning>\n</example>\n\n<example>\n// User: Implement user registration, product catalog, shopping cart, checkout flow.\nAssistant: *Creates todo list breaking down each feature into specific tasks*\n<reasoning>\nMultiple complex features provided as list requiring organized task management.\n</reasoning>\n</example>\n\n### Task States and Management\n\n1. **Task States:**\n- pending: Not yet started\n- in_progress: Currently working on\n- completed: Finished successfully\n\n2. **Task Management:**\n- Update status in real-time\n- Mark complete IMMEDIATELY after finishing\n- Only ONE task in_progress at a time\n- Complete current tasks before starting new ones\n\n3. **Task Breakdown:**\n- Create specific, actionable items\n- Break complex tasks into manageable steps\n- Use clear, descriptive names\n\n4. **Parallel Todo Writes:**\n- Prefer creating the first todo as in_progress\n- Start working on todos by using tool calls in the same tool call batch as the todo write\n- Batch todo updates with other tool calls for better latency and lower costs for the user\n",
-          "parameters": {
-            "$schema": "http://json-schema.org/draft-07/schema#",
-            "type": "object",
-            "properties": {
-              "merge": {
-                "type": "boolean",
-                "description": "Whether to merge the todos with the existing todos. If true, the todos will be merged into the existing todos based on the id field. You can leave unchanged properties undefined. If false, the new todos will replace the existing todos."
-              },
-              "todos": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "description": "Unique identifier for the todo item"
-                    },
-                    "content": {
-                      "description": "The description/content of the todo item",
-                      "type": "string"
-                    },
-                    "status": {
-                      "description": "The current status of the todo item",
-                      "type": "string",
-                      "enum": [
-                        "pending",
-                        "in_progress",
-                        "completed"
-                      ]
-                    }
-                  },
-                  "required": [
-                    "id"
-                  ],
-                  "additionalProperties": false
-                },
-                "description": "Array of todo items. When merge is true, only include todos that need updates. When merge is false, this is the complete list."
-              }
-            },
-            "required": [
-              "merge",
-              "todos"
-            ],
-            "additionalProperties": false
-          }
-        }
-      },
-      {
-        "type": "function",
-        "function": {
           "name": "run_type_checks",
           "description": "Run TypeScript type checks on the current workspace. You can provide paths to specific files or directories, or omit the argument to get diagnostics for all files.\n\n- If a file path is provided, returns diagnostics for that file only\n- If a directory path is provided, returns diagnostics for all files within that directory\n- If no path is provided, returns diagnostics for all files in the workspace\n- This tool can return type errors that were already present before your edits, so avoid calling it with a very wide scope of files\n- NEVER call this tool on a file unless you've edited it or are about to edit it",
           "parameters": {

--- a/e2e-tests/snapshots/local_agent_persistent_todos.spec.ts_after-persistent-todos.txt
+++ b/e2e-tests/snapshots/local_agent_persistent_todos.spec.ts_after-persistent-todos.txt
@@ -1,0 +1,29 @@
+=== src/lib/utils.test.ts ===
+import { formatDate, safeParseJSON } from "./utils";
+
+test("formatDate returns ISO string", () => {
+  const d = new Date("2024-01-01");
+  expect(formatDate(d)).toBe("2024-01-01T00:00:00.000Z");
+});
+
+test("safeParseJSON parses valid JSON", () => {
+  expect(safeParseJSON('{"a":1}')).toEqual({ a: 1 });
+});
+
+test("safeParseJSON returns null for invalid JSON", () => {
+  expect(safeParseJSON("not json")).toBeNull();
+});
+
+
+=== src/lib/utils.ts ===
+export function formatDate(d: Date): string {
+  return d.toISOString();
+}
+
+export function safeParseJSON(str: string): unknown {
+  try {
+    return JSON.parse(str);
+  } catch {
+    return null;
+  }
+}

--- a/e2e-tests/snapshots/local_agent_persistent_todos.spec.ts_local-agent---persistent-todos-across-turns-1.aria.yml
+++ b/e2e-tests/snapshots/local_agent_persistent_todos.spec.ts_local-agent---persistent-todos-across-turns-1.aria.yml
@@ -1,0 +1,81 @@
+- paragraph: /Generate an AI_RULES\.md file for this app\. Describe the tech stack in 5-\d+ bullet points and describe clear rules about what libraries to use for what\./
+- button "file1.txt file1.txt Edit":
+  - img
+  - text: ""
+  - button "Edit":
+    - img
+    - text: ""
+  - img
+- paragraph: More EOM
+- button "Copy":
+  - img
+- img
+- text: Approved
+- img
+- text: claude-opus-4-5
+- img
+- text: less than a minute ago
+- img
+- text: (1 files changed)
+- button "Copy Request ID":
+  - img
+  - text: ""
+- paragraph: tc=local-agent/persistent-todos
+- paragraph: I'll create a task list to track the work.Let me create the utility module first.
+- 'button "utils.ts src/lib/utils.ts Edit Summary: Create utility module"':
+  - img
+  - text: ""
+  - button "Edit":
+    - img
+    - text: ""
+  - img
+  - text: ""
+- paragraph: Marking the first task as done.I've completed the utility module. I'll continue with the remaining tasks.I see there are remaining tasks. I'll pick these up in the next turn.
+- button "Copy":
+  - img
+- img
+- text: Approved
+- img
+- text: claude-opus-4-5
+- img
+- text: less than a minute ago
+- img
+- text: (1 files changed)
+- button "Copy Request ID":
+  - img
+  - text: ""
+- paragraph: tc=local-agent/persistent-todos-resume
+- paragraph: I see there are unfinished todos from last time. Let me continue.Adding error handling to the utility module.
+- 'button "utils.ts src/lib/utils.ts Edit Summary: Add error handling utility"':
+  - img
+  - text: ""
+  - button "Edit":
+    - img
+    - text: ""
+  - img
+  - text: ""
+- paragraph: Now writing the tests.
+- 'button "utils.test.ts src/lib/utils.test.ts Edit Summary: Write tests for utility module"':
+  - img
+  - text: ""
+  - button "Edit":
+    - img
+    - text: ""
+  - img
+  - text: ""
+- paragraph: Marking all remaining tasks as done.All tasks from the previous turn are now complete! I created the utility module, added error handling, and wrote the tests.
+- button "Copy":
+  - img
+- img
+- text: claude-opus-4-5
+- img
+- text: less than a minute ago
+- button "Copy Request ID":
+  - img
+  - text: ""
+- button "Undo":
+  - img
+  - text: ""
+- button "Retry":
+  - img
+  - text: ""

--- a/rules/electron-ipc.md
+++ b/rules/electron-ipc.md
@@ -83,13 +83,6 @@ queryClient.invalidateQueries({ queryKey: queryKeys.apps.all });
 
 **Adding new keys:** Add entries to the appropriate domain in `queryKeys.ts`. Follow the existing pattern with `all` for the base key and factory functions using object parameters for parameterized keys.
 
-## Local agent tool definitions
-
-- Agent tool definitions live in `src/pro/main/ipc/handlers/local_agent/tools/`. Each tool has a `ToolDefinition` with optional flags.
-- **`modifiesState: true`** must be set on any tool that writes to disk or modifies external state (files, database, etc.). This flag controls whether the tool is available in read-only (ask) mode and plan-only mode — see `buildAgentToolSet` in `tool_definitions.ts`.
-- Similarly, code in the `handleLocalAgentStream` handler that writes to the workspace (e.g., `ensureDyadGitignored`) should be guarded with `if (!readOnly && !planModeOnly)` checks.
-- Use `fs.promises` (not sync `fs` methods) in any code running on the Electron main process (e.g., `todo_persistence.ts`) to avoid blocking the event loop.
-
 ## React + IPC integration pattern
 
 When creating hooks/components that call IPC handlers:

--- a/rules/electron-ipc.md
+++ b/rules/electron-ipc.md
@@ -83,6 +83,13 @@ queryClient.invalidateQueries({ queryKey: queryKeys.apps.all });
 
 **Adding new keys:** Add entries to the appropriate domain in `queryKeys.ts`. Follow the existing pattern with `all` for the base key and factory functions using object parameters for parameterized keys.
 
+## Local agent tool definitions
+
+- Agent tool definitions live in `src/pro/main/ipc/handlers/local_agent/tools/`. Each tool has a `ToolDefinition` with optional flags.
+- **`modifiesState: true`** must be set on any tool that writes to disk or modifies external state (files, database, etc.). This flag controls whether the tool is available in read-only (ask) mode and plan-only mode — see `buildAgentToolSet` in `tool_definitions.ts`.
+- Similarly, code in the `handleLocalAgentStream` handler that writes to the workspace (e.g., `ensureDyadGitignored`) should be guarded with `if (!readOnly && !planModeOnly)` checks.
+- Use `fs.promises` (not sync `fs` methods) in any code running on the Electron main process (e.g., `todo_persistence.ts`) to avoid blocking the event loop.
+
 ## React + IPC integration pattern
 
 When creating hooks/components that call IPC handlers:

--- a/rules/local-agent-tools.md
+++ b/rules/local-agent-tools.md
@@ -1,0 +1,12 @@
+# Local Agent Tool Definitions
+
+Agent tool definitions live in `src/pro/main/ipc/handlers/local_agent/tools/`. Each tool has a `ToolDefinition` with optional flags.
+
+## Read-only / plan-only mode
+
+- **`modifiesState: true`** must be set on any tool that writes to disk or modifies external state (files, database, etc.). This flag controls whether the tool is available in read-only (ask) mode and plan-only mode — see `buildAgentToolSet` in `tool_definitions.ts`.
+- Similarly, code in the `handleLocalAgentStream` handler that writes to the workspace (e.g., `ensureDyadGitignored`, injecting synthetic todo reminders) should be guarded with `if (!readOnly && !planModeOnly)` checks. Injecting instructions that reference state-changing tools into non-writable runs will confuse the model since those tools are filtered out.
+
+## Async I/O
+
+- Use `fs.promises` (not sync `fs` methods) in any code running on the Electron main process (e.g., `todo_persistence.ts`) to avoid blocking the event loop.

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -549,6 +549,8 @@ export async function handleLocalAgentStream(
     // reads, giving it natural priority over stale todos.
     if (
       !messageOverride &&
+      !readOnly &&
+      !planModeOnly &&
       persistedTodos.length > 0 &&
       hasIncompleteTodos(persistedTodos)
     ) {

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -552,7 +552,10 @@ export async function handleLocalAgentStream(
       persistedTodos.length > 0 &&
       hasIncompleteTodos(persistedTodos)
     ) {
-      const todoSummary = formatTodoSummary(persistedTodos);
+      const incompleteTodos = persistedTodos.filter(
+        (t) => t.status === "pending" || t.status === "in_progress",
+      );
+      const todoSummary = formatTodoSummary(incompleteTodos);
       const syntheticMessage: ModelMessage = {
         role: "user",
         content: [

--- a/src/pro/main/ipc/handlers/local_agent/prepare_step_utils.ts
+++ b/src/pro/main/ipc/handlers/local_agent/prepare_step_utils.ts
@@ -23,14 +23,19 @@ export function hasIncompleteTodos(todos: Todo[]): boolean {
 }
 
 /**
+ * Format a list of todos as a bullet-point summary string.
+ */
+export function formatTodoSummary(todos: Todo[]): string {
+  return todos.map((t) => `- [${t.status}] ${t.content}`).join("\n");
+}
+
+/**
  * Build a reminder message for incomplete todos.
  */
 export function buildTodoReminderMessage(todos: Todo[]): string {
   const incompleteTodos = todos.filter(isIncompleteTodo);
 
-  const todoList = incompleteTodos
-    .map((t) => `- [${t.status}] ${t.content}`)
-    .join("\n");
+  const todoList = formatTodoSummary(incompleteTodos);
 
   // Note: The "incomplete todo(s)" substring is used as a detection marker by test
   // infrastructure in testing/fake-llm-server/ (chatCompletionHandler.ts and

--- a/src/pro/main/ipc/handlers/local_agent/todo_persistence.ts
+++ b/src/pro/main/ipc/handlers/local_agent/todo_persistence.ts
@@ -1,0 +1,89 @@
+/**
+ * Todo persistence utilities.
+ *
+ * Reads/writes per-chat todo JSON files so that todos survive across turns.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import log from "electron-log";
+import type { Todo } from "./tools/types";
+
+const logger = log.scope("todo_persistence");
+
+/**
+ * Return the path to the todos JSON file for a given chat.
+ *
+ * Layout: `<appPath>/.dyad/todos/<chatId>.json`
+ */
+export function getTodosFilePath(appPath: string, chatId: number): string {
+  return path.join(appPath, ".dyad", "todos", `${chatId}.json`);
+}
+
+/**
+ * Persist the current todos list to disk.
+ *
+ * Creates the `.dyad/todos/` directory if it does not exist.
+ */
+export async function saveTodos(
+  appPath: string,
+  chatId: number,
+  todos: Todo[],
+): Promise<void> {
+  const filePath = getTodosFilePath(appPath, chatId);
+  try {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    const data = JSON.stringify(
+      { todos, updatedAt: new Date().toISOString() },
+      null,
+      2,
+    );
+    fs.writeFileSync(filePath, data, "utf-8");
+  } catch (err) {
+    logger.warn("Failed to save todos:", err);
+  }
+}
+
+/**
+ * Load previously persisted todos for a chat.
+ *
+ * Returns `[]` if the file does not exist or is corrupted.
+ */
+export async function loadTodos(
+  appPath: string,
+  chatId: number,
+): Promise<Todo[]> {
+  const filePath = getTodosFilePath(appPath, chatId);
+  try {
+    if (!fs.existsSync(filePath)) {
+      return [];
+    }
+    const raw = fs.readFileSync(filePath, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed?.todos)) {
+      return parsed.todos as Todo[];
+    }
+    logger.warn("Unexpected todos file format, returning empty list");
+    return [];
+  } catch (err) {
+    logger.warn("Failed to load todos, returning empty list:", err);
+    return [];
+  }
+}
+
+/**
+ * Delete the todos file for a chat (e.g. when all todos are completed).
+ */
+export async function deleteTodos(
+  appPath: string,
+  chatId: number,
+): Promise<void> {
+  const filePath = getTodosFilePath(appPath, chatId);
+  try {
+    if (fs.existsSync(filePath)) {
+      fs.unlinkSync(filePath);
+    }
+  } catch (err) {
+    logger.warn("Failed to delete todos file:", err);
+  }
+}

--- a/src/pro/main/ipc/handlers/local_agent/tools/update_todos.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/update_todos.ts
@@ -102,6 +102,7 @@ export const updateTodosTool: ToolDefinition<
   description: DESCRIPTION,
   inputSchema: updateTodosSchema,
   defaultConsent: "always",
+  modifiesState: true,
 
   getConsentPreview: (args) => {
     const count = args.todos.length;
@@ -151,7 +152,7 @@ export const updateTodosTool: ToolDefinition<
     // Persist todos to disk so they survive across turns
     const allCompleted =
       ctx.todos.length > 0 && ctx.todos.every((t) => t.status === "completed");
-    if (allCompleted) {
+    if (allCompleted || ctx.todos.length === 0) {
       await deleteTodos(ctx.appPath, ctx.chatId);
     } else {
       await saveTodos(ctx.appPath, ctx.chatId, ctx.todos);

--- a/src/pro/main/ipc/handlers/local_agent/tools/update_todos.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/update_todos.ts
@@ -102,7 +102,6 @@ export const updateTodosTool: ToolDefinition<
   description: DESCRIPTION,
   inputSchema: updateTodosSchema,
   defaultConsent: "always",
-  modifiesState: true,
 
   getConsentPreview: (args) => {
     const count = args.todos.length;

--- a/src/pro/main/ipc/handlers/local_agent/tools/update_todos.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/update_todos.ts
@@ -102,7 +102,7 @@ export const updateTodosTool: ToolDefinition<
   description: DESCRIPTION,
   inputSchema: updateTodosSchema,
   defaultConsent: "always",
-  modifiesState:true,
+  modifiesState: true,
 
   getConsentPreview: (args) => {
     const count = args.todos.length;

--- a/src/pro/main/ipc/handlers/local_agent/tools/update_todos.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/update_todos.ts
@@ -102,6 +102,7 @@ export const updateTodosTool: ToolDefinition<
   description: DESCRIPTION,
   inputSchema: updateTodosSchema,
   defaultConsent: "always",
+  modifiesState:true,
 
   getConsentPreview: (args) => {
     const count = args.todos.length;

--- a/src/pro/main/ipc/handlers/local_agent/tools/update_todos.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/update_todos.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { ToolDefinition, AgentContext, Todo } from "./types";
+import { saveTodos, deleteTodos } from "../todo_persistence";
 
 const todoSchema = z.object({
   id: z.string().describe("Unique identifier for the todo item"),
@@ -146,6 +147,15 @@ export const updateTodosTool: ToolDefinition<
 
     // Send todos to renderer for UI display
     ctx.onUpdateTodos(ctx.todos);
+
+    // Persist todos to disk so they survive across turns
+    const allCompleted =
+      ctx.todos.length > 0 && ctx.todos.every((t) => t.status === "completed");
+    if (allCompleted) {
+      await deleteTodos(ctx.appPath, ctx.chatId);
+    } else {
+      await saveTodos(ctx.appPath, ctx.chatId, ctx.todos);
+    }
 
     const completed = ctx.todos.filter((t) => t.status === "completed").length;
     const inProgressTodos = ctx.todos.filter((t) => t.status === "in_progress");


### PR DESCRIPTION
## Summary
Add persistence layer for todos so they survive across multiple turns in a chat session. Todos are now saved to disk after each update and automatically loaded and injected into the conversation context when a new turn begins.

## Key Changes
- **New module `todo_persistence.ts`**: Provides utilities to save, load, and delete todo JSON files stored in `.dyad/todos/<chatId>.json`
  - `getTodosFilePath()`: Constructs the file path for a chat's todos
  - `saveTodos()`: Persists todos to disk with metadata (updatedAt timestamp)
  - `loadTodos()`: Loads previously saved todos, gracefully handling missing or corrupted files
  - `deleteTodos()`: Removes the todos file when all todos are completed

- **Updated `local_agent_handler.ts`**: 
  - Load persisted todos at the start of each turn
  - Emit loaded todos to the renderer immediately so the UI reflects them
  - Initialize the agent context with persisted todos instead of an empty array
  - Inject a synthetic system message reminding the LLM of incomplete todos from the previous turn, following the same pattern as existing todo reminder logic
  - Ensure `.dyad/` directory is gitignored (idempotent operation)

- **Updated `update_todos.ts`**:
  - Persist todos to disk after each tool execution
  - Delete the todos file when all todos are marked as completed

## Implementation Details
- Todos are stored as JSON with an `updatedAt` timestamp for potential future use
- File I/O errors are logged as warnings but don't interrupt the agent flow (graceful degradation)
- The synthetic message injection for persisted todos only occurs if there are incomplete todos, avoiding unnecessary context pollution
- The `.dyad/` gitignore step is idempotent and aligns with existing patterns in the codebase

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2713" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
