### PR TITLE
Include SQL execution result in execute_sql tool output

### DIFF
--- a/src/pro/main/ipc/handlers/local_agent/tools/execute_sql.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/execute_sql.ts
@@ -36,7 +36,7 @@ export const executeSqlTool: ToolDefinition<z.infer<typeof executeSqlSchema>> =
         throw new Error("Supabase is not connected to this app");
       }
 
-      await executeSupabaseSql({
+      const sqlResult = await executeSupabaseSql({
         supabaseProjectId: ctx.supabaseProjectId,
         query: args.query,
         organizationSlug: ctx.supabaseOrganizationSlug ?? null,
@@ -48,10 +48,10 @@ export const executeSqlTool: ToolDefinition<z.infer<typeof executeSqlSchema>> =
         try {
           await writeMigrationFile(ctx.appPath, args.query, args.description);
         } catch (error) {
-          return `SQL executed, but failed to write migration file: ${error}`;
+          return `SQL executed, but failed to write migration file: ${error}\n\nSQL result:\n${sqlResult}`;
         }
       }
 
-      return "Successfully executed SQL query";
+      return `Successfully executed SQL query.\n\nSQL result:\n${sqlResult}`;
     },
   };


### PR DESCRIPTION
Fixes #2790 

## Summary
- Return SQL execution output from execute_sql tool instead of discarding it
- Surface migration write failures alongside SQL execution results
- Preserve existing migration behavior while improving feedback for callers

## Test plan
- npm run fmt
- npm run lint:fix
- npm run ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2797" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
