### PR TITLE
 Support Caveman Mode

### DIFF
--- a/e2e-tests/caveman_mode.spec.ts
+++ b/e2e-tests/caveman_mode.spec.ts
@@ -1,0 +1,37 @@
+import { expect } from "@playwright/test";
+import fs from "fs";
+import { test } from "./helpers/test_helper";
+
+test("caveman mode - ultra injects system prompt", async ({ po }) => {
+  await po.setUpDyadPro();
+
+  await po.navigation.goToSettingsTab();
+  await po.page.getByRole("combobox", { name: /Caveman Mode/i }).click();
+
+  const ultraOption = po.page.getByRole("option", { name: /Ultra/i });
+  await ultraOption.waitFor({ state: "visible" });
+  await ultraOption.click();
+
+  await expect(
+    po.page.getByRole("combobox", { name: /Caveman Mode/i }),
+  ).toHaveText(/Ultra/i);
+
+  await po.page.getByText("Go Back").click();
+  await po.sendPrompt("[dump] caveman mode request");
+
+  await expect(po.page.getByTestId("messages-list")).toContainText(
+    "[[dyad-dump-path=",
+  );
+
+  const messagesListText = await po.page
+    .getByTestId("messages-list")
+    .textContent();
+  const dumpMatches = [
+    ...(messagesListText?.matchAll(/\[\[dyad-dump-path=([^\]]+)\]\]/g) ?? []),
+  ];
+  expect(dumpMatches.length).toBeGreaterThan(0);
+
+  const rawDump = fs.readFileSync(dumpMatches.at(-1)![1], "utf-8");
+
+  expect(rawDump).toMatch(/# CAVEMAN MODE: ULTRA/i);
+});

--- a/src/__tests__/readSettings.test.ts
+++ b/src/__tests__/readSettings.test.ts
@@ -67,6 +67,7 @@ describe("readSettings", () => {
       expect(scrubSettings(result)).toMatchInlineSnapshot(`
         {
           "autoExpandPreviewPanel": true,
+          "cavemanMode": "off",
           "enableAutoFixProblems": false,
           "enableAutoUpdate": true,
           "enableContextCompaction": true,
@@ -459,6 +460,7 @@ describe("readSettings", () => {
       expect(scrubSettings(result)).toMatchInlineSnapshot(`
         {
           "autoExpandPreviewPanel": true,
+          "cavemanMode": "off",
           "enableAutoFixProblems": false,
           "enableAutoUpdate": true,
           "enableContextCompaction": true,

--- a/src/components/CavemanModeSelector.tsx
+++ b/src/components/CavemanModeSelector.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { useSettings } from "@/hooks/useSettings";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useTranslation } from "react-i18next";
+import { Label } from "@/components/ui/label";
+import { CavemanMode } from "@/lib/schemas";
+
+interface OptionInfo {
+  value: CavemanMode;
+  labelKey: string;
+  descriptionKey: string;
+}
+
+const options: OptionInfo[] = [
+  {
+    value: "off",
+    labelKey: "ai.cavemanOff",
+    descriptionKey: "ai.cavemanOffDescription",
+  },
+  {
+    value: "lite",
+    labelKey: "ai.cavemanLite",
+    descriptionKey: "ai.cavemanLiteDescription",
+  },
+  {
+    value: "full",
+    labelKey: "ai.cavemanFull",
+    descriptionKey: "ai.cavemanFullDescription",
+  },
+  {
+    value: "ultra",
+    labelKey: "ai.cavemanUltra",
+    descriptionKey: "ai.cavemanUltraDescription",
+  },
+];
+
+export const CavemanModeSelector: React.FC = () => {
+  const { settings, updateSettings } = useSettings();
+  const { t } = useTranslation("settings");
+
+  const handleValueChange = (value: string) => {
+    updateSettings({ cavemanMode: value as CavemanMode });
+  };
+
+  const currentValue = settings?.cavemanMode || "off";
+  const currentOption =
+    options.find((opt) => opt.value === currentValue) || options[0];
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center gap-4">
+        <Label
+          htmlFor="caveman-mode"
+          className="text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
+          {t("ai.cavemanMode")}
+        </Label>
+        <Select
+          value={currentValue}
+          onValueChange={(v) => v && handleValueChange(v)}
+        >
+          <SelectTrigger className="w-[180px]" id="caveman-mode">
+            <SelectValue placeholder={t("ai.selectCavemanMode")} />
+          </SelectTrigger>
+          <SelectContent>
+            {options.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {t(option.labelKey as any)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="text-sm text-gray-500 dark:text-gray-400">
+        {t(currentOption.descriptionKey as any)}
+      </div>
+    </div>
+  );
+};

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -89,7 +89,17 @@
     "apiKeyEmpty": "API Key cannot be empty.",
     "errorTogglingPro": "Error toggling Dyad Pro: {{error}}",
     "failedSaveApiKey": "Failed to save API key.",
-    "failedDeleteApiKey": "Failed to delete API key."
+    "failedDeleteApiKey": "Failed to delete API key.",
+    "cavemanMode": "Caveman Mode",
+    "selectCavemanMode": "Select caveman mode",
+    "cavemanOff": "Off",
+    "cavemanOffDescription": "Default, standard responses with full context and detail.",
+    "cavemanLite": "Lite",
+    "cavemanLiteDescription": "Professional & Concise. Cuts the fluff while keeping the response clear and respectful.",
+    "cavemanFull": "Full",
+    "cavemanFullDescription": "Direct & Fast. No pleasantries. Just the facts and code you need, delivered instantly.",
+    "cavemanUltra": "Ultra",
+    "cavemanUltraDescription": "Maximum token savings. Extreme brevity using keywords and short phrases."
   },
   "telemetry": {
     "title": "Telemetry",

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -21,6 +21,7 @@ import type { SmartContextMode } from "../../lib/schemas";
 import {
   constructSystemPrompt,
   readAiRules,
+  injectCavemanPrompt,
 } from "../../prompts/system_prompt";
 import { getThemePromptById } from "../utils/theme_utils";
 import {
@@ -792,6 +793,7 @@ ${componentSnippet}
           enableTurboEditsV2: isTurboEditsV2Enabled(settings),
           themePrompt,
           basicAgentMode: isBasicAgentMode(settings),
+          cavemanMode: settings.cavemanMode,
         });
 
         // Add information about mentioned apps if any
@@ -806,7 +808,10 @@ ${componentSnippet}
         const isSecurityReviewIntent =
           req.prompt.startsWith("/security-review");
         if (isSecurityReviewIntent) {
-          systemPrompt = SECURITY_REVIEW_SYSTEM_PROMPT;
+          systemPrompt = injectCavemanPrompt(
+            SECURITY_REVIEW_SYSTEM_PROMPT,
+            settings.cavemanMode,
+          );
           try {
             const appPath = getDyadAppPath(updatedChat.app.path);
             const rulesPath = path.join(appPath, "SECURITY_RULES.md");
@@ -869,7 +874,10 @@ ${componentSnippet}
           "Summarize from chat-id=",
         );
         if (isSummarizeIntent) {
-          systemPrompt = SUMMARIZE_CHAT_SYSTEM_PROMPT;
+          systemPrompt = injectCavemanPrompt(
+            SUMMARIZE_CHAT_SYSTEM_PROMPT,
+            settings.cavemanMode,
+          );
         }
 
         // Update the system prompt for images if there are image attachments
@@ -1188,6 +1196,7 @@ This conversation includes one or more image attachments. When the user uploads 
             enableTurboEditsV2: false,
             themePrompt,
             readOnly: true,
+            cavemanMode: settings.cavemanMode,
           });
 
           // Return value indicates success/failure for quota tracking.
@@ -1229,6 +1238,7 @@ This conversation includes one or more image attachments. When the user uploads 
             chatMode: "plan",
             enableTurboEditsV2: false,
             themePrompt,
+            cavemanMode: settings.cavemanMode,
           });
 
           await handleLocalAgentStream(event, req, abortController, {
@@ -1326,6 +1336,7 @@ This conversation includes one or more image attachments. When the user uploads 
                 ),
                 chatMode: "build",
                 enableTurboEditsV2: false,
+                cavemanMode: settings.cavemanMode,
               }),
               files: files,
               dyadDisableFiles: true,

--- a/src/ipc/handlers/token_count_handlers.ts
+++ b/src/ipc/handlers/token_count_handlers.ts
@@ -86,6 +86,7 @@ export function registerTokenCountHandlers() {
           selectedChatMode === "local-agent" ? "build" : selectedChatMode,
         enableTurboEditsV2: isTurboEditsV2Enabled(settings),
         themePrompt,
+        cavemanMode: settings.cavemanMode,
       });
       let supabaseContext = "";
 

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -281,6 +281,9 @@ export type SmartContextMode = z.infer<typeof SmartContextModeSchema>;
 export const AgentToolConsentSchema = z.enum(["ask", "always", "never"]);
 export type AgentToolConsent = z.infer<typeof AgentToolConsentSchema>;
 
+export const CavemanModeSchema = z.enum(["off", "lite", "full", "ultra"]);
+export type CavemanMode = z.infer<typeof CavemanModeSchema>;
+
 /**
  * Base fields shared between StoredUserSettings and UserSettings
  */
@@ -358,6 +361,7 @@ const BaseUserSettingsFields = {
   enableContextCompaction: z.boolean().optional(),
   skipNotificationBanner: z.boolean().optional(),
   enableSelectAppFromHomeChatInput: z.boolean().optional(),
+  cavemanMode: CavemanModeSchema.optional(),
 };
 
 /**

--- a/src/lib/settingsSearchIndex.ts
+++ b/src/lib/settingsSearchIndex.ts
@@ -40,6 +40,7 @@ export const SETTING_IDS = {
   enableSelectAppFromHomeChatInput:
     "setting-enable-select-app-from-home-chat-input",
   reset: "setting-reset",
+  cavemanMode: "setting-caveman-mode",
 } as const;
 
 type SearchableSettingItem = {
@@ -210,6 +211,14 @@ export const SETTINGS_SEARCH_INDEX: SearchableSettingItem[] = [
       "window",
       "memory",
     ],
+    sectionId: SECTION_IDS.ai,
+    sectionLabel: "AI",
+  },
+  {
+    id: SETTING_IDS.cavemanMode,
+    label: "Caveman Mode",
+    description: "Compresses AI responses to be more terse and concise",
+    keywords: ["caveman", "mode", "terse", "concise", "ai"],
     sectionId: SECTION_IDS.ai,
     sectionLabel: "AI",
   },

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -48,6 +48,7 @@ const DEFAULT_SETTINGS: UserSettings = {
   enableNativeGit: true,
   autoExpandPreviewPanel: true,
   enableContextCompaction: true,
+  cavemanMode: "off",
 };
 
 const SETTINGS_FILE = "user-settings.json";

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -9,6 +9,7 @@ import { TelemetrySwitch } from "@/components/TelemetrySwitch";
 import { MaxChatTurnsSelector } from "@/components/MaxChatTurnsSelector";
 import { MaxToolCallStepsSelector } from "@/components/MaxToolCallStepsSelector";
 import { ThinkingBudgetSelector } from "@/components/ThinkingBudgetSelector";
+import { CavemanModeSelector } from "@/components/CavemanModeSelector";
 import { useSettings } from "@/hooks/useSettings";
 import { useAppVersion } from "@/hooks/useAppVersion";
 import { Button } from "@/components/ui/button";
@@ -463,6 +464,9 @@ export function AISettings() {
           Automatically compact long conversations to stay within context
           limits. Original messages are preserved in the app data directory.
         </div>
+      </div>
+      <div id={SETTING_IDS.cavemanMode} className="mt-4">
+        <CavemanModeSelector />
       </div>
     </div>
   );

--- a/src/prompts/system_prompt.ts
+++ b/src/prompts/system_prompt.ts
@@ -4,6 +4,7 @@ import log from "electron-log";
 import { TURBO_EDITS_V2_SYSTEM_PROMPT } from "../pro/main/prompts/turbo_edits_v2_prompt";
 import { constructLocalAgentPrompt } from "./local_agent_prompt";
 import { constructPlanModePrompt } from "./plan_mode_prompt";
+import { CavemanMode } from "@/lib/schemas";
 
 const logger = log.scope("system_prompt");
 
@@ -506,6 +507,61 @@ When tools are used, provide a brief human-readable summary of the information g
 
 When tools are not used, simply state: **"Ok, looks like I don't need any tools, I can start building."**
 `;
+//caveman prompts
+const CAVEMAN_PROMPTS: Record<"lite" | "full" | "ultra", string> = {
+  lite: `# CAVEMAN MODE: LITE
+No filler. No hedging. Keep articles + full sentences. Professional but tight.
+DROP: just/really/basically/actually/simply/essentially/generally
+DROP: "sure", "certainly", "of course", "happy to", "I'd recommend"
+DROP: "it might be worth", "you could consider", "in order to", "make sure to"
+Keep: articles (a/an/the), full grammar, complete sentences.
+Technical terms exact. Code blocks unchanged. Errors quoted exact.
+Pattern: [thing] [action] [reason]. [next step].`,
+
+  full: `# CAVEMAN MODE: FULL
+Terse like smart caveman. Technical substance stay. Fluff die.
+DROP: articles (a/an/the), filler (just/really/basically/actually/simply),
+pleasantries (sure/certainly/of course/happy to/I'd be happy to),
+hedging (might/could consider/it's worth noting/perhaps/maybe).
+Fragments OK. Short synonyms: big not "extensive", fix not "implement a solution for",
+use not "utilize", because not "the reason is because".
+Drop "you should/make sure to/remember to" — state the action directly.
+Technical terms exact. Code blocks unchanged. Errors quoted exact.
+Pattern: [thing] [action] [reason]. [next step].
+NOT: "Sure! I'd be happy to help. The issue you're experiencing is likely caused by..."
+YES: "Bug in auth middleware. Token expiry check use < not <=. Fix:"
+AUTO-CLARITY: security warnings, irreversible/destructive actions, multi-step sequences
+where fragment order risks misread — write those in full. Resume caveman after.`,
+
+  ultra: `# CAVEMAN MODE: ULTRA — OVERRIDES ALL OTHER STYLE INSTRUCTIONS
+Maximum compression. One word when one word enough.
+DROP: articles, conjunctions, pronouns, all filler and hedging.
+ABBREVIATE: DB/auth/config/req/res/fn/impl/ctx/env/deps
+ARROWS for causality: X → Y
+Fragments only. No intro. No outro. No follow-up question.
+Short synonyms: big/fix/use/fast/slow — never the long version.
+Technical terms exact. Code blocks unchanged. Errors quoted exact.
+Pattern: [thing] → [effect]. [fix].
+NOT: "The reason your component re-renders is that you're creating a new object reference."
+YES: "Inline obj prop → new ref → re-render. useMemo."
+AUTO-CLARITY (no exception): security warnings, irreversible/destructive actions,
+breaking changes, data migrations — write these in full plain English,
+then resume ultra. Future debuggers need the context.`,
+};
+
+/**
+ * Injects caveman mode instructions into a system prompt if enabled.
+ */
+export const injectCavemanPrompt = (
+  prompt: string,
+  cavemanMode?: CavemanMode,
+) => {
+  if (cavemanMode && cavemanMode !== "off") {
+    // Prepend for higher priority and to ensure it overrides other style instructions
+    return CAVEMAN_PROMPTS[cavemanMode] + "\n\n" + prompt;
+  }
+  return prompt;
+};
 
 export const constructSystemPrompt = ({
   aiRules,
@@ -514,6 +570,7 @@ export const constructSystemPrompt = ({
   themePrompt,
   readOnly,
   basicAgentMode,
+  cavemanMode,
 }: {
   aiRules: string | undefined;
   chatMode?: "build" | "ask" | "local-agent" | "plan";
@@ -523,16 +580,19 @@ export const constructSystemPrompt = ({
   readOnly?: boolean;
   /** If true, use basic agent mode (free tier with limited tools) */
   basicAgentMode?: boolean;
+  cavemanMode?: CavemanMode;
 }) => {
   if (chatMode === "plan") {
-    return constructPlanModePrompt(aiRules, themePrompt);
+    const planPrompt = constructPlanModePrompt(aiRules, themePrompt);
+    return injectCavemanPrompt(planPrompt, cavemanMode);
   }
 
   if (chatMode === "local-agent") {
-    return constructLocalAgentPrompt(aiRules, themePrompt, {
+    const localAgentPrompt = constructLocalAgentPrompt(aiRules, themePrompt, {
       readOnly,
       basicAgentMode,
     });
+    return injectCavemanPrompt(localAgentPrompt, cavemanMode);
   }
 
   let systemPrompt = getSystemPromptForChatMode({
@@ -549,7 +609,7 @@ export const constructSystemPrompt = ({
     systemPrompt += "\n\n" + themePrompt;
   }
 
-  return systemPrompt;
+  return injectCavemanPrompt(systemPrompt, cavemanMode);
 };
 
 export const getSystemPromptForChatMode = ({


### PR DESCRIPTION

closes #3255 
## Summary

This PR implements Caveman Mode, a new user setting that allows for significant token savings and faster response times by compressing AI responses. The feature injects specific instructions into the system prompt to force the AI into more terse and concise communication styles.

Users can select from four levels in Settings > AI Settings:

Off: Standard responses (default).
Lite: ~25% compression; professional but brief.
Full: ~50% compression; very terse, sentence fragments allowed.
Ultra: ~75% compression; maximum token saving  (caveman-style).

## implementation 
Core Logic
src/prompts/system_prompt.ts: Defined strictly typed instruction sets for Lite, Full, and Ultra modes. Introduced a centralized injectCavemanPrompt helper to handle consistent injection across all system prompt construction paths.
src/ipc/handlers/chat_stream_handlers.ts: Integrated the setting into main chat streams and expanded support to special prompts like /security-review and Summarize.
src/lib/schemas.ts & src/main/settings.ts: Added cavemanMode to the user settings schema and default state.
UI & UX
src/components/CavemanModeSelector.tsx [NEW]: Extracted the selector into a modular component for better maintainability.
src/pages/settings.tsx: Cleaned up the settings page by using the new dedicated component.
src/i18n/locales/en/settings.json: Added full localization support for labels and compression level descriptions.
src/lib/settingsSearchIndex.ts: Integrated the new setting into global search with keywords: terse, concise, brief.

## Testing
npm run e2e -- caveman_mode.spec.ts 



---
<img width="1255" height="687" alt="image" src="https://github.com/user-attachments/assets/e99f9977-15b2-4cd1-b479-59059c66f066" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/3264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
