### PR TITLE
perf: simplify incremental streaming parser state

### DIFF
--- a/src/atoms/chatAtoms.ts
+++ b/src/atoms/chatAtoms.ts
@@ -7,6 +7,7 @@ import type {
 import type { ListedApp } from "@/ipc/types/app";
 import type { Getter, Setter } from "jotai";
 import { atom } from "jotai";
+import type { ParserState } from "@/lib/streamingMessageParser";
 
 // Per-chat atoms implemented with maps keyed by chatId
 export const chatMessagesByIdAtom = atom<Map<number, Message[]>>(new Map());
@@ -263,3 +264,23 @@ export const streamCompletedSuccessfullyByIdAtom = atom<Map<number, boolean>>(
 
 // Tracks if the queue is paused for each chat (Map<chatId, isPaused>)
 export const queuePausedByIdAtom = atom<Map<number, boolean>>(new Map());
+
+// Cache of incremental parser state per assistant message id. The renderer
+// reads from this map when present; otherwise it falls back to a one-shot
+// parse from message.content. Updated in the streaming chunk handler so
+// committed blocks keep stable refs across patches and only the open
+// trailing block changes shape per chunk. Cleared on stream end / full
+// message replace so the renderer reparses from the finalized DB content.
+export const streamingBlocksByMessageIdAtom = atom<Map<number, ParserState>>(
+  new Map(),
+);
+
+// Sidecar overlay for tool-input XML preview during Pro/Agent v2 streaming.
+// Lives outside message.content so the patch protocol stays strictly
+// append-only — buildXml output rewrites its prefix each JSON delta, which
+// would otherwise force non-tail patch escalation to fullMessages. Cleared
+// when the server sends an empty preview (onXmlComplete commits the
+// finalized XML into fullResponse) or on stream end.
+export const streamingPreviewByMessageIdAtom = atom<Map<number, string>>(
+  new Map(),
+);

--- a/src/atoms/chatAtoms.ts
+++ b/src/atoms/chatAtoms.ts
@@ -7,7 +7,6 @@ import type {
 import type { ListedApp } from "@/ipc/types/app";
 import type { Getter, Setter } from "jotai";
 import { atom } from "jotai";
-import type { ParserState } from "@/lib/streamingMessageParser";
 
 // Per-chat atoms implemented with maps keyed by chatId
 export const chatMessagesByIdAtom = atom<Map<number, Message[]>>(new Map());
@@ -265,22 +264,9 @@ export const streamCompletedSuccessfullyByIdAtom = atom<Map<number, boolean>>(
 // Tracks if the queue is paused for each chat (Map<chatId, isPaused>)
 export const queuePausedByIdAtom = atom<Map<number, boolean>>(new Map());
 
-// Cache of incremental parser state per assistant message id. The renderer
-// reads from this map when present; otherwise it falls back to a one-shot
-// parse from message.content. Updated in the streaming chunk handler so
-// committed blocks keep stable refs across patches and only the open
-// trailing block changes shape per chunk. Cleared on stream end / full
-// message replace so the renderer reparses from the finalized DB content.
-export const streamingBlocksByMessageIdAtom = atom<Map<number, ParserState>>(
-  new Map(),
-);
-
 // Sidecar overlay for tool-input XML preview during Pro/Agent v2 streaming.
-// Lives outside message.content so the patch protocol stays strictly
-// append-only — buildXml output rewrites its prefix each JSON delta, which
-// would otherwise force non-tail patch escalation to fullMessages. Cleared
-// when the server sends an empty preview (onXmlComplete commits the
-// finalized XML into fullResponse) or on stream end.
-export const streamingPreviewByMessageIdAtom = atom<Map<number, string>>(
+// Lives outside message.content so the patch protocol stays strictly append-only.
+// Keyed by chat id; only the last streaming assistant message renders it.
+export const streamingPreviewByChatIdAtom = atom<Map<number, string>>(
   new Map(),
 );

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -197,7 +197,10 @@ const ChatMessage = ({
               >
                 {message.role === "assistant" ? (
                   <>
-                    <DyadMarkdownParser content={assistantTextContent} />
+                    <DyadMarkdownParser
+                      content={assistantTextContent}
+                      messageId={message.id}
+                    />
                     {isLastMessage && isStreaming && (
                       <StreamingLoadingAnimation variant="streaming" />
                     )}

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -200,6 +200,7 @@ const ChatMessage = ({
                     <DyadMarkdownParser
                       content={assistantTextContent}
                       messageId={message.id}
+                      showStreamingPreview={isLastMessage && isStreaming}
                     />
                     {isLastMessage && isStreaming && (
                       <StreamingLoadingAnimation variant="streaming" />

--- a/src/components/chat/DyadMarkdownParser.tsx
+++ b/src/components/chat/DyadMarkdownParser.tsx
@@ -18,7 +18,12 @@ import { DyadCodebaseContext } from "./DyadCodebaseContext";
 import { DyadThink } from "./DyadThink";
 import { CodeHighlight } from "./CodeHighlight";
 import { useAtomValue } from "jotai";
-import { isStreamingByIdAtom, selectedChatIdAtom } from "@/atoms/chatAtoms";
+import {
+  isStreamingByIdAtom,
+  selectedChatIdAtom,
+  streamingBlocksByMessageIdAtom,
+  streamingPreviewByMessageIdAtom,
+} from "@/atoms/chatAtoms";
 import { CustomTagState } from "./stateTypes";
 import { DyadOutput } from "./DyadOutput";
 import { DyadProblemSummary } from "./DyadProblemSummary";
@@ -49,13 +54,22 @@ import { DyadScript } from "./DyadScript";
 import { mapActionToButton } from "./ChatInput";
 import { SuggestedAction } from "@/lib/schemas";
 import { FixAllErrorsButton } from "./FixAllErrorsButton";
-import { type Block, parseFullMessage } from "@/lib/streamingMessageParser";
+import {
+  type Block,
+  getOpenBlock,
+  parseFullMessage,
+} from "@/lib/streamingMessageParser";
 
 interface DyadMarkdownParserProps {
   content: string;
+  /**
+   * Assistant message id. When present, the renderer reads the incremental
+   * parser state from streamingBlocksByMessageIdAtom so completed blocks
+   * keep referential identity across streaming chunks. Without it the
+   * renderer falls back to a one-shot parse of `content`.
+   */
+  messageId?: number;
 }
-
-type CustomTagBlock = Extract<Block, { kind: "custom-tag" }>;
 
 const customLink = ({
   node: _node,
@@ -93,74 +107,135 @@ export const VanillaMarkdownParser = ({ content }: { content: string }) => {
 /**
  * Custom component to parse markdown content with Dyad-specific tags.
  *
- * Block list is produced by an incremental dyad-tag parser
- * (src/lib/streamingMessageParser.ts) called one-shot per render.
+ * The block list is sourced from an incremental parser (see
+ * src/lib/streamingMessageParser.ts) so completed blocks keep referential
+ * identity across streaming chunks. That lets React.memo skip every prior
+ * block, leaving only the open trailing block to re-render per chunk.
  */
 export const DyadMarkdownParser: React.FC<DyadMarkdownParserProps> = ({
   content,
+  messageId,
 }) => {
   const chatId = useAtomValue(selectedChatIdAtom);
   const isStreaming = useAtomValue(isStreamingByIdAtom).get(chatId!) ?? false;
   const deferredContent = useDeferredValue(content);
   const contentToParse = isStreaming ? deferredContent : content;
 
-  const blocks = useMemo(
-    () => parseFullMessage(contentToParse).blocks,
-    [contentToParse],
-  );
+  const streamingStates = useAtomValue(streamingBlocksByMessageIdAtom);
+  const parserState =
+    messageId !== undefined ? streamingStates.get(messageId) : undefined;
 
-  const { errorMessages, lastErrorIndex, errorCount } = useMemo(() => {
+  // Sidecar tool-input XML preview (Pro/Agent v2). Lives outside the
+  // message's parsed-block tree so the patch protocol can stay strictly
+  // append-only — buildXml output rewrites its prefix per JSON delta and
+  // would otherwise force escalation to fullMessages.
+  const previewStates = useAtomValue(streamingPreviewByMessageIdAtom);
+  const previewXml =
+    messageId !== undefined ? previewStates.get(messageId) : undefined;
+  const previewBlocks = useMemo<Block[] | null>(() => {
+    if (!previewXml) return null;
+    return parseFullMessage(previewXml).blocks;
+  }, [previewXml]);
+
+  // While streaming, closed blocks live in parserState.blocks (immutable-
+  // appended on commit) and the open block comes from getOpenBlock. The
+  // closed-blocks array ref is stable across chunks that don't close a
+  // block, so MemoClosedBlocks skips its subtree entirely on those chunks
+  // (O(1) per chunk).
+  const closedBlocks = parserState?.blocks;
+  const openBlock = parserState ? getOpenBlock(parserState) : null;
+
+  // Fallback path: no parser state (history, post-DB-restore). One-shot
+  // parse of the full content.
+  const fallbackBlocks = useMemo<Block[] | null>(() => {
+    if (parserState !== undefined) return null;
+    return parseFullMessage(contentToParse).blocks;
+  }, [parserState, contentToParse]);
+
+  // Aggregate error messages for the FixAllErrorsButton. Recomputes only
+  // when one of the input arrays gets a new ref (closed blocks: on commit;
+  // fallback: on content change).
+  const { errorMessages, errorCount } = useMemo(() => {
     const errors: string[] = [];
-    let lastIndex = -1;
-    let count = 0;
-
-    blocks.forEach((block, index) => {
+    const collectFrom = (block: Block) => {
       if (
         block.kind === "custom-tag" &&
         block.tag === "dyad-output" &&
         block.attributes.type === "error"
       ) {
-        const errorMessage = block.attributes.message;
-        if (errorMessage?.trim()) {
-          errors.push(errorMessage.trim());
-          count++;
-          lastIndex = index;
-        }
+        const msg = block.attributes.message?.trim();
+        if (msg) errors.push(msg);
       }
-    });
-
-    return {
-      errorMessages: errors,
-      lastErrorIndex: lastIndex,
-      errorCount: count,
     };
-  }, [blocks]);
+    if (closedBlocks) {
+      for (const block of closedBlocks) collectFrom(block);
+    } else if (fallbackBlocks) {
+      for (const block of fallbackBlocks) collectFrom(block);
+    }
+    return { errorMessages: errors, errorCount: errors.length };
+  }, [closedBlocks, fallbackBlocks]);
+
+  const showFixAll =
+    errorCount > 1 && !isStreaming && chatId !== null && chatId !== undefined;
 
   return (
     <>
-      {blocks.map((block, index) => (
+      {closedBlocks ? (
+        <MemoClosedBlocks blocks={closedBlocks} isStreaming={isStreaming} />
+      ) : fallbackBlocks ? (
+        fallbackBlocks.map((block) => (
+          <React.Fragment key={block.id}>
+            {renderBlock(block, isStreaming)}
+          </React.Fragment>
+        ))
+      ) : null}
+      {openBlock ? renderBlock(openBlock, isStreaming) : null}
+      {previewBlocks
+        ? previewBlocks.map((block) => (
+            <React.Fragment key={`preview-${block.id}`}>
+              {renderBlock(block, isStreaming)}
+            </React.Fragment>
+          ))
+        : null}
+      {showFixAll && (
+        <div className="mt-3 w-full flex">
+          <FixAllErrorsButton errorMessages={errorMessages} chatId={chatId!} />
+        </div>
+      )}
+    </>
+  );
+};
+
+function renderBlock(block: Block, isStreaming: boolean): React.ReactNode {
+  if (block.kind === "markdown") {
+    return block.content ? <MemoMarkdown content={block.content} /> : null;
+  }
+  return <MemoBlockCustomTag block={block} isStreaming={isStreaming} />;
+}
+
+// Memoized wrapper for closed blocks. Memo hits when the `blocks` array ref
+// is unchanged (chunks that just extend the open block) so the entire
+// closed-block subtree is skipped — O(1) per chunk in the common case.
+// On commit chunks, the wrapper re-renders and reconciles N child fibers,
+// but each child is also memoed on `prev.block === next.block` so closed
+// children short-circuit and never re-render their subtrees.
+const MemoClosedBlocks = React.memo(function MemoClosedBlocks({
+  blocks,
+  isStreaming,
+}: {
+  blocks: Block[];
+  isStreaming: boolean;
+}) {
+  return (
+    <>
+      {blocks.map((block) => (
         <React.Fragment key={block.id}>
-          {block.kind === "markdown" ? (
-            block.content && <MemoMarkdown content={block.content} />
-          ) : (
-            <MemoCustomTag block={block} isStreaming={isStreaming} />
-          )}
-          {index === lastErrorIndex &&
-            errorCount > 1 &&
-            !isStreaming &&
-            chatId && (
-              <div className="mt-3 w-full flex">
-                <FixAllErrorsButton
-                  errorMessages={errorMessages}
-                  chatId={chatId}
-                />
-              </div>
-            )}
+          {renderBlock(block, isStreaming)}
         </React.Fragment>
       ))}
     </>
   );
-};
+});
 
 // Module-level constants so MemoMarkdown never gets fresh refs for these
 // props, which would defeat ReactMarkdown's internal prop-equality checks.
@@ -168,9 +243,7 @@ const REMARK_PLUGINS = [remarkGfm];
 const MARKDOWN_COMPONENTS = { code: CodeHighlight, a: customLink };
 
 // Memoized markdown piece. Without this, ReactMarkdown re-parses every
-// completed segment's text into an AST on every streaming chunk —
-// the dominant per-render cost during long streams. Memoizing on
-// `content` lets completed segments skip that re-parse entirely.
+// completed segment's text into an AST on every streaming chunk.
 const MemoMarkdown = React.memo(function MemoMarkdown({
   content,
 }: {
@@ -186,27 +259,14 @@ const MemoMarkdown = React.memo(function MemoMarkdown({
   );
 });
 
-function customTagBlockEqual(a: CustomTagBlock, b: CustomTagBlock): boolean {
-  if (a.tag !== b.tag) return false;
-  if (a.content !== b.content) return false;
-  if (a.inProgress !== b.inProgress) return false;
-  const aKeys = Object.keys(a.attributes);
-  const bKeys = Object.keys(b.attributes);
-  if (aKeys.length !== bKeys.length) return false;
-  for (const k of aKeys) {
-    if (a.attributes[k] !== b.attributes[k]) return false;
-  }
-  return true;
-}
+type CustomTagBlock = Extract<Block, { kind: "custom-tag" }>;
 
-// Memoized custom-tag piece. parseFullMessage rebuilds Block objects on
-// every chunk (new refs), so React.memo's default referential equality
-// would never hit. The custom comparator deep-checks the fields that
-// actually affect the rendered output, so completed dyad tags skip
-// renderCustomTag and the React subtree rebuild when only later blocks
-// change.
-const MemoCustomTag = React.memo(
-  function MemoCustomTag({
+// Memoized custom-tag block. The incremental parser preserves the Block
+// reference for any completed (closed) tag across streaming patches, so
+// referential equality on `block` is sufficient — completed blocks
+// short-circuit and skip renderCustomTag entirely.
+const MemoBlockCustomTag = React.memo(
+  function MemoBlockCustomTag({
     block,
     isStreaming,
   }: {
@@ -216,9 +276,9 @@ const MemoCustomTag = React.memo(
     return <>{renderCustomTag(block, { isStreaming })}</>;
   },
   (prev, next) =>
-    customTagBlockEqual(prev.block, next.block) &&
-    // Completed tags don't use isStreaming (getState returns "finished"
-    // regardless), so skip the check to avoid a one-time re-render of every
+    prev.block === next.block &&
+    // Completed tags ignore isStreaming (getState returns "finished"
+    // regardless), so skip the check to avoid one-time re-renders of every
     // completed tag when streaming ends.
     (prev.block.inProgress === false || prev.isStreaming === next.isStreaming),
 );

--- a/src/components/chat/DyadMarkdownParser.tsx
+++ b/src/components/chat/DyadMarkdownParser.tsx
@@ -1,4 +1,4 @@
-import React, { useDeferredValue, useMemo } from "react";
+import React, { useDeferredValue, useMemo, useRef } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
@@ -21,8 +21,7 @@ import { useAtomValue } from "jotai";
 import {
   isStreamingByIdAtom,
   selectedChatIdAtom,
-  streamingBlocksByMessageIdAtom,
-  streamingPreviewByMessageIdAtom,
+  streamingPreviewByChatIdAtom,
 } from "@/atoms/chatAtoms";
 import { CustomTagState } from "./stateTypes";
 import { DyadOutput } from "./DyadOutput";
@@ -55,20 +54,18 @@ import { mapActionToButton } from "./ChatInput";
 import { SuggestedAction } from "@/lib/schemas";
 import { FixAllErrorsButton } from "./FixAllErrorsButton";
 import {
+  advanceParser,
   type Block,
   getOpenBlock,
+  initialParserState,
   parseFullMessage,
+  type ParserState,
 } from "@/lib/streamingMessageParser";
 
 interface DyadMarkdownParserProps {
   content: string;
-  /**
-   * Assistant message id. When present, the renderer reads the incremental
-   * parser state from streamingBlocksByMessageIdAtom so completed blocks
-   * keep referential identity across streaming chunks. Without it the
-   * renderer falls back to a one-shot parse of `content`.
-   */
   messageId?: number;
+  showStreamingPreview?: boolean;
 }
 
 const customLink = ({
@@ -107,55 +104,52 @@ export const VanillaMarkdownParser = ({ content }: { content: string }) => {
 /**
  * Custom component to parse markdown content with Dyad-specific tags.
  *
- * The block list is sourced from an incremental parser (see
- * src/lib/streamingMessageParser.ts) so completed blocks keep referential
- * identity across streaming chunks. That lets React.memo skip every prior
- * block, leaving only the open trailing block to re-render per chunk.
+ * The block list is sourced from a component-local incremental parser. Completed
+ * blocks keep referential identity across streaming chunks, so React.memo can
+ * skip prior blocks and leave only the open trailing block to re-render.
  */
 export const DyadMarkdownParser: React.FC<DyadMarkdownParserProps> = ({
   content,
   messageId,
+  showStreamingPreview = false,
 }) => {
   const chatId = useAtomValue(selectedChatIdAtom);
   const isStreaming = useAtomValue(isStreamingByIdAtom).get(chatId!) ?? false;
   const deferredContent = useDeferredValue(content);
   const contentToParse = isStreaming ? deferredContent : content;
 
-  const streamingStates = useAtomValue(streamingBlocksByMessageIdAtom);
-  const parserState =
-    messageId !== undefined ? streamingStates.get(messageId) : undefined;
+  const parserCacheRef = useRef<{
+    messageId?: number;
+    content: string;
+    state: ParserState;
+  } | null>(null);
 
-  // Sidecar tool-input XML preview (Pro/Agent v2). Lives outside the
-  // message's parsed-block tree so the patch protocol can stay strictly
-  // append-only — buildXml output rewrites its prefix per JSON delta and
-  // would otherwise force escalation to fullMessages.
-  const previewStates = useAtomValue(streamingPreviewByMessageIdAtom);
-  const previewXml =
-    messageId !== undefined ? previewStates.get(messageId) : undefined;
-  const previewBlocks = useMemo<Block[] | null>(() => {
-    if (!previewXml) return null;
-    return parseFullMessage(previewXml).blocks;
-  }, [previewXml]);
+  const parserState = useMemo(() => {
+    const cached = parserCacheRef.current;
+    if (
+      cached &&
+      cached.messageId === messageId &&
+      contentToParse.startsWith(cached.content)
+    ) {
+      const state = advanceParser(cached.state, contentToParse);
+      parserCacheRef.current = { messageId, content: contentToParse, state };
+      return state;
+    }
 
-  // While streaming, closed blocks live in parserState.blocks (immutable-
-  // appended on commit) and the open block comes from getOpenBlock. The
-  // closed-blocks array ref is stable across chunks that don't close a
-  // block, so MemoClosedBlocks skips its subtree entirely on those chunks
-  // (O(1) per chunk).
-  const closedBlocks = parserState?.blocks;
-  const openBlock = parserState ? getOpenBlock(parserState) : null;
+    const state = advanceParser(initialParserState(), contentToParse);
+    parserCacheRef.current = { messageId, content: contentToParse, state };
+    return state;
+  }, [messageId, contentToParse]);
 
-  // Fallback path: no parser state (history, post-DB-restore). One-shot
-  // parse of the full content.
-  const fallbackBlocks = useMemo<Block[] | null>(() => {
-    if (parserState !== undefined) return null;
-    return parseFullMessage(contentToParse).blocks;
-  }, [parserState, contentToParse]);
+  const closedBlocks = parserState.blocks;
+  const openBlock = getOpenBlock(parserState);
 
-  // Aggregate error messages for the FixAllErrorsButton. Recomputes only
-  // when one of the input arrays gets a new ref (closed blocks: on commit;
-  // fallback: on content change).
+  // The button is hidden while streaming, so avoid scanning the block list on
+  // every chunk. Do the full scan only for settled content.
   const { errorMessages, errorCount } = useMemo(() => {
+    if (isStreaming) {
+      return { errorMessages: [], errorCount: 0 };
+    }
     const errors: string[] = [];
     const collectFrom = (block: Block) => {
       if (
@@ -167,36 +161,21 @@ export const DyadMarkdownParser: React.FC<DyadMarkdownParserProps> = ({
         if (msg) errors.push(msg);
       }
     };
-    if (closedBlocks) {
-      for (const block of closedBlocks) collectFrom(block);
-    } else if (fallbackBlocks) {
-      for (const block of fallbackBlocks) collectFrom(block);
-    }
+    for (const block of closedBlocks) collectFrom(block);
+    if (openBlock) collectFrom(openBlock);
     return { errorMessages: errors, errorCount: errors.length };
-  }, [closedBlocks, fallbackBlocks]);
+  }, [closedBlocks, openBlock, isStreaming]);
 
   const showFixAll =
     errorCount > 1 && !isStreaming && chatId !== null && chatId !== undefined;
 
   return (
     <>
-      {closedBlocks ? (
-        <MemoClosedBlocks blocks={closedBlocks} isStreaming={isStreaming} />
-      ) : fallbackBlocks ? (
-        fallbackBlocks.map((block) => (
-          <React.Fragment key={block.id}>
-            {renderBlock(block, isStreaming)}
-          </React.Fragment>
-        ))
-      ) : null}
+      <MemoClosedBlocks blocks={closedBlocks} isStreaming={isStreaming} />
       {openBlock ? renderBlock(openBlock, isStreaming) : null}
-      {previewBlocks
-        ? previewBlocks.map((block) => (
-            <React.Fragment key={`preview-${block.id}`}>
-              {renderBlock(block, isStreaming)}
-            </React.Fragment>
-          ))
-        : null}
+      {showStreamingPreview && chatId !== null && chatId !== undefined && (
+        <StreamingPreviewBlocks chatId={chatId} isStreaming={isStreaming} />
+      )}
       {showFixAll && (
         <div className="mt-3 w-full flex">
           <FixAllErrorsButton errorMessages={errorMessages} chatId={chatId!} />
@@ -205,6 +184,33 @@ export const DyadMarkdownParser: React.FC<DyadMarkdownParserProps> = ({
     </>
   );
 };
+
+function StreamingPreviewBlocks({
+  chatId,
+  isStreaming,
+}: {
+  chatId: number;
+  isStreaming: boolean;
+}) {
+  const previewStates = useAtomValue(streamingPreviewByChatIdAtom);
+  const previewXml = previewStates.get(chatId);
+  const previewBlocks = useMemo<Block[] | null>(() => {
+    if (!previewXml) return null;
+    return parseFullMessage(previewXml).blocks;
+  }, [previewXml]);
+
+  if (!previewBlocks) return null;
+
+  return (
+    <>
+      {previewBlocks.map((block) => (
+        <React.Fragment key={`preview-${block.id}`}>
+          {renderBlock(block, isStreaming)}
+        </React.Fragment>
+      ))}
+    </>
+  );
+}
 
 function renderBlock(block: Block, isStreaming: boolean): React.ReactNode {
   if (block.kind === "markdown") {

--- a/src/hooks/useStreamChat.ts
+++ b/src/hooks/useStreamChat.ts
@@ -13,6 +13,8 @@ import {
   recentStreamChatIdsAtom,
   queuedMessagesByIdAtom,
   streamCompletedSuccessfullyByIdAtom,
+  streamingBlocksByMessageIdAtom,
+  streamingPreviewByMessageIdAtom,
   queuePausedByIdAtom,
   type QueuedMessageItem,
 } from "@/atoms/chatAtoms";
@@ -24,6 +26,10 @@ import type { ChatSummary } from "@/lib/schemas";
 import { useChats } from "./useChats";
 import { useLoadApp } from "./useLoadApp";
 import { applyStreamingPatch } from "@/lib/applyStreamingPatch";
+import {
+  advanceParser,
+  initialParserState,
+} from "@/lib/streamingMessageParser";
 import {
   triggerResync,
   syncChatFromDb,
@@ -110,6 +116,8 @@ export function useStreamChat({
   const setStreamCompletedSuccessfullyById = useSetAtom(
     streamCompletedSuccessfullyByIdAtom,
   );
+  const setStreamingBlocksById = useSetAtom(streamingBlocksByMessageIdAtom);
+  const setStreamingPreviewById = useSetAtom(streamingPreviewByMessageIdAtom);
   const queuePausedById = useAtomValue(queuePausedByIdAtom);
   const setQueuePausedById = useSetAtom(queuePausedByIdAtom);
 
@@ -260,6 +268,7 @@ export function useStreamChat({
               messages: updatedMessages,
               streamingMessageId,
               streamingPatch,
+              streamingPreview,
               chunkSeq,
               effectiveChatMode,
               chatModeFallbackReason,
@@ -288,6 +297,29 @@ export function useStreamChat({
                 hasIncrementedStreamCount = true;
               }
 
+              if (streamingPreview) {
+                // Sidecar tool-input XML overlay. Doesn't touch
+                // message.content or parser state — just updates the
+                // preview atom keyed by message id. Empty content clears
+                // the overlay (server sends empty preview when the tool's
+                // finalized XML is committed into fullResponse via
+                // onXmlComplete).
+                const { messageId, content } = streamingPreview;
+                setStreamingPreviewById((prev) => {
+                  const existing = prev.get(messageId);
+                  if (content === "") {
+                    if (existing === undefined) return prev;
+                    const next = new Map(prev);
+                    next.delete(messageId);
+                    return next;
+                  }
+                  if (existing === content) return prev;
+                  const next = new Map(prev);
+                  next.set(messageId, content);
+                  return next;
+                });
+              }
+
               if (updatedMessages) {
                 // Full messages update (initial load, post-compaction, etc.)
                 setMessagesById((prev) => {
@@ -295,6 +327,36 @@ export function useStreamChat({
                   next.set(chatId, updatedMessages);
                   return next;
                 });
+                // A fullMessages payload is authoritative: it can replace
+                // the content of messages still in the payload (mid-turn
+                // compaction in local_agent_handler does this, as does the
+                // non-tail-patch escalation in sendResponseChunk). Any
+                // cached parser state keyed by those ids is stale.
+                //
+                // When the payload identifies the active streaming
+                // message, recompute its parser state fresh. Keeping
+                // parserState defined across the replacement holds
+                // DyadMarkdownParser on the parser-backed render path so
+                // the response doesn't briefly swap to a fallback parse.
+                //
+                // For any other ids we still hold state for, clear them.
+                const clearAll = <V>(prev: Map<number, V>) =>
+                  prev.size === 0 ? prev : new Map<number, V>();
+                const streamingMsg =
+                  streamingMessageId !== undefined
+                    ? updatedMessages.find((m) => m.id === streamingMessageId)
+                    : undefined;
+                if (streamingMessageId !== undefined && streamingMsg) {
+                  const freshState = advanceParser(
+                    initialParserState(),
+                    streamingMsg.content ?? "",
+                  );
+                  setStreamingBlocksById(
+                    () => new Map([[streamingMessageId, freshState]]),
+                  );
+                } else {
+                  setStreamingBlocksById(clearAll);
+                }
               } else if (
                 streamingMessageId !== undefined &&
                 streamingPatch !== undefined
@@ -305,8 +367,36 @@ export function useStreamChat({
                   streamingMessageId,
                   streamingPatch,
                 );
-                if (!applied) {
+                if (applied) {
+                  // Advance cached parser state to match the new content.
+                  // advanceParser preserves refs for already-committed
+                  // blocks, so only the open trailing block changes shape
+                  // per chunk. On shrink (offset < prev cursor), the parser
+                  // resets internally and re-runs from scratch.
+                  const messages = store.get(chatMessagesByIdAtom).get(chatId);
+                  const msg = messages?.find(
+                    (m) => m.id === streamingMessageId,
+                  );
+                  const newContent = msg?.content ?? "";
+                  setStreamingBlocksById((prev) => {
+                    const prevState =
+                      prev.get(streamingMessageId) ?? initialParserState();
+                    const nextState = advanceParser(prevState, newContent);
+                    if (nextState === prevState) return prev;
+                    const next = new Map(prev);
+                    next.set(streamingMessageId, nextState);
+                    return next;
+                  });
+                } else {
                   triggerResync(chatId, setMessagesById, store);
+                  // Drop parser state for this message so the renderer
+                  // re-parses from the resynced (full DB) content.
+                  setStreamingBlocksById((prev) => {
+                    if (!prev.has(streamingMessageId)) return prev;
+                    const next = new Map(prev);
+                    next.delete(streamingMessageId);
+                    return next;
+                  });
                 }
               }
 
@@ -469,6 +559,27 @@ export function useStreamChat({
                         next.set(chatId, merged);
                         return next;
                       });
+                      // Stream ended successfully — drop parser states and
+                      // preview overlays for finalized messages so the
+                      // renderer falls back to a one-shot parse of the
+                      // merged DB content.
+                      const finalizedIds = new Set(
+                        latestChat.messages.map((m) => m.id),
+                      );
+                      const dropFinalized = <V>(prev: Map<number, V>) => {
+                        if (prev.size === 0) return prev;
+                        let changed = false;
+                        const next = new Map(prev);
+                        for (const id of prev.keys()) {
+                          if (finalizedIds.has(id)) {
+                            next.delete(id);
+                            changed = true;
+                          }
+                        }
+                        return changed ? next : prev;
+                      };
+                      setStreamingBlocksById(dropFinalized);
+                      setStreamingPreviewById(dropFinalized);
                     }
                   } catch (error) {
                     console.warn(

--- a/src/hooks/useStreamChat.ts
+++ b/src/hooks/useStreamChat.ts
@@ -243,6 +243,29 @@ export function useStreamChat({
       }
       const targetAppId =
         appId ?? resolvedAppIdFromChat ?? selectedAppId ?? null;
+
+      // Drop cached parser state and preview overlays for every message
+      // id currently associated with this chat. Used by every stream
+      // teardown path (cancellation, error, exception, success-with-
+      // resync) so per-message sidecar overlays and parser caches don't
+      // outlive the stream that produced them. Entries owned by other
+      // chats are not touched — both atoms are global maps.
+      const dropStreamingStateForChat = (chatId: number) => {
+        const messages = store.get(chatMessagesByIdAtom).get(chatId) ?? [];
+        if (messages.length === 0) return;
+        const ids = new Set(messages.map((m) => m.id));
+        const dropIds = <V>(prev: Map<number, V>) => {
+          let changed = false;
+          const next = new Map(prev);
+          for (const id of ids) {
+            if (next.delete(id)) changed = true;
+          }
+          return changed ? next : prev;
+        };
+        setStreamingBlocksById(dropIds);
+        setStreamingPreviewById(dropIds);
+      };
+
       try {
         const cachedChat =
           requestedChatMode === null
@@ -321,42 +344,72 @@ export function useStreamChat({
               }
 
               if (updatedMessages) {
+                // Read the chat's old messages before replacing so we
+                // know which ids belong to this chat. The atoms are
+                // global maps keyed by message id, so we must only touch
+                // entries for this chat — entries owned by other chats
+                // (concurrent streams, e.g. background queue processing)
+                // stay intact.
+                const oldMessagesForChat =
+                  store.get(chatMessagesByIdAtom).get(chatId) ?? [];
+                const oldIdsForChat = new Set(
+                  oldMessagesForChat.map((m) => m.id),
+                );
+                const newIdsForChat = new Set(updatedMessages.map((m) => m.id));
+
                 // Full messages update (initial load, post-compaction, etc.)
                 setMessagesById((prev) => {
                   const next = new Map(prev);
                   next.set(chatId, updatedMessages);
                   return next;
                 });
-                // A fullMessages payload is authoritative: it can replace
-                // the content of messages still in the payload (mid-turn
-                // compaction in local_agent_handler does this, as does the
-                // non-tail-patch escalation in sendResponseChunk). Any
-                // cached parser state keyed by those ids is stale.
+                // A fullMessages payload is authoritative for this chat:
+                // it can replace the content of messages still in the
+                // payload (mid-turn compaction in local_agent_handler does
+                // this, as does the non-tail-patch escalation in
+                // sendResponseChunk). Cached parser state for any of this
+                // chat's prior message ids is now stale.
                 //
                 // When the payload identifies the active streaming
                 // message, recompute its parser state fresh. Keeping
                 // parserState defined across the replacement holds
                 // DyadMarkdownParser on the parser-backed render path so
                 // the response doesn't briefly swap to a fallback parse.
-                //
-                // For any other ids we still hold state for, clear them.
-                const clearAll = <V>(prev: Map<number, V>) =>
-                  prev.size === 0 ? prev : new Map<number, V>();
                 const streamingMsg =
                   streamingMessageId !== undefined
                     ? updatedMessages.find((m) => m.id === streamingMessageId)
                     : undefined;
-                if (streamingMessageId !== undefined && streamingMsg) {
-                  const freshState = advanceParser(
-                    initialParserState(),
-                    streamingMsg.content ?? "",
-                  );
-                  setStreamingBlocksById(
-                    () => new Map([[streamingMessageId, freshState]]),
-                  );
-                } else {
-                  setStreamingBlocksById(clearAll);
-                }
+                setStreamingBlocksById((prev) => {
+                  let changed = false;
+                  const next = new Map(prev);
+                  for (const id of oldIdsForChat) {
+                    if (next.delete(id)) changed = true;
+                  }
+                  if (streamingMessageId !== undefined && streamingMsg) {
+                    const freshState = advanceParser(
+                      initialParserState(),
+                      streamingMsg.content ?? "",
+                    );
+                    next.set(streamingMessageId, freshState);
+                    return next;
+                  }
+                  return changed ? next : prev;
+                });
+                // Drop preview overlays only for ids that were in this
+                // chat but are gone from the new payload (e.g. compacted
+                // messages). Previews for messages still in the chat stay
+                // valid; the server clears them via an empty preview when
+                // a tool call commits.
+                setStreamingPreviewById((prev) => {
+                  let changed = false;
+                  const next = new Map(prev);
+                  for (const id of oldIdsForChat) {
+                    if (!newIdsForChat.has(id) && next.delete(id)) {
+                      changed = true;
+                    }
+                  }
+                  return changed ? next : prev;
+                });
               } else if (
                 streamingMessageId !== undefined &&
                 streamingPatch !== undefined
@@ -436,6 +489,11 @@ export function useStreamChat({
                     next.set(chatId, updatedMessages);
                     return next;
                   });
+                  // Stream cancelled — drop parser state and preview
+                  // overlays for this chat's messages so any in-flight
+                  // sidecar overlay or stale parser state from a
+                  // partial tool call doesn't outlive the stream.
+                  dropStreamingStateForChat(chatId);
                 }
 
                 if (response.pausePromptQueue) {
@@ -638,6 +696,12 @@ export function useStreamChat({
                 return next;
               });
               syncChatFromDb(chatId, setMessagesById, "[CHAT] onError", store);
+              // Stream errored — drop parser state and preview overlays
+              // for this chat's messages. syncChatFromDb has replaced
+              // local message content with the DB state, so any cached
+              // parser state is now stale; sidecar previews from
+              // in-flight tool calls should not outlive the stream.
+              dropStreamingStateForChat(chatId);
               invalidateChats();
               refreshApp();
               refreshVersions();
@@ -651,6 +715,10 @@ export function useStreamChat({
         pendingStreamChatIds.delete(chatId);
         latestChunkByChatId.delete(chatId);
         cancelAckTimer(chatId);
+        // Defensive cleanup: no chunks streamed yet, but a prior stream
+        // for this chat may have left entries that should not survive a
+        // failed re-start.
+        dropStreamingStateForChat(chatId);
 
         console.error("[CHAT] Exception during streaming setup:", error);
         setIsStreamingById((prev) => {

--- a/src/hooks/useStreamChat.ts
+++ b/src/hooks/useStreamChat.ts
@@ -13,8 +13,7 @@ import {
   recentStreamChatIdsAtom,
   queuedMessagesByIdAtom,
   streamCompletedSuccessfullyByIdAtom,
-  streamingBlocksByMessageIdAtom,
-  streamingPreviewByMessageIdAtom,
+  streamingPreviewByChatIdAtom,
   queuePausedByIdAtom,
   type QueuedMessageItem,
 } from "@/atoms/chatAtoms";
@@ -26,10 +25,6 @@ import type { ChatSummary } from "@/lib/schemas";
 import { useChats } from "./useChats";
 import { useLoadApp } from "./useLoadApp";
 import { applyStreamingPatch } from "@/lib/applyStreamingPatch";
-import {
-  advanceParser,
-  initialParserState,
-} from "@/lib/streamingMessageParser";
 import {
   triggerResync,
   syncChatFromDb,
@@ -116,8 +111,7 @@ export function useStreamChat({
   const setStreamCompletedSuccessfullyById = useSetAtom(
     streamCompletedSuccessfullyByIdAtom,
   );
-  const setStreamingBlocksById = useSetAtom(streamingBlocksByMessageIdAtom);
-  const setStreamingPreviewById = useSetAtom(streamingPreviewByMessageIdAtom);
+  const setStreamingPreviewByChatId = useSetAtom(streamingPreviewByChatIdAtom);
   const queuePausedById = useAtomValue(queuePausedByIdAtom);
   const setQueuePausedById = useSetAtom(queuePausedByIdAtom);
 
@@ -244,26 +238,13 @@ export function useStreamChat({
       const targetAppId =
         appId ?? resolvedAppIdFromChat ?? selectedAppId ?? null;
 
-      // Drop cached parser state and preview overlays for every message
-      // id currently associated with this chat. Used by every stream
-      // teardown path (cancellation, error, exception, success-with-
-      // resync) so per-message sidecar overlays and parser caches don't
-      // outlive the stream that produced them. Entries owned by other
-      // chats are not touched — both atoms are global maps.
-      const dropStreamingStateForChat = (chatId: number) => {
-        const messages = store.get(chatMessagesByIdAtom).get(chatId) ?? [];
-        if (messages.length === 0) return;
-        const ids = new Set(messages.map((m) => m.id));
-        const dropIds = <V>(prev: Map<number, V>) => {
-          let changed = false;
+      const clearStreamingPreviewForChat = (chatId: number) => {
+        setStreamingPreviewByChatId((prev) => {
+          if (!prev.has(chatId)) return prev;
           const next = new Map(prev);
-          for (const id of ids) {
-            if (next.delete(id)) changed = true;
-          }
-          return changed ? next : prev;
-        };
-        setStreamingBlocksById(dropIds);
-        setStreamingPreviewById(dropIds);
+          next.delete(chatId);
+          return next;
+        });
       };
 
       try {
@@ -322,93 +303,31 @@ export function useStreamChat({
 
               if (streamingPreview) {
                 // Sidecar tool-input XML overlay. Doesn't touch
-                // message.content or parser state — just updates the
-                // preview atom keyed by message id. Empty content clears
-                // the overlay (server sends empty preview when the tool's
-                // finalized XML is committed into fullResponse via
-                // onXmlComplete).
-                const { messageId, content } = streamingPreview;
-                setStreamingPreviewById((prev) => {
-                  const existing = prev.get(messageId);
+                // message.content. Empty content clears the overlay (server
+                // sends an empty preview when the tool's finalized XML is
+                // committed into fullResponse via onXmlComplete).
+                const { content } = streamingPreview;
+                setStreamingPreviewByChatId((prev) => {
+                  const existing = prev.get(chatId);
                   if (content === "") {
                     if (existing === undefined) return prev;
                     const next = new Map(prev);
-                    next.delete(messageId);
+                    next.delete(chatId);
                     return next;
                   }
                   if (existing === content) return prev;
                   const next = new Map(prev);
-                  next.set(messageId, content);
+                  next.set(chatId, content);
                   return next;
                 });
               }
 
               if (updatedMessages) {
-                // Read the chat's old messages before replacing so we
-                // know which ids belong to this chat. The atoms are
-                // global maps keyed by message id, so we must only touch
-                // entries for this chat — entries owned by other chats
-                // (concurrent streams, e.g. background queue processing)
-                // stay intact.
-                const oldMessagesForChat =
-                  store.get(chatMessagesByIdAtom).get(chatId) ?? [];
-                const oldIdsForChat = new Set(
-                  oldMessagesForChat.map((m) => m.id),
-                );
-                const newIdsForChat = new Set(updatedMessages.map((m) => m.id));
-
                 // Full messages update (initial load, post-compaction, etc.)
                 setMessagesById((prev) => {
                   const next = new Map(prev);
                   next.set(chatId, updatedMessages);
                   return next;
-                });
-                // A fullMessages payload is authoritative for this chat:
-                // it can replace the content of messages still in the
-                // payload (mid-turn compaction in local_agent_handler does
-                // this, as does the non-tail-patch escalation in
-                // sendResponseChunk). Cached parser state for any of this
-                // chat's prior message ids is now stale.
-                //
-                // When the payload identifies the active streaming
-                // message, recompute its parser state fresh. Keeping
-                // parserState defined across the replacement holds
-                // DyadMarkdownParser on the parser-backed render path so
-                // the response doesn't briefly swap to a fallback parse.
-                const streamingMsg =
-                  streamingMessageId !== undefined
-                    ? updatedMessages.find((m) => m.id === streamingMessageId)
-                    : undefined;
-                setStreamingBlocksById((prev) => {
-                  let changed = false;
-                  const next = new Map(prev);
-                  for (const id of oldIdsForChat) {
-                    if (next.delete(id)) changed = true;
-                  }
-                  if (streamingMessageId !== undefined && streamingMsg) {
-                    const freshState = advanceParser(
-                      initialParserState(),
-                      streamingMsg.content ?? "",
-                    );
-                    next.set(streamingMessageId, freshState);
-                    return next;
-                  }
-                  return changed ? next : prev;
-                });
-                // Drop preview overlays only for ids that were in this
-                // chat but are gone from the new payload (e.g. compacted
-                // messages). Previews for messages still in the chat stay
-                // valid; the server clears them via an empty preview when
-                // a tool call commits.
-                setStreamingPreviewById((prev) => {
-                  let changed = false;
-                  const next = new Map(prev);
-                  for (const id of oldIdsForChat) {
-                    if (!newIdsForChat.has(id) && next.delete(id)) {
-                      changed = true;
-                    }
-                  }
-                  return changed ? next : prev;
                 });
               } else if (
                 streamingMessageId !== undefined &&
@@ -420,36 +339,8 @@ export function useStreamChat({
                   streamingMessageId,
                   streamingPatch,
                 );
-                if (applied) {
-                  // Advance cached parser state to match the new content.
-                  // advanceParser preserves refs for already-committed
-                  // blocks, so only the open trailing block changes shape
-                  // per chunk. On shrink (offset < prev cursor), the parser
-                  // resets internally and re-runs from scratch.
-                  const messages = store.get(chatMessagesByIdAtom).get(chatId);
-                  const msg = messages?.find(
-                    (m) => m.id === streamingMessageId,
-                  );
-                  const newContent = msg?.content ?? "";
-                  setStreamingBlocksById((prev) => {
-                    const prevState =
-                      prev.get(streamingMessageId) ?? initialParserState();
-                    const nextState = advanceParser(prevState, newContent);
-                    if (nextState === prevState) return prev;
-                    const next = new Map(prev);
-                    next.set(streamingMessageId, nextState);
-                    return next;
-                  });
-                } else {
+                if (!applied) {
                   triggerResync(chatId, setMessagesById, store);
-                  // Drop parser state for this message so the renderer
-                  // re-parses from the resynced (full DB) content.
-                  setStreamingBlocksById((prev) => {
-                    if (!prev.has(streamingMessageId)) return prev;
-                    const next = new Map(prev);
-                    next.delete(streamingMessageId);
-                    return next;
-                  });
                 }
               }
 
@@ -469,6 +360,7 @@ export function useStreamChat({
               pendingStreamChatIds.delete(chatId);
               latestChunkByChatId.delete(chatId);
               cancelAckTimer(chatId);
+              clearStreamingPreviewForChat(chatId);
               void (async () => {
                 // Only mark as successful if NOT cancelled - wasCancelled flag is set
                 // by the backend when user cancels the stream
@@ -489,11 +381,6 @@ export function useStreamChat({
                     next.set(chatId, updatedMessages);
                     return next;
                   });
-                  // Stream cancelled — drop parser state and preview
-                  // overlays for this chat's messages so any in-flight
-                  // sidecar overlay or stale parser state from a
-                  // partial tool call doesn't outlive the stream.
-                  dropStreamingStateForChat(chatId);
                 }
 
                 if (response.pausePromptQueue) {
@@ -617,27 +504,6 @@ export function useStreamChat({
                         next.set(chatId, merged);
                         return next;
                       });
-                      // Stream ended successfully — drop parser states and
-                      // preview overlays for finalized messages so the
-                      // renderer falls back to a one-shot parse of the
-                      // merged DB content.
-                      const finalizedIds = new Set(
-                        latestChat.messages.map((m) => m.id),
-                      );
-                      const dropFinalized = <V>(prev: Map<number, V>) => {
-                        if (prev.size === 0) return prev;
-                        let changed = false;
-                        const next = new Map(prev);
-                        for (const id of prev.keys()) {
-                          if (finalizedIds.has(id)) {
-                            next.delete(id);
-                            changed = true;
-                          }
-                        }
-                        return changed ? next : prev;
-                      };
-                      setStreamingBlocksById(dropFinalized);
-                      setStreamingPreviewById(dropFinalized);
                     }
                   } catch (error) {
                     console.warn(
@@ -672,6 +538,7 @@ export function useStreamChat({
               pendingStreamChatIds.delete(chatId);
               latestChunkByChatId.delete(chatId);
               cancelAckTimer(chatId);
+              clearStreamingPreviewForChat(chatId);
 
               for (const warningMessage of warningMessages ?? []) {
                 showWarning(warningMessage);
@@ -696,12 +563,6 @@ export function useStreamChat({
                 return next;
               });
               syncChatFromDb(chatId, setMessagesById, "[CHAT] onError", store);
-              // Stream errored — drop parser state and preview overlays
-              // for this chat's messages. syncChatFromDb has replaced
-              // local message content with the DB state, so any cached
-              // parser state is now stale; sidecar previews from
-              // in-flight tool calls should not outlive the stream.
-              dropStreamingStateForChat(chatId);
               invalidateChats();
               refreshApp();
               refreshVersions();
@@ -715,10 +576,7 @@ export function useStreamChat({
         pendingStreamChatIds.delete(chatId);
         latestChunkByChatId.delete(chatId);
         cancelAckTimer(chatId);
-        // Defensive cleanup: no chunks streamed yet, but a prior stream
-        // for this chat may have left entries that should not survive a
-        // failed re-start.
-        dropStreamingStateForChat(chatId);
+        clearStreamingPreviewForChat(chatId);
 
         console.error("[CHAT] Exception during streaming setup:", error);
         setIsStreamingById((prev) => {
@@ -744,6 +602,7 @@ export function useStreamChat({
       setIsPreviewOpen,
       setStreamCompletedSuccessfullyById,
       setQueuePausedById,
+      setStreamingPreviewByChatId,
       selectedAppId,
       refetchUserBudget,
       settings,

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -865,6 +865,7 @@ ${componentSnippet}
       safeSend(event.sender, "chat:response:chunk", {
         chatId: req.chatId,
         messages: updatedChat.messages,
+        streamingMessageId: placeholderAssistantMessage.id,
       });
 
       let fullResponse = "";
@@ -2034,6 +2035,7 @@ ${problemReport.problems
           safeSend(event.sender, "chat:response:chunk", {
             chatId: req.chatId,
             messages: chat!.messages,
+            streamingMessageId: placeholderAssistantMessage.id,
           });
 
           if (status.error) {

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -865,7 +865,6 @@ ${componentSnippet}
       safeSend(event.sender, "chat:response:chunk", {
         chatId: req.chatId,
         messages: updatedChat.messages,
-        streamingMessageId: placeholderAssistantMessage.id,
       });
 
       let fullResponse = "";
@@ -2035,7 +2034,6 @@ ${problemReport.problems
           safeSend(event.sender, "chat:response:chunk", {
             chatId: req.chatId,
             messages: chat!.messages,
-            streamingMessageId: placeholderAssistantMessage.id,
           });
 
           if (status.error) {

--- a/src/ipc/types/chat.ts
+++ b/src/ipc/types/chat.ts
@@ -128,17 +128,42 @@ export const StreamingPatchSchema = z.object({
 export type StreamingPatch = z.infer<typeof StreamingPatchSchema>;
 
 /**
+ * Schema for a transient tool-input XML preview.
+ *
+ * Pro/Agent v2 tools stream their args as JSON deltas; the handler rebuilds
+ * a complete XML representation per delta (see `buildXml`). That output is
+ * not append-only — closing quotes and brackets shift as attribute values
+ * grow — so it cannot be expressed as a tail-only `StreamingPatch` against
+ * `message.content`. Routing it through the patch protocol forces non-tail
+ * escalations to `fullMessages` sends, which are expensive on long turns.
+ *
+ * Instead, previews ride a dedicated field. The renderer overlays the
+ * preview after the message's parsed blocks and clears it when the field
+ * is absent / empty (e.g. `onXmlComplete` commits the finalized XML into
+ * `fullResponse` and emits an empty preview).
+ */
+export const StreamingPreviewSchema = z.object({
+  messageId: z.number(),
+  content: z.string(),
+});
+export type StreamingPreview = z.infer<typeof StreamingPreviewSchema>;
+
+/**
  * Schema for chat response chunk event.
  *
- * Supports two modes:
- * 1. Full update: `messages` is set with the complete messages array
- * 2. Incremental tail patch: `streamingMessageId` + `streamingPatch`
+ * Three independent update modes that may appear separately or alongside
+ * each other:
+ * 1. Full update: `messages` set with the complete messages array.
+ * 2. Incremental tail patch: `streamingMessageId` + `streamingPatch`.
+ * 3. Tool-input XML preview overlay: `streamingPreview`. Doesn't touch
+ *    `message.content`; rendered as a sidecar block on the frontend.
  */
 export const ChatResponseChunkSchema = z.object({
   chatId: z.number(),
   messages: z.array(MessageSchema).optional(),
   streamingMessageId: z.number().optional(),
   streamingPatch: StreamingPatchSchema.optional(),
+  streamingPreview: StreamingPreviewSchema.optional(),
   // Monotonic chunk sequence used for ack-based backpressure on the canned
   // test streaming path. Real LLM streams omit this field; the renderer
   // only acks when chunkSeq is present.

--- a/src/ipc/types/chat.ts
+++ b/src/ipc/types/chat.ts
@@ -137,13 +137,11 @@ export type StreamingPatch = z.infer<typeof StreamingPatchSchema>;
  * `message.content`. Routing it through the patch protocol forces non-tail
  * escalations to `fullMessages` sends, which are expensive on long turns.
  *
- * Instead, previews ride a dedicated field. The renderer overlays the
- * preview after the message's parsed blocks and clears it when the field
- * is absent / empty (e.g. `onXmlComplete` commits the finalized XML into
- * `fullResponse` and emits an empty preview).
+ * Instead, previews ride a dedicated field. The renderer overlays the preview
+ * on the active streaming assistant message for this chunk's chat and clears it
+ * when content is empty or the stream ends.
  */
 export const StreamingPreviewSchema = z.object({
-  messageId: z.number(),
   content: z.string(),
 });
 export type StreamingPreview = z.infer<typeof StreamingPreviewSchema>;

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -1604,6 +1604,15 @@ export async function handleLocalAgentStream(
       clearTimeout(pendingXmlEmitTimer);
       pendingXmlEmitTimer = null;
     }
+    // If an in-progress tool's XML preview was overlaid in the renderer
+    // and the stream tore down before onXmlComplete could commit and
+    // clear it (cancel, error, abort), explicitly clear the overlay so
+    // a stale XML preview doesn't persist past stream end. Idempotent
+    // when the overlay is already empty.
+    if (streamingPreview.length > 0) {
+      sendPreview("");
+      streamingPreview = "";
+    }
   }
 }
 

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -110,6 +110,10 @@ const logger = log.scope("local_agent_handler");
 const PLANNING_QUESTIONNAIRE_TOOL_NAME = "planning_questionnaire";
 const MAX_TERMINATED_STREAM_RETRIES = 3;
 const STREAM_RETRY_BASE_DELAY_MS = 400;
+// IPC send rate cap for in-progress tool XML preview overlays. Each call
+// to onXmlStream rewrites the buffered XML prefix; without throttling the
+// renderer receives one IPC per JSON delta.
+const XML_STREAM_THROTTLE_MS = 50;
 const STREAM_CONTINUE_MESSAGE =
   "[System] Your previous response stream was interrupted by a transient network error. Continue from exactly where you left off and do not repeat text that has already been sent.";
 
@@ -382,6 +386,9 @@ export async function handleLocalAgentStream(
     settings.maxToolCallSteps ?? DEFAULT_MAX_TOOL_CALL_STEPS;
   let fullResponse = "";
   let streamingPreview = ""; // Temporary preview for current tool, not persisted
+  // Throttle state for onXmlStream. Resets per-stream.
+  let lastXmlEmittedAt = 0;
+  let pendingXmlEmitTimer: NodeJS.Timeout | null = null;
   // Tracks what was last sent to the renderer for the placeholder
   // assistant message so we can emit only the tail diff. Updated by both
   // streaming-patch sends and full-messages-replacement sends so that the
@@ -409,6 +416,18 @@ export async function handleLocalAgentStream(
       fullMessages,
       lastSentRef,
     );
+  // Sidecar preview send — independent of the patch protocol. The renderer
+  // overlays this string after the message's parsed blocks and clears the
+  // overlay when content is empty. Used for tool-input XML preview.
+  const sendPreview = (content: string) => {
+    safeSend(event.sender, "chat:response:chunk", {
+      chatId: req.chatId,
+      streamingPreview: {
+        messageId: placeholderMessageId,
+        content,
+      },
+    });
+  };
   let postMidTurnCompactionStartStep: number | null = null;
 
   const appendInlineCompactionToTurn = async (
@@ -503,9 +522,12 @@ export async function handleLocalAgentStream(
       (accumulatedSummary: string) => {
         // Stream compaction summary to the frontend in real-time.
         // During mid-turn compaction, keep already streamed content visible.
+        // streamingPreview rides a separate overlay channel — do NOT mix it
+        // into message.content here; the renderer continues to show its
+        // preview overlay alongside this compaction-progress block.
         const compactionPreview = `<dyad-compaction title="Compacting conversation">\n${escapeXmlContent(accumulatedSummary)}\n</dyad-compaction>`;
         const previewContent = options?.showOnTopOfCurrentResponse
-          ? `${fullResponse}${streamingPreview ? streamingPreview : ""}\n${compactionPreview}`
+          ? `${fullResponse}\n${compactionPreview}`
           : compactionPreview;
         sendChunk(previewContent, { fullMessages: true });
       },
@@ -550,7 +572,9 @@ export async function handleLocalAgentStream(
     }
 
     if (options?.showOnTopOfCurrentResponse) {
-      sendChunk(fullResponse + streamingPreview, { fullMessages: true });
+      // streamingPreview rides the overlay channel; don't double-render it
+      // by mixing into message.content here.
+      sendChunk(fullResponse, { fullMessages: true });
     }
 
     return compactionResult.success;
@@ -617,17 +641,49 @@ export async function handleLocalAgentStream(
       fileEditTracker,
       isDyadPro: isDyadProEnabled(settings),
       onXmlStream: (accumulatedXml: string) => {
-        // Stream accumulated XML to UI without persisting
+        // Stream the in-progress tool XML as a sidecar preview overlay.
+        // Does NOT enter `message.content` or `fullResponse` — the patch
+        // protocol stays strictly append-only. buildXml output (which
+        // rewrites the prefix every JSON delta as attribute values grow)
+        // therefore can't perturb the streaming-patch base. Preview chunks
+        // are throttled because each one is a renderer state write.
         streamingPreview = accumulatedXml;
-        sendChunk(fullResponse + streamingPreview);
+        const now = Date.now();
+        const elapsed = now - lastXmlEmittedAt;
+        if (elapsed >= XML_STREAM_THROTTLE_MS) {
+          if (pendingXmlEmitTimer !== null) {
+            clearTimeout(pendingXmlEmitTimer);
+            pendingXmlEmitTimer = null;
+          }
+          sendPreview(streamingPreview);
+          lastXmlEmittedAt = now;
+        } else if (pendingXmlEmitTimer === null) {
+          const wait = XML_STREAM_THROTTLE_MS - elapsed;
+          pendingXmlEmitTimer = setTimeout(() => {
+            pendingXmlEmitTimer = null;
+            sendPreview(streamingPreview);
+            lastXmlEmittedAt = Date.now();
+          }, wait);
+        }
+        // else: timer already armed; it will emit the latest streamingPreview
+        // (captured via closure) when it fires.
       },
       onXmlComplete: (finalXml: string) => {
-        // Write final XML to DB and UI
+        // Commit final XML to fullResponse and clear the preview overlay.
         const xmlChunk = `${finalXml}\n`;
         fullResponse += xmlChunk;
-        streamingPreview = ""; // Clear preview
+        streamingPreview = "";
+        // Cancel any deferred preview emit — clearing the preview below
+        // supersedes any in-flight throttled fire.
+        if (pendingXmlEmitTimer !== null) {
+          clearTimeout(pendingXmlEmitTimer);
+          pendingXmlEmitTimer = null;
+        }
         updateResponseInDb(placeholderMessageId, fullResponse);
         sendChunk(fullResponse);
+        // Empty preview = renderer clears its overlay atom for this message.
+        sendPreview("");
+        lastXmlEmittedAt = Date.now();
       },
       requireConsent: async (params: {
         toolName: string;
@@ -1540,6 +1596,14 @@ export async function handleLocalAgentStream(
         warningMessages.length > 0 ? [...new Set(warningMessages)] : undefined,
     });
     return false; // Error - don't consume quota
+  } finally {
+    // Drop any deferred onXmlStream emit — stream is done; trailing fires
+    // would race the chat:response:end and either get dropped by the
+    // renderer or land on a torn-down placeholder.
+    if (pendingXmlEmitTimer !== null) {
+      clearTimeout(pendingXmlEmitTimer);
+      pendingXmlEmitTimer = null;
+    }
   }
 }
 
@@ -1684,16 +1748,40 @@ function sendResponseChunk(
     safeSend(event.sender, "chat:response:chunk", {
       chatId,
       messages: currentMessages,
+      // Identify the active streaming placeholder so the renderer can
+      // recompute parser state fresh for that message and keep its
+      // parser-backed render path stable across the replacement.
+      streamingMessageId: placeholderMessageId,
     });
     // Renderer's placeholder content now matches fullResponse — keep the
     // tail-diff baseline in sync so the next streaming patch is correct.
     lastSentRef.value = fullResponse;
   } else {
+    const oldLen = lastSentRef.value.length;
     const patch = computeStreamingPatch(fullResponse, lastSentRef.value);
-    lastSentRef.value = fullResponse;
     if (!patch) {
       return;
     }
+    // Streaming patches are reserved for true append-only tail growth
+    // (offset === oldLen). When offset < oldLen the new content diverges
+    // inside the prior tail; applying the patch on the renderer would
+    // cleanly shrink visible content with no mismatch, briefly vanishing
+    // the response. Escalate to a fullMessages send so the renderer
+    // authoritatively replaces content and recomputes parser state.
+    if (patch.offset < oldLen) {
+      sendResponseChunk(
+        event,
+        chatId,
+        chat,
+        fullResponse,
+        placeholderMessageId,
+        hiddenMessageIds,
+        true,
+        lastSentRef,
+      );
+      return;
+    }
+    lastSentRef.value = fullResponse;
     safeSend(event.sender, "chat:response:chunk", {
       chatId,
       streamingMessageId: placeholderMessageId,

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -422,10 +422,7 @@ export async function handleLocalAgentStream(
   const sendPreview = (content: string) => {
     safeSend(event.sender, "chat:response:chunk", {
       chatId: req.chatId,
-      streamingPreview: {
-        messageId: placeholderMessageId,
-        content,
-      },
+      streamingPreview: { content },
     });
   };
   let postMidTurnCompactionStartStep: number | null = null;
@@ -1604,15 +1601,7 @@ export async function handleLocalAgentStream(
       clearTimeout(pendingXmlEmitTimer);
       pendingXmlEmitTimer = null;
     }
-    // If an in-progress tool's XML preview was overlaid in the renderer
-    // and the stream tore down before onXmlComplete could commit and
-    // clear it (cancel, error, abort), explicitly clear the overlay so
-    // a stale XML preview doesn't persist past stream end. Idempotent
-    // when the overlay is already empty.
-    if (streamingPreview.length > 0) {
-      sendPreview("");
-      streamingPreview = "";
-    }
+    streamingPreview = "";
   }
 }
 
@@ -1757,10 +1746,6 @@ function sendResponseChunk(
     safeSend(event.sender, "chat:response:chunk", {
       chatId,
       messages: currentMessages,
-      // Identify the active streaming placeholder so the renderer can
-      // recompute parser state fresh for that message and keep its
-      // parser-backed render path stable across the replacement.
-      streamingMessageId: placeholderMessageId,
     });
     // Renderer's placeholder content now matches fullResponse — keep the
     // tail-diff baseline in sync so the next streaming patch is correct.
@@ -1776,7 +1761,7 @@ function sendResponseChunk(
     // inside the prior tail; applying the patch on the renderer would
     // cleanly shrink visible content with no mismatch, briefly vanishing
     // the response. Escalate to a fullMessages send so the renderer
-    // authoritatively replaces content and recomputes parser state.
+    // authoritatively replaces content.
     if (patch.offset < oldLen) {
       sendResponseChunk(
         event,


### PR DESCRIPTION
## Summary

This is a simplified alternate version of #3418.

- keeps the incremental parser and memoized closed/open block rendering path
- moves parser state from global Jotai atoms into a component-local cache in DyadMarkdownParser
- reduces useStreamChat back to message patching plus a small chat-keyed streaming XML preview overlay
- removes streamingMessageId from full-message chunks where it was only used to reset renderer parser state
- clears the sidecar preview from renderer stream teardown instead of relying on a post-terminal chunk

## Why

The original PR had the right core performance idea, but most of the complexity came from synchronizing a second parser-state model with message patches, full-message replacements, resync, cancellation, errors, and stream completion. Keeping the parser state local to the renderer component preserves the closed-block referential identity win while avoiding that lifecycle bookkeeping.

## Validation

- npm test -- src/__tests__/streamingMessageParser.test.ts src/components/chat/DyadMarkdownParser.test.tsx
- npm run fmt
- npm run lint
- npm run ts
