### PR TITLE
feat: Add React DevTools in development

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "bump": "node scripts/bump-version.mjs",
     "clean": "rimraf out scaffold/node_modules",
     "start": "electron-forge start",
+    "dev": "cross-env NODE_ENV=development npm start",
     "dev:engine": "cross-env DYAD_ENGINE_URL=http://localhost:8080/v1 npm start",
     "staging:engine": "cross-env DYAD_ENGINE_URL=https://staging---dyad-llm-engine-kq7pivehnq-uc.a.run.app/v1 npm start",
     "package": "npm run clean && electron-forge package",

--- a/src/main.ts
+++ b/src/main.ts
@@ -358,12 +358,17 @@ const createWindow = () => {
     );
   }
 
-  // Send force-close event if it was detected
+  // Send force-close event if it was detected (only once, even with reload)
+  let forceCloseMessageSent = false;
   if (pendingForceCloseData) {
     mainWindow.webContents.on("did-finish-load", () => {
-      mainWindow?.webContents.send("force-close-detected", {
-        performanceData: pendingForceCloseData,
-      });
+      if (!forceCloseMessageSent) {
+        forceCloseMessageSent = true;
+        mainWindow?.webContents.send("force-close-detected", {
+          performanceData: pendingForceCloseData,
+        });
+        pendingForceCloseData = null;
+      }
     });
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,12 @@
-import { app, BrowserWindow, dialog, Menu, protocol, net } from "electron";
+import {
+  app,
+  BrowserWindow,
+  dialog,
+  Menu,
+  protocol,
+  net,
+  session,
+} from "electron";
 import * as path from "node:path";
 import { registerIpcHandlers } from "./ipc/ipc_host";
 import dotenv from "dotenv";
@@ -87,6 +95,42 @@ if (process.defaultApp) {
 }
 
 export async function onReady() {
+  // Load React DevTools extension in development
+  if (process.env.NODE_ENV === "development") {
+    const userDataDir = process.env.LOCALAPPDATA || "";
+    const chromeUserData = path.join(
+      userDataDir,
+      "Google",
+      "Chrome",
+      "User Data",
+      "Default",
+      "Extensions",
+    );
+    // React DevTools extension ID
+    const reactDevToolsId = "fmkadmapgofadopljbjfkapdkoienihi";
+    const extensionsDir = path.join(chromeUserData, reactDevToolsId);
+
+    if (fs.existsSync(extensionsDir)) {
+      try {
+        const versions = fs.readdirSync(extensionsDir);
+        const latestVersion = versions.sort().reverse()[0];
+        const extensionPath = path.join(extensionsDir, latestVersion);
+        await session.defaultSession.loadExtension(extensionPath, {
+          allowFileAccess: true,
+        });
+        logger.info("React DevTools loaded successfully");
+        // Add small delay to ensure extension is fully initialized
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      } catch (err) {
+        logger.error("Failed to load React DevTools:", err);
+      }
+    } else {
+      logger.warn(
+        "React DevTools extension not found. Install it in Chrome first.",
+      );
+    }
+  }
+
   try {
     const backupManager = new BackupManager({
       settingsFile: getSettingsFilePath(),
@@ -283,10 +327,6 @@ const createWindow = () => {
       path.join(__dirname, "../renderer/main_window/index.html"),
     );
   }
-  if (process.env.NODE_ENV === "development") {
-    // Open the DevTools.
-    mainWindow.webContents.openDevTools();
-  }
 
   // Send force-close event if it was detected
   if (pendingForceCloseData) {
@@ -295,6 +335,25 @@ const createWindow = () => {
         performanceData: pendingForceCloseData,
       });
       pendingForceCloseData = null;
+    });
+  }
+
+  // Open DevTools after page loads in development (allows extension to inject properly)
+  if (process.env.NODE_ENV === "development") {
+    let devToolsOpened = false;
+
+    mainWindow.webContents.on("did-finish-load", () => {
+      if (!devToolsOpened) {
+        devToolsOpened = true;
+        // Add delay to ensure extension is fully injected
+        setTimeout(() => {
+          mainWindow?.webContents.openDevTools();
+          // Reload page to trigger extension injection properly
+          setTimeout(() => {
+            mainWindow?.webContents.reloadIgnoringCache();
+          }, 500);
+        }, 500);
+      }
     });
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -358,36 +358,47 @@ const createWindow = () => {
     );
   }
 
-  // Send force-close event if it was detected (only once, even with reload)
+  // Handle force-close message and dev reload together
+  // In dev: reload first for React DevTools, then send force-close (to preserve message)
+  // In prod: send force-close once without reload
+  let devReloaded = false;
   let forceCloseMessageSent = false;
-  if (pendingForceCloseData) {
-    mainWindow.webContents.on("did-finish-load", () => {
-      if (!forceCloseMessageSent) {
+
+  mainWindow.webContents.on("did-finish-load", () => {
+    // Development: reload once for React DevTools extension injection
+    if (process.env.NODE_ENV === "development") {
+      if (!devReloaded) {
+        devReloaded = true;
+        // Open DevTools and reload for extension injection
+        setTimeout(() => {
+          if (!mainWindow?.isDestroyed()) {
+            mainWindow?.webContents.openDevTools();
+            setTimeout(() => {
+              if (!mainWindow?.isDestroyed()) {
+                mainWindow?.webContents.reloadIgnoringCache();
+              }
+            }, 500);
+          }
+        }, 500);
+      } else if (pendingForceCloseData && !forceCloseMessageSent) {
+        // After reload: now send force-close so message persists
         forceCloseMessageSent = true;
         mainWindow?.webContents.send("force-close-detected", {
           performanceData: pendingForceCloseData,
         });
         pendingForceCloseData = null;
       }
-    });
-  }
-
-  // Open DevTools and reload in development to allow extension injection
-  if (process.env.NODE_ENV === "development") {
-    let reloaded = false;
-    mainWindow.webContents.on("did-finish-load", () => {
-      if (!reloaded) {
-        reloaded = true;
-        // Add delay to allow extension to init, then reload page for injection
-        setTimeout(() => {
-          mainWindow?.webContents.openDevTools();
-          setTimeout(() => {
-            mainWindow?.webContents.reloadIgnoringCache();
-          }, 500);
-        }, 500);
+    } else {
+      // Production: send force-close once without reload
+      if (pendingForceCloseData && !forceCloseMessageSent) {
+        forceCloseMessageSent = true;
+        mainWindow?.webContents.send("force-close-detected", {
+          performanceData: pendingForceCloseData,
+        });
+        pendingForceCloseData = null;
       }
-    });
-  }
+    }
+  });
 
   // Enable native context menu on right-click
   mainWindow.webContents.on("context-menu", (event, params) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -350,6 +350,19 @@ const createWindow = () => {
     // backgroundColor: "#00000001",
     // frame: false,
   });
+  // In development, wait for DevTools to open, then reload the page once so React DevTools initializes correctly
+  if (process.env.NODE_ENV === "development") {
+    mainWindow.webContents.once("devtools-opened", () => {
+      setTimeout(() => {
+        const windowRef = mainWindow;
+        if (!windowRef?.isDestroyed()) {
+          windowRef?.webContents.reloadIgnoringCache();
+        }
+      }, 300);
+    });
+    mainWindow.webContents.openDevTools();
+  }
+
   // and load the index.html of the app.
   if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {
     mainWindow.loadURL(MAIN_WINDOW_VITE_DEV_SERVER_URL);
@@ -359,45 +372,29 @@ const createWindow = () => {
     );
   }
 
-  // Handle force-close message and dev reload together
-  // In dev: reload first for React DevTools, then send force-close (to preserve message)
-  // In prod: send force-close once without reload
-  let devReloaded = false;
+  // Handle force-close message and development reload coordination
   let forceCloseMessageSent = false;
+  let devToolsReloadedCount = 0;
 
   mainWindow.webContents.on("did-finish-load", () => {
-    // Development: reload once for React DevTools extension injection
     if (process.env.NODE_ENV === "development") {
-      if (!devReloaded) {
-        devReloaded = true;
-        // Add delay to allow extension to init, then reload page for injection
-        setTimeout(() => {
-          if (!mainWindow?.isDestroyed()) {
-            mainWindow?.webContents.openDevTools();
-            setTimeout(() => {
-              if (!mainWindow?.isDestroyed()) {
-                mainWindow?.webContents.reloadIgnoringCache();
-              }
-            }, 500);
-          }
-        }, 500);
-      } else if (pendingForceCloseData && !forceCloseMessageSent) {
-        // After reload: now send force-close so message persists
-        forceCloseMessageSent = true;
-        mainWindow?.webContents.send("force-close-detected", {
+      // In dev, wait until AFTER the DevTools-triggered reload before sending the message
+      if (devToolsReloadedCount === 0) {
+        devToolsReloadedCount++;
+        return; // Ignore first load, we will reload momentarily
+      }
+    }
+
+    // Send force-close once after the correct load
+    if (pendingForceCloseData && !forceCloseMessageSent) {
+      forceCloseMessageSent = true;
+      const windowRef = mainWindow;
+      if (!windowRef?.isDestroyed()) {
+        windowRef?.webContents.send("force-close-detected", {
           performanceData: pendingForceCloseData,
         });
-        pendingForceCloseData = null;
       }
-    } else {
-      // Production: send force-close once without reload
-      if (pendingForceCloseData && !forceCloseMessageSent) {
-        forceCloseMessageSent = true;
-        mainWindow?.webContents.send("force-close-detected", {
-          performanceData: pendingForceCloseData,
-        });
-        pendingForceCloseData = null;
-      }
+      pendingForceCloseData = null;
     }
   });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -369,13 +369,15 @@ const createWindow = () => {
     if (process.env.NODE_ENV === "development") {
       if (!devReloaded) {
         devReloaded = true;
+        // Capture window reference at schedule time to prevent stale callbacks on new windows
+        const windowRef = mainWindow;
         // Open DevTools and reload for extension injection
         setTimeout(() => {
-          if (!mainWindow?.isDestroyed()) {
-            mainWindow?.webContents.openDevTools();
+          if (!windowRef?.isDestroyed()) {
+            windowRef?.webContents.openDevTools();
             setTimeout(() => {
-              if (!mainWindow?.isDestroyed()) {
-                mainWindow?.webContents.reloadIgnoringCache();
+              if (!windowRef?.isDestroyed()) {
+                windowRef?.webContents.reloadIgnoringCache();
               }
             }, 500);
           }

--- a/src/main.ts
+++ b/src/main.ts
@@ -98,7 +98,6 @@ export async function onReady() {
   // Load React DevTools extension in development
   if (process.env.NODE_ENV === "development") {
     let chromeUserData: string;
-
     // Determine Chrome extensions path based on platform
     if (process.platform === "win32") {
       chromeUserData = path.join(
@@ -139,8 +138,10 @@ export async function onReady() {
       try {
         const versions = fs.readdirSync(extensionsDir);
         if (versions.length > 0) {
-          // Get the latest version (most recently created directory)
-          const latestVersion = versions.sort().reverse()[0];
+          // Get the latest version using numeric sort to handle version boundaries (e.g., 9.0.0 vs 10.0.0)
+          const latestVersion = versions
+            .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
+            .reverse()[0];
           const extensionPath = path.join(extensionsDir, latestVersion);
           await session.defaultSession.loadExtension(extensionPath, {
             allowFileAccess: true,
@@ -369,15 +370,13 @@ const createWindow = () => {
     if (process.env.NODE_ENV === "development") {
       if (!devReloaded) {
         devReloaded = true;
-        // Capture window reference at schedule time to prevent stale callbacks on new windows
-        const windowRef = mainWindow;
-        // Open DevTools and reload for extension injection
+        // Add delay to allow extension to init, then reload page for injection
         setTimeout(() => {
-          if (!windowRef?.isDestroyed()) {
-            windowRef?.webContents.openDevTools();
+          if (!mainWindow?.isDestroyed()) {
+            mainWindow?.webContents.openDevTools();
             setTimeout(() => {
-              if (!windowRef?.isDestroyed()) {
-                windowRef?.webContents.reloadIgnoringCache();
+              if (!mainWindow?.isDestroyed()) {
+                mainWindow?.webContents.reloadIgnoringCache();
               }
             }, 500);
           }

--- a/src/main.ts
+++ b/src/main.ts
@@ -97,15 +97,40 @@ if (process.defaultApp) {
 export async function onReady() {
   // Load React DevTools extension in development
   if (process.env.NODE_ENV === "development") {
-    const userDataDir = process.env.LOCALAPPDATA || "";
-    const chromeUserData = path.join(
-      userDataDir,
-      "Google",
-      "Chrome",
-      "User Data",
-      "Default",
-      "Extensions",
-    );
+    let chromeUserData: string;
+
+    // Determine Chrome extensions path based on platform
+    if (process.platform === "win32") {
+      chromeUserData = path.join(
+        process.env.LOCALAPPDATA || "",
+        "Google",
+        "Chrome",
+        "User Data",
+        "Default",
+        "Extensions",
+      );
+    } else if (process.platform === "darwin") {
+      // macOS
+      chromeUserData = path.join(
+        process.env.HOME || "",
+        "Library",
+        "Application Support",
+        "Google",
+        "Chrome",
+        "Default",
+        "Extensions",
+      );
+    } else {
+      // Linux
+      chromeUserData = path.join(
+        process.env.HOME || "",
+        ".config",
+        "google-chrome",
+        "Default",
+        "Extensions",
+      );
+    }
+
     // React DevTools extension ID
     const reactDevToolsId = "fmkadmapgofadopljbjfkapdkoienihi";
     const extensionsDir = path.join(chromeUserData, reactDevToolsId);
@@ -113,14 +138,19 @@ export async function onReady() {
     if (fs.existsSync(extensionsDir)) {
       try {
         const versions = fs.readdirSync(extensionsDir);
-        const latestVersion = versions.sort().reverse()[0];
-        const extensionPath = path.join(extensionsDir, latestVersion);
-        await session.defaultSession.loadExtension(extensionPath, {
-          allowFileAccess: true,
-        });
-        logger.info("React DevTools loaded successfully");
-        // Add small delay to ensure extension is fully initialized
-        await new Promise((resolve) => setTimeout(resolve, 500));
+        if (versions.length > 0) {
+          // Get the latest version (most recently created directory)
+          const latestVersion = versions.sort().reverse()[0];
+          const extensionPath = path.join(extensionsDir, latestVersion);
+          await session.defaultSession.loadExtension(extensionPath, {
+            allowFileAccess: true,
+          });
+          logger.info("React DevTools loaded successfully");
+        } else {
+          logger.warn(
+            "React DevTools extension directory is empty. Install it in Chrome first.",
+          );
+        }
       } catch (err) {
         logger.error("Failed to load React DevTools:", err);
       }
@@ -330,25 +360,22 @@ const createWindow = () => {
 
   // Send force-close event if it was detected
   if (pendingForceCloseData) {
-    mainWindow.webContents.once("did-finish-load", () => {
+    mainWindow.webContents.on("did-finish-load", () => {
       mainWindow?.webContents.send("force-close-detected", {
         performanceData: pendingForceCloseData,
       });
-      pendingForceCloseData = null;
     });
   }
 
-  // Open DevTools after page loads in development (allows extension to inject properly)
+  // Open DevTools and reload in development to allow extension injection
   if (process.env.NODE_ENV === "development") {
-    let devToolsOpened = false;
-
+    let reloaded = false;
     mainWindow.webContents.on("did-finish-load", () => {
-      if (!devToolsOpened) {
-        devToolsOpened = true;
-        // Add delay to ensure extension is fully injected
+      if (!reloaded) {
+        reloaded = true;
+        // Add delay to allow extension to init, then reload page for injection
         setTimeout(() => {
           mainWindow?.webContents.openDevTools();
-          // Reload page to trigger extension injection properly
           setTimeout(() => {
             mainWindow?.webContents.reloadIgnoringCache();
           }, 500);


### PR DESCRIPTION
probleme :
Before this change, developers couldn't inspect React components in the Electron app's DevTools. The DevTools only showed the Elements tab (DOM), not the ⚛️ React Components tab. This made debugging React components much harder.

solution:
We added automatic loading of React DevTools extension when running in development mode, so the React Components tab is available in Electron DevTools.

Two simple files changed:

[main.ts]→ Added React DevTools extension loading code
[package.json] → Added npm run dev script

New script: "dev": "cross-env NODE_ENV=development npm start"
This sets [NODE_ENV=development]( so React DevTools loads


📝 Steps to Enable This Feature
For Developers Using Dyad
Step 1: Install React DevTools Extension in Chrome

Open Google Chrome
Go to: [https://chromewebstore.google.com/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi]
Click "Add to Chrome"
Confirm the installation
Step 2: Run the App in Dev Mode





expected behavior
<img width="1591" height="870" alt="Capture d&#39;écran 2026-04-01 152857" src="https://github.com/user-attachments/assets/341130e8-38ac-4d61-84cb-5415b248278d" />

<!-- devin-review-badge-begin -->

---







<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/3112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
