### PR TITLE
perf: cancel orphaned baseStream branch to fix RAM leak during streaming

### DIFF
--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -67,6 +67,7 @@ import { requireMcpToolConsent } from "../utils/mcp_consent";
 import { handleLocalAgentStream } from "../../pro/main/ipc/handlers/local_agent/local_agent_handler";
 
 import { safeSend } from "../utils/safe_sender";
+import { cancelOrphanedBaseStream } from "../utils/stream_text_utils";
 import { cleanFullResponse } from "../utils/cleanFullResponse";
 import { generateProblemReport } from "../processors/tsc";
 import { createProblemFixPrompt } from "@/shared/problem_prompt";
@@ -1182,29 +1183,11 @@ This conversation includes one or more image attachments. When the user uploads 
             abortSignal: abortController.signal,
           });
           // Read .fullStream now (not lazily) so the SDK's `teeStream()`
-          // runs synchronously: that call splits the SDK's internal
-          // `baseStream` into two branches and reassigns the unread branch
-          // back onto `streamResult.baseStream`. We immediately cancel
-          // that orphaned branch so it never queues chunks.
-          //
-          // Why: WhatWG `tee()` enqueues every upstream chunk into both
-          // branches' controllers regardless of whether they have a
-          // reader. We only consume one branch (`fullStream`), so without
-          // this cancel the other branch's queue grows unbounded as the
-          // model streams — the dominant in-flight leak observed in heap
-          // snapshots (`{part, partialOutput}` objects parked in a
-          // `ReadableStreamDefaultController` queue, rooted via the
-          // undici connection pool). Cancel runs before any chunks are
-          // pumped, so the orphan controller closes immediately and
-          // future enqueues to it are no-ops.
+          // runs synchronously, then cancel the orphaned tee branch
+          // before any chunks are pumped. See `cancelOrphanedBaseStream`
+          // for the underlying SDK behavior and why this is required.
           const fullStream = streamResult.fullStream;
-          const orphan: any = streamResult;
-          orphan?.baseStream?.cancel?.()?.catch?.((err: unknown) => {
-            logger.warn(
-              "Failed to cancel orphaned streamText baseStream branch",
-              err,
-            );
-          });
+          cancelOrphanedBaseStream(streamResult);
           return {
             fullStream,
             usage: streamResult.usage,

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -1181,8 +1181,32 @@ This conversation includes one or more image attachments. When the user uploads 
             },
             abortSignal: abortController.signal,
           });
+          // Read .fullStream now (not lazily) so the SDK's `teeStream()`
+          // runs synchronously: that call splits the SDK's internal
+          // `baseStream` into two branches and reassigns the unread branch
+          // back onto `streamResult.baseStream`. We immediately cancel
+          // that orphaned branch so it never queues chunks.
+          //
+          // Why: WhatWG `tee()` enqueues every upstream chunk into both
+          // branches' controllers regardless of whether they have a
+          // reader. We only consume one branch (`fullStream`), so without
+          // this cancel the other branch's queue grows unbounded as the
+          // model streams — the dominant in-flight leak observed in heap
+          // snapshots (`{part, partialOutput}` objects parked in a
+          // `ReadableStreamDefaultController` queue, rooted via the
+          // undici connection pool). Cancel runs before any chunks are
+          // pumped, so the orphan controller closes immediately and
+          // future enqueues to it are no-ops.
+          const fullStream = streamResult.fullStream;
+          const orphan: any = streamResult;
+          orphan?.baseStream?.cancel?.()?.catch?.((err: unknown) => {
+            logger.warn(
+              "Failed to cancel orphaned streamText baseStream branch",
+              err,
+            );
+          });
           return {
-            fullStream: streamResult.fullStream,
+            fullStream,
             usage: streamResult.usage,
           };
         };

--- a/src/ipc/handlers/compaction/compaction_handler.ts
+++ b/src/ipc/handlers/compaction/compaction_handler.ts
@@ -17,6 +17,7 @@ import {
   shouldTriggerCompaction,
 } from "@/ipc/utils/token_utils";
 import { safeSend } from "@/ipc/utils/safe_sender";
+import { cancelOrphanedBaseStream } from "@/ipc/utils/stream_text_utils";
 import { COMPACTION_SYSTEM_PROMPT } from "@/prompts/compaction_system_prompt";
 import {
   storePreCompactionMessages,
@@ -198,9 +199,15 @@ export async function performCompaction(
       maxRetries: 2,
     });
 
+    // Read .textStream now (not lazily) so the SDK's tee runs
+    // synchronously, then cancel the orphaned branch before any chunks
+    // are pumped. See `cancelOrphanedBaseStream` for why this is required.
+    const textStream = summaryResult.textStream;
+    cancelOrphanedBaseStream(summaryResult);
+
     // Stream summary text to the frontend as it generates
     let summary = "";
-    for await (const chunk of summaryResult.textStream) {
+    for await (const chunk of textStream) {
       summary += chunk;
       onSummaryChunk?.(summary);
     }

--- a/src/ipc/handlers/help_bot_handlers.ts
+++ b/src/ipc/handlers/help_bot_handlers.ts
@@ -3,6 +3,7 @@ import { readSettings } from "../../main/settings";
 
 import log from "electron-log";
 import { safeSend } from "../utils/safe_sender";
+import { cancelOrphanedBaseStream } from "../utils/stream_text_utils";
 import {
   createOpenAI,
   openai,
@@ -92,9 +93,16 @@ export function registerHelpBotHandlers() {
         },
       });
 
+      // Read .fullStream now (not lazily) so the SDK's `teeStream()`
+      // runs synchronously, then cancel the orphaned tee branch before
+      // any chunks are pumped. See `cancelOrphanedBaseStream` for why
+      // this is required.
+      const fullStream = stream.fullStream;
+      cancelOrphanedBaseStream(stream);
+
       (async () => {
         try {
-          for await (const part of stream.fullStream) {
+          for await (const part of fullStream) {
             if (abortController.signal.aborted) break;
 
             if (part.type === "text-delta") {

--- a/src/ipc/utils/stream_text_utils.ts
+++ b/src/ipc/utils/stream_text_utils.ts
@@ -2,16 +2,6 @@ import log from "electron-log";
 
 const logger = log.scope("stream_text_utils");
 
-// Minimal structural type for the undocumented `baseStream` field the AI
-// SDK leaves on its `streamText` result after `.fullStream` is read. The
-// SDK does not expose this in its public types, so we narrow just enough
-// to call `.cancel()` without falling back to `any`.
-interface StreamTextResultWithBaseStream {
-  baseStream?: {
-    cancel?: () => Promise<void> | void;
-  };
-}
-
 /**
  * Cancel the orphaned `baseStream` tee branch the AI SDK leaves behind
  * after `.fullStream` is read.
@@ -32,11 +22,8 @@ interface StreamTextResultWithBaseStream {
  * enqueues to it are no-ops.
  */
 export function cancelOrphanedBaseStream(streamResult: unknown): void {
-  const orphan = streamResult as StreamTextResultWithBaseStream;
-  const baseStream = orphan?.baseStream;
-  const cancel = baseStream?.cancel;
-  if (typeof cancel !== "function") return;
-  Promise.resolve(cancel.call(baseStream)).catch((err: unknown) => {
+  const orphan: any = streamResult;
+  orphan?.baseStream?.cancel?.()?.catch?.((err: unknown) => {
     logger.warn("Failed to cancel orphaned streamText baseStream branch", err);
   });
 }

--- a/src/ipc/utils/stream_text_utils.ts
+++ b/src/ipc/utils/stream_text_utils.ts
@@ -1,0 +1,42 @@
+import log from "electron-log";
+
+const logger = log.scope("stream_text_utils");
+
+// Minimal structural type for the undocumented `baseStream` field the AI
+// SDK leaves on its `streamText` result after `.fullStream` is read. The
+// SDK does not expose this in its public types, so we narrow just enough
+// to call `.cancel()` without falling back to `any`.
+interface StreamTextResultWithBaseStream {
+  baseStream?: {
+    cancel?: () => Promise<void> | void;
+  };
+}
+
+/**
+ * Cancel the orphaned `baseStream` tee branch the AI SDK leaves behind
+ * after `.fullStream` is read.
+ *
+ * Reading `.fullStream` runs the SDK's `teeStream()` synchronously: it
+ * splits the SDK's internal `baseStream` into two branches and
+ * reassigns the unread branch back onto `streamResult.baseStream`.
+ * WhatWG `tee()` enqueues every upstream chunk into both branches'
+ * controllers regardless of whether they have a reader, so the unread
+ * branch's queue grows unbounded as the model streams — the dominant
+ * in-flight memory leak observed in heap snapshots (`{part,
+ * partialOutput}` objects parked in a `ReadableStreamDefaultController`
+ * queue, rooted via the undici connection pool).
+ *
+ * Call this immediately after reading `.fullStream` and before the
+ * stream begins pumping chunks. The cancel runs before any chunks are
+ * pumped, so the orphan controller closes immediately and future
+ * enqueues to it are no-ops.
+ */
+export function cancelOrphanedBaseStream(streamResult: unknown): void {
+  const orphan = streamResult as StreamTextResultWithBaseStream;
+  const baseStream = orphan?.baseStream;
+  const cancel = baseStream?.cancel;
+  if (typeof cancel !== "function") return;
+  Promise.resolve(cancel.call(baseStream)).catch((err: unknown) => {
+    logger.warn("Failed to cancel orphaned streamText baseStream branch", err);
+  });
+}

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -981,11 +981,28 @@ export async function handleLocalAgentStream(
             },
           });
 
+          // Read .fullStream now (not lazily) so the SDK's `teeStream()`
+          // runs synchronously and `streamResult.baseStream` is the
+          // orphaned tee branch by the time we cancel it. WhatWG `tee()`
+          // enqueues every upstream chunk into both branches regardless
+          // of whether they have a reader; we only consume one
+          // (`fullStream`), so without this cancel the other branch's
+          // queue grows unbounded as the model streams — the dominant
+          // in-flight leak observed in heap snapshots.
+          const fullStream = streamResult.fullStream;
+          const orphan: any = streamResult;
+          orphan?.baseStream?.cancel?.()?.catch?.((err: unknown) => {
+            logger.warn(
+              "Failed to cancel orphaned streamText baseStream branch",
+              err,
+            );
+          });
+
           let inThinkingBlock = false;
           let streamErrorFromIteration: unknown;
 
           try {
-            for await (const part of streamResult.fullStream) {
+            for await (const part of fullStream) {
               if (abortController.signal.aborted) {
                 logger.log(`Stream aborted for chat ${req.chatId}`);
                 // Clean up pending consent/questionnaire requests to prevent stale UI banners

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -28,6 +28,7 @@ import { getDyadAppPath } from "@/paths/paths";
 import { detectFrameworkType } from "@/ipc/utils/framework_utils";
 import { getModelClient } from "@/ipc/utils/get_model_client";
 import { safeSend } from "@/ipc/utils/safe_sender";
+import { cancelOrphanedBaseStream } from "@/ipc/utils/stream_text_utils";
 import { getMaxTokens, getTemperature } from "@/ipc/utils/token_utils";
 import {
   getProviderOptions,
@@ -982,21 +983,11 @@ export async function handleLocalAgentStream(
           });
 
           // Read .fullStream now (not lazily) so the SDK's `teeStream()`
-          // runs synchronously and `streamResult.baseStream` is the
-          // orphaned tee branch by the time we cancel it. WhatWG `tee()`
-          // enqueues every upstream chunk into both branches regardless
-          // of whether they have a reader; we only consume one
-          // (`fullStream`), so without this cancel the other branch's
-          // queue grows unbounded as the model streams — the dominant
-          // in-flight leak observed in heap snapshots.
+          // runs synchronously, then cancel the orphaned tee branch
+          // before any chunks are pumped. See `cancelOrphanedBaseStream`
+          // for the underlying SDK behavior and why this is required.
           const fullStream = streamResult.fullStream;
-          const orphan: any = streamResult;
-          orphan?.baseStream?.cancel?.()?.catch?.((err: unknown) => {
-            logger.warn(
-              "Failed to cancel orphaned streamText baseStream branch",
-              err,
-            );
-          });
+          cancelOrphanedBaseStream(streamResult);
 
           let inThinkingBlock = false;
           let streamErrorFromIteration: unknown;

--- a/src/pro/main/ipc/handlers/themes_handlers.ts
+++ b/src/pro/main/ipc/handlers/themes_handlers.ts
@@ -12,6 +12,7 @@ import { streamText, TextPart, ImagePart } from "ai";
 import { readSettings } from "../../../../main/settings";
 import { IS_TEST_BUILD } from "@/ipc/utils/test_utils";
 import { getModelClient } from "../../../../ipc/utils/get_model_client";
+import { cancelOrphanedBaseStream } from "../../../../ipc/utils/stream_text_utils";
 import { v4 as uuidv4 } from "uuid";
 import type {
   SetAppThemeParams,
@@ -722,7 +723,15 @@ images: ${imagesPart}`;
           messages: [{ role: "user", content: contentParts }],
         });
 
-        const result = await stream.text;
+        // Read .textStream now (not lazily) so the SDK's tee runs
+        // synchronously, then cancel the orphaned branch before any
+        // chunks are pumped. `await stream.text` would internally
+        // consume `.fullStream` and leave the orphan queueing the
+        // whole response.
+        const textStream = stream.textStream;
+        cancelOrphanedBaseStream(stream);
+        let result = "";
+        for await (const chunk of textStream) result += chunk;
 
         return { prompt: result };
       } catch (error) {
@@ -953,7 +962,15 @@ source: Live website (screenshot and content provided)`;
           messages: [{ role: "user", content: contentParts }],
         });
 
-        const result = await stream.text;
+        // Read .textStream now (not lazily) so the SDK's tee runs
+        // synchronously, then cancel the orphaned branch before any
+        // chunks are pumped. `await stream.text` would internally
+        // consume `.fullStream` and leave the orphan queueing the
+        // whole response.
+        const textStream = stream.textStream;
+        cancelOrphanedBaseStream(stream);
+        let result = "";
+        for await (const chunk of textStream) result += chunk;
 
         return { prompt: result };
       } catch (error) {


### PR DESCRIPTION
Related to #3240, but not a fix.

The AI SDK tees its internal baseStream every time `.fullStream` is read, leaving the unread branch queueing every chunk indefinitely. Cancel that orphaned branch immediately so it never accumulates — the dominant leak path observed during long LLM responses.

For reference, the following was logged by the performance monitor while streaming an extremely long LLM response (Pro mode enabled, using Kimi K2.5 for low cost and willingness to comply with large requests). I included logs up to the point that Dyad became unresponsive. Dyad crashes either way, which is why this is not a fix. Even so, it's a clear improvement.

Without patch:
```txt
20:47:44.939 (performance-monitor) › Performance: Memory=310MB, CPU=8.42%, System Memory=7329/14772MB (49.62%), System CPU=13.31%
20:48:14.939 (performance-monitor) › Performance: Memory=331MB, CPU=8.19%, System Memory=7624/14772MB (51.61%), System CPU=14.13%
20:48:44.939 (performance-monitor) › Performance: Memory=337MB, CPU=9.68%, System Memory=7790/14772MB (52.73%), System CPU=13.71%
20:49:14.951 (performance-monitor) › Performance: Memory=349MB, CPU=10.34%, System Memory=8017/14772MB (54.27%), System CPU=13.82%
20:49:44.952 (performance-monitor) › Performance: Memory=371MB, CPU=10.04%, System Memory=8258/14772MB (55.9%), System CPU=13.54%
20:50:14.952 (performance-monitor) › Performance: Memory=461MB, CPU=9.73%, System Memory=8716/14772MB (59%), System CPU=13.48%
20:50:44.952 (performance-monitor) › Performance: Memory=524MB, CPU=9.12%, System Memory=9252/14772MB (62.63%), System CPU=13.79%
20:51:14.952 (performance-monitor) › Performance: Memory=596MB, CPU=9.25%, System Memory=9829/14772MB (66.54%), System CPU=13.84%
20:51:44.952 (performance-monitor) › Performance: Memory=676MB, CPU=8.95%, System Memory=10448/14772MB (70.73%), System CPU=13.71%
20:52:14.952 (performance-monitor) › Performance: Memory=766MB, CPU=9.77%, System Memory=11181/14772MB (75.69%), System CPU=13.9%
20:52:44.952 (performance-monitor) › Performance: Memory=866MB, CPU=8.92%, System Memory=11866/14772MB (80.33%), System CPU=13.33%
20:53:14.952 (performance-monitor) › Performance: Memory=982MB, CPU=8.63%, System Memory=12669/14772MB (85.76%), System CPU=14.06%
20:53:44.953 (performance-monitor) › Performance: Memory=1090MB, CPU=8.23%, System Memory=13349/14772MB (90.37%), System CPU=13.67%
```

With patch:
```txt
20:37:12.873 (performance-monitor) › Performance: Memory=315MB, CPU=3.34%, System Memory=7948/14772MB (53.81%), System CPU=13.4%
20:37:42.873 (performance-monitor) › Performance: Memory=316MB, CPU=8.33%, System Memory=8241/14772MB (55.79%), System CPU=20.59%
20:38:12.873 (performance-monitor) › Performance: Memory=320MB, CPU=8.65%, System Memory=8580/14772MB (58.08%), System CPU=21.9%
20:38:42.873 (performance-monitor) › Performance: Memory=325MB, CPU=8.96%, System Memory=8634/14772MB (58.45%), System CPU=17.78%
20:39:12.873 (performance-monitor) › Performance: Memory=325MB, CPU=7.52%, System Memory=8814/14772MB (59.67%), System CPU=16.08%
20:39:42.874 (performance-monitor) › Performance: Memory=329MB, CPU=7.96%, System Memory=9094/14772MB (61.56%), System CPU=16.39%
20:40:12.874 (performance-monitor) › Performance: Memory=341MB, CPU=7.87%, System Memory=9381/14772MB (63.5%), System CPU=16.03%
20:40:42.873 (performance-monitor) › Performance: Memory=342MB, CPU=7.87%, System Memory=9720/14772MB (65.8%), System CPU=16.24%
20:41:12.873 (performance-monitor) › Performance: Memory=371MB, CPU=9.77%, System Memory=10296/14772MB (69.7%), System CPU=16.05%
20:41:42.874 (performance-monitor) › Performance: Memory=374MB, CPU=9.51%, System Memory=10740/14772MB (72.71%), System CPU=16.3%
20:42:12.873 (performance-monitor) › Performance: Memory=376MB, CPU=9.79%, System Memory=11160/14772MB (75.55%), System CPU=16.27%
20:42:42.881 (performance-monitor) › Performance: Memory=379MB, CPU=9.79%, System Memory=11774/14772MB (79.7%), System CPU=16.75%
20:43:12.881 (performance-monitor) › Performance: Memory=412MB, CPU=9.96%, System Memory=12646/14772MB (85.61%), System CPU=16.57%
20:43:42.882 (performance-monitor) › Performance: Memory=416MB, CPU=9.78%, System Memory=12876/14772MB (87.17%), System CPU=21.77%
```

An example prompt that could be used to produce the results above (assumes use of Next.js template):

```txt
Build a complete, fully functional, production-ready personal finance management web application using Next.js, TypeScript, and Tailwind CSS. Use the Next.js App Router. For any data that needs to persist, use localStorage. API routes should handle business logic (calculations, transformations, validation) but must not connect to any database. This is a single-prompt, one-shot build. Do not ask clarifying questions. Do not summarize or skip any file. Generate every single file listed below in full — no placeholders, no ellipses, no "// ... rest of implementation", no truncation of any kind. Every file must be independently complete and immediately runnable.

APP ROUTER PAGES & LAYOUTS: app/layout.tsx, app/page.tsx, app/loading.tsx, app/error.tsx, app/not-found.tsx, app/dashboard/page.tsx, app/dashboard/loading.tsx, app/accounts/page.tsx, app/accounts/[id]/page.tsx, app/transactions/page.tsx, app/transactions/[id]/page.tsx, app/transactions/add/page.tsx, app/transactions/[id]/edit/page.tsx, app/budgets/page.tsx, app/budgets/[id]/page.tsx, app/budgets/create/page.tsx, app/goals/page.tsx, app/goals/[id]/page.tsx, app/goals/create/page.tsx, app/investments/page.tsx, app/investments/[id]/page.tsx, app/reports/page.tsx, app/reports/monthly/page.tsx, app/reports/annual/page.tsx, app/reports/categories/page.tsx, app/net-worth/page.tsx, app/cash-flow/page.tsx, app/recurring/page.tsx, app/subscriptions/page.tsx, app/import/page.tsx, app/export/page.tsx, app/settings/page.tsx, app/settings/profile/page.tsx, app/onboarding/page.tsx API ROUTES (each fully implemented with request parsing, validation, and response shaping — no database, logic only): app/api/transactions/route.ts, app/api/transactions/[id]/route.ts, app/api/accounts/route.ts, app/api/accounts/[id]/route.ts, app/api/budgets/route.ts, app/api/budgets/[id]/route.ts, app/api/goals/route.ts, app/api/goals/[id]/route.ts, app/api/investments/route.ts, app/api/investments/[id]/route.ts, app/api/reports/monthly/route.ts, app/api/reports/annual/route.ts, app/api/reports/categories/route.ts, app/api/net-worth/route.ts, app/api/cash-flow/route.ts, app/api/recurring/route.ts, app/api/import/route.ts, app/api/export/route.ts, app/api/notifications/route.ts, app/api/settings/route.ts COMPONENTS — Layout: components/layout/AppShell.tsx, components/layout/Sidebar.tsx, components/layout/TopBar.tsx, components/layout/Breadcrumb.tsx, components/layout/PageHeader.tsx, components/layout/SectionDivider.tsx, components/layout/EmptyState.tsx, components/layout/ErrorBoundary.tsx, components/layout/LoadingScreen.tsx, components/layout/MobileNav.tsx COMPONENTS — Data Display: components/transactions/TransactionTable.tsx, components/transactions/TransactionRow.tsx, components/transactions/TransactionFilters.tsx, components/transactions/TransactionSearch.tsx, components/accounts/AccountCard.tsx, components/accounts/AccountList.tsx, components/budgets/BudgetCard.tsx, components/budgets/BudgetProgressBar.tsx, components/budgets/BudgetList.tsx, components/goals/GoalCard.tsx, components/goals/GoalProgressRing.tsx, components/goals/GoalList.tsx, components/investments/InvestmentCard.tsx, components/investments/InvestmentTable.tsx, components/dashboard/NetWorthCard.tsx, components/dashboard/StatCard.tsx, components/dashboard/StatGrid.tsx, components/shared/CategoryBadge.tsx, components/shared/RecurringBadge.tsx, components/shared/TagList.tsx COMPONENTS — Charts (all using recharts, each fully implemented with real data wiring): components/charts/SpendingPieChart.tsx, components/charts/SpendingBarChart.tsx, components/charts/IncomeVsExpenseChart.tsx, components/charts/NetWorthLineChart.tsx, components/charts/CashFlowChart.tsx, components/charts/BudgetUsageChart.tsx, components/charts/GoalProjectionChart.tsx, components/charts/InvestmentGrowthChart.tsx, components/charts/MonthlyTrendChart.tsx, components/charts/CategoryBreakdownChart.tsx, components/charts/WeeklySpendingChart.tsx, components/charts/SavingsRateChart.tsx COMPONENTS — Forms: components/forms/TransactionForm.tsx, components/forms/AccountForm.tsx, components/forms/BudgetForm.tsx, components/forms/GoalForm.tsx, components/forms/InvestmentForm.tsx, components/forms/RecurringTransactionForm.tsx, components/forms/CategoryForm.tsx, components/forms/ProfileForm.tsx, components/forms/ImportForm.tsx, components/forms/CurrencySelector.tsx, components/forms/DateRangePicker.tsx, components/forms/CategoryPicker.tsx, components/forms/AccountPicker.tsx, components/forms/AmountInput.tsx COMPONENTS — Modals & Overlays: components/modals/ConfirmDeleteModal.tsx, components/modals/TransactionDetailModal.tsx, components/modals/QuickAddTransactionModal.tsx, components/modals/BudgetAlertModal.tsx, components/modals/GoalCompleteModal.tsx, components/modals/ExportModal.tsx, components/modals/ShortcutsModal.tsx, components/modals/EditCategoryModal.tsx COMPONENTS — Notifications & Feedback: components/feedback/Toast.tsx, components/feedback/ToastContainer.tsx, components/feedback/AlertBanner.tsx, components/feedback/InlineError.tsx, components/feedback/ProgressToast.tsx STATE MANAGEMENT (Zustand — each slice fully implemented with actions, selectors, and localStorage persistence middleware): store/accountsSlice.ts, store/transactionsSlice.ts, store/budgetsSlice.ts, store/goalsSlice.ts, store/investmentsSlice.ts, store/categoriesSlice.ts, store/tagsSlice.ts, store/recurringSlice.ts, store/notificationsSlice.ts, store/settingsSlice.ts, store/uiSlice.ts, store/reportsSlice.ts, store/store.ts, store/persist.ts CUSTOM HOOKS (each fully implemented): hooks/useAccounts.ts, hooks/useTransactions.ts, hooks/useBudgets.ts, hooks/useGoals.ts, hooks/useInvestments.ts, hooks/useCategories.ts, hooks/useTags.ts, hooks/useRecurring.ts, hooks/useNotifications.ts, hooks/useSettings.ts, hooks/useReports.ts, hooks/useNetWorth.ts, hooks/useCashFlow.ts, hooks/useSavingsRate.ts, hooks/useFilters.ts, hooks/usePagination.ts, hooks/useSortable.ts, hooks/useSearch.ts, hooks/useModal.ts, hooks/useToast.ts, hooks/useConfirm.ts, hooks/useKeyboardShortcuts.ts, hooks/useLocalStorage.ts, hooks/useDebounce.ts, hooks/useWindowSize.ts, hooks/useOnClickOutside.ts, hooks/useExport.ts, hooks/useImport.ts SERVICES: services/transactionService.ts, services/accountService.ts, services/budgetService.ts, services/goalService.ts, services/investmentService.ts, services/categoryService.ts, services/recurringService.ts, services/reportService.ts, services/exportService.ts, services/importService.ts, services/currencyService.ts, services/notificationService.ts, services/storageService.ts UTILITIES: lib/formatCurrency.ts, lib/formatDate.ts, lib/formatPercent.ts, lib/formatNumber.ts, lib/calculateBudgetUsage.ts, lib/calculateNetWorth.ts, lib/calculateCashFlow.ts, lib/calculateSavingsRate.ts, lib/calculateGoalProgress.ts, lib/calculateInvestmentReturn.ts, lib/groupTransactionsByDate.ts, lib/groupTransactionsByCategory.ts, lib/filterTransactions.ts, lib/sortTransactions.ts, lib/detectRecurring.ts, lib/parseCsvRow.ts, lib/validateTransaction.ts, lib/validateBudget.ts, lib/validateGoal.ts, lib/generateId.ts, lib/deepClone.ts, lib/debounce.ts, lib/throttle.ts, lib/clamp.ts, lib/slugify.ts TYPE DEFINITIONS: types/account.types.ts, types/transaction.types.ts, types/budget.types.ts, types/goal.types.ts, types/investment.types.ts, types/category.types.ts, types/recurring.types.ts, types/report.types.ts, types/notification.types.ts, types/settings.types.ts, types/ui.types.ts, types/import.types.ts, types/export.types.ts, types/store.types.ts CONSTANTS & CONFIG: constants/categories.ts, constants/currencies.ts, constants/defaultSettings.ts, constants/chartColors.ts, constants/keybindings.ts, constants/routes.ts, constants/limits.ts, constants/regex.ts, constants/intervals.ts TESTS (each with at minimum 10 meaningful test cases): tests/transactionService.test.ts, tests/budgetService.test.ts, tests/goalService.test.ts, tests/formatCurrency.test.ts, tests/calculateNetWorth.test.ts, tests/filterTransactions.test.ts, tests/accountsSlice.test.ts, tests/transactionsSlice.test.ts, tests/useTransactions.test.ts, tests/useBudgets.test.ts ROOT CONFIG FILES: package.json, tsconfig.json, next.config.ts, tailwind.config.ts, postcss.config.ts, .eslintrc.json, .prettierrc, middleware.ts, README.md

Proceed through every file in the order listed above. Do not stop between files. Do not output any commentary between files — just the filename as a comment header followed immediately by the full file contents. Do not finish until every file has been output in full.

You MUST fully complete the task and generate every file (and thus a complete, working app) in just a single response. If you require more than one response to complete your task, we will start over, so it MUST be done in a single go.

Do not worry about integrating with APIs; just mock API data if you need to.
```