### PR TITLE
ci: ensure Homebrew paths available for gh on self-hosted macOS runners

### DIFF
--- a/.github/workflows/pr-review-responder.yml
+++ b/.github/workflows/pr-review-responder.yml
@@ -234,6 +234,14 @@ jobs:
         env:
           PR_CONTENTS_RW_GITHUB_TOKEN: ${{ secrets.PR_CONTENTS_RW_GITHUB_TOKEN }}
 
+      - name: Ensure Homebrew paths are available
+        if: steps.pr-info.outputs.should_continue == 'true'
+        run: |
+          # Self-hosted macOS runners often have gh installed via Homebrew, but
+          # non-interactive shells may not include Homebrew directories in PATH.
+          echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
+          echo "/usr/local/bin" >> "$GITHUB_PATH"
+
       - name: Update labels to pending
         if: steps.pr-info.outputs.should_continue == 'true'
         run: |


### PR DESCRIPTION
Made-with: Cursor
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2896" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
