### PR TITLE
Mask API key in settings to prevent exposure

### DIFF
--- a/src/components/settings/ApiKeyConfiguration.tsx
+++ b/src/components/settings/ApiKeyConfiguration.tsx
@@ -13,9 +13,9 @@ import { Button } from "@/components/ui/button";
 import { UserSettings } from "@/lib/schemas";
 import { showError } from "@/lib/toast";
 
-// Helper function to mask ENV API keys (move or duplicate if needed elsewhere)
+// Helper function to mask API keys
 const maskEnvApiKey = (key: string | undefined): string => {
-  if (!key) return "Not Set";
+  if (!key) return "****";
   if (key.length < 8) return "****";
   return `${key.substring(0, 4)}...${key.substring(key.length - 4)}`;
 };
@@ -51,7 +51,6 @@ export function ApiKeyConfiguration({
   isDyad,
   updateSettings,
 }: ApiKeyConfigurationProps) {
-  // Special handling for Azure OpenAI which requires environment variables
   if (provider === "azure") {
     return (
       <AzureConfiguration
@@ -61,7 +60,7 @@ export function ApiKeyConfiguration({
       />
     );
   }
-  // Special handling for Google Vertex AI which uses service account credentials
+
   if (provider === "vertex") {
     return <VertexConfiguration />;
   }
@@ -73,18 +72,21 @@ export function ApiKeyConfiguration({
     !!userApiKey &&
     !userApiKey.startsWith("Invalid Key") &&
     userApiKey !== "Not Set";
+
   const hasEnvKey = !!envApiKey;
 
   const activeKeySource = isValidUserKey
     ? "settings"
     : hasEnvKey
-      ? "env"
-      : "none";
+    ? "env"
+    : "none";
 
-  const defaultAccordionValue = [];
+  const defaultAccordionValue: string[] = [];
+
   if (isValidUserKey || !hasEnvKey) {
     defaultAccordionValue.push("settings-key");
   }
+
   if (!isDyad && hasEnvKey) {
     defaultAccordionValue.push("env-key");
   }
@@ -102,12 +104,15 @@ export function ApiKeyConfiguration({
         <AccordionTrigger className="text-lg font-medium hover:no-underline cursor-pointer">
           API Key from Settings
         </AccordionTrigger>
+
         <AccordionContent className="pt-4 ">
           {isValidUserKey && (
             <Alert variant="default" className="mb-4">
               <KeyRound className="h-4 w-4" />
+
               <AlertTitle className="flex justify-between items-center">
                 <span>Current Key (Settings)</span>
+
                 <Button
                   variant="destructive"
                   size="sm"
@@ -119,8 +124,13 @@ export function ApiKeyConfiguration({
                   {isSaving ? "Deleting..." : "Delete"}
                 </Button>
               </AlertTitle>
+
               <AlertDescription>
-                <p className="font-mono text-sm">{userApiKey}</p>
+                {/* ✅ FIXED: masked API key */}
+                <p className="font-mono text-sm">
+                  {maskEnvApiKey(userApiKey)}
+                </p>
+
                 {activeKeySource === "settings" && (
                   <p className="text-xs text-green-600 dark:text-green-400 mt-1">
                     This key is currently active.
@@ -137,6 +147,7 @@ export function ApiKeyConfiguration({
             >
               {isValidUserKey ? "Update" : "Set"} {providerDisplayName} API Key
             </label>
+
             <div className="flex items-start space-x-2">
               <Input
                 id="apiKeyInput"
@@ -145,6 +156,7 @@ export function ApiKeyConfiguration({
                 placeholder={`Enter new ${providerDisplayName} API Key here`}
                 className={`flex-grow ${saveError ? "border-red-500" : ""}`}
               />
+
               <Button
                 onClick={async () => {
                   try {
@@ -173,10 +185,13 @@ export function ApiKeyConfiguration({
                 {isSaving ? "Saving..." : "Save Key"}
               </Button>
             </div>
-            {saveError && <p className="text-xs text-red-600">{saveError}</p>}
+
+            {saveError && (
+              <p className="text-xs text-red-600">{saveError}</p>
+            )}
+
             <p className="text-xs text-gray-500 dark:text-gray-400">
-              Setting a key here will override the environment variable (if
-              set).
+              Setting a key here will override the environment variable (if set).
             </p>
           </div>
         </AccordionContent>
@@ -190,20 +205,27 @@ export function ApiKeyConfiguration({
           <AccordionTrigger className="text-lg font-medium hover:no-underline cursor-pointer">
             API Key from Environment Variable
           </AccordionTrigger>
+
           <AccordionContent className="pt-4">
             {hasEnvKey ? (
               <Alert variant="default">
                 <KeyRound className="h-4 w-4" />
-                <AlertTitle>Environment Variable Key ({envVarName})</AlertTitle>
+
+                <AlertTitle>
+                  Environment Variable Key ({envVarName})
+                </AlertTitle>
+
                 <AlertDescription>
                   <p className="font-mono text-sm">
                     {maskEnvApiKey(envApiKey)}
                   </p>
+
                   {activeKeySource === "env" && (
                     <p className="text-xs text-green-600 dark:text-green-400 mt-1">
                       This key is currently active (no settings key set).
                     </p>
                   )}
+
                   {activeKeySource === "settings" && (
                     <p className="text-xs text-yellow-600 dark:text-yellow-400 mt-1">
                       This key is currently being overridden by the key set in
@@ -215,7 +237,9 @@ export function ApiKeyConfiguration({
             ) : (
               <Alert variant="default">
                 <Info className="h-4 w-4" />
+
                 <AlertTitle>Environment Variable Not Set</AlertTitle>
+
                 <AlertDescription>
                   The{" "}
                   <code className="font-mono bg-gray-100 dark:bg-gray-800 px-1 rounded text-xs">
@@ -225,10 +249,11 @@ export function ApiKeyConfiguration({
                 </AlertDescription>
               </Alert>
             )}
+
             <p className="text-xs text-gray-500 dark:text-gray-400 mt-3">
-              This key is set outside the application. If present, it will be
-              used only if no key is configured in the Settings section above.
-              Requires app restart to detect changes.
+              This key is set outside the application. If present, it will be used
+              only if no key is configured in the Settings section above. Requires
+              app restart to detect changes.
             </p>
           </AccordionContent>
         </AccordionItem>


### PR DESCRIPTION
### Summary

Fixes #3199: API keys were visible in plain text in the settings UI.

### Changes

* Masked API key display using existing helper function (`maskEnvApiKey`)
* Ensured consistency with environment variable key display

### Impact

* Prevents accidental exposure of sensitive API keys
* Improves security and user privacy

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/3212" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
