### PR TITLE
Add keppo-bot to workflow authorization lists

### DIFF
--- a/.github/workflows/bugbot-trigger.yml
+++ b/.github/workflows/bugbot-trigger.yml
@@ -17,7 +17,8 @@ jobs:
       github.event.pull_request.user.login == 'dyadbot' ||
       github.event.pull_request.user.login == 'dyad-assistant' ||
       github.event.pull_request.user.login == 'azizmejri1' ||
-      github.event.pull_request.user.login == 'princeaden1') &&
+      github.event.pull_request.user.login == 'princeaden1' ||
+      github.event.pull_request.user.login == 'keppo-bot') &&
       !contains(github.event.pull_request.body, '#skip-bugbot') &&
       !contains(github.event.pull_request.body, '#skip-bb')
     runs-on: ubuntu-latest

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -27,7 +27,8 @@ jobs:
       github.event.pull_request.user.login == 'dyadbot' ||
       github.event.pull_request.user.login == 'dyad-assistant' ||
       github.event.pull_request.user.login == 'azizmejri1' ||
-      github.event.pull_request.user.login == 'princeaden1'
+      github.event.pull_request.user.login == 'princeaden1' ||
+      github.event.pull_request.user.login == 'keppo-bot'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -61,7 +62,7 @@ jobs:
 
           # See: https://github.com/anthropics/claude-code-action/blob/v1/docs/security.md
           github_token: ${{ steps.app-token.outputs.token }}
-          allowed_non_write_users: "princeaden1,wwwillchen-bot,dyadbot,dyad-assistant" # remember, we already filter above.
+          allowed_non_write_users: "princeaden1,wwwillchen-bot,dyadbot,dyad-assistant,keppo-bot" # remember, we already filter above.
 
           # Disable progress tracking (try to save tokens)
           track_progress: false

--- a/.github/workflows/claude-rebase.yml
+++ b/.github/workflows/claude-rebase.yml
@@ -36,7 +36,7 @@ jobs:
           github-token: ${{ steps.base-app-token.outputs.token }}
           script: |
             const pr = context.payload.pull_request;
-            const allowedUsers = ['wwwillchen', 'wwwillchen-bot', 'dyadbot', 'dyad-assistant', 'azizmejri1', 'princeaden1'];
+            const allowedUsers = ['wwwillchen', 'wwwillchen-bot', 'dyadbot', 'dyad-assistant', 'azizmejri1', 'princeaden1', 'keppo-bot'];
             if (!allowedUsers.includes(pr.user.login)) {
               console.log(`PR author ${pr.user.login} is not allowed to use this workflow`);
               core.setOutput('should_continue', 'false');

--- a/.github/workflows/label-rebase-prs.yml
+++ b/.github/workflows/label-rebase-prs.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           github-token: ${{ secrets.PR_RW_GITHUB_TOKEN }}
           script: |
-            const allowedAuthors = ['wwwillchen', 'wwwillchen-bot', 'dyadbot', 'dyad-assistant'];
+            const allowedAuthors = ['wwwillchen', 'wwwillchen-bot', 'dyadbot', 'dyad-assistant', 'keppo-bot'];
 
             const prs = await github.paginate(github.rest.pulls.list, {
               owner: context.repo.owner,

--- a/.github/workflows/pr-review-responder.yml
+++ b/.github/workflows/pr-review-responder.yml
@@ -65,7 +65,7 @@ jobs:
 
               // Check that the person who applied the label is a trusted actor
               const actor = context.actor;
-              const allowedActors = ['wwwillchen', 'wwwillchen-bot', 'dyadbot', 'dyad-assistant'];
+              const allowedActors = ['wwwillchen', 'wwwillchen-bot', 'dyadbot', 'dyad-assistant', 'keppo-bot'];
               if (!allowedActors.includes(actor)) {
                 console.log(`Label applied by ${actor} who is not in the allowed actors list`);
                 core.setOutput('should_continue', 'false');
@@ -129,7 +129,7 @@ jobs:
             }
 
             // Only allow wwwillchen, wwwillchen-bot, dyadbot, dyad-assistant, and princeaden1 to use this workflow
-            if (prAuthor !== 'wwwillchen' && prAuthor !== 'wwwillchen-bot' && prAuthor !== 'dyadbot' && prAuthor !== 'dyad-assistant' && prAuthor !== 'princeaden1') {
+            if (prAuthor !== 'wwwillchen' && prAuthor !== 'wwwillchen-bot' && prAuthor !== 'dyadbot' && prAuthor !== 'dyad-assistant' && prAuthor !== 'princeaden1' && prAuthor !== 'keppo-bot') {
               console.log(`PR #${prNumber} author ${prAuthor} is not allowed to use this workflow`);
               core.setOutput('should_continue', 'false');
               return;


### PR DESCRIPTION
## Summary
This PR adds `keppo-bot` to the list of authorized users across multiple GitHub Actions workflows, granting it the same permissions and access as other trusted automation accounts.

## Key Changes
- **claude-pr-review.yml**: Added `keppo-bot` to the PR author filter condition and the `allowed_non_write_users` list
- **pr-review-responder.yml**: Added `keppo-bot` to both the label application authorization check and the PR author authorization check
- **bugbot-trigger.yml**: Added `keppo-bot` to the PR author filter condition
- **claude-rebase.yml**: Added `keppo-bot` to the `allowedUsers` list for rebase workflow authorization
- **label-rebase-prs.yml**: Added `keppo-bot` to the `allowedAuthors` list for automated PR labeling

## Implementation Details
The changes maintain consistency across all workflow files by adding `keppo-bot` alongside existing trusted accounts (`wwwillchen`, `wwwillchen-bot`, `dyadbot`, `dyad-assistant`, `azizmejri1`, and `princeaden1`). This allows the bot to trigger and participate in automated code review, rebasing, and labeling workflows.

https://claude.ai/code/session_01RAUbSCX5HVocXoiDKL9saD
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2981" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
