### PR TITLE
Disable credential persistence in all GitHub Actions checkout steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.ref || '' }}
           fetch-depth: 0
+          persist-credentials: false
       - name: Check if only .claude files changed
         id: check
         run: |
@@ -144,6 +145,7 @@ jobs:
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.ref || '' }}
+          persist-credentials: false
       - name: Initialize environment
         uses: actions/setup-node@v4
         with:
@@ -219,6 +221,7 @@ jobs:
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.ref || '' }}
+          persist-credentials: false
       - name: Initialize environment
         uses: actions/setup-node@v4
         with:
@@ -321,6 +324,7 @@ jobs:
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.ref || '' }}
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*

--- a/.github/workflows/claude-check-workflows.yml
+++ b/.github/workflows/claude-check-workflows.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Check workflow health
         uses: anthropics/claude-code-action@v1

--- a/.github/workflows/claude-deflake-e2e.yml
+++ b/.github/workflows/claude-deflake-e2e.yml
@@ -36,6 +36,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Initialize environment
         uses: actions/setup-node@v4

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -48,6 +48,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 1
+          persist-credentials: false
 
       - name: PR Review
         uses: anthropics/claude-code-action@v1

--- a/.github/workflows/claude-rebase.yml
+++ b/.github/workflows/claude-rebase.yml
@@ -63,6 +63,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Configure git remotes for cross-repo PR
         if: steps.check-author.outputs.should_continue == 'true'

--- a/.github/workflows/claude-rules-review.yml
+++ b/.github/workflows/claude-rules-review.yml
@@ -34,6 +34,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 200
+          persist-credentials: false
 
       - name: Review AGENTS.md and rules/
         uses: anthropics/claude-code-action@v1

--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -23,6 +23,8 @@ jobs:
           permission-issues: write
 
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: anthropics/claude-code-base-action@beta
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/closed-issue-comment.yml
+++ b/.github/workflows/closed-issue-comment.yml
@@ -25,6 +25,8 @@ jobs:
           permission-issues: write
 
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: anthropics/claude-code-action@v1
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/flakiness-upload.yml
+++ b/.github/workflows/flakiness-upload.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/nightly-runner-cleanup.yml
+++ b/.github/workflows/nightly-runner-cleanup.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout (for cleanup script)
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Nightly disk cleanup
         env:

--- a/.github/workflows/playwright-comment.yml
+++ b/.github/workflows/playwright-comment.yml
@@ -68,6 +68,7 @@ jobs:
         with:
           # base_ref is typically the target branch (e.g., main) and is safe to fetch
           ref: ${{ github.event.workflow_run.base_ref }}
+          persist-credentials: false
 
       - name: Setup Node.js
         if: ${{ steps.pr.outputs.number != '' }}

--- a/.github/workflows/pr-review-responder.yml
+++ b/.github/workflows/pr-review-responder.yml
@@ -238,6 +238,7 @@ jobs:
           repository: ${{ steps.pr-info.outputs.head_repo }}
           ref: ${{ steps.pr-info.outputs.head_branch }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Record HEAD before Claude Code
         if: steps.pr-info.outputs.should_continue == 'true'
@@ -370,6 +371,7 @@ jobs:
         with:
           path: __base
           sparse-checkout: scripts/pr-status-labeler.js
+          persist-credentials: false
 
       - name: Apply needs-human status label
         # Run when PR reaches a terminal state (cc:done or cc:failed) but NOT when

--- a/.github/workflows/pr-status-labeler.yml
+++ b/.github/workflows/pr-status-labeler.yml
@@ -73,6 +73,8 @@ jobs:
       - name: Checkout repository (default branch for trusted scripts)
         if: steps.pr-info.outputs.should_continue == 'true'
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Apply status label
         if: steps.pr-info.outputs.should_continue == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Github checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
       - name: Use Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
@@ -130,6 +132,8 @@ jobs:
     steps:
       - name: Github checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
       - name: Use Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
@@ -164,6 +168,8 @@ jobs:
     steps:
       - name: Github checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
       - name: Use Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:


### PR DESCRIPTION
## Summary
This PR adds `persist-credentials: false` to all `actions/checkout` steps across all GitHub Actions workflows to enhance security by preventing GitHub tokens from being persisted to disk.

## Key Changes
- Added `persist-credentials: false` configuration to checkout steps in 14 workflow files:
  - `release.yml` (3 jobs)
  - `ci.yml` (4 jobs)
  - `claude-check-workflows.yml`
  - `claude-triage.yml`
  - `closed-issue-comment.yml`
  - `flakiness-upload.yml`
  - `nightly-runner-cleanup.yml`
  - `pr-review-responder.yml` (2 checkout steps)
  - `pr-status-labeler.yml`
  - `claude-deflake-e2e.yml`
  - `claude-pr-review.yml`
  - `claude-rebase.yml`
  - `claude-rules-review.yml`
  - `playwright-comment.yml`

## Implementation Details
- The `persist-credentials: false` option prevents the GitHub token from being saved to the local git config, reducing the attack surface if the runner is compromised
- This is a security best practice for CI/CD workflows, especially when running untrusted code or when the runner may be shared
- The change is applied consistently across all workflows to maintain a uniform security posture

https://claude.ai/code/session_01LubmgQrWsqU9KEbCXJwTDB
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2968" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
