### PR TITLE
docs: emphasize build & rules-reading requirements in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@ Please read `CONTRIBUTING.md` which includes information for human code contribu
 
 ## Rules index
 
+> **IMPORTANT: BEFORE writing any code or making changes, you MUST read the relevant rule files from the table below.** Identify which areas your task touches and read those rule files first. Skipping this step leads to avoidable mistakes and rework.
+
 Detailed rules and learnings are in the `rules/` directory. Read the relevant file when working in that area.
 
 | File                                                                 | Read when...                                                                                     |
@@ -102,6 +104,8 @@ Our project relies on a combination of unit testing and E2E testing. Unless your
 Use unit testing for pure business logic and util functions.
 
 ### E2E testing
+
+> **IMPORTANT: You MUST run `npm run build` before running E2E tests.** E2E tests run against the built application, not the dev server. If you have changed any application code (i.e. anything outside of test files), you MUST re-run `npm run build` before running the tests, otherwise the tests will run against stale code and results will be misleading. Only changes to test code itself (e.g. files in `e2e-tests/`) do not require a rebuild.
 
 See [rules/e2e-testing.md](rules/e2e-testing.md) for full E2E testing guidance, including Playwright tips and fixture setup.
 


### PR DESCRIPTION
## Summary
- Added a prominent callout in the E2E testing section making it clear that `npm run build` must be run before E2E tests and re-run whenever application (non-test) code changes
- Added a prominent callout in the Rules index section emphasizing that relevant rule files must be read BEFORE writing any code or making changes

## Test plan
- Documentation-only change, no functional impact

#skip-bugbot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2720" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
