### PR TITLE
Fix missing chat tabs when running security review or fixing issues

### DIFF
--- a/e2e-tests/security_review.spec.ts
+++ b/e2e-tests/security_review.spec.ts
@@ -1,4 +1,5 @@
-import { test, testSkipIfWindows } from "./helpers/test_helper";
+import { test, testSkipIfWindows, Timeout } from "./helpers/test_helper";
+import { expect } from "@playwright/test";
 
 // Skipping because snapshotting the security findings table is not
 // consistent across platforms because different amounts of text
@@ -67,4 +68,41 @@ test("security review - multi-select and fix issues", async ({ po }) => {
   await fixSelectedButton.click();
   await po.chatActions.waitForChatCompletion();
   await po.snapshotMessages();
+});
+
+test("security review - creates chat tabs", async ({ po }) => {
+  await po.setUp({ autoApprove: true });
+  await po.sendPrompt("tc=1");
+
+  await po.previewPanel.selectPreviewMode("security");
+
+  // Initial tab count should be 1 (the first chat)
+  const closeButtons = po.page.getByLabel(/^Close tab:/);
+  await expect(async () => {
+    const count = await closeButtons.count();
+    expect(count).toBe(1);
+  }).toPass({ timeout: Timeout.MEDIUM });
+
+  // Run security review creates a new chat
+  await po.page
+    .getByRole("button", { name: "Run Security Review" })
+    .first()
+    .click();
+  await po.chatActions.waitForChatCompletion();
+
+  // Tab count should increase to 2
+  await expect(async () => {
+    const count = await closeButtons.count();
+    expect(count).toBe(2);
+  }).toPass({ timeout: Timeout.MEDIUM });
+
+  // Click Fix Issue creates another chat
+  await po.page.getByRole("button", { name: "Fix Issue" }).first().click();
+  await po.chatActions.waitForChatCompletion();
+
+  // Tab count should increase to 3
+  await expect(async () => {
+    const count = await closeButtons.count();
+    expect(count).toBe(3);
+  }).toPass({ timeout: Timeout.MEDIUM });
 });

--- a/src/components/preview_panel/SecurityPanel.tsx
+++ b/src/components/preview_panel/SecurityPanel.tsx
@@ -1,6 +1,5 @@
-import { useAtomValue, useSetAtom } from "jotai";
+import { useAtomValue } from "jotai";
 import { selectedAppIdAtom } from "@/atoms/appAtoms";
-import { selectedChatIdAtom } from "@/atoms/chatAtoms";
 import { useSecurityReview } from "@/hooks/useSecurityReview";
 import { ipc } from "@/ipc/types";
 import { queryKeys } from "@/lib/queryKeys";
@@ -24,7 +23,6 @@ import {
   Pencil,
   Wrench,
 } from "lucide-react";
-import { useNavigate } from "@tanstack/react-router";
 import { useStreamChat } from "@/hooks/useStreamChat";
 import { showError } from "@/lib/toast";
 import { Badge } from "@/components/ui/badge";
@@ -38,6 +36,7 @@ import { VanillaMarkdownParser } from "@/components/chat/DyadMarkdownParser";
 import { showSuccess, showWarning } from "@/lib/toast";
 import { useLoadAppFile } from "@/hooks/useLoadAppFile";
 import { useQueryClient } from "@tanstack/react-query";
+import { useSelectChat } from "@/hooks/useSelectChat";
 
 const getSeverityColor = (level: SecurityFinding["level"]) => {
   switch (level) {
@@ -699,8 +698,7 @@ function FindingDetailsDialog({
 
 export const SecurityPanel = () => {
   const selectedAppId = useAtomValue(selectedAppIdAtom);
-  const setSelectedChatId = useSetAtom(selectedChatIdAtom);
-  const navigate = useNavigate();
+  const { selectChat } = useSelectChat();
   const queryClient = useQueryClient();
   const { streamMessage } = useStreamChat({ hasChatId: false });
   const { data, isLoading, error, refetch } = useSecurityReview(selectedAppId);
@@ -785,9 +783,9 @@ export const SecurityPanel = () => {
       // Create a new chat
       const chatId = await ipc.chat.createChat(selectedAppId);
 
-      // Navigate to the new chat
-      setSelectedChatId(chatId);
-      await navigate({ to: "/chat", search: { id: chatId } });
+      // Select the new chat (updates session/recent tracking and navigates)
+      selectChat({ chatId, appId: selectedAppId });
+      queryClient.invalidateQueries({ queryKey: queryKeys.chats.all });
 
       // Stream the security review prompt
       await streamMessage({
@@ -817,9 +815,9 @@ export const SecurityPanel = () => {
 
       const chatId = await ipc.chat.createChat(selectedAppId);
 
-      // Navigate to the new chat
-      setSelectedChatId(chatId);
-      await navigate({ to: "/chat", search: { id: chatId } });
+      // Select the new chat (updates session/recent tracking and navigates)
+      selectChat({ chatId, appId: selectedAppId });
+      queryClient.invalidateQueries({ queryKey: queryKeys.chats.all });
 
       const prompt = `Please fix the following security issue in a simple and effective way:
 
@@ -887,9 +885,9 @@ ${finding.description}`;
       // Create a new chat
       const chatId = await ipc.chat.createChat(selectedAppId);
 
-      // Navigate to the new chat
-      setSelectedChatId(chatId);
-      await navigate({ to: "/chat", search: { id: chatId } });
+      // Select the new chat (updates session/recent tracking and navigates)
+      selectChat({ chatId, appId: selectedAppId });
+      queryClient.invalidateQueries({ queryKey: queryKeys.chats.all });
 
       // Build a comprehensive prompt for all selected issues
       const issuesList = findingsToFix


### PR DESCRIPTION
closes #3277 
Fix missing chat tabs when running security review or fixing security issues.

Bug Clicking "Fix Issue" or "Run Security Review" in the Security Panel creates a new chat and navigates to it, but the chat tab doesn't appear at the top. Switching to another tab makes the chat impossible to find until an edit happens in the stream.

Root Cause SecurityPanel.tsx was manually setting selectedChatId and calling navigate() after creating a chat, but this bypassed the session tracking atoms that ChatTabs uses to filter visible tabs. Specifically, ChatTabs only renders chats present in sessionOpenedChatIdsAtom (via getOrderedRecentChatIds). Since the security panel never called addSessionOpenedChatId or pushRecentViewedChatId, the newly created chat was excluded from the tab bar even though the query cache was stale.

Fix Replaced the manual navigation pattern with useSelectChat().selectChat() in all three handlers
before:
<img width="1565" height="869" alt="Capture d&#39;écran 2026-05-06 041220" src="https://github.com/user-attachments/assets/5e886f56-893c-41b6-a288-18d9d803b32e" />
after :
<img width="1159" height="733" alt="Capture d&#39;écran 2026-05-06 040009" src="https://github.com/user-attachments/assets/6fc187d6-f8f0-4970-832c-bf8b89d58297" />
