### PR TITLE
ci: cancel claude rebase when PR closes

### DIFF
--- a/.github/workflows/claude-rebase.yml
+++ b/.github/workflows/claude-rebase.yml
@@ -2,12 +2,16 @@ name: Claude Rebase
 
 on:
   pull_request_target:
-    types: [labeled]
+    types: [labeled, closed]
+
+concurrency:
+  group: claude-rebase-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   rebase:
     environment: ai-bots
-    if: github.event.label.name == 'cc:rebase'
+    if: github.event.action == 'labeled' && github.event.label.name == 'cc:rebase'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- trigger the Claude rebase workflow on PR close events
- add a per-PR concurrency group so a close/merge event cancels any in-progress rebase run
- restrict the rebase job itself to labeled events so closed PRs only trigger cancellation

## Test plan
- npm run fmt
- npm run lint:fix
- npm run ts
- npm test

#skip-bugbot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2915" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
