### PR TITLE
fix: show full file path in refactor suggestion tooltip

### DIFF
--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -1065,7 +1065,7 @@ function RefactorFileButton({ path }: { path: string }) {
     });
   };
   return (
-    <SuggestionButton onClick={onClick} tooltipText={t("refactorDescription")}>
+    <SuggestionButton onClick={onClick} tooltipText={path}>
       <span className="max-w-[180px] overflow-hidden whitespace-nowrap text-ellipsis">
         {t("refactorFile", { path: path.split("/").slice(-2).join("/") })}
       </span>


### PR DESCRIPTION
Fixes #3185

## Problem
The \"Refactor\" suggestion button displayed a truncated file path (e.g. \"Refactor property/Inte....\") in the button label, but the tooltip showed only a generic message: \"Refactor the file to improve maintainability\". This gave users no useful information about which specific file would be refactored.

## Solution
Changed the tooltip text from the generic `refactorDescription` translation string to the actual full file `path` prop. Now when hovering over a Refactor suggestion button, users see the complete file path that will be refactored.

## Testing
Manually verified the change: the `RefactorFileButton` component now passes `path` (the full file path) as `tooltipText` to `SuggestionButton`, replacing the generic description string.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/3190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
