### PR TITLE
feat(telemetry): track renderer crash via deferred PostHog event

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,9 @@ import {
   writeCrashSentinel,
   clearCrashSentinel,
   crashSentinelExists,
+  recordRendererCrash,
+  readRendererCrashRecord,
+  clearRendererCrashRecord,
 } from "./main/settings";
 import { sendTelemetryEvent } from "./ipc/utils/telemetry";
 import { handleSupabaseOAuthReturn } from "./supabase_admin/supabase_return_handler";
@@ -356,6 +359,7 @@ declare global {
 let mainWindow: BrowserWindow | null = null;
 let pendingForceCloseData: any = null;
 let pendingCrashDetected = false;
+let isAppQuitting = false;
 
 const createWindow = () => {
   // Create the browser window.
@@ -452,6 +456,47 @@ const createWindow = () => {
       pendingForceCloseData = null;
       pendingCrashDetected = false;
     }
+
+    // Forward any pending renderer crash recorded on a previous load. We send
+    // this from `did-finish-load` rather than `render-process-gone` because the
+    // renderer (which owns the PostHog client) is dead at crash time.
+    const rendererCrash = readRendererCrashRecord();
+    if (rendererCrash) {
+      sendTelemetryEvent("renderer:crash_detected", {
+        // Mark as error so renderer PostHog before_send sampling does not
+        // drop 90% of events for non-Pro users (see src/renderer.tsx).
+        error: true,
+        reason: rendererCrash.reason,
+        exit_code: rendererCrash.exitCode,
+        crash_count: rendererCrash.count,
+        crash_timestamp: rendererCrash.timestamp,
+        ms_since_crash: Date.now() - rendererCrash.timestamp,
+      });
+      clearRendererCrashRecord();
+    }
+  });
+
+  // Persist any non-clean renderer-process termination so we can report it on
+  // the next successful renderer load. We deliberately do nothing here besides
+  // writing the record: triggering reloads/dialogs is out of scope for the
+  // telemetry hook.
+  mainWindow.webContents.on("render-process-gone", (_event, details) => {
+    if (isAppQuitting) {
+      return;
+    }
+    if (details.reason === "clean-exit") {
+      return;
+    }
+    logger.warn(
+      "Renderer process gone:",
+      details.reason,
+      "exitCode=",
+      details.exitCode,
+    );
+    recordRendererCrash({
+      reason: details.reason,
+      exitCode: details.exitCode,
+    });
   });
 
   // Enable native context menu on right-click
@@ -790,6 +835,7 @@ app.on("window-all-closed", () => {
 // cleanup in will-quit cannot race against OS-imposed termination timeouts
 // (e.g. Windows WM_ENDSESSION) and leave the sentinel behind as a false positive.
 app.on("before-quit", () => {
+  isAppQuitting = true;
   clearCrashSentinel();
 });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -511,19 +511,12 @@ const createWindow = () => {
     );
     // Capture the latest heartbeat snapshot synchronously so the record pins
     // the pre-crash performance state, matching the semantics of
-    // `app:crash_detected`. `readSettings` may throw if settings are
-    // unreadable; treat that as "no snapshot" rather than failing the crash
-    // write.
-    let performance: ReturnType<typeof readSettings>["lastKnownPerformance"];
-    try {
-      performance = readSettings().lastKnownPerformance;
-    } catch (error) {
-      logger.warn("Unable to read perf snapshot for renderer crash:", error);
-    }
+    // `app:crash_detected`. `readSettings` returns `DEFAULT_SETTINGS` on any
+    // I/O or parse failure rather than throwing, so this is safe to inline.
     recordRendererCrash({
       reason: details.reason,
       exitCode: details.exitCode,
-      performance,
+      performance: readSettings().lastKnownPerformance,
     });
   });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ import log from "electron-log";
 import {
   getSettingsFilePath,
   writeSettings,
+  readSettings,
   readEffectiveSettings,
   writeCrashSentinel,
   clearCrashSentinel,
@@ -462,6 +463,7 @@ const createWindow = () => {
     // renderer (which owns the PostHog client) is dead at crash time.
     const rendererCrash = readRendererCrashRecord();
     if (rendererCrash) {
+      const perf = rendererCrash.performance;
       sendTelemetryEvent("renderer:crash_detected", {
         // Mark as error so renderer PostHog before_send sampling does not
         // drop 90% of events for non-Pro users (see src/renderer.tsx).
@@ -471,6 +473,20 @@ const createWindow = () => {
         crash_count: rendererCrash.count,
         crash_timestamp: rendererCrash.timestamp,
         ms_since_crash: Date.now() - rendererCrash.timestamp,
+        // Mirror the `app:crash_detected` performance fields so the two
+        // events can be unioned in PostHog without per-event field mapping.
+        has_performance_data: !!perf,
+        ...(perf && {
+          last_known_memory_mb: perf.memoryUsageMB,
+          last_known_cpu_pct: perf.cpuUsagePercent,
+          last_known_system_memory_mb: perf.systemMemoryUsageMB,
+          last_known_system_memory_total_mb: perf.systemMemoryTotalMB,
+          last_known_system_cpu_pct: perf.systemCpuPercent,
+          last_known_snapshot_timestamp: perf.timestamp,
+          // Match `app:crash_detected` semantics: measured at send time, not
+          // crash time. `ms_since_crash` already covers the crash → send gap.
+          time_since_last_heartbeat_ms: Date.now() - perf.timestamp,
+        }),
       });
       clearRendererCrashRecord();
     }
@@ -493,9 +509,21 @@ const createWindow = () => {
       "exitCode=",
       details.exitCode,
     );
+    // Capture the latest heartbeat snapshot synchronously so the record pins
+    // the pre-crash performance state, matching the semantics of
+    // `app:crash_detected`. `readSettings` may throw if settings are
+    // unreadable; treat that as "no snapshot" rather than failing the crash
+    // write.
+    let performance: ReturnType<typeof readSettings>["lastKnownPerformance"];
+    try {
+      performance = readSettings().lastKnownPerformance;
+    } catch (error) {
+      logger.warn("Unable to read perf snapshot for renderer crash:", error);
+    }
     recordRendererCrash({
       reason: details.reason,
       exitCode: details.exitCode,
+      performance,
     });
   });
 

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -57,6 +57,7 @@ const DEFAULT_SETTINGS: UserSettings = {
 };
 
 const CRASH_SENTINEL_FILE = "session.lock";
+const RENDERER_CRASH_FILE = "renderer-crash.json";
 const SETTINGS_FILE = "user-settings.json";
 const RESTORE_SETTINGS_DOCS_URL =
   "https://www.dyad.sh/docs/guides/migrate-restore#restoring-settings-from-backup";
@@ -99,6 +100,77 @@ export function clearCrashSentinel(): void {
 
 export function crashSentinelExists(): boolean {
   return fs.existsSync(getCrashSentinelPath());
+}
+
+export interface RendererCrashRecord {
+  reason: string;
+  exitCode?: number;
+  timestamp: number;
+  count: number;
+}
+
+function getRendererCrashPath(): string {
+  return path.join(getUserDataPath(), RENDERER_CRASH_FILE);
+}
+
+// Record a renderer crash so we can send a telemetry event on the next renderer
+// load. The renderer is dead at the time of writing, so the event cannot be
+// captured directly; we persist a small JSON record and forward it once the
+// renderer IPC bridge comes back up. If the renderer crashes again before the
+// record is consumed, we keep the latest reason/exitCode and bump `count`.
+export function recordRendererCrash(
+  details: Omit<RendererCrashRecord, "count" | "timestamp"> &
+    Partial<Pick<RendererCrashRecord, "timestamp">>,
+): void {
+  try {
+    const previous = readRendererCrashRecord();
+    const record: RendererCrashRecord = {
+      reason: details.reason,
+      exitCode: details.exitCode,
+      timestamp: details.timestamp ?? Date.now(),
+      count: (previous?.count ?? 0) + 1,
+    };
+    const filePath = getRendererCrashPath();
+    const tmpPath = `${filePath}.tmp`;
+    fs.writeFileSync(tmpPath, JSON.stringify(record));
+    fs.renameSync(tmpPath, filePath);
+  } catch (error) {
+    logger.error("Error writing renderer crash record:", error);
+  }
+}
+
+export function readRendererCrashRecord(): RendererCrashRecord | null {
+  try {
+    const filePath = getRendererCrashPath();
+    if (!fs.existsSync(filePath)) {
+      return null;
+    }
+    const raw = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+    if (typeof raw !== "object" || raw === null) {
+      return null;
+    }
+    const reason = typeof raw.reason === "string" ? raw.reason : "unknown";
+    const exitCode =
+      typeof raw.exitCode === "number" ? raw.exitCode : undefined;
+    const timestamp =
+      typeof raw.timestamp === "number" ? raw.timestamp : Date.now();
+    const count =
+      typeof raw.count === "number" && raw.count > 0 ? raw.count : 1;
+    return { reason, exitCode, timestamp, count };
+  } catch (error) {
+    logger.error("Error reading renderer crash record:", error);
+    return null;
+  }
+}
+
+export function clearRendererCrashRecord(): void {
+  try {
+    fs.unlinkSync(getRendererCrashPath());
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      logger.error("Error clearing renderer crash record:", error);
+    }
+  }
 }
 
 export function readSettings(): UserSettings {

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -102,11 +102,16 @@ export function crashSentinelExists(): boolean {
   return fs.existsSync(getCrashSentinelPath());
 }
 
+export type RendererCrashPerformanceSnapshot = NonNullable<
+  UserSettings["lastKnownPerformance"]
+>;
+
 export interface RendererCrashRecord {
   reason: string;
   exitCode?: number;
   timestamp: number;
   count: number;
+  performance?: RendererCrashPerformanceSnapshot;
 }
 
 function getRendererCrashPath(): string {
@@ -129,6 +134,10 @@ export function recordRendererCrash(
       exitCode: details.exitCode,
       timestamp: details.timestamp ?? Date.now(),
       count: (previous?.count ?? 0) + 1,
+      // Latest snapshot wins; if the caller didn't supply one (e.g. settings
+      // unreadable at crash time) fall back to whatever the previous record
+      // had so we don't lose pre-existing context.
+      performance: details.performance ?? previous?.performance,
     };
     const filePath = getRendererCrashPath();
     const tmpPath = `${filePath}.tmp`;
@@ -156,7 +165,8 @@ export function readRendererCrashRecord(): RendererCrashRecord | null {
       typeof raw.timestamp === "number" ? raw.timestamp : Date.now();
     const count =
       typeof raw.count === "number" && raw.count > 0 ? raw.count : 1;
-    return { reason, exitCode, timestamp, count };
+    const performance = parseRendererCrashPerformance(raw.performance);
+    return { reason, exitCode, timestamp, count, performance };
   } catch (error) {
     logger.error("Error reading renderer crash record:", error);
     return null;
@@ -171,6 +181,35 @@ export function clearRendererCrashRecord(): void {
       logger.error("Error clearing renderer crash record:", error);
     }
   }
+}
+
+// Lenient parser for the performance block on a renderer-crash record.
+// We deliberately accept partial data rather than throwing: the record may
+// have been written by an older build, and the fields are best-effort
+// telemetry — losing one of them shouldn't drop the whole crash report.
+function parseRendererCrashPerformance(
+  raw: unknown,
+): RendererCrashPerformanceSnapshot | undefined {
+  if (typeof raw !== "object" || raw === null) {
+    return undefined;
+  }
+  const candidate = raw as Record<string, unknown>;
+  if (typeof candidate.timestamp !== "number") {
+    return undefined;
+  }
+  if (typeof candidate.memoryUsageMB !== "number") {
+    return undefined;
+  }
+  const optionalNumber = (key: string): number | undefined =>
+    typeof candidate[key] === "number" ? (candidate[key] as number) : undefined;
+  return {
+    timestamp: candidate.timestamp,
+    memoryUsageMB: candidate.memoryUsageMB,
+    cpuUsagePercent: optionalNumber("cpuUsagePercent"),
+    systemMemoryUsageMB: optionalNumber("systemMemoryUsageMB"),
+    systemMemoryTotalMB: optionalNumber("systemMemoryTotalMB"),
+    systemCpuPercent: optionalNumber("systemCpuPercent"),
+  };
 }
 
 export function readSettings(): UserSettings {


### PR DESCRIPTION
## Summary
- Detect renderer crashes (`render-process-gone` with non-`clean-exit` reason) in main and persist them to a `renderer-crash.json` file in user data, mirroring the existing `session.lock` sentinel pattern used for main-process force-closes.
- On the next renderer `did-finish-load`, forward the record as a `renderer:crash_detected` PostHog event via the existing main→renderer telemetry IPC bridge, then clear the file.
- Capture `settings.lastKnownPerformance` synchronously at crash time and ship the same `last_known_*` / `has_performance_data` / `time_since_last_heartbeat_ms` fields as `app:crash_detected`, so the two events can be unioned in PostHog without per-event field mapping.
- Bump a `count` field on the record when the renderer crashes again before the previous record is sent, so back-to-back crashes are not lost. Skip `clean-exit` and skip when `before-quit` has already fired to avoid false positives during normal shutdown. Flag the event with `error: true` so non-Pro PostHog sampling does not drop 90% of crash events.

## Test plan
- `npm run fmt && npm run lint:fix && npm run ts`
- `npm test`
- Manual: trigger a renderer crash (e.g., via the debug button on `test/crash-renderer-button` that doubles the assistant message tree per click), confirm `renderer-crash.json` is written under user data, reload the app, and verify `renderer:crash_detected` reaches PostHog with the performance snapshot fields populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)