### PR TITLE
fix: hide stale remote-only branches from local delete actions

### DIFF
--- a/src/components/GithubBranchManager.test.ts
+++ b/src/components/GithubBranchManager.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { buildBranchListItems } from "@/components/GithubBranchManager";
+
+describe("buildBranchListItems", () => {
+  it("marks local and remote-only branches distinctly", () => {
+    expect(
+      buildBranchListItems(
+        ["main", "feature-local", "shared"],
+        ["shared", "staging"],
+      ),
+    ).toEqual([
+      { name: "feature-local", isLocal: true, isRemote: false },
+      { name: "main", isLocal: true, isRemote: false },
+      { name: "shared", isLocal: true, isRemote: true },
+      { name: "staging", isLocal: false, isRemote: true },
+    ]);
+  });
+});

--- a/src/components/GithubBranchManager.tsx
+++ b/src/components/GithubBranchManager.tsx
@@ -75,13 +75,36 @@ interface BranchManagerProps {
   onBranchChange?: () => void;
 }
 
+interface BranchListItem {
+  name: string;
+  isLocal: boolean;
+  isRemote: boolean;
+}
+
+export function buildBranchListItems(
+  localBranches: string[],
+  remoteBranches: string[],
+): BranchListItem[] {
+  const localBranchNames = new Set(localBranches);
+  const remoteBranchNames = new Set(remoteBranches);
+  const allBranchNames = new Set([...localBranchNames, ...remoteBranchNames]);
+
+  return Array.from(allBranchNames)
+    .sort()
+    .map((name) => ({
+      name,
+      isLocal: localBranchNames.has(name),
+      isRemote: remoteBranchNames.has(name),
+    }));
+}
+
 export function GithubBranchManager({
   appId,
   onBranchChange,
 }: BranchManagerProps) {
   const { settings } = useSettings();
   const navigate = useNavigate();
-  const [branches, setBranches] = useState<string[]>([]);
+  const [branches, setBranches] = useState<BranchListItem[]>([]);
   const [currentBranch, setCurrentBranch] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [newBranchName, setNewBranchName] = useState("");
@@ -151,10 +174,7 @@ export function GithubBranchManager({
         ipc.github.listRemoteBranches({ appId }).catch(() => []),
       ]);
 
-      // Merge local and remote branches, removing duplicates
-      const allBranches = new Set([...localResult.branches, ...remoteBranches]);
-
-      setBranches(Array.from(allBranches).sort());
+      setBranches(buildBranchListItems(localResult.branches, remoteBranches));
       setCurrentBranch(localResult.current || null);
     } catch (error: any) {
       showError(error.message || "Failed to load branches");
@@ -438,14 +458,18 @@ export function GithubBranchManager({
           </SelectTrigger>
           <SelectContent>
             {branches.map((branch) => (
-              <SelectItem key={branch} value={branch} aria-label={branch}>
+              <SelectItem
+                key={branch.name}
+                value={branch.name}
+                aria-label={branch.name}
+              >
                 <Network className="h-4 w-4 text-gray-500" />
                 <span className="font-medium text-sm">Branch:</span>
                 <span
                   data-testid="current-branch-display"
                   className="font-mono text-sm bg-gray-100 dark:bg-gray-800 px-2 py-0.5 rounded"
                 >
-                  {branch}
+                  {branch.name}
                 </span>
               </SelectItem>
             ))}
@@ -532,9 +556,9 @@ export function GithubBranchManager({
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="HEAD">HEAD (Current)</SelectItem>
-                    {branches.map((b) => (
-                      <SelectItem key={b} value={b}>
-                        {b}
+                    {branches.map((branch) => (
+                      <SelectItem key={branch.name} value={branch.name}>
+                        {branch.name}
                       </SelectItem>
                     ))}
                   </SelectContent>
@@ -824,20 +848,25 @@ export function GithubBranchManager({
                 <div className="space-y-1 max-h-40 overflow-y-auto border rounded-md p-2">
                   {branches.map((branch) => (
                     <div
-                      key={branch}
+                      key={branch.name}
                       className="flex items-center justify-between text-sm py-1 px-2 hover:bg-gray-50 dark:hover:bg-gray-800 rounded"
-                      data-testid={`branch-item-${branch}`}
+                      data-testid={`branch-item-${branch.name}`}
                     >
                       <span
                         className={
-                          branch === currentBranch
+                          branch.name === currentBranch
                             ? "font-bold text-blue-600"
                             : ""
                         }
                       >
-                        {branch}
+                        {branch.name}
+                        {!branch.isLocal && branch.isRemote && (
+                          <span className="ml-2 text-xs text-muted-foreground">
+                            remote
+                          </span>
+                        )}
                       </span>
-                      {branch !== currentBranch && (
+                      {branch.name !== currentBranch && (
                         <DropdownMenu
                           onOpenChange={(open) => {
                             if (open) setIsExpanded(true);
@@ -845,35 +874,45 @@ export function GithubBranchManager({
                         >
                           <DropdownMenuTrigger
                             className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 hover:bg-accent hover:text-accent-foreground h-6 w-6"
-                            data-testid={`branch-actions-${branch}`}
+                            data-testid={`branch-actions-${branch.name}`}
                           >
                             <MoreHorizontal className="h-4 w-4" />
                           </DropdownMenuTrigger>
                           <DropdownMenuContent align="end">
                             <DropdownMenuItem
-                              onClick={() => setBranchToMerge(branch)}
+                              onClick={() => setBranchToMerge(branch.name)}
                               data-testid="merge-branch-menu-item"
                             >
                               <GitMerge className="mr-2 h-4 w-4" />
                               Merge into {currentBranch}
                             </DropdownMenuItem>
                             <DropdownMenuItem
+                              disabled={!branch.isLocal}
                               onClick={() => {
-                                setBranchToRename(branch);
-                                setRenameBranchName(branch);
+                                if (!branch.isLocal) return;
+                                setBranchToRename(branch.name);
+                                setRenameBranchName(branch.name);
                               }}
                               data-testid="rename-branch-menu-item"
                             >
                               <Edit2 className="mr-2 h-4 w-4" />
-                              Rename
+                              {branch.isLocal
+                                ? "Rename"
+                                : "Rename (local only)"}
                             </DropdownMenuItem>
                             <DropdownMenuItem
                               className="text-red-600"
-                              onClick={() => setBranchToDelete(branch)}
+                              disabled={!branch.isLocal}
+                              onClick={() => {
+                                if (!branch.isLocal) return;
+                                setBranchToDelete(branch.name);
+                              }}
                               data-testid="delete-branch-menu-item"
                             >
                               <Trash2 className="mr-2 h-4 w-4" />
-                              Delete
+                              {branch.isLocal
+                                ? "Delete"
+                                : "Delete (local only)"}
                             </DropdownMenuItem>
                           </DropdownMenuContent>
                         </DropdownMenu>

--- a/src/components/GithubBranchManager.tsx
+++ b/src/components/GithubBranchManager.tsx
@@ -889,30 +889,24 @@ export function GithubBranchManager({
                             <DropdownMenuItem
                               disabled={!branch.isLocal}
                               onClick={() => {
-                                if (!branch.isLocal) return;
                                 setBranchToRename(branch.name);
                                 setRenameBranchName(branch.name);
                               }}
                               data-testid="rename-branch-menu-item"
                             >
                               <Edit2 className="mr-2 h-4 w-4" />
-                              {branch.isLocal
-                                ? "Rename"
-                                : "Rename (local only)"}
+                              Rename
                             </DropdownMenuItem>
                             <DropdownMenuItem
                               className="text-red-600"
                               disabled={!branch.isLocal}
                               onClick={() => {
-                                if (!branch.isLocal) return;
                                 setBranchToDelete(branch.name);
                               }}
                               data-testid="delete-branch-menu-item"
                             >
                               <Trash2 className="mr-2 h-4 w-4" />
-                              {branch.isLocal
-                                ? "Delete"
-                                : "Delete (local only)"}
+                              Delete
                             </DropdownMenuItem>
                           </DropdownMenuContent>
                         </DropdownMenu>

--- a/src/ipc/git_types.ts
+++ b/src/ipc/git_types.ts
@@ -69,6 +69,7 @@ export interface GitAuthorParam {
 export interface GitFetchParams extends GitBaseParams {
   remote?: string;
   accessToken?: string;
+  prune?: boolean;
 }
 
 export interface GitPullParams extends GitBaseParams {

--- a/src/ipc/handlers/git_branch_handlers.ts
+++ b/src/ipc/handlers/git_branch_handlers.ts
@@ -332,6 +332,9 @@ async function handleListLocalBranches(
   return { branches, current: current || null };
 }
 
+const PRUNE_THROTTLE_MS = 30_000;
+const lastPruneByApp = new Map<number, number>();
+
 async function handleListRemoteBranches(
   event: IpcMainInvokeEvent,
   { appId, remote = "origin" }: { appId: number; remote?: string },
@@ -341,14 +344,17 @@ async function handleListRemoteBranches(
   const appPath = getDyadAppPath(app.path);
   const settings = readSettings();
 
-  if (app.githubOrg && app.githubRepo && settings.githubAccessToken?.value) {
+  const now = Date.now();
+  const lastPrune = lastPruneByApp.get(appId) ?? 0;
+  if (app.githubOrg && app.githubRepo && now - lastPrune >= PRUNE_THROTTLE_MS) {
     try {
       await gitFetch({
         path: appPath,
         remote,
-        accessToken: settings.githubAccessToken.value,
+        accessToken: settings.githubAccessToken?.value,
         prune: true,
       });
+      lastPruneByApp.set(appId, now);
     } catch (error: any) {
       logger.warn(
         `Failed to refresh remote branches before listing: ${error.message}`,

--- a/src/ipc/handlers/git_branch_handlers.ts
+++ b/src/ipc/handlers/git_branch_handlers.ts
@@ -339,6 +339,22 @@ async function handleListRemoteBranches(
   const app = await db.query.apps.findFirst({ where: eq(apps.id, appId) });
   if (!app) throw new Error("App not found");
   const appPath = getDyadAppPath(app.path);
+  const settings = readSettings();
+
+  if (app.githubOrg && app.githubRepo && settings.githubAccessToken?.value) {
+    try {
+      await gitFetch({
+        path: appPath,
+        remote,
+        accessToken: settings.githubAccessToken.value,
+        prune: true,
+      });
+    } catch (error: any) {
+      logger.warn(
+        `Failed to refresh remote branches before listing: ${error.message}`,
+      );
+    }
+  }
 
   const branches = await gitListRemoteBranches({ path: appPath, remote });
   return branches;

--- a/src/ipc/utils/git_utils.ts
+++ b/src/ipc/utils/git_utils.ts
@@ -1182,16 +1182,22 @@ export async function gitFetch({
   path,
   remote = "origin",
   accessToken,
+  prune = false,
 }: GitFetchParams): Promise<void> {
   const settings = readSettings();
   if (settings.enableNativeGit) {
-    await execOrThrow(["fetch", remote], path, "Failed to fetch from remote");
+    const args = ["fetch", remote];
+    if (prune) {
+      args.push("--prune");
+    }
+    await execOrThrow(args, path, "Failed to fetch from remote");
   } else {
     await git.fetch({
       fs,
       http,
       dir: path,
       remote,
+      prune,
       onAuth: accessToken
         ? () => ({
             username: accessToken,


### PR DESCRIPTION
## Summary
- prune remote-tracking refs before listing GitHub branches when auth is available
- track local vs remote-only branch entries in the branch manager instead of flattening them
- disable rename/delete for remote-only branches and add coverage for branch list classification

## Test plan
- npm run fmt
- npm run lint:fix
- npm run ts
- npm test -- --run src/components/GithubBranchManager.test.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/2997" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
