### PR TITLE
fix: use atomic write for settings to prevent corruption on crash

### DIFF
--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -249,7 +249,11 @@ export function writeSettings(settings: Partial<UserSettings>): void {
     }
     // Use StoredUserSettingsSchema for writing to maintain backwards compatibility
     const validatedSettings = StoredUserSettingsSchema.parse(newSettings);
-    fs.writeFileSync(filePath, JSON.stringify(validatedSettings, null, 2));
+    // Write to a temp file first, then atomically rename to prevent corruption
+    // if the process is killed mid-write (fixes settings wipe on crash).
+    const tempPath = filePath + ".tmp";
+    fs.writeFileSync(tempPath, JSON.stringify(validatedSettings, null, 2));
+    fs.renameSync(tempPath, filePath);
   } catch (error) {
     logger.error("Error writing settings:", error);
   }


### PR DESCRIPTION
Fixes #3089

## Problem
When Dyad crashes or is force-killed while `writeSettings()` is executing, the settings file can be left empty or partially written. On the next startup, `JSON.parse` fails on the corrupted file, and `readSettings()` falls back to `DEFAULT_SETTINGS` — wiping all user settings including API keys.

## Solution
Replace the direct `fs.writeFileSync(filePath, ...)` call with an atomic write-then-rename pattern:
1. Write the new settings to a `.tmp` file alongside the real settings file
2. Atomically rename the `.tmp` file to the real settings file

`rename(2)` is atomic on POSIX systems (and near-atomic on Windows) — if the process is killed mid-rename, either the old file or the new file will be present, never a partial or empty result. This eliminates the corruption window that causes settings to be wiped.

## Testing
- Manually verified the change writes to a temp file before renaming
- The settings file path is unchanged for end users; only the write path uses a temp file
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/3141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
