### PR TITLE
Improve chat responsiveness during streamed code output

### DIFF
--- a/src/components/chat/DyadMarkdownParser.tsx
+++ b/src/components/chat/DyadMarkdownParser.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useDeferredValue, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
@@ -146,10 +146,13 @@ export const DyadMarkdownParser: React.FC<DyadMarkdownParserProps> = ({
 }) => {
   const chatId = useAtomValue(selectedChatIdAtom);
   const isStreaming = useAtomValue(isStreamingByIdAtom).get(chatId!) ?? false;
+  const deferredContent = useDeferredValue(content);
+  const contentToParse = isStreaming ? deferredContent : content;
+
   // Extract content pieces (markdown and custom tags)
   const contentPieces = useMemo(() => {
-    return parseCustomTags(content);
-  }, [content]);
+    return parseCustomTags(contentToParse);
+  }, [contentToParse]);
 
   // Extract error messages and track positions
   const { errorMessages, lastErrorIndex, errorCount } = useMemo(() => {


### PR DESCRIPTION
### Motivation
- Prevent the UI from becoming sluggish while the assistant streams large or rapidly-updated messages by deferring expensive markdown/custom-tag parsing during active streaming.

### Description
- Use React's `useDeferredValue` in `DyadMarkdownParser` and switch the parser to consume a `contentToParse` value that is the deferred `content` only while `isStreaming` is true, and update the `useMemo` dependency to `contentToParse` so final rendering uses the full, current content.

### Testing
- Ran `npm run fmt`, `npm run lint`, and `npm run ts` in this environment, and all three failed due to the npm registry returning `403 Forbidden` for required tooling (formatter/linter/typechecker) rather than code errors in the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b10fad1e74832782eea5db1ccb0196)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2987" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
