### PR TITLE
ci: pin flakiness and lowercase the privileged-author allowlist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,11 @@ jobs:
             AUTHOR="${{ github.event.pull_request.user.login }}"
           fi
           echo "Author: $AUTHOR"
-          case "$AUTHOR" in
-            wwwillchen|keppo-bot|keppo-bot\[bot\]|dyad-assistant|azizmejri1|RyanGroch)
+          # Lowercase before matching so a login like "RyanGroch" matches the
+          # same lowercased allowlist used by the AI-review workflows.
+          AUTHOR_LC="${AUTHOR,,}"
+          case "$AUTHOR_LC" in
+            wwwillchen|keppo-bot|keppo-bot\[bot\]|dyad-assistant|azizmejri1|ryangroch)
               echo "is_privileged=true" >> $GITHUB_OUTPUT
               ;;
             *)
@@ -99,7 +102,7 @@ jobs:
       # The "image" field is a JSON-encoded array string so that fromJSON() in runs-on
       # can produce the correct label(s) for both GitHub-hosted and self-hosted runners.
       #
-      # Privileged authors (wwwillchen, keppo-bot/keppo-bot[bot], dyad-assistant, azizmejri1, RyanGroch):
+      # Privileged authors (wwwillchen, keppo-bot/keppo-bot[bot], dyad-assistant, azizmejri1, ryangroch):
       #   - Self-hosted macOS ARM64 runners, no Windows, no sharding.
       #
       #   build (macOS self-hosted) ──> e2e-tests (macOS self-hosted, shard 1/1)

--- a/.github/workflows/flakiness-upload.yml
+++ b/.github/workflows/flakiness-upload.yml
@@ -49,5 +49,7 @@ jobs:
       - name: Upload to Flakiness.io
         env:
           FLAKINESS_ACCESS_TOKEN: ${{ secrets.FLAKINESS_ACCESS_TOKEN }}
+        # Pin to an exact version so a compromised "latest" can't exfil the
+        # FLAKINESS_ACCESS_TOKEN / GITHUB_TOKEN exposed to this step.
         run: |
-          find . -name report.json -exec npx -y flakiness upload {} +
+          find . -name report.json -exec npx -y flakiness@0.255.0 upload {} +


### PR DESCRIPTION
## Summary

Two small workflow-hardening fixes from a security audit of `.github/workflows/`:

- **`flakiness-upload.yml`**: pin `npx flakiness@0.255.0`. The previous `npx -y flakiness` pulled `latest` on every run while `FLAKINESS_ACCESS_TOKEN` and `GITHUB_TOKEN` were in the environment — a compromised release would have had immediate exfil. Pinning closes that window.
- **`ci.yml`**: lowercase the PR author before the `case` check so the privileged-runner allowlist (`wwwillchen|keppo-bot|keppo-bot[bot]|dyad-assistant|azizmejri1|ryangroch`) stays in sync with the lowercased allowlist already used by the Claude / Codex / BugBot review workflows. Previously `RyanGroch` (mixed case) only matched here, and `ryangroch` only matched there — fail-safe but brittle.

## Test plan

- [x] `npm run fmt && npm run lint:fix && npm run ts` clean
- [x] `npm test` — 1305/1305 passing
- [ ] Confirm next privileged-author CI run still routes to self-hosted macOS (matrix populated from the `case`)
- [ ] Confirm next fork-PR CI completion still triggers the `flakiness-upload.yml` job successfully with the pinned version

🤖 Generated with [Claude Code](https://claude.com/claude-code)