### PR TITLE
[codex] Allow any provider for explicit Basic Agent mode

### DIFF
--- a/src/__tests__/chatMode.test.ts
+++ b/src/__tests__/chatMode.test.ts
@@ -42,7 +42,7 @@ describe("chat mode resolution", () => {
     ).toEqual({ mode: "plan" });
   });
 
-  it("falls back when stored local-agent mode has no provider", () => {
+  it("keeps stored local-agent mode when no provider is configured", () => {
     const settings = makeSettings({ defaultChatMode: "build" });
 
     expect(
@@ -52,7 +52,7 @@ describe("chat mode resolution", () => {
         envVars: {},
         freeAgentQuotaAvailable: true,
       }),
-    ).toEqual({ mode: "build", fallbackReason: "no-provider" });
+    ).toEqual({ mode: "local-agent" });
   });
 
   it("falls back when stored local-agent mode is out of quota", () => {
@@ -180,7 +180,23 @@ describe("chat mode resolution", () => {
     ).toEqual({ mode: "local-agent" });
   });
 
-  it("reports quota exhausted before Pro required when a provider is configured", () => {
+  it("keeps stored local-agent mode without a provider when Pro is enabled without a key", () => {
+    const settings = makeSettings({
+      enableDyadPro: true,
+      defaultChatMode: "build",
+    });
+
+    expect(
+      resolveChatMode({
+        storedChatMode: "local-agent",
+        settings,
+        envVars: {},
+        freeAgentQuotaAvailable: true,
+      }),
+    ).toEqual({ mode: "local-agent" });
+  });
+
+  it("reports quota exhausted when Pro is enabled without a key", () => {
     const settings = makeSettings({
       enableDyadPro: true,
       defaultChatMode: "build",

--- a/src/__tests__/chatMode.test.ts
+++ b/src/__tests__/chatMode.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { normalizeStoredChatMode, resolveChatMode } from "@/lib/chatMode";
-import type { UserSettings } from "@/lib/schemas";
+import { getEffectiveDefaultChatMode, type UserSettings } from "@/lib/schemas";
 
 function makeSettings(overrides: Partial<UserSettings> = {}): UserSettings {
   return {
@@ -71,6 +71,76 @@ describe("chat mode resolution", () => {
         freeAgentQuotaAvailable: false,
       }),
     ).toEqual({ mode: "build", fallbackReason: "quota-exhausted" });
+  });
+
+  it("allows stored local-agent mode with a non-OpenAI/Anthropic provider", () => {
+    const settings = makeSettings({
+      defaultChatMode: "build",
+      providerSettings: {
+        google: { apiKey: { value: "test-key" } },
+      },
+    });
+
+    expect(
+      resolveChatMode({
+        storedChatMode: "local-agent",
+        settings,
+        envVars: {},
+        freeAgentQuotaAvailable: true,
+      }),
+    ).toEqual({ mode: "local-agent" });
+  });
+
+  it("allows stored local-agent mode with a non-OpenAI/Anthropic env var provider", () => {
+    const settings = makeSettings({ defaultChatMode: "build" });
+
+    expect(
+      resolveChatMode({
+        storedChatMode: "local-agent",
+        settings,
+        envVars: { OPENROUTER_API_KEY: "test-key" },
+        freeAgentQuotaAvailable: true,
+      }),
+    ).toEqual({ mode: "local-agent" });
+  });
+
+  it("still reports quota exhausted for stored local-agent mode with another provider", () => {
+    const settings = makeSettings({
+      defaultChatMode: "build",
+      providerSettings: {
+        google: { apiKey: { value: "test-key" } },
+      },
+    });
+
+    expect(
+      resolveChatMode({
+        storedChatMode: "local-agent",
+        settings,
+        envVars: {},
+        freeAgentQuotaAvailable: false,
+      }),
+    ).toEqual({ mode: "build", fallbackReason: "quota-exhausted" });
+  });
+
+  it("does not auto-default to basic agent for non-OpenAI/Anthropic providers", () => {
+    const settings = makeSettings({
+      providerSettings: {
+        google: { apiKey: { value: "test-key" } },
+      },
+    });
+
+    expect(getEffectiveDefaultChatMode(settings, {}, true)).toBe("build");
+  });
+
+  it("does not honor a local-agent default for non-OpenAI/Anthropic providers", () => {
+    const settings = makeSettings({
+      defaultChatMode: "local-agent",
+      providerSettings: {
+        google: { apiKey: { value: "test-key" } },
+      },
+    });
+
+    expect(getEffectiveDefaultChatMode(settings, {}, true)).toBe("build");
   });
 
   it("does not treat unknown quota as exhausted", () => {

--- a/src/components/ChatModeSelector.tsx
+++ b/src/components/ChatModeSelector.tsx
@@ -71,7 +71,6 @@ export function ChatModeSelector() {
 
     fallbackToastKeyRef.current = toastKey;
     showChatModeFallbackToast({
-      reason: fallbackReason,
       effectiveMode,
       isPro: isProEnabled,
       toastId: toastKey,

--- a/src/hooks/useChatMode.ts
+++ b/src/hooks/useChatMode.ts
@@ -55,16 +55,9 @@ export function useChatMode(chatId: number | null | undefined) {
     return getUnavailableChatModeReason({
       mode: storedChatMode,
       settings,
-      envVars,
       freeAgentQuotaAvailable,
     });
-  }, [
-    activeChatId,
-    envVars,
-    freeAgentQuotaAvailable,
-    settings,
-    storedChatMode,
-  ]);
+  }, [activeChatId, freeAgentQuotaAvailable, settings, storedChatMode]);
 
   const effectiveMode =
     activeChatId && fallbackReason ? effectiveDefaultMode : selectedMode;

--- a/src/ipc/handlers/chat_mode_resolution.ts
+++ b/src/ipc/handlers/chat_mode_resolution.ts
@@ -70,13 +70,14 @@ export async function getInitialChatModeForNewChat(
 }
 
 function getChatModeEnvVars(): Record<string, string | undefined> {
-  const openAiEnvVar = PROVIDER_TO_ENV_VAR.openai;
-  const anthropicEnvVar = PROVIDER_TO_ENV_VAR.anthropic;
+  const envVarNames = new Set([
+    ...Object.values(PROVIDER_TO_ENV_VAR),
+    "AZURE_RESOURCE_NAME",
+  ]);
 
-  return {
-    [openAiEnvVar]: getEnvVar(openAiEnvVar),
-    [anthropicEnvVar]: getEnvVar(anthropicEnvVar),
-  };
+  return Object.fromEntries(
+    [...envVarNames].map((envVarName) => [envVarName, getEnvVar(envVarName)]),
+  );
 }
 
 async function getFreeAgentQuotaAvailableIfNeeded(

--- a/src/ipc/types/chat.ts
+++ b/src/ipc/types/chat.ts
@@ -117,9 +117,7 @@ export const ChatResponseChunkSchema = z.object({
   streamingMessageId: z.number().optional(),
   streamingContent: z.string().optional(),
   effectiveChatMode: ChatModeSchema.optional(),
-  chatModeFallbackReason: z
-    .enum(["pro-required", "quota-exhausted", "no-provider"])
-    .optional(),
+  chatModeFallbackReason: z.literal("quota-exhausted").optional(),
 });
 
 export type ChatResponseChunk = z.infer<typeof ChatResponseChunkSchema>;

--- a/src/lib/chatMode.ts
+++ b/src/lib/chatMode.ts
@@ -1,7 +1,5 @@
-import { isAnyNonDyadProviderSetup } from "./providerUtils";
 import {
   getEffectiveDefaultChatMode,
-  hasDyadProKey,
   isDyadProEnabled,
   migrateStoredChatMode,
   StoredChatModeSchema,
@@ -9,10 +7,7 @@ import {
   type UserSettings,
 } from "./schemas";
 
-export type ChatModeFallbackReason =
-  | "pro-required"
-  | "quota-exhausted"
-  | "no-provider";
+export type ChatModeFallbackReason = "quota-exhausted";
 
 export interface ChatModeResolution {
   mode: ChatMode;
@@ -37,12 +32,10 @@ export function normalizeStoredChatMode(
 export function getUnavailableChatModeReason({
   mode,
   settings,
-  envVars,
   freeAgentQuotaAvailable,
 }: {
   mode: ChatMode | null | undefined;
   settings: UserSettings;
-  envVars: Record<string, string | undefined>;
   freeAgentQuotaAvailable?: boolean;
 }): ChatModeFallbackReason | undefined {
   if (mode !== "local-agent") {
@@ -53,19 +46,11 @@ export function getUnavailableChatModeReason({
     return undefined;
   }
 
-  if (isAnyNonDyadProviderSetup(settings, envVars)) {
-    if (freeAgentQuotaAvailable === false) {
-      return "quota-exhausted";
-    }
-
-    return undefined;
+  if (freeAgentQuotaAvailable === false) {
+    return "quota-exhausted";
   }
 
-  if (settings.enableDyadPro === true && !hasDyadProKey(settings)) {
-    return "pro-required";
-  }
-
-  return "no-provider";
+  return undefined;
 }
 
 export function resolveChatMode({
@@ -93,7 +78,6 @@ export function resolveChatMode({
   const fallbackReason = getUnavailableChatModeReason({
     mode: chatMode,
     settings,
-    envVars,
     freeAgentQuotaAvailable,
   });
 

--- a/src/lib/chatMode.ts
+++ b/src/lib/chatMode.ts
@@ -1,4 +1,4 @@
-import { isOpenAIOrAnthropicSetup } from "./providerUtils";
+import { isAnyNonDyadProviderSetup } from "./providerUtils";
 import {
   getEffectiveDefaultChatMode,
   hasDyadProKey,
@@ -53,7 +53,7 @@ export function getUnavailableChatModeReason({
     return undefined;
   }
 
-  if (isOpenAIOrAnthropicSetup(settings, envVars)) {
+  if (isAnyNonDyadProviderSetup(settings, envVars)) {
     if (freeAgentQuotaAvailable === false) {
       return "quota-exhausted";
     }

--- a/src/lib/chatModeStream.ts
+++ b/src/lib/chatModeStream.ts
@@ -20,7 +20,6 @@ export function handleEffectiveChatModeChunk(
 
   if (chunk.chatModeFallbackReason) {
     showChatModeFallbackToast({
-      reason: chunk.chatModeFallbackReason,
       effectiveMode: chunk.effectiveChatMode,
       isPro: settings ? isDyadProEnabled(settings) : false,
       toastId: getChatModeFallbackToastId({

--- a/src/lib/chatModeToast.ts
+++ b/src/lib/chatModeToast.ts
@@ -30,23 +30,16 @@ export function getChatModeFallbackToastId({
 }
 
 export function showChatModeFallbackToast({
-  reason,
   effectiveMode,
   isPro,
   toastId,
 }: {
-  reason: ChatModeFallbackReason;
   effectiveMode: ChatMode;
   isPro: boolean;
   toastId?: string;
 }) {
   const modeName = getChatModeDisplayName(effectiveMode, isPro);
-  const message =
-    reason === "pro-required"
-      ? `Agent v2 unavailable (Pro required). Using ${modeName} mode.`
-      : reason === "quota-exhausted"
-        ? `Quota exhausted. Using ${modeName} mode.`
-        : `No provider configured. Using ${modeName} mode.`;
+  const message = `Quota exhausted. Using ${modeName} mode.`;
 
   toast.warning(message, {
     id: toastId,

--- a/src/lib/providerUtils.ts
+++ b/src/lib/providerUtils.ts
@@ -3,7 +3,10 @@ import {
   type VertexProviderSetting,
   type AzureProviderSetting,
 } from "./schemas";
-import { PROVIDER_TO_ENV_VAR } from "../ipc/shared/language_model_constants";
+import {
+  CLOUD_PROVIDERS,
+  PROVIDER_TO_ENV_VAR,
+} from "../ipc/shared/language_model_constants";
 
 export interface ProviderCheckOptions {
   settings: UserSettings | null;
@@ -92,5 +95,42 @@ export function isOpenAIOrAnthropicSetup(
   const options: ProviderCheckOptions = { settings, envVars };
   return (
     isProviderSetup("openai", options) || isProviderSetup("anthropic", options)
+  );
+}
+
+/**
+ * Checks whether any non-Dyad cloud or custom provider is configured.
+ * Used for allowing an explicitly selected Basic Agent mode without changing
+ * the stricter OpenAI/Anthropic defaulting behavior.
+ */
+export function isAnyNonDyadProviderSetup(
+  settings: UserSettings,
+  envVars: Record<string, string | undefined>,
+  providerData?: { id: string; envVarName?: string; type?: string }[],
+): boolean {
+  if (!settings) return false;
+
+  const options: ProviderCheckOptions = { settings, envVars, providerData };
+  const builtinCloudProviders = Object.keys(CLOUD_PROVIDERS).filter(
+    (provider) => provider !== "auto",
+  );
+
+  if (
+    builtinCloudProviders.some((provider) => isProviderSetup(provider, options))
+  ) {
+    return true;
+  }
+
+  if (
+    providerData
+      ?.filter((provider) => provider.type === "custom")
+      .some((provider) => isProviderSetup(provider.id, options))
+  ) {
+    return true;
+  }
+
+  return Object.entries(settings.providerSettings ?? {}).some(
+    ([provider, providerSettings]) =>
+      provider !== "auto" && Boolean(providerSettings?.apiKey?.value),
   );
 }

--- a/src/lib/providerUtils.ts
+++ b/src/lib/providerUtils.ts
@@ -3,10 +3,7 @@ import {
   type VertexProviderSetting,
   type AzureProviderSetting,
 } from "./schemas";
-import {
-  CLOUD_PROVIDERS,
-  PROVIDER_TO_ENV_VAR,
-} from "../ipc/shared/language_model_constants";
+import { PROVIDER_TO_ENV_VAR } from "../ipc/shared/language_model_constants";
 
 export interface ProviderCheckOptions {
   settings: UserSettings | null;
@@ -95,42 +92,5 @@ export function isOpenAIOrAnthropicSetup(
   const options: ProviderCheckOptions = { settings, envVars };
   return (
     isProviderSetup("openai", options) || isProviderSetup("anthropic", options)
-  );
-}
-
-/**
- * Checks whether any non-Dyad cloud or custom provider is configured.
- * Used for allowing an explicitly selected Basic Agent mode without changing
- * the stricter OpenAI/Anthropic defaulting behavior.
- */
-export function isAnyNonDyadProviderSetup(
-  settings: UserSettings,
-  envVars: Record<string, string | undefined>,
-  providerData?: { id: string; envVarName?: string; type?: string }[],
-): boolean {
-  if (!settings) return false;
-
-  const options: ProviderCheckOptions = { settings, envVars, providerData };
-  const builtinCloudProviders = Object.keys(CLOUD_PROVIDERS).filter(
-    (provider) => provider !== "auto",
-  );
-
-  if (
-    builtinCloudProviders.some((provider) => isProviderSetup(provider, options))
-  ) {
-    return true;
-  }
-
-  if (
-    providerData
-      ?.filter((provider) => provider.type === "custom")
-      .some((provider) => isProviderSetup(provider.id, options))
-  ) {
-    return true;
-  }
-
-  return Object.entries(settings.providerSettings ?? {}).some(
-    ([provider, providerSettings]) =>
-      provider !== "auto" && Boolean(providerSettings?.apiKey?.value),
   );
 }


### PR DESCRIPTION
## Summary

- Allow explicitly selected/stored local-agent mode for non-Pro users when any non-Dyad cloud/custom provider is configured, instead of only OpenAI or Anthropic.
- Keep auto-default behavior unchanged: Basic Agent still only auto-defaults when OpenAI or Anthropic is configured.
- Include all known provider env vars in the main-process chat-mode resolver so env-var configured providers are recognized for explicit Agent mode.

## Root Cause

PR #3249 moved chat-mode fallback enforcement into the per-turn resolver. That unintentionally applied the OpenAI/Anthropic-only defaulting rule to explicit Basic Agent usage, causing users with other configured providers to fall back with "No provider configured".

## Validation

- npm test -- src/__tests__/chatMode.test.ts
- npm run fmt
- npm run lint:fix
- npm run lint
- npm run ts
- git diff --check