### PR TITLE
Fix safe storage settings failures

### DIFF
--- a/rules/electron-ipc.md
+++ b/rules/electron-ipc.md
@@ -69,6 +69,8 @@ writeSettings({
 
 **Stale-read race condition:** If you call `readSettings()` before an async operation (network call, file I/O), then use the snapshot to construct the write, any concurrent settings changes during the async gap will be silently overwritten. Always call `readSettings()` immediately before `writeSettings()` — never across an `await` boundary.
 
+**Electron readiness:** `readSettings()` and `writeSettings()` may decrypt/encrypt secrets through Electron `safeStorage`, which throws `safeStorage cannot be used before app is ready` before `app.whenReady()`. Queue pre-ready entry points like deep links (`open-url`, `second-instance`) until the app/window is ready before calling OAuth/settings handlers.
+
 ## Handler expectations
 
 - Handlers should `throw new Error("...")` on failure instead of returning `{ success: false }` style payloads.

--- a/src/__tests__/deep_link_queue.test.ts
+++ b/src/__tests__/deep_link_queue.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+import { createDeepLinkQueue } from "@/main/deep_link_queue";
+
+describe("createDeepLinkQueue", () => {
+  it("queues deep links until the app is marked ready", () => {
+    const handler = vi.fn();
+    const queue = createDeepLinkQueue(handler);
+
+    queue.handle("dyad://one");
+    queue.handle("dyad://two");
+
+    expect(handler).not.toHaveBeenCalled();
+
+    queue.markReady();
+
+    expect(handler).toHaveBeenNthCalledWith(1, "dyad://one");
+    expect(handler).toHaveBeenNthCalledWith(2, "dyad://two");
+  });
+
+  it("handles deep links immediately after the app is marked ready", () => {
+    const handler = vi.fn();
+    const queue = createDeepLinkQueue(handler);
+
+    queue.markReady();
+    queue.handle("dyad://ready");
+    queue.markReady();
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith("dyad://ready");
+  });
+});

--- a/src/__tests__/readSettings.test.ts
+++ b/src/__tests__/readSettings.test.ts
@@ -541,11 +541,24 @@ describe("readSettings", () => {
       });
     });
 
-    it("should handle decryption errors gracefully", () => {
+    it("should drop a secret that cannot be decrypted without discarding settings", () => {
       const mockFileContent = {
+        selectedModel: {
+          name: "gpt-4",
+          provider: "openai",
+        },
+        telemetryConsent: "opted_in",
         githubAccessToken: {
           value: "corrupted-encrypted-data",
           encryptionType: "electron-safe-storage",
+        },
+        providerSettings: {
+          openai: {
+            apiKey: {
+              value: "plaintext-api-key",
+              encryptionType: "plaintext",
+            },
+          },
         },
       };
 
@@ -557,13 +570,81 @@ describe("readSettings", () => {
 
       const result = readSettings();
 
-      expect(result).toMatchObject({
-        selectedModel: {
-          name: "auto",
-          provider: "auto",
-        },
-        releaseChannel: "stable",
+      expect(result.selectedModel).toEqual({
+        name: "gpt-4",
+        provider: "openai",
       });
+      expect(result.telemetryConsent).toBe("opted_in");
+      expect(result.githubAccessToken).toBeUndefined();
+      expect(result.providerSettings.openai.apiKey?.value).toBe(
+        "plaintext-api-key",
+      );
+    });
+
+    it("should not treat safeStorage readiness errors as corrupt secrets", () => {
+      const mockFileContent = {
+        selectedModel: {
+          name: "gpt-4",
+          provider: "openai",
+        },
+        githubAccessToken: {
+          value: "encrypted-token",
+          encryptionType: "electron-safe-storage",
+        },
+      };
+
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readFileSync.mockReturnValue(JSON.stringify(mockFileContent));
+      mockSafeStorage.decryptString.mockImplementation(() => {
+        throw new Error("safeStorage cannot be used before app is ready");
+      });
+
+      const result = readSettings();
+
+      expect(result.selectedModel).toEqual({
+        name: "auto",
+        provider: "auto",
+      });
+      expect(result.githubAccessToken).toBeUndefined();
+    });
+
+    it("should drop a Supabase organization when one organization secret cannot be decrypted", () => {
+      const mockFileContent = {
+        selectedModel: {
+          name: "gpt-4",
+          provider: "openai",
+        },
+        supabase: {
+          organizations: {
+            badOrg: {
+              accessToken: {
+                value: "corrupted-access-token",
+                encryptionType: "electron-safe-storage",
+              },
+              refreshToken: {
+                value: "encrypted-refresh-token",
+                encryptionType: "electron-safe-storage",
+              },
+              expiresIn: 3600,
+              tokenTimestamp: 123,
+            },
+          },
+        },
+      };
+
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readFileSync.mockReturnValue(JSON.stringify(mockFileContent));
+      mockSafeStorage.decryptString.mockImplementationOnce(() => {
+        throw new DyadError("Decryption failed", DyadErrorKind.External);
+      });
+
+      const result = readSettings();
+
+      expect(result.selectedModel).toEqual({
+        name: "gpt-4",
+        provider: "openai",
+      });
+      expect(result.supabase?.organizations).toEqual({});
     });
   });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,12 +54,14 @@ import { cleanupOldMediaFiles } from "./ipc/utils/media_cleanup";
 import fs from "fs";
 import { gitAddSafeDirectory } from "./ipc/utils/git_utils";
 import { getDyadAppsBaseDirectory, getDyadAppPath } from "./paths/paths";
+import { createDeepLinkQueue } from "./main/deep_link_queue";
 
 log.errorHandler.startCatching();
 log.eventLogger.startLogging();
 log.scope.labelPadding = false;
 
 const logger = log.scope("main");
+const deepLinkQueue = createDeepLinkQueue(handleDeepLinkReturn);
 
 // Load environment variables from .env file
 dotenv.config();
@@ -413,6 +415,8 @@ const createWindow = () => {
       }
     }
 
+    deepLinkQueue.markReady();
+
     // Send force-close once after the correct load
     if (pendingCrashDetected && !forceCloseMessageSent) {
       forceCloseMessageSent = true;
@@ -606,7 +610,7 @@ protocol.registerSchemesAsPrivileged([
 // Deep link handling still works via the 'open-url' event registered below.
 // The 'second-instance' handler is intentionally omitted since it requires the singleton lock.
 if (IS_TEST_BUILD) {
-  app.whenReady().then(onReady);
+  startAppWhenReady();
 } else {
   const gotTheLock = app.requestSingleInstanceLock();
 
@@ -622,17 +626,21 @@ if (IS_TEST_BUILD) {
       // the commandLine is array of strings in which last element is deep link url
       const url = commandLine.at(-1);
       if (url) {
-        handleDeepLinkReturn(url);
+        deepLinkQueue.handle(url);
       }
     });
-    app.whenReady().then(onReady);
+    startAppWhenReady();
   }
 }
 
 // Handle the protocol. In this case, we choose to show an Error Box.
 app.on("open-url", (event, url) => {
-  handleDeepLinkReturn(url);
+  deepLinkQueue.handle(url);
 });
+
+function startAppWhenReady() {
+  app.whenReady().then(onReady);
+}
 
 async function handleDeepLinkReturn(url: string) {
   // example url: "dyad://supabase-oauth-return?token=a&refreshToken=b"

--- a/src/main/deep_link_queue.ts
+++ b/src/main/deep_link_queue.ts
@@ -1,0 +1,29 @@
+type DeepLinkHandler = (url: string) => void | Promise<void>;
+
+export function createDeepLinkQueue(handler: DeepLinkHandler) {
+  let isReady = false;
+  const queuedUrls: string[] = [];
+
+  return {
+    handle(url: string) {
+      if (!isReady) {
+        queuedUrls.push(url);
+        return;
+      }
+
+      void handler(url);
+    },
+
+    markReady() {
+      if (isReady) {
+        return;
+      }
+
+      isReady = true;
+      const urls = queuedUrls.splice(0);
+      for (const url of urls) {
+        void handler(url);
+      }
+    },
+  };
+}

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -224,102 +224,127 @@ function readExistingSettingsFile(filePath: string): UserSettings {
   if (supabase) {
     // Decrypt legacy tokens (kept but ignored)
     if (supabase.refreshToken) {
-      const encryptionType = supabase.refreshToken.encryptionType;
-      if (encryptionType) {
-        supabase.refreshToken = {
-          value: decrypt(supabase.refreshToken),
-          encryptionType,
-        };
+      const decrypted = decryptStoredSecret(
+        supabase.refreshToken,
+        "Supabase refresh token",
+      );
+      if (decrypted) {
+        supabase.refreshToken = decrypted;
+      } else {
+        delete supabase.refreshToken;
       }
     }
     if (supabase.accessToken) {
-      const encryptionType = supabase.accessToken.encryptionType;
-      if (encryptionType) {
-        supabase.accessToken = {
-          value: decrypt(supabase.accessToken),
-          encryptionType,
-        };
+      const decrypted = decryptStoredSecret(
+        supabase.accessToken,
+        "Supabase access token",
+      );
+      if (decrypted) {
+        supabase.accessToken = decrypted;
+      } else {
+        delete supabase.accessToken;
       }
     }
     // Decrypt tokens for each organization in the organizations map
     if (supabase.organizations) {
       for (const orgId in supabase.organizations) {
         const org = supabase.organizations[orgId];
-        if (org.accessToken) {
-          const encryptionType = org.accessToken.encryptionType;
-          if (encryptionType) {
-            org.accessToken = {
-              value: decrypt(org.accessToken),
-              encryptionType,
-            };
-          }
+        const accessToken = org.accessToken
+          ? decryptStoredSecret(
+              org.accessToken,
+              `Supabase access token for organization ${orgId}`,
+            )
+          : undefined;
+        const refreshToken = org.refreshToken
+          ? decryptStoredSecret(
+              org.refreshToken,
+              `Supabase refresh token for organization ${orgId}`,
+            )
+          : undefined;
+
+        if (!accessToken || !refreshToken) {
+          delete supabase.organizations[orgId];
+          continue;
         }
-        if (org.refreshToken) {
-          const encryptionType = org.refreshToken.encryptionType;
-          if (encryptionType) {
-            org.refreshToken = {
-              value: decrypt(org.refreshToken),
-              encryptionType,
-            };
-          }
-        }
+
+        org.accessToken = accessToken;
+        org.refreshToken = refreshToken;
       }
     }
   }
   const neon = combinedSettings.neon;
   if (neon) {
     if (neon.refreshToken) {
-      const encryptionType = neon.refreshToken.encryptionType;
-      if (encryptionType) {
-        neon.refreshToken = {
-          value: decrypt(neon.refreshToken),
-          encryptionType,
-        };
+      const decrypted = decryptStoredSecret(
+        neon.refreshToken,
+        "Neon refresh token",
+      );
+      if (decrypted) {
+        neon.refreshToken = decrypted;
+      } else {
+        delete neon.refreshToken;
       }
     }
     if (neon.accessToken) {
-      const encryptionType = neon.accessToken.encryptionType;
-      if (encryptionType) {
-        neon.accessToken = {
-          value: decrypt(neon.accessToken),
-          encryptionType,
-        };
+      const decrypted = decryptStoredSecret(
+        neon.accessToken,
+        "Neon access token",
+      );
+      if (decrypted) {
+        neon.accessToken = decrypted;
+      } else {
+        delete neon.accessToken;
       }
     }
   }
   if (combinedSettings.githubAccessToken) {
-    const encryptionType = combinedSettings.githubAccessToken.encryptionType;
-    combinedSettings.githubAccessToken = {
-      value: decrypt(combinedSettings.githubAccessToken),
-      encryptionType,
-    };
+    const decrypted = decryptStoredSecret(
+      combinedSettings.githubAccessToken,
+      "GitHub access token",
+    );
+    if (decrypted) {
+      combinedSettings.githubAccessToken = decrypted;
+    } else {
+      delete combinedSettings.githubAccessToken;
+    }
   }
   if (combinedSettings.vercelAccessToken) {
-    const encryptionType = combinedSettings.vercelAccessToken.encryptionType;
-    combinedSettings.vercelAccessToken = {
-      value: decrypt(combinedSettings.vercelAccessToken),
-      encryptionType,
-    };
+    const decrypted = decryptStoredSecret(
+      combinedSettings.vercelAccessToken,
+      "Vercel access token",
+    );
+    if (decrypted) {
+      combinedSettings.vercelAccessToken = decrypted;
+    } else {
+      delete combinedSettings.vercelAccessToken;
+    }
   }
   for (const provider in combinedSettings.providerSettings) {
     if (combinedSettings.providerSettings[provider].apiKey) {
-      const encryptionType =
-        combinedSettings.providerSettings[provider].apiKey.encryptionType;
-      combinedSettings.providerSettings[provider].apiKey = {
-        value: decrypt(combinedSettings.providerSettings[provider].apiKey),
-        encryptionType,
-      };
+      const decrypted = decryptStoredSecret(
+        combinedSettings.providerSettings[provider].apiKey,
+        `${provider} API key`,
+      );
+      if (decrypted) {
+        combinedSettings.providerSettings[provider].apiKey = decrypted;
+      } else {
+        delete combinedSettings.providerSettings[provider].apiKey;
+      }
     }
     // Decrypt Vertex service account key if present
     const v = combinedSettings.providerSettings[
       provider
     ] as VertexProviderSetting;
     if (provider === "vertex" && v?.serviceAccountKey) {
-      const encryptionType = v.serviceAccountKey.encryptionType;
-      v.serviceAccountKey = {
-        value: decrypt(v.serviceAccountKey),
-        encryptionType,
-      };
+      const decrypted = decryptStoredSecret(
+        v.serviceAccountKey,
+        "Vertex service account key",
+      );
+      if (decrypted) {
+        v.serviceAccountKey = decrypted;
+      } else {
+        delete v.serviceAccountKey;
+      }
     }
   }
 
@@ -333,6 +358,29 @@ function readExistingSettingsFile(filePath: string): UserSettings {
   const migratedSettings = migrateStoredSettings(storedSettings);
   // Validate the migrated settings against the active schema
   return UserSettingsSchema.parse(migratedSettings);
+}
+
+function decryptStoredSecret(data: Secret, label: string): Secret | undefined {
+  try {
+    const encryptionType = data.encryptionType;
+    return {
+      value: decrypt(data),
+      encryptionType,
+    };
+  } catch (error) {
+    if (isSafeStorageNotReadyError(error)) {
+      throw error;
+    }
+    logger.warn(`Could not decrypt ${label}; ignoring stored secret.`, error);
+    return undefined;
+  }
+}
+
+function isSafeStorageNotReadyError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.message.includes("safeStorage cannot be used before app is ready")
+  );
 }
 
 function readSettingsForWrite(filePath: string): {


### PR DESCRIPTION
## Summary
- Queue deep links until the main window is ready before processing OAuth and prompt callbacks
- Treat individual secret decryption failures as missing secrets instead of discarding all settings
- Add unit coverage for deep-link queuing and resilient settings reads

## Test plan
- npm run fmt, npm run lint:fix, npm run ts
- npm test