### PR TITLE
Switch PR review workflow runner to macOS ARM self-hosted

### DIFF
--- a/.github/workflows/pr-review-responder.yml
+++ b/.github/workflows/pr-review-responder.yml
@@ -22,7 +22,10 @@ jobs:
       github.event_name == 'workflow_run' ||
       (github.event_name == 'pull_request_target' && github.event.label.name == 'cc:request:now')
     environment: ai-bots
-    runs-on: ubuntu-latest
+    runs-on:
+      - self-hosted
+      - macOS
+      - ARM64
     permissions:
       actions: write
       contents: write


### PR DESCRIPTION
## Summary
- Update PR review responder workflow to run on a macOS ARM self-hosted runner for compatibility with macOS-specific tooling.
- Keep permissions and trigger logic unchanged while replacing  runner label.

## Test plan
- Ran required checks locally: 
> dyad@0.39.0-beta.1 fmt
> npx oxfmt


> dyad@0.39.0-beta.1 lint:fix
> npx oxlint --fix --fix-suggestions --fix-dangerously

Found 0 warnings and 0 errors.
Finished in 32ms on 813 files with 88 rules using 10 threads.

> dyad@0.39.0-beta.1 ts
> npm run ts:main && npm run ts:workers


> dyad@0.39.0-beta.1 ts:main
> npx tsgo -p tsconfig.app.json --noEmit --incremental


> dyad@0.39.0-beta.1 ts:workers
> npx tsc -p workers/tsc/tsconfig.json --noEmit --incremental.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2893" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
