### PR TITLE
fix: use crash-safe diff+apply for gitStageToRevert

### DIFF
--- a/src/__tests__/useParseRouter.test.ts
+++ b/src/__tests__/useParseRouter.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   buildRouteLabel,
+  findRouteFiles,
   parseRoutesFromRouterFile,
   parseRoutesFromNextFiles,
 } from "@/hooks/useParseRouter";
@@ -23,6 +24,46 @@ describe("buildRouteLabel", () => {
 
   it("should handle deeply nested paths", () => {
     expect(buildRouteLabel("/admin/settings/security")).toBe("Security");
+  });
+});
+
+describe("findRouteFiles", () => {
+  it("should find files with 'routes' in their name", () => {
+    const files = [
+      "src/routes/publicRoutes.tsx",
+      "src/routes/protectedRoutes.tsx",
+      "src/App.tsx",
+      "src/components/Header.tsx",
+    ];
+    const result = findRouteFiles(files);
+    expect(result).toEqual([
+      "src/routes/publicRoutes.tsx",
+      "src/routes/protectedRoutes.tsx",
+    ]);
+  });
+
+  it("should find files with 'route' (singular) in their name", () => {
+    const files = ["src/AppRoute.tsx", "src/index.ts"];
+    const result = findRouteFiles(files);
+    expect(result).toEqual(["src/AppRoute.tsx"]);
+  });
+
+  it("should be case-insensitive", () => {
+    const files = ["src/Routes.tsx", "src/ROUTES.ts", "src/routes.jsx"];
+    const result = findRouteFiles(files);
+    expect(result).toHaveLength(3);
+  });
+
+  it("should only match JS/TS extensions", () => {
+    const files = ["src/routes.md", "src/routes.tsx", "src/routes.css"];
+    const result = findRouteFiles(files);
+    expect(result).toEqual(["src/routes.tsx"]);
+  });
+
+  it("should return empty array when no route files found", () => {
+    const files = ["src/App.tsx", "src/main.ts", "src/components/Button.tsx"];
+    const result = findRouteFiles(files);
+    expect(result).toEqual([]);
   });
 });
 

--- a/src/hooks/useParseRouter.ts
+++ b/src/hooks/useParseRouter.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useLoadAppFile } from "@/hooks/useLoadAppFile";
 import { useLoadApp } from "@/hooks/useLoadApp";
+import { ipc } from "@/ipc/types";
 
 export interface ParsedRoute {
   path: string;
@@ -19,6 +20,35 @@ export function buildRouteLabel(path: string): string {
         .pop()
         ?.replace(/[-_]/g, " ")
         .replace(/^\w/, (c) => c.toUpperCase()) || path;
+}
+
+/**
+ * Finds files in the app's file list that are likely to contain route definitions.
+ * Matches filenames containing "route" or "routes" (case-insensitive).
+ */
+export function findRouteFiles(files: string[]): string[] {
+  return files.filter((f) => {
+    const basename = f.split("/").pop() || "";
+    return /routes?\./i.test(basename) && /\.[jt]sx?$/.test(basename);
+  });
+}
+
+/**
+ * Merges route arrays, deduplicating by path.
+ */
+function mergeRoutes(
+  primary: ParsedRoute[],
+  ...rest: ParsedRoute[][]
+): ParsedRoute[] {
+  const merged = [...primary];
+  for (const routes of rest) {
+    for (const route of routes) {
+      if (!merged.some((r) => r.path === route.path)) {
+        merged.push(route);
+      }
+    }
+  }
+  return merged;
 }
 
 /**
@@ -130,9 +160,11 @@ export function parseRoutesFromNextFiles(files: string[]): ParsedRoute[] {
 
 /**
  * Loads the app router file and parses available routes for quick navigation.
+ * Falls back to scanning imported route files when App.tsx contains no inline routes.
  */
 export function useParseRouter(appId: number | null) {
   const [routes, setRoutes] = useState<ParsedRoute[]>([]);
+  const [importedRoutes, setImportedRoutes] = useState<ParsedRoute[]>([]);
 
   // Load app to access the file list
   const {
@@ -156,14 +188,50 @@ export function useParseRouter(appId: number | null) {
     return app.files.some((f) => f.toLowerCase().includes("next.config"));
   }, [app?.files]);
 
+  // When no routes found in App.tsx, scan route-named files for route definitions
+  useEffect(() => {
+    if (isNextApp || !appId || !app?.files) {
+      setImportedRoutes([]);
+      return;
+    }
+    const directRoutes = parseRoutesFromRouterFile(routerContent ?? null);
+    if (directRoutes.length > 0) {
+      setImportedRoutes([]);
+      return;
+    }
+    const routeFiles = findRouteFiles(app.files);
+    if (routeFiles.length === 0) {
+      setImportedRoutes([]);
+      return;
+    }
+    Promise.all(
+      routeFiles.map((filePath) =>
+        ipc.app.readAppFile({ appId, filePath }).catch(() => null),
+      ),
+    ).then((contents) => {
+      const discovered: ParsedRoute[] = [];
+      for (const content of contents) {
+        if (!content) continue;
+        const fileRoutes = parseRoutesFromRouterFile(content);
+        for (const route of fileRoutes) {
+          if (!discovered.some((r) => r.path === route.path)) {
+            discovered.push(route);
+          }
+        }
+      }
+      setImportedRoutes(discovered);
+    });
+  }, [appId, isNextApp, app?.files, routerContent]);
+
   // Parse routes either from Next.js file-based routing or from router file
   useEffect(() => {
     if (isNextApp && app?.files) {
       setRoutes(parseRoutesFromNextFiles(app.files));
     } else {
-      setRoutes(parseRoutesFromRouterFile(routerContent ?? null));
+      const directRoutes = parseRoutesFromRouterFile(routerContent ?? null);
+      setRoutes(mergeRoutes(directRoutes, importedRoutes));
     }
-  }, [isNextApp, app?.files, routerContent]);
+  }, [isNextApp, app?.files, routerContent, importedRoutes]);
 
   const combinedLoading = appLoading || routerFileLoading;
   const combinedError = appError || routerFileError || null;

--- a/src/ipc/utils/git_utils.ts
+++ b/src/ipc/utils/git_utils.ts
@@ -9,7 +9,7 @@ import {
 import fs from "node:fs";
 import { promises as fsPromises } from "node:fs";
 import pathModule from "node:path";
-import { platform } from "node:os";
+import { platform, tmpdir } from "node:os";
 import { readSettings } from "../../main/settings";
 import log from "electron-log";
 import { normalizePath } from "../../../shared/normalizePath";
@@ -383,21 +383,41 @@ export async function gitStageToRevert({
       );
     }
 
-    // Reset the working directory and index to match the target commit state
-    // This effectively undoes all changes since the target commit
-    await execOrThrow(
-      ["reset", "--hard", targetOid],
+    // Use git diff + apply to stage changes without ever moving branch pointers.
+    // The old approach (git reset --hard targetOid; git reset --soft currentCommit)
+    // is crash-unsafe: if the process is killed between the two resets, the branch
+    // pointer is left at targetOid and all newer commits appear lost to the user.
+    // With diff+apply, no branch pointers are touched at any point.
+    const diffResult = await execGit(
+      ["diff", "--binary", "HEAD", targetOid],
       path,
-      `Failed to reset to target commit '${targetOid}'`,
     );
+    if (diffResult.exitCode !== 0) {
+      throw new DyadError(
+        `Failed to compute diff to target commit '${targetOid}': ${diffResult.stderr.trim()}`,
+        DyadErrorKind.Conflict,
+      );
+    }
 
-    // Reset back to the original HEAD but keep the working directory as it is
-    // This stages all the changes needed to revert to the target state
-    await execOrThrow(
-      ["reset", "--soft", currentCommit],
-      path,
-      "Failed to reset back to original HEAD",
-    );
+    if (diffResult.stdout.trim()) {
+      // Write the patch to a temp file so git apply can consume it.
+      // --index applies the patch to both the staging area and the working tree.
+      const tmpDir = await fsPromises.mkdtemp(
+        pathModule.join(tmpdir(), "dyad-revert-"),
+      );
+      const tmpPatchFile = pathModule.join(tmpDir, "changes.patch");
+      try {
+        await fsPromises.writeFile(tmpPatchFile, diffResult.stdout);
+        await execOrThrow(
+          ["apply", "--index", tmpPatchFile],
+          path,
+          `Failed to apply changes when reverting to '${targetOid}'`,
+        );
+      } finally {
+        await fsPromises.unlink(tmpPatchFile).catch(() => {});
+        await fsPromises.rmdir(tmpDir).catch(() => {});
+      }
+    }
   } else {
     // Get status matrix comparing the target commit (previousVersionId as HEAD) with current working directory
     const matrix = await git.statusMatrix({


### PR DESCRIPTION
Fixes #3135

## Problem

When using native git (enabled by default since v0.33.0), the `gitStageToRevert` function reverted app files using a two-step sequence:

```
git reset --hard <targetOid>    # step 1: moves branch pointer to old commit
git reset --soft <currentCommit> # step 2: restores branch pointer
```

If the Electron process was killed between steps 1 and 2 (crash, OOM, force-quit), the `main` branch pointer would be left pointing at the old commit. All newer commits would become unreachable from the branch, appearing lost to the user — even though they still exist in the git object store and reflog.

This matches the symptom in #3135: "you destroy all versions after the version I went back to."

## Solution

Replace the two-step reset with `git diff --binary HEAD <targetOid>` + `git apply --index <patch>`:

- `git diff --binary` produces a complete patch (text and binary files) from the current HEAD to the target version
- `git apply --index` applies the patch to both the staging area and the working tree

At no point is any branch pointer moved. If the process is killed mid-operation, the branch stays intact and the user's history is preserved.

A temporary file is used for the patch because dugite's `exec` does not support stdin piping. The `--binary` flag ensures binary assets (images, fonts, etc.) are correctly included in the patch.

## Testing

- The fix preserves the existing clean-working-tree safety check (refuses to run if there are uncommitted changes)
- The early-return when `currentCommit === targetOid` is unchanged
- The isomorphic-git fallback path is unchanged (it did not have this issue)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/3180" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
