### PR TITLE
Allow wwwillchen-bot in claude PR review workflow

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -48,7 +48,7 @@ jobs:
 
           # See: https://github.com/anthropics/claude-code-action/blob/v1/docs/security.md
           github_token: ${{ secrets.GITHUB_TOKEN }} # bypass OIDC
-          allowed_non_write_users: "princeaden1" # remember, we already filter above.
+          allowed_non_write_users: "princeaden1,wwwillchen-bot" # remember, we already filter above.
 
           # Disable progress tracking (try to save tokens)
           track_progress: false


### PR DESCRIPTION
## Summary
- Add `wwwillchen-bot` to `allowed_non_write_users` in `.github/workflows/claude-pr-review.yml`
- Keep existing `princeaden1` allowlist entry and broaden workflow access for trusted bot-driven contributions

## Test plan
- npm run fmt
- npm run lint:fix
- npm run ts

#skip-bugbot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2882" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
