### PR TITLE
Fix inability to type in ContextFilesPicker dialog inputs

### DIFF
--- a/src/components/ContextFilesPicker.tsx
+++ b/src/components/ContextFilesPicker.tsx
@@ -128,7 +128,10 @@ export function ContextFilesPicker() {
         Codebase context
       </DialogTrigger>
 
-      <DialogContent className="max-w-md max-h-[80vh] overflow-y-auto">
+      <DialogContent
+        className="max-w-md max-h-[80vh] overflow-y-auto"
+        onKeyDown={(e) => e.stopPropagation()}
+      >
         <DialogHeader>
           <DialogTitle>Codebase Context</DialogTitle>
           <DialogDescription>


### PR DESCRIPTION
Stop keydown event propagation on DialogContent to prevent the parent DropdownMenu's typeahead handler from swallowing keypresses.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/3098" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
