### PR TITLE
chore: bump @ai-sdk/openai to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dyad",
-  "version": "0.37.0",
+  "version": "0.38.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dyad",
-      "version": "0.37.0",
+      "version": "0.38.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/amazon-bedrock": "^4.0.46",
@@ -15,7 +15,7 @@
         "@ai-sdk/google": "^3.0.20",
         "@ai-sdk/google-vertex": "^4.0.41",
         "@ai-sdk/mcp": "^1.0.18",
-        "@ai-sdk/openai": "^3.0.25",
+        "@ai-sdk/openai": "^3.0.36",
         "@ai-sdk/openai-compatible": "^2.0.26",
         "@ai-sdk/provider-utils": "^4.0.13",
         "@ai-sdk/xai": "^3.0.46",
@@ -202,6 +202,22 @@
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
+    "node_modules/@ai-sdk/azure/node_modules/@ai-sdk/openai": {
+      "version": "3.0.25",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.25.tgz",
+      "integrity": "sha512-DsaN46R98+D1W3lU3fKuPU3ofacboLaHlkAwxJPgJ8eup1AJHmPK1N1y10eJJbJcF6iby8Tf/vanoZxc9JPUfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.7",
+        "@ai-sdk/provider-utils": "4.0.13"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
     "node_modules/@ai-sdk/gateway": {
       "version": "3.0.32",
       "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.32.tgz",
@@ -272,13 +288,13 @@
       }
     },
     "node_modules/@ai-sdk/openai": {
-      "version": "3.0.25",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.25.tgz",
-      "integrity": "sha512-DsaN46R98+D1W3lU3fKuPU3ofacboLaHlkAwxJPgJ8eup1AJHmPK1N1y10eJJbJcF6iby8Tf/vanoZxc9JPUfw==",
+      "version": "3.0.36",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.36.tgz",
+      "integrity": "sha512-foY3onGY8l3q9niMw0Cwe9xrYnm46keIWL57NRw6F3DKzSW9TYTfx0cQJs/j8lXJ8lPzqNxpMO/zXOkqCUt3IQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.7",
-        "@ai-sdk/provider-utils": "4.0.13"
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.15"
       },
       "engines": {
         "node": ">=18"
@@ -295,6 +311,35 @@
       "dependencies": {
         "@ai-sdk/provider": "3.0.7",
         "@ai-sdk/provider-utils": "4.0.13"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai/node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/openai/node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.15.tgz",
+      "integrity": "sha512-8XiKWbemmCbvNN0CLR9u3PQiet4gtEVIrX4zzLxnCj06AwsEDJwJVBbKrEI4t6qE8XRSIvU2irka0dcpziKW6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
       },
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@ai-sdk/google": "^3.0.20",
     "@ai-sdk/google-vertex": "^4.0.41",
     "@ai-sdk/mcp": "^1.0.18",
-    "@ai-sdk/openai": "^3.0.25",
+    "@ai-sdk/openai": "^3.0.36",
     "@ai-sdk/openai-compatible": "^2.0.26",
     "@ai-sdk/provider-utils": "^4.0.13",
     "@ai-sdk/xai": "^3.0.46",


### PR DESCRIPTION
## Summary
- Bump @ai-sdk/openai dependency in package.json from ^3.0.25 to ^3.0.36.
- Refresh package-lock.json to match the updated resolution.

## Test plan
- npm run fmt
- npm run lint:fix
- npm run ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2812" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
