### PR TITLE
feat: add posthog event for app crash detection

### DIFF
--- a/e2e-tests/performance_monitor.spec.ts
+++ b/e2e-tests/performance_monitor.spec.ts
@@ -5,12 +5,11 @@ import * as path from "node:path";
 
 testWithConfig({
   preLaunchHook: async ({ userDataDir }) => {
-    // Set up a force-close scenario by creating settings with isRunning: true
-    // and lastKnownPerformance data
+    // Set up a force-close scenario by leaving the session.lock crash sentinel
+    // file behind and providing lastKnownPerformance data in settings.
     const settingsPath = path.join(userDataDir, "user-settings.json");
     const settings = {
       hasRunBefore: true,
-      isRunning: true, // Simulate force-close
       enableAutoUpdate: false,
       releaseChannel: "stable",
       lastKnownPerformance: {
@@ -26,6 +25,10 @@ testWithConfig({
 
     fs.mkdirSync(userDataDir, { recursive: true });
     fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+    fs.writeFileSync(
+      path.join(userDataDir, "session.lock"),
+      String(Date.now()),
+    );
   },
 })(
   "force-close detection shows dialog with performance data",
@@ -74,11 +77,11 @@ testWithConfig({
 
 testWithConfig({
   preLaunchHook: async ({ userDataDir }) => {
-    // Set up scenario without force-close (proper shutdown)
+    // Set up scenario without force-close (proper shutdown): no session.lock
+    // sentinel file, but lastKnownPerformance is still populated.
     const settingsPath = path.join(userDataDir, "user-settings.json");
     const settings = {
       hasRunBefore: true,
-      isRunning: false, // Proper shutdown - no force-close
       enableAutoUpdate: false,
       releaseChannel: "stable",
       lastKnownPerformance: {

--- a/src/components/ForceCloseDialog.tsx
+++ b/src/components/ForceCloseDialog.tsx
@@ -45,6 +45,12 @@ export function ForceCloseDialog({
             <div className="space-y-4 pt-2 text-muted-foreground">
               <div className="text-base">{t("home:forceCloseDescription")}</div>
 
+              {!performanceData && (
+                <div className="rounded-lg border bg-muted/50 p-4 text-sm">
+                  {t("home:noDiagnosticData")}
+                </div>
+              )}
+
               {performanceData && (
                 <div className="rounded-lg border bg-muted/50 p-4 space-y-3">
                   <div className="font-semibold text-sm text-foreground">

--- a/src/i18n/locales/en/home.json
+++ b/src/i18n/locales/en/home.json
@@ -52,6 +52,7 @@
   "forceCloseDetected": "Force Close Detected",
   "forceCloseDescription": "The app was not closed properly the last time it was running. This could indicate a crash or unexpected termination.",
   "lastKnownState": "Last Known State:",
+  "noDiagnosticData": "No diagnostic data available for this crash.",
   "processMetrics": "Process Metrics",
   "memory": "Memory:",
   "cpu": "CPU:",

--- a/src/i18n/locales/pt-BR/home.json
+++ b/src/i18n/locales/pt-BR/home.json
@@ -49,6 +49,7 @@
   "forceCloseDetected": "Fechamento Forçado Detectado",
   "forceCloseDescription": "O app não foi fechado corretamente na última vez que foi executado. Isso pode indicar uma falha ou encerramento inesperado.",
   "lastKnownState": "Último Estado Conhecido:",
+  "noDiagnosticData": "Nenhum dado de diagnóstico disponível para esta falha.",
   "processMetrics": "Métricas do Processo",
   "memory": "Memória:",
   "cpu": "CPU:",

--- a/src/i18n/locales/zh-CN/home.json
+++ b/src/i18n/locales/zh-CN/home.json
@@ -49,6 +49,7 @@
   "forceCloseDetected": "检测到强制关闭",
   "forceCloseDescription": "上次运行时应用未正常关闭。这可能表示崩溃或意外终止。",
   "lastKnownState": "最后已知状态：",
+  "noDiagnosticData": "此次崩溃无可用诊断数据。",
   "processMetrics": "进程指标",
   "memory": "内存：",
   "cpu": "CPU：",

--- a/src/main.ts
+++ b/src/main.ts
@@ -216,6 +216,8 @@ export async function onReady() {
     }
   }
 
+  // TODO: Remove legacyIsRunningCrash migration path after a few releases
+  // once existing users have launched at least once on the sentinel build.
   if (legacyIsRunningCrash) {
     writeSettings({ isRunning: false });
   }
@@ -425,6 +427,7 @@ const createWindow = () => {
       }
 
       sendTelemetryEvent("app:crash_detected", {
+        has_performance_data: !!pendingForceCloseData,
         ...(pendingForceCloseData && {
           last_known_memory_mb: pendingForceCloseData.memoryUsageMB,
           last_known_cpu_pct: pendingForceCloseData.cpuUsagePercent,

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,11 @@ import {
   getSettingsFilePath,
   writeSettings,
   readEffectiveSettings,
+  writeCrashSentinel,
+  clearCrashSentinel,
+  crashSentinelExists,
 } from "./main/settings";
+import { sendTelemetryEvent } from "./ipc/utils/telemetry";
 import { handleSupabaseOAuthReturn } from "./supabase_admin/supabase_return_handler";
 import { handleDyadProReturn } from "./main/pro";
 import { IS_TEST_BUILD } from "./ipc/utils/test_utils";
@@ -191,9 +195,12 @@ export async function onReady() {
     gitAddSafeDirectory(`${getDyadAppsBaseDirectory()}/*`);
   }
 
-  // Check if app was force-closed
-  if (settings.isRunning) {
+  // Check if app was force-closed by checking for the crash sentinel file.
+  // The sentinel is written at startup and deleted in before-quit on clean exit.
+  // If it exists at startup, the previous session ended without a clean quit.
+  if (crashSentinelExists()) {
     logger.warn("App was force-closed on previous run");
+    pendingCrashDetected = true;
 
     // Store performance data to send after window is created
     if (settings.lastKnownPerformance) {
@@ -202,8 +209,7 @@ export async function onReady() {
     }
   }
 
-  // Set isRunning to true at startup
-  writeSettings({ isRunning: true });
+  writeCrashSentinel();
 
   // Start performance monitoring
   startPerformanceMonitoring();
@@ -334,6 +340,7 @@ declare global {
 
 let mainWindow: BrowserWindow | null = null;
 let pendingForceCloseData: any = null;
+let pendingCrashDetected = false;
 
 const createWindow = () => {
   // Create the browser window.
@@ -394,15 +401,35 @@ const createWindow = () => {
     }
 
     // Send force-close once after the correct load
-    if (pendingForceCloseData && !forceCloseMessageSent) {
+    if (pendingCrashDetected && !forceCloseMessageSent) {
       forceCloseMessageSent = true;
-      const windowRef = mainWindow;
-      if (!windowRef?.isDestroyed()) {
-        windowRef?.webContents.send("force-close-detected", {
-          performanceData: pendingForceCloseData,
-        });
+
+      if (pendingForceCloseData) {
+        const windowRef = mainWindow;
+        if (!windowRef?.isDestroyed()) {
+          windowRef?.webContents.send("force-close-detected", {
+            performanceData: pendingForceCloseData,
+          });
+        }
       }
+
+      sendTelemetryEvent("app:crash_detected", {
+        ...(pendingForceCloseData && {
+          last_known_memory_mb: pendingForceCloseData.memoryUsageMB,
+          last_known_cpu_pct: pendingForceCloseData.cpuUsagePercent,
+          last_known_system_memory_mb:
+            pendingForceCloseData.systemMemoryUsageMB,
+          last_known_system_memory_total_mb:
+            pendingForceCloseData.systemMemoryTotalMB,
+          last_known_system_cpu_pct: pendingForceCloseData.systemCpuPercent,
+          last_known_snapshot_timestamp: pendingForceCloseData.timestamp,
+          time_since_last_heartbeat_ms:
+            Date.now() - pendingForceCloseData.timestamp,
+        }),
+      });
+
       pendingForceCloseData = null;
+      pendingCrashDetected = false;
     }
   });
 
@@ -734,11 +761,17 @@ app.on("window-all-closed", () => {
   }
 });
 
-// Only set isRunning to false when the app is properly quit by the user.
+// Clear the crash sentinel as early as possible on clean exit so that slow
+// cleanup in will-quit cannot race against OS-imposed termination timeouts
+// (e.g. Windows WM_ENDSESSION) and leave the sentinel behind as a false positive.
+app.on("before-quit", () => {
+  clearCrashSentinel();
+});
+
 // IMPORTANT: This handler must be synchronous because Electron's EventEmitter
 // does not await async callbacks — the returned Promise would be silently ignored.
 app.on("will-quit", () => {
-  logger.info("App is quitting, setting isRunning to false");
+  logger.info("App is quitting");
 
   // Stop the garbage collection timer
   stopAppGarbageCollection();
@@ -749,8 +782,6 @@ app.on("will-quit", () => {
 
   // Stop performance monitoring and capture final metrics
   stopPerformanceMonitoring();
-
-  writeSettings({ isRunning: false });
 });
 
 app.on("activate", () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -427,6 +427,9 @@ const createWindow = () => {
       }
 
       sendTelemetryEvent("app:crash_detected", {
+        // Mark as error so renderer PostHog before_send sampling does not
+        // drop 90% of events for non-Pro users (see src/renderer.tsx).
+        error: true,
         has_performance_data: !!pendingForceCloseData,
         ...(pendingForceCloseData && {
           last_known_memory_mb: pendingForceCloseData.memoryUsageMB,

--- a/src/main.ts
+++ b/src/main.ts
@@ -198,7 +198,14 @@ export async function onReady() {
   // Check if app was force-closed by checking for the crash sentinel file.
   // The sentinel is written at startup and deleted in before-quit on clean exit.
   // If it exists at startup, the previous session ended without a clean quit.
-  if (crashSentinelExists()) {
+  //
+  // Migration fallback: builds prior to the sentinel approach used a
+  // settings.isRunning flag to detect crashes. On first launch of a new build
+  // after a force-close of an old build, the sentinel won't exist yet but
+  // settings.isRunning may still be true. Honour it once, then clear it so
+  // subsequent runs rely solely on the sentinel.
+  const legacyIsRunningCrash = settings.isRunning === true;
+  if (crashSentinelExists() || legacyIsRunningCrash) {
     logger.warn("App was force-closed on previous run");
     pendingCrashDetected = true;
 
@@ -207,6 +214,10 @@ export async function onReady() {
       logger.warn("Last known performance:", settings.lastKnownPerformance);
       pendingForceCloseData = settings.lastKnownPerformance;
     }
+  }
+
+  if (legacyIsRunningCrash) {
+    writeSettings({ isRunning: false });
   }
 
   writeCrashSentinel();

--- a/src/main.ts
+++ b/src/main.ts
@@ -415,13 +415,13 @@ const createWindow = () => {
     if (pendingCrashDetected && !forceCloseMessageSent) {
       forceCloseMessageSent = true;
 
-      if (pendingForceCloseData) {
-        const windowRef = mainWindow;
-        if (!windowRef?.isDestroyed()) {
-          windowRef?.webContents.send("force-close-detected", {
+      const windowRef = mainWindow;
+      if (!windowRef?.isDestroyed()) {
+        windowRef?.webContents.send("force-close-detected", {
+          ...(pendingForceCloseData && {
             performanceData: pendingForceCloseData,
-          });
-        }
+          }),
+        });
       }
 
       sendTelemetryEvent("app:crash_detected", {

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -56,6 +56,7 @@ const DEFAULT_SETTINGS: UserSettings = {
   previewIdleTimeoutPolicy: "default",
 };
 
+const CRASH_SENTINEL_FILE = "session.lock";
 const SETTINGS_FILE = "user-settings.json";
 const RESTORE_SETTINGS_DOCS_URL =
   "https://www.dyad.sh/docs/guides/migrate-restore#restoring-settings-from-backup";
@@ -72,6 +73,30 @@ const rendererErrorToastReadyWebContents = new WeakSet<WebContents>();
 
 export function getSettingsFilePath(): string {
   return path.join(getUserDataPath(), SETTINGS_FILE);
+}
+
+export function getCrashSentinelPath(): string {
+  return path.join(getUserDataPath(), CRASH_SENTINEL_FILE);
+}
+
+export function writeCrashSentinel(): void {
+  try {
+    fs.writeFileSync(getCrashSentinelPath(), String(Date.now()));
+  } catch (error) {
+    logger.error("Error writing crash sentinel:", error);
+  }
+}
+
+export function clearCrashSentinel(): void {
+  try {
+    fs.unlinkSync(getCrashSentinelPath());
+  } catch {
+    // File may not exist; that's fine
+  }
+}
+
+export function crashSentinelExists(): boolean {
+  return fs.existsSync(getCrashSentinelPath());
 }
 
 export function readSettings(): UserSettings {

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -75,7 +75,7 @@ export function getSettingsFilePath(): string {
   return path.join(getUserDataPath(), SETTINGS_FILE);
 }
 
-export function getCrashSentinelPath(): string {
+function getCrashSentinelPath(): string {
   return path.join(getUserDataPath(), CRASH_SENTINEL_FILE);
 }
 

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -90,8 +90,10 @@ export function writeCrashSentinel(): void {
 export function clearCrashSentinel(): void {
   try {
     fs.unlinkSync(getCrashSentinelPath());
-  } catch {
-    // File may not exist; that's fine
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      logger.error("Error clearing crash sentinel:", error);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Add `app:crash_detected` PostHog telemetry event sent on next launch after a non-clean exit.
- Replace `settings.isRunning` flag with a filesystem sentinel (`session.lock`) written at startup and cleared in `before-quit`, avoiding races with OS termination timeouts (e.g. Windows `WM_ENDSESSION`) during slow `will-quit` cleanup.
- Include last-known performance snapshot (memory/CPU, system memory/CPU, time since last heartbeat) in the crash event when available.

## Test plan
- [x] Force-kill the app, relaunch, confirm `app:crash_detected` event appears in PostHog with last-known performance fields populated.
- [x] Quit the app cleanly, relaunch, confirm no crash event is sent.
- [x] Verify `session.lock` is created on startup and removed on clean exit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

A few other notes:
- I _think_ this should also fix the issue where the crash handler appears on Windows even when there was no crash.
    - My observation has been that when I SIGINT the main process (Ctrl+C on the terminal in development), that would previously sometimes cause the crash handler to appear on Windows the next time that I'd launch Dyad. I did not observe the same on Linux or macOS.
    - From what I can tell, after this patch, a SIGINT no longer causes the crash handler to trigger on Windows, so it may fix the underlying problem.
    - This PR also introduces a `session.lock` file to track whether the app is running instead of a setting. I'm a bit torn on this; in theory it makes cleanup simpler so we can avoid false positives, but I think moving the cleanup to the "before-quit" event instead of the "will-quit" event does most of the lifting in practice.
- Currently, the PostHog event is sent when the crash handler appears. There are some other approaches:
    - We could send an event when just the renderer crashes, but the cleanest way would be to send the event from the main process, which would require the `posthog-node` library.
    - We could also send the event when the crash actually happens. I don't think Electron's native `crashReporter` can do this, but there is a library, `@sentry/electron`, which could handle this if we decide it's something we really want. We would also need the `posthog-node` library.