### PR TITLE
Remove Turbo model options

### DIFF
--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -20,7 +20,6 @@ import { ipc, type LanguageModel, LocalModel } from "@/ipc/types";
 import { useLanguageModelProviders } from "@/hooks/useLanguageModelProviders";
 import { useSettings } from "@/hooks/useSettings";
 import { PriceBadge } from "@/components/PriceBadge";
-import { TURBO_MODELS } from "@/ipc/shared/language_model_constants";
 import { cn } from "@/lib/utils";
 import { useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "@/lib/queryKeys";
@@ -161,11 +160,7 @@ export function ModelPicker() {
   const autoModels =
     !loading && modelsByProviders && modelsByProviders["auto"]
       ? modelsByProviders["auto"].filter((model) => {
-          if (
-            settings &&
-            !dyadProEnabled &&
-            ["turbo", "value"].includes(model.apiName)
-          ) {
+          if (settings && !dyadProEnabled && model.apiName === "value") {
             return false;
           }
           if (settings && dyadProEnabled && model.apiName === "free") {
@@ -200,9 +195,7 @@ export function ModelPicker() {
       return !(provider && provider.secondary);
     },
   );
-  const primaryProviders: [string, LanguageModel[]][] = dyadProEnabled
-    ? [["auto", TURBO_MODELS], ...primaryProviderEntries]
-    : primaryProviderEntries;
+  const primaryProviders: [string, LanguageModel[]][] = primaryProviderEntries;
   const secondaryProviders = providerEntries.filter(([providerId, models]) => {
     if (models.length === 0) return false;
     const provider = providers?.find((p) => p.id === providerId);
@@ -240,9 +233,7 @@ export function ModelPicker() {
 
   const getProviderDisplayName = (providerId: string) => {
     const provider = providers?.find((p) => p.id === providerId);
-    return provider?.id === "auto"
-      ? "Dyad Turbo"
-      : (provider?.name ?? providerId);
+    return provider?.name ?? providerId;
   };
 
   const handleCloudModelSelect = (providerId: string, model: LanguageModel) => {

--- a/src/components/ProBanner.tsx
+++ b/src/components/ProBanner.tsx
@@ -17,8 +17,8 @@ import { useSettings } from "@/hooks/useSettings";
 export function ProBanner() {
   const { settings } = useSettings();
 
-  const [selectedBanner] = useState<"ai" | "smart" | "turbo">(() => {
-    const options = ["ai", "smart", "turbo"] as const;
+  const [selectedBanner] = useState<"ai" | "smart">(() => {
+    const options = ["ai", "smart"] as const;
     return options[Math.floor(Math.random() * options.length)];
   });
 
@@ -28,13 +28,7 @@ export function ProBanner() {
 
   return (
     <div className="mt-6 max-w-2xl mx-auto">
-      {selectedBanner === "ai" ? (
-        <AiAccessBanner />
-      ) : selectedBanner === "smart" ? (
-        <SmartContextBanner />
-      ) : (
-        <TurboBanner />
-      )}
+      {selectedBanner === "ai" ? <AiAccessBanner /> : <SmartContextBanner />}
     </div>
   );
 }
@@ -177,48 +171,6 @@ export function SmartContextBanner() {
             type="button"
             aria-label="Get Dyad Pro"
             className="inline-flex items-center rounded-md bg-white/90 text-emerald-800 hover:bg-white shadow px-3 py-1.5 text-xs sm:text-sm font-semibold focus:outline-none focus:ring-2 focus:ring-white/50"
-          >
-            {t("proBanner.getDyadPro")}
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-export function TurboBanner() {
-  const { t } = useTranslation("home");
-  return (
-    <div
-      className="w-full py-2 sm:py-2.5 md:py-3 rounded-lg bg-gradient-to-br from-rose-50 via-rose-100 to-rose-200 dark:from-rose-800 dark:via-fuchsia-800 dark:to-rose-800 flex items-center justify-center relative overflow-hidden ring-1 ring-inset ring-rose-900/10 dark:ring-white/5 shadow-sm cursor-pointer transition-all duration-200 hover:shadow-md hover:-translate-y-[1px]"
-      onClick={() => {
-        ipc.system.openExternalUrl(
-          "https://www.dyad.sh/pro?utm_source=dyad-app&utm_medium=app&utm_campaign=in-app-banner-turbo",
-        );
-      }}
-    >
-      <div
-        className="absolute inset-0 z-0 bg-gradient-to-tr from-white/60 via-transparent to-transparent pointer-events-none dark:from-white/10"
-        aria-hidden="true"
-      />
-      <div className="absolute inset-0 z-0 pointer-events-none dark:hidden">
-        <div className="absolute -top-10 -left-8 h-44 w-44 rounded-full blur-2xl bg-rose-200/50" />
-        <div className="absolute -bottom-12 -right-8 h-56 w-56 rounded-full blur-3xl bg-fuchsia-200/50" />
-      </div>
-      <div className="relative z-10 px-4 md:px-6 pr-6 md:pr-8">
-        <div className="mt-0.5 sm:mt-1 flex items-center gap-2 sm:gap-3 justify-center">
-          <div className="flex flex-col items-center text-center">
-            <div className="text-xl font-semibold tracking-tight text-rose-900 dark:text-rose-100">
-              {t("proBanner.generateCode4x")}
-            </div>
-            <div className="text-sm sm:text-base mt-1 text-rose-700 dark:text-rose-200/80">
-              {t("proBanner.withTurboModels")}
-            </div>
-          </div>
-          <button
-            type="button"
-            aria-label="Get Dyad Pro"
-            className="inline-flex items-center rounded-md bg-white/90 text-rose-800 hover:bg-white shadow px-3 py-1.5 text-xs sm:text-sm font-semibold focus:outline-none focus:ring-2 focus:ring-white/50"
           >
             {t("proBanner.getDyadPro")}
           </button>

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -156,7 +156,6 @@
     "otherProviders": "Other AI providers",
     "providerCount_one": "{{count}} provider",
     "providerCount_other": "{{count}} providers",
-    "dyadTurbo": "Dyad Turbo",
     "modelCount_one": "{{count}} model",
     "modelCount_other": "{{count}} models",
     "providerModels": "{{name}} Models",

--- a/src/i18n/locales/en/home.json
+++ b/src/i18n/locales/en/home.json
@@ -69,9 +69,7 @@
     "accessLeadingModels": "Access leading AI models with one plan",
     "getDyadPro": "Get Dyad Pro",
     "upTo3xCheaper": "Up to 3x cheaper",
-    "byUsingSmartContext": "by using Smart Context",
-    "generateCode4x": "Generate code 4-10x faster",
-    "withTurboModels": "with Turbo Models & Turbo Edits"
+    "byUsingSmartContext": "by using Smart Context"
   },
   "setup": {
     "buildNewApp": "Build a new app",

--- a/src/i18n/locales/es/chat.json
+++ b/src/i18n/locales/es/chat.json
@@ -157,7 +157,6 @@
     "otherProviders": "Otros proveedores de IA",
     "providerCount_one": "{{count}} proveedor",
     "providerCount_other": "{{count}} proveedores",
-    "dyadTurbo": "Dyad Turbo",
     "modelCount_one": "{{count}} modelo",
     "modelCount_other": "{{count}} modelos",
     "providerModels": "Modelos de {{name}}",

--- a/src/i18n/locales/es/home.json
+++ b/src/i18n/locales/es/home.json
@@ -69,9 +69,7 @@
     "accessLeadingModels": "Accede a los modelos líderes de IA con un solo plan",
     "getDyadPro": "Consigue Dyad Pro",
     "upTo3xCheaper": "Hasta 3 veces más barato",
-    "byUsingSmartContext": "al usar Smart Context",
-    "generateCode4x": "Genera código de 4 a 10 veces más rápido",
-    "withTurboModels": "con Modelos Turbo y Ediciones Turbo"
+    "byUsingSmartContext": "al usar Smart Context"
   },
   "setup": {
     "buildNewApp": "Construir una nueva aplicación",

--- a/src/i18n/locales/pt-BR/chat.json
+++ b/src/i18n/locales/pt-BR/chat.json
@@ -156,7 +156,6 @@
     "otherProviders": "Outros provedores de IA",
     "providerCount_one": "{{count}} provedor",
     "providerCount_other": "{{count}} provedores",
-    "dyadTurbo": "Dyad Turbo",
     "modelCount_one": "{{count}} modelo",
     "modelCount_other": "{{count}} modelos",
     "providerModels": "Modelos {{name}}",

--- a/src/i18n/locales/pt-BR/home.json
+++ b/src/i18n/locales/pt-BR/home.json
@@ -66,9 +66,7 @@
     "accessLeadingModels": "Acesse os melhores modelos de IA com um único plano",
     "getDyadPro": "Obtenha o Dyad Pro",
     "upTo3xCheaper": "Até 3x mais barato",
-    "byUsingSmartContext": "usando o Contexto Inteligente",
-    "generateCode4x": "Gere código 4-10x mais rápido",
-    "withTurboModels": "com Turbo Models e Turbo Edits"
+    "byUsingSmartContext": "usando o Contexto Inteligente"
   },
   "setup": {
     "buildNewApp": "Criar um novo app",

--- a/src/i18n/locales/zh-CN/chat.json
+++ b/src/i18n/locales/zh-CN/chat.json
@@ -156,7 +156,6 @@
     "otherProviders": "其他 AI 提供商",
     "providerCount_one": "{{count}} 个提供商",
     "providerCount_other": "{{count}} 个提供商",
-    "dyadTurbo": "Dyad Turbo",
     "modelCount_one": "{{count}} 个模型",
     "modelCount_other": "{{count}} 个模型",
     "providerModels": "{{name}} 模型",

--- a/src/i18n/locales/zh-CN/home.json
+++ b/src/i18n/locales/zh-CN/home.json
@@ -66,9 +66,7 @@
     "accessLeadingModels": "一个计划即可访问领先的 AI 模型",
     "getDyadPro": "获取 Dyad Pro",
     "upTo3xCheaper": "便宜高达 3 倍",
-    "byUsingSmartContext": "通过使用智能上下文",
-    "generateCode4x": "代码生成速度提升 4-10 倍",
-    "withTurboModels": "使用 Turbo 模型和 Turbo Edits"
+    "byUsingSmartContext": "通过使用智能上下文"
   },
   "setup": {
     "buildNewApp": "构建新应用",

--- a/src/ipc/shared/language_model_constants.ts
+++ b/src/ipc/shared/language_model_constants.ts
@@ -1,5 +1,3 @@
-import { LanguageModel } from "@/ipc/types";
-
 export const PROVIDERS_THAT_SUPPORT_THINKING: (keyof typeof MODEL_OPTIONS)[] = [
   "google",
   "vertex",
@@ -356,16 +354,6 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
       tag: "Budget",
       tagColor: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300",
     },
-    {
-      name: "turbo",
-      displayName: "Turbo",
-      description: "Use very fast open-source frontier models",
-      maxOutputTokens: 32_000,
-      contextWindow: 256_000,
-      temperature: 0,
-      tag: "Fast",
-      tagColor: "bg-rose-500/15 text-rose-700 dark:text-rose-300",
-    },
   ],
   azure: [
     {
@@ -530,29 +518,6 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
     },
   ],
 };
-
-export const TURBO_MODELS: LanguageModel[] = [
-  {
-    apiName: "glm-4.7:turbo",
-    displayName: "GLM 4.7",
-    description: "Strong coding model (very fast)",
-    maxOutputTokens: 32_000,
-    contextWindow: 131_000,
-    temperature: 0.7,
-    dollarSigns: 3,
-    type: "cloud",
-  },
-  {
-    apiName: "kimi-k2:turbo",
-    displayName: "Kimi K2",
-    description: "Kimi 0905 update (fast)",
-    maxOutputTokens: 16_000,
-    contextWindow: 256_000,
-    temperature: 0,
-    dollarSigns: 2,
-    type: "cloud",
-  },
-];
 
 export const FREE_OPENROUTER_MODEL_NAMES = MODEL_OPTIONS.openrouter
   .filter(


### PR DESCRIPTION
## Summary
- Remove the special Turbo auto model option and hardcoded Turbo model list.
- Stop injecting Turbo models into the Pro model picker.
- Remove Turbo Models banner copy and unused localization keys.

## Test plan
- npm test -- src/components/ModelPicker.test.tsx
- jq empty on edited locale JSON files
- npm run fmt && npm run lint:fix && npm run ts
- npm test