### PR TITLE
fix(gh-permission-hook): Allow pipe character on new line

### DIFF
--- a/.claude/hooks/gh-permission-hook.py
+++ b/.claude/hooks/gh-permission-hook.py
@@ -132,7 +132,7 @@ DOUBLE_QUOTED_STRING_PATTERN = re.compile(r'"[^"]*"')
 # Safe pipe destinations - broad whitelist of common text-processing commands
 # Claude Code's own permission system provides the primary security layer
 SAFE_PIPE_PATTERN = re.compile(
-    r'\|\s*('
+    r'\s*\|\s*('
     r'jq|head|tail|grep|egrep|fgrep|wc|sort|uniq|cut|tr'
     r'|base64|cat|column|fmt|fold|paste'
     r'|expand|unexpand|rev|tac|nl|od|xxd|hexdump|strings'


### PR DESCRIPTION
Using a version of this hook in my own claude code, I've found that claude sometimes splits long commands over multiple lines. This hook currently allows any whitespace after a pipe character, but not before, resulting in commands like
```shell
gh api repos/repo/file.go --jq '.content'
 | base64 -d
```
being blocked.

This patch also allows whitespace before the pipe character, which seems to fix the issue :^)