### PR TITLE
fix(e2e): deflake context_limit_banner, attach_image, and prompt_libr…

### DIFF
--- a/e2e-tests/attach_image.spec.ts
+++ b/e2e-tests/attach_image.spec.ts
@@ -104,6 +104,11 @@ test("attach image - chat - upload to codebase", async ({ po }) => {
 
   await po.sendPrompt("[[UPLOAD_IMAGE_TO_CODEBASE]]");
 
+  // Wait for the uploaded file card to render before snapshotting
+  await expect(
+    po.page.getByRole("button", { name: /file\.png/ }),
+  ).toBeVisible();
+
   await po.snapshotServerDump("last-message", { name: "upload-to-codebase" });
   await po.snapshotMessages({ replaceDumpPath: true });
 

--- a/e2e-tests/context_limit_banner.spec.ts
+++ b/e2e-tests/context_limit_banner.spec.ts
@@ -15,7 +15,7 @@ test("context limit banner shows 'running out' when near context limit", async (
   const contextLimitBanner = po.chatActions
     .getChatInputContainer()
     .getByTestId("context-limit-banner");
-  await expect(contextLimitBanner).toBeVisible({ timeout: Timeout.MEDIUM });
+  await expect(contextLimitBanner).toBeVisible({ timeout: Timeout.LONG });
 
   // Verify banner text for near-limit case
   await expect(contextLimitBanner).toContainText(
@@ -57,7 +57,7 @@ test("context limit banner shows 'costs extra' for long context", async ({
   const contextLimitBanner = po.chatActions
     .getChatInputContainer()
     .getByTestId("context-limit-banner");
-  await expect(contextLimitBanner).toBeVisible({ timeout: Timeout.MEDIUM });
+  await expect(contextLimitBanner).toBeVisible({ timeout: Timeout.LONG });
 
   // Verify banner text for long context case
   await expect(contextLimitBanner).toContainText(

--- a/e2e-tests/prompt_library.spec.ts
+++ b/e2e-tests/prompt_library.spec.ts
@@ -11,7 +11,14 @@ test("create and edit prompt", async ({ po }) => {
     content: "prompt1content",
   });
 
-  await expect(po.page.getByTestId("prompt-card")).toMatchAriaSnapshot();
+  // Wait for prompt card to be fully rendered
+  const promptCard = po.page.getByTestId("prompt-card");
+  await expect(promptCard).toBeVisible();
+  await expect(
+    promptCard.getByRole("heading", { name: "title1" }),
+  ).toBeVisible();
+  await expect(promptCard).toContainText("desc");
+  await expect(promptCard).toContainText("prompt1content");
 
   await po.page.getByTestId("edit-prompt-button").click();
   await po.page
@@ -19,7 +26,13 @@ test("create and edit prompt", async ({ po }) => {
     .fill("prompt1content-edited");
   await po.page.getByRole("button", { name: "Save" }).click();
 
-  await expect(po.page.getByTestId("prompt-card")).toMatchAriaSnapshot();
+  // Verify edited content is displayed
+  await expect(promptCard).toBeVisible();
+  await expect(
+    promptCard.getByRole("heading", { name: "title1" }),
+  ).toBeVisible();
+  await expect(promptCard).toContainText("desc");
+  await expect(promptCard).toContainText("prompt1content-edited");
 });
 
 test("delete prompt", async ({ po }) => {

--- a/e2e-tests/snapshots/prompt_library.spec.ts_create-and-edit-prompt-1.aria.yml
+++ b/e2e-tests/snapshots/prompt_library.spec.ts_create-and-edit-prompt-1.aria.yml
@@ -1,7 +1,0 @@
-- heading "title1" [level=3]
-- paragraph: desc
-- button:
-  - img
-- button:
-  - img
-- text: prompt1content

--- a/e2e-tests/snapshots/prompt_library.spec.ts_create-and-edit-prompt-2.aria.yml
+++ b/e2e-tests/snapshots/prompt_library.spec.ts_create-and-edit-prompt-2.aria.yml
@@ -1,7 +1,0 @@
-- heading "title1" [level=3]
-- paragraph: desc
-- button:
-  - img
-- button:
-  - img
-- text: prompt1content-edited


### PR DESCRIPTION
…ary tests

- context_limit_banner: increase banner visibility timeout from MEDIUM to LONG since token counting IPC fires asynchronously after streaming ends
- attach_image: wait for file card button to render before taking aria snapshot in the upload-to-codebase test
- prompt_library: replace flaky toMatchAriaSnapshot with explicit assertions (toBeVisible, toContainText, getByRole) since Chrome's accessibility tree non-deterministically merges heading and paragraph text
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2725" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
