### PR TITLE
fix: use user message instead of assistant prefill for continuation retry

### DIFF
--- a/e2e-tests/snapshots/partial_response.spec.ts_partial-message-is-resumed-1.txt
+++ b/e2e-tests/snapshots/partial_response.spec.ts_partial-message-is-resumed-1.txt
@@ -128,7 +128,12 @@ role: user
 message: tc=partial-write
 
 ===
-role: assistant
-message: START OF MESSAGE
+role: user
+message: Your previous response was cut off. Here is what you generated so far:
+
+START OF MESSAGE
 <dyad-write path="src/new-file.ts" description="this file will be partially written">
 const a = "[[STRING_TO_BE_FINISHED]]
+
+
+Continue exactly where you left off. Do not repeat any content that was already generated. Only output the remaining content.

--- a/e2e-tests/snapshots/partial_response.spec.ts_partial-message-is-resumed-1.txt
+++ b/e2e-tests/snapshots/partial_response.spec.ts_partial-message-is-resumed-1.txt
@@ -128,12 +128,12 @@ role: user
 message: tc=partial-write
 
 ===
-role: user
-message: Your previous response was cut off. Here is what you generated so far:
-
-START OF MESSAGE
+role: assistant
+message: START OF MESSAGE
 <dyad-write path="src/new-file.ts" description="this file will be partially written">
 const a = "[[STRING_TO_BE_FINISHED]]
 
 
-Continue exactly where you left off. Do not repeat any content that was already generated. Only output the remaining content.
+===
+role: user
+message: Your previous response did not finish completely. Continue exactly where you left off without any preamble.

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -1457,8 +1457,13 @@ ${formattedSearchReplaceIssues}`,
                 chatMessages: [
                   ...chatMessages,
                   {
+                    role: "assistant",
+                    content: fullResponse,
+                  },
+                  {
                     role: "user",
-                    content: `Your previous response was cut off. Here is what you generated so far:\n\n${fullResponse}\n\nContinue exactly where you left off. Do not repeat any content that was already generated. Only output the remaining content.`,
+                    content:
+                      "Your previous response did not finish completely. Continue exactly where you left off without any preamble.",
                   },
                 ],
                 modelClient,

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -1453,10 +1453,13 @@ ${formattedSearchReplaceIssues}`,
               continuationAttempts++;
 
               const { fullStream: contStream } = await simpleStreamText({
-                // Build messages: replay history then pre-fill assistant with current partial.
+                // Build messages: replay history, then ask the model to continue from the partial response.
                 chatMessages: [
                   ...chatMessages,
-                  { role: "assistant", content: fullResponse },
+                  {
+                    role: "user",
+                    content: `Your previous response was cut off. Here is what you generated so far:\n\n${fullResponse}\n\nContinue exactly where you left off. Do not repeat any content that was already generated. Only output the remaining content.`,
+                  },
                 ],
                 modelClient,
                 files: files,

--- a/testing/fake-llm-server/chatCompletionHandler.ts
+++ b/testing/fake-llm-server/chatCompletionHandler.ts
@@ -334,11 +334,12 @@ export default Index;
       }
     }
 
+    // Continuation requests embed the partial assistant output inside a user message
+    // ("Your previous response was cut off...") so the marker is not at the end of
+    // lastMessage — use includes(), not endsWith(). See chat_stream_handlers continuation prompt.
     if (
       lastMessage &&
-      lastMessage.content &&
-      typeof lastMessage.content === "string" &&
-      lastMessage.content.trim().endsWith("[[STRING_TO_BE_FINISHED]]")
+      getTextContent(lastMessage).includes("[[STRING_TO_BE_FINISHED]]")
     ) {
       messageContent = `[[STRING_IS_FINISHED]]";</dyad-write>\nFinished writing file.`;
       messageContent += "\n\n" + generateDump(req);

--- a/testing/fake-llm-server/chatCompletionHandler.ts
+++ b/testing/fake-llm-server/chatCompletionHandler.ts
@@ -59,7 +59,8 @@ export const createChatCompletionHandler =
     if (
       !localAgentFixture &&
       (userTextContent.includes("incomplete todo(s)") ||
-        userTextContent.includes("previous response stream was interrupted"))
+        userTextContent.includes("previous response stream was interrupted") ||
+        userTextContent.includes("did not finish completely"))
     ) {
       for (const msg of userMessages) {
         const textContent = getTextContent(msg);
@@ -334,12 +335,13 @@ export default Index;
       }
     }
 
-    // Continuation requests embed the partial assistant output inside a user message
-    // ("Your previous response was cut off...") so the marker is not at the end of
-    // lastMessage — use includes(), not endsWith(). See chat_stream_handlers continuation prompt.
+    // Continuation requests: the partial assistant output is in a preceding assistant
+    // message, then a user message asks to continue ("did not finish completely").
+    // Check any message for the marker. See chat_stream_handlers continuation prompt.
     if (
-      lastMessage &&
-      getTextContent(lastMessage).includes("[[STRING_TO_BE_FINISHED]]")
+      messages.some((m: any) =>
+        getTextContent(m).includes("[[STRING_TO_BE_FINISHED]]"),
+      )
     ) {
       messageContent = `[[STRING_IS_FINISHED]]";</dyad-write>\nFinished writing file.`;
       messageContent += "\n\n" + generateDump(req);


### PR DESCRIPTION
## Summary
- Non-Anthropic providers (OpenAI, Google, Ollama, etc.) error with "The model does not support assistant message prefill" when the unclosed `dyad-write` continuation retry triggers
- The continuation logic was using an assistant message as the last message (prefill pattern), which only Anthropic supports
- Replaced with a user message that includes the partial response and asks the model to continue where it left off

## Test plan
- Use a non-Anthropic provider (e.g. OpenAI, Gemini) in build mode
- Trigger a response that produces an unclosed `<dyad-write>` tag (e.g. a large file write that gets cut off)
- Verify the continuation retry no longer errors and the model completes the response

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/3027" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
