### PR TITLE
display notificatioin on chat change and agent/MCP consent

### DIFF
--- a/e2e-tests/chat_completion_notifications.spec.ts
+++ b/e2e-tests/chat_completion_notifications.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
 import { test, testWithConfig } from "./helpers/test_helper";
 import { Timeout } from "./helpers/constants";
 
@@ -6,6 +6,16 @@ import { Timeout } from "./helpers/constants";
  * E2E tests for native notifications. We stub window.Notification and validate
  * behavior under two triggers: app hidden and different-chat view.
  */
+
+// Type definitions for page objects
+interface ChatActionsPageObject {
+  clickNewChat(): Promise<void>;
+  sendPrompt(
+    text: string,
+    options?: { skipWaitForCompletion?: boolean },
+  ): Promise<void>;
+  waitForChatCompletion(options?: { timeout?: number }): Promise<void>;
+}
 
 const testWithNotificationsEnabled = testWithConfig({
   preLaunchHook: async ({ userDataDir }) => {
@@ -19,15 +29,16 @@ const testWithNotificationsEnabled = testWithConfig({
   },
 });
 
-async function enableNotifications(po: { navigation: any; settings: any }) {
+async function enableNotifications(po: {
+  navigation: any;
+  settings: any;
+}): Promise<void> {
   await po.navigation.goToSettingsTab();
   await po.settings.enableChatEventNotifications();
   await po.navigation.goToChatTab();
 }
 
-async function simulateAppHidden(po: {
-  page: import("@playwright/test").Page;
-}) {
+async function simulateAppHidden(po: { page: Page }): Promise<void> {
   await po.page.evaluate(() => {
     Object.defineProperty(document, "visibilityState", {
       value: "hidden",
@@ -44,21 +55,21 @@ async function simulateAppHidden(po: {
   });
 }
 
-async function triggerHidden(po: { page: import("@playwright/test").Page }) {
+async function triggerHidden(po: { page: Page }): Promise<void> {
   await simulateAppHidden(po);
 }
 
 async function triggerDifferentChat(
-  po: { chatActions: any; page: any },
+  po: { chatActions: ChatActionsPageObject; page: Page },
   currentChatId: number,
-) {
-  await switchToDifferentChat(po, currentChatId);
+): Promise<number> {
+  return switchToDifferentChat(po, currentChatId);
 }
 
 async function expectNavigatedToChat(
-  po: { page: import("@playwright/test").Page },
+  po: { page: Page },
   chatId: number,
-) {
+): Promise<void> {
   await expect
     .poll(
       async () => {
@@ -70,11 +81,14 @@ async function expectNavigatedToChat(
     .toBe(chatId);
 }
 
-function getChatIdFromUrl(po: { page: import("@playwright/test").Page }) {
+function getChatIdFromUrl(po: { page: Page }): number {
   return Number(po.page.url().match(/\?id=(\d+)/)?.[1]);
 }
 
-async function createChat(po: { chatActions: any; page: any }) {
+async function createChat(po: {
+  chatActions: ChatActionsPageObject;
+  page: Page;
+}): Promise<number> {
   await po.chatActions.clickNewChat();
   const chatId = getChatIdFromUrl(po);
   expect(chatId).toBeTruthy();
@@ -82,9 +96,9 @@ async function createChat(po: { chatActions: any; page: any }) {
 }
 
 async function switchToDifferentChat(
-  po: { chatActions: any; page: any },
+  po: { chatActions: ChatActionsPageObject; page: Page },
   currentChatId: number,
-) {
+): Promise<number> {
   const activeId = getChatIdFromUrl(po);
   if (activeId !== currentChatId) return activeId;
   await po.chatActions.clickNewChat();

--- a/e2e-tests/chat_completion_notifications.spec.ts
+++ b/e2e-tests/chat_completion_notifications.spec.ts
@@ -1,0 +1,646 @@
+import { expect } from "@playwright/test";
+import { test, testWithConfig } from "./helpers/test_helper";
+import { Timeout } from "./helpers/constants";
+
+/**
+ * E2E tests for native notifications. We stub window.Notification and validate
+ * behavior under two triggers: app hidden and different-chat view.
+ */
+
+const testWithNotificationsEnabled = testWithConfig({
+  preLaunchHook: async ({ userDataDir }) => {
+    const fs = await import("fs");
+    const path = await import("path");
+    fs.mkdirSync(userDataDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(userDataDir, "user-settings.json"),
+      JSON.stringify({ enableChatEventNotifications: true }, null, 2),
+    );
+  },
+});
+
+async function enableNotifications(po: { navigation: any; settings: any }) {
+  await po.navigation.goToSettingsTab();
+  await po.settings.enableChatEventNotifications();
+  await po.navigation.goToChatTab();
+}
+
+async function simulateAppHidden(po: {
+  page: import("@playwright/test").Page;
+}) {
+  await po.page.evaluate(() => {
+    Object.defineProperty(document, "visibilityState", {
+      value: "hidden",
+      configurable: true,
+    });
+    Object.defineProperty(document, "hidden", {
+      value: true,
+      configurable: true,
+    });
+    Object.defineProperty(document, "hasFocus", {
+      value: () => false,
+      configurable: true,
+    });
+  });
+}
+
+async function triggerHidden(po: { page: import("@playwright/test").Page }) {
+  await simulateAppHidden(po);
+}
+
+async function triggerDifferentChat(
+  po: { chatActions: any; page: any },
+  currentChatId: number,
+) {
+  await switchToDifferentChat(po, currentChatId);
+}
+
+async function expectNavigatedToChat(
+  po: { page: import("@playwright/test").Page },
+  chatId: number,
+) {
+  await expect
+    .poll(
+      async () => {
+        const url = po.page.url();
+        return Number(url.match(/\?id=(\d+)/)?.[1]);
+      },
+      { timeout: Timeout.MEDIUM },
+    )
+    .toBe(chatId);
+}
+
+function getChatIdFromUrl(po: { page: import("@playwright/test").Page }) {
+  return Number(po.page.url().match(/\?id=(\d+)/)?.[1]);
+}
+
+async function createChat(po: { chatActions: any; page: any }) {
+  await po.chatActions.clickNewChat();
+  const chatId = getChatIdFromUrl(po);
+  expect(chatId).toBeTruthy();
+  return chatId;
+}
+
+async function switchToDifferentChat(
+  po: { chatActions: any; page: any },
+  currentChatId: number,
+) {
+  const activeId = getChatIdFromUrl(po);
+  if (activeId !== currentChatId) return activeId;
+  await po.chatActions.clickNewChat();
+  const newId = getChatIdFromUrl(po);
+  expect(newId).toBeTruthy();
+  expect(newId).not.toBe(currentChatId);
+  return newId;
+}
+
+// Completion (app hidden): tag, title/body, non-sticky
+testWithNotificationsEnabled(
+  "chat completion notification when app hidden",
+  async ({ po }) => {
+    await po.setUp({ autoApprove: true });
+    await po.importApp("minimal");
+
+    // Wait for the initial stream triggered by importing the app to finish
+    await po.chatActions.waitForChatCompletion({ timeout: Timeout.LONG });
+
+    await enableNotifications(po);
+
+    // Create a fresh chat for the notification test
+    const chatId = await createChat(po);
+
+    // Inject notifications AFTER page is fully loaded
+    await po.browserNotifications.injectFakeNotifications();
+
+    await po.chatActions.sendPrompt("hello", { skipWaitForCompletion: true });
+    await triggerHidden(po);
+
+    const notification =
+      await po.browserNotifications.waitForNotificationWithTag(
+        `dyad-chat-complete-${chatId}`,
+      );
+
+    expect(notification.title).toBe("minimal");
+    expect(notification.body).toContain("Chat response completed");
+    expect(notification.requireInteraction).toBeFalsy();
+    expect(notification.closed).toBe(false);
+  },
+);
+
+// Completion (different chat): tag, title/body, non-sticky
+testWithNotificationsEnabled(
+  "chat completion notification when viewing different chat",
+  async ({ po }) => {
+    await po.setUp({ autoApprove: true });
+    await po.importApp("minimal");
+    await po.chatActions.waitForChatCompletion({ timeout: Timeout.LONG });
+    await enableNotifications(po);
+
+    const chatId = await createChat(po);
+    await po.browserNotifications.injectFakeNotifications();
+
+    await po.chatActions.sendPrompt("hello", { skipWaitForCompletion: true });
+    await triggerDifferentChat(po, chatId);
+
+    const notification =
+      await po.browserNotifications.waitForNotificationWithTag(
+        `dyad-chat-complete-${chatId}`,
+      );
+
+    expect(notification.title).toBe("minimal");
+    expect(notification.body).toContain("Chat response completed");
+    expect(notification.requireInteraction).toBeFalsy();
+    expect(notification.closed).toBe(false);
+  },
+);
+
+// Completion auto-close on focus (app hidden)
+testWithNotificationsEnabled(
+  "notification auto-closes when user focuses chat",
+  async ({ po }) => {
+    await po.setUp({ autoApprove: true });
+    await po.importApp("minimal");
+
+    // Wait for the initial stream triggered by importing the app to finish
+    await po.chatActions.waitForChatCompletion({ timeout: Timeout.LONG });
+
+    await enableNotifications(po);
+
+    // Create a fresh chat for the notification test
+    const chatId = await createChat(po);
+
+    await po.browserNotifications.injectFakeNotifications();
+
+    await po.chatActions.sendPrompt("hello", { skipWaitForCompletion: true });
+    await triggerHidden(po);
+
+    const tag = `dyad-chat-complete-${chatId}`;
+    let notification =
+      await po.browserNotifications.waitForNotificationWithTag(tag);
+    expect(notification.closed).toBe(false);
+
+    // Simulate window focus (which triggers handleFocus in useNotificationHandler)
+    await po.page.evaluate(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    // Wait for notification to auto-close
+    await expect
+      .poll(
+        async () => {
+          const n =
+            await po.browserNotifications.waitForNotificationWithTag(tag);
+          return n.closed;
+        },
+        { timeout: Timeout.MEDIUM },
+      )
+      .toBe(true);
+  },
+);
+
+// Completion click navigates back to chat (different chat)
+testWithNotificationsEnabled(
+  "notification click navigates to the chat",
+  async ({ po }) => {
+    await po.setUp({ autoApprove: true });
+    await po.importApp("minimal");
+
+    // Wait for the initial stream triggered by importing the app to finish
+    await po.chatActions.waitForChatCompletion({ timeout: Timeout.LONG });
+
+    await enableNotifications(po);
+
+    // Create a fresh chat for the notification test
+    const initialChatId = await createChat(po);
+
+    await po.browserNotifications.injectFakeNotifications();
+
+    await po.chatActions.sendPrompt("test", { skipWaitForCompletion: true });
+    await triggerDifferentChat(po, initialChatId);
+
+    const tag = `dyad-chat-complete-${initialChatId}`;
+    await po.browserNotifications.waitForNotificationWithTag(tag);
+
+    // Click notification to navigate back
+    await po.browserNotifications.clickNotificationWithTag(tag);
+
+    await expectNavigatedToChat(po, initialChatId);
+  },
+);
+
+// Completion dedupe by tag (app hidden)
+testWithNotificationsEnabled(
+  "duplicate notification tags close previous notification",
+  async ({ po }) => {
+    await po.setUp({ autoApprove: true });
+    await po.importApp("minimal");
+
+    // Wait for the initial stream triggered by importing the app to finish
+    await po.chatActions.waitForChatCompletion({ timeout: Timeout.LONG });
+
+    await enableNotifications(po);
+
+    // Create a fresh chat for the notification test
+    const chatId = await createChat(po);
+
+    await po.browserNotifications.injectFakeNotifications();
+    const tag = `dyad-chat-complete-${chatId}`;
+
+    // Send first message
+    await po.chatActions.sendPrompt("first", { skipWaitForCompletion: true });
+    await triggerHidden(po);
+
+    await po.browserNotifications.waitForNotificationWithTag(tag);
+    let notifications = await po.browserNotifications.getCreatedNotifications();
+    expect(notifications.filter((n) => n.tag === tag)).toHaveLength(1);
+
+    // We are already on the correct chat, and the previous stream is complete
+    // because the notification was triggered. We can just send the second message.
+    // Send second message - should create new notification with same tag
+    await po.chatActions.sendPrompt("second", { skipWaitForCompletion: true });
+    await triggerHidden(po);
+
+    await po.browserNotifications.waitForNotificationWithTag(tag);
+
+    // Check that we have 2 notifications with the tag
+    // (the new one should have closed the old one)
+    notifications = await po.browserNotifications.getCreatedNotifications();
+    const tagNotifications = notifications.filter((n) => n.tag === tag);
+    expect(tagNotifications.length).toBeGreaterThanOrEqual(1);
+
+    // Latest one should be open
+    const latest = tagNotifications[tagNotifications.length - 1];
+    expect(latest.closed).toBe(false);
+  },
+);
+
+// Verifies no notifications are created when the feature is disabled.
+test("notification not created when notifications disabled", async ({ po }) => {
+  await po.setUp({ autoApprove: true });
+  await po.importApp("minimal");
+  await po.browserNotifications.injectFakeNotifications();
+
+  // Notifications should be disabled by default
+  const notifications = await po.browserNotifications.getCreatedNotifications();
+  expect(notifications).toHaveLength(0);
+
+  await po.chatActions.sendPrompt("hello");
+  await po.chatActions.waitForChatCompletion();
+
+  // Still no notifications
+  const notificationsAfter =
+    await po.browserNotifications.getCreatedNotifications();
+  expect(notificationsAfter).toHaveLength(0);
+});
+
+// Completion permission denied shows toast (app hidden)
+testWithNotificationsEnabled(
+  "notification permission denied shows fallback warning",
+  async ({ po }) => {
+    await po.setUp({ autoApprove: true });
+    await po.importApp("minimal");
+
+    // Wait for the initial stream triggered by importing the app to finish
+    await po.chatActions.waitForChatCompletion({ timeout: Timeout.LONG });
+
+    await enableNotifications(po);
+
+    // Create a fresh chat for the notification test
+    const _chatId = await createChat(po);
+
+    await po.browserNotifications.injectFakeNotifications();
+    await po.browserNotifications.setPermission("denied");
+
+    await po.chatActions.sendPrompt("hello", { skipWaitForCompletion: true });
+    await triggerHidden(po);
+
+    // Should show fallback toast instead of notification
+    const notifications =
+      await po.browserNotifications.getCreatedNotifications();
+    expect(notifications).toHaveLength(0);
+
+    // Check for warning toast
+    await po.toastNotifications.waitForToastWithText(
+      "Enable notifications for Dyad",
+    );
+  },
+);
+
+// Agent consent (app hidden): sticky notification
+testWithNotificationsEnabled(
+  "agent consent notification when app hidden",
+  async ({ po, electronApp }) => {
+    await po.setUp({ autoApprove: false });
+    await po.importApp("minimal");
+    await po.chatActions.waitForChatCompletion({ timeout: Timeout.LONG });
+    await enableNotifications(po);
+
+    const chatId = await createChat(po);
+    await triggerHidden(po);
+    await po.browserNotifications.injectFakeNotifications();
+    // Simulate Agent Consent IPC Event from Main process
+    await electronApp.evaluate(
+      ({ BrowserWindow }, { chatId }) => {
+        const window = BrowserWindow.getAllWindows()[0];
+        window.webContents.send("agent-tool:consent-request", {
+          requestId: "test-request",
+          chatId,
+          toolName: "test_tool",
+        });
+      },
+      { chatId },
+    );
+
+    const tag = `dyad-agent-consent-${chatId}-test_tool`;
+    const notification =
+      await po.browserNotifications.waitForNotificationWithTag(tag);
+    expect(notification.requireInteraction).toBe(true);
+  },
+);
+
+// Agent consent (different chat): sticky notification
+testWithNotificationsEnabled(
+  "agent consent notification when viewing different chat",
+  async ({ po, electronApp }) => {
+    await po.setUp({ autoApprove: false });
+    await po.importApp("minimal");
+    await po.chatActions.waitForChatCompletion({ timeout: Timeout.LONG });
+    await enableNotifications(po);
+
+    const chatId = await createChat(po);
+    await triggerDifferentChat(po, chatId);
+    await po.browserNotifications.injectFakeNotifications();
+
+    await electronApp.evaluate(
+      ({ BrowserWindow }, { chatId }) => {
+        const window = BrowserWindow.getAllWindows()[0];
+        window.webContents.send("agent-tool:consent-request", {
+          requestId: "test-request",
+          chatId,
+          toolName: "test_tool",
+        });
+      },
+      { chatId },
+    );
+
+    const tag = `dyad-agent-consent-${chatId}-test_tool`;
+    const notification =
+      await po.browserNotifications.waitForNotificationWithTag(tag);
+    expect(notification.requireInteraction).toBe(true);
+  },
+);
+
+// Agent consent click navigates back to chat (different chat)
+testWithNotificationsEnabled(
+  "agent consent notification click navigates to chat",
+  async ({ po, electronApp }) => {
+    await po.setUp({ autoApprove: false });
+    await po.importApp("minimal");
+    await po.chatActions.waitForChatCompletion({ timeout: Timeout.LONG });
+    await enableNotifications(po);
+
+    const chatId = await createChat(po);
+    await triggerDifferentChat(po, chatId);
+    await po.browserNotifications.injectFakeNotifications();
+
+    await electronApp.evaluate(
+      ({ BrowserWindow }, { chatId }) => {
+        const window = BrowserWindow.getAllWindows()[0];
+        window.webContents.send("agent-tool:consent-request", {
+          requestId: "test-request",
+          chatId,
+          toolName: "test_tool",
+        });
+      },
+      { chatId },
+    );
+
+    const tag = `dyad-agent-consent-${chatId}-test_tool`;
+    await po.browserNotifications.waitForNotificationWithTag(tag);
+
+    await po.browserNotifications.clickNotificationWithTag(tag);
+    await expectNavigatedToChat(po, chatId);
+  },
+);
+
+// MCP consent (app hidden): sticky notification with tool info
+testWithNotificationsEnabled(
+  "mcp consent notification when app hidden",
+  async ({ po, electronApp }) => {
+    await po.setUp({ autoApprove: false });
+    await po.importApp("minimal");
+    await po.chatActions.waitForChatCompletion({ timeout: Timeout.LONG });
+    await enableNotifications(po);
+
+    const chatId = await createChat(po);
+    await triggerHidden(po);
+    await po.browserNotifications.injectFakeNotifications();
+    // Simulate MCP Consent IPC Event from Main process
+    await electronApp.evaluate(
+      ({ BrowserWindow }, { chatId }) => {
+        const window = BrowserWindow.getAllWindows()[0];
+        window.webContents.send("mcp:tool-consent-request", {
+          requestId: "mcp-request",
+          serverId: 1,
+          chatId,
+          toolName: "mcp_tool",
+          serverName: "Test Server",
+        });
+      },
+      { chatId },
+    );
+
+    const tag = `dyad-mcp-consent-${chatId}-mcp_tool`;
+    const notification =
+      await po.browserNotifications.waitForNotificationWithTag(tag);
+    expect(notification.body).toContain("mcp_tool");
+    expect(notification.requireInteraction).toBe(true);
+  },
+);
+
+// MCP consent (different chat): sticky notification with tool info
+testWithNotificationsEnabled(
+  "mcp consent notification when viewing different chat",
+  async ({ po, electronApp }) => {
+    await po.setUp({ autoApprove: false });
+    await po.importApp("minimal");
+    await po.chatActions.waitForChatCompletion({ timeout: Timeout.LONG });
+    await enableNotifications(po);
+
+    const chatId = await createChat(po);
+    await triggerDifferentChat(po, chatId);
+    await po.browserNotifications.injectFakeNotifications();
+
+    await electronApp.evaluate(
+      ({ BrowserWindow }, { chatId }) => {
+        const window = BrowserWindow.getAllWindows()[0];
+        window.webContents.send("mcp:tool-consent-request", {
+          requestId: "mcp-request",
+          serverId: 1,
+          chatId,
+          toolName: "mcp_tool",
+          serverName: "Test Server",
+        });
+      },
+      { chatId },
+    );
+
+    const tag = `dyad-mcp-consent-${chatId}-mcp_tool`;
+    const notification =
+      await po.browserNotifications.waitForNotificationWithTag(tag);
+    expect(notification.body).toContain("mcp_tool");
+    expect(notification.requireInteraction).toBe(true);
+  },
+);
+
+// MCP consent click navigates back to chat (different chat)
+testWithNotificationsEnabled(
+  "mcp consent notification click navigates to chat",
+  async ({ po, electronApp }) => {
+    await po.setUp({ autoApprove: false });
+    await po.importApp("minimal");
+    await po.chatActions.waitForChatCompletion({ timeout: Timeout.LONG });
+    await enableNotifications(po);
+
+    const chatId = await createChat(po);
+    await triggerDifferentChat(po, chatId);
+    await po.browserNotifications.injectFakeNotifications();
+
+    await electronApp.evaluate(
+      ({ BrowserWindow }, { chatId }) => {
+        const window = BrowserWindow.getAllWindows()[0];
+        window.webContents.send("mcp:tool-consent-request", {
+          requestId: "mcp-request",
+          serverId: 1,
+          chatId,
+          toolName: "mcp_tool",
+          serverName: "Test Server",
+        });
+      },
+      { chatId },
+    );
+
+    const tag = `dyad-mcp-consent-${chatId}-mcp_tool`;
+    await po.browserNotifications.waitForNotificationWithTag(tag);
+
+    await po.browserNotifications.clickNotificationWithTag(tag);
+    await expectNavigatedToChat(po, chatId);
+  },
+);
+
+// Planning questionnaire (app hidden): tagged sticky notification
+testWithNotificationsEnabled(
+  "planning questionnaire notification when app hidden",
+  async ({ po, electronApp }) => {
+    await po.setUp({ autoApprove: false });
+    await po.importApp("minimal");
+    await po.chatActions.waitForChatCompletion({ timeout: Timeout.LONG });
+    await enableNotifications(po);
+
+    const chatId = await createChat(po);
+    await triggerHidden(po);
+    await po.browserNotifications.injectFakeNotifications();
+    // Simulate Questionnaire Event from Main process
+    await electronApp.evaluate(
+      ({ BrowserWindow }, { chatId }) => {
+        const window = BrowserWindow.getAllWindows()[0];
+        window.webContents.send("plan:questionnaire", {
+          chatId,
+          requestId: "plan-request",
+          questions: [
+            {
+              id: "q1",
+              type: "text",
+              question: "What is your favorite color?",
+            },
+          ],
+        });
+      },
+      { chatId },
+    );
+
+    const tag = `dyad-plan-questionnaire-${chatId}-Planning Questions`;
+    const notification =
+      await po.browserNotifications.waitForNotificationWithTag(tag);
+    expect(notification.body).toContain("Planning Questions");
+    expect(notification.requireInteraction).toBe(true);
+  },
+);
+
+// Planning questionnaire (different chat): tagged sticky notification
+testWithNotificationsEnabled(
+  "planning questionnaire notification when viewing different chat",
+  async ({ po, electronApp }) => {
+    await po.setUp({ autoApprove: false });
+    await po.importApp("minimal");
+    await po.chatActions.waitForChatCompletion({ timeout: Timeout.LONG });
+    await enableNotifications(po);
+
+    const chatId = await createChat(po);
+    await triggerDifferentChat(po, chatId);
+    await po.browserNotifications.injectFakeNotifications();
+
+    await electronApp.evaluate(
+      ({ BrowserWindow }, { chatId }) => {
+        const window = BrowserWindow.getAllWindows()[0];
+        window.webContents.send("plan:questionnaire", {
+          chatId,
+          requestId: "plan-request",
+          questions: [
+            {
+              id: "q1",
+              type: "text",
+              question: "What is your favorite color?",
+            },
+          ],
+        });
+      },
+      { chatId },
+    );
+
+    const tag = `dyad-plan-questionnaire-${chatId}-Planning Questions`;
+    const notification =
+      await po.browserNotifications.waitForNotificationWithTag(tag);
+    expect(notification.body).toContain("Planning Questions");
+    expect(notification.requireInteraction).toBe(true);
+  },
+);
+
+// Planning questionnaire click navigates back to chat (different chat)
+testWithNotificationsEnabled(
+  "planning questionnaire notification click navigates to chat",
+  async ({ po, electronApp }) => {
+    await po.setUp({ autoApprove: false });
+    await po.importApp("minimal");
+    await po.chatActions.waitForChatCompletion({ timeout: Timeout.LONG });
+    await enableNotifications(po);
+
+    const chatId = await createChat(po);
+    await triggerDifferentChat(po, chatId);
+    await po.browserNotifications.injectFakeNotifications();
+
+    await electronApp.evaluate(
+      ({ BrowserWindow }, { chatId }) => {
+        const window = BrowserWindow.getAllWindows()[0];
+        window.webContents.send("plan:questionnaire", {
+          chatId,
+          requestId: "plan-request",
+          questions: [
+            {
+              id: "q1",
+              type: "text",
+              question: "What is your favorite color?",
+            },
+          ],
+        });
+      },
+      { chatId },
+    );
+
+    const tag = `dyad-plan-questionnaire-${chatId}-Planning Questions`;
+    await po.browserNotifications.waitForNotificationWithTag(tag);
+
+    await po.browserNotifications.clickNotificationWithTag(tag);
+    await expectNavigatedToChat(po, chatId);
+  },
+);

--- a/e2e-tests/helpers/page-objects/PageObject.ts
+++ b/e2e-tests/helpers/page-objects/PageObject.ts
@@ -30,6 +30,7 @@ import { ModelPicker } from "./components/ModelPicker";
 import { Settings } from "./components/Settings";
 import { AppManagement } from "./components/AppManagement";
 import { PromptLibrary } from "./components/PromptLibrary";
+import { BrowserNotifications } from "./components/BrowserNotifications";
 
 // Import dialog page objects
 import { ContextFilesPickerDialog } from "./dialogs/ContextFilesPickerDialog";
@@ -53,6 +54,7 @@ export class PageObject {
   public settings: Settings;
   public appManagement: AppManagement;
   public promptLibrary: PromptLibrary;
+  public browserNotifications: BrowserNotifications;
 
   constructor(
     public electronApp: ElectronApplication,
@@ -75,6 +77,7 @@ export class PageObject {
     this.settings = new Settings(this.page, userDataDir, fakeLlmPort);
     this.appManagement = new AppManagement(this.page, electronApp, userDataDir);
     this.promptLibrary = new PromptLibrary(this.page);
+    this.browserNotifications = new BrowserNotifications(this.page);
   }
 
   // ================================

--- a/e2e-tests/helpers/page-objects/components/BrowserNotifications.ts
+++ b/e2e-tests/helpers/page-objects/components/BrowserNotifications.ts
@@ -1,0 +1,178 @@
+/**
+ * Page object for browser (OS) notifications.
+ * Since we can't reliably test the actual OS notification surface in an automated way, this page object injects a fake Notification implementation into the app that captures created notifications. This allows us to assert on notification creation, content, and simulated interactions without relying on the OS.
+ */
+
+import { Page, expect } from "@playwright/test";
+import { Timeout } from "../../constants";
+
+export interface FakeNotificationRecord {
+  title: string;
+  body?: string;
+  tag?: string;
+  requireInteraction?: boolean;
+  closed: boolean;
+}
+
+export class BrowserNotifications {
+  constructor(public page: Page) {}
+
+  /**
+   * Inject a fake window.Notification global that captures created notifications.
+   * Must be called before triggering notification-creating flows.
+   */
+  async injectFakeNotifications() {
+    await this.page.evaluate(() => {
+      const created: any[] = [];
+
+      class FakeNotification {
+        static permission: NotificationPermission = "granted";
+        static requestPermission: () => Promise<NotificationPermission> =
+          async () => "granted";
+
+        title: string;
+        options: NotificationOptions;
+        onclick: (() => void) | null = null;
+        onclose: (() => void) | null = null;
+        closed = false;
+
+        constructor(title: string, options: NotificationOptions = {}) {
+          this.title = title;
+          this.options = options;
+          created.push(this);
+        }
+
+        close() {
+          this.closed = true;
+          this.onclose?.();
+        }
+      }
+
+      Object.defineProperty(window, "Notification", {
+        configurable: true,
+        value: FakeNotification,
+      });
+
+      (window as any).__createdNotifications = created;
+    });
+  }
+
+  /**
+   * Set the fake notification permission to a specific value.
+   * Useful for testing permission denial/default flows.
+   */
+  async setPermission(permission: NotificationPermission) {
+    await this.page.evaluate((perm) => {
+      const Notification = window.Notification as any;
+      if (Notification) {
+        Notification.permission = perm;
+        if (perm === "denied") {
+          Notification.requestPermission = async () => "denied";
+        } else if (perm === "default") {
+          Notification.requestPermission = async () => "granted";
+        }
+      }
+    }, permission);
+  }
+
+  async getCreatedNotifications(): Promise<FakeNotificationRecord[]> {
+    return await this.page.evaluate(() => {
+      const notifications = (window as any).__createdNotifications ?? [];
+      return notifications.map((n: any) => ({
+        title: n.title,
+        body: n.options?.body,
+        tag: n.options?.tag,
+        requireInteraction: n.options?.requireInteraction,
+        closed: n.closed,
+      }));
+    });
+  }
+
+  async waitForNotificationWithTag(
+    tag: string,
+    timeout = Timeout.MEDIUM,
+  ): Promise<FakeNotificationRecord> {
+    await expect
+      .poll(
+        async () => {
+          const notifications = await this.getCreatedNotifications();
+          return notifications.find((n) => n.tag === tag);
+        },
+        { timeout },
+      )
+      .toBeTruthy();
+
+    const notifications = await this.getCreatedNotifications();
+    return notifications.find((n) => n.tag === tag)!;
+  }
+
+  async waitForNotificationWithText(
+    title: string,
+    body?: string,
+    timeout = Timeout.MEDIUM,
+  ): Promise<FakeNotificationRecord> {
+    await expect
+      .poll(
+        async () => {
+          const notifications = await this.getCreatedNotifications();
+          return notifications.find(
+            (n) => n.title.includes(title) && (!body || n.body?.includes(body)),
+          );
+        },
+        { timeout },
+      )
+      .toBeTruthy();
+
+    const notifications = await this.getCreatedNotifications();
+    return notifications.find(
+      (n) => n.title.includes(title) && (!body || n.body?.includes(body)),
+    )!;
+  }
+
+  async clickNotificationWithTag(tag: string) {
+    await this.page.evaluate((targetTag) => {
+      const notifications = (window as any).__createdNotifications ?? [];
+      const notification = notifications.find(
+        (n: any) => n.options?.tag === targetTag,
+      );
+      if (notification?.onclick) {
+        notification.onclick.call(notification);
+      }
+    }, tag);
+  }
+
+  async closeNotificationWithTag(tag: string) {
+    await this.page.evaluate((targetTag) => {
+      const notifications = (window as any).__createdNotifications ?? [];
+      const notification = notifications.find(
+        (n: any) => n.options?.tag === targetTag,
+      );
+      if (notification) {
+        notification.close();
+      }
+    }, tag);
+  }
+
+  async getActiveNotificationCount(): Promise<number> {
+    return await this.page.evaluate(() => {
+      const notifications = (window as any).__createdNotifications ?? [];
+      return notifications.filter((n: any) => !n.closed).length;
+    });
+  }
+
+  async assertNotificationClosed(tag: string) {
+    const notification = await this.waitForNotificationWithTag(tag);
+    expect(notification.closed).toBe(true);
+  }
+
+  async assertNotificationOpen(tag: string) {
+    const notification = await this.waitForNotificationWithTag(tag);
+    expect(notification.closed).toBe(false);
+  }
+
+  async clearNotifications() {
+    await this.page.evaluate(() => {
+      (window as any).__createdNotifications = [];
+    });
+  }
+}

--- a/e2e-tests/helpers/page-objects/components/Settings.ts
+++ b/e2e-tests/helpers/page-objects/components/Settings.ts
@@ -54,6 +54,25 @@ export class Settings {
     await this.page.getByRole("switch", { name: "Auto-update" }).click();
   }
 
+  async enableChatEventNotifications() {
+    await expect(
+      this.page.getByRole("heading", { level: 1, name: "Settings" }),
+    ).toBeVisible();
+
+    const label = this.page.getByText("Enable notifications", { exact: true });
+
+    // Find the switch button that is a sibling to the label by going to the parent container
+    const toggleButton = label.locator("xpath=..").getByRole("switch");
+    await expect(toggleButton).toBeAttached();
+
+    await toggleButton.scrollIntoViewIfNeeded();
+
+    const ariaChecked = await toggleButton.getAttribute("aria-checked");
+    if (ariaChecked !== "true") {
+      await label.click();
+    }
+  }
+
   async changeReleaseChannel(channel: "stable" | "beta") {
     await this.page.getByRole("combobox", { name: "Release Channel" }).click();
     await this.page

--- a/src/atoms/chatAtoms.ts
+++ b/src/atoms/chatAtoms.ts
@@ -8,6 +8,29 @@ import type { ListedApp } from "@/ipc/types/app";
 import type { Getter, Setter } from "jotai";
 import { atom } from "jotai";
 
+// Chat completion events - used to notify when a stream has completed
+export type ChatCompletionEvent = {
+  sequence: number;
+  chatId: number;
+  title?: string;
+};
+
+let nextChatCompletionSequence = 0;
+
+//  atom that holds the latest chat completion event
+export const chatCompletionEventAtom = atom<ChatCompletionEvent | null>(null);
+
+// Atom to publish new chat completion events
+export const publishChatCompletionEventAtom = atom(
+  null,
+  (_get, set, payload: Omit<ChatCompletionEvent, "sequence">) => {
+    set(chatCompletionEventAtom, {
+      sequence: ++nextChatCompletionSequence,
+      ...payload,
+    });
+  },
+);
+
 // Per-chat atoms implemented with maps keyed by chatId
 export const chatMessagesByIdAtom = atom<Map<number, Message[]>>(new Map());
 export const chatErrorByIdAtom = atom<Map<number, string | null>>(new Map());

--- a/src/hooks/useEnableNotifications.ts
+++ b/src/hooks/useEnableNotifications.ts
@@ -3,8 +3,11 @@ import { useSettings } from "@/hooks/useSettings";
 import { detectIsMac } from "@/hooks/useChatModeToggle";
 
 function sendTestNotification() {
-  if (Notification.permission === "granted") {
-    new Notification("Dyad", {
+  if (
+    typeof window.Notification !== "undefined" &&
+    window.Notification.permission === "granted"
+  ) {
+    new window.Notification("Dyad", {
       body: "Notifications are working! You'll be notified when responses finish or input is needed.",
     });
   }
@@ -22,12 +25,13 @@ export function useEnableNotifications() {
   }, [isMac]);
 
   const enable = useCallback(async () => {
-    if (Notification.permission === "denied") {
+    if (typeof window.Notification === "undefined") return;
+    if (window.Notification.permission === "denied") {
       openMacGuide();
       return;
     }
-    if (Notification.permission === "default") {
-      const permission = await Notification.requestPermission();
+    if (window.Notification.permission === "default") {
+      const permission = await window.Notification.requestPermission();
       if (permission !== "granted") {
         openMacGuide();
         return;

--- a/src/hooks/useNotificationHandler.ts
+++ b/src/hooks/useNotificationHandler.ts
@@ -173,8 +173,8 @@ export function useNotificationHandler() {
         !document.hasFocus();
       if (!shouldNotify) return;
       let currentPermission =
-        typeof Notification !== "undefined"
-          ? Notification.permission
+        typeof window.Notification !== "undefined"
+          ? window.Notification.permission
           : "denied";
 
       if (currentPermission === "default") {

--- a/src/hooks/useNotificationHandler.ts
+++ b/src/hooks/useNotificationHandler.ts
@@ -1,0 +1,414 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback, useEffect, useRef } from "react";
+import { useAtomValue } from "jotai";
+import { useRouterState } from "@tanstack/react-router";
+import { chatCompletionEventAtom } from "@/atoms/chatAtoms";
+import { useSelectChat } from "./useSelectChat";
+import { ipc } from "../ipc/types";
+import { showWarning } from "../lib/toast";
+
+import {
+  resolveAppIdForChat,
+  resolveAppNameForAppId,
+  resolveChatSummary,
+} from "../lib/chatUtils";
+
+import { useSettings } from "./useSettings";
+import { planEventClient } from "../ipc/types/plan";
+
+// Auto-close timer for completion notifications (give user enough time to navigate to chat completed)
+const AUTO_CLOSE_MS = 10_000;
+
+// Truncate text
+function truncate(text: string, limit: number): string {
+  if (text.length <= limit) return text;
+  const spaceIdx = text.lastIndexOf(" ", limit);
+  return text.slice(0, spaceIdx > 0 ? spaceIdx : limit) + "...";
+}
+
+/**
+ * Hook that handles all OS-level notifications (Completions, Agent Consent, MCP Consent, Planning Questionnaire).
+ * Listens for browser events for completions and IPC events for consent and questionnaire.
+ */
+export function useNotificationHandler() {
+  const { selectChat } = useSelectChat();
+  const queryClient = useQueryClient();
+  const { settings } = useSettings();
+
+  const selectChatRef = useRef(selectChat);
+  const notificationsEnabled = settings?.enableChatEventNotifications === true;
+  const notificationsEnabledRef = useRef(notificationsEnabled);
+  const consentPermissionPromptedRef = useRef(false);
+  const consentDeniedWarningShownRef = useRef(false);
+  const completionPermissionRequestedRef = useRef(false);
+  const completionDeniedWarningShownRef = useRef(false);
+
+  // Track actual route to detect when user is viewing other page
+  const routerState = useRouterState();
+  const currentRouteRef = useRef({
+    pathname: routerState.location.pathname,
+    chatIdFromRoute: routerState.location.search.id as number | undefined,
+  });
+  useEffect(() => {
+    currentRouteRef.current = {
+      pathname: routerState.location.pathname,
+      chatIdFromRoute: routerState.location.search.id as number | undefined,
+    };
+  }, [routerState.location.pathname, routerState.location.search.id]);
+
+  // Update notificationsEnabled when setting changes
+  useEffect(() => {
+    notificationsEnabledRef.current = notificationsEnabled;
+  }, [notificationsEnabled]);
+
+  // Track notifications and timers for auto-close
+  const autoCloseTimersRef = useRef(
+    new Map<string, ReturnType<typeof setTimeout>>(),
+  );
+  const notificationsRef = useRef(new Map<string, Notification>());
+  const notificationChatIdByTagRef = useRef(new Map<string, number>());
+
+  useEffect(() => {
+    selectChatRef.current = selectChat;
+  }, [selectChat]);
+
+  const requestNotificationPermission = useCallback(async () => {
+    if (typeof window.Notification === "undefined") return "denied" as const;
+    if (window.Notification.permission !== "default")
+      return window.Notification.permission;
+    return window.Notification.requestPermission();
+  }, []);
+
+  // Shared helper for showing/closing native notifications
+  const showNativeNotification = useCallback(
+    async (params: {
+      chatId: number;
+      title: string;
+      body: string;
+      tag: string;
+      requireInteraction?: boolean;
+      autoClose?: boolean;
+    }) => {
+      const { chatId, title, body, tag, requireInteraction, autoClose } =
+        params;
+
+      // Deduplicate by tag to avoid collisions
+      notificationsRef.current.get(tag)?.close();
+      const existingTimer = autoCloseTimersRef.current.get(tag);
+      if (existingTimer) clearTimeout(existingTimer);
+
+      let notification: Notification;
+      try {
+        notification = new Notification(title, {
+          body,
+          tag,
+          requireInteraction,
+        });
+      } catch (error) {
+        console.error("Failed to create notification:", error);
+        return;
+      }
+      notificationsRef.current.set(tag, notification);
+      notificationChatIdByTagRef.current.set(tag, chatId);
+
+      const cleanup = () => {
+        // Only clear state if this is the same notification instance currently tracked
+        if (notificationsRef.current.get(tag) !== notification) return;
+        const timer = autoCloseTimersRef.current.get(tag);
+        if (timer) clearTimeout(timer);
+        notificationsRef.current.delete(tag);
+        notificationChatIdByTagRef.current.delete(tag);
+        autoCloseTimersRef.current.delete(tag);
+      };
+
+      if (autoClose) {
+        const timer = setTimeout(() => {
+          notification.close();
+          cleanup();
+        }, AUTO_CLOSE_MS);
+        autoCloseTimersRef.current.set(tag, timer);
+      }
+
+      notification.onclose = cleanup;
+
+      notification.onclick = async () => {
+        ipc.system.focusWindow().catch(console.error);
+
+        // Navigate to chat that triggered the notification
+        const appId = await resolveAppIdForChat(chatId, queryClient);
+        if (appId) {
+          selectChatRef.current({ chatId, appId });
+        } else {
+          showWarning("Could not open this chat. It may have been deleted.");
+        }
+        notification.close();
+      };
+    },
+    [queryClient],
+  );
+
+  /**
+   * Unified logic for handling Agent and MCP consent requests.
+   * All consent requests are scoped to a specific chat (chatId always > 0).
+   * Respects enableChatEventNotifications setting.
+   */
+  const handleConsentRequest = useCallback(
+    async (params: {
+      chatId: number;
+      toolName: string;
+      sourceLabel?: string;
+      tagPrefix: string;
+    }) => {
+      // Skip if notifications are disabled
+      if (!notificationsEnabledRef.current) return;
+
+      const id = params.chatId;
+      // Notify if viewing different page OR app is hidden/minimized OR app is unfocused(two screen case).
+      const isViewingConsentChat =
+        currentRouteRef.current.pathname === "/chat" &&
+        currentRouteRef.current.chatIdFromRoute === id;
+      const shouldNotify =
+        !isViewingConsentChat ||
+        document.visibilityState === "hidden" ||
+        !document.hasFocus();
+      if (!shouldNotify) return;
+      let currentPermission =
+        typeof Notification !== "undefined"
+          ? Notification.permission
+          : "denied";
+
+      if (currentPermission === "default") {
+        if (!consentPermissionPromptedRef.current) {
+          consentPermissionPromptedRef.current = true;
+          currentPermission = await requestNotificationPermission();
+        } else {
+          currentPermission = "denied";
+        }
+      }
+
+      // Fallback Warning if notifications are unavailable or permission denied
+      if (currentPermission !== "granted") {
+        if (!consentDeniedWarningShownRef.current) {
+          consentDeniedWarningShownRef.current = true;
+          const target = params.sourceLabel
+            ? ` from "${params.sourceLabel}"`
+            : "";
+          showWarning(
+            `"${params.toolName}"${target} needs your approval. Enable notifications for Dyad in your operating system's notification settings.`,
+          );
+        }
+        return;
+      }
+
+      // Recheck visibility & focus after async permission request — user may have navigated/unfocused during dialog
+      const isStillViewingConsentChat =
+        currentRouteRef.current.pathname === "/chat" &&
+        currentRouteRef.current.chatIdFromRoute === id;
+      const stillShouldNotify =
+        !isStillViewingConsentChat ||
+        document.visibilityState === "hidden" ||
+        !document.hasFocus();
+      if (!stillShouldNotify) return;
+
+      // All consent requests are scoped to a chat, so resolve app/chat info
+      const chatSummary = await resolveChatSummary(id, queryClient);
+      // get app name so user knows which app is making the request
+      const appName = chatSummary?.appId
+        ? await resolveAppNameForAppId(chatSummary.appId, queryClient)
+        : "Dyad";
+      const title = appName;
+
+      showNativeNotification({
+        chatId: id,
+        title,
+        body: `"${params.toolName}" wants to run. Click to review and approve.`,
+        // Include toolName in tag to avoid collision when same chat has multiple consent requests
+        tag: `${params.tagPrefix}-${id}-${params.toolName}`,
+        requireInteraction: true,
+      });
+    },
+    [queryClient, requestNotificationPermission, showNativeNotification],
+  );
+
+  const completionEvent = useAtomValue(chatCompletionEventAtom);
+
+  useEffect(() => {
+    if (!completionEvent) return;
+
+    const { chatId, title: summary } = completionEvent;
+    const isViewingThisChat =
+      currentRouteRef.current.pathname === "/chat" &&
+      currentRouteRef.current.chatIdFromRoute === chatId;
+    const shouldNotify =
+      !isViewingThisChat ||
+      document.visibilityState === "hidden" ||
+      !document.hasFocus();
+
+    if (!notificationsEnabledRef.current || !shouldNotify) return;
+
+    if (typeof window.Notification === "undefined") return;
+
+    void (async () => {
+      if (window.Notification.permission === "granted") {
+        const chatSummary = await resolveChatSummary(chatId, queryClient);
+        const appName = chatSummary?.appId
+          ? await resolveAppNameForAppId(chatSummary.appId, queryClient)
+          : "Dyad";
+        const chatTitle = chatSummary?.title ?? null;
+
+        const bodyContext = summary || chatTitle || "Chat response completed";
+        const trimmed = truncate(bodyContext, 60);
+
+        showNativeNotification({
+          chatId,
+          title: appName,
+          body: trimmed,
+          tag: `dyad-chat-complete-${chatId}`,
+          autoClose: true,
+        });
+        return;
+      }
+
+      if (window.Notification.permission === "denied") {
+        if (!completionDeniedWarningShownRef.current) {
+          completionDeniedWarningShownRef.current = true;
+          showWarning(
+            "Enable notifications for Dyad in your operating system's notification settings to receive chat completion alerts.",
+          );
+        }
+        return;
+      }
+
+      if (
+        !completionPermissionRequestedRef.current &&
+        window.Notification.permission === "default"
+      ) {
+        completionPermissionRequestedRef.current = true;
+        const permission = await requestNotificationPermission();
+
+        if (permission !== "granted") {
+          if (permission === "denied") {
+            completionDeniedWarningShownRef.current = true;
+            showWarning(
+              "Enable notifications for Dyad in your operating system's notification settings to receive chat completion alerts.",
+            );
+          }
+          return;
+        }
+
+        if (permission === "granted") {
+          const isStillViewingThisChat =
+            currentRouteRef.current.pathname === "/chat" &&
+            currentRouteRef.current.chatIdFromRoute === chatId;
+          const stillShouldNotify =
+            !isStillViewingThisChat ||
+            document.visibilityState === "hidden" ||
+            !document.hasFocus();
+
+          if (stillShouldNotify) {
+            const chatSummary = await resolveChatSummary(chatId, queryClient);
+            const appName = chatSummary?.appId
+              ? await resolveAppNameForAppId(chatSummary.appId, queryClient)
+              : "Dyad";
+            const chatTitle = chatSummary?.title ?? null;
+
+            const bodyContext =
+              summary || chatTitle || "Chat response completed";
+            const trimmed = truncate(bodyContext, 60);
+
+            showNativeNotification({
+              chatId,
+              title: appName,
+              body: trimmed,
+              tag: `dyad-chat-complete-${chatId}`,
+              autoClose: true,
+            });
+          }
+        }
+        return;
+      }
+    })();
+  }, [
+    completionEvent,
+    queryClient,
+    showNativeNotification,
+    requestNotificationPermission,
+  ]);
+
+  // Agent Tool Consent Listener (IPC)
+  useEffect(() => {
+    const unsubscribe = ipc.events.agent.onConsentRequest(async (payload) => {
+      handleConsentRequest({
+        chatId: payload.chatId,
+        toolName: payload.toolName,
+        tagPrefix: "dyad-agent-consent",
+      }).catch(console.error);
+    });
+    return () => unsubscribe();
+  }, [handleConsentRequest]);
+
+  // MCP Tool Consent Listener (IPC)
+  useEffect(() => {
+    const unsubscribe = ipc.events.mcp.onConsentRequest(async (payload) => {
+      handleConsentRequest({
+        chatId: payload.chatId,
+        toolName: payload.toolName,
+        sourceLabel: payload.serverName || "an MCP server",
+        tagPrefix: "dyad-mcp-consent",
+      }).catch(console.error);
+    });
+    return () => unsubscribe();
+  }, [handleConsentRequest]);
+
+  // Planning Questionnaire Listener (IPC)
+  useEffect(() => {
+    const unsubscribe = planEventClient.onQuestionnaire(async (payload) => {
+      handleConsentRequest({
+        chatId: payload.chatId,
+        toolName: "Planning Questions",
+        sourceLabel: `${payload.questions.length} questions`,
+        tagPrefix: "dyad-plan-questionnaire",
+      }).catch(console.error);
+    });
+    return () => unsubscribe();
+  }, [handleConsentRequest]);
+
+  // Close notifications when window gains focus (user returned to app).
+  useEffect(() => {
+    const handleFocus = () => {
+      const currentChatId = currentRouteRef.current.chatIdFromRoute;
+
+      for (const [tag, notification] of notificationsRef.current.entries()) {
+        // Close completion notifications (informational, in-app handles it)
+        if (tag.startsWith("dyad-chat-complete-")) {
+          notification.close();
+          const timer = autoCloseTimersRef.current.get(tag);
+          if (timer) clearTimeout(timer);
+          autoCloseTimersRef.current.delete(tag);
+          notificationsRef.current.delete(tag);
+        }
+        // Close consent notifications for the currently focused chat (in-app banner shows it)
+        // to avoid OS + in-app UI duplication
+        else if (
+          (tag.startsWith("dyad-agent-consent-") ||
+            tag.startsWith("dyad-mcp-consent-") ||
+            tag.startsWith("dyad-plan-questionnaire-")) &&
+          currentChatId
+        ) {
+          const chatIdInTag = notificationChatIdByTagRef.current.get(tag);
+          if (chatIdInTag === currentChatId) {
+            notification.close();
+            const timer = autoCloseTimersRef.current.get(tag);
+            if (timer) clearTimeout(timer);
+            autoCloseTimersRef.current.delete(tag);
+            notificationChatIdByTagRef.current.delete(tag);
+            notificationsRef.current.delete(tag);
+          }
+        }
+      }
+    };
+
+    window.addEventListener("focus", handleFocus);
+    return () => window.removeEventListener("focus", handleFocus);
+  }, []);
+}

--- a/src/hooks/usePlanEvents.ts
+++ b/src/hooks/usePlanEvents.ts
@@ -2,7 +2,6 @@ import { useEffect, useRef } from "react";
 import { useAtomValue, useSetAtom } from "jotai";
 import { useNavigate } from "@tanstack/react-router";
 import { useQueryClient } from "@tanstack/react-query";
-import { useSettings } from "./useSettings";
 import { queryKeys } from "@/lib/queryKeys";
 import {
   planStateAtom,
@@ -38,17 +37,14 @@ export function usePlanEvents() {
   const setSelectedChatId = useSetAtom(selectedChatIdAtom);
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const { settings } = useSettings();
 
   // Use refs for values accessed in event handlers to avoid stale closures
   const planStateRef = useRef(planState);
   const selectedAppIdRef = useRef(selectedAppId);
-  const settingsRef = useRef(settings);
 
   // Keep refs up to date
   planStateRef.current = planState;
   selectedAppIdRef.current = selectedAppId;
-  settingsRef.current = settings;
 
   useEffect(() => {
     // Handle plan updates
@@ -168,7 +164,11 @@ export function usePlanEvents() {
       },
     );
 
+
     // Handle questionnaire events (part of the planning flow)
+
+    // Handle questionnaire events - set pending questionnaire for in-app display
+
     const unsubscribeQuestionnaire = planEventClient.onQuestionnaire(
       (payload: PlanQuestionnairePayload) => {
         setPendingQuestionnaire((prev) => {
@@ -177,12 +177,6 @@ export function usePlanEvents() {
           return next;
         });
 
-        showUserInputNotification({
-          appId: selectedAppIdRef.current,
-          queryClient,
-          settings: settingsRef.current,
-          body: "A questionnaire needs your input",
-        });
       },
     );
 

--- a/src/hooks/usePlanEvents.ts
+++ b/src/hooks/usePlanEvents.ts
@@ -19,7 +19,6 @@ import {
 } from "@/ipc/types/plan";
 import { ipc } from "@/ipc/types";
 import { showError } from "@/lib/toast";
-import { showUserInputNotification } from "@/lib/userInputNotification";
 
 /**
  * Hook to handle plan mode IPC events.
@@ -164,7 +163,6 @@ export function usePlanEvents() {
       },
     );
 
-
     // Handle questionnaire events (part of the planning flow)
 
     // Handle questionnaire events - set pending questionnaire for in-app display
@@ -176,7 +174,6 @@ export function usePlanEvents() {
           next.set(payload.chatId, payload);
           return next;
         });
-
       },
     );
 

--- a/src/hooks/useStreamChat.ts
+++ b/src/hooks/useStreamChat.ts
@@ -14,13 +14,13 @@ import {
   queuedMessagesByIdAtom,
   streamCompletedSuccessfullyByIdAtom,
   queuePausedByIdAtom,
+  publishChatCompletionEventAtom,
   type QueuedMessageItem,
 } from "@/atoms/chatAtoms";
 import { ipc } from "@/ipc/types";
 import { isPreviewOpenAtom } from "@/atoms/viewAtoms";
 import { pendingScreenshotAppIdAtom } from "@/atoms/previewAtoms";
-import type { ChatResponseEnd, App, Chat } from "@/ipc/types";
-import type { ChatSummary } from "@/lib/schemas";
+import type { ChatResponseEnd, Chat } from "@/ipc/types";
 import { useChats } from "./useChats";
 import { useLoadApp } from "./useLoadApp";
 import { applyStreamingPatch } from "@/lib/applyStreamingPatch";
@@ -43,6 +43,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "@/lib/queryKeys";
 import { applyCancellationNoticeToLastAssistantMessage } from "@/shared/chatCancellation";
 import { handleEffectiveChatModeChunk } from "@/lib/chatModeStream";
+import { resolveAppIdForChat } from "@/lib/chatUtils";
 
 export function getRandomNumberId() {
   return Math.floor(Math.random() * 1_000_000_000_000_000);
@@ -92,6 +93,7 @@ export function useStreamChat({
   const errorById = useAtomValue(chatErrorByIdAtom);
   const setErrorById = useSetAtom(chatErrorByIdAtom);
   const setIsPreviewOpen = useSetAtom(isPreviewOpenAtom);
+  const publishChatCompletionEvent = useSetAtom(publishChatCompletionEventAtom);
   const [selectedAppId] = useAtom(selectedAppIdAtom);
   const { invalidateChats } = useChats(selectedAppId);
   const { refreshApp } = useLoadApp(selectedAppId);
@@ -217,22 +219,10 @@ export function useStreamChat({
       // pass one. Falling back to `selectedAppId` is wrong for background
       // queue processing, where the user may have switched to a different
       // app while a queued message streams for the original chat.
-      let resolvedAppIdFromChat: number | null = null;
-      if (appId === undefined) {
-        // queryKeys.chats.all matches detail/search caches too (non-array data),
-        // so guard against non-array entries before calling .find.
-        const chatsCaches = queryClient.getQueriesData<ChatSummary[]>({
-          queryKey: queryKeys.chats.all,
-        });
-        for (const [, cachedChats] of chatsCaches) {
-          if (!Array.isArray(cachedChats)) continue;
-          const found = cachedChats.find((c) => c.id === chatId);
-          if (found) {
-            resolvedAppIdFromChat = found.appId;
-            break;
-          }
-        }
-      }
+      const resolvedAppIdFromChat =
+        appId === undefined
+          ? await resolveAppIdForChat(chatId, queryClient)
+          : null;
       const targetAppId =
         appId ?? resolvedAppIdFromChat ?? selectedAppId ?? null;
       try {
@@ -362,33 +352,9 @@ export function useStreamChat({
                     next.set(chatId, true);
                     return next;
                   });
-                }
-
-                // Show native notification if enabled and window is not focused
-                // Fire-and-forget to avoid blocking UI updates
-                const notificationsEnabled =
-                  settings?.enableChatEventNotifications === true;
-                if (
-                  notificationsEnabled &&
-                  Notification.permission === "granted" &&
-                  !document.hasFocus()
-                ) {
-                  const app = queryClient.getQueryData<App | null>(
-                    queryKeys.apps.detail({ appId: targetAppId ?? null }),
-                  );
-                  const chats = queryClient.getQueryData<ChatSummary[]>(
-                    queryKeys.chats.list({ appId: targetAppId ?? null }),
-                  );
-                  const chat = chats?.find((c) => c.id === chatId);
-                  const appName = app?.name ?? "Dyad";
-                  const rawTitle = response.chatSummary ?? chat?.title;
-                  const body = rawTitle
-                    ? rawTitle.length > 80
-                      ? rawTitle.slice(0, 80) + "…"
-                      : rawTitle
-                    : "Chat response completed";
-                  new Notification(appName, {
-                    body,
+                  publishChatCompletionEvent({
+                    chatId,
+                    title: response.chatSummary,
                   });
                 }
 

--- a/src/ipc/handlers/chat_handlers.ts
+++ b/src/ipc/handlers/chat_handlers.ts
@@ -93,6 +93,31 @@ export function registerChatHandlers() {
     };
   });
 
+  createTypedHandler(chatContracts.getChatMetadata, async (_, chatId) => {
+    const chat = await db.query.chats.findFirst({
+      where: eq(chats.id, chatId),
+      columns: {
+        id: true,
+        appId: true,
+        title: true,
+        createdAt: true,
+        chatMode: true,
+      },
+    });
+
+    if (!chat) {
+      throw new DyadError("Chat not found", DyadErrorKind.NotFound);
+    }
+
+    return {
+      id: chat.id,
+      appId: chat.appId,
+      title: chat.title,
+      createdAt: chat.createdAt,
+      chatMode: normalizeStoredChatMode(chat.chatMode),
+    };
+  });
+
   createTypedHandler(chatContracts.getChats, async (_, appId) => {
     // If appId is provided, filter chats for that app
     const query = appId

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -1609,7 +1609,7 @@ This conversation includes one or more image attachments. When the user uploads 
           settings.enableMcpServersForBuildMode &&
           selectedChatMode === "build"
         ) {
-          const tools = await getMcpTools(event);
+          const tools = await getMcpTools(event, req.chatId);
           const hasEnabledMcpServers = Object.keys(tools).length > 0;
 
           // Only run MCP agent path if build mode has enabled MCP servers
@@ -2318,7 +2318,10 @@ ${otherAppsCodebaseInfo}
 `;
 }
 
-async function getMcpTools(event: IpcMainInvokeEvent): Promise<ToolSet> {
+async function getMcpTools(
+  event: IpcMainInvokeEvent,
+  chatId: number,
+): Promise<ToolSet> {
   const mcpToolSet: ToolSet = {};
   try {
     const servers = await db
@@ -2346,6 +2349,7 @@ async function getMcpTools(event: IpcMainInvokeEvent): Promise<ToolSet> {
               toolName: name,
               toolDescription: mcpTool.description,
               inputPreview,
+              chatId,
             });
 
             if (!ok)

--- a/src/ipc/handlers/window_handlers.ts
+++ b/src/ipc/handlers/window_handlers.ts
@@ -40,6 +40,19 @@ export function registerWindowHandlers() {
     window.close();
   });
 
+  createTypedHandler(systemContracts.focusWindow, async (event) => {
+    const window = BrowserWindow.fromWebContents(event.sender);
+    if (!window) {
+      logger.error("Failed to get BrowserWindow instance for focus command");
+      return;
+    }
+    if (window.isMinimized()) {
+      window.restore();
+    }
+    window.show(); // Ensures window is visible on macOS
+    window.focus();
+  });
+
   createTypedHandler(systemContracts.getSystemPlatform, async () => {
     return platform();
   });

--- a/src/ipc/types/chat.ts
+++ b/src/ipc/types/chat.ts
@@ -44,6 +44,7 @@ export const NullableChatModeSchema = StoredChatModeSchema.nullable().transform(
  */
 export const ChatSchema = z.object({
   id: z.number(),
+  appId: z.number(),
   title: z.string(),
   messages: z.array(MessageSchema),
   initialCommitHash: z.string().nullable().optional(),
@@ -243,6 +244,18 @@ export const chatContracts = {
         chatMode: NullableChatModeSchema,
       }),
     ),
+  }),
+
+  getChatMetadata: defineContract({
+    channel: "get-chat-metadata",
+    input: z.number(),
+    output: z.object({
+      id: z.number(),
+      appId: z.number(),
+      title: z.string().nullable(),
+      createdAt: z.date(),
+      chatMode: NullableChatModeSchema,
+    }),
   }),
 
   createChat: defineContract({

--- a/src/ipc/types/mcp.ts
+++ b/src/ipc/types/mcp.ts
@@ -106,6 +106,7 @@ export const McpConsentRequestSchema = z.object({
   toolName: z.string(),
   toolDescription: z.string().nullable().optional(),
   inputPreview: z.string().nullable().optional(),
+  chatId: z.number(),
 });
 
 export type McpConsentRequestPayload = z.infer<typeof McpConsentRequestSchema>;

--- a/src/ipc/types/system.ts
+++ b/src/ipc/types/system.ts
@@ -129,6 +129,13 @@ export const systemContracts = {
     output: z.void(),
   }),
 
+  // restore focus to main window
+  focusWindow: defineContract({
+    channel: "window:focus",
+    input: z.void(),
+    output: z.void(),
+  }),
+
   // Platform info
   getSystemPlatform: defineContract({
     channel: "get-system-platform",

--- a/src/ipc/utils/mcp_consent.ts
+++ b/src/ipc/utils/mcp_consent.ts
@@ -84,6 +84,7 @@ export async function requireMcpToolConsent(
     toolName: string;
     toolDescription?: string | null;
     inputPreview?: string | null;
+    chatId: number;
   },
 ): Promise<boolean> {
   const current = await getStoredConsent(params.serverId, params.toolName);

--- a/src/lib/chatUtils.ts
+++ b/src/lib/chatUtils.ts
@@ -1,0 +1,83 @@
+import { QueryClient } from "@tanstack/react-query";
+import { ChatSummary } from "./schemas";
+import { queryKeys } from "./queryKeys";
+import { ipc } from "../ipc/types";
+
+type ResolveChatSummaryOptions = {
+  cacheOnly?: boolean;
+};
+
+/**
+ * Resolves a minimal chat summary for a given chatId.
+ * Cache-first with an optional IPC fallback.
+ */
+export async function resolveChatSummary(
+  chatId: number,
+  queryClient: QueryClient,
+  options: ResolveChatSummaryOptions = {},
+): Promise<ChatSummary | null> {
+  const chatsCaches = queryClient.getQueriesData<ChatSummary[]>({
+    queryKey: queryKeys.chats.all,
+  });
+
+  for (const [, cachedChats] of chatsCaches) {
+    if (!Array.isArray(cachedChats)) continue;
+    const found = cachedChats.find((c) => c.id === chatId);
+    if (found) return found;
+  }
+
+  if (options.cacheOnly) return null;
+
+  try {
+    const chat = await ipc.chat.getChatMetadata(chatId);
+    return {
+      id: chat.id,
+      appId: chat.appId,
+      title: chat.title,
+      createdAt: chat.createdAt,
+      chatMode: chat.chatMode,
+    };
+  } catch (error) {
+    console.warn(
+      `[CHAT_UTILS] Failed to fetch chat metadata for ${chatId}:`,
+      error,
+    );
+    return null;
+  }
+}
+
+/**
+ * Attempts to resolve an app name for a given appId.
+ * Searches the local cache first, then falls back to IPC.
+ */
+export async function resolveAppNameForAppId(
+  appId: number,
+  queryClient: QueryClient,
+): Promise<string> {
+  const app = queryClient.getQueryData<{ name: string } | null>(
+    queryKeys.apps.detail({ appId }),
+  );
+  if (app?.name) return app.name;
+
+  try {
+    const fetchedApp = await ipc.app.getApp(appId);
+    return fetchedApp?.name ?? "Dyad";
+  } catch (error) {
+    console.error("[CHAT_UTILS] Failed to resolve app name via IPC:", error);
+  }
+
+  return "Dyad";
+}
+
+/**
+ * Resolves the appId for a given chatId by checking the TanStack Query cache
+ * and falling back to a direct IPC fetch if necessary.
+ */
+export async function resolveAppIdForChat(
+  chatId: number,
+  queryClient: QueryClient,
+  options: ResolveChatSummaryOptions = {},
+): Promise<number | null> {
+  const summary = await resolveChatSummary(chatId, queryClient, options);
+  return summary?.appId ?? null;
+}

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -1820,6 +1820,7 @@ async function getMcpTools(
                 toolName: name,
                 toolDescription: mcpTool.description,
                 inputPreview,
+                chatId: ctx.chatId,
               });
 
               if (!ok) throw new Error(`User declined running tool ${key}`);

--- a/src/routes/root.tsx
+++ b/src/routes/root.tsx
@@ -1,10 +1,14 @@
 import { createRootRoute, Outlet } from "@tanstack/react-router";
 import Layout from "../app/layout";
+import { useNotificationHandler } from "../hooks/useNotificationHandler";
 
 export const rootRoute = createRootRoute({
-  component: () => (
-    <Layout>
-      <Outlet />
-    </Layout>
-  ),
+  component: () => {
+    useNotificationHandler();
+    return (
+      <Layout>
+        <Outlet />
+      </Layout>
+    );
+  },
 });


### PR DESCRIPTION
closes #3325 
## Summary

Improves Dyad's native notification workflow so users never miss chat completions or blocking permission requests, with a unified, simple mental model for controlling all notification types.

## Problem
Previously, chat completion notifications and consent requests were scattered across multiple handlers with overlapping logic, timers, and closure issues. MCP consent schema had [chatId] as optional, creating confusion about "global MCP tools" and resulting in inconsistent behavior.

## Solution
Centralized Notification Handler
Created useNotificationHandler.ts as a single source of truth for all OS-level notifications:

## Listens for stream completion custom events
Listens for IPC-based consent requests (agent consent, MCP consent, planning questionnaire)
Manages notification lifecycle (creation, deduplication, auto-close, cleanup)
Handles focus events to auto-close notifications when user returns to app
Unified Notification Control
Single enableChatEventNotifications toggle now controls all notification types (completions, agent consent, MCP consent, questionnaire) for a simpler, more intuitive mental model. Users can opt into/out of all notifications as a group.


Chat Completion Notifications

Respects user's enableChatEventNotifications toggle
Auto-closes after 10 seconds (gives user time to navigate)
Tag-deduplicated to prevent spam
On click: focuses window + navigates to the specified chat 
Graceful fallback to in-app toast if OS permission denied
Consent Notifications (Agent + MCP + Questionnaire)

All controlled by the same enableChatEventNotifications toggle (unified behavior)
Shows OS notification when app is unfocused or when viewing a different chat/page
Uses requireInteraction: true to keep notification visible until clicked
Auto-closes when window gains focus (user sees in-app consent UI instead)
Same click-to-focus and navigation behavior as completions

Made [chatId: z.number()]required in MCP consent schema (was optional), matching agent consent. This enforces the invariant that MCP tools are always scoped to a specific chat, never "global."

Efficient IPC Helpers
New in chatUtils.ts:

resolveChatSummary() – Cache-first lookup using lightweight [getChatMetadata()]
resolveAppNameForAppId() – Reusable app name lookup
resolveAppIdForChat() – Cache-first with IPC fallback
New IPC endpoints:

[system.focusWindow()] window restore
Event-Driven Design
Stream completion dispatches CustomEvent("dyad-stream-completion") instead of directly calling notification code. 