### PR TITLE
fix: Neon migration push fails in packaged app

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -129,6 +129,12 @@ const config: ForgeConfig = {
       "node_modules/@vscode",
       "node_modules/drizzle-kit",
       "node_modules/drizzle-orm",
+      // Peer-dep driver that drizzle-kit dynamically imports for Neon
+      // migrations. Without this, packaged builds swallow the "package not
+      // found" error (drizzle-kit's introspect catches and exits 0) and
+      // silently produce no schema. We copy the whole @neondatabase scope
+      // dir so the staged resolution path matches the scope'd package name.
+      "node_modules/@neondatabase",
     ],
     // ignore: [/node_modules\/(?!(better-sqlite3|bindings|file-uri-to-path)\/)/],
   },

--- a/src/ipc/handlers/migration_handlers.ts
+++ b/src/ipc/handlers/migration_handlers.ts
@@ -121,12 +121,13 @@ export function registerMigrationHandlers() {
 
       // 8. Find the generated schema file
       const schemaOutDir = path.join(tmpDir, "schema-out");
+      const introspectDiagnostics = `drizzle-kit exit=${introspectResult.exitCode}; stdout=${introspectResult.stdout.trim() || "<empty>"}; stderr=${introspectResult.stderr.trim() || "<empty>"}`;
       let schemaFiles: string[];
       try {
         schemaFiles = await fs.readdir(schemaOutDir);
       } catch {
         throw new DyadError(
-          "drizzle-kit introspect did not generate output. Your development database may have an unsupported schema.",
+          `drizzle-kit introspect did not generate output (schema-out missing). ${introspectDiagnostics}`,
           DyadErrorKind.Internal,
         );
       }
@@ -136,7 +137,7 @@ export function registerMigrationHandlers() {
         schemaFiles.find((f) => f.endsWith(".ts") && f !== "relations.ts");
       if (!tsSchemaFile) {
         throw new DyadError(
-          "drizzle-kit introspect did not generate any schema files.",
+          `drizzle-kit introspect did not generate any schema files. schema-out contents: [${schemaFiles.join(", ") || "<empty>"}]. ${introspectDiagnostics}`,
           DyadErrorKind.Internal,
         );
       }

--- a/src/ipc/utils/migration_utils.ts
+++ b/src/ipc/utils/migration_utils.ts
@@ -35,19 +35,20 @@ export async function getProductionBranchId(
   return { branchId: prodBranch.id };
 }
 
-/**
- * Resolves the path to the drizzle-kit bin.cjs file.
- */
-export function getDrizzleKitPath(): string {
+type StagedPackage = "drizzle-kit" | "drizzle-orm" | "@neondatabase/serverless";
+
+// In packaged builds these live directly under process.resourcesPath (no
+// surrounding node_modules/), because forge's extraResource copies them
+// to the Resources root.
+function getBundledPackageDir(pkg: StagedPackage): string {
   if (!app.isPackaged) {
-    return path.join(
-      app.getAppPath(),
-      "node_modules",
-      "drizzle-kit",
-      "bin.cjs",
-    );
+    return path.join(app.getAppPath(), "node_modules", pkg);
   }
-  return path.join(process.resourcesPath, "drizzle-kit", "bin.cjs");
+  return path.join(process.resourcesPath, pkg);
+}
+
+export function getDrizzleKitPath(): string {
+  return path.join(getBundledPackageDir("drizzle-kit"), "bin.cjs");
 }
 
 /**
@@ -126,23 +127,56 @@ export async function spawnDrizzleKit({
     );
   }
 
-  const drizzleKitBin = getDrizzleKitPath();
+  // Build a node_modules/ tree so drizzle-kit's bin.cjs can resolve its
+  // peer deps via the normal upward walk. bin.cjs MUST be copied, not
+  // symlinked: Electron's utilityProcess.fork ignores --preserve-symlinks-main,
+  // so a symlinked entry point realpath's back to resourcesPath/ where the
+  // peer deps aren't reachable.
+  const nodeModulesDir = path.join(cwd, "node_modules");
+  await fs.mkdir(nodeModulesDir, { recursive: true });
 
-  // Create a node_modules symlink in the working directory so that generated
-  // schema files can resolve drizzle-orm and other dependencies through
-  // standard Node.js module resolution (walking up to find node_modules),
-  // in addition to the NODE_PATH env var set below.
-  const nodeModulesPath = app.isPackaged
-    ? process.resourcesPath
-    : path.join(app.getAppPath(), "node_modules");
-  const symlinkTarget = path.join(cwd, "node_modules");
+  const stagedDrizzleKitDir = path.join(nodeModulesDir, "drizzle-kit");
+  await fs.mkdir(stagedDrizzleKitDir, { recursive: true });
+  const srcDrizzleKitDir = getBundledPackageDir("drizzle-kit");
+  await fs.copyFile(
+    path.join(srcDrizzleKitDir, "bin.cjs"),
+    path.join(stagedDrizzleKitDir, "bin.cjs"),
+  );
+  await fs.copyFile(
+    path.join(srcDrizzleKitDir, "package.json"),
+    path.join(stagedDrizzleKitDir, "package.json"),
+  );
+  // esbuild is bundled under drizzle-kit/node_modules and is needed to
+  // compile the .ts schema during push.
   try {
-    await fs.symlink(nodeModulesPath, symlinkTarget, "junction");
-  } catch (symlinkErr) {
-    logger.warn(
-      `Failed to create node_modules symlink: ${symlinkErr}. Falling back to NODE_PATH.`,
+    await fs.symlink(
+      path.join(srcDrizzleKitDir, "node_modules"),
+      path.join(stagedDrizzleKitDir, "node_modules"),
+      "junction",
     );
+  } catch (symlinkErr) {
+    logger.warn(`Failed to stage drizzle-kit node_modules: ${symlinkErr}`);
   }
+
+  // @neondatabase/serverless is the Postgres driver drizzle-kit picks for
+  // Neon. If it can't be resolved, drizzle-kit's introspect catches the
+  // error and still exits 0 — the failure looks like "no schema produced".
+  const peerPackages: StagedPackage[] = [
+    "drizzle-orm",
+    "@neondatabase/serverless",
+  ];
+  for (const pkg of peerPackages) {
+    const stagedPath = path.join(nodeModulesDir, pkg);
+    try {
+      // Scoped packages need their @scope/ parent created first.
+      await fs.mkdir(path.dirname(stagedPath), { recursive: true });
+      await fs.symlink(getBundledPackageDir(pkg), stagedPath, "junction");
+    } catch (symlinkErr) {
+      logger.warn(`Failed to stage ${pkg} symlink: ${symlinkErr}`);
+    }
+  }
+
+  const drizzleKitBin = path.join(stagedDrizzleKitDir, "bin.cjs");
 
   return new Promise((resolve, reject) => {
     logger.info(`Running drizzle-kit: ${drizzleKitBin} ${args.join(" ")}`);
@@ -164,7 +198,7 @@ export async function spawnDrizzleKit({
             TEMP: process.env.TEMP,
             TMP: process.env.TMP,
             TMPDIR: process.env.TMPDIR,
-            NODE_PATH: nodeModulesPath,
+            NODE_PATH: nodeModulesDir,
             DRIZZLE_DATABASE_URL: connectionUri,
           }).filter(([, v]) => v !== undefined),
         ),

--- a/src/ipc/utils/migration_utils.ts
+++ b/src/ipc/utils/migration_utils.ts
@@ -47,10 +47,6 @@ function getBundledPackageDir(pkg: StagedPackage): string {
   return path.join(process.resourcesPath, pkg);
 }
 
-export function getDrizzleKitPath(): string {
-  return path.join(getBundledPackageDir("drizzle-kit"), "bin.cjs");
-}
-
 /**
  * Writes a temporary drizzle config file (.js) for introspect or push.
  */
@@ -147,7 +143,9 @@ export async function spawnDrizzleKit({
     path.join(stagedDrizzleKitDir, "package.json"),
   );
   // esbuild is bundled under drizzle-kit/node_modules and is needed to
-  // compile the .ts schema during push.
+  // compile the .ts schema during push. EEXIST is harmless — spawnDrizzleKit
+  // is called twice per request (introspect + push) against the same cwd,
+  // so the symlink may already exist from the first call.
   try {
     await fs.symlink(
       path.join(srcDrizzleKitDir, "node_modules"),
@@ -155,12 +153,19 @@ export async function spawnDrizzleKit({
       "junction",
     );
   } catch (symlinkErr) {
-    logger.warn(`Failed to stage drizzle-kit node_modules: ${symlinkErr}`);
+    if ((symlinkErr as NodeJS.ErrnoException).code !== "EEXIST") {
+      throw new DyadError(
+        `Failed to stage drizzle-kit node_modules: ${symlinkErr}`,
+        DyadErrorKind.Internal,
+      );
+    }
   }
 
   // @neondatabase/serverless is the Postgres driver drizzle-kit picks for
   // Neon. If it can't be resolved, drizzle-kit's introspect catches the
   // error and still exits 0 — the failure looks like "no schema produced".
+  // Non-EEXIST failures here would recreate that silent-failure mode, so
+  // surface them immediately.
   const peerPackages: StagedPackage[] = [
     "drizzle-orm",
     "@neondatabase/serverless",
@@ -172,7 +177,12 @@ export async function spawnDrizzleKit({
       await fs.mkdir(path.dirname(stagedPath), { recursive: true });
       await fs.symlink(getBundledPackageDir(pkg), stagedPath, "junction");
     } catch (symlinkErr) {
-      logger.warn(`Failed to stage ${pkg} symlink: ${symlinkErr}`);
+      if ((symlinkErr as NodeJS.ErrnoException).code !== "EEXIST") {
+        throw new DyadError(
+          `Failed to stage ${pkg} symlink: ${symlinkErr}`,
+          DyadErrorKind.Internal,
+        );
+      }
     }
   }
 


### PR DESCRIPTION
closes #3266 
Three issues, all from Node module resolution vs. Electron packaging:

- @neondatabase/serverless wasn't shipped — added to extraResource. drizzle-kit auto-picks it as the Postgres driver; without it, introspect silently exits 0.
- Packaged packages land directly under Resources/, not inside a node_modules/, so Node's upward walk can't find them. We build a temp node_modules/ tree per migration.
- bin.cjs must be copied, not symlinked — Electron's utilityProcess.fork ignores --preserve-symlinks-main, so a symlinked entry point realpath-resolves back to Resources/ and misses the staged peer deps.
