### PR TITLE
fix: show View Plan button even when complete attribute is stale

### DIFF
--- a/src/components/chat/DyadWritePlan.tsx
+++ b/src/components/chat/DyadWritePlan.tsx
@@ -27,20 +27,22 @@ export const DyadWritePlan: React.FC<DyadWritePlanProps> = ({ node }) => {
   // Consider in progress if state is pending OR complete is explicitly "false"
   const isInProgress = state === "pending" || complete === "false";
 
-  const { savedPlan, hasPlanInMemory } = usePlan({ enabled: !isInProgress });
+  // Always load plan data regardless of isInProgress so we can show the View Plan
+  // button even when complete="false" is stale (e.g. after switching chats).
+  const { savedPlan, hasPlanInMemory } = usePlan();
 
   const hasPlan = hasPlanInMemory || !!savedPlan;
 
   return (
     <div
       className={`my-4 border rounded-lg overflow-hidden ${
-        isInProgress ? "border-primary/60" : "border-primary/20"
+        isInProgress && !hasPlan ? "border-primary/60" : "border-primary/20"
       } bg-primary/5`}
     >
       <div className="px-4 py-3 flex items-center justify-between">
         <div className="flex items-center gap-2">
           <FileText
-            className={`text-primary ${isInProgress ? "animate-pulse" : ""}`}
+            className={`text-primary ${isInProgress && !hasPlan ? "animate-pulse" : ""}`}
             size={20}
           />
           <div className="flex items-center gap-2">
@@ -62,7 +64,7 @@ export const DyadWritePlan: React.FC<DyadWritePlanProps> = ({ node }) => {
           </div>
         </div>
         <div className="flex items-center">
-          {!isInProgress && hasPlan && (
+          {hasPlan && (
             <button
               type="button"
               onClick={() => {
@@ -75,7 +77,7 @@ export const DyadWritePlan: React.FC<DyadWritePlanProps> = ({ node }) => {
               View Plan
             </button>
           )}
-          {isInProgress && (
+          {isInProgress && !hasPlan && (
             <span className="flex items-center gap-1.5 text-xs text-primary px-3 py-1 bg-primary/20 rounded-md font-medium">
               <Loader2 size={12} className="animate-spin" />
               Generating plan...
@@ -83,7 +85,7 @@ export const DyadWritePlan: React.FC<DyadWritePlanProps> = ({ node }) => {
           )}
         </div>
       </div>
-      {isInProgress && (
+      {isInProgress && !hasPlan && (
         <div className="px-4 pb-3">
           <div
             className="h-1.5 w-full rounded-full overflow-hidden"


### PR DESCRIPTION
Fixes #3037

## Problem

The "View Plan" button disappears when switching to a different chat and returning to the original chat that has a generated plan.

**Root cause**: The `isInProgress` flag is computed as `state === "pending" || complete === "false"`. In some cases, the `complete` attribute can be stale (i.e., remain as `"false"` in the rendered message metadata after the plan finishes generating). When `isInProgress` is `true`, `usePlan` is disabled (via `enabled: !isInProgress`), which prevents loading the plan from memory or disk. If `hasPlanInMemory` is also `false` (e.g., after chat navigation), `hasPlan` becomes `false` and the "View Plan" button is hidden.

## Solution

Two changes to `DyadWritePlan.tsx`:

1. **Always load plan data** — removed the `enabled: !isInProgress` restriction from `usePlan()`. The plan is now always fetched from memory or disk, even when the `complete` attribute appears stale.

2. **Show View Plan button whenever plan data exists** — changed the button visibility condition from `!isInProgress && hasPlan` to just `hasPlan`. The "Generating plan..." indicator is now shown only when `isInProgress && !hasPlan` (actively generating with no plan data available yet).

3. **Updated styling** — the animated border and pulsing icon now only appear when `isInProgress && !hasPlan`, consistent with the button logic.

## Testing

- Generate a plan in plan mode → "View Plan" button appears ✓
- Switch to a different chat, then return → "View Plan" button persists ✓
- Actively generating a plan (no data yet) → "Generating plan..." indicator shown ✓
- Plan data in memory overrides stale `complete="false"` attribute → button shown ✓
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/3127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
