### PR TITLE
ci: ensure Homebrew paths available for gh on self-hosted macOS runners

### DIFF
--- a/.github/workflows/pr-review-responder.yml
+++ b/.github/workflows/pr-review-responder.yml
@@ -234,6 +234,14 @@ jobs:
         env:
           PR_CONTENTS_RW_GITHUB_TOKEN: ${{ secrets.PR_CONTENTS_RW_GITHUB_TOKEN }}
 
+      - name: Ensure Homebrew paths are available
+        if: steps.pr-info.outputs.should_continue == 'true'
+        run: |
+          # Self-hosted macOS runners often have gh installed via Homebrew, but
+          # non-interactive shells may not include Homebrew directories in PATH.
+          echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
+          echo "/usr/local/bin" >> "$GITHUB_PATH"
+
       - name: Update labels to pending
         if: steps.pr-info.outputs.should_continue == 'true'
         run: |

--- a/drizzle/0026_lying_joseph.sql
+++ b/drizzle/0026_lying_joseph.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `prompts` ADD `slug` text;--> statement-breakpoint
+CREATE UNIQUE INDEX `prompts_slug_unique` ON `prompts` (`slug`);

--- a/drizzle/meta/0026_snapshot.json
+++ b/drizzle/meta/0026_snapshot.json
@@ -1,0 +1,906 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "80dda8f1-cd0c-411a-8d8c-1e9c32c485e3",
+  "prevId": "8aa6589b-2eb5-4d16-98a1-6354539472c4",
+  "tables": {
+    "apps": {
+      "name": "apps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "github_org": {
+          "name": "github_org",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_repo": {
+          "name": "github_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_branch": {
+          "name": "github_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supabase_project_id": {
+          "name": "supabase_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supabase_parent_project_id": {
+          "name": "supabase_parent_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supabase_organization_slug": {
+          "name": "supabase_organization_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_project_id": {
+          "name": "neon_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_development_branch_id": {
+          "name": "neon_development_branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_preview_branch_id": {
+          "name": "neon_preview_branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vercel_project_id": {
+          "name": "vercel_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vercel_project_name": {
+          "name": "vercel_project_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vercel_team_id": {
+          "name": "vercel_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vercel_deployment_url": {
+          "name": "vercel_deployment_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "install_command": {
+          "name": "install_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_command": {
+          "name": "start_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chat_context": {
+          "name": "chat_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "theme_id": {
+          "name": "theme_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chats": {
+      "name": "chats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "initial_commit_hash": {
+          "name": "initial_commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "compacted_at": {
+          "name": "compacted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "compaction_backup_path": {
+          "name": "compaction_backup_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pending_compaction": {
+          "name": "pending_compaction",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chats_app_id_apps_id_fk": {
+          "name": "chats_app_id_apps_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_themes": {
+      "name": "custom_themes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "language_model_providers": {
+      "name": "language_model_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_base_url": {
+          "name": "api_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "env_var_name": {
+          "name": "env_var_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "language_models": {
+      "name": "language_models",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_name": {
+          "name": "api_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "builtin_provider_id": {
+          "name": "builtin_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "custom_provider_id": {
+          "name": "custom_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_output_tokens": {
+          "name": "max_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "language_models_custom_provider_id_language_model_providers_id_fk": {
+          "name": "language_models_custom_provider_id_language_model_providers_id_fk",
+          "tableFrom": "language_models",
+          "tableTo": "language_model_providers",
+          "columnsFrom": [
+            "custom_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "env_json": {
+          "name": "env_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "headers_json": {
+          "name": "headers_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_tool_consents": {
+      "name": "mcp_tool_consents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consent": {
+          "name": "consent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ask'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "uniq_mcp_consent": {
+          "name": "uniq_mcp_consent",
+          "columns": [
+            "server_id",
+            "tool_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "mcp_tool_consents_server_id_mcp_servers_id_fk": {
+          "name": "mcp_tool_consents_server_id_mcp_servers_id_fk",
+          "tableFrom": "mcp_tool_consents",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "approval_state": {
+          "name": "approval_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_commit_hash": {
+          "name": "source_commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "commit_hash": {
+          "name": "commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_tokens_used": {
+          "name": "max_tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ai_messages_json": {
+          "name": "ai_messages_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "using_free_agent_mode_quota": {
+          "name": "using_free_agent_mode_quota",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_compaction_summary": {
+          "name": "is_compaction_summary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_chat_id_chats_id_fk": {
+          "name": "messages_chat_id_chats_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompts": {
+      "name": "prompts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "prompts_slug_unique": {
+          "name": "prompts_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "versions": {
+      "name": "versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "commit_hash": {
+          "name": "commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "neon_db_timestamp": {
+          "name": "neon_db_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "versions_app_commit_unique": {
+          "name": "versions_app_commit_unique",
+          "columns": [
+            "app_id",
+            "commit_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "versions_app_id_apps_id_fk": {
+          "name": "versions_app_id_apps_id_fk",
+          "tableFrom": "versions",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1770256089560,
       "tag": "0025_lush_stark_industries",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "6",
+      "when": 1771025337064,
+      "tag": "0026_lying_joseph",
+      "breakpoints": true
     }
   ]
 }

--- a/e2e-tests/helpers/page-objects/components/PromptLibrary.ts
+++ b/e2e-tests/helpers/page-objects/components/PromptLibrary.ts
@@ -12,10 +12,12 @@ export class PromptLibrary {
     title,
     description,
     content,
+    slug,
   }: {
     title: string;
     description?: string;
     content: string;
+    slug?: string;
   }) {
     await this.page.getByRole("button", { name: "New Prompt" }).click();
     await this.page.getByRole("textbox", { name: "Title" }).fill(title);
@@ -23,6 +25,9 @@ export class PromptLibrary {
       await this.page
         .getByRole("textbox", { name: "Description (optional)" })
         .fill(description);
+    }
+    if (slug !== undefined) {
+      await this.page.getByPlaceholder("Slash command (optional)").fill(slug);
     }
     await this.page.getByRole("textbox", { name: "Content" }).fill(content);
     await this.page.getByRole("button", { name: "Save" }).click();

--- a/e2e-tests/prompt_library.spec.ts
+++ b/e2e-tests/prompt_library.spec.ts
@@ -81,6 +81,7 @@ test("slash menu shows skills and selecting one inserts command", async ({
     title: "E2E Test Skill",
     description: "desc",
     content: "Run the E2E test skill content.",
+    slug: "e2e-test-skill",
   });
 
   await po.navigation.goToAppsTab();
@@ -95,4 +96,27 @@ test("slash menu shows skills and selecting one inserts command", async ({
 
   await skillsMenu.getByText("e2e-test-skill").click();
   await expect(chatInput).toContainText("/e2e-test-skill");
+});
+
+test("slash command is expanded to prompt content in message", async ({
+  po,
+}) => {
+  await po.setUp();
+  await po.navigation.goToLibraryTab();
+  await po.page.getByRole("link", { name: "Prompts" }).click();
+  await po.promptLibrary.createPrompt({
+    title: "Webapp Testing Skill",
+    description: "E2E testing helper",
+    content: "Run comprehensive E2E tests for the login and signup flows.",
+    slug: "webapp-testing",
+  });
+
+  await po.navigation.goToAppsTab();
+  const chatInput = po.chatActions.getChatInput();
+  await chatInput.click();
+  await chatInput.fill("[dump] /webapp-testing for the new feature");
+  await po.page.getByRole("button", { name: "Send message" }).click();
+  await po.chatActions.waitForChatCompletion();
+
+  await po.snapshotServerDump("all-messages");
 });

--- a/e2e-tests/prompt_library.spec.ts
+++ b/e2e-tests/prompt_library.spec.ts
@@ -70,3 +70,29 @@ test("use prompt", async ({ po }) => {
 
   await po.snapshotServerDump("last-message");
 });
+
+test("slash menu shows skills and selecting one inserts command", async ({
+  po,
+}) => {
+  await po.setUp();
+  await po.navigation.goToLibraryTab();
+  await po.page.getByRole("link", { name: "Prompts" }).click();
+  await po.promptLibrary.createPrompt({
+    title: "E2E Test Skill",
+    description: "desc",
+    content: "Run the E2E test skill content.",
+  });
+
+  await po.navigation.goToAppsTab();
+  const chatInput = po.chatActions.getChatInput();
+  await chatInput.click();
+  await chatInput.fill("/");
+
+  const skillsMenu = po.page.locator('[data-mentions-menu="true"]');
+  await expect(skillsMenu).toBeVisible();
+  await expect(skillsMenu).toContainText("e2e-test-skill");
+  await expect(skillsMenu).toContainText("Skill");
+
+  await skillsMenu.getByText("e2e-test-skill").click();
+  await expect(chatInput).toContainText("/e2e-test-skill");
+});

--- a/e2e-tests/snapshots/prompt_library.spec.ts_slash-command-is-expanded-to-prompt-content-in-message-1.txt
+++ b/e2e-tests/snapshots/prompt_library.spec.ts_slash-command-is-expanded-to-prompt-content-in-message-1.txt
@@ -1,0 +1,7 @@
+===
+role: system
+message: [[SYSTEM_MESSAGE]]
+
+===
+role: user
+message: [dump] Run comprehensive E2E tests for the login and signup flows. for the new feature

--- a/package-lock.json
+++ b/package-lock.json
@@ -288,13 +288,13 @@
       }
     },
     "node_modules/@ai-sdk/openai": {
-      "version": "3.0.36",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.36.tgz",
-      "integrity": "sha512-foY3onGY8l3q9niMw0Cwe9xrYnm46keIWL57NRw6F3DKzSW9TYTfx0cQJs/j8lXJ8lPzqNxpMO/zXOkqCUt3IQ==",
+      "version": "3.0.37",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.37.tgz",
+      "integrity": "sha512-bcYjT3/58i/C0DN3AnrjiGsAb0kYivZLWWUtgTjsBurHSht/LTEy+w3dw5XQe3FmZwX7Z/mUQCiA3wB/5Kf7ow==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.15"
+        "@ai-sdk/provider-utils": "4.0.16"
       },
       "engines": {
         "node": ">=18"
@@ -332,9 +332,9 @@
       }
     },
     "node_modules/@ai-sdk/openai/node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.15.tgz",
-      "integrity": "sha512-8XiKWbemmCbvNN0CLR9u3PQiet4gtEVIrX4zzLxnCj06AwsEDJwJVBbKrEI4t6qE8XRSIvU2irka0dcpziKW6w==",
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.16.tgz",
+      "integrity": "sha512-kBvDqNkt5EwlzF9FujmNhhtl8FYg3e8FO8P5uneKliqfRThWemzBj+wfYr7ZCymAQhTRnwSSz1/SOqhOAwmx9g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -288,13 +288,13 @@
       }
     },
     "node_modules/@ai-sdk/openai": {
-      "version": "3.0.37",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.37.tgz",
-      "integrity": "sha512-bcYjT3/58i/C0DN3AnrjiGsAb0kYivZLWWUtgTjsBurHSht/LTEy+w3dw5XQe3FmZwX7Z/mUQCiA3wB/5Kf7ow==",
+      "version": "3.0.36",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.36.tgz",
+      "integrity": "sha512-foY3onGY8l3q9niMw0Cwe9xrYnm46keIWL57NRw6F3DKzSW9TYTfx0cQJs/j8lXJ8lPzqNxpMO/zXOkqCUt3IQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.16"
+        "@ai-sdk/provider-utils": "4.0.15"
       },
       "engines": {
         "node": ">=18"
@@ -332,9 +332,9 @@
       }
     },
     "node_modules/@ai-sdk/openai/node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.16.tgz",
-      "integrity": "sha512-kBvDqNkt5EwlzF9FujmNhhtl8FYg3e8FO8P5uneKliqfRThWemzBj+wfYr7ZCymAQhTRnwSSz1/SOqhOAwmx9g==",
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.15.tgz",
+      "integrity": "sha512-8XiKWbemmCbvNN0CLR9u3PQiet4gtEVIrX4zzLxnCj06AwsEDJwJVBbKrEI4t6qE8XRSIvU2irka0dcpziKW6w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",

--- a/src/__tests__/replaceSlashSkillReference.test.ts
+++ b/src/__tests__/replaceSlashSkillReference.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import {
+  replaceSlashSkillReference,
+  deriveSlugFromTitle,
+  slugForPrompt,
+} from "@/ipc/utils/replaceSlashSkillReference";
+
+describe("replaceSlashSkillReference", () => {
+  it("returns original when no slash-slug pattern present", () => {
+    const input = "Hello world";
+    const output = replaceSlashSkillReference(input, {
+      webapp: "content",
+    });
+    expect(output).toBe(input);
+  });
+
+  it("returns original when promptsBySlug is empty", () => {
+    const input = "/webapp-testing for the login page";
+    const output = replaceSlashSkillReference(input, {});
+    expect(output).toBe(input);
+  });
+
+  it("replaces /slug at start with content", () => {
+    const input = "/webapp-testing for the login page";
+    const promptsBySlug = { "webapp-testing": "Run E2E tests for the app." };
+    const output = replaceSlashSkillReference(input, promptsBySlug);
+    expect(output).toBe("Run E2E tests for the app. for the login page");
+  });
+
+  it("replaces /slug after space with content", () => {
+    const input = "Please do /github-actions-debugging now";
+    const promptsBySlug = {
+      "github-actions-debugging": "Debug failing GitHub Actions workflows.",
+    };
+    const output = replaceSlashSkillReference(input, promptsBySlug);
+    expect(output).toBe(
+      "Please do Debug failing GitHub Actions workflows. now",
+    );
+  });
+
+  it("replaces multiple /slug occurrences", () => {
+    const input = "/one and /two end";
+    const promptsBySlug = { one: "First", two: "Second" };
+    const output = replaceSlashSkillReference(input, promptsBySlug);
+    expect(output).toBe("First and Second end");
+  });
+
+  it("leaves unknown slug intact", () => {
+    const input = "/unknown-slug here";
+    const promptsBySlug = { "other-slug": "Content" };
+    const output = replaceSlashSkillReference(input, promptsBySlug);
+    expect(output).toBe("/unknown-slug here");
+  });
+
+  it("does not replace slash in middle of path-like text", () => {
+    const input = "path/to/file";
+    const promptsBySlug = { path: "Nope", to: "Nope", file: "Nope" };
+    const output = replaceSlashSkillReference(input, promptsBySlug);
+    expect(output).toBe("path/to/file");
+  });
+
+  it("replaces /slug and preserves trailing space", () => {
+    const input = "/webapp-testing extra";
+    const promptsBySlug = { "webapp-testing": "Content" };
+    const output = replaceSlashSkillReference(input, promptsBySlug);
+    expect(output).toBe("Content extra");
+  });
+});
+
+describe("deriveSlugFromTitle", () => {
+  it("lowercases and replaces spaces with hyphens", () => {
+    expect(deriveSlugFromTitle("Web App Testing")).toBe("web-app-testing");
+  });
+
+  it("strips non-alphanumeric characters", () => {
+    expect(deriveSlugFromTitle("Hello, World!")).toBe("hello-world");
+  });
+
+  it("returns empty string for title with only special chars", () => {
+    expect(deriveSlugFromTitle("!!!")).toBe("");
+  });
+});
+
+describe("slugForPrompt", () => {
+  it("returns explicit slug when set", () => {
+    expect(slugForPrompt({ title: "My Prompt", slug: "custom" })).toBe(
+      "custom",
+    );
+  });
+
+  it("derives slug from title when slug is null", () => {
+    expect(slugForPrompt({ title: "Web App Testing", slug: null })).toBe(
+      "web-app-testing",
+    );
+  });
+
+  it("derives slug from title when slug is empty string", () => {
+    expect(slugForPrompt({ title: "Web App Testing", slug: "" as any })).toBe(
+      "web-app-testing",
+    );
+  });
+});

--- a/src/__tests__/replaceSlashSkillReference.test.ts
+++ b/src/__tests__/replaceSlashSkillReference.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
   replaceSlashSkillReference,
-  deriveSlugFromTitle,
   slugForPrompt,
 } from "@/ipc/utils/replaceSlashSkillReference";
 
@@ -65,19 +64,19 @@ describe("replaceSlashSkillReference", () => {
     const output = replaceSlashSkillReference(input, promptsBySlug);
     expect(output).toBe("Content extra");
   });
-});
 
-describe("deriveSlugFromTitle", () => {
-  it("lowercases and replaces spaces with hyphens", () => {
-    expect(deriveSlugFromTitle("Web App Testing")).toBe("web-app-testing");
+  it("matches case-sensitive slugs", () => {
+    const input = "/FOO-Bar here";
+    const promptsBySlug = { "FOO-Bar": "Matched", "foo-bar": "Wrong" };
+    const output = replaceSlashSkillReference(input, promptsBySlug);
+    expect(output).toBe("Matched here");
   });
 
-  it("strips non-alphanumeric characters", () => {
-    expect(deriveSlugFromTitle("Hello, World!")).toBe("hello-world");
-  });
-
-  it("returns empty string for title with only special chars", () => {
-    expect(deriveSlugFromTitle("!!!")).toBe("");
+  it("does not match different-cased slug", () => {
+    const input = "/foo-bar here";
+    const promptsBySlug = { "FOO-BAR": "Content" };
+    const output = replaceSlashSkillReference(input, promptsBySlug);
+    expect(output).toBe("/foo-bar here");
   });
 });
 
@@ -88,15 +87,11 @@ describe("slugForPrompt", () => {
     );
   });
 
-  it("derives slug from title when slug is null", () => {
-    expect(slugForPrompt({ title: "Web App Testing", slug: null })).toBe(
-      "web-app-testing",
-    );
+  it("returns null when slug is null", () => {
+    expect(slugForPrompt({ title: "Web App Testing", slug: null })).toBeNull();
   });
 
-  it("derives slug from title when slug is empty string", () => {
-    expect(slugForPrompt({ title: "Web App Testing", slug: "" as any })).toBe(
-      "web-app-testing",
-    );
+  it("returns null when slug is empty string", () => {
+    expect(slugForPrompt({ title: "Web App Testing", slug: "" })).toBeNull();
   });
 });

--- a/src/components/CreatePromptDialog.tsx
+++ b/src/components/CreatePromptDialog.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/components/ui/dialog";
 import { Plus, Save, Edit2 } from "lucide-react";
 
-const SLUG_REGEX = /^[a-z0-9-]*$/;
+const SLUG_REGEX = /^[a-zA-Z0-9-]*$/;
 
 interface CreateOrEditPromptDialogProps {
   mode: "create" | "edit";
@@ -223,7 +223,7 @@ export function CreateOrEditPromptDialog({
               placeholder="Slash command (optional)"
               value={draft.slug}
               onChange={(e) => {
-                const v = e.target.value.toLowerCase().replace(/\s/g, "-");
+                const v = e.target.value;
                 if (v === "" || SLUG_REGEX.test(v))
                   setDraft((d) => ({ ...d, slug: v }));
               }}
@@ -231,8 +231,8 @@ export function CreateOrEditPromptDialog({
             />
             <p className="text-xs text-muted-foreground mt-1">
               {slugInvalid
-                ? "Use only lowercase letters, numbers, and hyphens."
-                : "Used as /command in chat. Leave empty to derive from title."}
+                ? "Use only letters, numbers, and hyphens."
+                : "Used as /command in chat."}
             </p>
           </div>
           <Textarea

--- a/src/components/CreatePromptDialog.tsx
+++ b/src/components/CreatePromptDialog.tsx
@@ -13,6 +13,8 @@ import {
 } from "@/components/ui/dialog";
 import { Plus, Save, Edit2 } from "lucide-react";
 
+const SLUG_REGEX = /^[a-z0-9-]*$/;
+
 interface CreateOrEditPromptDialogProps {
   mode: "create" | "edit";
   prompt?: {
@@ -20,17 +22,20 @@ interface CreateOrEditPromptDialogProps {
     title: string;
     description: string | null;
     content: string;
+    slug: string | null;
   };
   onCreatePrompt?: (prompt: {
     title: string;
     description?: string;
     content: string;
+    slug?: string | null;
   }) => Promise<any>;
   onUpdatePrompt?: (prompt: {
     id: number;
     title: string;
     description?: string;
     content: string;
+    slug?: string | null;
   }) => Promise<any>;
   trigger?: React.ReactNode;
   prefillData?: {
@@ -60,6 +65,7 @@ export function CreateOrEditPromptDialog({
     title: "",
     description: "",
     content: "",
+    slug: "",
   });
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -89,15 +95,17 @@ export function CreateOrEditPromptDialog({
         title: prompt.title,
         description: prompt.description || "",
         content: prompt.content,
+        slug: prompt.slug || "",
       });
     } else if (prefillData) {
       setDraft({
         title: prefillData.title,
         description: prefillData.description,
         content: prefillData.content,
+        slug: "",
       });
     } else {
-      setDraft({ title: "", description: "", content: "" });
+      setDraft({ title: "", description: "", content: "", slug: "" });
     }
   }, [mode, prompt, prefillData, open]);
 
@@ -120,26 +128,36 @@ export function CreateOrEditPromptDialog({
         title: prompt.title,
         description: prompt.description || "",
         content: prompt.content,
+        slug: prompt.slug || "",
       });
     } else if (prefillData) {
       setDraft({
         title: prefillData.title,
         description: prefillData.description,
         content: prefillData.content,
+        slug: "",
       });
     } else {
-      setDraft({ title: "", description: "", content: "" });
+      setDraft({ title: "", description: "", content: "", slug: "" });
     }
   };
 
+  const slugTrimmed = draft.slug.trim();
+  const slugInvalid = slugTrimmed !== "" && !SLUG_REGEX.test(slugTrimmed);
+
   const onSave = async () => {
-    if (!draft.title.trim() || !draft.content.trim()) return;
+    if (!draft.title.trim() || !draft.content.trim() || slugInvalid) return;
+
+    // In edit mode, empty slug means "clear it" (null), not "don't change" (undefined).
+    const slugValue =
+      slugTrimmed === "" ? (mode === "edit" ? null : undefined) : slugTrimmed;
 
     if (mode === "create" && onCreatePrompt) {
       await onCreatePrompt({
         title: draft.title.trim(),
         description: draft.description.trim() || undefined,
         content: draft.content,
+        slug: slugValue,
       });
     } else if (mode === "edit" && onUpdatePrompt && prompt) {
       await onUpdatePrompt({
@@ -147,6 +165,7 @@ export function CreateOrEditPromptDialog({
         title: draft.title.trim(),
         description: draft.description.trim() || undefined,
         content: draft.content,
+        slug: slugValue,
       });
     }
 
@@ -199,6 +218,23 @@ export function CreateOrEditPromptDialog({
               setDraft((d) => ({ ...d, description: e.target.value }))
             }
           />
+          <div>
+            <Input
+              placeholder="Slash command (optional)"
+              value={draft.slug}
+              onChange={(e) => {
+                const v = e.target.value.toLowerCase().replace(/\s/g, "-");
+                if (v === "" || SLUG_REGEX.test(v))
+                  setDraft((d) => ({ ...d, slug: v }));
+              }}
+              className="font-mono"
+            />
+            <p className="text-xs text-muted-foreground mt-1">
+              {slugInvalid
+                ? "Use only lowercase letters, numbers, and hyphens."
+                : "Used as /command in chat. Leave empty to derive from title."}
+            </p>
+          </div>
           <Textarea
             ref={textareaRef}
             placeholder="Content"
@@ -218,7 +254,9 @@ export function CreateOrEditPromptDialog({
           </Button>
           <Button
             onClick={onSave}
-            disabled={!draft.title.trim() || !draft.content.trim()}
+            disabled={
+              !draft.title.trim() || !draft.content.trim() || slugInvalid
+            }
           >
             <Save className="mr-2 h-4 w-4" /> Save
           </Button>
@@ -239,6 +277,7 @@ export function CreatePromptDialog({
     title: string;
     description?: string;
     content: string;
+    slug?: string | null;
   }) => Promise<any>;
   prefillData?: {
     title: string;

--- a/src/components/chat/LexicalChatInput.tsx
+++ b/src/components/chat/LexicalChatInput.tsx
@@ -28,11 +28,14 @@ import { selectedAppIdAtom } from "@/atoms/appAtoms";
 import { MENTION_REGEX, parseAppMentions } from "@/shared/parse_mention_apps";
 import { useLoadApp } from "@/hooks/useLoadApp";
 import { HistoryNavigation, HISTORY_TRIGGER } from "./HistoryNavigation";
+import { slugForPrompt } from "@/ipc/utils/replaceSlashSkillReference";
 
 // Define the theme for mentions
 const beautifulMentionsTheme: BeautifulMentionsTheme = {
   "@": "px-2 py-0.5 mx-0.5 bg-accent text-accent-foreground rounded-md",
   "@Focused": "outline-none ring-2 ring-ring",
+  "/": "px-2 py-0.5 mx-0.5 bg-accent text-accent-foreground rounded-md",
+  "/Focused": "outline-none ring-2 ring-ring",
 };
 
 // Custom menu item component
@@ -41,9 +44,18 @@ const CustomMenuItem = forwardRef<
   BeautifulMentionsMenuItemProps
 >(({ selected, item, ...props }, ref) => {
   const isPrompt = item.data?.type === "prompt";
+  const isSkill = item.data?.type === "skill";
   const isApp = item.data?.type === "app";
   const isHistory = item.data?.type === "history";
-  const label = isPrompt ? "Prompt" : isApp ? "App" : isHistory ? "" : "File";
+  const label = isSkill
+    ? "Skill"
+    : isPrompt
+      ? "Prompt"
+      : isApp
+        ? "App"
+        : isHistory
+          ? ""
+          : "File";
   const value = (item as any)?.value;
 
   // For history items, show full text without label
@@ -76,7 +88,7 @@ const CustomMenuItem = forwardRef<
       <div className="flex items-center space-x-2 min-w-0">
         <span
           className={`px-2 py-0.5 text-xs font-medium rounded-md flex-shrink-0 ${
-            isPrompt
+            isSkill || isPrompt
               ? "bg-purple-500 text-white"
               : isApp
                 ? "bg-primary text-primary-foreground"
@@ -286,7 +298,11 @@ export function LexicalChatInput({
 
   // Prepare mention items - convert apps to mention format
   const mentionItems = React.useMemo(() => {
-    const result: Record<string, any[]> = { "@": [], [HISTORY_TRIGGER]: [] };
+    const result: Record<string, any[]> = {
+      "@": [],
+      "/": [],
+      [HISTORY_TRIGGER]: [],
+    };
 
     // Add history items under the history trigger - always available regardless of app loading
     // Reverse so most recent appears at the bottom
@@ -298,6 +314,16 @@ export function LexicalChatInput({
         type: "history",
       }));
     result[HISTORY_TRIGGER] = historyItems;
+
+    // Skills (slash commands): all prompts by slug
+    const skillItems = (prompts || [])
+      .map((p) => ({
+        value: slugForPrompt(p),
+        type: "skill",
+        id: p.id,
+      }))
+      .filter((item) => item.value !== "");
+    result["/"] = skillItems;
 
     if (!apps) return result;
 

--- a/src/components/chat/LexicalChatInput.tsx
+++ b/src/components/chat/LexicalChatInput.tsx
@@ -322,7 +322,7 @@ export function LexicalChatInput({
         type: "skill",
         id: p.id,
       }))
-      .filter((item) => item.value !== "");
+      .filter((item) => item.value != null && item.value !== "");
     result["/"] = skillItems;
 
     if (!apps) return result;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -10,18 +10,23 @@ export type AiMessagesJsonV6 = {
   sdkVersion: typeof AI_MESSAGES_SDK_VERSION;
 };
 
-export const prompts = sqliteTable("prompts", {
-  id: integer("id").primaryKey({ autoIncrement: true }),
-  title: text("title").notNull(),
-  description: text("description"),
-  content: text("content").notNull(),
-  createdAt: integer("created_at", { mode: "timestamp" })
-    .notNull()
-    .default(sql`(unixepoch())`),
-  updatedAt: integer("updated_at", { mode: "timestamp" })
-    .notNull()
-    .default(sql`(unixepoch())`),
-});
+export const prompts = sqliteTable(
+  "prompts",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    title: text("title").notNull(),
+    description: text("description"),
+    content: text("content").notNull(),
+    slug: text("slug"),
+    createdAt: integer("created_at", { mode: "timestamp" })
+      .notNull()
+      .default(sql`(unixepoch())`),
+    updatedAt: integer("updated_at", { mode: "timestamp" })
+      .notNull()
+      .default(sql`(unixepoch())`),
+  },
+  (table) => [unique("prompts_slug_unique").on(table.slug)],
+);
 
 export const apps = sqliteTable("apps", {
   id: integer("id").primaryKey({ autoIncrement: true }),

--- a/src/hooks/usePrompts.ts
+++ b/src/hooks/usePrompts.ts
@@ -7,6 +7,7 @@ export interface PromptItem {
   title: string;
   description: string | null;
   content: string;
+  slug: string | null;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -26,8 +27,14 @@ export function usePrompts() {
       title: string;
       description?: string;
       content: string;
+      slug?: string | null;
     }): Promise<PromptItem> => {
-      return ipc.prompt.create(params);
+      return ipc.prompt.create({
+        title: params.title,
+        description: params.description,
+        content: params.content,
+        slug: params.slug ?? undefined,
+      });
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.prompts.all });
@@ -43,8 +50,15 @@ export function usePrompts() {
       title: string;
       description?: string;
       content: string;
+      slug?: string | null;
     }): Promise<void> => {
-      return ipc.prompt.update(params);
+      return ipc.prompt.update({
+        id: params.id,
+        title: params.title,
+        description: params.description,
+        content: params.content,
+        slug: params.slug ?? undefined,
+      });
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.prompts.all });

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -81,6 +81,10 @@ import { parseAppMentions } from "@/shared/parse_mention_apps";
 import { prompts as promptsTable } from "../../db/schema";
 import { inArray } from "drizzle-orm";
 import { replacePromptReference } from "../utils/replacePromptReference";
+import {
+  replaceSlashSkillReference,
+  deriveSlugFromTitle,
+} from "../utils/replaceSlashSkillReference";
 import { parsePlanFile, validatePlanId } from "./planUtils";
 import { ensureDyadGitignored } from "./gitignoreUtils";
 import { DYAD_MEDIA_DIR_NAME } from "../utils/media_path_utils";
@@ -373,6 +377,32 @@ export function registerChatStreamHandlers() {
         }
       } catch (e) {
         logger.error("Failed to inline referenced prompts:", e);
+      }
+
+      // Expand /slug skill references (e.g. /webapp-testing) to prompt content
+      try {
+        const slashSkillPattern = /(?:^|\s)\/([a-z0-9-]+)(?=\s|$)/;
+        if (slashSkillPattern.test(userPrompt)) {
+          const allPrompts = db.select().from(promptsTable).all();
+          const promptsBySlug: Record<string, string> = {};
+          // Prefer explicit slug; then add derived slug for prompts with null slug (first wins on collision)
+          for (const p of allPrompts) {
+            if (p.slug && !promptsBySlug[p.slug]) {
+              promptsBySlug[p.slug] = p.content;
+            }
+          }
+          for (const p of allPrompts) {
+            if (p.slug == null) {
+              const derived = deriveSlugFromTitle(p.title);
+              if (derived && !promptsBySlug[derived]) {
+                promptsBySlug[derived] = p.content;
+              }
+            }
+          }
+          userPrompt = replaceSlashSkillReference(userPrompt, promptsBySlug);
+        }
+      } catch (e) {
+        logger.error("Failed to expand slash skill references:", e);
       }
 
       // Expand /implement-plan= into full implementation prompt

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -81,10 +81,7 @@ import { parseAppMentions } from "@/shared/parse_mention_apps";
 import { prompts as promptsTable } from "../../db/schema";
 import { inArray } from "drizzle-orm";
 import { replacePromptReference } from "../utils/replacePromptReference";
-import {
-  replaceSlashSkillReference,
-  deriveSlugFromTitle,
-} from "../utils/replaceSlashSkillReference";
+import { replaceSlashSkillReference } from "../utils/replaceSlashSkillReference";
 import { parsePlanFile, validatePlanId } from "./planUtils";
 import { ensureDyadGitignored } from "./gitignoreUtils";
 import { DYAD_MEDIA_DIR_NAME } from "../utils/media_path_utils";
@@ -381,22 +378,13 @@ export function registerChatStreamHandlers() {
 
       // Expand /slug skill references (e.g. /webapp-testing) to prompt content
       try {
-        const slashSkillPattern = /(?:^|\s)\/([a-z0-9-]+)(?=\s|$)/;
+        const slashSkillPattern = /(?:^|\s)\/([a-zA-Z0-9-]+)(?=\s|$)/;
         if (slashSkillPattern.test(userPrompt)) {
           const allPrompts = db.select().from(promptsTable).all();
           const promptsBySlug: Record<string, string> = {};
-          // Prefer explicit slug; then add derived slug for prompts with null slug (first wins on collision)
           for (const p of allPrompts) {
             if (p.slug && !promptsBySlug[p.slug]) {
               promptsBySlug[p.slug] = p.content;
-            }
-          }
-          for (const p of allPrompts) {
-            if (p.slug == null) {
-              const derived = deriveSlugFromTitle(p.title);
-              if (derived && !promptsBySlug[derived]) {
-                promptsBySlug[derived] = p.content;
-              }
             }
           }
           userPrompt = replaceSlashSkillReference(userPrompt, promptsBySlug);

--- a/src/ipc/handlers/prompt_handlers.ts
+++ b/src/ipc/handlers/prompt_handlers.ts
@@ -15,13 +15,14 @@ export function registerPromptHandlers() {
       title: r.title,
       description: r.description,
       content: r.content,
+      slug: r.slug,
       createdAt: r.createdAt,
       updatedAt: r.updatedAt,
     }));
   });
 
   createTypedHandler(promptContracts.create, async (_, params) => {
-    const { title, content, description } = params;
+    const { title, content, description, slug } = params;
     if (!title || !content) {
       throw new Error("Title and content are required");
     }
@@ -31,6 +32,7 @@ export function registerPromptHandlers() {
         title,
         description,
         content,
+        slug: slug ?? null,
       })
       .run();
 
@@ -42,19 +44,21 @@ export function registerPromptHandlers() {
       title: row.title,
       description: row.description,
       content: row.content,
+      slug: row.slug,
       createdAt: row.createdAt,
       updatedAt: row.updatedAt,
     };
   });
 
   createTypedHandler(promptContracts.update, async (_, params) => {
-    const { id, title, content, description } = params;
+    const { id, title, content, description, slug } = params;
     if (!id) throw new Error("Prompt id is required");
     const now = new Date();
     const updateData: Record<string, any> = { updatedAt: now };
     if (title !== undefined) updateData.title = title;
     if (content !== undefined) updateData.content = content;
     if (description !== undefined) updateData.description = description;
+    if (slug !== undefined) updateData.slug = slug ?? null;
     db.update(prompts).set(updateData).where(eq(prompts.id, id)).run();
   });
 

--- a/src/ipc/types/prompts.ts
+++ b/src/ipc/types/prompts.ts
@@ -5,11 +5,22 @@ import { defineContract, createClient } from "../contracts/core";
 // Prompt Schemas
 // =============================================================================
 
+const slugSchema = z
+  .string()
+  .optional()
+  .nullable()
+  .refine(
+    (s) => s === undefined || s === null || s === "" || /^[a-z0-9-]+$/.test(s),
+    "Slug must be lowercase letters, numbers, and hyphens only",
+  )
+  .transform((s) => (s === "" ? undefined : s));
+
 export const PromptDtoSchema = z.object({
   id: z.number(),
   title: z.string(),
   description: z.string().nullable(),
   content: z.string(),
+  slug: z.string().nullable(),
   createdAt: z.date(),
   updatedAt: z.date(),
 });
@@ -20,6 +31,7 @@ export const CreatePromptParamsDtoSchema = z.object({
   title: z.string(),
   description: z.string().optional(),
   content: z.string(),
+  slug: slugSchema,
 });
 
 export type CreatePromptParamsDto = z.infer<typeof CreatePromptParamsDtoSchema>;
@@ -29,6 +41,7 @@ export const UpdatePromptParamsDtoSchema = z.object({
   title: z.string().optional(),
   description: z.string().optional(),
   content: z.string().optional(),
+  slug: slugSchema,
 });
 
 export type UpdatePromptParamsDto = z.infer<typeof UpdatePromptParamsDtoSchema>;

--- a/src/ipc/types/prompts.ts
+++ b/src/ipc/types/prompts.ts
@@ -10,8 +10,9 @@ const slugSchema = z
   .optional()
   .nullable()
   .refine(
-    (s) => s === undefined || s === null || s === "" || /^[a-z0-9-]+$/.test(s),
-    "Slug must be lowercase letters, numbers, and hyphens only",
+    (s) =>
+      s === undefined || s === null || s === "" || /^[a-zA-Z0-9-]+$/.test(s),
+    "Slug must be letters, numbers, and hyphens only",
   )
   .transform((s) => (s === "" ? undefined : s));
 

--- a/src/ipc/utils/replaceSlashSkillReference.ts
+++ b/src/ipc/utils/replaceSlashSkillReference.ts
@@ -1,0 +1,45 @@
+/**
+ * Derives a slug from a prompt title by lowercasing, replacing spaces with
+ * hyphens, and stripping non-alphanumeric/hyphen characters.
+ */
+export function deriveSlugFromTitle(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z0-9-]/g, "");
+}
+
+/**
+ * Returns the effective slug for a prompt: explicit slug if set, otherwise
+ * derived from the title.
+ */
+export function slugForPrompt(p: {
+  title: string;
+  slug: string | null;
+}): string {
+  if (p.slug) return p.slug;
+  return deriveSlugFromTitle(p.title);
+}
+
+/**
+ * Replaces slash-skill references like /webapp-testing with the corresponding
+ * prompt content. Only matches /slug when slug is a single token (lowercase
+ * letters, numbers, hyphens) at word boundary (start of string or after
+ * whitespace, and followed by space or end).
+ */
+export function replaceSlashSkillReference(
+  userPrompt: string,
+  promptsBySlug: Record<string, string>,
+): string {
+  if (typeof userPrompt !== "string" || userPrompt.length === 0)
+    return userPrompt;
+  if (Object.keys(promptsBySlug).length === 0) return userPrompt;
+
+  return userPrompt.replace(
+    /(^|\s)\/([a-z0-9-]+)(?=\s|$)/g,
+    (match: string, before: string, slug: string) => {
+      const content = promptsBySlug[slug];
+      return content !== undefined ? `${before}${content}` : match;
+    },
+  );
+}

--- a/src/ipc/utils/replaceSlashSkillReference.ts
+++ b/src/ipc/utils/replaceSlashSkillReference.ts
@@ -1,30 +1,17 @@
 /**
- * Derives a slug from a prompt title by lowercasing, replacing spaces with
- * hyphens, and stripping non-alphanumeric/hyphen characters.
- */
-export function deriveSlugFromTitle(title: string): string {
-  return title
-    .toLowerCase()
-    .replace(/\s+/g, "-")
-    .replace(/[^a-z0-9-]/g, "");
-}
-
-/**
- * Returns the effective slug for a prompt: explicit slug if set, otherwise
- * derived from the title.
+ * Returns the explicit slug for a prompt, or null if none is set.
  */
 export function slugForPrompt(p: {
   title: string;
   slug: string | null;
-}): string {
-  if (p.slug) return p.slug;
-  return deriveSlugFromTitle(p.title);
+}): string | null {
+  return p.slug || null;
 }
 
 /**
  * Replaces slash-skill references like /webapp-testing with the corresponding
- * prompt content. Only matches /slug when slug is a single token (lowercase
- * letters, numbers, hyphens) at word boundary (start of string or after
+ * prompt content. Only matches /slug when slug is a single token (letters,
+ * numbers, hyphens) at word boundary (start of string or after
  * whitespace, and followed by space or end).
  */
 export function replaceSlashSkillReference(
@@ -36,7 +23,7 @@ export function replaceSlashSkillReference(
   if (Object.keys(promptsBySlug).length === 0) return userPrompt;
 
   return userPrompt.replace(
-    /(^|\s)\/([a-z0-9-]+)(?=\s|$)/g,
+    /(^|\s)\/([a-zA-Z0-9-]+)(?=\s|$)/g,
     (match: string, before: string, slug: string) => {
       const content = promptsBySlug[slug];
       return content !== undefined ? `${before}${content}` : match;

--- a/src/pages/library.tsx
+++ b/src/pages/library.tsx
@@ -85,6 +85,8 @@ export default function LibraryPage() {
   );
 }
 
+import { slugForPrompt } from "@/ipc/utils/replaceSlashSkillReference";
+
 function PromptCard({
   prompt,
   onUpdate,
@@ -95,15 +97,18 @@ function PromptCard({
     title: string;
     description: string | null;
     content: string;
+    slug: string | null;
   };
   onUpdate: (p: {
     id: number;
     title: string;
     description?: string;
     content: string;
+    slug?: string | null;
   }) => Promise<void>;
   onDelete: (id: number) => Promise<void>;
 }) {
+  const slashCommand = slugForPrompt(prompt);
   return (
     <div
       data-testid="prompt-card"
@@ -116,6 +121,11 @@ function PromptCard({
             {prompt.description && (
               <p className="text-sm text-muted-foreground">
                 {prompt.description}
+              </p>
+            )}
+            {slashCommand && (
+              <p className="text-xs text-muted-foreground mt-1 font-mono">
+                Use /{slashCommand} in chat
               </p>
             )}
           </div>


### PR DESCRIPTION
Adds a step to the PR Review Responder workflow to ensure Homebrew paths (`/opt/homebrew/bin` and `/usr/local/bin`) are available in PATH on self-hosted macOS runners. Non-interactive shells may not include these directories, which can cause `gh` (installed via Homebrew) to be unavailable.

## Test plan
- Workflow runs on next PR with cc:request label; verify gh commands succeed on self-hosted macOS runner.
#skip-bugbot

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2895" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
