### PR TITLE
Neon: banner for custom email provider in production

### DIFF
--- a/src/components/NeonConnector.tsx
+++ b/src/components/NeonConnector.tsx
@@ -25,7 +25,14 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { useLoadApp } from "@/hooks/useLoadApp";
 import { useDeepLink } from "@/contexts/DeepLinkContext";
 import { Switch } from "@/components/ui/switch";
-import { ExternalLink, Loader2, Plus, RefreshCw, Trash2 } from "lucide-react";
+import {
+  ExternalLink,
+  Info,
+  Loader2,
+  Plus,
+  RefreshCw,
+  Trash2,
+} from "lucide-react";
 import { useTheme } from "@/contexts/ThemeContext";
 import { useNeon } from "@/hooks/useNeon";
 import { useQueryClient } from "@tanstack/react-query";
@@ -506,6 +513,21 @@ export function NeonConnector({ appId }: { appId: number }) {
                 <p className="text-xs text-muted-foreground pl-9">
                   {t("integrations.neon.emailVerificationHelp")}
                 </p>
+                <button
+                  type="button"
+                  onClick={() =>
+                    ipc.system.openExternalUrl(
+                      "https://neon.com/docs/auth/production-checklist#email-provider",
+                    )
+                  }
+                  className="mt-2 w-full flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-800 hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-900/20 dark:text-blue-200 dark:hover:bg-blue-900/30 transition-colors"
+                >
+                  <Info className="h-4 w-4 flex-shrink-0 text-blue-600 dark:text-blue-400" />
+                  <span className="flex-1 text-left">
+                    {t("integrations.neon.customEmailProviderHint")}
+                  </span>
+                  <ExternalLink className="h-3.5 w-3.5 flex-shrink-0 opacity-70" />
+                </button>
               </div>
             )}
 

--- a/src/i18n/locales/en/home.json
+++ b/src/i18n/locales/en/home.json
@@ -594,6 +594,7 @@
       "errorLoadingBranches": "Failed to load branches: {{message}}",
       "noBranchesFound": "No branches were found for this Neon project yet.",
       "emailVerificationHelp": "When enabled, users must verify their email address before they can sign in to your app.",
+      "customEmailProviderHint": "For production, set up a custom email provider",
       "openInConsole": "Open in Neon Console",
       "completingSignIn": "Complete sign-in in your browser…",
       "projectDisconnected": "Project disconnected successfully",

--- a/src/i18n/locales/pt-BR/home.json
+++ b/src/i18n/locales/pt-BR/home.json
@@ -568,6 +568,7 @@
       "emailVerificationDisabled": "Verificação de e-mail desativada",
       "emailVerificationEnabled": "Verificação de e-mail ativada",
       "emailVerificationHelp": "Quando ativada, os usuários devem verificar seu endereço de e-mail antes de poderem fazer login no seu app.",
+      "customEmailProviderHint": "Para produção, configure um provedor de e-mail personalizado",
       "envUpdated": "DATABASE_URL atualizado em .env.local.",
       "errorLoadingBranches": "Falha ao carregar branches: {{message}}",
       "errorLoadingProjects": "Falha ao carregar projetos: {{message}}",

--- a/src/i18n/locales/zh-CN/home.json
+++ b/src/i18n/locales/zh-CN/home.json
@@ -569,6 +569,7 @@
       "emailVerificationDisabled": "邮箱验证已禁用",
       "emailVerificationEnabled": "邮箱验证已启用",
       "emailVerificationHelp": "启用后，用户必须验证其电子邮件地址才能登录您的应用。",
+      "customEmailProviderHint": "生产环境请配置自定义邮件服务商",
       "envUpdated": "DATABASE_URL 已在 .env.local 中更新。",
       "errorLoadingBranches": "加载分支失败：{{message}}",
       "errorLoadingProjects": "加载项目失败：{{message}}",


### PR DESCRIPTION
@azizmejri1 - I added an info banner with a link to https://neon.com/docs/auth/production-checklist#email-provider under the email verification toggle so users know to not rely on it for production

<img width="506" height="377" alt="image" src="https://github.com/user-attachments/assets/7f403de7-de2f-462e-84c0-8eb0779af87a" />

## Summary
- Add a compact, clickable info banner below the Neon email verification toggle that recommends configuring a custom email provider for production.
- Link opens the Neon Auth production checklist (email provider section).
- Add `integrations.neon.customEmailProviderHint` strings for English, Portuguese (Brazil), and Chinese (Simplified).

## Test plan
- Open Neon integration for a connected Next.js app and confirm the banner appears under email verification with correct copy.
- Click the banner and confirm the Neon docs open in the browser.
