### PR TITLE
feat: gate home chat app selector behind experiment setting

### DIFF
--- a/e2e-tests/helpers/page-objects/PageObject.ts
+++ b/e2e-tests/helpers/page-objects/PageObject.ts
@@ -89,11 +89,13 @@ export class PageObject {
     disableNativeGit = false,
     enableAutoFixProblems = false,
     enableBasicAgent = false,
+    enableSelectAppFromHomeChatInput = false,
   }: {
     autoApprove?: boolean;
     disableNativeGit?: boolean;
     enableAutoFixProblems?: boolean;
     enableBasicAgent?: boolean;
+    enableSelectAppFromHomeChatInput?: boolean;
   } = {}) {
     await this.baseSetup();
     await this.navigation.goToSettingsTab();
@@ -105,6 +107,9 @@ export class PageObject {
     }
     if (enableAutoFixProblems) {
       await this.settings.toggleAutoFixProblems();
+    }
+    if (enableSelectAppFromHomeChatInput) {
+      await this.settings.toggleEnableSelectAppFromHomeChatInput();
     }
     await this.settings.setUpTestProvider();
     await this.settings.setUpTestModel();

--- a/e2e-tests/helpers/page-objects/components/Settings.ts
+++ b/e2e-tests/helpers/page-objects/components/Settings.ts
@@ -36,6 +36,14 @@ export class Settings {
       .click();
   }
 
+  async toggleEnableSelectAppFromHomeChatInput() {
+    await this.page
+      .getByRole("switch", {
+        name: "Enable Select App from Home Chat Input",
+      })
+      .click();
+  }
+
   async toggleAutoUpdate() {
     await this.page.getByRole("switch", { name: "Auto-update" }).click();
   }

--- a/e2e-tests/home_chat_existing_app.spec.ts
+++ b/e2e-tests/home_chat_existing_app.spec.ts
@@ -2,7 +2,10 @@ import { test } from "./helpers/test_helper";
 import { expect } from "@playwright/test";
 
 test("home chat - start new chat in existing app", async ({ po }) => {
-  await po.setUp({ autoApprove: true });
+  await po.setUp({
+    autoApprove: true,
+    enableSelectAppFromHomeChatInput: true,
+  });
 
   // Create an app first
   await po.sendPrompt("create a todo application");
@@ -48,7 +51,10 @@ test("home chat - start new chat in existing app", async ({ po }) => {
 });
 
 test("home chat - clear selected app", async ({ po }) => {
-  await po.setUp({ autoApprove: true });
+  await po.setUp({
+    autoApprove: true,
+    enableSelectAppFromHomeChatInput: true,
+  });
 
   // Create an app first
   await po.sendPrompt("create a todo application");

--- a/src/components/chat/HomeChatInput.tsx
+++ b/src/components/chat/HomeChatInput.tsx
@@ -36,7 +36,7 @@ import { AppSearchDialog } from "../AppSearchDialog";
 import { useVoiceToText } from "@/hooks/useVoiceToText";
 import { useUserBudgetInfo } from "@/hooks/useUserBudgetInfo";
 import { ipc } from "@/ipc/types";
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 import { showError } from "@/lib/toast";
 
 export function HomeChatInput({
@@ -70,6 +70,13 @@ export function HomeChatInput({
 
   const [appSearchOpen, setAppSearchOpen] = useState(false);
   const { apps } = useLoadApps();
+
+  // Clear selected app when the experiment flag is disabled
+  useEffect(() => {
+    if (!settings?.enableSelectAppFromHomeChatInput) {
+      setSelectedApp(null);
+    }
+  }, [settings?.enableSelectAppFromHomeChatInput, setSelectedApp]);
 
   const typingText = useTypingPlaceholder([
     "an ecommerce store...",

--- a/src/components/chat/HomeChatInput.tsx
+++ b/src/components/chat/HomeChatInput.tsx
@@ -277,46 +277,48 @@ export function HomeChatInput({
           <div className="px-2 flex items-center justify-between pb-0.5 pt-0.5">
             <div className="flex items-center">
               <ChatInputControls showContextFilesPicker={false} />
-              <Tooltip>
-                <TooltipTrigger
-                  render={
-                    <button
-                      onClick={() => setAppSearchOpen(true)}
-                      className={cn(
-                        "cursor-pointer px-2 py-1 ml-1.5 text-xs font-medium rounded-lg transition-colors flex items-center gap-1",
-                        selectedApp
-                          ? "bg-primary/10 text-primary hover:bg-primary/15"
-                          : "text-foreground/80 hover:text-foreground hover:bg-muted/60",
-                      )}
-                      data-testid="home-app-selector"
-                    />
-                  }
-                >
-                  <FolderOpenIcon size={14} />
-                  <span className="truncate max-w-[150px]">
-                    {selectedApp ? selectedApp.name : "No app selected"}
-                  </span>
-                  {selectedApp && (
-                    <button
-                      type="button"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setSelectedApp(null);
-                      }}
-                      className="hover:bg-primary/20 rounded-sm p-0.5 transition-colors"
-                      aria-label="Deselect app"
-                      data-testid="home-app-selector-clear"
-                    >
-                      <XIcon size={12} />
-                    </button>
-                  )}
-                </TooltipTrigger>
-                <TooltipContent>
-                  {selectedApp
-                    ? "Change selected app"
-                    : "Select an existing app"}
-                </TooltipContent>
-              </Tooltip>
+              {settings?.enableSelectAppFromHomeChatInput && (
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <button
+                        onClick={() => setAppSearchOpen(true)}
+                        className={cn(
+                          "cursor-pointer px-2 py-1 ml-1.5 text-xs font-medium rounded-lg transition-colors flex items-center gap-1",
+                          selectedApp
+                            ? "bg-primary/10 text-primary hover:bg-primary/15"
+                            : "text-foreground/80 hover:text-foreground hover:bg-muted/60",
+                        )}
+                        data-testid="home-app-selector"
+                      />
+                    }
+                  >
+                    <FolderOpenIcon size={14} />
+                    <span className="truncate max-w-[150px]">
+                      {selectedApp ? selectedApp.name : "No app selected"}
+                    </span>
+                    {selectedApp && (
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setSelectedApp(null);
+                        }}
+                        className="hover:bg-primary/20 rounded-sm p-0.5 transition-colors"
+                        aria-label="Deselect app"
+                        data-testid="home-app-selector-clear"
+                      >
+                        <XIcon size={12} />
+                      </button>
+                    )}
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    {selectedApp
+                      ? "Change selected app"
+                      : "Select an existing app"}
+                  </TooltipContent>
+                </Tooltip>
+              )}
             </div>
 
             <AuxiliaryActionsMenu

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -352,6 +352,7 @@ const BaseUserSettingsFields = {
   hideLocalAgentNewChatToast: z.boolean().optional(),
   enableContextCompaction: z.boolean().optional(),
   skipNotificationBanner: z.boolean().optional(),
+  enableSelectAppFromHomeChatInput: z.boolean().optional(),
 };
 
 /**

--- a/src/lib/settingsSearchIndex.ts
+++ b/src/lib/settingsSearchIndex.ts
@@ -34,6 +34,8 @@ export const SETTING_IDS = {
   neon: "setting-neon",
   nativeGit: "setting-native-git",
   enableMcpServersForBuildMode: "setting-enable-mcp-servers-for-build-mode",
+  enableSelectAppFromHomeChatInput:
+    "setting-enable-select-app-from-home-chat-input",
   reset: "setting-reset",
 } as const;
 
@@ -328,6 +330,15 @@ export const SETTINGS_SEARCH_INDEX: SearchableSettingItem[] = [
     label: "Enable MCP servers for Build mode",
     description: "Allow MCP servers to be used when in Build mode",
     keywords: ["mcp", "build", "agent", "tools", "experiment", "server"],
+    sectionId: SECTION_IDS.experiments,
+    sectionLabel: "Experiments",
+  },
+  {
+    id: SETTING_IDS.enableSelectAppFromHomeChatInput,
+    label: "Enable Select App from Home Chat Input",
+    description:
+      "Show an app selector in the home chat input to start a chat referencing an existing app",
+    keywords: ["app", "select", "home", "chat", "experiment", "input"],
     sectionId: SECTION_IDS.experiments,
     sectionLabel: "Experiments",
   },

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -219,6 +219,27 @@ export default function SettingsPage() {
                   servers are always enabled in Agent mode.
                 </div>
               </div>
+              <div className="space-y-1 mt-4">
+                <div className="flex items-center space-x-2">
+                  <Switch
+                    id="enable-select-app-from-home-chat-input"
+                    aria-label="Enable Select App from Home Chat Input"
+                    checked={!!settings?.enableSelectAppFromHomeChatInput}
+                    onCheckedChange={(checked) => {
+                      updateSettings({
+                        enableSelectAppFromHomeChatInput: checked,
+                      });
+                    }}
+                  />
+                  <Label htmlFor="enable-select-app-from-home-chat-input">
+                    Enable Select App from Home Chat Input
+                  </Label>
+                </div>
+                <div className="text-sm text-gray-500 dark:text-gray-400">
+                  Show an app selector in the home chat input to start a chat
+                  referencing an existing app.
+                </div>
+              </div>
             </div>
           </div>
 

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -219,7 +219,10 @@ export default function SettingsPage() {
                   servers are always enabled in Agent mode.
                 </div>
               </div>
-              <div className="space-y-1 mt-4">
+              <div
+                id={SETTING_IDS.enableSelectAppFromHomeChatInput}
+                className="space-y-1 mt-4"
+              >
                 <div className="flex items-center space-x-2">
                   <Switch
                     id="enable-select-app-from-home-chat-input"


### PR DESCRIPTION
## Summary
- Add `enableSelectAppFromHomeChatInput` experiment setting with toggle in Settings UI
- Conditionally render the app selector ("No app selected") in HomeChatInput based on the setting
- Update e2e tests to enable the flag via `setUp()` UI toggle instead of writing `user-settings.json` directly

## Test plan
- [ ] Verify the app selector is hidden by default on the home chat input
- [ ] Enable the toggle in Settings > Experiments and verify the app selector appears
- [ ] Run e2e tests: `npx playwright test home_chat_existing_app`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2964" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
