### PR TITLE
chore: remove Anthropic context-1m beta header

### DIFF
--- a/src/ipc/utils/provider_options.ts
+++ b/src/ipc/utils/provider_options.ts
@@ -96,16 +96,11 @@ export interface GetAiHeadersParams {
 }
 
 /**
- * Returns AI request headers based on the provider.
- * Currently adds Anthropic-specific beta header for extended context.
+ * Returns extra AI request headers for the provider (e.g. beta flags).
+ * Currently none; reserved for future provider-specific headers.
  */
-export function getAiHeaders({
-  builtinProviderId,
-}: GetAiHeadersParams): Record<string, string> | undefined {
-  if (builtinProviderId === "anthropic") {
-    return {
-      "anthropic-beta": "context-1m-2025-08-07",
-    };
-  }
+export function getAiHeaders(
+  _params: GetAiHeadersParams,
+): Record<string, string> | undefined {
   return undefined;
 }


### PR DESCRIPTION
## Summary
- Stop sending `anthropic-beta: context-1m-2025-08-07` on Anthropic API requests.
- `getAiHeaders` remains for future provider-specific headers but currently returns `undefined`.

## Test plan
- `npm run fmt && npm run lint:fix && npm run ts`
- `npm test` (952 tests)

#skip-bugbot

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/3103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
