### PR TITLE
Add staging Next.js template option for local demo

### DIFF
--- a/src/shared/templates.ts
+++ b/src/shared/templates.ts
@@ -39,7 +39,7 @@ export const localTemplatesData: Template[] = [
     description: "Uses Next.js, React.js, Shadcn, Tailwind and TypeScript.",
     imageUrl:
       "https://github.com/user-attachments/assets/96258e4f-abce-4910-a62a-a9dff77965f2",
-    githubUrl: "https://github.com/dyad-sh/nextjs-template",
+    githubUrl: "https://github.com/test4lance/dyad-staging-template",
     isOfficial: true,
   },
   {

--- a/src/shared/templates.ts
+++ b/src/shared/templates.ts
@@ -39,6 +39,16 @@ export const localTemplatesData: Template[] = [
     description: "Uses Next.js, React.js, Shadcn, Tailwind and TypeScript.",
     imageUrl:
       "https://github.com/user-attachments/assets/96258e4f-abce-4910-a62a-a9dff77965f2",
+    githubUrl: "https://github.com/dyad-sh/nextjs-template",
+    isOfficial: true,
+  },
+  {
+    id: "next-staging",
+    title: "Next.js Template (Staging)",
+    description:
+      "Uses Next.js, React.js, Shadcn, Tailwind and TypeScript for local staging demo.",
+    imageUrl:
+      "https://github.com/user-attachments/assets/96258e4f-abce-4910-a62a-a9dff77965f2",
     githubUrl: "https://github.com/test4lance/dyad-staging-template",
     isOfficial: true,
   },


### PR DESCRIPTION
## Summary
- Keep existing official Next.js template source as-is.
- Add a second local template entry `next-staging` that points to `https://github.com/test4lance/dyad-staging-template`.

## Why
Expose the staging template in client template list without replacing the official Next.js template.

## Notes
No runtime logic changes; only local template catalog update.