### PR TITLE
fix: detect routes from imported route files when App.tsx has no inline routes

### DIFF
--- a/src/__tests__/useParseRouter.test.ts
+++ b/src/__tests__/useParseRouter.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   buildRouteLabel,
+  findRouteFiles,
   parseRoutesFromRouterFile,
   parseRoutesFromNextFiles,
 } from "@/hooks/useParseRouter";
@@ -23,6 +24,46 @@ describe("buildRouteLabel", () => {
 
   it("should handle deeply nested paths", () => {
     expect(buildRouteLabel("/admin/settings/security")).toBe("Security");
+  });
+});
+
+describe("findRouteFiles", () => {
+  it("should find files with 'routes' in their name", () => {
+    const files = [
+      "src/routes/publicRoutes.tsx",
+      "src/routes/protectedRoutes.tsx",
+      "src/App.tsx",
+      "src/components/Header.tsx",
+    ];
+    const result = findRouteFiles(files);
+    expect(result).toEqual([
+      "src/routes/publicRoutes.tsx",
+      "src/routes/protectedRoutes.tsx",
+    ]);
+  });
+
+  it("should find files with 'route' (singular) in their name", () => {
+    const files = ["src/AppRoute.tsx", "src/index.ts"];
+    const result = findRouteFiles(files);
+    expect(result).toEqual(["src/AppRoute.tsx"]);
+  });
+
+  it("should be case-insensitive", () => {
+    const files = ["src/Routes.tsx", "src/ROUTES.ts", "src/routes.jsx"];
+    const result = findRouteFiles(files);
+    expect(result).toHaveLength(3);
+  });
+
+  it("should only match JS/TS extensions", () => {
+    const files = ["src/routes.md", "src/routes.tsx", "src/routes.css"];
+    const result = findRouteFiles(files);
+    expect(result).toEqual(["src/routes.tsx"]);
+  });
+
+  it("should return empty array when no route files found", () => {
+    const files = ["src/App.tsx", "src/main.ts", "src/components/Button.tsx"];
+    const result = findRouteFiles(files);
+    expect(result).toEqual([]);
   });
 });
 

--- a/src/hooks/useParseRouter.ts
+++ b/src/hooks/useParseRouter.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useLoadAppFile } from "@/hooks/useLoadAppFile";
 import { useLoadApp } from "@/hooks/useLoadApp";
+import { ipc } from "@/ipc/types";
 
 export interface ParsedRoute {
   path: string;
@@ -19,6 +20,35 @@ export function buildRouteLabel(path: string): string {
         .pop()
         ?.replace(/[-_]/g, " ")
         .replace(/^\w/, (c) => c.toUpperCase()) || path;
+}
+
+/**
+ * Finds files in the app's file list that are likely to contain route definitions.
+ * Matches filenames containing "route" or "routes" (case-insensitive).
+ */
+export function findRouteFiles(files: string[]): string[] {
+  return files.filter((f) => {
+    const basename = f.split("/").pop() || "";
+    return /routes?\./i.test(basename) && /\.[jt]sx?$/.test(basename);
+  });
+}
+
+/**
+ * Merges route arrays, deduplicating by path.
+ */
+function mergeRoutes(
+  primary: ParsedRoute[],
+  ...rest: ParsedRoute[][]
+): ParsedRoute[] {
+  const merged = [...primary];
+  for (const routes of rest) {
+    for (const route of routes) {
+      if (!merged.some((r) => r.path === route.path)) {
+        merged.push(route);
+      }
+    }
+  }
+  return merged;
 }
 
 /**
@@ -130,9 +160,11 @@ export function parseRoutesFromNextFiles(files: string[]): ParsedRoute[] {
 
 /**
  * Loads the app router file and parses available routes for quick navigation.
+ * Falls back to scanning imported route files when App.tsx contains no inline routes.
  */
 export function useParseRouter(appId: number | null) {
   const [routes, setRoutes] = useState<ParsedRoute[]>([]);
+  const [importedRoutes, setImportedRoutes] = useState<ParsedRoute[]>([]);
 
   // Load app to access the file list
   const {
@@ -156,14 +188,50 @@ export function useParseRouter(appId: number | null) {
     return app.files.some((f) => f.toLowerCase().includes("next.config"));
   }, [app?.files]);
 
+  // When no routes found in App.tsx, scan route-named files for route definitions
+  useEffect(() => {
+    if (isNextApp || !appId || !app?.files) {
+      setImportedRoutes([]);
+      return;
+    }
+    const directRoutes = parseRoutesFromRouterFile(routerContent ?? null);
+    if (directRoutes.length > 0) {
+      setImportedRoutes([]);
+      return;
+    }
+    const routeFiles = findRouteFiles(app.files);
+    if (routeFiles.length === 0) {
+      setImportedRoutes([]);
+      return;
+    }
+    Promise.all(
+      routeFiles.map((filePath) =>
+        ipc.app.readAppFile({ appId, filePath }).catch(() => null),
+      ),
+    ).then((contents) => {
+      const discovered: ParsedRoute[] = [];
+      for (const content of contents) {
+        if (!content) continue;
+        const fileRoutes = parseRoutesFromRouterFile(content);
+        for (const route of fileRoutes) {
+          if (!discovered.some((r) => r.path === route.path)) {
+            discovered.push(route);
+          }
+        }
+      }
+      setImportedRoutes(discovered);
+    });
+  }, [appId, isNextApp, app?.files, routerContent]);
+
   // Parse routes either from Next.js file-based routing or from router file
   useEffect(() => {
     if (isNextApp && app?.files) {
       setRoutes(parseRoutesFromNextFiles(app.files));
     } else {
-      setRoutes(parseRoutesFromRouterFile(routerContent ?? null));
+      const directRoutes = parseRoutesFromRouterFile(routerContent ?? null);
+      setRoutes(mergeRoutes(directRoutes, importedRoutes));
     }
-  }, [isNextApp, app?.files, routerContent]);
+  }, [isNextApp, app?.files, routerContent, importedRoutes]);
 
   const combinedLoading = appLoading || routerFileLoading;
   const combinedError = appError || routerFileError || null;


### PR DESCRIPTION
Fixes #3157

## Problem

When a React Router app organizes routes into separate files (e.g. `publicRoutes.tsx`, `protectedRoutes.tsx`) and imports them as function calls in `App.tsx`, the route dropdown shows \"Loading routes...\" indefinitely. The existing parser uses a regex to find `<Route path=\"...\">` elements directly in `App.tsx`, so it finds nothing when routes are split across multiple files.

## Solution

Added a fallback in `useParseRouter`: when no routes are found directly in `App.tsx`, the hook now:
1. Scans the app's file list for files whose name contains `route` or `routes` (case-insensitive, e.g. `publicRoutes.tsx`, `AppRoutes.ts`)
2. Loads those files via the existing `ipc.app.readAppFile` IPC channel
3. Parses `<Route path=\"...\">` from each file and merges them (deduplicating by path)

Apps that already have inline routes in `App.tsx` are unaffected — the fallback only activates when the primary parse returns no routes.

New exported helper `findRouteFiles(files)` is tested independently.

## Testing

- Added unit tests for `findRouteFiles` covering: pattern matching, singular/plural `route`/`routes`, case-insensitivity, extension filtering, and empty result cases
- All existing `parseRoutesFromRouterFile` and `parseRoutesFromNextFiles` tests continue to pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/3166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
