### PR TITLE
chore: add princeaden1 to PR review responder allowed users

### DIFF
--- a/.github/workflows/pr-review-responder.yml
+++ b/.github/workflows/pr-review-responder.yml
@@ -110,8 +110,8 @@ jobs:
               prAuthor = pr.user.login;
             }
 
-            // Only allow wwwillchen and wwwillchen-bot to use this workflow
-            if (prAuthor !== 'wwwillchen' && prAuthor !== 'wwwillchen-bot') {
+            // Only allow wwwillchen, wwwillchen-bot, and princeaden1 to use this workflow
+            if (prAuthor !== 'wwwillchen' && prAuthor !== 'wwwillchen-bot' && prAuthor !== 'princeaden1') {
               console.log(`PR #${prNumber} author ${prAuthor} is not allowed to use this workflow`);
               core.setOutput('should_continue', 'false');
               return;


### PR DESCRIPTION
## Summary
Adds `princeaden1` to the allowed users list for the PR review responder workflow (alongside wwwillchen and wwwillchen-bot).

## Test plan
- CI workflow runs on this PR
- No functional changes to application code; workflow change only

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2894" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
