### PR TITLE
Make proxy check for Next.js more conservative

### DIFF
--- a/src/prompts/neon_prompt.ts
+++ b/src/prompts/neon_prompt.ts
@@ -124,7 +124,7 @@ function getNextJsNeonPrompt(
   nextjsMajorVersion: number | null,
   isLocalAgentMode: boolean,
 ): string {
-  const supportsProxy = nextjsMajorVersion === null || nextjsMajorVersion >= 16;
+  const supportsProxy = nextjsMajorVersion !== null && nextjsMajorVersion >= 16;
 
   const authDecisionSteps = isLocalAgentMode
     ? `4. **If** user needs auth APIs or sessions → call \`read_guide\` with guide="add-authentication"${emailVerificationEnabled ? `, then call \`read_guide\` with guide="add-email-verification"` : ""}, then follow the Neon Auth API path.


### PR DESCRIPTION
@azizmejri1 - I've defaulted to assuming not proxy supported if next.js major version isn't properly detected because it looks like middleware is only deprecated (and not yet removed) in next.js 16: https://nextjs.org/docs/app/api-reference/file-conventions/proxy - this shouldn't affect most apps, but i think it's better to be more conservative here.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/3242" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
