### PR TITLE
chore: add dyadbot to allowlists

### DIFF
--- a/.claude/skills/deflake-e2e-recent-commits/SKILL.md
+++ b/.claude/skills/deflake-e2e-recent-commits/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: dyad:deflake-e2e-recent-commits
-description: Automatically gather flaky E2E tests from recent CI runs on the main branch and from recent PRs by wwwillchen/wwwillchen-bot, then deflake them.
+description: Automatically gather flaky E2E tests from recent CI runs on the main branch and from recent PRs by wwwillchen/wwwillchen-bot/dyadbot, then deflake them.
 ---
 
 # Deflake E2E Tests from Recent Commits
 
-Automatically gather flaky E2E tests from recent CI runs on the main branch and from recent PRs by wwwillchen/wwwillchen-bot, then deflake them.
+Automatically gather flaky E2E tests from recent CI runs on the main branch and from recent PRs by wwwillchen/wwwillchen-bot/dyadbot, then deflake them.
 
 ## Arguments
 
@@ -49,29 +49,31 @@ Automatically gather flaky E2E tests from recent CI runs on the main branch and 
 
    **Note:** Some runs may not have an html-report artifact (e.g., if they were cancelled early, the merge-reports job didn't complete, or artifacts have expired past the 3-day retention period). Skip these runs and continue to the next one.
 
-2. **Gather flaky tests from recent PRs by wwwillchen and wwwillchen-bot:**
+2. **Gather flaky tests from recent PRs by wwwillchen, wwwillchen-bot, and dyadbot:**
 
-   In addition to main branch CI runs, scan recent open PRs authored by `wwwillchen` or `wwwillchen-bot` for flaky tests reported in Playwright report comments.
+In addition to main branch CI runs, scan recent open PRs authored by `wwwillchen`, `wwwillchen-bot`, or `dyadbot` for flaky tests reported in Playwright report comments.
 
-   a. List recent open PRs by these authors:
+a. List recent open PRs by these authors:
 
-   ```
-   gh pr list --author wwwillchen --state open --limit 10 --json number,title
-   gh pr list --author wwwillchen-bot --state open --limit 10 --json number,title
-   ```
+```
+gh pr list --author wwwillchen --state open --limit 10 --json number,title
+gh pr list --author wwwillchen-bot --state open --limit 10 --json number,title
+gh pr list --author dyadbot --state open --limit 10 --json number,title
+```
 
-   b. For each PR, find the most recent Playwright Test Results comment (posted by a bot, containing "🎭 Playwright Test Results"):
+b. For each PR, find the most recent Playwright Test Results comment (posted by a bot, containing "🎭 Playwright Test Results"):
 
-   ```
-   gh api "repos/{owner}/{repo}/issues/<pr_number>/comments" --jq '[.[] | select(.user.type == "Bot" and (.body | contains("Playwright Test Results")))] | last'
-   ```
+```
+gh api "repos/{owner}/{repo}/issues/<pr_number>/comments" --jq '[.[] | select(.user.type == "Bot" and (.body | contains("Playwright Test Results")))] | last'
+```
 
-   c. Parse the comment body to extract flaky tests. The comment format includes a "⚠️ Flaky Tests" section with test names in backticks:
-   - Look for lines matching the pattern: ``- `<test_title>` (passed after N retries)``
-   - Extract the test title from within the backticks
-   - The test title format is: `<spec_file.spec.ts> > <Suite Name> > <Test Name>`
+c. Parse the comment body to extract flaky tests. The comment format includes a "⚠️ Flaky Tests" section with test names in backticks:
 
-   d. Add these flaky tests to the overall collection, noting they came from PR #N for the summary
+- Look for lines matching the pattern: ``- `<test_title>` (passed after N retries)``
+- Extract the test title from within the backticks
+- The test title format is: `<spec_file.spec.ts> > <Suite Name> > <Test Name>`
+
+d. Add these flaky tests to the overall collection, noting they came from PR #N for the summary
 
 3. **Deduplicate and rank by frequency:**
 
@@ -147,11 +149,12 @@ Automatically gather flaky E2E tests from recent CI runs on the main branch and 
 
    Report:
    - Total flaky tests found across main branch commits and PRs
-   - Sources of flaky tests (main branch CI runs vs. PR comments from wwwillchen/wwwillchen-bot)
-   - Which tests were successfully deflaked
-   - What fixes were applied to each
-   - Which tests could not be fixed (and why)
-   - Verification results
+
+- Sources of flaky tests (main branch CI runs vs. PR comments from wwwillchen/wwwillchen-bot/dyadbot)
+  - Which tests were successfully deflaked
+  - What fixes were applied to each
+  - Which tests could not be fixed (and why)
+  - Verification results
 
 8. **Create PR with fixes:**
 

--- a/.claude/skills/pr-fix-comments/SKILL.md
+++ b/.claude/skills/pr-fix-comments/SKILL.md
@@ -33,6 +33,7 @@ Only process review comments from these trusted authors. Comments from other aut
 - cubic-dev-ai
 - cursor
 - github-actions
+- dyadbot
 - chatgpt-codex-connector
 - devin-ai-integration
 

--- a/.github/workflows/bugbot-trigger.yml
+++ b/.github/workflows/bugbot-trigger.yml
@@ -11,6 +11,7 @@ jobs:
     if: |
       (github.event.pull_request.user.login == 'wwwillchen' ||
       github.event.pull_request.user.login == 'wwwillchen-bot' ||
+      github.event.pull_request.user.login == 'dyadbot' ||
       github.event.pull_request.user.login == 'azizmejri1' ||
       github.event.pull_request.user.login == 'princeaden1') &&
       !contains(github.event.pull_request.body, '#skip-bugbot') &&

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
             AUTHOR="${{ github.event.pull_request.user.login }}"
           fi
           echo "Author: $AUTHOR"
-          if [ "$AUTHOR" = "wwwillchen" ] || [ "$AUTHOR" = "wwwillchen-bot" ] || [ "$AUTHOR" = "azizmejri1" ]; then
+          if [ "$AUTHOR" = "wwwillchen" ] || [ "$AUTHOR" = "wwwillchen-bot" ] || [ "$AUTHOR" = "dyadbot" ] || [ "$AUTHOR" = "azizmejri1" ]; then
             echo "is_privileged=true" >> $GITHUB_OUTPUT
           else
             echo "is_privileged=false" >> $GITHUB_OUTPUT
@@ -96,7 +96,7 @@ jobs:
       # The "image" field is a JSON-encoded array string so that fromJSON() in runs-on
       # can produce the correct label(s) for both GitHub-hosted and self-hosted runners.
       #
-      # Privileged authors (wwwillchen, wwwillchen-bot, azizmejri1):
+      # Privileged authors (wwwillchen, wwwillchen-bot, dyadbot, azizmejri1):
       #   - Self-hosted macOS ARM64 runners, no Windows, no sharding.
       #
       #   build (macOS self-hosted) ──> e2e-tests (macOS self-hosted, shard 1/1)

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -21,6 +21,7 @@ jobs:
     if: |
       github.event.pull_request.user.login == 'wwwillchen' ||
       github.event.pull_request.user.login == 'wwwillchen-bot' ||
+      github.event.pull_request.user.login == 'dyadbot' ||
       github.event.pull_request.user.login == 'azizmejri1' ||
       github.event.pull_request.user.login == 'princeaden1'
     runs-on: ubuntu-latest
@@ -48,7 +49,7 @@ jobs:
 
           # See: https://github.com/anthropics/claude-code-action/blob/v1/docs/security.md
           github_token: ${{ secrets.GITHUB_TOKEN }} # bypass OIDC
-          allowed_non_write_users: "princeaden1,wwwillchen-bot" # remember, we already filter above.
+          allowed_non_write_users: "princeaden1,wwwillchen-bot,dyadbot" # remember, we already filter above.
 
           # Disable progress tracking (try to save tokens)
           track_progress: false

--- a/.github/workflows/claude-rebase.yml
+++ b/.github/workflows/claude-rebase.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           script: |
             const pr = context.payload.pull_request;
-            const allowedUsers = ['wwwillchen', 'wwwillchen-bot', 'azizmejri1', 'princeaden1'];
+            const allowedUsers = ['wwwillchen', 'wwwillchen-bot', 'dyadbot', 'azizmejri1', 'princeaden1'];
             if (!allowedUsers.includes(pr.user.login)) {
               console.log(`PR author ${pr.user.login} is not allowed to use this workflow`);
               core.setOutput('should_continue', 'false');

--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -108,14 +108,14 @@ jobs:
 
             ### Surfacing Helpful Comments
 
-            If a **high-confidence** duplicate is found and there is a helpful comment from **wwwillchen@** or **wwwillchen-bot@** on the original issue, include a recommendation in your comment:
+            If a **high-confidence** duplicate is found and there is a helpful comment from **wwwillchen@**, **wwwillchen-bot@**, or **dyadbot@** on the original issue, include a recommendation in your comment:
 
             > You might want to try [summary of the suggestion] based on this earlier [comment]([direct link to the comment]).
 
             **Notes:**
 
             - Only do this for high-confidence duplicates where you're very confident the issues are the same.
-            - Only surface comments from wwwillchen@ or wwwillchen-bot@ — do not surface comments from other users.
+            - Only surface comments from wwwillchen@, wwwillchen-bot@, or dyadbot@ — do not surface comments from other users.
             - Link directly to the specific comment, not just the issue.
 
             ### If No Duplicates Found

--- a/.github/workflows/label-rebase-prs.yml
+++ b/.github/workflows/label-rebase-prs.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           github-token: ${{ secrets.PR_RW_GITHUB_TOKEN }}
           script: |
-            const allowedAuthors = ['wwwillchen', 'wwwillchen-bot'];
+            const allowedAuthors = ['wwwillchen', 'wwwillchen-bot', 'dyadbot'];
 
             const prs = await github.paginate(github.rest.pulls.list, {
               owner: context.repo.owner,

--- a/.github/workflows/merge-pr.yml
+++ b/.github/workflows/merge-pr.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   # Allowed authors for auto-merge (update in one place)
-  ALLOWED_MERGE_AUTHORS: wwwillchen,wwwillchen-bot
+  ALLOWED_MERGE_AUTHORS: wwwillchen,wwwillchen-bot,dyadbot
 
 jobs:
   merge:

--- a/.github/workflows/pr-review-responder.yml
+++ b/.github/workflows/pr-review-responder.yml
@@ -50,7 +50,7 @@ jobs:
 
               // Check that the person who applied the label is a trusted actor
               const actor = context.actor;
-              const allowedActors = ['wwwillchen', 'wwwillchen-bot'];
+              const allowedActors = ['wwwillchen', 'wwwillchen-bot', 'dyadbot'];
               if (!allowedActors.includes(actor)) {
                 console.log(`Label applied by ${actor} who is not in the allowed actors list`);
                 core.setOutput('should_continue', 'false');
@@ -113,8 +113,8 @@ jobs:
               prAuthor = pr.user.login;
             }
 
-            // Only allow wwwillchen, wwwillchen-bot, and princeaden1 to use this workflow
-            if (prAuthor !== 'wwwillchen' && prAuthor !== 'wwwillchen-bot' && prAuthor !== 'princeaden1') {
+            // Only allow wwwillchen, wwwillchen-bot, dyadbot, and princeaden1 to use this workflow
+            if (prAuthor !== 'wwwillchen' && prAuthor !== 'wwwillchen-bot' && prAuthor !== 'dyadbot' && prAuthor !== 'princeaden1') {
               console.log(`PR #${prNumber} author ${prAuthor} is not allowed to use this workflow`);
               core.setOutput('should_continue', 'false');
               return;

--- a/plans/faster-pr-workflows.md
+++ b/plans/faster-pr-workflows.md
@@ -4,7 +4,7 @@
 
 ## Summary
 
-Improve the speed of landing PRs for the maintainer (wwwillchen/wwwillchen-bot) by optimizing the CI pipeline, automating the fix-and-retry loop, and improving developer feedback during wait times. The current workflow is already highly automated — this plan targets the remaining friction: CI wall-clock time, human-in-the-loop steps, and the "waiting black hole" between push and merge.
+Improve the speed of landing PRs for the maintainer (wwwillchen/wwwillchen-bot/dyadbot) by optimizing the CI pipeline, automating the fix-and-retry loop, and improving developer feedback during wait times. The current workflow is already highly automated — this plan targets the remaining friction: CI wall-clock time, human-in-the-loop steps, and the "waiting black hole" between push and merge.
 
 ## Problem Statement
 


### PR DESCRIPTION
## Summary
- Added dyadbot wherever wwwillchen-bot was allowlisted in CI workflows and automation policy docs.
- Updated trusted author/bot references in PR workflow selectors and skill docs to include dyadbot.

## Test plan
- Ran 
> dyad@0.39.0-beta.1 fmt
> npx oxfmt
- Ran 
> dyad@0.39.0-beta.1 lint:fix
> npx oxlint --fix --fix-suggestions --fix-dangerously

Found 0 warnings and 0 errors.
Finished in 18ms on 817 files with 88 rules using 10 threads.
- Ran 
> dyad@0.39.0-beta.1 ts
> npm run ts:main && npm run ts:workers


> dyad@0.39.0-beta.1 ts:main
> npx tsgo -p tsconfig.app.json --noEmit --incremental


> dyad@0.39.0-beta.1 ts:workers
> npx tsc -p workers/tsc/tsconfig.json --noEmit --incremental
- Verified remaining allowlist references for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2899" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
