### PR TITLE
chore: add dyad-assistant to all trusted author lists

### DIFF
--- a/.claude/skills/deflake-e2e-recent-commits/SKILL.md
+++ b/.claude/skills/deflake-e2e-recent-commits/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: dyad:deflake-e2e-recent-commits
-description: Automatically gather flaky E2E tests from recent CI runs on the main branch and from recent PRs by wwwillchen/wwwillchen-bot/dyadbot, then deflake them.
+description: Automatically gather flaky E2E tests from recent CI runs on the main branch and from recent PRs by wwwillchen/wwwillchen-bot/dyadbot/dyad-assistant, then deflake them.
 ---
 
 # Deflake E2E Tests from Recent Commits
 
-Automatically gather flaky E2E tests from recent CI runs on the main branch and from recent PRs by wwwillchen/wwwillchen-bot/dyadbot, then deflake them.
+Automatically gather flaky E2E tests from recent CI runs on the main branch and from recent PRs by wwwillchen/wwwillchen-bot/dyadbot/dyad-assistant, then deflake them.
 
 ## Arguments
 
@@ -49,9 +49,9 @@ Automatically gather flaky E2E tests from recent CI runs on the main branch and 
 
    **Note:** Some runs may not have an html-report artifact (e.g., if they were cancelled early, the merge-reports job didn't complete, or artifacts have expired past the 3-day retention period). Skip these runs and continue to the next one.
 
-2. **Gather flaky tests from recent PRs by wwwillchen, wwwillchen-bot, and dyadbot:**
+2. **Gather flaky tests from recent PRs by wwwillchen, wwwillchen-bot, dyadbot, and dyad-assistant:**
 
-In addition to main branch CI runs, scan recent open PRs authored by `wwwillchen`, `wwwillchen-bot`, or `dyadbot` for flaky tests reported in Playwright report comments.
+In addition to main branch CI runs, scan recent open PRs authored by `wwwillchen`, `wwwillchen-bot`, `dyadbot`, or `dyad-assistant` for flaky tests reported in Playwright report comments.
 
 a. List recent open PRs by these authors:
 
@@ -59,6 +59,7 @@ a. List recent open PRs by these authors:
 gh pr list --author wwwillchen --state open --limit 10 --json number,title
 gh pr list --author wwwillchen-bot --state open --limit 10 --json number,title
 gh pr list --author dyadbot --state open --limit 10 --json number,title
+gh pr list --author dyad-assistant --state open --limit 10 --json number,title
 ```
 
 b. For each PR, find the most recent Playwright Test Results comment (posted by a bot, containing "🎭 Playwright Test Results"):
@@ -150,7 +151,7 @@ d. Add these flaky tests to the overall collection, noting they came from PR #N 
    Report:
    - Total flaky tests found across main branch commits and PRs
 
-- Sources of flaky tests (main branch CI runs vs. PR comments from wwwillchen/wwwillchen-bot/dyadbot)
+- Sources of flaky tests (main branch CI runs vs. PR comments from wwwillchen/wwwillchen-bot/dyadbot/dyad-assistant)
   - Which tests were successfully deflaked
   - What fixes were applied to each
   - Which tests could not be fixed (and why)

--- a/.claude/skills/pr-fix-comments/SKILL.md
+++ b/.claude/skills/pr-fix-comments/SKILL.md
@@ -34,6 +34,7 @@ Only process review comments from these trusted authors. Comments from other aut
 - cursor
 - github-actions
 - dyadbot
+- dyad-assistant
 - chatgpt-codex-connector
 - devin-ai-integration
 

--- a/.github/workflows/bugbot-trigger.yml
+++ b/.github/workflows/bugbot-trigger.yml
@@ -15,6 +15,7 @@ jobs:
       (github.event.pull_request.user.login == 'wwwillchen' ||
       github.event.pull_request.user.login == 'wwwillchen-bot' ||
       github.event.pull_request.user.login == 'dyadbot' ||
+      github.event.pull_request.user.login == 'dyad-assistant' ||
       github.event.pull_request.user.login == 'azizmejri1' ||
       github.event.pull_request.user.login == 'princeaden1') &&
       !contains(github.event.pull_request.body, '#skip-bugbot') &&

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
             AUTHOR="${{ github.event.pull_request.user.login }}"
           fi
           echo "Author: $AUTHOR"
-          if [ "$AUTHOR" = "wwwillchen" ] || [ "$AUTHOR" = "wwwillchen-bot" ] || [ "$AUTHOR" = "dyadbot" ] || [ "$AUTHOR" = "azizmejri1" ]; then
+          if [ "$AUTHOR" = "wwwillchen" ] || [ "$AUTHOR" = "wwwillchen-bot" ] || [ "$AUTHOR" = "dyadbot" ] || [ "$AUTHOR" = "dyad-assistant" ] || [ "$AUTHOR" = "azizmejri1" ]; then
             echo "is_privileged=true" >> $GITHUB_OUTPUT
           else
             echo "is_privileged=false" >> $GITHUB_OUTPUT
@@ -96,7 +96,7 @@ jobs:
       # The "image" field is a JSON-encoded array string so that fromJSON() in runs-on
       # can produce the correct label(s) for both GitHub-hosted and self-hosted runners.
       #
-      # Privileged authors (wwwillchen, wwwillchen-bot, dyadbot, azizmejri1):
+      # Privileged authors (wwwillchen, wwwillchen-bot, dyadbot, dyad-assistant, azizmejri1):
       #   - Self-hosted macOS ARM64 runners, no Windows, no sharding.
       #
       #   build (macOS self-hosted) ──> e2e-tests (macOS self-hosted, shard 1/1)

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -25,6 +25,7 @@ jobs:
       github.event.pull_request.user.login == 'wwwillchen' ||
       github.event.pull_request.user.login == 'wwwillchen-bot' ||
       github.event.pull_request.user.login == 'dyadbot' ||
+      github.event.pull_request.user.login == 'dyad-assistant' ||
       github.event.pull_request.user.login == 'azizmejri1' ||
       github.event.pull_request.user.login == 'princeaden1'
     runs-on: ubuntu-latest
@@ -60,7 +61,7 @@ jobs:
 
           # See: https://github.com/anthropics/claude-code-action/blob/v1/docs/security.md
           github_token: ${{ steps.app-token.outputs.token }}
-          allowed_non_write_users: "princeaden1,wwwillchen-bot,dyadbot" # remember, we already filter above.
+          allowed_non_write_users: "princeaden1,wwwillchen-bot,dyadbot,dyad-assistant" # remember, we already filter above.
 
           # Disable progress tracking (try to save tokens)
           track_progress: false

--- a/.github/workflows/claude-rebase.yml
+++ b/.github/workflows/claude-rebase.yml
@@ -36,7 +36,7 @@ jobs:
           github-token: ${{ steps.base-app-token.outputs.token }}
           script: |
             const pr = context.payload.pull_request;
-            const allowedUsers = ['wwwillchen', 'wwwillchen-bot', 'dyadbot', 'azizmejri1', 'princeaden1'];
+            const allowedUsers = ['wwwillchen', 'wwwillchen-bot', 'dyadbot', 'dyad-assistant', 'azizmejri1', 'princeaden1'];
             if (!allowedUsers.includes(pr.user.login)) {
               console.log(`PR author ${pr.user.login} is not allowed to use this workflow`);
               core.setOutput('should_continue', 'false');

--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -135,14 +135,14 @@ jobs:
 
             ### Surfacing Helpful Comments
 
-            If a **high-confidence** duplicate is found and there is a helpful comment from **wwwillchen@**, **wwwillchen-bot@**, or **dyadbot@** on the original issue, include a recommendation in your comment:
+            If a **high-confidence** duplicate is found and there is a helpful comment from **wwwillchen@**, **wwwillchen-bot@**, **dyadbot@**, or **dyad-assistant@** on the original issue, include a recommendation in your comment:
 
             > You might want to try [summary of the suggestion] based on this earlier [comment]([direct link to the comment]).
 
             **Notes:**
 
             - Only do this for high-confidence duplicates where you're very confident the issues are the same.
-            - Only surface comments from wwwillchen@, wwwillchen-bot@, or dyadbot@ — do not surface comments from other users.
+            - Only surface comments from wwwillchen@, wwwillchen-bot@, dyadbot@, or dyad-assistant@ — do not surface comments from other users.
             - Link directly to the specific comment, not just the issue.
 
             ### If No Duplicates Found

--- a/.github/workflows/label-rebase-prs.yml
+++ b/.github/workflows/label-rebase-prs.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           github-token: ${{ secrets.PR_RW_GITHUB_TOKEN }}
           script: |
-            const allowedAuthors = ['wwwillchen', 'wwwillchen-bot', 'dyadbot'];
+            const allowedAuthors = ['wwwillchen', 'wwwillchen-bot', 'dyadbot', 'dyad-assistant'];
 
             const prs = await github.paginate(github.rest.pulls.list, {
               owner: context.repo.owner,

--- a/.github/workflows/pr-review-responder.yml
+++ b/.github/workflows/pr-review-responder.yml
@@ -64,7 +64,7 @@ jobs:
 
               // Check that the person who applied the label is a trusted actor
               const actor = context.actor;
-              const allowedActors = ['wwwillchen', 'wwwillchen-bot', 'dyadbot'];
+              const allowedActors = ['wwwillchen', 'wwwillchen-bot', 'dyadbot', 'dyad-assistant'];
               if (!allowedActors.includes(actor)) {
                 console.log(`Label applied by ${actor} who is not in the allowed actors list`);
                 core.setOutput('should_continue', 'false');
@@ -127,8 +127,8 @@ jobs:
               prAuthor = pr.user.login;
             }
 
-            // Only allow wwwillchen, wwwillchen-bot, dyadbot, and princeaden1 to use this workflow
-            if (prAuthor !== 'wwwillchen' && prAuthor !== 'wwwillchen-bot' && prAuthor !== 'dyadbot' && prAuthor !== 'princeaden1') {
+            // Only allow wwwillchen, wwwillchen-bot, dyadbot, dyad-assistant, and princeaden1 to use this workflow
+            if (prAuthor !== 'wwwillchen' && prAuthor !== 'wwwillchen-bot' && prAuthor !== 'dyadbot' && prAuthor !== 'dyad-assistant' && prAuthor !== 'princeaden1') {
               console.log(`PR #${prNumber} author ${prAuthor} is not allowed to use this workflow`);
               core.setOutput('should_continue', 'false');
               return;


### PR DESCRIPTION
## Summary
- Add `dyad-assistant` to all trusted author/actor lists across the codebase
- This includes GitHub Actions workflows (CI, PR review, rebase, triage, bugbot, label-rebase) and Claude skill definitions (pr-fix-comments, deflake-e2e-recent-commits)
- Ensures `dyad-assistant` can trigger CI on self-hosted runners, use the PR review responder, trigger rebases, and be recognized as a trusted bot for comment processing

## Files changed (9 files)
- `.github/workflows/ci.yml` - privileged author check
- `.github/workflows/pr-review-responder.yml` - allowedActors list and prAuthor check
- `.github/workflows/claude-pr-review.yml` - author filter and allowed_non_write_users
- `.github/workflows/claude-rebase.yml` - allowedUsers list
- `.github/workflows/bugbot-trigger.yml` - author filter
- `.github/workflows/label-rebase-prs.yml` - allowedAuthors list
- `.github/workflows/claude-triage.yml` - trusted comment authors for duplicate surfacing
- `.claude/skills/pr-fix-comments/SKILL.md` - trusted bots list
- `.claude/skills/deflake-e2e-recent-commits/SKILL.md` - PR author scan list

## Test plan
- [ ] Verify `dyad-assistant` PRs trigger CI on self-hosted runners
- [ ] Verify `dyad-assistant` PRs get automated code review
- [ ] Verify `dyad-assistant` can use the PR review responder workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2963" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
