### PR TITLE
Filter retry 429 telemetry noise

### DIFF
--- a/rules/git-workflow.md
+++ b/rules/git-workflow.md
@@ -24,6 +24,10 @@ gh pr create --head <owner>:<branch> ...
 
 This can happen when remotes are configured in a non-fork layout and `gh` fails to infer the branch mapping.
 
+## `gh pr create` body quoting
+
+When passing a PR body inline via `gh pr create --body "..."`, unescaped backticks are evaluated by `zsh` before `gh` runs. Avoid backticks in inline bodies, or use a body file / heredoc so literal code identifiers do not turn into `command not found` errors.
+
 ## Skipping automated review
 
 Add `#skip-bugbot` to the PR description for trivial PRs that won't affect end-users, such as:

--- a/src/__tests__/telemetry.test.ts
+++ b/src/__tests__/telemetry.test.ts
@@ -12,6 +12,20 @@ describe("shouldFilterTelemetryException", () => {
     ).toBe(true);
   });
 
+  it("filters RateLimitError 429s from retryWithRateLimit", () => {
+    const error = new Error("Rate limited (429): Too Many Requests");
+    error.name = "RateLimitError";
+
+    expect(shouldFilterTelemetryException(error)).toBe(true);
+  });
+
+  it("does not filter non-429 RateLimitError variants", () => {
+    const error = new Error("Rate limited (503): Service Unavailable");
+    error.name = "RateLimitError";
+
+    expect(shouldFilterTelemetryException(error)).toBe(false);
+  });
+
   it("does not filter different Supabase auth failures", () => {
     expect(
       shouldFilterTelemetryException(

--- a/src/ipc/utils/telemetry.ts
+++ b/src/ipc/utils/telemetry.ts
@@ -53,6 +53,14 @@ export function sendTelemetryException(
 }
 
 export function shouldFilterTelemetryException(error: unknown): boolean {
+  if (
+    error instanceof Error &&
+    error.name === "RateLimitError" &&
+    error.message.includes("(429)")
+  ) {
+    return true;
+  }
+
   const message =
     error instanceof Error ? error.message : String(error ?? "Unknown error");
 


### PR DESCRIPTION
## Summary
- filter PostHog telemetry exceptions for  instances emitted by 
- keep existing telemetry filtering behavior for other exception types unchanged
- add unit coverage for filtered 429 and non-filtered non-429 rate limit errors

## Test plan
- npm run fmt
- npm run lint:fix
- npm run ts
- npm test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/3024" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
