### PR TITLE
perf: throttle and backpressure streaming-patch IPC sends

### DIFF
--- a/src/hooks/useStreamChat.ts
+++ b/src/hooks/useStreamChat.ts
@@ -24,6 +24,7 @@ import type { ChatSummary } from "@/lib/schemas";
 import { useChats } from "./useChats";
 import { useLoadApp } from "./useLoadApp";
 import { applyStreamingPatch } from "@/lib/applyStreamingPatch";
+import { recordChunkApplied, cancelChunkAcks } from "@/lib/chunkAckScheduler";
 import {
   triggerResync,
   syncChatFromDb,
@@ -51,37 +52,6 @@ export function getRandomNumberId() {
 // Module-level set to track chatIds with active/pending streams
 // This prevents race conditions when clicking rapidly before state updates
 const pendingStreamChatIds = new Set<number>();
-
-// Throttled ack scheduler for the canned test stream's ack-based
-// backpressure. Stores the highest chunkSeq received per chatId; at most
-// one ack per ACK_THROTTLE_MS is sent per chatId, carrying the latest
-// received seq. Real LLM streams omit chunkSeq, so the scheduler is never
-// armed for them.
-const ACK_THROTTLE_MS = 250;
-const latestChunkByChatId = new Map<number, number>();
-const ackTimerByChatId = new Map<number, ReturnType<typeof setTimeout>>();
-
-function scheduleThrottledAck(chatId: number): void {
-  if (ackTimerByChatId.has(chatId)) return;
-  const timer = setTimeout(() => {
-    ackTimerByChatId.delete(chatId);
-    const seq = latestChunkByChatId.get(chatId);
-    if (seq === undefined) return;
-    void ipc.chat.responseAck({ chatId, lastSeq: seq }).catch(() => {
-      // Ignore ack failures; main has no retry path and acks are
-      // advisory under throttling.
-    });
-  }, ACK_THROTTLE_MS);
-  ackTimerByChatId.set(chatId, timer);
-}
-
-function cancelAckTimer(chatId: number): void {
-  const timer = ackTimerByChatId.get(chatId);
-  if (timer !== undefined) {
-    clearTimeout(timer);
-    ackTimerByChatId.delete(chatId);
-  }
-}
 
 export function useStreamChat({
   hasChatId = true,
@@ -310,22 +280,14 @@ export function useStreamChat({
                 }
               }
 
-              // Ack-based backpressure for the canned test stream. Real
-              // LLM streams omit chunkSeq, so this is a no-op for them.
-              // Coalesce many incoming chunks into a single ack fired on a
-              // fixed throttle interval (ACK_THROTTLE_MS).
-              if (chunkSeq !== undefined) {
-                const prev = latestChunkByChatId.get(chatId) ?? 0;
-                if (chunkSeq > prev) {
-                  latestChunkByChatId.set(chatId, chunkSeq);
-                }
-                scheduleThrottledAck(chatId);
-              }
+              // Ack-based backpressure: chunks carrying chunkSeq are acked
+              // on a throttled cadence. Both the canned test stream and the
+              // production throttle path use this.
+              recordChunkApplied(chatId, chunkSeq);
             },
             onEnd: (response: ChatResponseEnd) => {
               pendingStreamChatIds.delete(chatId);
-              latestChunkByChatId.delete(chatId);
-              cancelAckTimer(chatId);
+              cancelChunkAcks(chatId);
               void (async () => {
                 // Only mark as successful if NOT cancelled - wasCancelled flag is set
                 // by the backend when user cancels the stream
@@ -501,8 +463,7 @@ export function useStreamChat({
             onError: ({ error: errorMessage, warningMessages }) => {
               // Remove from pending set now that stream ended with error
               pendingStreamChatIds.delete(chatId);
-              latestChunkByChatId.delete(chatId);
-              cancelAckTimer(chatId);
+              cancelChunkAcks(chatId);
 
               for (const warningMessage of warningMessages ?? []) {
                 showWarning(warningMessage);
@@ -538,8 +499,7 @@ export function useStreamChat({
       } catch (error) {
         // Remove from pending set on exception
         pendingStreamChatIds.delete(chatId);
-        latestChunkByChatId.delete(chatId);
-        cancelAckTimer(chatId);
+        cancelChunkAcks(chatId);
 
         console.error("[CHAT] Exception during streaming setup:", error);
         setIsStreamingById((prev) => {

--- a/src/hooks/useStreamChat.ts
+++ b/src/hooks/useStreamChat.ts
@@ -258,6 +258,11 @@ export function useStreamChat({
                 hasIncrementedStreamCount = true;
               }
 
+              // Ack-based backpressure: only ack chunks the renderer
+              // actually integrated. Acking a chunk whose patch failed would
+              // release main-process backpressure while the renderer base is
+              // still stale (resync in flight), letting the producer drain
+              // further patches against a base that can't accept them.
               if (updatedMessages) {
                 // Full messages update (initial load, post-compaction, etc.)
                 setMessagesById((prev) => {
@@ -265,6 +270,7 @@ export function useStreamChat({
                   next.set(chatId, updatedMessages);
                   return next;
                 });
+                recordChunkApplied(chatId, chunkSeq);
               } else if (
                 streamingMessageId !== undefined &&
                 streamingPatch !== undefined
@@ -275,15 +281,12 @@ export function useStreamChat({
                   streamingMessageId,
                   streamingPatch,
                 );
-                if (!applied) {
+                if (applied) {
+                  recordChunkApplied(chatId, chunkSeq);
+                } else {
                   triggerResync(chatId, setMessagesById, store);
                 }
               }
-
-              // Ack-based backpressure: chunks carrying chunkSeq are acked
-              // on a throttled cadence. Both the canned test stream and the
-              // production throttle path use this.
-              recordChunkApplied(chatId, chunkSeq);
             },
             onEnd: (response: ChatResponseEnd) => {
               pendingStreamChatIds.delete(chatId);

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -45,7 +45,10 @@ import {
 } from "../processors/response_processor";
 import { streamTestResponse, getTestResponse } from "./testing_chat_handlers";
 import { recordAckForChat } from "../utils/ack_backpressure";
-import { createStreamingPatchThrottle } from "../utils/streaming_patch_throttle";
+import {
+  createStreamingPatchThrottle,
+  destroyChunkThrottleForChat,
+} from "../utils/streaming_patch_throttle";
 import type { StreamingPatchThrottle } from "../utils/streaming_patch_throttle";
 import { getModelClient, ModelClient } from "../utils/get_model_client";
 import log from "electron-log";
@@ -1896,6 +1899,17 @@ ${problemReport.problems
     } else {
       logger.warn(`No active stream found for chat ${chatId}`);
     }
+
+    // Drain + tear down the active stream's chunk throttle BEFORE emitting
+    // chat:response:end. The renderer unregisters onChunk on end
+    // (createStreamClient in core.ts) and skips the DB resync when
+    // wasCancelled (useStreamChat.ts), so any tail patch still buffered in
+    // the 16ms throttle window or backpressure buffer would otherwise be
+    // silently lost — leaving the UI truncated relative to persisted DB
+    // content. Routed through the per-chatId registry so this works
+    // without the cancelStream handler holding a direct throttle ref.
+    // Idempotent — no-op if no active throttle is registered for the chat.
+    destroyChunkThrottleForChat(chatId);
 
     // Send the end event to the renderer with wasCancelled flag
     safeSend(event.sender, "chat:response:end", {

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -43,11 +43,10 @@ import {
   dryRunSearchReplace,
   processFullResponseActions,
 } from "../processors/response_processor";
-import {
-  streamTestResponse,
-  getTestResponse,
-  noteAck,
-} from "./testing_chat_handlers";
+import { streamTestResponse, getTestResponse } from "./testing_chat_handlers";
+import { recordAckForChat } from "../utils/ack_backpressure";
+import { createStreamingPatchThrottle } from "../utils/streaming_patch_throttle";
+import type { StreamingPatchThrottle } from "../utils/streaming_patch_throttle";
 import { getModelClient, ModelClient } from "../utils/get_model_client";
 import log from "electron-log";
 import { sendTelemetryEvent } from "../utils/telemetry";
@@ -250,12 +249,13 @@ export function registerChatStreamHandlers() {
   createTypedHandler(
     chatContracts.responseAck,
     async (_event, { chatId, lastSeq }) => {
-      noteAck(chatId, lastSeq);
+      recordAckForChat(chatId, lastSeq);
     },
   );
 
   ipcMain.handle("chat:stream", async (event, req: ChatStreamParams) => {
     let attachmentPaths: string[] = [];
+    let chunkThrottle: StreamingPatchThrottle | null = null;
     try {
       let dyadRequestId: string | undefined;
       // Create an AbortController for this stream
@@ -1213,6 +1213,20 @@ This conversation includes one or more image attachments. When the user uploads 
         // assuming pure appends.
         let lastSentContent = "";
 
+        chunkThrottle = createStreamingPatchThrottle({
+          chatId: req.chatId,
+          logTag: "ipc-throttle:stream",
+          send: (patch, chunkSeq) => {
+            safeSend(event.sender, "chat:response:chunk", {
+              chatId: req.chatId,
+              streamingMessageId: placeholderAssistantMessage.id,
+              streamingPatch: patch,
+              chunkSeq,
+            });
+          },
+        });
+        const throttle = chunkThrottle;
+
         const processResponseChunkUpdate = async ({
           fullResponse,
         }: {
@@ -1236,11 +1250,7 @@ This conversation includes one or more image attachments. When the user uploads 
           if (!patch) {
             return fullResponse;
           }
-          safeSend(event.sender, "chat:response:chunk", {
-            chatId: req.chatId,
-            streamingMessageId: placeholderAssistantMessage.id,
-            streamingPatch: patch,
-          });
+          throttle.queue(patch);
           return fullResponse;
         };
 
@@ -1795,6 +1805,10 @@ ${problemReport.problems
             },
           });
 
+          // Drop any pending throttled tail patch — sending it after this
+          // full messages-replacement would re-apply against the wrong base
+          // and truncate the renderer's content.
+          chunkThrottle?.cancel();
           safeSend(event.sender, "chat:response:chunk", {
             chatId: req.chatId,
             messages: chat!.messages,
@@ -1837,6 +1851,11 @@ ${problemReport.problems
 
       return "error";
     } finally {
+      // Drop any pending throttled tail patch and emit the throttle's
+      // end-of-stream summary log. Idempotent — agent paths early-return
+      // before the throttle is ever constructed.
+      chunkThrottle?.destroy();
+
       // Clean up the abort controller
       activeStreams.delete(req.chatId);
 

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -1822,6 +1822,15 @@ ${problemReport.problems
             });
           }
 
+          // Drain + tear down the throttle BEFORE chat:response:end. The
+          // renderer unregisters its onChunk handler the moment it receives
+          // end (createStreamClient in core.ts), so any patch flushed after
+          // end is silently dropped. Idempotent — the finally below is just
+          // a safety net for paths that didn't reach this point. Here the
+          // earlier cancel() + fullMessages-replacement already emptied the
+          // coalescer, so destroy's flush is a no-op.
+          chunkThrottle?.destroy();
+
           // Signal that the stream has completed
           safeSend(event.sender, "chat:response:end", {
             chatId: req.chatId,
@@ -1832,6 +1841,13 @@ ${problemReport.problems
             chatSummary,
           } satisfies ChatResponseEnd);
         } else {
+          // Drain + tear down the throttle BEFORE chat:response:end so the
+          // renderer (which unregisters onChunk on end) still applies any
+          // tail patch buffered in the 16ms throttle window. Without this,
+          // fast completions that finished inside the window lose their
+          // last bytes until a later DB resync.
+          chunkThrottle?.destroy();
+
           safeSend(event.sender, "chat:response:end", {
             chatId: req.chatId,
             updatedFiles: false,
@@ -1844,6 +1860,10 @@ ${problemReport.problems
       return req.chatId;
     } catch (error) {
       logger.error("Error calling LLM:", error);
+      // Drain + tear down BEFORE chat:response:error: the renderer
+      // unregisters onChunk on error too, so a tail patch flushed
+      // afterwards by the finally would be dropped.
+      chunkThrottle?.destroy();
       safeSend(event.sender, "chat:response:error", {
         chatId: req.chatId,
         error: `Sorry, there was an error processing your request: ${error}`,

--- a/src/ipc/handlers/testing_chat_handlers.ts
+++ b/src/ipc/handlers/testing_chat_handlers.ts
@@ -1,14 +1,16 @@
 import { safeSend } from "../utils/safe_sender";
 import { cleanFullResponse } from "../utils/cleanFullResponse";
 import { computeStreamingPatch } from "../utils/stream_text_utils";
+import { createAckBackpressure } from "../utils/ack_backpressure";
 
 /**
  * Maximum number of unacked chunks the canned test stream is allowed to
- * keep in flight. The sender skips a send while
- * `lastSentSeq - lastAcked > MAX_IN_FLIGHT`, which lets the renderer's ack
- * cadence pace the stream when the renderer falls behind.
+ * keep in flight. The sender holds when in-flight reaches this count,
+ * letting the renderer's ack cadence pace the stream when it falls behind.
+ * Tighter than the production throttle's threshold because the test fixture
+ * stress-tests the backpressure machinery itself.
  */
-const MAX_IN_FLIGHT = 1;
+const MAX_IN_FLIGHT = 2;
 
 type ResponseEntry = string | (() => string);
 
@@ -157,26 +159,6 @@ export function getTestResponse(prompt: string): string | null {
 }
 
 /**
- * Per-stream ack state for the canned test stream backpressure path. Real
- * LLM streams do not register entries here, so `noteAck` is a no-op for
- * them.
- */
-type AckEntry = { lastAcked: number };
-const ackState = new Map<number, AckEntry>();
-
-export function noteAck(chatId: number, lastSeq: number): void {
-  const entry = ackState.get(chatId);
-  if (!entry) return;
-  if (lastSeq > entry.lastAcked) {
-    entry.lastAcked = lastSeq;
-  }
-}
-
-function clearAck(chatId: number): void {
-  ackState.delete(chatId);
-}
-
-/**
  * Byte size of each streamed chunk. Sized to keep the 24 MB stress fixture
  * under a few thousand iterations so the loop yield + per-iter work stay
  * tractable.
@@ -188,14 +170,12 @@ const CHUNK_SIZE = 500;
  * streaming patches, mirroring the real LLM path. The renderer applies each
  * patch to its local copy of the placeholder assistant message.
  *
- * Ack-based backpressure: each iteration appends to fullResponse and
- * increments currentSeq. The IPC send fires only while in-flight chunks
- * (`lastSentSeq - lastAcked`) are at or below MAX_IN_FLIGHT, so a slow
- * renderer naturally throttles the sender via its ack cadence.
+ * Ack-based backpressure (via {@link createAckBackpressure}): the IPC send
+ * skips while the backpressure handle is held, so a slow renderer naturally
+ * paces the sender via its ack cadence.
  *
- * The 10ms loop yield lets the noteAck IPC handler run; without it, the
- * synchronous loop monopolizes the main process and acks are never
- * observed.
+ * The 10ms loop yield lets the ipcMain ack handler run; without it, the
+ * synchronous loop monopolizes the main process and acks are never observed.
  *
  * `cleanFullResponse` runs once on the canned input up front. Its rewrite
  * is local to fully-formed `<dyad-*>` tags and idempotent, so the cleaned
@@ -214,11 +194,12 @@ export async function streamTestResponse(
   const cleanedResponse = cleanFullResponse(testResponse);
   let fullResponse = "";
   let lastSentContent = "";
-  let currentSeq = 0;
-  let lastSentSeq = 0;
   let offset = 0;
 
-  ackState.set(chatId, { lastAcked: 0 });
+  const backpressure = createAckBackpressure({
+    chatId,
+    threshold: MAX_IN_FLIGHT,
+  });
 
   try {
     while (offset < cleanedResponse.length) {
@@ -227,22 +208,18 @@ export async function streamTestResponse(
       const end = Math.min(offset + CHUNK_SIZE, cleanedResponse.length);
       fullResponse += cleanedResponse.slice(offset, end);
       offset = end;
-      currentSeq++;
 
-      const lastAcked = ackState.get(chatId)?.lastAcked ?? 0;
-      const inFlight = lastSentSeq - lastAcked;
-
-      if (inFlight <= MAX_IN_FLIGHT) {
+      if (!backpressure.isHeld()) {
         const patch = computeStreamingPatch(fullResponse, lastSentContent);
         if (patch) {
+          const chunkSeq = backpressure.markSent();
           safeSend(event.sender, "chat:response:chunk", {
             chatId,
             streamingMessageId: placeholderAssistantMessageId,
             streamingPatch: patch,
-            chunkSeq: currentSeq,
+            chunkSeq,
           });
           lastSentContent = fullResponse;
-          lastSentSeq = currentSeq;
         }
       }
 
@@ -251,19 +228,20 @@ export async function streamTestResponse(
 
     // Final flush: guarantee the renderer ends with the complete response,
     // even if the last iterations were skipped due to backpressure.
-    if (!abortController.signal.aborted && lastSentSeq < currentSeq) {
+    if (!abortController.signal.aborted && lastSentContent !== fullResponse) {
       const patch = computeStreamingPatch(fullResponse, lastSentContent);
       if (patch) {
+        const chunkSeq = backpressure.markSent();
         safeSend(event.sender, "chat:response:chunk", {
           chatId,
           streamingMessageId: placeholderAssistantMessageId,
           streamingPatch: patch,
-          chunkSeq: currentSeq,
+          chunkSeq,
         });
       }
     }
   } finally {
-    clearAck(chatId);
+    backpressure.destroy();
   }
 
   return fullResponse;

--- a/src/ipc/utils/ack_backpressure.ts
+++ b/src/ipc/utils/ack_backpressure.ts
@@ -79,8 +79,14 @@ export function createAckBackpressure(opts: {
 
     recordAck(seq) {
       if (destroyed || seq <= lastAckedSeq) return;
+      // Clamp to lastSentSeq so a delayed ack from a previous stream on the
+      // same chatId (seqs restart per instance) can't push lastAckedSeq past
+      // sent — that would make sent − acked go negative and effectively
+      // disable backpressure for many subsequent sends.
+      const clamped = seq > lastSentSeq ? lastSentSeq : seq;
+      if (clamped <= lastAckedSeq) return;
       const wasHeld = lastSentSeq - lastAckedSeq >= threshold;
-      lastAckedSeq = seq;
+      lastAckedSeq = clamped;
       const isHeldNow = lastSentSeq - lastAckedSeq >= threshold;
       if (wasHeld && !isHeldNow) {
         for (const cb of resumeCallbacks) cb();

--- a/src/ipc/utils/ack_backpressure.ts
+++ b/src/ipc/utils/ack_backpressure.ts
@@ -25,17 +25,6 @@ export interface AckBackpressure {
   /** Update the highest acked seq. Called by the IPC ack handler. */
   recordAck(seq: number): void;
 
-  /**
-   * Roll back a `markSent()` whose subsequent `send` threw. Only undoes the
-   * most recent reservation, and only if no later `markSent` followed and
-   * the seq has not been acked. No-op otherwise — this is opportunistic
-   * cleanup, not a generic undo. Without it a synchronous send failure
-   * leaves `lastSentSeq` ahead of what the renderer ever received, so the
-   * renderer can never ack that seq and backpressure stays inflated for
-   * the rest of the stream.
-   */
-  unmarkSent(seq: number): void;
-
   /** True when in-flight count (sent − acked) is at or above threshold. */
   isHeld(): boolean;
 
@@ -101,18 +90,6 @@ export function createAckBackpressure(opts: {
       const isHeldNow = lastSentSeq - lastAckedSeq >= threshold;
       if (wasHeld && !isHeldNow) {
         for (const cb of resumeCallbacks) cb();
-      }
-    },
-
-    unmarkSent(seq) {
-      if (destroyed) return;
-      // Only roll back the most recent reservation, and only when nothing
-      // has acked it. If another markSent has already followed, the
-      // monotonic seq invariant we'd need to repair is non-local — leave
-      // it alone.
-      if (lastSentSeq === seq && lastAckedSeq < seq) {
-        lastSentSeq = seq - 1;
-        nextSeq = seq;
       }
     },
 

--- a/src/ipc/utils/ack_backpressure.ts
+++ b/src/ipc/utils/ack_backpressure.ts
@@ -25,6 +25,17 @@ export interface AckBackpressure {
   /** Update the highest acked seq. Called by the IPC ack handler. */
   recordAck(seq: number): void;
 
+  /**
+   * Roll back a `markSent()` whose subsequent `send` threw. Only undoes the
+   * most recent reservation, and only if no later `markSent` followed and
+   * the seq has not been acked. No-op otherwise — this is opportunistic
+   * cleanup, not a generic undo. Without it a synchronous send failure
+   * leaves `lastSentSeq` ahead of what the renderer ever received, so the
+   * renderer can never ack that seq and backpressure stays inflated for
+   * the rest of the stream.
+   */
+  unmarkSent(seq: number): void;
+
   /** True when in-flight count (sent − acked) is at or above threshold. */
   isHeld(): boolean;
 
@@ -90,6 +101,18 @@ export function createAckBackpressure(opts: {
       const isHeldNow = lastSentSeq - lastAckedSeq >= threshold;
       if (wasHeld && !isHeldNow) {
         for (const cb of resumeCallbacks) cb();
+      }
+    },
+
+    unmarkSent(seq) {
+      if (destroyed) return;
+      // Only roll back the most recent reservation, and only when nothing
+      // has acked it. If another markSent has already followed, the
+      // monotonic seq invariant we'd need to repair is non-local — leave
+      // it alone.
+      if (lastSentSeq === seq && lastAckedSeq < seq) {
+        lastSentSeq = seq - 1;
+        nextSeq = seq;
       }
     },
 

--- a/src/ipc/utils/ack_backpressure.ts
+++ b/src/ipc/utils/ack_backpressure.ts
@@ -1,0 +1,114 @@
+/**
+ * Generic ack-based backpressure for chunked main→renderer IPC streams.
+ *
+ * Tracks `sent − acked` in-flight chunk count. When that exceeds the
+ * configured threshold the producer is "held" and should stop sending.
+ * Each ack lowers the in-flight count; once it drops back under threshold,
+ * the optional `onResume` callback fires so the producer can drain.
+ *
+ * No watchdog: callers are expected to recover from a stalled ack channel
+ * via end-of-stream cleanup (e.g. a full messages-replacement) rather than
+ * forcing drains here.
+ *
+ * Per-chat registry lets the single `chat:response:ack` IPC handler route
+ * acks to whichever active stream owns that chatId (canned test stream or
+ * production throttle).
+ */
+export interface AckBackpressure {
+  /**
+   * Mark a chunk as sent and assign it the next monotonic seq. The caller
+   * must embed the returned seq in the IPC payload so the renderer can
+   * echo it back via ack.
+   */
+  markSent(): number;
+
+  /** Update the highest acked seq. Called by the IPC ack handler. */
+  recordAck(seq: number): void;
+
+  /** True when in-flight count (sent − acked) is at or above threshold. */
+  isHeld(): boolean;
+
+  /** Subscribe to drain events fired when in-flight drops back under threshold. */
+  onResume(cb: () => void): void;
+
+  /** Snapshot of current backpressure stats. Useful for end-of-stream logging. */
+  stats(): {
+    sent: number;
+    acked: number;
+    maxBacklog: number;
+  };
+
+  /** Tear down and remove from the registry. Idempotent. */
+  destroy(): void;
+}
+
+const backpressuresByChatId = new Map<number, AckBackpressure>();
+
+/** Routes an ack from the renderer to whichever active backpressure owns `chatId`. */
+export function recordAckForChat(chatId: number, seq: number): void {
+  backpressuresByChatId.get(chatId)?.recordAck(seq);
+}
+
+export function createAckBackpressure(opts: {
+  chatId: number;
+  threshold: number;
+}): AckBackpressure {
+  const { chatId, threshold } = opts;
+
+  let nextSeq = 1;
+  let lastSentSeq = 0;
+  let lastAckedSeq = 0;
+  let maxBacklog = 0;
+  let destroyed = false;
+  const resumeCallbacks: Array<() => void> = [];
+
+  // Replace any pre-existing instance for this chat — two streams shouldn't
+  // overlap, but if one leaks (test teardown, crash before destroy) the new
+  // one should own ack routing.
+  const prior = backpressuresByChatId.get(chatId);
+  if (prior) prior.destroy();
+
+  const handle: AckBackpressure = {
+    markSent() {
+      const seq = nextSeq++;
+      lastSentSeq = seq;
+      const backlog = lastSentSeq - lastAckedSeq;
+      if (backlog > maxBacklog) maxBacklog = backlog;
+      return seq;
+    },
+
+    recordAck(seq) {
+      if (destroyed || seq <= lastAckedSeq) return;
+      const wasHeld = lastSentSeq - lastAckedSeq >= threshold;
+      lastAckedSeq = seq;
+      const isHeldNow = lastSentSeq - lastAckedSeq >= threshold;
+      if (wasHeld && !isHeldNow) {
+        for (const cb of resumeCallbacks) cb();
+      }
+    },
+
+    isHeld() {
+      return lastSentSeq - lastAckedSeq >= threshold;
+    },
+
+    onResume(cb) {
+      resumeCallbacks.push(cb);
+    },
+
+    stats() {
+      return { sent: lastSentSeq, acked: lastAckedSeq, maxBacklog };
+    },
+
+    destroy() {
+      if (destroyed) return;
+      destroyed = true;
+      resumeCallbacks.length = 0;
+      if (backpressuresByChatId.get(chatId) === handle) {
+        backpressuresByChatId.delete(chatId);
+      }
+    },
+  };
+
+  backpressuresByChatId.set(chatId, handle);
+  return handle;
+}

--- a/src/ipc/utils/streaming_patch_coalesce.ts
+++ b/src/ipc/utils/streaming_patch_coalesce.ts
@@ -1,0 +1,65 @@
+import type { StreamingPatch } from "@/ipc/types";
+
+/**
+ * Pure StreamingPatch merge buffer. Holds at most one pending patch and
+ * merges any new patch into it. No timers, no IPC, no backpressure — just
+ * the merge math, suitable for layering under a throttle or backpressure
+ * gate.
+ *
+ * Coalesce semantics mirror the renderer's reconstruction
+ * (`current.slice(0, offset) + content`):
+ *   - If the new patch's offset is lower than the pending patch's, the
+ *     newer patch fully supersedes (its tail rewrote bytes earlier than
+ *     where the pending patch began).
+ *   - Otherwise the merged patch keeps the lower offset and concatenates
+ *     the older pending content's prefix with the newer content. The
+ *     older patch's `prefixHash` wins — it describes the authoritative
+ *     agreed-upon prefix at that offset.
+ */
+export interface PatchCoalescer {
+  /** Merge a new patch into the pending buffer. */
+  add(patch: StreamingPatch): void;
+
+  /** Return and clear the merged pending patch, or null if none. */
+  drain(): StreamingPatch | null;
+
+  /** Drop the pending patch without returning it. */
+  reset(): void;
+
+  /** True when a pending patch is buffered. */
+  hasPending(): boolean;
+}
+
+export function createPatchCoalescer(): PatchCoalescer {
+  let pending: StreamingPatch | null = null;
+
+  return {
+    add(next) {
+      if (!pending) {
+        pending = { ...next };
+        return;
+      }
+      if (next.offset < pending.offset) {
+        pending = { ...next };
+        return;
+      }
+      const prefixLen = next.offset - pending.offset;
+      pending = {
+        offset: pending.offset,
+        content: pending.content.slice(0, prefixLen) + next.content,
+        prefixHash: pending.prefixHash,
+      };
+    },
+    drain() {
+      const out = pending;
+      pending = null;
+      return out;
+    },
+    reset() {
+      pending = null;
+    },
+    hasPending() {
+      return pending !== null;
+    },
+  };
+}

--- a/src/ipc/utils/streaming_patch_throttle.ts
+++ b/src/ipc/utils/streaming_patch_throttle.ts
@@ -1,0 +1,155 @@
+import log from "electron-log";
+import type { StreamingPatch } from "@/ipc/types";
+import {
+  createAckBackpressure,
+  type AckBackpressure,
+} from "./ack_backpressure";
+import { createPatchCoalescer } from "./streaming_patch_coalesce";
+
+const logger = log.scope("streaming_patch_throttle");
+
+// IPC patch send window. Newer patches arriving inside this window are
+// coalesced and emitted on the trailing edge instead of firing per-chunk.
+// 16ms ≈ 60Hz: caps renderer paint work to one apply-per-frame while
+// keeping streaming text visually smooth.
+export const IPC_STREAM_THROTTLE_MS = 16;
+
+// Hold sends when in-flight (sent − acked) reaches this many patches —
+// the renderer is falling behind and adding more sends just deepens the
+// queue. New patches keep coalescing into the pending merged patch; drain
+// resumes when an ack pulls backlog under threshold (one big catch-up
+// patch instead of many small ones). End-of-stream full-messages
+// replacement always delivers final content, so a stalled ack channel
+// can't strand the renderer on stale state — no watchdog needed.
+export const IPC_STREAM_BACKPRESSURE_THRESHOLD = 20;
+
+export type SendPatchFn = (patch: StreamingPatch, chunkSeq: number) => void;
+
+export interface StreamingPatchThrottle {
+  /** Queue a patch for throttled, backpressured send to the renderer. */
+  queue(patch: StreamingPatch): void;
+
+  /** Drop any pending patch without sending. Use before a full-messages-replacement. */
+  cancel(): void;
+
+  /** Tear down and emit a one-shot end-of-stream summary. Idempotent. */
+  destroy(emitSummary?: boolean): void;
+}
+
+/**
+ * Throttled, backpressured sender for `chat:response:chunk` tail patches.
+ *
+ * Composes three concerns:
+ * - **coalesce** ({@link createPatchCoalescer}): merge fast-arriving patches
+ *   into a single pending tail patch.
+ * - **backpressure** ({@link createAckBackpressure}): hold sends when the
+ *   renderer falls behind, resume on ack drain.
+ * - **throttle window**: leading-edge fire if the window has elapsed,
+ *   otherwise trailing-edge fire at window's end.
+ *
+ * `cancel()` MUST be called before any full messages-array replacement on
+ * the same channel — a stale tail patch firing after a messages-replacement
+ * gets reapplied against the wrong base and truncates the renderer's
+ * content.
+ */
+export function createStreamingPatchThrottle(opts: {
+  chatId: number;
+  send: SendPatchFn;
+  throttleMs?: number;
+  threshold?: number;
+  logTag?: string;
+}): StreamingPatchThrottle {
+  const chatId = opts.chatId;
+  const throttleMs = opts.throttleMs ?? IPC_STREAM_THROTTLE_MS;
+  const threshold = opts.threshold ?? IPC_STREAM_BACKPRESSURE_THRESHOLD;
+  const logTag = opts.logTag ?? "ipc-throttle";
+  const send = opts.send;
+
+  const coalescer = createPatchCoalescer();
+  const backpressure: AckBackpressure = createAckBackpressure({
+    chatId,
+    threshold,
+  });
+
+  let trailingTimer: NodeJS.Timeout | null = null;
+  let lastSentAt = 0;
+  let destroyed = false;
+
+  function clearTrailing(): void {
+    if (trailingTimer) {
+      clearTimeout(trailingTimer);
+      trailingTimer = null;
+    }
+  }
+
+  function flushPending(now: number): void {
+    const patch = coalescer.drain();
+    if (!patch) return;
+    lastSentAt = now;
+    const seq = backpressure.markSent();
+    try {
+      send(patch, seq);
+    } catch (err) {
+      logger.warn(`[${logTag}] send failed chat=${chatId} seq=${seq}`, err);
+    }
+  }
+
+  /**
+   * Send `pending` honoring the throttle window: fires immediately if the
+   * window has elapsed, otherwise arms a trailing-edge timer. No-op when
+   * nothing is pending or a timer is already armed.
+   */
+  function scheduleFlush(): void {
+    if (destroyed || !coalescer.hasPending() || trailingTimer) return;
+    const now = Date.now();
+    const elapsed = now - lastSentAt;
+    if (elapsed >= throttleMs) {
+      flushPending(now);
+      return;
+    }
+    const wait = throttleMs - elapsed;
+    trailingTimer = setTimeout(() => {
+      trailingTimer = null;
+      if (coalescer.hasPending()) flushPending(Date.now());
+    }, wait);
+  }
+
+  // Drain coalesced patch when ack pulls in-flight count back under threshold.
+  backpressure.onResume(() => {
+    if (coalescer.hasPending()) scheduleFlush();
+  });
+
+  return {
+    queue(patch) {
+      if (destroyed) return;
+      coalescer.add(patch);
+      if (backpressure.isHeld()) {
+        // Renderer behind. Cancel any armed trailing send and let new
+        // patches keep coalescing into the buffer. `onResume` resumes
+        // the drain once an ack pulls backlog back under threshold.
+        clearTrailing();
+        return;
+      }
+      scheduleFlush();
+    },
+
+    cancel() {
+      clearTrailing();
+      coalescer.reset();
+    },
+
+    destroy(emitSummary = true) {
+      if (destroyed) return;
+      destroyed = true;
+      clearTrailing();
+      coalescer.reset();
+      const { sent, acked, maxBacklog } = backpressure.stats();
+      backpressure.destroy();
+      if (emitSummary && sent > 0) {
+        logger.log(
+          `[${logTag}] summary chat=${chatId} sent=${sent} acked=${acked} maxBacklog=${maxBacklog} throttleMs=${throttleMs} threshold=${threshold}`,
+        );
+      }
+    },
+  };
+}

--- a/src/ipc/utils/streaming_patch_throttle.ts
+++ b/src/ipc/utils/streaming_patch_throttle.ts
@@ -36,6 +36,24 @@ export interface StreamingPatchThrottle {
   destroy(emitSummary?: boolean): void;
 }
 
+// Per-chat registry so out-of-band callers (currently `cancelStream`) can
+// flush+tear down whichever active throttle owns a given chatId. Without
+// this, `cancelStream` would emit `chat:response:end` while the main
+// stream's throttle still has a buffered tail patch — and the renderer
+// (which unregisters `onChunk` on end and skips DB resync when
+// `wasCancelled`) would never see those final bytes.
+const chunkThrottlesByChatId = new Map<number, StreamingPatchThrottle>();
+
+/**
+ * Flush + tear down the active throttle for `chatId`, if any. Safe to call
+ * when no throttle is registered (no-op). Used by the cancelStream IPC
+ * handler to drain pending patches synchronously *before* it emits
+ * `chat:response:end`.
+ */
+export function destroyChunkThrottleForChat(chatId: number): void {
+  chunkThrottlesByChatId.get(chatId)?.destroy();
+}
+
 /**
  * Throttled, backpressured sender for `chat:response:chunk` tail patches.
  *
@@ -127,7 +145,13 @@ export function createStreamingPatchThrottle(opts: {
     if (coalescer.hasPending()) scheduleFlush();
   });
 
-  return {
+  // Replace any pre-existing instance for this chat — two streams shouldn't
+  // overlap, but if one leaks (test teardown, crash before destroy) the
+  // new one should own the registry slot so cancelStream routes correctly.
+  const prior = chunkThrottlesByChatId.get(chatId);
+  if (prior) prior.destroy();
+
+  const handle: StreamingPatchThrottle = {
     queue(patch) {
       if (destroyed) return;
       coalescer.add(patch);
@@ -171,6 +195,12 @@ export function createStreamingPatchThrottle(opts: {
           `[${logTag}] summary chat=${chatId} sent=${sent} acked=${acked} maxBacklog=${maxBacklog} throttleMs=${throttleMs} threshold=${threshold}`,
         );
       }
+      if (chunkThrottlesByChatId.get(chatId) === handle) {
+        chunkThrottlesByChatId.delete(chatId);
+      }
     },
   };
+
+  chunkThrottlesByChatId.set(chatId, handle);
+  return handle;
 }

--- a/src/ipc/utils/streaming_patch_throttle.ts
+++ b/src/ipc/utils/streaming_patch_throttle.ts
@@ -85,11 +85,19 @@ export function createStreamingPatchThrottle(opts: {
   function flushPending(now: number): void {
     const patch = coalescer.drain();
     if (!patch) return;
-    lastSentAt = now;
     const seq = backpressure.markSent();
     try {
       send(patch, seq);
+      // Only commit lastSentAt after a successful send so a throw (rare
+      // with safeSend, possible with a custom callback) doesn't widen the
+      // throttle window's effective starting point.
+      lastSentAt = now;
     } catch (err) {
+      // Roll back the reservation: the renderer never received this seq
+      // and so will never ack it. Without this rollback, lastSentSeq stays
+      // ahead of what's actually in flight and backpressure (sent − acked)
+      // is permanently inflated for the rest of the stream.
+      backpressure.unmarkSent(seq);
       logger.warn(`[${logTag}] send failed chat=${chatId} seq=${seq}`, err);
     }
   }
@@ -142,6 +150,19 @@ export function createStreamingPatchThrottle(opts: {
       if (destroyed) return;
       destroyed = true;
       clearTrailing();
+      // Flush any final coalesced patch synchronously before tearing down so
+      // a slow renderer doesn't lose the last bytes that landed inside the
+      // throttle window or the backpressure buffer. This matters for the
+      // cancel path (the cancelStream IPC handler emits chat:response:end
+      // immediately, racing the trailing-edge timer) and as a safety net
+      // for the success path (callers should send a fullMessages-replacement
+      // first, but if they don't, we don't want to truncate). Callers that
+      // explicitly need to drop pending state — e.g. before a
+      // fullMessages-replacement, where a stale tail patch would re-apply
+      // against the wrong base — must call cancel() first.
+      if (coalescer.hasPending()) {
+        flushPending(Date.now());
+      }
       coalescer.reset();
       const { sent, acked, maxBacklog } = backpressure.stats();
       backpressure.destroy();

--- a/src/ipc/utils/streaming_patch_throttle.ts
+++ b/src/ipc/utils/streaming_patch_throttle.ts
@@ -33,7 +33,7 @@ export interface StreamingPatchThrottle {
   cancel(): void;
 
   /** Tear down and emit a one-shot end-of-stream summary. Idempotent. */
-  destroy(emitSummary?: boolean): void;
+  destroy(): void;
 }
 
 // Per-chat registry so out-of-band callers (currently `cancelStream`) can
@@ -103,21 +103,8 @@ export function createStreamingPatchThrottle(opts: {
   function flushPending(now: number): void {
     const patch = coalescer.drain();
     if (!patch) return;
-    const seq = backpressure.markSent();
-    try {
-      send(patch, seq);
-      // Only commit lastSentAt after a successful send so a throw (rare
-      // with safeSend, possible with a custom callback) doesn't widen the
-      // throttle window's effective starting point.
-      lastSentAt = now;
-    } catch (err) {
-      // Roll back the reservation: the renderer never received this seq
-      // and so will never ack it. Without this rollback, lastSentSeq stays
-      // ahead of what's actually in flight and backpressure (sent − acked)
-      // is permanently inflated for the rest of the stream.
-      backpressure.unmarkSent(seq);
-      logger.warn(`[${logTag}] send failed chat=${chatId} seq=${seq}`, err);
-    }
+    send(patch, backpressure.markSent());
+    lastSentAt = now;
   }
 
   /**
@@ -170,7 +157,7 @@ export function createStreamingPatchThrottle(opts: {
       coalescer.reset();
     },
 
-    destroy(emitSummary = true) {
+    destroy() {
       if (destroyed) return;
       destroyed = true;
       clearTrailing();
@@ -190,7 +177,7 @@ export function createStreamingPatchThrottle(opts: {
       coalescer.reset();
       const { sent, acked, maxBacklog } = backpressure.stats();
       backpressure.destroy();
-      if (emitSummary && sent > 0) {
+      if (sent > 0) {
         logger.log(
           `[${logTag}] summary chat=${chatId} sent=${sent} acked=${acked} maxBacklog=${maxBacklog} throttleMs=${throttleMs} threshold=${threshold}`,
         );

--- a/src/lib/chunkAckScheduler.ts
+++ b/src/lib/chunkAckScheduler.ts
@@ -1,0 +1,53 @@
+import { ipc } from "@/ipc/types";
+
+/**
+ * Renderer-side throttled ack scheduler for chat-response chunk seqs.
+ *
+ * Coalesces consecutive applied seqs per chatId into one ack per throttle
+ * window — main only needs the *latest* seq to drive its backpressure, so
+ * batching avoids flooding the IPC channel during fast streams.
+ *
+ * Used by both the canned test stream path (in `useStreamChat.onChunk`)
+ * and the production throttle path (which carries the same `chunkSeq`
+ * top-level field on each chunk).
+ */
+const ACK_THROTTLE_MS = 250;
+
+const latestSeqByChatId = new Map<number, number>();
+const timerByChatId = new Map<number, ReturnType<typeof setTimeout>>();
+
+/**
+ * Record an applied seq for a chat. Schedules a throttled ack flush.
+ * No-op when `seq` is undefined (chunks with no seq don't need acking).
+ */
+export function recordChunkApplied(
+  chatId: number,
+  seq: number | undefined,
+): void {
+  if (seq === undefined) return;
+  const prev = latestSeqByChatId.get(chatId) ?? 0;
+  if (seq > prev) latestSeqByChatId.set(chatId, seq);
+  if (timerByChatId.has(chatId)) return;
+  const timer = setTimeout(() => {
+    timerByChatId.delete(chatId);
+    const lastSeq = latestSeqByChatId.get(chatId);
+    if (lastSeq === undefined) return;
+    void ipc.chat.responseAck({ chatId, lastSeq }).catch(() => {
+      // Acks are advisory; main has no retry path, swallow errors.
+    });
+  }, ACK_THROTTLE_MS);
+  timerByChatId.set(chatId, timer);
+}
+
+/**
+ * Cancel any pending ack timer and forget the latest-seq state for a chat.
+ * Call on stream end (renderer-side onEnd/onError) to release resources.
+ */
+export function cancelChunkAcks(chatId: number): void {
+  const timer = timerByChatId.get(chatId);
+  if (timer !== undefined) {
+    clearTimeout(timer);
+    timerByChatId.delete(chatId);
+  }
+  latestSeqByChatId.delete(chatId);
+}

--- a/src/lib/chunkAckScheduler.ts
+++ b/src/lib/chunkAckScheduler.ts
@@ -32,8 +32,10 @@ export function recordChunkApplied(
     timerByChatId.delete(chatId);
     const lastSeq = latestSeqByChatId.get(chatId);
     if (lastSeq === undefined) return;
-    void ipc.chat.responseAck({ chatId, lastSeq }).catch(() => {
-      // Acks are advisory; main has no retry path, swallow errors.
+    void ipc.chat.responseAck({ chatId, lastSeq }).catch((err) => {
+      // Acks are advisory; main has no retry path. Log so a misbehaving
+      // IPC channel is visible in devtools instead of failing silently.
+      console.error("chat.responseAck failed", { chatId, lastSeq, err });
     });
   }, ACK_THROTTLE_MS);
   timerByChatId.set(chatId, timer);

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -411,21 +411,12 @@ export async function handleLocalAgentStream(
   }
 
   // Throttle outbound tail-patch IPC so the renderer isn't deluged on fast
-  // streams. Constructed AFTER the Pro early-return so we don't allocate a
-  // throttle only to immediately tear it down. Destroyed in the outer
-  // finally below.
-  const chunkThrottle = createStreamingPatchThrottle({
-    chatId: req.chatId,
-    logTag: "ipc-throttle:agent",
-    send: (patch, chunkSeq) => {
-      safeSend(event.sender, "chat:response:chunk", {
-        chatId: req.chatId,
-        streamingMessageId: placeholderMessageId,
-        streamingPatch: patch,
-        chunkSeq,
-      });
-    },
-  });
+  // streams. Declared null here and constructed inside the main try/finally
+  // below so a throw in the pre-stream setup (loadChat, "Chat not found",
+  // pending compaction) can't leak the registry entry / pending setTimeout.
+  // sendResponseChunk tolerates a null throttle for the pre-creation
+  // full-messages sends (initial empty placeholder, mid-compaction preview).
+  let chunkThrottle: StreamingPatchThrottle | null = null;
 
   const loadChat = async () =>
     db.query.chats.findFirst({
@@ -548,6 +539,22 @@ export async function handleLocalAgentStream(
   const warningMessages: string[] = [];
 
   try {
+    // Allocate the chunk throttle inside the try so the matching finally
+    // below always destroys it. Pre-stream setup (loadChat, compaction) ran
+    // above without a throttle to keep the leak window at zero.
+    chunkThrottle = createStreamingPatchThrottle({
+      chatId: req.chatId,
+      logTag: "ipc-throttle:agent",
+      send: (patch, chunkSeq) => {
+        safeSend(event.sender, "chat:response:chunk", {
+          chatId: req.chatId,
+          streamingMessageId: placeholderMessageId,
+          streamingPatch: patch,
+          chunkSeq,
+        });
+      },
+    });
+
     // Get model client
     const { modelClient } = await getModelClient(
       settings.selectedModel,
@@ -1486,7 +1493,7 @@ export async function handleLocalAgentStream(
   } finally {
     // Drop any pending throttled tail patch and emit the throttle's
     // end-of-stream summary log.
-    chunkThrottle.destroy();
+    chunkThrottle?.destroy();
   }
 }
 
@@ -1617,7 +1624,12 @@ function sendResponseChunk(
   sendFullMessages: boolean | undefined,
   /** Mutable ref tracking the renderer's last seen placeholder content. */
   lastSentRef: { value: string },
-  throttle: StreamingPatchThrottle,
+  /**
+   * Null when called before the throttle is constructed (initial placeholder
+   * send and pre-stream compaction preview). Both pre-construction sites
+   * use sendFullMessages, so there's no pending tail patch to cancel.
+   */
+  throttle: StreamingPatchThrottle | null,
 ) {
   if (sendFullMessages) {
     const currentMessages = [...chat.messages].filter(
@@ -1632,7 +1644,7 @@ function sendResponseChunk(
     // Drop any pending throttled tail patch — sending it after this full
     // messages-replacement would re-apply against the wrong base and
     // truncate the renderer's content.
-    throttle.cancel();
+    throttle?.cancel();
     safeSend(event.sender, "chat:response:chunk", {
       chatId,
       messages: currentMessages,
@@ -1646,7 +1658,7 @@ function sendResponseChunk(
     if (!patch) {
       return;
     }
-    throttle.queue(patch);
+    throttle?.queue(patch);
   }
 }
 

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -1454,6 +1454,14 @@ export async function handleLocalAgentStream(
       }
     }
 
+    // Authoritative final-state replacement before chat:response:end.
+    // Mirrors the chat_stream_handlers success path: sends the full messages
+    // array and cancels any pending throttled tail patch, so a patch still
+    // buffered in the 16ms window can't be dropped by the upcoming
+    // throttle.destroy() and leave the renderer's last assistant message
+    // truncated relative to the persisted DB content.
+    sendChunk(fullResponse, { fullMessages: true });
+
     // Send completion
     safeSend(event.sender, "chat:response:end", {
       chatId: req.chatId,

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -102,6 +102,10 @@ import {
 } from "./retry_replay_utils";
 import { setChatSummaryTool } from "./tools/set_chat_summary";
 import { computeStreamingPatch } from "@/ipc/utils/stream_text_utils";
+import {
+  createStreamingPatchThrottle,
+  type StreamingPatchThrottle,
+} from "@/ipc/utils/streaming_patch_throttle";
 
 const logger = log.scope("local_agent_handler");
 const PLANNING_QUESTIONNAIRE_TOOL_NAME = "planning_questionnaire";
@@ -364,6 +368,7 @@ export async function handleLocalAgentStream(
       hiddenMessageIdsForStreaming,
       fullMessages,
       lastSentRef,
+      chunkThrottle,
     );
   let postMidTurnCompactionStartStep: number | null = null;
 
@@ -404,6 +409,23 @@ export async function handleLocalAgentStream(
     });
     return false;
   }
+
+  // Throttle outbound tail-patch IPC so the renderer isn't deluged on fast
+  // streams. Constructed AFTER the Pro early-return so we don't allocate a
+  // throttle only to immediately tear it down. Destroyed in the outer
+  // finally below.
+  const chunkThrottle = createStreamingPatchThrottle({
+    chatId: req.chatId,
+    logTag: "ipc-throttle:agent",
+    send: (patch, chunkSeq) => {
+      safeSend(event.sender, "chat:response:chunk", {
+        chatId: req.chatId,
+        streamingMessageId: placeholderMessageId,
+        streamingPatch: patch,
+        chunkSeq,
+      });
+    },
+  });
 
   const loadChat = async () =>
     db.query.chats.findFirst({
@@ -1461,6 +1483,10 @@ export async function handleLocalAgentStream(
         warningMessages.length > 0 ? [...new Set(warningMessages)] : undefined,
     });
     return false; // Error - don't consume quota
+  } finally {
+    // Drop any pending throttled tail patch and emit the throttle's
+    // end-of-stream summary log.
+    chunkThrottle.destroy();
   }
 }
 
@@ -1591,6 +1617,7 @@ function sendResponseChunk(
   sendFullMessages: boolean | undefined,
   /** Mutable ref tracking the renderer's last seen placeholder content. */
   lastSentRef: { value: string },
+  throttle: StreamingPatchThrottle,
 ) {
   if (sendFullMessages) {
     const currentMessages = [...chat.messages].filter(
@@ -1602,6 +1629,10 @@ function sendResponseChunk(
     if (placeholderMsg) {
       placeholderMsg.content = fullResponse;
     }
+    // Drop any pending throttled tail patch — sending it after this full
+    // messages-replacement would re-apply against the wrong base and
+    // truncate the renderer's content.
+    throttle.cancel();
     safeSend(event.sender, "chat:response:chunk", {
       chatId,
       messages: currentMessages,
@@ -1615,11 +1646,7 @@ function sendResponseChunk(
     if (!patch) {
       return;
     }
-    safeSend(event.sender, "chat:response:chunk", {
-      chatId,
-      streamingMessageId: placeholderMessageId,
-      streamingPatch: patch,
-    });
+    throttle.queue(patch);
   }
 }
 

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -1462,6 +1462,12 @@ export async function handleLocalAgentStream(
     // truncated relative to the persisted DB content.
     sendChunk(fullResponse, { fullMessages: true });
 
+    // Drain + tear down the throttle BEFORE chat:response:end. The renderer
+    // unregisters onChunk on end (createStreamClient in core.ts), so a
+    // patch flushed afterwards is silently dropped. Idempotent — the
+    // finally below is just a safety net.
+    chunkThrottle?.destroy();
+
     // Send completion
     safeSend(event.sender, "chat:response:end", {
       chatId: req.chatId,
@@ -1491,6 +1497,10 @@ export async function handleLocalAgentStream(
     }
 
     logger.error("Local agent error:", error);
+    // Drain + tear down BEFORE chat:response:error so a tail patch buffered
+    // in the throttle window still reaches the renderer (which unregisters
+    // onChunk on error).
+    chunkThrottle?.destroy();
     safeSend(event.sender, "chat:response:error", {
       chatId: req.chatId,
       error: `Error: ${getErrorMessage(error)}`,


### PR DESCRIPTION
Coalesces chat:response:chunk tail patches into a single trailing-edge send per ~16ms window (60Hz cap) so fast streams don't deluge the renderer. Each chunk carries a monotonic chunkSeq; the renderer acks the highest applied seq (throttled) so the main process can compute IPC backlog (sent − acked) and hold further sends when in-flight count exceeds the threshold. New patches keep coalescing into the pending merged patch; drain resumes when an ack pulls backlog back under the threshold — one larger catch-up patch instead of many small ones.

No watchdog: if acks stall, end-of-stream full-messages replacement still delivers the authoritative final content, so the renderer can't get stuck on stale state. Throttle is cancelled before any full-messages replacement to prevent a stale tail patch from being re-applied against the wrong base.

Architecture splits three concerns into composable factory modules:
- streaming_patch_coalesce.ts: pure StreamingPatch merge buffer
- ack_backpressure.ts: generic ack-driven hold/resume gate, reused by both the canned test stream (testing_chat_handlers.ts) and the new production throttle
- streaming_patch_throttle.ts: composes both with a leading/trailing edge throttle window

The renderer-side throttled-ack scheduler is also extracted (chunkAckScheduler.ts) so the canned test path and the production throttle path go through the same helper instead of inlining ack logic in useStreamChat.

---

I also intend to open a PR to do incremental parsing of the LLM response in the renderer, but that's a larger change that I'd rather handle after this one.