### PR TITLE
fix: force checkout when restoring a previous version

### DIFF
--- a/src/ipc/git_types.ts
+++ b/src/ipc/git_types.ts
@@ -24,6 +24,7 @@ export interface GitListFilesParams extends GitBaseParams {
 }
 export interface GitCheckoutParams extends GitBaseParams {
   ref: string;
+  force?: boolean;
 }
 export interface GitBranchRenameParams extends GitBaseParams {
   oldBranch: string;

--- a/src/ipc/handlers/version_handlers.ts
+++ b/src/ipc/handlers/version_handlers.ts
@@ -448,6 +448,7 @@ export function registerVersionHandlers() {
       await gitCheckout({
         path: fullAppPath,
         ref: gitRef,
+        force: true,
       });
     });
   });

--- a/src/ipc/utils/git_utils.ts
+++ b/src/ipc/utils/git_utils.ts
@@ -332,17 +332,15 @@ export async function gitCommit({
 export async function gitCheckout({
   path,
   ref,
+  force,
 }: GitCheckoutParams): Promise<void> {
   const settings = readSettings();
   if (settings.enableNativeGit) {
-    await execOrThrow(
-      ["checkout", ref],
-      path,
-      `Failed to checkout ref '${ref}'`,
-    );
+    const args = force ? ["checkout", "--force", ref] : ["checkout", ref];
+    await execOrThrow(args, path, `Failed to checkout ref '${ref}'`);
     return;
   } else {
-    return git.checkout({ fs, dir: path, ref });
+    return git.checkout({ fs, dir: path, ref, force: !!force });
   }
 }
 


### PR DESCRIPTION
Fixes #2763

## Problem
When a user tries to restore a previous version of their app while having local edits, the checkout fails with `CheckoutConflictError: Your local changes to the following files would be overwritten by checkout`. This blocks version restore entirely, even though the user explicitly wants to replace the current state with the older version.

## Solution
Add a `force` option to `GitCheckoutParams` and `gitCheckout` utility, then pass `force: true` in the `checkoutVersion` IPC handler. This uses `git checkout --force` for native git and `{ force: true }` for isomorphic-git.

Restoring a version is an explicit user action to replace the current working state, so forcing the checkout is the correct behavior — it mirrors what the user actually wants.

## Testing
- Tested with native git enabled: `git checkout --force <ref>` is used and succeeds with local changes present
- Tested with native git disabled: isomorphic-git's `force: true` option is passed
- Other callers of `gitCheckout` (branch switching, GitHub operations) are unaffected as they don't pass `force: true`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/3153" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
