### PR TITLE
ci: allowlist bot authors for e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
           fi
           echo "Author: $AUTHOR"
           case "$AUTHOR" in
-            wwwillchen|keppo-bot|keppo-bot[bot]|dyad-assistant|azizmejri1)
+            wwwillchen|keppo-bot|keppo-bot\[bot\]|dyad-assistant|azizmejri1|RyanGroch)
               echo "is_privileged=true" >> $GITHUB_OUTPUT
               ;;
             *)
@@ -99,7 +99,7 @@ jobs:
       # The "image" field is a JSON-encoded array string so that fromJSON() in runs-on
       # can produce the correct label(s) for both GitHub-hosted and self-hosted runners.
       #
-      # Privileged authors (wwwillchen, keppo-bot/keppo-bot[bot], dyad-assistant, azizmejri1):
+      # Privileged authors (wwwillchen, keppo-bot/keppo-bot[bot], dyad-assistant, azizmejri1, RyanGroch):
       #   - Self-hosted macOS ARM64 runners, no Windows, no sharding.
       #
       #   build (macOS self-hosted) ──> e2e-tests (macOS self-hosted, shard 1/1)

--- a/rules/git-workflow.md
+++ b/rules/git-workflow.md
@@ -65,6 +65,10 @@ When running GitHub Actions with `pull_request_target` on cross-repo PRs (from f
 
 Actions performed using the default `GITHUB_TOKEN` (including labels added by `github-actions[bot]` via `actions/github-script`) do **not** trigger `pull_request_target` or other workflow events. This is a GitHub limitation to prevent infinite loops. If one workflow adds a label that should trigger another workflow (e.g., `label-rebase-prs.yml` adds `cc:rebase` to trigger `claude-rebase.yml`), the label-adding step must use a **PAT** or **GitHub App token** (e.g., `PR_RW_GITHUB_TOKEN`) instead of `GITHUB_TOKEN`.
 
+## Bash `case` allowlists in workflows
+
+When matching GitHub bot logins in Bash `case` patterns, escape literal square brackets. For example, `keppo-bot[bot]` is parsed as a character class and does not match the login; use `keppo-bot\[bot\]`.
+
 ## GitHub API calls with special characters
 
 When using `gh api` to post comments or replies containing backticks, `$()`, or other shell metacharacters, the security hook will block the command. Instead of passing the body inline with `-f body="..."`, write a JSON file and use `--input`:


### PR DESCRIPTION
## Summary
- Escape the keppo-bot[bot] Bash case pattern so it matches the literal bot login.
- Add RyanGroch to the privileged CI author allow-list for E2E test routing.

## Test plan
- npm run fmt && npm run lint:fix && npm run ts
- npm test

#skip-bugbot
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/3248" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
