### PR TITLE
ci: route deflake E2E workflow to PAT token

### DIFF
--- a/.github/workflows/claude-deflake-e2e.yml
+++ b/.github/workflows/claude-deflake-e2e.yml
@@ -19,10 +19,7 @@ jobs:
       - self-hosted
       - macOS
       - ARM64
-    permissions:
-      actions: read
-      contents: write
-      pull-requests: write
+    permissions: {}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -41,7 +38,7 @@ jobs:
       - name: Install node modules
         run: npm ci --no-audit --no-fund --progress=false
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.DEFLAKE_E2E_PAT_GITHUB_TOKEN }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
@@ -66,11 +63,11 @@ jobs:
       - name: Deflake E2E tests
         uses: anthropics/claude-code-action@v1
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.DEFLAKE_E2E_PAT_GITHUB_TOKEN }}
           CLAUDE_CODE_MAX_OUTPUT_TOKENS: 48000
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.DEFLAKE_E2E_PAT_GITHUB_TOKEN }}
           claude_args: --model claude-opus-4-6
           prompt: |
             /dyad:deflake-e2e-recent-commits ${{ inputs.commit_count || '10' }}


### PR DESCRIPTION
## Summary
- Update deflake E2E workflow permissions to use explicit PAT token secrets instead of default GITHUB_TOKEN.
- Reduce workflow repository permissions to empty set and align token usage for install and Claude action steps.
- Maintain existing deflake behavior while removing default token-dependent permission requirements.

## Test plan
- npm run fmt
- npm run lint:fix
- npm run ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2726" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
