### PR TITLE
fix: create .gitignore for electron react vite template

### DIFF
--- a/e2e-tests/fixtures/import-app/electron-react-vite/.gitignore
+++ b/e2e-tests/fixtures/import-app/electron-react-vite/.gitignore
@@ -1,0 +1,22 @@
+# Dependencies
+/node_modules
+
+# Build artifacts
+/dist
+/build
+/out
+/release
+
+# Environment variables
+.env
+.env.local
+.env.*.local
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# OS generated files
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
## Summary

This file defines patterns for files and directories that should be ignored by Git within the new Electron React Vite template. It prevents unnecessary build artifacts, node modules, and other temporary files from being committed to the repository.

## Changes

- `e2e-tests/fixtures/import-app/electron-react-vite/.gitignore` (new)

This file defines patterns for files and directories that should be ignored by Git within the new Electron React Vite template. It prevents unnecessary build artifacts, node modules, and other temporary files from being committed to the repository.

## Testing

- [x] Verified changes follow existing project conventions
- [x] Confirmed no regressions in affected code paths


Closes #1271
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/3085" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
