### PR TITLE
fix: refresh user budget when pro key is set via deep link

### DIFF
--- a/src/app/TitleBar.tsx
+++ b/src/app/TitleBar.tsx
@@ -32,7 +32,8 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { useRunApp } from "@/hooks/useRunApp";
 import { showError, showSuccess } from "@/lib/toast";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { queryKeys } from "@/lib/queryKeys";
 import { useTranslation } from "react-i18next";
 
 export const TitleBar = () => {
@@ -41,6 +42,7 @@ export const TitleBar = () => {
   const { apps } = useLoadApps();
   const { navigate } = useRouter();
   const { settings, refreshSettings } = useSettings();
+  const queryClient = useQueryClient();
   const [isSuccessDialogOpen, setIsSuccessDialogOpen] = useState(false);
   const platform = useSystemPlatform();
   const showWindowControls = platform !== null && platform !== "darwin";
@@ -54,6 +56,8 @@ export const TitleBar = () => {
     const handleDeepLink = async () => {
       if (lastDeepLink?.type === "dyad-pro-return") {
         await refreshSettings();
+        // Refetch user budget when Dyad Pro key is set via deep link
+        queryClient.invalidateQueries({ queryKey: queryKeys.userBudget.info });
         showDyadProSuccessDialog();
         clearLastDeepLink();
       }


### PR DESCRIPTION
## Summary
- When a user enters a pro key via deep link, the budget query was not invalidated, leaving stale budget data until the 5-minute cache expired
- Added `queryClient.invalidateQueries` for the user budget query in the deep link handler in `TitleBar.tsx`, matching the behavior already present in the manual key entry path

## Test plan
- [ ] Enter a Dyad Pro key via deep link (`dyad://dyad-pro-return?key=...`) and verify the budget display updates immediately
- [ ] Enter a Dyad Pro key manually in settings and verify budget still refreshes (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2956" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
