### PR TITLE
fix: omit default temperature for custom models

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,10 @@ npm run init-precommit
 
 **Note:** Running `npm install` may update `package-lock.json` with version changes or peer dependency flag removals. If rebasing or performing git operations, commit these changes first to avoid "unstaged changes" errors.
 
+## Git worktrees
+
+When you create a new git worktree for this repository, run `npm install` inside the new worktree before starting development. Each worktree has its own working directory and needs its dependencies installed there.
+
 ## Pre-commit checks
 
 RUN THE FOLLOWING CHECKS before you do a commit.

--- a/src/__tests__/token_utils.test.ts
+++ b/src/__tests__/token_utils.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { getTemperature } from "../ipc/utils/token_utils";
+import { findLanguageModel } from "../ipc/utils/findLanguageModel";
+
+vi.mock("../../src/main/settings", () => ({
+  readSettings: vi.fn(),
+}));
+
+vi.mock("../ipc/utils/findLanguageModel", () => ({
+  findLanguageModel: vi.fn(),
+}));
+
+const mockFindLanguageModel = vi.mocked(findLanguageModel);
+
+describe("getTemperature", () => {
+  it("does not set a default temperature for custom models", async () => {
+    mockFindLanguageModel.mockResolvedValueOnce({
+      id: 1,
+      apiName: "custom-model",
+      displayName: "Custom Model",
+      type: "custom",
+    });
+
+    await expect(
+      getTemperature({ provider: "custom::provider", name: "custom-model" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("keeps the fallback temperature for non-custom models without metadata", async () => {
+    mockFindLanguageModel.mockResolvedValueOnce({
+      apiName: "cloud-model",
+      displayName: "Cloud Model",
+      type: "cloud",
+    });
+
+    await expect(
+      getTemperature({ provider: "provider", name: "cloud-model" }),
+    ).resolves.toBe(0);
+  });
+});

--- a/src/ipc/utils/token_utils.ts
+++ b/src/ipc/utils/token_utils.ts
@@ -33,8 +33,11 @@ export async function getMaxTokens(
 
 export async function getTemperature(
   model: LargeLanguageModel,
-): Promise<number> {
+): Promise<number | undefined> {
   const modelOption = await findLanguageModel(model);
+  if (modelOption?.type === "custom") {
+    return modelOption.temperature;
+  }
   return modelOption?.temperature ?? 0;
 }
 


### PR DESCRIPTION
## Summary

- Avoid sending a fallback temperature of 0 for custom models unless the custom model has an explicit temperature configured.
- Add unit coverage for custom-model temperature handling and non-custom fallback behavior.
- Document that new git worktrees need their own npm install before development.

## Tests

- Not run in this metadata-only update; existing PR changes add Vitest coverage in src/__tests__/token_utils.test.ts.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/3301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
