### PR TITLE
Handle local agent connection recovery

### DIFF
--- a/e2e-tests/fixtures/engine/local-agent/connection-drop.ts
+++ b/e2e-tests/fixtures/engine/local-agent/connection-drop.ts
@@ -1,0 +1,29 @@
+import type { LocalAgentFixture } from "../../../../testing/fake-llm-server/localAgentTypes";
+
+/**
+ * Tests automatic retry after connection drop (e.g., TCP terminated mid-stream).
+ * The fake server will destroy the socket on the 1st attempt, and the local agent
+ * handler should automatically retry and succeed on the 2nd attempt.
+ */
+export const fixture: LocalAgentFixture = {
+  description: "Automatic retry after connection drop",
+  dropConnectionOnAttempts: [1],
+  turns: [
+    {
+      text: "I'll create a file for you.",
+      toolCalls: [
+        {
+          name: "write_file",
+          args: {
+            path: "src/recovered.ts",
+            content: `export const recovered = true;\n`,
+            description: "File created after connection recovery",
+          },
+        },
+      ],
+    },
+    {
+      text: "Successfully created the file after automatic retry.",
+    },
+  ],
+};

--- a/e2e-tests/local_agent_connection_retry.spec.ts
+++ b/e2e-tests/local_agent_connection_retry.spec.ts
@@ -1,0 +1,27 @@
+import { testSkipIfWindows } from "./helpers/test_helper";
+
+/**
+ * E2E test for local-agent connection retry resilience.
+ * Verifies that the agent automatically recovers from transient connection
+ * drops (e.g., TCP terminated mid-stream) by retrying the stream.
+ */
+
+testSkipIfWindows(
+  "local-agent - recovers from connection drop",
+  async ({ po }) => {
+    await po.setUpDyadPro({ localAgent: true });
+    await po.importApp("minimal");
+    await po.chatActions.selectLocalAgentMode();
+
+    // The connection-drop fixture drops the connection on the 1st attempt.
+    // The local agent handler should automatically retry and succeed.
+    await po.sendPrompt("tc=local-agent/connection-drop");
+
+    // Verify the agent completed successfully by checking messages and file output
+    await po.snapshotMessages();
+    await po.snapshotAppFiles({
+      name: "after-connection-retry",
+      files: ["src/recovered.ts"],
+    });
+  },
+);

--- a/e2e-tests/snapshots/local_agent_connection_retry.spec.ts_after-connection-retry.txt
+++ b/e2e-tests/snapshots/local_agent_connection_retry.spec.ts_after-connection-retry.txt
@@ -1,0 +1,2 @@
+=== src/recovered.ts ===
+export const recovered = true;

--- a/e2e-tests/snapshots/local_agent_connection_retry.spec.ts_local-agent---recovers-from-connection-drop-1.aria.yml
+++ b/e2e-tests/snapshots/local_agent_connection_retry.spec.ts_local-agent---recovers-from-connection-drop-1.aria.yml
@@ -1,0 +1,48 @@
+- paragraph: /Generate an AI_RULES\.md file for this app\. Describe the tech stack in 5-\d+ bullet points and describe clear rules about what libraries to use for what\./
+- button "file1.txt file1.txt Edit":
+  - img
+  - text: ""
+  - button "Edit":
+    - img
+    - text: ""
+  - img
+- paragraph: More EOM
+- button "Copy":
+  - img
+- img
+- text: Approved
+- img
+- text: claude-opus-4-5
+- img
+- text: less than a minute ago
+- img
+- text: (1 files changed)
+- button "Copy Request ID":
+  - img
+  - text: ""
+- paragraph: tc=local-agent/connection-drop
+- paragraph: I'll create a file for you.
+- 'button "recovered.ts src/recovered.ts Edit Summary: File created after connection recovery"':
+  - img
+  - text: ""
+  - button "Edit":
+    - img
+    - text: ""
+  - img
+  - text: ""
+- paragraph: Successfully created the file after automatic retry.
+- button "Copy":
+  - img
+- img
+- text: claude-opus-4-5
+- img
+- text: less than a minute ago
+- button "Copy Request ID":
+  - img
+  - text: ""
+- button "Undo":
+  - img
+  - text: ""
+- button "Retry":
+  - img
+  - text: ""

--- a/src/__tests__/local_agent_handler.test.ts
+++ b/src/__tests__/local_agent_handler.test.ts
@@ -847,6 +847,87 @@ describe("handleLocalAgentStream", () => {
       expect(lastContentUpdate.data.content).toContain("Hello, ");
       expect(lastContentUpdate.data.content).toContain("world!");
     });
+
+    it("should retry and resume when a stream terminates transiently", async () => {
+      // Arrange
+      const { event, getMessagesByChannel } = createFakeEvent();
+      mockSettings = buildTestSettings({ enableDyadPro: true });
+      mockChatData = buildTestChat();
+
+      const streamMessagesByAttempt: any[][] = [];
+      let attemptCount = 0;
+      mockStreamTextImpl = (options) => {
+        attemptCount += 1;
+        streamMessagesByAttempt.push(options.messages ?? []);
+
+        if (attemptCount === 1) {
+          return {
+            fullStream: (async function* () {
+              yield { type: "text-delta", text: "Partial response. " };
+              throw new TypeError("terminated");
+            })(),
+            response: Promise.resolve({ messages: [] }),
+            steps: Promise.resolve([]),
+          };
+        }
+
+        return {
+          fullStream: (async function* () {
+            yield { type: "text-delta", text: "Recovered output." };
+          })(),
+          response: Promise.resolve({
+            messages: [
+              {
+                role: "assistant",
+                content: [{ type: "text", text: "Recovered output." }],
+              },
+            ],
+          }),
+          steps: Promise.resolve([{ toolCalls: [] }]),
+        };
+      };
+
+      // Act
+      await handleLocalAgentStream(
+        event,
+        { chatId: 1, prompt: "test" },
+        new AbortController(),
+        {
+          placeholderMessageId: 10,
+          systemPrompt: "You are helpful",
+          dyadRequestId,
+        },
+      );
+
+      // Assert
+      expect(attemptCount).toBe(2);
+      expect(getMessagesByChannel("chat:response:error")).toHaveLength(0);
+
+      const contentUpdates = dbOperations.updates.filter(
+        (u) => u.data.content !== undefined,
+      );
+      const finalContent = contentUpdates[contentUpdates.length - 1].data
+        .content as string;
+      expect(finalContent).toContain("Partial response.");
+      expect(finalContent).toContain("Recovered output.");
+
+      const continuationInstructionFound = (
+        streamMessagesByAttempt[1] ?? []
+      ).some(
+        (message: any) =>
+          message.role === "user" &&
+          Array.isArray(message.content) &&
+          message.content.some(
+            (part: any) =>
+              part.type === "text" &&
+              typeof part.text === "string" &&
+              part.text.includes(
+                "previous response stream was interrupted by a transient network error",
+              ),
+          ),
+      );
+      expect(continuationInstructionFound).toBe(true);
+    });
   });
 
   describe("Stream processing - reasoning blocks", () => {

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -79,6 +79,10 @@ import { getPostCompactionMessages } from "@/ipc/handlers/compaction/compaction_
 
 const logger = log.scope("local_agent_handler");
 const PLANNING_QUESTIONNAIRE_TOOL_NAME = "planning_questionnaire";
+const MAX_TERMINATED_STREAM_RETRIES = 2;
+const STREAM_RETRY_BASE_DELAY_MS = 400;
+const STREAM_CONTINUE_MESSAGE =
+  "[System] Your previous response stream was interrupted by a transient network error. Continue from exactly where you left off and do not repeat text that has already been sent.";
 
 // ============================================================================
 // Tool Streaming State Management
@@ -587,321 +591,427 @@ export async function handleLocalAgentStream(
       postMidTurnCompactionStartStep = null;
       baseMessageHistoryCount = currentMessageHistory.length;
 
-      // Stream the response
-      const streamResult = streamText({
-        model: modelClient.model,
-        headers: getAiHeaders({
-          builtinProviderId: modelClient.builtinProviderId,
-        }),
-        providerOptions: getProviderOptions({
-          dyadAppId: chat.app.id,
-          dyadRequestId,
-          dyadDisableFiles: true, // Local agent uses tools, not file injection
-          files: [],
-          mentionedAppsCodebases: [],
-          builtinProviderId: modelClient.builtinProviderId,
-          settings,
-        }),
-        maxOutputTokens,
-        temperature,
-        maxRetries: 2,
-        system: systemPrompt,
-        messages: currentMessageHistory,
-        tools: allTools,
-        stopWhen: [
-          stepCountIs(25),
-          hasToolCall(addIntegrationTool.name),
-          // In plan mode, also stop after writing a plan or exiting plan mode.
-          ...(planModeOnly
-            ? [hasToolCall(writePlanTool.name), hasToolCall(exitPlanTool.name)]
-            : []),
-        ],
-        abortSignal: abortController.signal,
-        // Inject pending user messages (e.g., images from web_crawl) between steps
-        // We must re-inject all accumulated messages each step because the AI SDK
-        // doesn't persist dynamically injected messages in its internal state.
-        // We track the insertion index so messages appear at the same position each step.
-        prepareStep: async (options) => {
-          let stepOptions = options;
-
-          if (
-            !messageOverride &&
-            compactBeforeNextStep &&
-            !compactedMidTurn &&
-            settings.enableContextCompaction !== false
-          ) {
-            compactBeforeNextStep = false;
-            const inFlightTailMessages = options.messages.slice(
-              baseMessageHistoryCount,
-            );
-            const compacted = await maybePerformPendingCompaction({
-              showOnTopOfCurrentResponse: true,
-              force: true,
-            });
-
-            if (compacted) {
-              compactedMidTurn = true;
-              // Preserve only messages generated after this compaction boundary.
-              postMidTurnCompactionStartStep = options.stepNumber;
-              // Clear stale injected messages — their insertAtIndex values are
-              // based on the pre-compaction message array which has been rebuilt
-              // with a different (typically smaller) count. Keeping them would
-              // cause injectMessagesAtPositions to splice at wrong positions.
-              allInjectedMessages.length = 0;
-              const compactedMessageHistory = buildChatMessageHistory(
-                chat.messages,
-                {
-                  // Keep the structured in-flight assistant/tool messages from
-                  // the current stream instead of the placeholder DB content.
-                  excludeMessageIds: new Set([placeholderMessageId]),
-                },
-              );
-              baseMessageHistoryCount = compactedMessageHistory.length;
-              stepOptions = {
-                ...options,
-                // Preserve in-flight turn messages so same-turn tool loops can
-                // continue, while later turns are compacted via persisted history.
-                messages: [...compactedMessageHistory, ...inFlightTailMessages],
-              };
-            } else {
-              // Prevent repeated compaction attempts if the first one fails.
-              compactionFailedMidTurn = true;
-            }
-          }
-
-          const preparedStep = prepareStepMessages(
-            stepOptions,
-            pendingUserMessages,
-            allInjectedMessages,
-          );
-
-          // prepareStepMessages returns undefined when it has no additional
-          // injections/cleanups to apply. If we already replaced the base
-          // message history (e.g., after mid-turn compaction), we still need
-          // to return the updated options.
-          let result =
-            preparedStep ?? (stepOptions === options ? undefined : stepOptions);
-
-          return result;
-        },
-        onStepFinish: async (step) => {
-          if (!hasInjectedPlanningQuestionnaireReflection) {
-            const questionnaireError =
-              getPlanningQuestionnaireErrorFromStep(step);
-            if (questionnaireError) {
-              pendingUserMessages.push([
-                {
-                  type: "text",
-                  text: buildPlanningQuestionnaireReflectionMessage(
-                    questionnaireError,
-                    planModeOnly,
-                  ),
-                },
-              ]);
-              hasInjectedPlanningQuestionnaireReflection = true;
-              logger.info(
-                `Injected synthetic planning_questionnaire reflection message for chat ${req.chatId}`,
-              );
-            }
-          }
-
-          if (
-            settings.enableContextCompaction === false ||
-            compactedMidTurn ||
-            typeof step.usage.totalTokens !== "number"
-          ) {
-            return;
-          }
-
-          const shouldCompact = await checkAndMarkForCompaction(
-            req.chatId,
-            step.usage.totalTokens,
-          );
-
-          // If this step triggered tool calls, compact before the next step
-          // in this same user turn instead of waiting for the next message.
-          // Only attempt mid-turn compaction once per turn.
-          if (
-            shouldCompact &&
-            step.toolCalls.length > 0 &&
-            !compactionFailedMidTurn
-          ) {
-            compactBeforeNextStep = true;
-          }
-        },
-        onFinish: async (response) => {
-          const totalTokens = response.usage?.totalTokens;
-          const inputTokens = response.usage?.inputTokens;
-          const cachedInputTokens = response.usage?.cachedInputTokens;
-          logger.log(
-            "Total tokens used:",
-            totalTokens,
-            "Input tokens:",
-            inputTokens,
-            "Cached input tokens:",
-            cachedInputTokens,
-            "Cache hit ratio:",
-            cachedInputTokens
-              ? (cachedInputTokens ?? 0) / (inputTokens ?? 0)
-              : 0,
-          );
-          if (typeof totalTokens === "number") {
-            await db
-              .update(messages)
-              .set({ maxTokensUsed: totalTokens })
-              .where(eq(messages.id, placeholderMessageId))
-              .catch((err) => logger.error("Failed to save token count", err));
-          }
-        },
-        onError: (error: any) => {
-          const errorMessage = error?.error?.message || JSON.stringify(error);
-          logger.error("Local agent stream error:", errorMessage);
-          safeSend(event.sender, "chat:response:error", {
-            chatId: req.chatId,
-            error: `AI error: ${errorMessage}`,
-          });
-        },
-      });
-
-      // Process the stream
-      let inThinkingBlock = false;
       let passProducedChatText = false;
-
-      try {
-        for await (const part of streamResult.fullStream) {
-          if (abortController.signal.aborted) {
-            logger.log(`Stream aborted for chat ${req.chatId}`);
-            // Clean up pending consent/questionnaire requests to prevent stale UI banners
-            clearPendingConsentsForChat(req.chatId);
-            clearPendingQuestionnairesForChat(req.chatId);
-            break;
-          }
-
-          let chunk = "";
-
-          // Handle thinking block transitions
-          if (
-            inThinkingBlock &&
-            !["reasoning-delta", "reasoning-end", "reasoning-start"].includes(
-              part.type,
-            )
-          ) {
-            chunk = "</think>\n";
-            inThinkingBlock = false;
-          }
-
-          switch (part.type) {
-            case "text-delta":
-              passProducedChatText = true;
-              chunk += part.text;
-              break;
-
-            case "reasoning-start":
-              if (!inThinkingBlock) {
-                chunk = "<think>";
-                inThinkingBlock = true;
-              }
-              break;
-
-            case "reasoning-delta":
-              if (!inThinkingBlock) {
-                chunk = "<think>";
-                inThinkingBlock = true;
-              }
-              chunk += part.text;
-              break;
-
-            case "reasoning-end":
-              if (inThinkingBlock) {
-                chunk = "</think>\n";
-                inThinkingBlock = false;
-              }
-              break;
-
-            case "tool-input-start": {
-              // Initialize streaming state for this tool call
-              getOrCreateStreamingEntry(part.id, part.toolName);
-              break;
-            }
-
-            case "tool-input-delta": {
-              // Accumulate args and stream XML preview
-              const entry = getOrCreateStreamingEntry(part.id);
-              if (entry) {
-                entry.argsAccumulated += part.delta;
-                const toolDef = findToolDefinition(entry.toolName);
-                if (toolDef?.buildXml) {
-                  const argsPartial = parsePartialJson(entry.argsAccumulated);
-                  const xml = toolDef.buildXml(argsPartial, false);
-                  if (xml) {
-                    ctx.onXmlStream(xml);
-                  }
-                }
-              }
-              break;
-            }
-
-            case "tool-input-end": {
-              // Build final XML and persist
-              const entry = getOrCreateStreamingEntry(part.id);
-              if (entry) {
-                const toolDef = findToolDefinition(entry.toolName);
-                if (toolDef?.buildXml) {
-                  const argsPartial = parsePartialJson(entry.argsAccumulated);
-                  const xml = toolDef.buildXml(argsPartial, true);
-                  if (xml) {
-                    ctx.onXmlComplete(xml);
-                  }
-                }
-              }
-              cleanupStreamingEntry(part.id);
-              break;
-            }
-
-            case "tool-call":
-              // Tool execution happens via execute callbacks
-              break;
-
-            case "tool-result":
-              // Tool results are already handled by the execute callback
-              break;
-          }
-
-          if (chunk) {
-            fullResponse += chunk;
-            await updateResponseInDb(placeholderMessageId, fullResponse);
-            sendResponseChunk(
-              event,
-              req.chatId,
-              chat,
-              fullResponse,
-              placeholderMessageId,
-              hiddenMessageIdsForStreaming,
-            );
-          }
-        }
-      } catch (error) {
-        if (!abortController.signal.aborted) {
-          throw error;
-        }
-        logger.log(`Stream interrupted after abort for chat ${req.chatId}`);
-      }
-
-      // Close thinking block if still open
-      if (inThinkingBlock) {
-        fullResponse += "</think>\n";
-        await updateResponseInDb(placeholderMessageId, fullResponse);
-      }
-
-      // Get response messages for this pass
       let responseMessages: ModelMessage[] = [];
-      let steps: Awaited<typeof streamResult.steps> = [];
-      try {
-        const response = await streamResult.response;
-        steps = await streamResult.steps;
-        responseMessages = response.messages;
-      } catch (err) {
-        logger.warn("Failed to retrieve stream response messages:", err);
+      let steps: Array<{
+        toolCalls: Array<unknown>;
+        response?: { messages?: ModelMessage[] };
+      }> = [];
+      let terminatedRetryCount = 0;
+      let needsContinuationInstruction = false;
+
+      while (!abortController.signal.aborted) {
+        let passAttemptSawToolActivity = false;
+        let streamErrorFromCallback: unknown;
+        const passAttemptResponseStartLength = fullResponse.length;
+        const attemptMessages = needsContinuationInstruction
+          ? [
+              ...currentMessageHistory,
+              buildTerminatedRetryContinuationInstruction(),
+            ]
+          : currentMessageHistory;
+
+        const streamResult = streamText({
+          model: modelClient.model,
+          headers: getAiHeaders({
+            builtinProviderId: modelClient.builtinProviderId,
+          }),
+          providerOptions: getProviderOptions({
+            dyadAppId: chat.app.id,
+            dyadRequestId,
+            dyadDisableFiles: true, // Local agent uses tools, not file injection
+            files: [],
+            mentionedAppsCodebases: [],
+            builtinProviderId: modelClient.builtinProviderId,
+            settings,
+          }),
+          maxOutputTokens,
+          temperature,
+          maxRetries: 2,
+          system: systemPrompt,
+          messages: attemptMessages,
+          tools: allTools,
+          stopWhen: [
+            stepCountIs(25),
+            hasToolCall(addIntegrationTool.name),
+            // In plan mode, also stop after writing a plan or exiting plan mode.
+            ...(planModeOnly
+              ? [
+                  hasToolCall(writePlanTool.name),
+                  hasToolCall(exitPlanTool.name),
+                ]
+              : []),
+          ],
+          abortSignal: abortController.signal,
+          // Inject pending user messages (e.g., images from web_crawl) between steps
+          // We must re-inject all accumulated messages each step because the AI SDK
+          // doesn't persist dynamically injected messages in its internal state.
+          // We track the insertion index so messages appear at the same position each step.
+          prepareStep: async (options) => {
+            let stepOptions = options;
+
+            if (
+              !messageOverride &&
+              compactBeforeNextStep &&
+              !compactedMidTurn &&
+              settings.enableContextCompaction !== false
+            ) {
+              compactBeforeNextStep = false;
+              const inFlightTailMessages = options.messages.slice(
+                baseMessageHistoryCount,
+              );
+              const compacted = await maybePerformPendingCompaction({
+                showOnTopOfCurrentResponse: true,
+                force: true,
+              });
+
+              if (compacted) {
+                compactedMidTurn = true;
+                // Preserve only messages generated after this compaction boundary.
+                postMidTurnCompactionStartStep = options.stepNumber;
+                // Clear stale injected messages — their insertAtIndex values are
+                // based on the pre-compaction message array which has been rebuilt
+                // with a different (typically smaller) count. Keeping them would
+                // cause injectMessagesAtPositions to splice at wrong positions.
+                allInjectedMessages.length = 0;
+                const compactedMessageHistory = buildChatMessageHistory(
+                  chat.messages,
+                  {
+                    // Keep the structured in-flight assistant/tool messages from
+                    // the current stream instead of the placeholder DB content.
+                    excludeMessageIds: new Set([placeholderMessageId]),
+                  },
+                );
+                baseMessageHistoryCount = compactedMessageHistory.length;
+                stepOptions = {
+                  ...options,
+                  // Preserve in-flight turn messages so same-turn tool loops can
+                  // continue, while later turns are compacted via persisted history.
+                  messages: [
+                    ...compactedMessageHistory,
+                    ...inFlightTailMessages,
+                  ],
+                };
+              } else {
+                // Prevent repeated compaction attempts if the first one fails.
+                compactionFailedMidTurn = true;
+              }
+            }
+
+            const preparedStep = prepareStepMessages(
+              stepOptions,
+              pendingUserMessages,
+              allInjectedMessages,
+            );
+
+            // prepareStepMessages returns undefined when it has no additional
+            // injections/cleanups to apply. If we already replaced the base
+            // message history (e.g., after mid-turn compaction), we still need
+            // to return the updated options.
+            let result =
+              preparedStep ??
+              (stepOptions === options ? undefined : stepOptions);
+
+            return result;
+          },
+          onStepFinish: async (step) => {
+            if (step.toolCalls.length > 0) {
+              passAttemptSawToolActivity = true;
+            }
+
+            if (!hasInjectedPlanningQuestionnaireReflection) {
+              const questionnaireError =
+                getPlanningQuestionnaireErrorFromStep(step);
+              if (questionnaireError) {
+                pendingUserMessages.push([
+                  {
+                    type: "text",
+                    text: buildPlanningQuestionnaireReflectionMessage(
+                      questionnaireError,
+                      planModeOnly,
+                    ),
+                  },
+                ]);
+                hasInjectedPlanningQuestionnaireReflection = true;
+                logger.info(
+                  `Injected synthetic planning_questionnaire reflection message for chat ${req.chatId}`,
+                );
+              }
+            }
+
+            if (
+              settings.enableContextCompaction === false ||
+              compactedMidTurn ||
+              typeof step.usage.totalTokens !== "number"
+            ) {
+              return;
+            }
+
+            const shouldCompact = await checkAndMarkForCompaction(
+              req.chatId,
+              step.usage.totalTokens,
+            );
+
+            // If this step triggered tool calls, compact before the next step
+            // in this same user turn instead of waiting for the next message.
+            // Only attempt mid-turn compaction once per turn.
+            if (
+              shouldCompact &&
+              step.toolCalls.length > 0 &&
+              !compactionFailedMidTurn
+            ) {
+              compactBeforeNextStep = true;
+            }
+          },
+          onFinish: async (response) => {
+            const totalTokens = response.usage?.totalTokens;
+            const inputTokens = response.usage?.inputTokens;
+            const cachedInputTokens = response.usage?.cachedInputTokens;
+            logger.log(
+              "Total tokens used:",
+              totalTokens,
+              "Input tokens:",
+              inputTokens,
+              "Cached input tokens:",
+              cachedInputTokens,
+              "Cache hit ratio:",
+              cachedInputTokens
+                ? (cachedInputTokens ?? 0) / (inputTokens ?? 0)
+                : 0,
+            );
+            if (typeof totalTokens === "number") {
+              await db
+                .update(messages)
+                .set({ maxTokensUsed: totalTokens })
+                .where(eq(messages.id, placeholderMessageId))
+                .catch((err) =>
+                  logger.error("Failed to save token count", err),
+                );
+            }
+          },
+          onError: (error: any) => {
+            const normalizedError = unwrapStreamError(error);
+            streamErrorFromCallback = normalizedError;
+            logger.error(
+              "Local agent stream error:",
+              getErrorMessage(normalizedError),
+            );
+          },
+        });
+
+        let inThinkingBlock = false;
+        let streamErrorFromIteration: unknown;
+
+        try {
+          for await (const part of streamResult.fullStream) {
+            if (abortController.signal.aborted) {
+              logger.log(`Stream aborted for chat ${req.chatId}`);
+              // Clean up pending consent/questionnaire requests to prevent stale UI banners
+              clearPendingConsentsForChat(req.chatId);
+              clearPendingQuestionnairesForChat(req.chatId);
+              break;
+            }
+
+            let chunk = "";
+
+            // Handle thinking block transitions
+            if (
+              inThinkingBlock &&
+              !["reasoning-delta", "reasoning-end", "reasoning-start"].includes(
+                part.type,
+              )
+            ) {
+              chunk = "</think>\n";
+              inThinkingBlock = false;
+            }
+
+            switch (part.type) {
+              case "text-delta":
+                passProducedChatText = true;
+                chunk += part.text;
+                break;
+
+              case "reasoning-start":
+                if (!inThinkingBlock) {
+                  chunk = "<think>";
+                  inThinkingBlock = true;
+                }
+                break;
+
+              case "reasoning-delta":
+                if (!inThinkingBlock) {
+                  chunk = "<think>";
+                  inThinkingBlock = true;
+                }
+                chunk += part.text;
+                break;
+
+              case "reasoning-end":
+                if (inThinkingBlock) {
+                  chunk = "</think>\n";
+                  inThinkingBlock = false;
+                }
+                break;
+
+              case "tool-input-start": {
+                passAttemptSawToolActivity = true;
+                // Initialize streaming state for this tool call
+                getOrCreateStreamingEntry(part.id, part.toolName);
+                break;
+              }
+
+              case "tool-input-delta": {
+                passAttemptSawToolActivity = true;
+                // Accumulate args and stream XML preview
+                const entry = getOrCreateStreamingEntry(part.id);
+                if (entry) {
+                  entry.argsAccumulated += part.delta;
+                  const toolDef = findToolDefinition(entry.toolName);
+                  if (toolDef?.buildXml) {
+                    const argsPartial = parsePartialJson(entry.argsAccumulated);
+                    const xml = toolDef.buildXml(argsPartial, false);
+                    if (xml) {
+                      ctx.onXmlStream(xml);
+                    }
+                  }
+                }
+                break;
+              }
+
+              case "tool-input-end": {
+                passAttemptSawToolActivity = true;
+                // Build final XML and persist
+                const entry = getOrCreateStreamingEntry(part.id);
+                if (entry) {
+                  const toolDef = findToolDefinition(entry.toolName);
+                  if (toolDef?.buildXml) {
+                    const argsPartial = parsePartialJson(entry.argsAccumulated);
+                    const xml = toolDef.buildXml(argsPartial, true);
+                    if (xml) {
+                      ctx.onXmlComplete(xml);
+                    }
+                  }
+                }
+                cleanupStreamingEntry(part.id);
+                break;
+              }
+
+              case "tool-call":
+                passAttemptSawToolActivity = true;
+                // Tool execution happens via execute callbacks
+                break;
+
+              case "tool-result":
+                passAttemptSawToolActivity = true;
+                // Tool results are already handled by the execute callback
+                break;
+            }
+
+            if (chunk) {
+              fullResponse += chunk;
+              await updateResponseInDb(placeholderMessageId, fullResponse);
+              sendResponseChunk(
+                event,
+                req.chatId,
+                chat,
+                fullResponse,
+                placeholderMessageId,
+                hiddenMessageIdsForStreaming,
+              );
+            }
+          }
+        } catch (error) {
+          if (!abortController.signal.aborted) {
+            streamErrorFromIteration = error;
+          } else {
+            logger.log(`Stream interrupted after abort for chat ${req.chatId}`);
+          }
+        }
+
+        // Close thinking block if still open
+        if (inThinkingBlock) {
+          fullResponse += "</think>\n";
+          await updateResponseInDb(placeholderMessageId, fullResponse);
+        }
+
+        if (abortController.signal.aborted) {
+          break;
+        }
+
+        const streamError = streamErrorFromIteration ?? streamErrorFromCallback;
+        if (streamError) {
+          if (
+            shouldRetryTerminatedStreamError({
+              error: streamError,
+              retryCount: terminatedRetryCount,
+              sawToolActivity: passAttemptSawToolActivity,
+              aborted: abortController.signal.aborted,
+            })
+          ) {
+            maybeAppendPartialResponseForRetry({
+              partialResponse: fullResponse.slice(
+                passAttemptResponseStartLength,
+              ),
+              currentMessageHistoryRef: currentMessageHistory,
+              accumulatedAiMessagesRef: accumulatedAiMessages,
+              onCurrentMessageHistoryUpdate: (next) =>
+                (currentMessageHistory = next),
+            });
+            terminatedRetryCount += 1;
+            needsContinuationInstruction = true;
+            const retryDelayMs =
+              STREAM_RETRY_BASE_DELAY_MS * terminatedRetryCount;
+            logger.warn(
+              `Transient stream termination for chat ${req.chatId}; retrying pass (${terminatedRetryCount}/${MAX_TERMINATED_STREAM_RETRIES}) after ${retryDelayMs}ms`,
+            );
+            await delay(retryDelayMs);
+            continue;
+          }
+          throw streamError;
+        }
+
+        try {
+          const response = await streamResult.response;
+          steps = (await streamResult.steps) ?? [];
+          responseMessages = response.messages;
+        } catch (err) {
+          if (
+            shouldRetryTerminatedStreamError({
+              error: err,
+              retryCount: terminatedRetryCount,
+              sawToolActivity: passAttemptSawToolActivity,
+              aborted: abortController.signal.aborted,
+            })
+          ) {
+            maybeAppendPartialResponseForRetry({
+              partialResponse: fullResponse.slice(
+                passAttemptResponseStartLength,
+              ),
+              currentMessageHistoryRef: currentMessageHistory,
+              accumulatedAiMessagesRef: accumulatedAiMessages,
+              onCurrentMessageHistoryUpdate: (next) =>
+                (currentMessageHistory = next),
+            });
+            terminatedRetryCount += 1;
+            needsContinuationInstruction = true;
+            const retryDelayMs =
+              STREAM_RETRY_BASE_DELAY_MS * terminatedRetryCount;
+            logger.warn(
+              `Transient stream termination while finalizing response for chat ${req.chatId}; retrying pass (${terminatedRetryCount}/${MAX_TERMINATED_STREAM_RETRIES}) after ${retryDelayMs}ms`,
+            );
+            await delay(retryDelayMs);
+            continue;
+          }
+          logger.warn("Failed to retrieve stream response messages:", err);
+          steps = [];
+          responseMessages = [];
+        }
+
+        break;
+      }
+
+      if (abortController.signal.aborted) {
+        break;
       }
 
       if (responseMessages.length > 0) {
@@ -913,7 +1023,7 @@ export async function handleLocalAgentStream(
                 // We want the step just before compaction to determine how many
                 // response messages to skip (they belong to pre-compaction context).
                 const prevStepMessages =
-                  steps[postMidTurnCompactionStartStep - 1]?.response.messages;
+                  steps[postMidTurnCompactionStartStep - 1]?.response?.messages;
                 if (!prevStepMessages) {
                   logger.warn(
                     `No step data found at index ${postMidTurnCompactionStartStep - 1} for mid-turn compaction slicing; persisting all messages`,
@@ -1055,6 +1165,95 @@ export async function handleLocalAgentStream(
     });
     return false; // Error - don't consume quota
   }
+}
+
+function buildTerminatedRetryContinuationInstruction(): ModelMessage {
+  return {
+    role: "user",
+    content: [{ type: "text", text: STREAM_CONTINUE_MESSAGE }],
+  };
+}
+
+function unwrapStreamError(error: unknown): unknown {
+  if (isRecord(error) && "error" in error) {
+    return error.error;
+  }
+  return error;
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return `${error.name}: ${error.message}`;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
+function isTerminatedStreamError(error: unknown): boolean {
+  const normalized = unwrapStreamError(error);
+  const message = getErrorMessage(normalized).toLowerCase();
+  if (message.includes("typeerror: terminated") || message === "terminated") {
+    return true;
+  }
+  const cause =
+    isRecord(normalized) && "cause" in normalized
+      ? normalized.cause
+      : undefined;
+  if (cause) {
+    return isTerminatedStreamError(cause);
+  }
+  return false;
+}
+
+function shouldRetryTerminatedStreamError(params: {
+  error: unknown;
+  retryCount: number;
+  sawToolActivity: boolean;
+  aborted: boolean;
+}): boolean {
+  const { error, retryCount, sawToolActivity, aborted } = params;
+  return (
+    !aborted &&
+    !sawToolActivity &&
+    retryCount < MAX_TERMINATED_STREAM_RETRIES &&
+    isTerminatedStreamError(error)
+  );
+}
+
+function maybeAppendPartialResponseForRetry(params: {
+  partialResponse: string;
+  currentMessageHistoryRef: ModelMessage[];
+  accumulatedAiMessagesRef: ModelMessage[];
+  onCurrentMessageHistoryUpdate: (next: ModelMessage[]) => void;
+}) {
+  const {
+    partialResponse,
+    currentMessageHistoryRef,
+    accumulatedAiMessagesRef,
+    onCurrentMessageHistoryUpdate,
+  } = params;
+  if (!partialResponse.trim()) {
+    return;
+  }
+  const assistantContinuationMessage: ModelMessage = {
+    role: "assistant",
+    content: [{ type: "text", text: partialResponse }],
+  };
+  onCurrentMessageHistoryUpdate([
+    ...currentMessageHistoryRef,
+    assistantContinuationMessage,
+  ]);
+  accumulatedAiMessagesRef.push(assistantContinuationMessage);
+}
+
+async function delay(ms: number): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, ms));
 }
 
 async function updateResponseInDb(messageId: number, content: string) {

--- a/testing/fake-llm-server/localAgentHandler.ts
+++ b/testing/fake-llm-server/localAgentHandler.ts
@@ -21,6 +21,10 @@ try {
 // Cache loaded fixtures to avoid re-importing
 const fixtureCache = new Map<string, LocalAgentFixture>();
 
+// Track connection attempts per session+turn for connection drop simulation.
+// Key: `${sessionId}-${passIndex}-${turnIndex}`, Value: attempt count
+const connectionAttempts = new Map<string, number>();
+
 /**
  * Generate a session ID from the first user message
  * This allows us to track conversation state across requests
@@ -410,6 +414,40 @@ export async function handleLocalAgentFixture(
             ),
           })),
         };
+      }
+    }
+
+    // Check if we should simulate a connection drop for this attempt
+    if (
+      fixture.dropConnectionOnAttempts &&
+      fixture.dropConnectionOnAttempts.length > 0
+    ) {
+      const attemptKey = `${sessionId}-${passIndex}-${turnIndex}`;
+      const currentAttempt = (connectionAttempts.get(attemptKey) || 0) + 1;
+      connectionAttempts.set(attemptKey, currentAttempt);
+
+      console.log(
+        `[local-agent] Connection attempt ${currentAttempt} for ${attemptKey}, ` +
+          `drop on: [${fixture.dropConnectionOnAttempts.join(", ")}]`,
+      );
+
+      if (fixture.dropConnectionOnAttempts.includes(currentAttempt)) {
+        console.log(
+          `[local-agent] Simulating connection drop on attempt ${currentAttempt}`,
+        );
+        // Stream partial data then destroy the socket to simulate a network interruption
+        res.setHeader("Content-Type", "text/event-stream");
+        res.setHeader("Cache-Control", "no-cache");
+        res.setHeader("Connection", "keep-alive");
+        res.write(
+          createStreamChunk(
+            "Partial response before connection dr",
+            "assistant",
+          ),
+        );
+        // Destroy the underlying socket to trigger a "terminated" error on the client
+        res.socket?.destroy();
+        return;
       }
     }
 

--- a/testing/fake-llm-server/localAgentTypes.ts
+++ b/testing/fake-llm-server/localAgentTypes.ts
@@ -47,4 +47,11 @@ export type LocalAgentFixture = {
    * Use this when testing todo follow-up loop behavior.
    */
   passes?: Pass[];
+  /**
+   * For testing connection resilience: drop the connection on these attempt
+   * numbers (1-indexed) for the first turn. The fake server will stream partial
+   * data then destroy the socket, simulating a network interruption.
+   * E.g., [1] means drop on the 1st attempt, succeed on the 2nd.
+   */
+  dropConnectionOnAttempts?: number[];
 };


### PR DESCRIPTION
## Summary
- Handle connection-drop and retry behavior in local agent IPC handling.
- Add an end-to-end scenario that verifies recovery after a temporary local agent disconnect.
- Align test fixtures and snapshots for local-agent reconnection behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2852" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
