### PR TITLE
Exclude Capacitor sync output from codebase context

### DIFF
--- a/src/__tests__/codebase.test.ts
+++ b/src/__tests__/codebase.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { execFile } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import type { AppChatContext } from "../lib/schemas";
+
+vi.mock("electron-log", () => ({
+  default: {
+    scope: () => ({
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      log: vi.fn(),
+      warn: vi.fn(),
+    }),
+  },
+}));
+
+let mockSettings = {
+  enableNativeGit: true,
+  enableDyadPro: false,
+  enableProSmartFilesContextMode: false,
+};
+
+vi.mock("@/main/settings", () => ({
+  readSettings: vi.fn(() => mockSettings),
+}));
+
+import { extractCodebase } from "../utils/codebase";
+
+const execFileAsync = promisify(execFile);
+const EMPTY_CHAT_CONTEXT: AppChatContext = {
+  contextPaths: [],
+  smartContextAutoIncludes: [],
+};
+
+async function runGit(repoDir: string, args: string[]): Promise<void> {
+  await execFileAsync("git", args, { cwd: repoDir });
+}
+
+async function createCapacitorLikeRepo(): Promise<string> {
+  const repoDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "dyad-"));
+
+  await runGit(repoDir, ["init"]);
+
+  await fs.promises.mkdir(path.join(repoDir, "src"), { recursive: true });
+  await fs.promises.mkdir(
+    path.join(repoDir, "android", "app", "src", "main", "java", "com", "app"),
+    { recursive: true },
+  );
+  await fs.promises.mkdir(
+    path.join(repoDir, "android", "app", "src", "main", "assets", "public"),
+    { recursive: true },
+  );
+  await fs.promises.mkdir(
+    path.join(repoDir, "ios", "App", "App", "public", "assets"),
+    { recursive: true },
+  );
+  await fs.promises.mkdir(path.join(repoDir, "ios", "App", "App"), {
+    recursive: true,
+  });
+
+  await fs.promises.writeFile(
+    path.join(repoDir, "src", "main.ts"),
+    "export const app = true;\n",
+  );
+  await fs.promises.writeFile(
+    path.join(
+      repoDir,
+      "android",
+      "app",
+      "src",
+      "main",
+      "java",
+      "com",
+      "app",
+      "MainActivity.java",
+    ),
+    "class MainActivity {}\n",
+  );
+  await fs.promises.writeFile(
+    path.join(repoDir, "ios", "App", "App", "AppDelegate.swift"),
+    "final class AppDelegate {}\n",
+  );
+  await fs.promises.writeFile(
+    path.join(
+      repoDir,
+      "android",
+      "app",
+      "src",
+      "main",
+      "assets",
+      "public",
+      "bundle.js",
+    ),
+    "console.log('android bundle');\n",
+  );
+  await fs.promises.writeFile(
+    path.join(repoDir, "ios", "App", "App", "public", "assets", "bundle.js"),
+    "console.log('ios bundle');\n",
+  );
+  await fs.promises.writeFile(
+    path.join(
+      repoDir,
+      "android",
+      "app",
+      "src",
+      "main",
+      "assets",
+      "public",
+      ".gitignore",
+    ),
+    "*\n!.gitignore\n",
+  );
+  await fs.promises.writeFile(
+    path.join(repoDir, "ios", "App", "App", "public", ".gitignore"),
+    "*\n!.gitignore\n",
+  );
+
+  return repoDir;
+}
+
+describe("extractCodebase", () => {
+  let repoDir: string | undefined;
+
+  afterEach(async () => {
+    mockSettings = {
+      enableNativeGit: true,
+      enableDyadPro: false,
+      enableProSmartFilesContextMode: false,
+    };
+
+    if (repoDir) {
+      await fs.promises.rm(repoDir, { recursive: true, force: true });
+      repoDir = undefined;
+    }
+  });
+
+  it.each([true, false])(
+    "skips generated Capacitor sync output when enableNativeGit=%s",
+    async (enableNativeGit) => {
+      repoDir = await createCapacitorLikeRepo();
+      mockSettings = {
+        ...mockSettings,
+        enableNativeGit,
+      };
+
+      const { files } = await extractCodebase({
+        appPath: repoDir,
+        chatContext: EMPTY_CHAT_CONTEXT,
+      });
+
+      const filePaths = files.map((file) => file.path);
+
+      expect(filePaths).toContain("src/main.ts");
+      expect(filePaths).toContain(
+        "android/app/src/main/java/com/app/MainActivity.java",
+      );
+      expect(filePaths).toContain("ios/App/App/AppDelegate.swift");
+      expect(filePaths).not.toContain(
+        "android/app/src/main/assets/public/bundle.js",
+      );
+      expect(filePaths).not.toContain("ios/App/App/public/assets/bundle.js");
+      expect(
+        filePaths.some((filePath) =>
+          filePath.startsWith("android/app/src/main/assets/public/"),
+        ),
+      ).toBe(false);
+      expect(
+        filePaths.some((filePath) =>
+          filePath.startsWith("ios/App/App/public/"),
+        ),
+      ).toBe(false);
+    },
+  );
+});

--- a/src/utils/codebase.ts
+++ b/src/utils/codebase.ts
@@ -65,6 +65,16 @@ const EXCLUDED_DIRS = [
   "venv",
 ];
 
+// Capacitor sync copies the built web app into native project folders.
+// These are generated artifacts and can massively inflate token usage.
+//
+// ex: https://github.com/dyad-sh/dyad/issues/1149
+const EXCLUDED_PATH_PREFIXES = [
+  "android/app/src/main/assets/public",
+  "ios/App/App/public",
+  "ios/App/public",
+];
+
 // Files to always exclude
 const EXCLUDED_FILES = ["pnpm-lock.yaml", "package-lock.json"];
 
@@ -118,6 +128,19 @@ const fileContentCache = new Map<string, FileCache>();
 const gitIgnoreCache = new Map<string, boolean>();
 // Map to store .gitignore file paths and their modification times
 const gitIgnoreMtimes = new Map<string, number>();
+
+function normalizeRelativePath(relativePath: string): string {
+  return relativePath.split(path.sep).join("/");
+}
+
+function isExcludedPath(relativePath: string): boolean {
+  const normalizedPath = normalizeRelativePath(relativePath);
+  return EXCLUDED_PATH_PREFIXES.some(
+    (excludedPath) =>
+      normalizedPath === excludedPath ||
+      normalizedPath.startsWith(`${excludedPath}/`),
+  );
+}
 
 /**
  * Check if a path should be ignored based on git ignore rules. Uses isomorphic-git
@@ -276,7 +299,12 @@ async function collectFilesNativeGit(dir: string): Promise<string[]> {
       files.map(async (file) => {
         try {
           const stats = await fsAsync.lstat(file);
-          if (!stats.isFile() || stats.size > MAX_FILE_SIZE) {
+          const relativePath = path.relative(dir, file);
+          if (
+            !stats.isFile() ||
+            stats.size > MAX_FILE_SIZE ||
+            isExcludedPath(relativePath)
+          ) {
             return "";
           }
           return file;
@@ -314,9 +342,14 @@ async function collectFilesIsoGit(
     // Process entries concurrently
     const promises = entries.map(async (entry) => {
       const fullPath = path.join(dir, entry.name);
+      const relativePath = path.relative(baseDir, fullPath);
 
       // Skip excluded directories
       if (entry.isDirectory() && EXCLUDED_DIRS.includes(entry.name)) {
+        return;
+      }
+
+      if (isExcludedPath(relativePath)) {
         return;
       }
 
@@ -529,6 +562,8 @@ export async function extractCodebase({
       }
     }
   }
+
+  files = files.filter((file) => !isExcludedPath(path.relative(appPath, file)));
 
   // Collect files from contextPaths and smartContextAutoIncludes
   const { contextPaths, smartContextAutoIncludes, excludePaths } = chatContext;


### PR DESCRIPTION
## Summary
- exclude Capacitor-synced web bundle copies from codebase extraction
- keep actual Android and iOS source files available in context
- add regression coverage for both native Git and isomorphic-git collection paths

## Why
Capacitor sync copies the built web app into native folders like `android/app/src/main/assets/public` and `ios/App/App/public`. Those files are generated artifacts and can drastically inflate token usage in Dyad after mobile syncs.

Addresses #1149.

## Testing
- npm test -- src/__tests__/git_utils.test.ts src/__tests__/codebase.test.ts
- npm run lint
- npm run fmt:check
- npm run ts
