### PR TITLE
 Fix Review & Commit Dialog Button Placement

### DIFF
--- a/src/components/chat/UncommittedFilesBanner.tsx
+++ b/src/components/chat/UncommittedFilesBanner.tsx
@@ -163,15 +163,18 @@ export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
           setIsDialogOpen(open);
         }}
       >
-        <DialogContent className="sm:max-w-lg" data-testid="commit-dialog">
-          <DialogHeader>
+        <DialogContent
+          className="sm:max-w-lg max-h-[85vh] flex flex-col overflow-hidden p-0"
+          data-testid="commit-dialog"
+        >
+          <DialogHeader className="px-6 pt-6 pb-2">
             <DialogTitle>Review & Commit Changes</DialogTitle>
             <DialogDescription>
               Review your changes and enter a commit message.
             </DialogDescription>
           </DialogHeader>
 
-          <div className="space-y-4">
+          <div className="space-y-4 px-6 pb-4 overflow-y-auto flex-1 min-h-0">
             <div>
               <label
                 htmlFor="commit-message"
@@ -193,7 +196,7 @@ export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
                 Changed files ({uncommittedFiles.length})
               </p>
               <div
-                className="max-h-60 overflow-y-auto rounded-md border p-2 space-y-1"
+                className="rounded-md border p-2 space-y-1"
                 data-testid="changed-files-list"
               >
                 {uncommittedFiles.map((file) => (
@@ -237,7 +240,7 @@ export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
               role="alertdialog"
               aria-labelledby="discard-confirm-title"
               aria-describedby="discard-confirm-desc"
-              className="flex items-start gap-2 rounded-md border border-destructive/50 bg-destructive/10 p-3"
+              className="mx-6 flex items-start gap-2 rounded-md border border-destructive/50 bg-destructive/10 p-3"
             >
               <TriangleAlert className="h-5 w-5 text-destructive shrink-0 mt-0.5" />
               <div className="flex-1 space-y-2">
@@ -272,7 +275,7 @@ export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
             </div>
           )}
 
-          <DialogFooter>
+          <DialogFooter className="px-6 pb-6 pt-2">
             <Button
               variant="outline"
               className="text-destructive hover:text-destructive hover:bg-destructive/10 mr-auto"

--- a/src/components/chat/UncommittedFilesBanner.tsx
+++ b/src/components/chat/UncommittedFilesBanner.tsx
@@ -18,6 +18,12 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
   useUncommittedFiles,
   type UncommittedFile,
 } from "@/hooks/useUncommittedFiles";
@@ -195,42 +201,54 @@ export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
               <p className="text-sm font-medium mb-2">
                 Changed files ({uncommittedFiles.length})
               </p>
-              <div
-                className="rounded-md border p-2 space-y-1"
-                data-testid="changed-files-list"
-              >
-                {uncommittedFiles.map((file) => (
-                  <div
-                    key={file.path}
-                    className="flex items-center gap-2 text-sm py-1 px-2 rounded hover:bg-muted"
-                  >
-                    {getStatusIcon(file.status)}
-                    <span
-                      className={cn(
-                        "flex-1 truncate font-mono text-xs",
-                        file.status === "deleted" && "line-through opacity-60",
-                      )}
+              <TooltipProvider delay={300}>
+                <div
+                  className="max-h-60 overflow-y-auto rounded-md border p-2 space-y-1"
+                  data-testid="changed-files-list"
+                >
+                  {uncommittedFiles.map((file) => (
+                    <div
+                      key={file.path}
+                      className="flex items-center gap-2 text-sm py-1 px-2 rounded hover:bg-muted"
                     >
-                      {file.path}
-                    </span>
-                    <span
-                      className={cn(
-                        "text-xs px-1.5 py-0.5 rounded",
-                        file.status === "added" &&
-                          "bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300",
-                        file.status === "modified" &&
-                          "bg-yellow-100 text-yellow-700 dark:bg-yellow-900 dark:text-yellow-300",
-                        file.status === "deleted" &&
-                          "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300",
-                        file.status === "renamed" &&
-                          "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300",
-                      )}
-                    >
-                      {getStatusLabel(file.status)}
-                    </span>
-                  </div>
-                ))}
-              </div>
+                      {getStatusIcon(file.status)}
+                      <Tooltip>
+                        <TooltipTrigger
+                          render={
+                            <span
+                              className={cn(
+                                "flex-1 truncate font-mono text-xs text-left cursor-default",
+                                file.status === "deleted" &&
+                                  "line-through opacity-60",
+                              )}
+                            />
+                          }
+                        >
+                          {file.path}
+                        </TooltipTrigger>
+                        <TooltipContent side="top" align="start">
+                          <p className="max-w-[400px] break-all">{file.path}</p>
+                        </TooltipContent>
+                      </Tooltip>
+                      <span
+                        className={cn(
+                          "text-xs px-1.5 py-0.5 rounded",
+                          file.status === "added" &&
+                            "bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300",
+                          file.status === "modified" &&
+                            "bg-yellow-100 text-yellow-700 dark:bg-yellow-900 dark:text-yellow-300",
+                          file.status === "deleted" &&
+                            "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300",
+                          file.status === "renamed" &&
+                            "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300",
+                        )}
+                      >
+                        {getStatusLabel(file.status)}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </TooltipProvider>
             </div>
           </div>
 


### PR DESCRIPTION
closes #3315 

##summary
"Review & commit" dialog buttons get pushed off-screen when there are many files or long filenames
Root Cause: The DialogContent component lacked proper overflow handling. When the discard confirmation panel appeared on top of a long file list, the footer buttons (Discard all, Cancel, Commit) were pushed below the visible area with no way to scroll to them.
before:
<img width="1106" height="524" alt="Capture d&#39;écran 2026-04-30 212025" src="https://github.com/user-attachments/assets/981aa7a4-38b1-4ff3-9c29-660abe744df5" />
after:
<img width="1596" height="882" alt="Capture d&#39;écran 2026-04-30 211415" src="https://github.com/user-attachments/assets/138d3420-2322-426e-bc1f-ac3af3438e63" />
