### PR TITLE
Provider-aware context compaction thresholds (Google vs others)

### DIFF
--- a/src/__tests__/token_utils.test.ts
+++ b/src/__tests__/token_utils.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { getTemperature } from "../ipc/utils/token_utils";
+import {
+  getCompactionThreshold,
+  getTemperature,
+  shouldTriggerCompaction,
+} from "../ipc/utils/token_utils";
 import { findLanguageModel } from "../ipc/utils/findLanguageModel";
 
 vi.mock("../../src/main/settings", () => ({
@@ -37,5 +41,54 @@ describe("getTemperature", () => {
     await expect(
       getTemperature({ provider: "provider", name: "cloud-model" }),
     ).resolves.toBe(0);
+  });
+});
+
+describe("getCompactionThreshold", () => {
+  describe("non-google providers", () => {
+    it("uses the 250k cap for large context windows", () => {
+      expect(getCompactionThreshold(400_000, "openai")).toBe(250_000);
+      expect(getCompactionThreshold(1_000_000, "anthropic")).toBe(250_000);
+    });
+
+    it("falls back to contextWindow - 25k when the cap is higher", () => {
+      expect(getCompactionThreshold(200_000, "openai")).toBe(175_000);
+      expect(getCompactionThreshold(128_000, "anthropic")).toBe(103_000);
+    });
+
+    it("treats unknown providers like non-google providers", () => {
+      expect(getCompactionThreshold(400_000, "vertex")).toBe(250_000);
+      expect(getCompactionThreshold(400_000, "openrouter")).toBe(250_000);
+    });
+  });
+
+  describe("google provider", () => {
+    it("uses the 190k cap for large context windows", () => {
+      expect(getCompactionThreshold(1_000_000, "google")).toBe(190_000);
+      expect(getCompactionThreshold(400_000, "google")).toBe(190_000);
+    });
+
+    it("falls back to contextWindow - 25k when the cap is higher", () => {
+      expect(getCompactionThreshold(200_000, "google")).toBe(175_000);
+      expect(getCompactionThreshold(128_000, "google")).toBe(103_000);
+    });
+  });
+});
+
+describe("shouldTriggerCompaction", () => {
+  it("triggers when token count meets the non-google threshold", () => {
+    expect(shouldTriggerCompaction(250_000, 400_000, "openai")).toBe(true);
+    expect(shouldTriggerCompaction(249_999, 400_000, "openai")).toBe(false);
+  });
+
+  it("triggers earlier for google than for other providers", () => {
+    expect(shouldTriggerCompaction(190_000, 1_000_000, "google")).toBe(true);
+    expect(shouldTriggerCompaction(190_000, 1_000_000, "openai")).toBe(false);
+  });
+
+  it("respects the contextWindow - 25k floor when the cap is higher", () => {
+    expect(shouldTriggerCompaction(175_000, 200_000, "openai")).toBe(true);
+    expect(shouldTriggerCompaction(174_999, 200_000, "openai")).toBe(false);
+    expect(shouldTriggerCompaction(175_000, 200_000, "google")).toBe(true);
   });
 });

--- a/src/ipc/handlers/compaction/compaction_handler.ts
+++ b/src/ipc/handlers/compaction/compaction_handler.ts
@@ -13,6 +13,7 @@ import { chats, messages } from "@/db/schema";
 import { readSettings } from "@/main/settings";
 import { getModelClient } from "@/ipc/utils/get_model_client";
 import {
+  getCompactionThreshold,
   getContextWindow,
   shouldTriggerCompaction,
 } from "@/ipc/utils/token_utils";
@@ -91,12 +92,17 @@ export async function checkAndMarkForCompaction(
   }
 
   const contextWindow = await getContextWindow();
-  const shouldCompact = shouldTriggerCompaction(totalTokens, contextWindow);
+  const provider = settings.selectedModel.provider;
+  const shouldCompact = shouldTriggerCompaction(
+    totalTokens,
+    contextWindow,
+    provider,
+  );
 
   if (shouldCompact) {
     await markChatForCompaction(chatId);
     logger.info(
-      `Compaction triggered for chat ${chatId}: ${totalTokens} tokens (threshold: ${Math.min(Math.floor(contextWindow * 0.8), 180_000)})`,
+      `Compaction triggered for chat ${chatId}: ${totalTokens} tokens (threshold: ${getCompactionThreshold(contextWindow, provider)})`,
     );
     return true;
   }

--- a/src/ipc/utils/token_utils.ts
+++ b/src/ipc/utils/token_utils.ts
@@ -58,7 +58,7 @@ export function getCompactionThreshold(
   provider: string,
 ): number {
   const cap = provider === "google" ? 190_000 : 250_000;
-  return Math.min(cap, contextWindow - 25_000);
+  return Math.min(cap, Math.max(0, contextWindow - 25_000));
 }
 
 /**

--- a/src/ipc/utils/token_utils.ts
+++ b/src/ipc/utils/token_utils.ts
@@ -43,10 +43,22 @@ export async function getTemperature(
 
 /**
  * Calculate the token threshold for triggering context compaction.
- * Returns the minimum of 80% of context window or 180k tokens.
+ *
+ * Returns the lower of a per-provider cap or `contextWindow - 25k`. The 25k
+ * headroom leaves room for the next user message + tool outputs before we hit
+ * the hard context limit.
+ *
+ * Per-provider caps differ because of input-token pricing tiers: Google bumps
+ * input price 2x once a request crosses 200k tokens, while other providers
+ * (e.g. OpenAI) only apply a 2x tier above ~272k tokens. We compact earlier
+ * for Google so requests stay in the cheaper input tier.
  */
-export function getCompactionThreshold(contextWindow: number): number {
-  return Math.min(Math.floor(contextWindow * 0.8), 180_000);
+export function getCompactionThreshold(
+  contextWindow: number,
+  provider: string,
+): number {
+  const cap = provider === "google" ? 190_000 : 250_000;
+  return Math.min(cap, contextWindow - 25_000);
 }
 
 /**
@@ -55,6 +67,7 @@ export function getCompactionThreshold(contextWindow: number): number {
 export function shouldTriggerCompaction(
   totalTokens: number,
   contextWindow: number,
+  provider: string,
 ): boolean {
-  return totalTokens >= getCompactionThreshold(contextWindow);
+  return totalTokens >= getCompactionThreshold(contextWindow, provider);
 }


### PR DESCRIPTION
## Summary

- Trigger compaction at the lower of a provider-specific cap or `contextWindow - 25k`: **250k** for non-Google providers, **190k** when `selectedModel.provider` is `google`.
- Documented rationale: Google applies a 2x input price step around 200k tokens; OpenAI and similar providers step around ~272k, so we compact earlier for Google to stay in the cheaper tier.
- Compaction handler now passes `settings.selectedModel.provider` into the threshold and logs the same value used for the decision.

## Test plan

- `npx vitest run src/__tests__/token_utils.test.ts`
- `npm test`


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dyad-sh/dyad/pull/3314" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
