### PR TITLE
ci: restore Playwright worker parallelism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,7 +274,11 @@ jobs:
       - name: E2E tests (Shard ${{ matrix.shard }}/${{ matrix.shardTotal }})
         env:
           FLAKINESS_ACCESS_TOKEN: ${{ secrets.FLAKINESS_ACCESS_TOKEN }}
+          # Self-hosted macOS runners can handle more parallelism.
+          PLAYWRIGHT_PARALLELISM: ${{ contains(matrix.os.image, 'self-hosted') && '3' || '1' }}
           # Self-hosted macOS runners use fewer retries (1) vs GitHub-hosted CI (2)
+          # TODO: If retry-only flakes persist, split retries into a separate
+          # unsharded Playwright run with PLAYWRIGHT_PARALLELISM=1.
           PLAYWRIGHT_RETRIES: ${{ contains(matrix.os.image, 'self-hosted') && '1' || '2' }}
         # You can add debug logging to make it easier to see what's failing
         # by adding "DEBUG=pw:browser" in front.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,21 +5,29 @@ import { FAKE_LLM_BASE_PORT } from "./e2e-tests/helpers/test-ports";
 export { FAKE_LLM_BASE_PORT };
 
 const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+const parallelism = parseInt(process.env.PLAYWRIGHT_PARALLELISM || "1", 10);
 
-// Single worker + one fake LLM server: parallel workers were flaky (shared state / timing).
+// Each parallel worker needs its own fake LLM server to avoid test interference.
 function generateWebServerConfigs(): PlaywrightTestConfig["webServer"] {
-  return {
-    // Server runs build to avoid race conditions with concurrent webServer starts
-    command: `cd testing/fake-llm-server && npm run build && npm start -- --port=${FAKE_LLM_BASE_PORT}`,
-    url: `http://localhost:${FAKE_LLM_BASE_PORT}/health`,
-    // In CI, always start a fresh server; locally, reuse if one is already running
-    reuseExistingServer: !process.env.CI,
-  };
+  const configs: NonNullable<PlaywrightTestConfig["webServer"]> = [];
+
+  for (let i = 0; i < parallelism; i++) {
+    const port = FAKE_LLM_BASE_PORT + i;
+    configs.push({
+      // Servers run build to avoid races when Playwright starts webServer entries concurrently.
+      command: `cd testing/fake-llm-server && npm run build && npm start -- --port=${port}`,
+      url: `http://localhost:${port}/health`,
+      // In CI, always start a fresh server; locally, reuse if one is already running
+      reuseExistingServer: !process.env.CI,
+    });
+  }
+
+  return configs;
 }
 
 const config: PlaywrightTestConfig = {
   testDir: "./e2e-tests",
-  workers: 1,
+  workers: parallelism,
   retries: parseInt(
     process.env.PLAYWRIGHT_RETRIES ?? (process.env.CI ? "2" : "0"),
     10,


### PR DESCRIPTION
## Summary
- Restore env-driven Playwright worker parallelism for E2E CI.
- Start one fake LLM web server per Playwright worker port.
- Add a TODO for splitting retry-only flakes into an unsharded retry run later.

## Test plan
- npm run fmt
- npm run lint:fix
- npm run ts
- npm test

#skip-bugbot