### PR TITLE
perf: change db to WAL mode

### DIFF
--- a/src/backup_manager.ts
+++ b/src/backup_manager.ts
@@ -296,12 +296,14 @@ export class BackupManager {
   ): Promise<void> {
     logger.debug(`Backing up SQLite database: ${sourcePath} → ${destPath}`);
     const sourceDb = new Database(sourcePath, {
-      readonly: true,
       timeout: 10000,
     });
 
     try {
-      // This is safe even if other connections are active
+      // Flush any pending WAL data into the main database file before backing up.
+      // This ensures the backup captures all committed data, even if a previous
+      // session crashed and left un-checkpointed writes in the WAL.
+      sourceDb.pragma("wal_checkpoint(TRUNCATE)");
       await sourceDb.backup(destPath);
       logger.info("Database backup completed successfully");
     } catch (error) {

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -52,6 +52,15 @@ export function initializeDatabase(): BetterSQLite3Database<typeof schema> & {
   const sqlite = new Database(dbPath, { timeout: 10000 });
   sqlite.pragma("foreign_keys = ON");
 
+  try {
+    sqlite.pragma("journal_mode = WAL");
+  } catch (error) {
+    logger.warn(
+      "Could not enable WAL mode, falling back to default journal mode:",
+      error,
+    );
+  }
+
   _db = drizzle(sqlite, { schema });
 
   try {


### PR DESCRIPTION
This PR changes the SQLite database setting to use WAL (Write-Ahead Logging) mode. From what I can tell, it should be an easy performance improvement with no real downside for our case. Documentation is here:
https://sqlite.org/wal.html

Also, the [docs for better-sqlite3](https://www.npmjs.com/package/better-sqlite3) explicitly recommend it:

> Though not required, it is generally important to set the WAL pragma for performance reasons.

I came across this as I was looking into the issue where the chat code blocks slow down Dyad's framerate. I'm not entirely sure whether this is related, but I did notice that sometimes database calls were taking a lot longer than I expected, and that would cause Dyad's framerate to drop significantly on my machine. This change seems to be an improvement in that regard, so it might also have an effect on the code blocks issue as well.

It's hard to accurately benchmark this because its effect is only substantial when there are multiple database calls going on at the same time. I can definitely attempt a benchmark if that would be worthwhile though.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/3140" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
