### PR TITLE
fix: throttle IPC chunk sends to reduce UI lag during AI code streaming

### DIFF
--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -165,6 +165,7 @@ async function processStreamChunks({
   chatId: number;
   processResponseChunkUpdate: (params: {
     fullResponse: string;
+    flush?: boolean;
   }) => Promise<string>;
 }): Promise<{ fullResponse: string; incrementalResponse: string }> {
   let incrementalResponse = "";
@@ -217,6 +218,12 @@ async function processStreamChunks({
       break;
     }
   }
+
+  // Flush any pending throttled update so the UI shows the final state
+  fullResponse = await processResponseChunkUpdate({
+    fullResponse,
+    flush: true,
+  });
 
   return { fullResponse, incrementalResponse };
 }
@@ -1062,11 +1069,15 @@ This conversation includes one or more image attachments. When the user uploads 
         };
 
         let lastDbSaveAt = 0;
+        let lastIpcSendAt = 0;
+        let pendingIpcResponse: string | null = null;
 
         const processResponseChunkUpdate = async ({
           fullResponse,
+          flush,
         }: {
           fullResponse: string;
+          flush?: boolean;
         }) => {
           // Store the current partial response
           partialResponses.set(req.chatId, fullResponse);
@@ -1081,6 +1092,17 @@ This conversation includes one or more image attachments. When the user uploads 
             lastDbSaveAt = now;
           }
 
+          // Throttle IPC sends to the renderer to avoid overwhelming the UI.
+          // Each send triggers markdown re-parsing and React re-renders, so
+          // sending on every token causes significant lag.
+          if (!flush && now - lastIpcSendAt < 50) {
+            pendingIpcResponse = fullResponse;
+            return fullResponse;
+          }
+
+          pendingIpcResponse = null;
+          lastIpcSendAt = now;
+
           // Update the placeholder assistant message content in the messages array
           const currentMessages = [...updatedChat.messages];
           if (
@@ -1090,7 +1112,7 @@ This conversation includes one or more image attachments. When the user uploads 
             currentMessages[currentMessages.length - 1].content = fullResponse;
           }
 
-          // Update the assistant message in the database
+          // Send updated messages to the renderer
           safeSend(event.sender, "chat:response:chunk", {
             chatId: req.chatId,
             messages: currentMessages,

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -473,6 +473,35 @@ export async function handleLocalAgentStream(
 
     // Build tool execute context
     const fileEditTracker: FileEditTracker = Object.create(null);
+
+    // Throttle IPC sends to the renderer to avoid overwhelming the UI.
+    // Each send triggers markdown re-parsing and React re-renders which
+    // causes significant lag during fast token streaming (e.g. code writing).
+    let lastChunkSendAt = 0;
+    let pendingChunkSend: (() => void) | null = null;
+    const CHUNK_THROTTLE_MS = 50;
+
+    const throttledSendResponseChunk = (
+      ...args: Parameters<typeof sendResponseChunk>
+    ) => {
+      const now = Date.now();
+      if (now - lastChunkSendAt < CHUNK_THROTTLE_MS) {
+        // Store as pending - will be flushed on next non-throttled call or at end
+        pendingChunkSend = () => sendResponseChunk(...args);
+        return;
+      }
+      pendingChunkSend = null;
+      lastChunkSendAt = now;
+      sendResponseChunk(...args);
+    };
+
+    const flushPendingChunkSend = () => {
+      if (pendingChunkSend) {
+        pendingChunkSend();
+        pendingChunkSend = null;
+      }
+    };
+
     const ctx: AgentContext = {
       event,
       appId: chat.app.id,
@@ -489,7 +518,7 @@ export async function handleLocalAgentStream(
       onXmlStream: (accumulatedXml: string) => {
         // Stream accumulated XML to UI without persisting
         streamingPreview = accumulatedXml;
-        sendResponseChunk(
+        throttledSendResponseChunk(
           event,
           req.chatId,
           chat,
@@ -503,6 +532,9 @@ export async function handleLocalAgentStream(
         const xmlChunk = `${finalXml}\n`;
         fullResponse += xmlChunk;
         streamingPreview = ""; // Clear preview
+        // Discard any pending throttled send since we're about to send
+        // the authoritative state with the completed XML
+        pendingChunkSend = null;
         updateResponseInDb(placeholderMessageId, fullResponse);
         sendResponseChunk(
           event,
@@ -956,7 +988,7 @@ export async function handleLocalAgentStream(
               if (chunk) {
                 fullResponse += chunk;
                 await updateResponseInDb(placeholderMessageId, fullResponse);
-                sendResponseChunk(
+                throttledSendResponseChunk(
                   event,
                   req.chatId,
                   chat,
@@ -975,6 +1007,9 @@ export async function handleLocalAgentStream(
               );
             }
           }
+
+          // Flush any pending throttled IPC send so the UI shows the final state
+          flushPendingChunkSend();
 
           // Close thinking block if still open
           if (inThinkingBlock) {


### PR DESCRIPTION
Each streaming token was triggering an IPC send to the renderer, causing markdown re-parsing (30+ regex patterns) and React re-renders on every chunk. This overwhelmed the UI during fast token streaming, especially when writing code via the local agent.

Added 50ms throttling to IPC sends in both the regular chat stream handler and the local agent handler, with flush-on-complete to ensure the final state is always shown. DB save throttling (150ms) was already present in the chat stream handler.

https://claude.ai/code/session_01BTcLj2qJc54evL5qQnH3pe
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2986" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
