### PR TITLE
test: performance testing infrastructure for streaming responses

### DIFF
--- a/src/hooks/useStreamChat.ts
+++ b/src/hooks/useStreamChat.ts
@@ -53,23 +53,29 @@ export function getRandomNumberId() {
 const pendingStreamChatIds = new Set<number>();
 
 // Throttled ack scheduler for the canned test stream's ack-based
-// backpressure. Stores the highest chunkSeq received per chatId; at most
-// one ack per ACK_THROTTLE_MS is sent per chatId, carrying the latest
-// received seq. Real LLM streams omit chunkSeq, so the scheduler is never
-// armed for them.
+// backpressure. Stores the highest chunkSeq received per chatId along
+// with the stream-instance token it belongs to; at most one ack per
+// ACK_THROTTLE_MS is sent per chatId, carrying the latest received seq
+// and its token. Real LLM streams omit chunkSeq, so the scheduler is
+// never armed for them.
 const ACK_THROTTLE_MS = 250;
-const latestChunkSeqByChatId = new Map<number, number>();
+type LatestChunkState = { token: number; seq: number };
+const latestChunkByChatId = new Map<number, LatestChunkState>();
 const ackTimerByChatId = new Map<number, ReturnType<typeof setTimeout>>();
 
 function scheduleThrottledAck(chatId: number): void {
   if (ackTimerByChatId.has(chatId)) return;
   const timer = setTimeout(() => {
     ackTimerByChatId.delete(chatId);
-    const seq = latestChunkSeqByChatId.get(chatId);
-    if (seq === undefined) return;
+    const state = latestChunkByChatId.get(chatId);
+    if (state === undefined) return;
     const electron = (window as unknown as { electron?: any }).electron;
     void electron?.ipcRenderer
-      ?.invoke("chat:response:ack", { chatId, lastSeq: seq })
+      ?.invoke("chat:response:ack", {
+        chatId,
+        lastSeq: state.seq,
+        streamToken: state.token,
+      })
       ?.catch(() => {
         // Ignore ack failures; main has no retry path and acks are
         // advisory under throttling.
@@ -264,6 +270,7 @@ export function useStreamChat({
               streamingMessageId,
               streamingPatch,
               chunkSeq,
+              chunkStreamToken,
               effectiveChatMode,
               chatModeFallbackReason,
             }) => {
@@ -316,18 +323,25 @@ export function useStreamChat({
               // Ack-based backpressure for the canned test stream. Real
               // LLM streams omit chunkSeq, so this is a no-op for them.
               // Coalesce many incoming chunks into a single ack fired on a
-              // fixed throttle interval (ACK_THROTTLE_MS).
-              if (chunkSeq !== undefined) {
-                const prev = latestChunkSeqByChatId.get(chatId) ?? 0;
-                if (chunkSeq > prev) {
-                  latestChunkSeqByChatId.set(chatId, chunkSeq);
+              // fixed throttle interval (ACK_THROTTLE_MS). State is keyed
+              // by stream token so a chunk from a new stream resets seq
+              // tracking and any pending ack reflects the new stream.
+              if (chunkSeq !== undefined && chunkStreamToken !== undefined) {
+                const prev = latestChunkByChatId.get(chatId);
+                if (prev === undefined || prev.token !== chunkStreamToken) {
+                  latestChunkByChatId.set(chatId, {
+                    token: chunkStreamToken,
+                    seq: chunkSeq,
+                  });
+                } else if (chunkSeq > prev.seq) {
+                  prev.seq = chunkSeq;
                 }
                 scheduleThrottledAck(chatId);
               }
             },
             onEnd: (response: ChatResponseEnd) => {
               pendingStreamChatIds.delete(chatId);
-              latestChunkSeqByChatId.delete(chatId);
+              latestChunkByChatId.delete(chatId);
               cancelAckTimer(chatId);
               void (async () => {
                 // Only mark as successful if NOT cancelled - wasCancelled flag is set
@@ -504,7 +518,7 @@ export function useStreamChat({
             onError: ({ error: errorMessage, warningMessages }) => {
               // Remove from pending set now that stream ended with error
               pendingStreamChatIds.delete(chatId);
-              latestChunkSeqByChatId.delete(chatId);
+              latestChunkByChatId.delete(chatId);
               cancelAckTimer(chatId);
 
               for (const warningMessage of warningMessages ?? []) {
@@ -541,7 +555,7 @@ export function useStreamChat({
       } catch (error) {
         // Remove from pending set on exception
         pendingStreamChatIds.delete(chatId);
-        latestChunkSeqByChatId.delete(chatId);
+        latestChunkByChatId.delete(chatId);
         cancelAckTimer(chatId);
 
         console.error("[CHAT] Exception during streaming setup:", error);

--- a/src/hooks/useStreamChat.ts
+++ b/src/hooks/useStreamChat.ts
@@ -67,13 +67,10 @@ function scheduleThrottledAck(chatId: number): void {
     ackTimerByChatId.delete(chatId);
     const seq = latestChunkByChatId.get(chatId);
     if (seq === undefined) return;
-    const electron = (window as unknown as { electron?: any }).electron;
-    void electron?.ipcRenderer
-      ?.invoke("chat:response:ack", { chatId, lastSeq: seq })
-      ?.catch(() => {
-        // Ignore ack failures; main has no retry path and acks are
-        // advisory under throttling.
-      });
+    void ipc.chat.responseAck({ chatId, lastSeq: seq }).catch(() => {
+      // Ignore ack failures; main has no retry path and acks are
+      // advisory under throttling.
+    });
   }, ACK_THROTTLE_MS);
   ackTimerByChatId.set(chatId, timer);
 }

--- a/src/hooks/useStreamChat.ts
+++ b/src/hooks/useStreamChat.ts
@@ -52,6 +52,40 @@ export function getRandomNumberId() {
 // This prevents race conditions when clicking rapidly before state updates
 const pendingStreamChatIds = new Set<number>();
 
+// Throttled ack scheduler for the canned test stream's ack-based
+// backpressure. Stores the highest chunkSeq received per chatId; at most
+// one ack per ACK_THROTTLE_MS is sent per chatId, carrying the latest
+// received seq. Real LLM streams omit chunkSeq, so the scheduler is never
+// armed for them.
+const ACK_THROTTLE_MS = 250;
+const latestChunkSeqByChatId = new Map<number, number>();
+const ackTimerByChatId = new Map<number, ReturnType<typeof setTimeout>>();
+
+function scheduleThrottledAck(chatId: number): void {
+  if (ackTimerByChatId.has(chatId)) return;
+  const timer = setTimeout(() => {
+    ackTimerByChatId.delete(chatId);
+    const seq = latestChunkSeqByChatId.get(chatId);
+    if (seq === undefined) return;
+    const electron = (window as unknown as { electron?: any }).electron;
+    void electron?.ipcRenderer
+      ?.invoke("chat:response:ack", { chatId, lastSeq: seq })
+      ?.catch(() => {
+        // Ignore ack failures; main has no retry path and acks are
+        // advisory under throttling.
+      });
+  }, ACK_THROTTLE_MS);
+  ackTimerByChatId.set(chatId, timer);
+}
+
+function cancelAckTimer(chatId: number): void {
+  const timer = ackTimerByChatId.get(chatId);
+  if (timer !== undefined) {
+    clearTimeout(timer);
+    ackTimerByChatId.delete(chatId);
+  }
+}
+
 export function useStreamChat({
   hasChatId = true,
 }: { hasChatId?: boolean } = {}) {
@@ -229,6 +263,7 @@ export function useStreamChat({
               messages: updatedMessages,
               streamingMessageId,
               streamingPatch,
+              chunkSeq,
               effectiveChatMode,
               chatModeFallbackReason,
             }) => {
@@ -277,9 +312,23 @@ export function useStreamChat({
                   triggerResync(chatId, setMessagesById, store);
                 }
               }
+
+              // Ack-based backpressure for the canned test stream. Real
+              // LLM streams omit chunkSeq, so this is a no-op for them.
+              // Coalesce many incoming chunks into a single ack fired on a
+              // fixed throttle interval (ACK_THROTTLE_MS).
+              if (chunkSeq !== undefined) {
+                const prev = latestChunkSeqByChatId.get(chatId) ?? 0;
+                if (chunkSeq > prev) {
+                  latestChunkSeqByChatId.set(chatId, chunkSeq);
+                }
+                scheduleThrottledAck(chatId);
+              }
             },
             onEnd: (response: ChatResponseEnd) => {
               pendingStreamChatIds.delete(chatId);
+              latestChunkSeqByChatId.delete(chatId);
+              cancelAckTimer(chatId);
               void (async () => {
                 // Only mark as successful if NOT cancelled - wasCancelled flag is set
                 // by the backend when user cancels the stream
@@ -455,6 +504,8 @@ export function useStreamChat({
             onError: ({ error: errorMessage, warningMessages }) => {
               // Remove from pending set now that stream ended with error
               pendingStreamChatIds.delete(chatId);
+              latestChunkSeqByChatId.delete(chatId);
+              cancelAckTimer(chatId);
 
               for (const warningMessage of warningMessages ?? []) {
                 showWarning(warningMessage);
@@ -490,6 +541,8 @@ export function useStreamChat({
       } catch (error) {
         // Remove from pending set on exception
         pendingStreamChatIds.delete(chatId);
+        latestChunkSeqByChatId.delete(chatId);
+        cancelAckTimer(chatId);
 
         console.error("[CHAT] Exception during streaming setup:", error);
         setIsStreamingById((prev) => {

--- a/src/hooks/useStreamChat.ts
+++ b/src/hooks/useStreamChat.ts
@@ -53,29 +53,23 @@ export function getRandomNumberId() {
 const pendingStreamChatIds = new Set<number>();
 
 // Throttled ack scheduler for the canned test stream's ack-based
-// backpressure. Stores the highest chunkSeq received per chatId along
-// with the stream-instance token it belongs to; at most one ack per
-// ACK_THROTTLE_MS is sent per chatId, carrying the latest received seq
-// and its token. Real LLM streams omit chunkSeq, so the scheduler is
-// never armed for them.
+// backpressure. Stores the highest chunkSeq received per chatId; at most
+// one ack per ACK_THROTTLE_MS is sent per chatId, carrying the latest
+// received seq. Real LLM streams omit chunkSeq, so the scheduler is never
+// armed for them.
 const ACK_THROTTLE_MS = 250;
-type LatestChunkState = { token: number; seq: number };
-const latestChunkByChatId = new Map<number, LatestChunkState>();
+const latestChunkByChatId = new Map<number, number>();
 const ackTimerByChatId = new Map<number, ReturnType<typeof setTimeout>>();
 
 function scheduleThrottledAck(chatId: number): void {
   if (ackTimerByChatId.has(chatId)) return;
   const timer = setTimeout(() => {
     ackTimerByChatId.delete(chatId);
-    const state = latestChunkByChatId.get(chatId);
-    if (state === undefined) return;
+    const seq = latestChunkByChatId.get(chatId);
+    if (seq === undefined) return;
     const electron = (window as unknown as { electron?: any }).electron;
     void electron?.ipcRenderer
-      ?.invoke("chat:response:ack", {
-        chatId,
-        lastSeq: state.seq,
-        streamToken: state.token,
-      })
+      ?.invoke("chat:response:ack", { chatId, lastSeq: seq })
       ?.catch(() => {
         // Ignore ack failures; main has no retry path and acks are
         // advisory under throttling.
@@ -270,7 +264,6 @@ export function useStreamChat({
               streamingMessageId,
               streamingPatch,
               chunkSeq,
-              chunkStreamToken,
               effectiveChatMode,
               chatModeFallbackReason,
             }) => {
@@ -323,18 +316,11 @@ export function useStreamChat({
               // Ack-based backpressure for the canned test stream. Real
               // LLM streams omit chunkSeq, so this is a no-op for them.
               // Coalesce many incoming chunks into a single ack fired on a
-              // fixed throttle interval (ACK_THROTTLE_MS). State is keyed
-              // by stream token so a chunk from a new stream resets seq
-              // tracking and any pending ack reflects the new stream.
-              if (chunkSeq !== undefined && chunkStreamToken !== undefined) {
-                const prev = latestChunkByChatId.get(chatId);
-                if (prev === undefined || prev.token !== chunkStreamToken) {
-                  latestChunkByChatId.set(chatId, {
-                    token: chunkStreamToken,
-                    seq: chunkSeq,
-                  });
-                } else if (chunkSeq > prev.seq) {
-                  prev.seq = chunkSeq;
+              // fixed throttle interval (ACK_THROTTLE_MS).
+              if (chunkSeq !== undefined) {
+                const prev = latestChunkByChatId.get(chatId) ?? 0;
+                if (chunkSeq > prev) {
+                  latestChunkByChatId.set(chatId, chunkSeq);
                 }
                 scheduleThrottledAck(chatId);
               }

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -43,9 +43,11 @@ import {
   dryRunSearchReplace,
   processFullResponseActions,
 } from "../processors/response_processor";
-import { streamTestResponse } from "./testing_chat_handlers";
-import { getTestResponse } from "./testing_chat_handlers";
-import { noteAck } from "./testing_chat_handlers";
+import {
+  streamTestResponse,
+  getTestResponse,
+  noteAck,
+} from "./testing_chat_handlers";
 import { getModelClient, ModelClient } from "../utils/get_model_client";
 import log from "electron-log";
 import { sendTelemetryEvent } from "../utils/telemetry";
@@ -244,13 +246,22 @@ async function processStreamChunks({
   return { fullResponse, incrementalResponse };
 }
 
+const AckPayloadSchema = z.object({
+  chatId: z.number().int().nonnegative().finite(),
+  lastSeq: z.number().int().nonnegative().finite(),
+});
+
 export function registerChatStreamHandlers() {
-  ipcMain.handle(
-    "chat:response:ack",
-    (_event, payload: { chatId: number; lastSeq: number }) => {
-      noteAck(payload.chatId, payload.lastSeq);
-    },
-  );
+  ipcMain.handle("chat:response:ack", (_event, payload: unknown) => {
+    const parsed = AckPayloadSchema.safeParse(payload);
+    if (!parsed.success) {
+      logger.warn(
+        `chat:response:ack rejected invalid payload: ${parsed.error.message}`,
+      );
+      return;
+    }
+    noteAck(parsed.data.chatId, parsed.data.lastSeq);
+  });
 
   ipcMain.handle("chat:stream", async (event, req: ChatStreamParams) => {
     let attachmentPaths: string[] = [];

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -246,22 +246,13 @@ async function processStreamChunks({
   return { fullResponse, incrementalResponse };
 }
 
-const AckPayloadSchema = z.object({
-  chatId: z.number().int().nonnegative().finite(),
-  lastSeq: z.number().int().nonnegative().finite(),
-});
-
 export function registerChatStreamHandlers() {
-  ipcMain.handle("chat:response:ack", (_event, payload: unknown) => {
-    const parsed = AckPayloadSchema.safeParse(payload);
-    if (!parsed.success) {
-      logger.warn(
-        `chat:response:ack rejected invalid payload: ${parsed.error.message}`,
-      );
-      return;
-    }
-    noteAck(parsed.data.chatId, parsed.data.lastSeq);
-  });
+  createTypedHandler(
+    chatContracts.responseAck,
+    async (_event, { chatId, lastSeq }) => {
+      noteAck(chatId, lastSeq);
+    },
+  );
 
   ipcMain.handle("chat:stream", async (event, req: ChatStreamParams) => {
     let attachmentPaths: string[] = [];

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -249,7 +249,6 @@ async function processStreamChunks({
 const AckPayloadSchema = z.object({
   chatId: z.number().int().nonnegative().finite(),
   lastSeq: z.number().int().nonnegative().finite(),
-  streamToken: z.number().int().nonnegative().finite(),
 });
 
 export function registerChatStreamHandlers() {
@@ -261,7 +260,7 @@ export function registerChatStreamHandlers() {
       );
       return;
     }
-    noteAck(parsed.data.chatId, parsed.data.lastSeq, parsed.data.streamToken);
+    noteAck(parsed.data.chatId, parsed.data.lastSeq);
   });
 
   ipcMain.handle("chat:stream", async (event, req: ChatStreamParams) => {

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -249,6 +249,7 @@ async function processStreamChunks({
 const AckPayloadSchema = z.object({
   chatId: z.number().int().nonnegative().finite(),
   lastSeq: z.number().int().nonnegative().finite(),
+  streamToken: z.number().int().nonnegative().finite(),
 });
 
 export function registerChatStreamHandlers() {
@@ -260,7 +261,7 @@ export function registerChatStreamHandlers() {
       );
       return;
     }
-    noteAck(parsed.data.chatId, parsed.data.lastSeq);
+    noteAck(parsed.data.chatId, parsed.data.lastSeq, parsed.data.streamToken);
   });
 
   ipcMain.handle("chat:stream", async (event, req: ChatStreamParams) => {

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -45,6 +45,7 @@ import {
 } from "../processors/response_processor";
 import { streamTestResponse } from "./testing_chat_handlers";
 import { getTestResponse } from "./testing_chat_handlers";
+import { noteAck } from "./testing_chat_handlers";
 import { getModelClient, ModelClient } from "../utils/get_model_client";
 import log from "electron-log";
 import { sendTelemetryEvent } from "../utils/telemetry";
@@ -244,6 +245,13 @@ async function processStreamChunks({
 }
 
 export function registerChatStreamHandlers() {
+  ipcMain.handle(
+    "chat:response:ack",
+    (_event, payload: { chatId: number; lastSeq: number }) => {
+      noteAck(payload.chatId, payload.lastSeq);
+    },
+  );
+
   ipcMain.handle("chat:stream", async (event, req: ChatStreamParams) => {
     let attachmentPaths: string[] = [];
     try {
@@ -621,7 +629,7 @@ ${componentSnippet}
           req.chatId,
           testResponse,
           abortController,
-          updatedChat,
+          placeholderAssistantMessage.id,
         );
       } else {
         // Normal AI processing for non-test prompts

--- a/src/ipc/handlers/testing_chat_handlers.ts
+++ b/src/ipc/handlers/testing_chat_handlers.ts
@@ -160,34 +160,13 @@ export function getTestResponse(prompt: string): string | null {
  * Per-stream ack state for the canned test stream backpressure path. Real
  * LLM streams do not register entries here, so `noteAck` is a no-op for
  * them.
- *
- * `token` is a generation counter assigned at stream start and echoed by
- * the renderer in every ack. It scopes acks to the stream instance that
- * produced them, so a delayed ack from a prior stream on the same chatId
- * is dropped instead of corrupting the new stream's `lastAcked`.
  */
-type AckEntry = { token: number; lastAcked: number };
+type AckEntry = { lastAcked: number };
 const ackState = new Map<number, AckEntry>();
 
-let nextStreamToken = 1;
-
-function allocateStreamToken(): number {
-  // Math.MAX_SAFE_INTEGER wraparound is well beyond any realistic stream
-  // count, but keep the arithmetic safe just in case.
-  const token = nextStreamToken;
-  nextStreamToken =
-    nextStreamToken >= Number.MAX_SAFE_INTEGER ? 1 : nextStreamToken + 1;
-  return token;
-}
-
-export function noteAck(
-  chatId: number,
-  lastSeq: number,
-  streamToken: number,
-): void {
+export function noteAck(chatId: number, lastSeq: number): void {
   const entry = ackState.get(chatId);
   if (!entry) return;
-  if (entry.token !== streamToken) return;
   if (lastSeq > entry.lastAcked) {
     entry.lastAcked = lastSeq;
   }
@@ -239,8 +218,7 @@ export async function streamTestResponse(
   let lastSentSeq = 0;
   let offset = 0;
 
-  const streamToken = allocateStreamToken();
-  ackState.set(chatId, { token: streamToken, lastAcked: 0 });
+  ackState.set(chatId, { lastAcked: 0 });
 
   try {
     while (offset < cleanedResponse.length) {
@@ -262,7 +240,6 @@ export async function streamTestResponse(
             streamingMessageId: placeholderAssistantMessageId,
             streamingPatch: patch,
             chunkSeq: currentSeq,
-            chunkStreamToken: streamToken,
           });
           lastSentContent = fullResponse;
           lastSentSeq = currentSeq;
@@ -282,7 +259,6 @@ export async function streamTestResponse(
           streamingMessageId: placeholderAssistantMessageId,
           streamingPatch: patch,
           chunkSeq: currentSeq,
-          chunkStreamToken: streamToken,
         });
       }
     }

--- a/src/ipc/handlers/testing_chat_handlers.ts
+++ b/src/ipc/handlers/testing_chat_handlers.ts
@@ -10,46 +10,15 @@ import { computeStreamingPatch } from "../utils/stream_text_utils";
  */
 const MAX_IN_FLIGHT = 1;
 
-// e.g. [dyad-qa=add-dep]
-// Canned responses for test prompts
-const TEST_RESPONSES: Record<string, string> = {
-  "ts-error": `This will get a TypeScript error.
-  
-  <dyad-write path="src/bad-file.ts" description="This will get a TypeScript error.">
-  import NonExistentClass from 'non-existent-class';
+type ResponseEntry = string | (() => string);
 
-  const x = new Object();
-  x.nonExistentMethod();
-  </dyad-write>
-  
-  EOM`,
-  "add-dep": `I'll add that dependency for you.
-  
-  <dyad-add-dependency packages="deno"></dyad-add-dependency>
-  
-  EOM`,
-  "add-non-existing-dep": `I'll add that dependency for you.
-  
-  <dyad-add-dependency packages="@angular/does-not-exist"></dyad-add-dependency>
-  
-  EOM`,
-  "add-multiple-deps": `I'll add that dependency for you.
-  
-  <dyad-add-dependency packages="react-router-dom react-query"></dyad-add-dependency>
-  
-  EOM`,
-  write: `Hello world
-  <dyad-write path="src/hello.ts" content="Hello world">
-  console.log("Hello world");
-  </dyad-write>
-  EOM`,
-  "string-literal-leak": `BEFORE TAG
-  <dyad-write path="src/pages/locations/neighborhoods/louisville/Highlands.tsx" description="Updating Highlands neighborhood page to use <a> tags.">
-import React from 'react';
-</dyad-write>
-AFTER TAG
-`,
-  "stress-many-writes-small": `Generating 5000 small files for stress test.
+function memoize(fn: () => string): () => string {
+  let cached: string | undefined;
+  return () => (cached ??= fn());
+}
+
+function buildStressManyWritesSmall(): string {
+  return `Generating 5000 small files for stress test.
 
 ${Array.from(
   { length: 5000 },
@@ -63,8 +32,11 @@ export default meta${i};
 </dyad-write>`,
 ).join("\n")}
 
-EOM`,
-  "stress-many-writes-large": `Generating 10000 ~100-line files for stress test.
+EOM`;
+}
+
+function buildStressManyWritesLarge(): string {
+  return `Generating 10000 ~100-line files for stress test.
 
 ${Array.from({ length: 10000 }, (_, i) => {
   const fields = Array.from(
@@ -121,7 +93,52 @@ export default meta${i};
 </dyad-write>`;
 }).join("\n")}
 
-EOM`,
+EOM`;
+}
+
+// e.g. [dyad-qa=add-dep]
+// Canned responses for test prompts. Stress fixtures are wrapped in
+// memoized thunks so the multi-megabyte strings are only built when an
+// explicit [dyad-qa=stress-...] prompt fires, not at module import.
+const TEST_RESPONSES: Record<string, ResponseEntry> = {
+  "ts-error": `This will get a TypeScript error.
+
+  <dyad-write path="src/bad-file.ts" description="This will get a TypeScript error.">
+  import NonExistentClass from 'non-existent-class';
+
+  const x = new Object();
+  x.nonExistentMethod();
+  </dyad-write>
+
+  EOM`,
+  "add-dep": `I'll add that dependency for you.
+
+  <dyad-add-dependency packages="deno"></dyad-add-dependency>
+
+  EOM`,
+  "add-non-existing-dep": `I'll add that dependency for you.
+
+  <dyad-add-dependency packages="@angular/does-not-exist"></dyad-add-dependency>
+
+  EOM`,
+  "add-multiple-deps": `I'll add that dependency for you.
+
+  <dyad-add-dependency packages="react-router-dom react-query"></dyad-add-dependency>
+
+  EOM`,
+  write: `Hello world
+  <dyad-write path="src/hello.ts" content="Hello world">
+  console.log("Hello world");
+  </dyad-write>
+  EOM`,
+  "string-literal-leak": `BEFORE TAG
+  <dyad-write path="src/pages/locations/neighborhoods/louisville/Highlands.tsx" description="Updating Highlands neighborhood page to use <a> tags.">
+import React from 'react';
+</dyad-write>
+AFTER TAG
+`,
+  "stress-many-writes-small": memoize(buildStressManyWritesSmall),
+  "stress-many-writes-large": memoize(buildStressManyWritesLarge),
 };
 
 /**
@@ -132,8 +149,9 @@ EOM`,
 export function getTestResponse(prompt: string): string | null {
   const match = prompt.match(/\[dyad-qa=([^\]]+)\]/);
   if (match) {
-    const testKey = match[1];
-    return TEST_RESPONSES[testKey] || null;
+    const entry = TEST_RESPONSES[match[1]];
+    if (entry === undefined) return null;
+    return typeof entry === "function" ? entry() : entry;
   }
   return null;
 }
@@ -159,6 +177,13 @@ function clearAck(chatId: number): void {
 }
 
 /**
+ * Byte size of each streamed chunk. Sized to keep the 24 MB stress fixture
+ * under a few thousand iterations so the loop yield + per-iter work stay
+ * tractable.
+ */
+const CHUNK_SIZE = 10000;
+
+/**
  * Streams a canned test response to the client incrementally via tail-only
  * streaming patches, mirroring the real LLM path. The renderer applies each
  * patch to its local copy of the placeholder assistant message.
@@ -172,12 +197,10 @@ function clearAck(chatId: number): void {
  * synchronous loop monopolizes the main process and acks are never
  * observed.
  *
- * @param event The IPC event
- * @param chatId The chat ID
- * @param testResponse The canned response to stream
- * @param abortController The abort controller for this stream
- * @param placeholderAssistantMessageId DB id of the placeholder assistant message to update incrementally
- * @returns The full streamed response
+ * `cleanFullResponse` runs once on the canned input up front. Its rewrite
+ * is local to fully-formed `<dyad-*>` tags and idempotent, so the cleaned
+ * full string is identical to the result of cleaning every growing prefix
+ * — and pre-cleaning avoids an O(N²) regex sweep over the accumulator.
  */
 export async function streamTestResponse(
   event: Electron.IpcMainInvokeEvent,
@@ -188,20 +211,22 @@ export async function streamTestResponse(
 ): Promise<string> {
   console.log(`Using canned response for test prompt`);
 
-  const chunks = testResponse.split(" ");
+  const cleanedResponse = cleanFullResponse(testResponse);
   let fullResponse = "";
   let lastSentContent = "";
   let currentSeq = 0;
   let lastSentSeq = 0;
+  let offset = 0;
 
   ackState.set(chatId, { lastAcked: 0 });
 
   try {
-    for (const chunk of chunks) {
+    while (offset < cleanedResponse.length) {
       if (abortController.signal.aborted) break;
 
-      fullResponse += chunk + " ";
-      fullResponse = cleanFullResponse(fullResponse);
+      const end = Math.min(offset + CHUNK_SIZE, cleanedResponse.length);
+      fullResponse += cleanedResponse.slice(offset, end);
+      offset = end;
       currentSeq++;
 
       const lastAcked = ackState.get(chatId)?.lastAcked ?? 0;
@@ -235,9 +260,7 @@ export async function streamTestResponse(
           streamingPatch: patch,
           chunkSeq: currentSeq,
         });
-        lastSentContent = fullResponse;
       }
-      lastSentSeq = currentSeq;
     }
   } finally {
     clearAck(chatId);

--- a/src/ipc/handlers/testing_chat_handlers.ts
+++ b/src/ipc/handlers/testing_chat_handlers.ts
@@ -160,13 +160,34 @@ export function getTestResponse(prompt: string): string | null {
  * Per-stream ack state for the canned test stream backpressure path. Real
  * LLM streams do not register entries here, so `noteAck` is a no-op for
  * them.
+ *
+ * `token` is a generation counter assigned at stream start and echoed by
+ * the renderer in every ack. It scopes acks to the stream instance that
+ * produced them, so a delayed ack from a prior stream on the same chatId
+ * is dropped instead of corrupting the new stream's `lastAcked`.
  */
-type AckEntry = { lastAcked: number };
+type AckEntry = { token: number; lastAcked: number };
 const ackState = new Map<number, AckEntry>();
 
-export function noteAck(chatId: number, lastSeq: number): void {
+let nextStreamToken = 1;
+
+function allocateStreamToken(): number {
+  // Math.MAX_SAFE_INTEGER wraparound is well beyond any realistic stream
+  // count, but keep the arithmetic safe just in case.
+  const token = nextStreamToken;
+  nextStreamToken =
+    nextStreamToken >= Number.MAX_SAFE_INTEGER ? 1 : nextStreamToken + 1;
+  return token;
+}
+
+export function noteAck(
+  chatId: number,
+  lastSeq: number,
+  streamToken: number,
+): void {
   const entry = ackState.get(chatId);
   if (!entry) return;
+  if (entry.token !== streamToken) return;
   if (lastSeq > entry.lastAcked) {
     entry.lastAcked = lastSeq;
   }
@@ -181,7 +202,7 @@ function clearAck(chatId: number): void {
  * under a few thousand iterations so the loop yield + per-iter work stay
  * tractable.
  */
-const CHUNK_SIZE = 10000;
+const CHUNK_SIZE = 500;
 
 /**
  * Streams a canned test response to the client incrementally via tail-only
@@ -218,7 +239,8 @@ export async function streamTestResponse(
   let lastSentSeq = 0;
   let offset = 0;
 
-  ackState.set(chatId, { lastAcked: 0 });
+  const streamToken = allocateStreamToken();
+  ackState.set(chatId, { token: streamToken, lastAcked: 0 });
 
   try {
     while (offset < cleanedResponse.length) {
@@ -240,6 +262,7 @@ export async function streamTestResponse(
             streamingMessageId: placeholderAssistantMessageId,
             streamingPatch: patch,
             chunkSeq: currentSeq,
+            chunkStreamToken: streamToken,
           });
           lastSentContent = fullResponse;
           lastSentSeq = currentSeq;
@@ -259,6 +282,7 @@ export async function streamTestResponse(
           streamingMessageId: placeholderAssistantMessageId,
           streamingPatch: patch,
           chunkSeq: currentSeq,
+          chunkStreamToken: streamToken,
         });
       }
     }

--- a/src/ipc/handlers/testing_chat_handlers.ts
+++ b/src/ipc/handlers/testing_chat_handlers.ts
@@ -1,5 +1,14 @@
 import { safeSend } from "../utils/safe_sender";
 import { cleanFullResponse } from "../utils/cleanFullResponse";
+import { computeStreamingPatch } from "../utils/stream_text_utils";
+
+/**
+ * Maximum number of unacked chunks the canned test stream is allowed to
+ * keep in flight. The sender skips a send while
+ * `lastSentSeq - lastAcked > MAX_IN_FLIGHT`, which lets the renderer's ack
+ * cadence pace the stream when the renderer falls behind.
+ */
+const MAX_IN_FLIGHT = 1;
 
 // e.g. [dyad-qa=add-dep]
 // Canned responses for test prompts
@@ -40,6 +49,79 @@ import React from 'react';
 </dyad-write>
 AFTER TAG
 `,
+  "stress-many-writes-small": `Generating 5000 small files for stress test.
+
+${Array.from(
+  { length: 5000 },
+  (_, i) =>
+    `<dyad-write path="src/stress/file_${i}.ts" description="stress file ${i}">
+export const id${i} = ${i};
+export const name${i} = "file_${i}";
+export const meta${i} = { id: id${i}, name: name${i} };
+export function describe${i}() { return \`\${name${i}}:\${id${i}}\`; }
+export default meta${i};
+</dyad-write>`,
+).join("\n")}
+
+EOM`,
+  "stress-many-writes-large": `Generating 10000 ~100-line files for stress test.
+
+${Array.from({ length: 10000 }, (_, i) => {
+  const fields = Array.from(
+    { length: 20 },
+    (_, j) => `  field_${j}: ${i * 20 + j},`,
+  ).join("\n");
+  const helpers = Array.from(
+    { length: 20 },
+    (_, j) =>
+      `export function helper_${i}_${j}(x: number): number {
+  return x + id${i} + ${j};
+}`,
+  ).join("\n");
+  return `<dyad-write path="src/stress/file_${i}.ts" description="stress file ${i}">
+export const id${i} = ${i};
+export const name${i} = "file_${i}";
+
+export interface Meta${i} {
+  id: number;
+  name: string;
+  index: number;
+}
+
+export const meta${i}: Meta${i} = {
+  id: id${i},
+  name: name${i},
+  index: ${i},
+};
+
+export const data${i} = {
+${fields}
+};
+
+export function get${i}(): number {
+  return id${i};
+}
+
+export function describe${i}(): string {
+  return \`\${name${i}}:\${id${i}}\`;
+}
+
+${helpers}
+
+export function summarize${i}(): string {
+  const parts = [
+    describe${i}(),
+    String(get${i}()),
+    JSON.stringify(meta${i}),
+  ];
+  return parts.join("|");
+}
+
+export default meta${i};
+</dyad-write>`;
+}).join("\n")}
+
+EOM`,
 };
 
 /**
@@ -57,12 +139,44 @@ export function getTestResponse(prompt: string): string | null {
 }
 
 /**
- * Streams a canned test response to the client
+ * Per-stream ack state for the canned test stream backpressure path. Real
+ * LLM streams do not register entries here, so `noteAck` is a no-op for
+ * them.
+ */
+type AckEntry = { lastAcked: number };
+const ackState = new Map<number, AckEntry>();
+
+export function noteAck(chatId: number, lastSeq: number): void {
+  const entry = ackState.get(chatId);
+  if (!entry) return;
+  if (lastSeq > entry.lastAcked) {
+    entry.lastAcked = lastSeq;
+  }
+}
+
+function clearAck(chatId: number): void {
+  ackState.delete(chatId);
+}
+
+/**
+ * Streams a canned test response to the client incrementally via tail-only
+ * streaming patches, mirroring the real LLM path. The renderer applies each
+ * patch to its local copy of the placeholder assistant message.
+ *
+ * Ack-based backpressure: each iteration appends to fullResponse and
+ * increments currentSeq. The IPC send fires only while in-flight chunks
+ * (`lastSentSeq - lastAcked`) are at or below MAX_IN_FLIGHT, so a slow
+ * renderer naturally throttles the sender via its ack cadence.
+ *
+ * The 10ms loop yield lets the noteAck IPC handler run; without it, the
+ * synchronous loop monopolizes the main process and acks are never
+ * observed.
+ *
  * @param event The IPC event
  * @param chatId The chat ID
  * @param testResponse The canned response to stream
  * @param abortController The abort controller for this stream
- * @param updatedChat The chat data with messages
+ * @param placeholderAssistantMessageId DB id of the placeholder assistant message to update incrementally
  * @returns The full streamed response
  */
 export async function streamTestResponse(
@@ -70,38 +184,63 @@ export async function streamTestResponse(
   chatId: number,
   testResponse: string,
   abortController: AbortController,
-  updatedChat: any,
+  placeholderAssistantMessageId: number,
 ): Promise<string> {
   console.log(`Using canned response for test prompt`);
 
-  // Simulate streaming by splitting the response into chunks
   const chunks = testResponse.split(" ");
   let fullResponse = "";
+  let lastSentContent = "";
+  let currentSeq = 0;
+  let lastSentSeq = 0;
 
-  for (const chunk of chunks) {
-    // Skip processing if aborted
-    if (abortController.signal.aborted) {
-      break;
+  ackState.set(chatId, { lastAcked: 0 });
+
+  try {
+    for (const chunk of chunks) {
+      if (abortController.signal.aborted) break;
+
+      fullResponse += chunk + " ";
+      fullResponse = cleanFullResponse(fullResponse);
+      currentSeq++;
+
+      const lastAcked = ackState.get(chatId)?.lastAcked ?? 0;
+      const inFlight = lastSentSeq - lastAcked;
+
+      if (inFlight <= MAX_IN_FLIGHT) {
+        const patch = computeStreamingPatch(fullResponse, lastSentContent);
+        if (patch) {
+          safeSend(event.sender, "chat:response:chunk", {
+            chatId,
+            streamingMessageId: placeholderAssistantMessageId,
+            streamingPatch: patch,
+            chunkSeq: currentSeq,
+          });
+          lastSentContent = fullResponse;
+          lastSentSeq = currentSeq;
+        }
+      }
+
+      await new Promise<void>((resolve) => setTimeout(() => resolve(), 10));
     }
 
-    // Add the word plus a space
-    fullResponse += chunk + " ";
-    fullResponse = cleanFullResponse(fullResponse);
-
-    // Send the current accumulated response
-    safeSend(event.sender, "chat:response:chunk", {
-      chatId: chatId,
-      messages: [
-        ...updatedChat.messages,
-        {
-          role: "assistant",
-          content: fullResponse,
-        },
-      ],
-    });
-
-    // Add a small delay to simulate streaming
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    // Final flush: guarantee the renderer ends with the complete response,
+    // even if the last iterations were skipped due to backpressure.
+    if (!abortController.signal.aborted && lastSentSeq < currentSeq) {
+      const patch = computeStreamingPatch(fullResponse, lastSentContent);
+      if (patch) {
+        safeSend(event.sender, "chat:response:chunk", {
+          chatId,
+          streamingMessageId: placeholderAssistantMessageId,
+          streamingPatch: patch,
+          chunkSeq: currentSeq,
+        });
+        lastSentContent = fullResponse;
+      }
+      lastSentSeq = currentSeq;
+    }
+  } finally {
+    clearAck(chatId);
   }
 
   return fullResponse;

--- a/src/ipc/preload/channels.ts
+++ b/src/ipc/preload/channels.ts
@@ -51,12 +51,18 @@ import { imageGenerationContracts } from "../types/image_generation";
 const CHAT_STREAM_CHANNELS = getStreamChannels(chatStreamContract);
 const HELP_STREAM_CHANNELS = getStreamChannels(helpStreamContract);
 
-// Test-only channels (handler only registered in E2E test builds, but channel always allowed)
+// Test-only channels. Most entries here have their handler only
+// registered in E2E test builds (the channel is always whitelisted in
+// preload). `chat:response:ack` is an exception: its handler is
+// registered unconditionally because the canned `[dyad-qa=...]` prompts
+// it backs are shipped in production builds, but the renderer only
+// arms its ack scheduler when a chunk carries a `chunkSeq`, and real
+// LLM streams never set that field — so the channel is invoked solely
+// for the canned test streams that issue stress-test [dyad-qa=...]
+// prompts.
 const TEST_INVOKE_CHANNELS = [
   "test:simulateQuotaTimeElapsed",
   "test:set-node-mock",
-  // Renderer→main ack for stress-test backpressure on the canned test
-  // streaming path. Real LLM streams do not use this channel.
   "chat:response:ack",
 ] as const;
 

--- a/src/ipc/preload/channels.ts
+++ b/src/ipc/preload/channels.ts
@@ -55,6 +55,9 @@ const HELP_STREAM_CHANNELS = getStreamChannels(helpStreamContract);
 const TEST_INVOKE_CHANNELS = [
   "test:simulateQuotaTimeElapsed",
   "test:set-node-mock",
+  // Renderer→main ack for stress-test backpressure on the canned test
+  // streaming path. Real LLM streams do not use this channel.
+  "chat:response:ack",
 ] as const;
 
 /**

--- a/src/ipc/preload/channels.ts
+++ b/src/ipc/preload/channels.ts
@@ -51,19 +51,10 @@ import { imageGenerationContracts } from "../types/image_generation";
 const CHAT_STREAM_CHANNELS = getStreamChannels(chatStreamContract);
 const HELP_STREAM_CHANNELS = getStreamChannels(helpStreamContract);
 
-// Test-only channels. Most entries here have their handler only
-// registered in E2E test builds (the channel is always whitelisted in
-// preload). `chat:response:ack` is an exception: its handler is
-// registered unconditionally because the canned `[dyad-qa=...]` prompts
-// it backs are shipped in production builds, but the renderer only
-// arms its ack scheduler when a chunk carries a `chunkSeq`, and real
-// LLM streams never set that field — so the channel is invoked solely
-// for the canned test streams that issue stress-test [dyad-qa=...]
-// prompts.
+// Test-only channels (handler only registered in E2E test builds, but channel always allowed)
 const TEST_INVOKE_CHANNELS = [
   "test:simulateQuotaTimeElapsed",
   "test:set-node-mock",
-  "chat:response:ack",
 ] as const;
 
 /**

--- a/src/ipc/types/chat.ts
+++ b/src/ipc/types/chat.ts
@@ -139,6 +139,10 @@ export const ChatResponseChunkSchema = z.object({
   messages: z.array(MessageSchema).optional(),
   streamingMessageId: z.number().optional(),
   streamingPatch: StreamingPatchSchema.optional(),
+  // Monotonic chunk sequence used for ack-based backpressure on the canned
+  // test streaming path. Real LLM streams omit this field; the renderer
+  // only acks when chunkSeq is present.
+  chunkSeq: z.number().optional(),
   effectiveChatMode: ChatModeSchema.optional(),
   chatModeFallbackReason: z.literal("quota-exhausted").optional(),
 });

--- a/src/ipc/types/chat.ts
+++ b/src/ipc/types/chat.ts
@@ -143,10 +143,6 @@ export const ChatResponseChunkSchema = z.object({
   // test streaming path. Real LLM streams omit this field; the renderer
   // only acks when chunkSeq is present.
   chunkSeq: z.number().int().nonnegative().finite().optional(),
-  // Per-stream-instance token paired with chunkSeq. Lets main reject
-  // delayed acks from a previous stream that target the same chatId.
-  // Always sent together with chunkSeq.
-  chunkStreamToken: z.number().int().nonnegative().finite().optional(),
   effectiveChatMode: ChatModeSchema.optional(),
   chatModeFallbackReason: z.literal("quota-exhausted").optional(),
 });

--- a/src/ipc/types/chat.ts
+++ b/src/ipc/types/chat.ts
@@ -303,6 +303,19 @@ export const chatContracts = {
     input: z.number(), // chatId
     output: z.boolean(),
   }),
+
+  // Renderer→main ack for stress-test backpressure on the canned test
+  // streaming path. The handler is registered unconditionally, but real
+  // LLM streams omit `chunkSeq`, so the renderer only invokes this
+  // channel for canned [dyad-qa=...] streams.
+  responseAck: defineContract({
+    channel: "chat:response:ack",
+    input: z.object({
+      chatId: z.number().int().nonnegative().finite(),
+      lastSeq: z.number().int().nonnegative().finite(),
+    }),
+    output: z.void(),
+  }),
 } as const;
 
 // =============================================================================

--- a/src/ipc/types/chat.ts
+++ b/src/ipc/types/chat.ts
@@ -142,7 +142,11 @@ export const ChatResponseChunkSchema = z.object({
   // Monotonic chunk sequence used for ack-based backpressure on the canned
   // test streaming path. Real LLM streams omit this field; the renderer
   // only acks when chunkSeq is present.
-  chunkSeq: z.number().optional(),
+  chunkSeq: z.number().int().nonnegative().finite().optional(),
+  // Per-stream-instance token paired with chunkSeq. Lets main reject
+  // delayed acks from a previous stream that target the same chatId.
+  // Always sent together with chunkSeq.
+  chunkStreamToken: z.number().int().nonnegative().finite().optional(),
   effectiveChatMode: ChatModeSchema.optional(),
   chatModeFallbackReason: z.literal("quota-exhausted").optional(),
 });


### PR DESCRIPTION
AI-generated description:

Adds a stress-test harness for the renderer's streaming-content path so subsequent perf work can be benchmarked end-to-end.

- Two canned stress responses:
  - `stress-many-writes-small`: 5000 dyad-write blocks of small ~5-line modules (id/name/meta/describe/default export).
  - `stress-many-writes-large`: 10000 dyad-write blocks of ~119-line modules (interface, typed const, 20-field data record, getter/describe, 20 helper functions, summarizer, default export). Total ~24 MB.
- streamTestResponse now sends each chunk through the same streamingPatch path real LLM streams use, keyed to the placeholder assistant message id. Drops the legacy `messages: [...]` send and `updatedChat` parameter.
- Ack-based backpressure for the canned stream only. Sender gate: inFlight (lastSentSeq - lastAcked) <= MAX_IN_FLIGHT (1). Slow renderer naturally throttles sender via ack cadence; fast renderer runs at full speed. 10ms loop yield lets the noteAck IPC handler run. Guaranteed final flush on loop exit ensures the renderer ends on the complete response. Real LLM streams omit chunkSeq, so the renderer-side ack scheduler is never armed for them.
- Renderer-side ack throttle ACK_THROTTLE_MS=250 — acks coalesce into one per-chatId timer firing the latest received chunkSeq. Cleanup on onEnd / onError / catch removes the timer and seq state.

---

Human-written description:

The first of a few PRs that I intend to open related to #3240. From what I've tested, I think that the issue is fixable. However, I'm breaking it into a few PRs to hopefully make it easier to review.

I'm opening this PR mainly because the current system that we have for the test responses isn't great for stress tests. It doesn't actually seem to render the responses incrementally; it waits until the response is finished and afterwards the response appears in the UI all at once. This PR fixes that problem, which makes the test response streaming more realistic.

A few other notes:
- In this context, "acking" refers to limiting the number of in-flight response chunks that can be waiting in the renderer's IPC queue at any given time, then having the renderer send an IPC response confirming that it has finished processing them. The reason I added this to the test responses is because the main process sends chunks way faster than the renderer can handle them, thus leading to a drift between the main process vs the renderer. 
    - I'm only adding this to the test responses for now; I haven't actually checked whether this happens with regular LLM responses. If it does, I'll probably add the acking to occur in real responses as well, but that's a later PR.
    - The drift does cause performance issues, so even though acking doesn't occur for regular LLM responses, I find that it makes the stress tests more realistic. 
    - I've set `MAX_IN_FLIGHT` to 1, which means that the renderer's IPC queue shouldn't have more than one (or maybe two) chunk(s) of the response in it at any given time. I did this because I find that the queue quickly maxes out no matter what I set the maximum to. This can always be changed later, and it only applies to test responses anyway so it shouldn't make too much of a difference.
- The "large" stress test is a little bit extreme, but it probably will do a decent job of confirming whether the issue has actually been fixed. Currently, I don't think Dyad can pass either test without crashing; that's what I'll be fixing in later PRs.

Current plan for follow-up PRs, which is of course tentative and very negotiable:
1. In order to lighten the load on the renderer, have the renderer store the current response as JSX instead of a string that it has to continuously re-parse. This means that each React rerender should be as simple as looping through an array, which for larger responses is less strain. Though we're currently caching with `useMemo` (see #3324) , even that requires checking that the cached value is correct, which adds more work. This could be a large change, so I might break it into several PRs; we'll see.
2. From there, we can optionally choose to temporarily hide (and drop from memory) some of the earlier Markdown/tool call blocks during streaming. I'm somewhat torn on this for the sake of UX; it means that if the LLM is generating 100s of files, the user might not be able to view one of the earlier files as it's generating. However, we'd only start hiding pieces as the response grows long, so it wouldn't affect the majority of responses. Also, from what I've tested I'm pretty sure that this completely fixes the performance issues described in #3240. Part 1 described above seems to help, but especially long responses can still cause problems.