### PR TITLE
fix: surface structured Vercel API error messages to users

### DIFF
--- a/src/ipc/handlers/vercel_handlers.ts
+++ b/src/ipc/handlers/vercel_handlers.ts
@@ -27,6 +27,28 @@ import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
 
 const logger = log.scope("vercel_handlers");
 
+/**
+ * Parses structured error info from Vercel SDK API errors.
+ * Vercel SDK throws errors with messages like:
+ *   "API error occurred: Status 400 ... Body: {"error":{"message":"...","action":"...","link":"..."}}"
+ * Returns a user-friendly message, or null if the error can't be parsed.
+ */
+function parseVercelApiError(err: any): string | null {
+  const message: string = err?.message ?? "";
+  const bodyMatch = message.match(/Body:\s*(\{[\s\S]*\})/);
+  if (!bodyMatch) return null;
+  try {
+    const parsed = JSON.parse(bodyMatch[1]);
+    const apiError = parsed?.error;
+    if (!apiError?.message) return null;
+    return apiError.link
+      ? `${apiError.message} See: ${apiError.link}`
+      : apiError.message;
+  } catch {
+    return null;
+  }
+}
+
 // Use test server URLs when in test mode
 const TEST_SERVER_BASE = `http://localhost:${process.env.FAKE_LLM_PORT || "3500"}`;
 
@@ -256,7 +278,9 @@ async function handleListVercelProjects(): Promise<VercelProject[]> {
   } catch (err: any) {
     if (err instanceof DyadError) throw err;
     logger.error("[Vercel Handler] Failed to list projects:", err);
-    throw new Error(err.message || "Failed to list Vercel projects.");
+    throw new Error(
+      parseVercelApiError(err) ?? err.message ?? "Failed to list Vercel projects.",
+    );
   }
 }
 
@@ -399,7 +423,9 @@ async function handleCreateProject(
   } catch (err: any) {
     if (err instanceof DyadError) throw err;
     logger.error("[Vercel Handler] Failed to create project:", err);
-    throw new Error(err.message || "Failed to create Vercel project.");
+    throw new Error(
+      parseVercelApiError(err) ?? err.message ?? "Failed to create Vercel project.",
+    );
   }
 }
 
@@ -453,7 +479,9 @@ async function handleConnectToExistingProject(
       "[Vercel Handler] Failed to connect to existing project:",
       err,
     );
-    throw new Error(err.message || "Failed to connect to existing project.");
+    throw new Error(
+      parseVercelApiError(err) ?? err.message ?? "Failed to connect to existing project.",
+    );
   }
 }
 
@@ -527,7 +555,9 @@ async function handleGetVercelDeployments(
   } catch (err: any) {
     if (err instanceof DyadError) throw err;
     logger.error("[Vercel Handler] Failed to get deployments:", err);
-    throw new Error(err.message || "Failed to get Vercel deployments.");
+    throw new Error(
+      parseVercelApiError(err) ?? err.message ?? "Failed to get Vercel deployments.",
+    );
   }
 }
 


### PR DESCRIPTION
Fixes #3051

## Problem

When the Vercel API returns a 400 error (e.g. requiring the user to add a GitHub Login Connection), the error response body contains structured fields: `message`, `action`, and `link`. The current code passes the raw SDK error string to the UI, which looks like:

```
API error occurred: Status 400 Content-Type "application/json; charset=utf-8". Body: {"error":{"code":"bad_request","message":"Failed to link repo. You need to add a Login Connection to your GitHub account first.","action":"Add a Login Connection","link":"https://vercel.com/docs/..."}}
```

This is confusing and unhelpful for users who just need to know what to do next.

## Solution

Add a `parseVercelApiError()` helper that extracts the human-readable `message` and `link` fields from Vercel API error bodies and returns a clean user-facing message like:

```
Failed to link repo. You need to add a Login Connection to your GitHub account first. See: https://vercel.com/docs/accounts/create-an-account#login-methods-and-connections
```

This is applied consistently across all four Vercel API error catch blocks (`createProject`, `connectExistingProject`, `listProjects`, `getDeployments`).

## Testing

- For errors that include a structured Vercel body, the user now sees only the friendly message + docs link
- For other SDK/network errors, the original `err.message` is used as before (no regression)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/3137" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
