### PR TITLE
fix: make refactor button tooltip show full file path

### DIFF
--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -1014,7 +1014,7 @@ function SuggestionButton({
 }: {
   onClick: () => void;
   children: React.ReactNode;
-  tooltipText: string;
+  tooltipText: string | string[];
 }) {
   const { isStreaming } = useStreamChat();
   return (
@@ -1031,7 +1031,11 @@ function SuggestionButton({
       >
         {children}
       </TooltipTrigger>
-      <TooltipContent>{tooltipText}</TooltipContent>
+      <TooltipContent>
+        {Array.isArray(tooltipText)
+          ? tooltipText.map((line) => <div key={line}>{line}</div>)
+          : tooltipText}
+      </TooltipContent>
     </Tooltip>
   );
 }
@@ -1065,7 +1069,10 @@ function RefactorFileButton({ path }: { path: string }) {
     });
   };
   return (
-    <SuggestionButton onClick={onClick} tooltipText={t("refactorDescription")}>
+    <SuggestionButton
+      onClick={onClick}
+      tooltipText={[t("refactorDescription"), path]}
+    >
       <span className="max-w-[180px] overflow-hidden whitespace-nowrap text-ellipsis">
         {t("refactorFile", { path: path.split("/").slice(-2).join("/") })}
       </span>


### PR DESCRIPTION
Closes #3185.

For context, a while back I had opened #2511 to close #1272. For some reason the change got reverted, though, which I think is why #3185 was opened.

This PR makes the essentially the same change as #2511, so it has the "refactor" button tooltip show the full path of the file it's going to refactor. #2511 also changed the width of the button, but I've changed my mind on that.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/3237" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
