### PR TITLE
Fix Supabase settings races that drop org connections

### DIFF
--- a/src/__tests__/supabase_return_handler.test.ts
+++ b/src/__tests__/supabase_return_handler.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { handleSupabaseOAuthReturn } from "@/supabase_admin/supabase_return_handler";
+import { readSettings, writeSettings } from "@/main/settings";
+import { listSupabaseOrganizations } from "@/supabase_admin/supabase_management_client";
+
+vi.mock("@/main/settings", () => ({
+  readSettings: vi.fn(),
+  writeSettings: vi.fn(),
+}));
+
+vi.mock("@/supabase_admin/supabase_management_client", () => ({
+  listSupabaseOrganizations: vi.fn(),
+}));
+
+vi.mock("electron-log", () => ({
+  default: {
+    scope: () => ({
+      error: vi.fn(),
+      warn: vi.fn(),
+    }),
+  },
+}));
+
+describe("handleSupabaseOAuthReturn", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(readSettings).mockReturnValue({
+      selectedModel: { name: "auto", provider: "auto" },
+      providerSettings: {},
+      telemetryConsent: "unset",
+      telemetryUserId: "test-user",
+      hasRunBefore: false,
+      experiments: {},
+      enableProLazyEditsMode: true,
+      enableProSmartFilesContextMode: true,
+      selectedChatMode: "build",
+      enableAutoFixProblems: false,
+      enableAutoUpdate: true,
+      releaseChannel: "stable",
+      selectedTemplateId: "react",
+      selectedThemeId: "default",
+      isRunning: false,
+      enableNativeGit: true,
+      autoExpandPreviewPanel: true,
+      enableContextCompaction: true,
+      supabase: {
+        organizations: {
+          "existing-org": {
+            accessToken: {
+              value: "existing-access",
+              encryptionType: "plaintext",
+            },
+            refreshToken: {
+              value: "existing-refresh",
+              encryptionType: "plaintext",
+            },
+            expiresIn: 3600,
+            tokenTimestamp: 1000,
+          },
+        },
+      },
+    } as any);
+  });
+
+  it("stores credentials for all returned organization slugs", async () => {
+    vi.mocked(listSupabaseOrganizations).mockResolvedValue([
+      { slug: "org-a" },
+      { slug: "org-b" },
+    ] as any);
+
+    await handleSupabaseOAuthReturn({
+      token: "new-access-token",
+      refreshToken: "new-refresh-token",
+      expiresIn: 7200,
+    });
+
+    expect(writeSettings).toHaveBeenCalledTimes(1);
+    expect(writeSettings).toHaveBeenCalledWith({
+      supabase: {
+        organizations: {
+          "existing-org": {
+            accessToken: {
+              value: "existing-access",
+              encryptionType: "plaintext",
+            },
+            refreshToken: {
+              value: "existing-refresh",
+              encryptionType: "plaintext",
+            },
+            expiresIn: 3600,
+            tokenTimestamp: 1000,
+          },
+          "org-a": {
+            accessToken: { value: "new-access-token" },
+            refreshToken: { value: "new-refresh-token" },
+            expiresIn: 7200,
+            tokenTimestamp: expect.any(Number),
+          },
+          "org-b": {
+            accessToken: { value: "new-access-token" },
+            refreshToken: { value: "new-refresh-token" },
+            expiresIn: 7200,
+            tokenTimestamp: expect.any(Number),
+          },
+        },
+      },
+    });
+  });
+
+  it("falls back to legacy token fields when organization lookup fails", async () => {
+    vi.mocked(listSupabaseOrganizations).mockRejectedValue(new Error("boom"));
+
+    await handleSupabaseOAuthReturn({
+      token: "legacy-access",
+      refreshToken: "legacy-refresh",
+      expiresIn: 1800,
+    });
+
+    expect(writeSettings).toHaveBeenCalledTimes(1);
+    expect(writeSettings).toHaveBeenCalledWith({
+      supabase: expect.objectContaining({
+        accessToken: { value: "legacy-access" },
+        refreshToken: { value: "legacy-refresh" },
+        expiresIn: 1800,
+        tokenTimestamp: expect.any(Number),
+      }),
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- serialize Supabase settings mutations with a shared `supabase-settings` lock to avoid interleaved overwrites
- preserve existing `supabase` fields/org maps during OAuth return, token refresh, and org deletion writes
- add a regression test for Supabase OAuth return credential persistence

## Test plan
- npm run fmt && npm run lint:fix && npm run ts
- npm test
- npm test -- src/__tests__/supabase_return_handler.test.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2820" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
