### PR TITLE
feat: add block-no-verify hook to .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,7 +8,6 @@
       "Write(/tmp/)",
       "Write(/tmp/**)",
       "Bash(mkdir)",
-
       "Bash(cat /tmp/*)",
       "Bash(head /tmp/*)",
       "Bash(tail /tmp/*)",
@@ -45,7 +44,6 @@
       "Bash(expand /tmp/*)",
       "Bash(unexpand /tmp/*)",
       "Skill(dyad:*)",
-
       "Bash(npm run:*)",
       "Bash(npm test:*)",
       "Bash(npm install:*)",
@@ -72,9 +70,7 @@
       "Bash(rm -f e2e-tests/screencast-demo.spec.ts)",
       "Bash(rm -rf e2e-tests/screencast-screenshots)",
       "Bash(rm -rf test-results/screencast-demo*)",
-
       "Bash(git:*)",
-
       "Bash(gh api:*)",
       "Bash(gh pr view:*)",
       "Bash(gh pr list:*)",
@@ -100,16 +96,13 @@
       "Bash(gh repo view:*)",
       "Bash(gh run view:*)",
       "Bash(gh run list:*)",
-
       "Bash(ps:*)",
       "Bash(lsof:*)",
       "Bash(pkill:*)",
       "Bash(jq:*)",
-
       "Bash(which:*)",
       "Bash(echo:*)",
       "Bash(pwd:*)",
-
       "Bash(ls:*)",
       "Bash(find:*)",
       "Bash(tree:*)",
@@ -123,7 +116,6 @@
       "Bash(less:*)",
       "Bash(file:*)",
       "Bash(stat:*)",
-
       "Bash(grep:*)",
       "Bash(rg:*)",
       "Bash(ag:*)",
@@ -133,9 +125,7 @@
       "Bash(uniq:*)",
       "Bash(cut:*)",
       "Bash(diff:*)",
-
       "Bash(chmod:*)",
-
       "Bash(pytest:*)",
       "Bash(python -m pytest:*)"
     ]
@@ -145,6 +135,11 @@
       {
         "matcher": "Bash",
         "hooks": [
+          {
+            "type": "command",
+            "command": "npx block-no-verify@1.1.2",
+            "timeout": 5000
+          },
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/gh-permission-hook.py",


### PR DESCRIPTION
## Summary

Adds `block-no-verify@1.1.2` as the first entry in the PreToolUse Bash hooks array in `.claude/settings.json`, to prevent agents from bypassing git hooks via the hook-skip flag.

## Details

The new hook entry is inserted before the existing `gh-permission-hook.py` and `python-permission-hook.py`:

```json
{
  "type": "command",
  "command": "npx block-no-verify@1.1.2",
  "timeout": 5000
}
```

The package reads `tool_input.command` from the Claude Code PreToolUse stdin payload, detects the hook-bypass flag (all variants across git subcommands), and exits 2 to block. No custom scripts needed.

## Closes

Closes #3046

---

_Disclosure: I am the author and maintainer of `block-no-verify`._

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/3047" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
