### PR TITLE
perf: incremental streaming renderer with component-local parser cache

### DIFF
--- a/e2e-tests/fixtures/streaming-render-large-block.md
+++ b/e2e-tests/fixtures/streaming-render-large-block.md
@@ -1,0 +1,474 @@
+Writing a large file to verify the in-progress open-block render path.
+
+<dyad-write path="src/streaming/StreamingRenderLargeBlock.tsx" description="Large block test fixture for in-progress render">
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+// This fixture is intentionally large so that the renderer spends a meaningful
+// portion of stream time inside the open dyad-write tag. The e2e test asserts
+// that the renderer surfaces the path attribute and the "Writing..." pending
+// indicator while the closing tag has not yet arrived.
+
+export interface StreamingRenderLargeBlockProps {
+  initialValue?: number;
+  step?: number;
+  label?: string;
+}
+
+const DEFAULT_STEP = 1;
+const DEFAULT_INITIAL_VALUE = 0;
+const DEFAULT_LABEL = "StreamingRenderLargeBlock";
+
+export const StreamingRenderLargeBlock: React.FC<StreamingRenderLargeBlockProps> = ({
+  initialValue = DEFAULT_INITIAL_VALUE,
+  step = DEFAULT_STEP,
+  label = DEFAULT_LABEL,
+}) => {
+  const [value, setValue] = useState<number>(initialValue);
+  const previousValue = useRef<number>(initialValue);
+
+  const increment = useCallback(() => {
+    setValue((prev) => prev + step);
+  }, [step]);
+
+  const decrement = useCallback(() => {
+    setValue((prev) => prev - step);
+  }, [step]);
+
+  const reset = useCallback(() => {
+    setValue(initialValue);
+  }, [initialValue]);
+
+  useEffect(() => {
+    previousValue.current = value;
+  }, [value]);
+
+  const summary = useMemo(() => {
+    return `${label}: current=${value}, previous=${previousValue.current}, step=${step}`;
+  }, [label, value, step]);
+
+  // Padding lines so the streamed content takes long enough that the e2e test
+  // can reliably observe the open dyad-write tag mid-stream. The fake LLM
+  // server streams 32 characters every 10ms, so each kilobyte of content adds
+  // roughly 300ms to the total stream time.
+  // padding-line-0001
+  // padding-line-0002
+  // padding-line-0003
+  // padding-line-0004
+  // padding-line-0005
+  // padding-line-0006
+  // padding-line-0007
+  // padding-line-0008
+  // padding-line-0009
+  // padding-line-0010
+  // padding-line-0011
+  // padding-line-0012
+  // padding-line-0013
+  // padding-line-0014
+  // padding-line-0015
+  // padding-line-0016
+  // padding-line-0017
+  // padding-line-0018
+  // padding-line-0019
+  // padding-line-0020
+  // padding-line-0021
+  // padding-line-0022
+  // padding-line-0023
+  // padding-line-0024
+  // padding-line-0025
+  // padding-line-0026
+  // padding-line-0027
+  // padding-line-0028
+  // padding-line-0029
+  // padding-line-0030
+  // padding-line-0031
+  // padding-line-0032
+  // padding-line-0033
+  // padding-line-0034
+  // padding-line-0035
+  // padding-line-0036
+  // padding-line-0037
+  // padding-line-0038
+  // padding-line-0039
+  // padding-line-0040
+  // padding-line-0041
+  // padding-line-0042
+  // padding-line-0043
+  // padding-line-0044
+  // padding-line-0045
+  // padding-line-0046
+  // padding-line-0047
+  // padding-line-0048
+  // padding-line-0049
+  // padding-line-0050
+  // padding-line-0051
+  // padding-line-0052
+  // padding-line-0053
+  // padding-line-0054
+  // padding-line-0055
+  // padding-line-0056
+  // padding-line-0057
+  // padding-line-0058
+  // padding-line-0059
+  // padding-line-0060
+  // padding-line-0061
+  // padding-line-0062
+  // padding-line-0063
+  // padding-line-0064
+  // padding-line-0065
+  // padding-line-0066
+  // padding-line-0067
+  // padding-line-0068
+  // padding-line-0069
+  // padding-line-0070
+  // padding-line-0071
+  // padding-line-0072
+  // padding-line-0073
+  // padding-line-0074
+  // padding-line-0075
+  // padding-line-0076
+  // padding-line-0077
+  // padding-line-0078
+  // padding-line-0079
+  // padding-line-0080
+  // padding-line-0081
+  // padding-line-0082
+  // padding-line-0083
+  // padding-line-0084
+  // padding-line-0085
+  // padding-line-0086
+  // padding-line-0087
+  // padding-line-0088
+  // padding-line-0089
+  // padding-line-0090
+  // padding-line-0091
+  // padding-line-0092
+  // padding-line-0093
+  // padding-line-0094
+  // padding-line-0095
+  // padding-line-0096
+  // padding-line-0097
+  // padding-line-0098
+  // padding-line-0099
+  // padding-line-0100
+  // padding-line-0101
+  // padding-line-0102
+  // padding-line-0103
+  // padding-line-0104
+  // padding-line-0105
+  // padding-line-0106
+  // padding-line-0107
+  // padding-line-0108
+  // padding-line-0109
+  // padding-line-0110
+  // padding-line-0111
+  // padding-line-0112
+  // padding-line-0113
+  // padding-line-0114
+  // padding-line-0115
+  // padding-line-0116
+  // padding-line-0117
+  // padding-line-0118
+  // padding-line-0119
+  // padding-line-0120
+  // padding-line-0121
+  // padding-line-0122
+  // padding-line-0123
+  // padding-line-0124
+  // padding-line-0125
+  // padding-line-0126
+  // padding-line-0127
+  // padding-line-0128
+  // padding-line-0129
+  // padding-line-0130
+  // padding-line-0131
+  // padding-line-0132
+  // padding-line-0133
+  // padding-line-0134
+  // padding-line-0135
+  // padding-line-0136
+  // padding-line-0137
+  // padding-line-0138
+  // padding-line-0139
+  // padding-line-0140
+  // padding-line-0141
+  // padding-line-0142
+  // padding-line-0143
+  // padding-line-0144
+  // padding-line-0145
+  // padding-line-0146
+  // padding-line-0147
+  // padding-line-0148
+  // padding-line-0149
+  // padding-line-0150
+  // padding-line-0151
+  // padding-line-0152
+  // padding-line-0153
+  // padding-line-0154
+  // padding-line-0155
+  // padding-line-0156
+  // padding-line-0157
+  // padding-line-0158
+  // padding-line-0159
+  // padding-line-0160
+  // padding-line-0161
+  // padding-line-0162
+  // padding-line-0163
+  // padding-line-0164
+  // padding-line-0165
+  // padding-line-0166
+  // padding-line-0167
+  // padding-line-0168
+  // padding-line-0169
+  // padding-line-0170
+  // padding-line-0171
+  // padding-line-0172
+  // padding-line-0173
+  // padding-line-0174
+  // padding-line-0175
+  // padding-line-0176
+  // padding-line-0177
+  // padding-line-0178
+  // padding-line-0179
+  // padding-line-0180
+  // padding-line-0181
+  // padding-line-0182
+  // padding-line-0183
+  // padding-line-0184
+  // padding-line-0185
+  // padding-line-0186
+  // padding-line-0187
+  // padding-line-0188
+  // padding-line-0189
+  // padding-line-0190
+  // padding-line-0191
+  // padding-line-0192
+  // padding-line-0193
+  // padding-line-0194
+  // padding-line-0195
+  // padding-line-0196
+  // padding-line-0197
+  // padding-line-0198
+  // padding-line-0199
+  // padding-line-0200
+  // padding-line-0201
+  // padding-line-0202
+  // padding-line-0203
+  // padding-line-0204
+  // padding-line-0205
+  // padding-line-0206
+  // padding-line-0207
+  // padding-line-0208
+  // padding-line-0209
+  // padding-line-0210
+  // padding-line-0211
+  // padding-line-0212
+  // padding-line-0213
+  // padding-line-0214
+  // padding-line-0215
+  // padding-line-0216
+  // padding-line-0217
+  // padding-line-0218
+  // padding-line-0219
+  // padding-line-0220
+  // padding-line-0221
+  // padding-line-0222
+  // padding-line-0223
+  // padding-line-0224
+  // padding-line-0225
+  // padding-line-0226
+  // padding-line-0227
+  // padding-line-0228
+  // padding-line-0229
+  // padding-line-0230
+  // padding-line-0231
+  // padding-line-0232
+  // padding-line-0233
+  // padding-line-0234
+  // padding-line-0235
+  // padding-line-0236
+  // padding-line-0237
+  // padding-line-0238
+  // padding-line-0239
+  // padding-line-0240
+  // padding-line-0241
+  // padding-line-0242
+  // padding-line-0243
+  // padding-line-0244
+  // padding-line-0245
+  // padding-line-0246
+  // padding-line-0247
+  // padding-line-0248
+  // padding-line-0249
+  // padding-line-0250
+  // padding-line-0251
+  // padding-line-0252
+  // padding-line-0253
+  // padding-line-0254
+  // padding-line-0255
+  // padding-line-0256
+  // padding-line-0257
+  // padding-line-0258
+  // padding-line-0259
+  // padding-line-0260
+  // padding-line-0261
+  // padding-line-0262
+  // padding-line-0263
+  // padding-line-0264
+  // padding-line-0265
+  // padding-line-0266
+  // padding-line-0267
+  // padding-line-0268
+  // padding-line-0269
+  // padding-line-0270
+  // padding-line-0271
+  // padding-line-0272
+  // padding-line-0273
+  // padding-line-0274
+  // padding-line-0275
+  // padding-line-0276
+  // padding-line-0277
+  // padding-line-0278
+  // padding-line-0279
+  // padding-line-0280
+  // padding-line-0281
+  // padding-line-0282
+  // padding-line-0283
+  // padding-line-0284
+  // padding-line-0285
+  // padding-line-0286
+  // padding-line-0287
+  // padding-line-0288
+  // padding-line-0289
+  // padding-line-0290
+  // padding-line-0291
+  // padding-line-0292
+  // padding-line-0293
+  // padding-line-0294
+  // padding-line-0295
+  // padding-line-0296
+  // padding-line-0297
+  // padding-line-0298
+  // padding-line-0299
+  // padding-line-0300
+  // padding-line-0301
+  // padding-line-0302
+  // padding-line-0303
+  // padding-line-0304
+  // padding-line-0305
+  // padding-line-0306
+  // padding-line-0307
+  // padding-line-0308
+  // padding-line-0309
+  // padding-line-0310
+  // padding-line-0311
+  // padding-line-0312
+  // padding-line-0313
+  // padding-line-0314
+  // padding-line-0315
+  // padding-line-0316
+  // padding-line-0317
+  // padding-line-0318
+  // padding-line-0319
+  // padding-line-0320
+  // padding-line-0321
+  // padding-line-0322
+  // padding-line-0323
+  // padding-line-0324
+  // padding-line-0325
+  // padding-line-0326
+  // padding-line-0327
+  // padding-line-0328
+  // padding-line-0329
+  // padding-line-0330
+  // padding-line-0331
+  // padding-line-0332
+  // padding-line-0333
+  // padding-line-0334
+  // padding-line-0335
+  // padding-line-0336
+  // padding-line-0337
+  // padding-line-0338
+  // padding-line-0339
+  // padding-line-0340
+  // padding-line-0341
+  // padding-line-0342
+  // padding-line-0343
+  // padding-line-0344
+  // padding-line-0345
+  // padding-line-0346
+  // padding-line-0347
+  // padding-line-0348
+  // padding-line-0349
+  // padding-line-0350
+  // padding-line-0351
+  // padding-line-0352
+  // padding-line-0353
+  // padding-line-0354
+  // padding-line-0355
+  // padding-line-0356
+  // padding-line-0357
+  // padding-line-0358
+  // padding-line-0359
+  // padding-line-0360
+  // padding-line-0361
+  // padding-line-0362
+  // padding-line-0363
+  // padding-line-0364
+  // padding-line-0365
+  // padding-line-0366
+  // padding-line-0367
+  // padding-line-0368
+  // padding-line-0369
+  // padding-line-0370
+  // padding-line-0371
+  // padding-line-0372
+  // padding-line-0373
+  // padding-line-0374
+  // padding-line-0375
+  // padding-line-0376
+  // padding-line-0377
+  // padding-line-0378
+  // padding-line-0379
+  // padding-line-0380
+  // padding-line-0381
+  // padding-line-0382
+  // padding-line-0383
+  // padding-line-0384
+  // padding-line-0385
+  // padding-line-0386
+  // padding-line-0387
+  // padding-line-0388
+  // padding-line-0389
+  // padding-line-0390
+  // padding-line-0391
+  // padding-line-0392
+  // padding-line-0393
+  // padding-line-0394
+  // padding-line-0395
+  // padding-line-0396
+  // padding-line-0397
+  // padding-line-0398
+  // padding-line-0399
+  // padding-line-0400
+
+  return (
+    <div data-testid="streaming-render-large-block">
+      <h1>{label}</h1>
+      <p>{summary}</p>
+      <button type="button" onClick={increment}>
+        Increment
+      </button>
+      <button type="button" onClick={decrement}>
+        Decrement
+      </button>
+      <button type="button" onClick={reset}>
+        Reset
+      </button>
+    </div>
+  );
+};
+
+export default StreamingRenderLargeBlock;
+</dyad-write>
+
+Wrote one large file.

--- a/e2e-tests/fixtures/streaming-render-multi-write.md
+++ b/e2e-tests/fixtures/streaming-render-multi-write.md
@@ -1,0 +1,84 @@
+Creating five files to verify streaming-renderer block stability.
+
+<dyad-write path="src/streaming/StreamingRenderBlockA.tsx" description="Block A test fixture">
+import React from "react";
+
+export const StreamingRenderBlockA = () => {
+  return (
+    <div data-testid="streaming-render-block-a">
+      <h1>Streaming Render Block A</h1>
+      <p>This block is the first of five emitted by the multi-write fixture.</p>
+      <p>Its purpose is to verify that closed blocks remain visible while later blocks are still streaming.</p>
+    </div>
+  );
+};
+
+export default StreamingRenderBlockA;
+</dyad-write>
+
+A short markdown paragraph between the first and second blocks so the parser sees a markdown segment as well as custom-tag segments.
+
+<dyad-write path="src/streaming/StreamingRenderBlockB.tsx" description="Block B test fixture">
+import React from "react";
+
+export const StreamingRenderBlockB = () => {
+  return (
+    <div data-testid="streaming-render-block-b">
+      <h1>Streaming Render Block B</h1>
+      <p>This block follows block A. By the time it appears, block A should already be closed and rendered.</p>
+      <p>The renderer must keep the block A subtree mounted across the chunks that produce block B.</p>
+    </div>
+  );
+};
+
+export default StreamingRenderBlockB;
+</dyad-write>
+
+Another markdown segment to exercise interleaved markdown and custom-tag block segments.
+
+<dyad-write path="src/streaming/StreamingRenderBlockC.tsx" description="Block C test fixture">
+import React from "react";
+
+export const StreamingRenderBlockC = () => {
+  return (
+    <div data-testid="streaming-render-block-c">
+      <h1>Streaming Render Block C</h1>
+      <p>This is the middle block of the fixture and serves as a sanity check that interior blocks render.</p>
+    </div>
+  );
+};
+
+export default StreamingRenderBlockC;
+</dyad-write>
+
+<dyad-write path="src/streaming/StreamingRenderBlockD.tsx" description="Block D test fixture">
+import React from "react";
+
+export const StreamingRenderBlockD = () => {
+  return (
+    <div data-testid="streaming-render-block-d">
+      <h1>Streaming Render Block D</h1>
+      <p>This is the fourth block of the fixture.</p>
+    </div>
+  );
+};
+
+export default StreamingRenderBlockD;
+</dyad-write>
+
+<dyad-write path="src/streaming/StreamingRenderBlockE.tsx" description="Block E test fixture">
+import React from "react";
+
+export const StreamingRenderBlockE = () => {
+  return (
+    <div data-testid="streaming-render-block-e">
+      <h1>Streaming Render Block E</h1>
+      <p>This is the last block of the fixture. By the time it appears, the test asserts blocks A through D are all still mounted.</p>
+    </div>
+  );
+};
+
+export default StreamingRenderBlockE;
+</dyad-write>
+
+All five files generated.

--- a/e2e-tests/streaming_renderer.spec.ts
+++ b/e2e-tests/streaming_renderer.spec.ts
@@ -1,0 +1,91 @@
+import { expect } from "@playwright/test";
+
+import { test } from "./helpers/test_helper";
+
+// These tests exercise the incremental streaming renderer in DyadMarkdownParser.
+// The fake LLM server streams responses character-by-character (32 chars / 10ms),
+// so the renderer sees many incremental chunks and the parser must build up the
+// block list piece-by-piece. The tests assert user-visible behavior; performance
+// properties (memo cache hit rates, closed-block ref stability, etc.) are
+// covered by unit tests on the parser and renderer.
+
+test("closed dyad-write blocks remain mounted while later blocks are still streaming", async ({
+  po,
+}) => {
+  await po.setUp();
+
+  await po.sendPrompt("tc=streaming-render-multi-write", {
+    skipWaitForCompletion: true,
+  });
+
+  const messagesList = po.page.getByTestId("messages-list");
+
+  const blockA = messagesList.getByText("StreamingRenderBlockA.tsx", {
+    exact: true,
+  });
+  const blockE = messagesList.getByText("StreamingRenderBlockE.tsx", {
+    exact: true,
+  });
+
+  // Block A is the first dyad-write in the fixture; it closes early in the
+  // stream. Wait for it to appear in the rendered output.
+  await expect(blockA).toBeVisible({ timeout: 15_000 });
+
+  // Block E is the last dyad-write; by the time it appears all earlier blocks
+  // must already be closed. This is the critical assertion: if the renderer
+  // were re-keying or unmounting closed blocks across chunks, block A would
+  // disappear by the time block E was rendered.
+  await expect(blockE).toBeVisible({ timeout: 15_000 });
+  await expect(blockA).toBeVisible();
+
+  // Wait for stream completion before final assertions.
+  await po.chatActions.waitForChatCompletion();
+
+  // All five blocks visible at the end of the stream.
+  for (const name of [
+    "StreamingRenderBlockA.tsx",
+    "StreamingRenderBlockB.tsx",
+    "StreamingRenderBlockC.tsx",
+    "StreamingRenderBlockD.tsx",
+    "StreamingRenderBlockE.tsx",
+  ]) {
+    await expect(messagesList.getByText(name, { exact: true })).toBeVisible();
+  }
+});
+
+test("in-progress dyad-write block surfaces path attribute and pending indicator before close tag arrives", async ({
+  po,
+}) => {
+  await po.setUp();
+
+  await po.sendPrompt("tc=streaming-render-large-block", {
+    skipWaitForCompletion: true,
+  });
+
+  const messagesList = po.page.getByTestId("messages-list");
+
+  // Wait for the pending indicator first. It only renders while the custom-tag
+  // block is in progress (state === "pending"); once the closing tag arrives
+  // the block transitions to "finished" and this indicator disappears. The
+  // fixture is sized so that the open-tag window is several seconds long,
+  // giving Playwright a comfortable window to observe it.
+  await expect(messagesList.getByText("Writing...")).toBeVisible({
+    timeout: 10_000,
+  });
+
+  // Path attribute is surfaced in the open-tag header as soon as the parser
+  // sees the opening `<dyad-write path="..." ...>` and emits a pending block.
+  // The pending indicator visible above implies the open block is rendered,
+  // so the path must be visible too.
+  await expect(
+    messagesList.getByText("StreamingRenderLargeBlock.tsx", { exact: true }),
+  ).toBeVisible();
+
+  await po.chatActions.waitForChatCompletion();
+
+  // After completion, the pending indicator is gone and the file path remains.
+  await expect(
+    messagesList.getByText("StreamingRenderLargeBlock.tsx", { exact: true }),
+  ).toBeVisible();
+  await expect(messagesList.getByText("Writing...")).not.toBeVisible();
+});

--- a/src/atoms/chatAtoms.ts
+++ b/src/atoms/chatAtoms.ts
@@ -263,3 +263,12 @@ export const streamCompletedSuccessfullyByIdAtom = atom<Map<number, boolean>>(
 
 // Tracks if the queue is paused for each chat (Map<chatId, isPaused>)
 export const queuePausedByIdAtom = atom<Map<number, boolean>>(new Map());
+
+// Sidecar overlay for tool-input XML preview during Pro/Agent v2 streaming.
+// Lives outside message.content so the patch protocol stays strictly
+// append-only — buildXml output rewrites its prefix per JSON delta, which
+// would otherwise force non-tail patch escalation to fullMessages. Keyed by
+// chat id; only the last streaming assistant message renders it.
+export const streamingPreviewByChatIdAtom = atom<Map<number, string>>(
+  new Map(),
+);

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -20,6 +20,7 @@ import {
 import { formatDistanceToNow, format } from "date-fns";
 import { useVersions } from "@/hooks/useVersions";
 import { useAtomValue } from "jotai";
+import { selectAtom } from "jotai/utils";
 import { selectedAppIdAtom } from "@/atoms/appAtoms";
 import {
   selectedChatIdAtom,
@@ -100,20 +101,24 @@ const ChatMessage = ({
     message.role === "assistant"
       ? stripCancelledResponseNotice(message.content)
       : "";
-  // Sidecar tool-input XML preview lives outside message.content, so a turn
-  // that starts with a tool call (empty content + active preview) must still
-  // mount DyadMarkdownParser to surface the preview overlay. Without this,
-  // the loading-animation branch fires and the preview is hidden until final
-  // content is committed.
+  // Sidecar tool-input XML preview lives outside message.content. Subscribe
+  // to a per-chat boolean derived atom so non-last messages don't re-render
+  // every preview chunk — only on the boolean transition.
   const selectedChatId = useAtomValue(selectedChatIdAtom);
-  const previewByChatId = useAtomValue(streamingPreviewByChatIdAtom);
+  const hasPreviewForChatAtom = useMemo(
+    () =>
+      selectAtom(streamingPreviewByChatIdAtom, (m) => {
+        if (selectedChatId == null) return false;
+        return (m.get(selectedChatId)?.length ?? 0) > 0;
+      }),
+    [selectedChatId],
+  );
+  const hasPreviewForChat = useAtomValue(hasPreviewForChatAtom);
   const hasStreamingPreview =
     message.role === "assistant" &&
     isLastMessage &&
     isStreaming &&
-    selectedChatId !== null &&
-    selectedChatId !== undefined &&
-    (previewByChatId.get(selectedChatId)?.length ?? 0) > 0;
+    hasPreviewForChat;
   const hasAssistantText =
     message.role === "assistant" &&
     (assistantTextContent.length > 0 || hasStreamingPreview);

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -109,6 +109,8 @@ const ChatMessage = ({
   const previewByChatId = useAtomValue(streamingPreviewByChatIdAtom);
   const hasStreamingPreview =
     message.role === "assistant" &&
+    isLastMessage &&
+    isStreaming &&
     selectedChatId !== null &&
     selectedChatId !== undefined &&
     (previewByChatId.get(selectedChatId)?.length ?? 0) > 0;

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -21,6 +21,10 @@ import { formatDistanceToNow, format } from "date-fns";
 import { useVersions } from "@/hooks/useVersions";
 import { useAtomValue } from "jotai";
 import { selectedAppIdAtom } from "@/atoms/appAtoms";
+import {
+  selectedChatIdAtom,
+  streamingPreviewByChatIdAtom,
+} from "@/atoms/chatAtoms";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import {
@@ -96,8 +100,21 @@ const ChatMessage = ({
     message.role === "assistant"
       ? stripCancelledResponseNotice(message.content)
       : "";
+  // Sidecar tool-input XML preview lives outside message.content, so a turn
+  // that starts with a tool call (empty content + active preview) must still
+  // mount DyadMarkdownParser to surface the preview overlay. Without this,
+  // the loading-animation branch fires and the preview is hidden until final
+  // content is committed.
+  const selectedChatId = useAtomValue(selectedChatIdAtom);
+  const previewByChatId = useAtomValue(streamingPreviewByChatIdAtom);
+  const hasStreamingPreview =
+    message.role === "assistant" &&
+    selectedChatId !== null &&
+    selectedChatId !== undefined &&
+    (previewByChatId.get(selectedChatId)?.length ?? 0) > 0;
   const hasAssistantText =
-    message.role === "assistant" && assistantTextContent.length > 0;
+    message.role === "assistant" &&
+    (assistantTextContent.length > 0 || hasStreamingPreview);
   //handle copy chat
   const { copyMessageContent, copied } = useCopyToClipboard();
   const handleCopyFormatted = async () => {

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -197,7 +197,11 @@ const ChatMessage = ({
               >
                 {message.role === "assistant" ? (
                   <>
-                    <DyadMarkdownParser content={assistantTextContent} />
+                    <DyadMarkdownParser
+                      content={assistantTextContent}
+                      messageId={message.id}
+                      showStreamingPreview={isLastMessage && isStreaming}
+                    />
                     {isLastMessage && isStreaming && (
                       <StreamingLoadingAnimation variant="streaming" />
                     )}

--- a/src/components/chat/DyadMarkdownParser.test.tsx
+++ b/src/components/chat/DyadMarkdownParser.test.tsx
@@ -1,6 +1,12 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import * as parserModule from "@/lib/streamingMessageParser";
+import type {
+  Block as ParserBlock,
+  ParserState,
+} from "@/lib/streamingMessageParser";
+
 // Track every render of the inner ReactMarkdown component keyed by the
 // content string it received. The DyadMarkdownParser wraps ReactMarkdown
 // inside a React.memo'd MemoMarkdown, so a call here means the memo did
@@ -111,5 +117,111 @@ describe("DyadMarkdownParser closed-block render counts", () => {
     }
     expect(markdownRenderCounts.get(MD1)).toBe(md1AfterClose);
     expect(markdownRenderCounts.get(MD2)).toBe(md2AfterClose);
+  });
+});
+
+describe("DyadMarkdownParser parser-cache perf metrics", () => {
+  // Spies on the exported parser entry points. Pre-cache builds rebuild
+  // every Block on every chunk via parseFullMessage; post-cache routes
+  // through advanceParser with a stable ParserState. We spy on both so a
+  // single test can run unmodified on either branch.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let advanceSpy: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let parseFullSpy: any;
+
+  beforeEach(() => {
+    markdownRenderCounts.clear();
+    advanceSpy = vi.spyOn(parserModule, "advanceParser");
+    parseFullSpy = vi.spyOn(parserModule, "parseFullMessage");
+  });
+
+  afterEach(() => {
+    cleanup();
+    advanceSpy.mockRestore();
+    parseFullSpy.mockRestore();
+  });
+
+  const MD1 = "First paragraph content goes here.\n\n";
+  const TAG1 = '<dyad-status title="S1" state="finished">ok</dyad-status>';
+  const MD2 = "\n\nSecond paragraph content goes here.\n\n";
+  const TAG2 = '<dyad-status title="S2" state="finished">ok</dyad-status>';
+  const MD3 = "\n\nThird paragraph content goes here.";
+  const FULL = MD1 + TAG1 + MD2 + TAG2 + MD3;
+
+  // Returned states in call order, with bytes-scanned for each call. For
+  // advanceParser we infer scanned bytes from the cursor delta; for
+  // parseFullMessage we treat the full input length as scanned (the parser
+  // restarts from cursor 0).
+  function collectCalls(): { state: ParserState; bytesScanned: number }[] {
+    const out: { state: ParserState; bytesScanned: number }[] = [];
+    (advanceSpy.mock.calls as unknown[][]).forEach((args, i) => {
+      const prev = args[0] as ParserState;
+      const next = advanceSpy.mock.results[i].value as ParserState;
+      out.push({ state: next, bytesScanned: next.cursor - prev.cursor });
+    });
+    (parseFullSpy.mock.calls as unknown[][]).forEach((args, i) => {
+      const content = args[0] as string;
+      const result = parseFullSpy.mock.results[i].value as {
+        state: ParserState;
+      };
+      out.push({ state: result.state, bytesScanned: content.length });
+    });
+    return out;
+  }
+
+  function streamFully() {
+    const { rerender } = render(
+      <DyadMarkdownParser content={FULL.slice(0, 1)} />,
+    );
+    for (let i = 2; i <= FULL.length; i++) {
+      rerender(<DyadMarkdownParser content={FULL.slice(0, i)} />);
+    }
+  }
+
+  it("scans each input byte at most a small constant number of times across a stream", () => {
+    streamFully();
+    const calls = collectCalls();
+    const totalBytesScanned = calls.reduce((s, c) => s + c.bytesScanned, 0);
+    // Linear in message length, not quadratic in chunk count. A parse-
+    // from-scratch implementation hits ~N²/2 (here ≈ 19_000) and busts
+    // this bound; the cached state.cursor keeps it near N.
+    expect(totalBytesScanned).toBeLessThanOrEqual(FULL.length * 2);
+  });
+
+  it("allocates each closed Block exactly once across the stream", () => {
+    streamFully();
+    const calls = collectCalls();
+    const closedBlockRefs = new Set<ParserBlock>();
+    for (const c of calls) {
+      for (const b of c.state.blocks) closedBlockRefs.add(b);
+    }
+    const finalClosedCount = calls[calls.length - 1].state.blocks.length;
+    // Without the cache, every chunk rebuilds every closed Block; the
+    // unique-ref count balloons to ~closedBlocks × chunks. With the
+    // cache, each closed Block keeps one stable reference.
+    expect(closedBlockRefs.size).toBeLessThanOrEqual(finalClosedCount + 1);
+  });
+
+  it("preserves the state.blocks array reference across chunks that do not close a block", () => {
+    streamFully();
+    const calls = collectCalls();
+    let nonClosingPairs = 0;
+    let stablePairs = 0;
+    for (let i = 1; i < calls.length; i++) {
+      const prev = calls[i - 1].state;
+      const next = calls[i].state;
+      if (next.blocks.length === prev.blocks.length) {
+        nonClosingPairs++;
+        if (prev.blocks === next.blocks) stablePairs++;
+      }
+    }
+    // Sanity: streaming a multi-block message char-by-char produces many
+    // chunks that do not close a block — make sure the harness saw them.
+    expect(nonClosingPairs).toBeGreaterThan(0);
+    // This is the property MemoClosedBlocks's default shallow equality
+    // depends on: when no block closes, the blocks-array ref must stay
+    // stable so React.memo bails out the entire subtree in O(1).
+    expect(stablePairs).toBe(nonClosingPairs);
   });
 });

--- a/src/components/chat/DyadMarkdownParser.test.tsx
+++ b/src/components/chat/DyadMarkdownParser.test.tsx
@@ -1,11 +1,27 @@
 import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { DyadMarkdownParser } from "./DyadMarkdownParser";
+// Track every render of the inner ReactMarkdown component keyed by the
+// content string it received. The DyadMarkdownParser wraps ReactMarkdown
+// inside a React.memo'd MemoMarkdown, so a call here means the memo did
+// not short-circuit — i.e. the block actually re-rendered.
+const markdownRenderCounts = new Map<string, number>();
+
+vi.mock("react-markdown", () => ({
+  default: function MockReactMarkdown({ children }: { children: string }) {
+    markdownRenderCounts.set(
+      children,
+      (markdownRenderCounts.get(children) ?? 0) + 1,
+    );
+    return null;
+  },
+}));
 
 vi.mock("../preview_panel/FileEditor", () => ({
   FileEditor: () => null,
 }));
+
+import { DyadMarkdownParser } from "./DyadMarkdownParser";
 
 describe("DyadMarkdownParser dyad-status", () => {
   afterEach(() => {
@@ -25,5 +41,75 @@ describe("DyadMarkdownParser dyad-status", () => {
 
     expect(screen.getByText("Supabase functions failed")).toBeTruthy();
     expect(statusCard.className).toContain("border-l-red-500");
+  });
+});
+
+describe("DyadMarkdownParser closed-block render counts", () => {
+  beforeEach(() => {
+    markdownRenderCounts.clear();
+  });
+  afterEach(() => {
+    cleanup();
+  });
+
+  // Three markdown segments separated by two closed dyad-status tags.
+  // After the parser consumes everything, each markdown segment becomes
+  // its own closed Block whose `content` is exactly the bytes between
+  // the previous tag's `>` and the next tag's `<`. We put the `\n\n`
+  // separators on the markdown-side of the constants so each constant
+  // matches the closed Block's content string verbatim.
+  const MD1 = "First paragraph content.\n\n";
+  const TAG1 = '<dyad-status title="S1" state="finished">ok</dyad-status>';
+  const MD2 = "\n\nSecond paragraph content.\n\n";
+  const TAG2 = '<dyad-status title="S2" state="finished">ok</dyad-status>';
+  const MD3 = "\n\nThird paragraph content.";
+  const FULL = MD1 + TAG1 + MD2 + TAG2 + MD3;
+
+  it("renders each markdown block exactly once for a one-shot parse", () => {
+    render(<DyadMarkdownParser content={FULL} />);
+
+    // MD1 / MD2 are closed markdown blocks. MD3 is the trailing open block
+    // (parser only closes a markdown block when a custom tag opens after
+    // it). All three should reach the inner ReactMarkdown exactly once.
+    expect(markdownRenderCounts.get(MD1)).toBe(1);
+    expect(markdownRenderCounts.get(MD2)).toBe(1);
+    expect(markdownRenderCounts.get(MD3)).toBe(1);
+  });
+
+  it("does not re-render closed markdown blocks as later content streams in", () => {
+    // Each markdown block closes when the parser consumes the '>' of the
+    // next custom tag's opening. After close, the closed-block's MemoMarkdown
+    // should never re-execute even though many more chunks arrive.
+    const md1ClosesAt = MD1.length + TAG1.indexOf(">") + 1;
+    const md2ClosesAt =
+      MD1.length + TAG1.length + MD2.length + TAG2.indexOf(">") + 1;
+
+    // Phase 1: render up through the chunk that closes MD1.
+    const { rerender } = render(
+      <DyadMarkdownParser content={FULL.slice(0, md1ClosesAt)} />,
+    );
+    const md1AfterClose = markdownRenderCounts.get(MD1) ?? 0;
+    expect(md1AfterClose).toBeGreaterThanOrEqual(1);
+
+    // Phase 2: stream one character at a time through MD2's close.
+    for (let i = md1ClosesAt + 1; i <= md2ClosesAt; i++) {
+      rerender(<DyadMarkdownParser content={FULL.slice(0, i)} />);
+    }
+    const md2AfterClose = markdownRenderCounts.get(MD2) ?? 0;
+    expect(md2AfterClose).toBeGreaterThanOrEqual(1);
+
+    // MD1 already closed; the renders in phase 2 should leave its count
+    // untouched. This is the property the component-local parser cache
+    // unlocks: a closed block's content prop is referentially stable, so
+    // React.memo skips its subtree on every subsequent chunk.
+    expect(markdownRenderCounts.get(MD1)).toBe(md1AfterClose);
+
+    // Phase 3: stream through the rest of the message. Both MD1 and MD2
+    // are already closed; neither should re-render.
+    for (let i = md2ClosesAt + 1; i <= FULL.length; i++) {
+      rerender(<DyadMarkdownParser content={FULL.slice(0, i)} />);
+    }
+    expect(markdownRenderCounts.get(MD1)).toBe(md1AfterClose);
+    expect(markdownRenderCounts.get(MD2)).toBe(md2AfterClose);
   });
 });

--- a/src/components/chat/DyadMarkdownParser.tsx
+++ b/src/components/chat/DyadMarkdownParser.tsx
@@ -157,44 +157,59 @@ export const DyadMarkdownParser: React.FC<DyadMarkdownParserProps> = ({
 
   // The button is hidden while streaming, so avoid scanning the block list on
   // every chunk. Do the full scan only for settled content.
-  const { errorMessages, errorCount } = useMemo(() => {
+  const { errorMessages, errorCount, lastErrorIndex } = useMemo(() => {
     if (isStreaming) {
-      return { errorMessages: [], errorCount: 0 };
+      return EMPTY_ERROR_SCAN;
     }
     const errors: string[] = [];
-    const collectFrom = (block: Block) => {
+    let lastIndex = -1;
+    closedBlocks.forEach((block, index) => {
       if (
         block.kind === "custom-tag" &&
         block.tag === "dyad-output" &&
         block.attributes.type === "error"
       ) {
         const msg = block.attributes.message?.trim();
-        if (msg) errors.push(msg);
+        if (msg) {
+          errors.push(msg);
+          lastIndex = index;
+        }
       }
+    });
+    return {
+      errorMessages: errors,
+      errorCount: errors.length,
+      lastErrorIndex: lastIndex,
     };
-    for (const block of closedBlocks) collectFrom(block);
-    if (openBlock) collectFrom(openBlock);
-    return { errorMessages: errors, errorCount: errors.length };
-  }, [closedBlocks, openBlock, isStreaming]);
+  }, [closedBlocks, isStreaming]);
 
   const showFixAll =
     errorCount > 1 && !isStreaming && chatId !== null && chatId !== undefined;
 
   return (
     <>
-      <MemoClosedBlocks blocks={closedBlocks} />
+      <MemoClosedBlocks
+        blocks={closedBlocks}
+        lastErrorIndex={lastErrorIndex}
+        errorMessages={errorMessages}
+        showFixAll={showFixAll}
+        chatId={chatId ?? null}
+      />
       {openBlock ? renderBlock(openBlock, isStreaming) : null}
       {showStreamingPreview && chatId !== null && chatId !== undefined && (
         <StreamingPreviewBlocks chatId={chatId} isStreaming={isStreaming} />
       )}
-      {showFixAll && (
-        <div className="mt-3 w-full flex">
-          <FixAllErrorsButton errorMessages={errorMessages} chatId={chatId!} />
-        </div>
-      )}
     </>
   );
 };
+
+// Stable ref for the "nothing to scan" return path so MemoClosedBlocks's
+// memo doesn't invalidate every render during streaming.
+const EMPTY_ERROR_SCAN: {
+  errorMessages: string[];
+  errorCount: number;
+  lastErrorIndex: number;
+} = { errorMessages: [], errorCount: 0, lastErrorIndex: -1 };
 
 function StreamingPreviewBlocks({
   chatId,
@@ -231,27 +246,52 @@ function renderBlock(block: Block, isStreaming: boolean): React.ReactNode {
 }
 
 // Memoized wrapper for closed blocks. Memo hits when the `blocks` array ref
-// is unchanged (chunks that just extend the open block) so the entire
-// closed-block subtree is skipped — O(1) per chunk in the common case.
-// On commit chunks, the wrapper re-renders and reconciles N child fibers,
-// but each child is also memoed on `prev.block === next.block` so closed
-// children short-circuit and never re-render their subtrees.
+// and error-related props are unchanged (chunks that just extend the open
+// block) so the entire closed-block subtree is skipped — O(1) per chunk in
+// the common case. On commit chunks, the wrapper re-renders and reconciles
+// N child fibers, but each child is also memoed on `prev.block === next.block`
+// so closed children short-circuit and never re-render their subtrees.
 //
 // Closed blocks are by definition not in progress, so renderBlock can pass
 // isStreaming: false here unconditionally — the inner MemoBlockCustomTag
 // comparator already short-circuits on inProgress === false. Dropping the
 // prop also avoids unnecessary re-renders when isStreaming flips while
 // this component is still mounted.
+//
+// FixAllErrorsButton is rendered inline immediately after the last closed
+// dyad-output error block (when there are multiple errors). Placing it
+// adjacent to the relevant errors makes the connection obvious and matches
+// the pre-PR behavior. The `errorMessages` reference is stabilized in the
+// parent's useMemo so streaming-time renders don't churn this memo.
 const MemoClosedBlocks = React.memo(function MemoClosedBlocks({
   blocks,
+  lastErrorIndex,
+  errorMessages,
+  showFixAll,
+  chatId,
 }: {
   blocks: Block[];
+  lastErrorIndex: number;
+  errorMessages: string[];
+  showFixAll: boolean;
+  chatId: number | null;
 }) {
   return (
     <>
-      {blocks.map((block) => (
+      {blocks.map((block, index) => (
         <React.Fragment key={block.id}>
           {renderBlock(block, false)}
+          {showFixAll &&
+            index === lastErrorIndex &&
+            chatId !== null &&
+            chatId !== undefined && (
+              <div className="mt-3 w-full flex">
+                <FixAllErrorsButton
+                  errorMessages={errorMessages}
+                  chatId={chatId}
+                />
+              </div>
+            )}
         </React.Fragment>
       ))}
     </>

--- a/src/components/chat/DyadMarkdownParser.tsx
+++ b/src/components/chat/DyadMarkdownParser.tsx
@@ -1,4 +1,4 @@
-import React, { useDeferredValue, useMemo } from "react";
+import React, { useDeferredValue, useMemo, useRef } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
@@ -18,7 +18,11 @@ import { DyadCodebaseContext } from "./DyadCodebaseContext";
 import { DyadThink } from "./DyadThink";
 import { CodeHighlight } from "./CodeHighlight";
 import { useAtomValue } from "jotai";
-import { isStreamingByIdAtom, selectedChatIdAtom } from "@/atoms/chatAtoms";
+import {
+  isStreamingByIdAtom,
+  selectedChatIdAtom,
+  streamingPreviewByChatIdAtom,
+} from "@/atoms/chatAtoms";
 import { CustomTagState } from "./stateTypes";
 import { DyadOutput } from "./DyadOutput";
 import { DyadProblemSummary } from "./DyadProblemSummary";
@@ -49,13 +53,20 @@ import { DyadScript } from "./DyadScript";
 import { mapActionToButton } from "./ChatInput";
 import { SuggestedAction } from "@/lib/schemas";
 import { FixAllErrorsButton } from "./FixAllErrorsButton";
-import { type Block, parseFullMessage } from "@/lib/streamingMessageParser";
+import {
+  advanceParser,
+  type Block,
+  getOpenBlock,
+  initialParserState,
+  parseFullMessage,
+  type ParserState,
+} from "@/lib/streamingMessageParser";
 
 interface DyadMarkdownParserProps {
   content: string;
+  messageId?: number;
+  showStreamingPreview?: boolean;
 }
-
-type CustomTagBlock = Extract<Block, { kind: "custom-tag" }>;
 
 const customLink = ({
   node: _node,
@@ -93,74 +104,159 @@ export const VanillaMarkdownParser = ({ content }: { content: string }) => {
 /**
  * Custom component to parse markdown content with Dyad-specific tags.
  *
- * Block list is produced by an incremental dyad-tag parser
- * (src/lib/streamingMessageParser.ts) called one-shot per render.
+ * The block list is sourced from a component-local incremental parser. Completed
+ * blocks keep referential identity across streaming chunks, so React.memo can
+ * skip prior blocks and leave only the open trailing block to re-render.
  */
 export const DyadMarkdownParser: React.FC<DyadMarkdownParserProps> = ({
   content,
+  messageId,
+  showStreamingPreview = false,
 }) => {
   const chatId = useAtomValue(selectedChatIdAtom);
-  const isStreaming = useAtomValue(isStreamingByIdAtom).get(chatId!) ?? false;
+  const isStreamingMap = useAtomValue(isStreamingByIdAtom);
+  const isStreaming =
+    chatId != null ? (isStreamingMap.get(chatId) ?? false) : false;
   const deferredContent = useDeferredValue(content);
   const contentToParse = isStreaming ? deferredContent : content;
 
-  const blocks = useMemo(
-    () => parseFullMessage(contentToParse).blocks,
-    [contentToParse],
-  );
+  // Component-local parser cache. Closed-block refs stay stable across chunks
+  // so MemoClosedBlocks can skip its subtree; only the open trailing block
+  // changes shape per chunk. On prefix-mismatch (full-message replace, etc.)
+  // we restart from initialParserState — same correctness as a one-shot parse.
+  //
+  // Note: we write to parserCacheRef inside useMemo. React docs flag this as
+  // a side effect during render; in practice the cache is purely advisory and
+  // advanceParser is deterministic on (state, content), so the worst case
+  // (StrictMode dev double-render, discarded concurrent render) is a wasted
+  // re-parse, not a correctness issue.
+  const parserCacheRef = useRef<{
+    messageId?: number;
+    content: string;
+    state: ParserState;
+  } | null>(null);
 
-  const { errorMessages, lastErrorIndex, errorCount } = useMemo(() => {
+  const parserState = useMemo(() => {
+    const cached = parserCacheRef.current;
+    if (
+      cached &&
+      cached.messageId === messageId &&
+      contentToParse.startsWith(cached.content)
+    ) {
+      const state = advanceParser(cached.state, contentToParse);
+      parserCacheRef.current = { messageId, content: contentToParse, state };
+      return state;
+    }
+    const state = advanceParser(initialParserState(), contentToParse);
+    parserCacheRef.current = { messageId, content: contentToParse, state };
+    return state;
+  }, [messageId, contentToParse]);
+
+  const closedBlocks = parserState.blocks;
+  const openBlock = getOpenBlock(parserState);
+
+  // The button is hidden while streaming, so avoid scanning the block list on
+  // every chunk. Do the full scan only for settled content.
+  const { errorMessages, errorCount } = useMemo(() => {
+    if (isStreaming) {
+      return { errorMessages: [], errorCount: 0 };
+    }
     const errors: string[] = [];
-    let lastIndex = -1;
-    let count = 0;
-
-    blocks.forEach((block, index) => {
+    const collectFrom = (block: Block) => {
       if (
         block.kind === "custom-tag" &&
         block.tag === "dyad-output" &&
         block.attributes.type === "error"
       ) {
-        const errorMessage = block.attributes.message;
-        if (errorMessage?.trim()) {
-          errors.push(errorMessage.trim());
-          count++;
-          lastIndex = index;
-        }
+        const msg = block.attributes.message?.trim();
+        if (msg) errors.push(msg);
       }
-    });
-
-    return {
-      errorMessages: errors,
-      lastErrorIndex: lastIndex,
-      errorCount: count,
     };
-  }, [blocks]);
+    for (const block of closedBlocks) collectFrom(block);
+    if (openBlock) collectFrom(openBlock);
+    return { errorMessages: errors, errorCount: errors.length };
+  }, [closedBlocks, openBlock, isStreaming]);
+
+  const showFixAll =
+    errorCount > 1 && !isStreaming && chatId !== null && chatId !== undefined;
 
   return (
     <>
-      {blocks.map((block, index) => (
-        <React.Fragment key={block.id}>
-          {block.kind === "markdown" ? (
-            block.content && <MemoMarkdown content={block.content} />
-          ) : (
-            <MemoCustomTag block={block} isStreaming={isStreaming} />
-          )}
-          {index === lastErrorIndex &&
-            errorCount > 1 &&
-            !isStreaming &&
-            chatId && (
-              <div className="mt-3 w-full flex">
-                <FixAllErrorsButton
-                  errorMessages={errorMessages}
-                  chatId={chatId}
-                />
-              </div>
-            )}
+      <MemoClosedBlocks blocks={closedBlocks} />
+      {openBlock ? renderBlock(openBlock, isStreaming) : null}
+      {showStreamingPreview && chatId !== null && chatId !== undefined && (
+        <StreamingPreviewBlocks chatId={chatId} isStreaming={isStreaming} />
+      )}
+      {showFixAll && (
+        <div className="mt-3 w-full flex">
+          <FixAllErrorsButton errorMessages={errorMessages} chatId={chatId!} />
+        </div>
+      )}
+    </>
+  );
+};
+
+function StreamingPreviewBlocks({
+  chatId,
+  isStreaming,
+}: {
+  chatId: number;
+  isStreaming: boolean;
+}) {
+  const previewStates = useAtomValue(streamingPreviewByChatIdAtom);
+  const previewXml = previewStates.get(chatId);
+  const previewBlocks = useMemo<Block[] | null>(() => {
+    if (!previewXml) return null;
+    return parseFullMessage(previewXml).blocks;
+  }, [previewXml]);
+
+  if (!previewBlocks) return null;
+
+  return (
+    <>
+      {previewBlocks.map((block) => (
+        <React.Fragment key={`preview-${block.id}`}>
+          {renderBlock(block, isStreaming)}
         </React.Fragment>
       ))}
     </>
   );
-};
+}
+
+function renderBlock(block: Block, isStreaming: boolean): React.ReactNode {
+  if (block.kind === "markdown") {
+    return block.content ? <MemoMarkdown content={block.content} /> : null;
+  }
+  return <MemoBlockCustomTag block={block} isStreaming={isStreaming} />;
+}
+
+// Memoized wrapper for closed blocks. Memo hits when the `blocks` array ref
+// is unchanged (chunks that just extend the open block) so the entire
+// closed-block subtree is skipped — O(1) per chunk in the common case.
+// On commit chunks, the wrapper re-renders and reconciles N child fibers,
+// but each child is also memoed on `prev.block === next.block` so closed
+// children short-circuit and never re-render their subtrees.
+//
+// Closed blocks are by definition not in progress, so renderBlock can pass
+// isStreaming: false here unconditionally — the inner MemoBlockCustomTag
+// comparator already short-circuits on inProgress === false. Dropping the
+// prop also avoids unnecessary re-renders when isStreaming flips while
+// this component is still mounted.
+const MemoClosedBlocks = React.memo(function MemoClosedBlocks({
+  blocks,
+}: {
+  blocks: Block[];
+}) {
+  return (
+    <>
+      {blocks.map((block) => (
+        <React.Fragment key={block.id}>
+          {renderBlock(block, false)}
+        </React.Fragment>
+      ))}
+    </>
+  );
+});
 
 // Module-level constants so MemoMarkdown never gets fresh refs for these
 // props, which would defeat ReactMarkdown's internal prop-equality checks.
@@ -168,9 +264,7 @@ const REMARK_PLUGINS = [remarkGfm];
 const MARKDOWN_COMPONENTS = { code: CodeHighlight, a: customLink };
 
 // Memoized markdown piece. Without this, ReactMarkdown re-parses every
-// completed segment's text into an AST on every streaming chunk —
-// the dominant per-render cost during long streams. Memoizing on
-// `content` lets completed segments skip that re-parse entirely.
+// completed segment's text into an AST on every streaming chunk.
 const MemoMarkdown = React.memo(function MemoMarkdown({
   content,
 }: {
@@ -186,27 +280,14 @@ const MemoMarkdown = React.memo(function MemoMarkdown({
   );
 });
 
-function customTagBlockEqual(a: CustomTagBlock, b: CustomTagBlock): boolean {
-  if (a.tag !== b.tag) return false;
-  if (a.content !== b.content) return false;
-  if (a.inProgress !== b.inProgress) return false;
-  const aKeys = Object.keys(a.attributes);
-  const bKeys = Object.keys(b.attributes);
-  if (aKeys.length !== bKeys.length) return false;
-  for (const k of aKeys) {
-    if (a.attributes[k] !== b.attributes[k]) return false;
-  }
-  return true;
-}
+type CustomTagBlock = Extract<Block, { kind: "custom-tag" }>;
 
-// Memoized custom-tag piece. parseFullMessage rebuilds Block objects on
-// every chunk (new refs), so React.memo's default referential equality
-// would never hit. The custom comparator deep-checks the fields that
-// actually affect the rendered output, so completed dyad tags skip
-// renderCustomTag and the React subtree rebuild when only later blocks
-// change.
-const MemoCustomTag = React.memo(
-  function MemoCustomTag({
+// Memoized custom-tag block. The incremental parser preserves the Block
+// reference for any completed (closed) tag across streaming patches, so
+// referential equality on `block` is sufficient — completed blocks
+// short-circuit and skip renderCustomTag entirely.
+const MemoBlockCustomTag = React.memo(
+  function MemoBlockCustomTag({
     block,
     isStreaming,
   }: {
@@ -216,9 +297,9 @@ const MemoCustomTag = React.memo(
     return <>{renderCustomTag(block, { isStreaming })}</>;
   },
   (prev, next) =>
-    customTagBlockEqual(prev.block, next.block) &&
-    // Completed tags don't use isStreaming (getState returns "finished"
-    // regardless), so skip the check to avoid a one-time re-render of every
+    prev.block === next.block &&
+    // Completed tags ignore isStreaming (getState returns "finished"
+    // regardless), so skip the check to avoid one-time re-renders of every
     // completed tag when streaming ends.
     (prev.block.inProgress === false || prev.isStreaming === next.isStreaming),
 );

--- a/src/components/chat/DyadMarkdownParser.tsx
+++ b/src/components/chat/DyadMarkdownParser.tsx
@@ -245,24 +245,10 @@ function renderBlock(block: Block, isStreaming: boolean): React.ReactNode {
   return <MemoBlockCustomTag block={block} isStreaming={isStreaming} />;
 }
 
-// Memoized wrapper for closed blocks. Memo hits when the `blocks` array ref
-// and error-related props are unchanged (chunks that just extend the open
-// block) so the entire closed-block subtree is skipped — O(1) per chunk in
-// the common case. On commit chunks, the wrapper re-renders and reconciles
-// N child fibers, but each child is also memoed on `prev.block === next.block`
-// so closed children short-circuit and never re-render their subtrees.
-//
-// Closed blocks are by definition not in progress, so renderBlock can pass
-// isStreaming: false here unconditionally — the inner MemoBlockCustomTag
-// comparator already short-circuits on inProgress === false. Dropping the
-// prop also avoids unnecessary re-renders when isStreaming flips while
-// this component is still mounted.
-//
-// FixAllErrorsButton is rendered inline immediately after the last closed
-// dyad-output error block (when there are multiple errors). Placing it
-// adjacent to the relevant errors makes the connection obvious and matches
-// the pre-PR behavior. The `errorMessages` reference is stabilized in the
-// parent's useMemo so streaming-time renders don't churn this memo.
+// Memoized wrapper for closed blocks. Memo hits when blocks ref + error
+// props are unchanged, so the closed-block subtree is skipped per chunk.
+// Closed children also memo on `prev.block === next.block` and skip their
+// subtrees on commit chunks.
 const MemoClosedBlocks = React.memo(function MemoClosedBlocks({
   blocks,
   lastErrorIndex,

--- a/src/hooks/usePlanImplementation.ts
+++ b/src/hooks/usePlanImplementation.ts
@@ -6,12 +6,17 @@ import {
   chatMessagesByIdAtom,
   chatErrorByIdAtom,
   chatStreamCountByIdAtom,
+  streamingPreviewByChatIdAtom,
 } from "@/atoms/chatAtoms";
 import { ipc } from "@/ipc/types";
 import { useSettings } from "./useSettings";
 import { handleEffectiveChatModeChunk } from "@/lib/chatModeStream";
 import { applyStreamingPatch } from "@/lib/applyStreamingPatch";
 import { triggerResync, syncChatFromDb } from "@/lib/resyncChat";
+import {
+  applyPreviewChunk,
+  clearPreviewForChat,
+} from "@/lib/streamingPreviewSync";
 
 /**
  * Hook to handle starting plan implementation when a plan is accepted.
@@ -26,6 +31,7 @@ export function usePlanImplementation() {
   const setMessagesById = useSetAtom(chatMessagesByIdAtom);
   const setErrorById = useSetAtom(chatErrorByIdAtom);
   const setStreamCountById = useSetAtom(chatStreamCountByIdAtom);
+  const setStreamingPreviewByChatId = useSetAtom(streamingPreviewByChatIdAtom);
   const store = useStore();
   const { settings } = useSettings();
 
@@ -112,6 +118,7 @@ export function usePlanImplementation() {
               messages: updatedMessages,
               streamingMessageId,
               streamingPatch,
+              streamingPreview,
               effectiveChatMode,
               chatModeFallbackReason,
             }) => {
@@ -135,6 +142,12 @@ export function usePlanImplementation() {
                 });
                 hasIncrementedStreamCount = true;
               }
+
+              applyPreviewChunk(
+                setStreamingPreviewByChatId,
+                chatId,
+                streamingPreview,
+              );
 
               if (updatedMessages) {
                 // Full messages update (initial load, post-compaction, etc.)
@@ -165,6 +178,7 @@ export function usePlanImplementation() {
                 next.set(chatId, false);
                 return next;
               });
+              clearPreviewForChat(setStreamingPreviewByChatId, chatId);
               syncChatFromDb(
                 chatId,
                 setMessagesById,
@@ -184,6 +198,7 @@ export function usePlanImplementation() {
                 next.set(chatId, false);
                 return next;
               });
+              clearPreviewForChat(setStreamingPreviewByChatId, chatId);
               syncChatFromDb(
                 chatId,
                 setMessagesById,
@@ -212,6 +227,7 @@ export function usePlanImplementation() {
     setMessagesById,
     setErrorById,
     setStreamCountById,
+    setStreamingPreviewByChatId,
     settings,
     store,
   ]);

--- a/src/hooks/useResolveMergeConflictsWithAI.ts
+++ b/src/hooks/useResolveMergeConflictsWithAI.ts
@@ -7,6 +7,7 @@ import {
   chatMessagesByIdAtom,
   isStreamingByIdAtom,
   chatStreamCountByIdAtom,
+  streamingPreviewByChatIdAtom,
 } from "@/atoms/chatAtoms";
 import { selectedAppIdAtom } from "@/atoms/appAtoms";
 import { showError } from "@/lib/toast";
@@ -16,6 +17,10 @@ import { useSettings } from "@/hooks/useSettings";
 import { handleEffectiveChatModeChunk } from "@/lib/chatModeStream";
 import { applyStreamingPatch } from "@/lib/applyStreamingPatch";
 import { triggerResync, syncChatFromDb } from "@/lib/resyncChat";
+import {
+  applyPreviewChunk,
+  clearPreviewForChat,
+} from "@/lib/streamingPreviewSync";
 
 interface UseResolveMergeConflictsWithAIProps {
   appId: number;
@@ -37,6 +42,7 @@ export function useResolveMergeConflictsWithAI({
   const setMessagesById = useSetAtom(chatMessagesByIdAtom);
   const setIsStreamingById = useSetAtom(isStreamingByIdAtom);
   const setStreamCountById = useSetAtom(chatStreamCountByIdAtom);
+  const setStreamingPreviewByChatId = useSetAtom(streamingPreviewByChatIdAtom);
   const store = useStore();
   const navigate = useNavigate();
   const [isResolving, setIsResolving] = useState(false);
@@ -110,6 +116,7 @@ For each file, review the conflict markers (<<<<<<<, =======, >>>>>>>) and choos
             messages,
             streamingMessageId,
             streamingPatch,
+            streamingPreview,
             effectiveChatMode,
             chatModeFallbackReason,
           }) => {
@@ -131,6 +138,12 @@ For each file, review the conflict markers (<<<<<<<, =======, >>>>>>>) and choos
               });
               hasIncrementedStreamCount = true;
             }
+
+            applyPreviewChunk(
+              setStreamingPreviewByChatId,
+              newChatId,
+              streamingPreview,
+            );
 
             if (messages) {
               // Full messages update (initial load, post-compaction, etc.)
@@ -160,6 +173,7 @@ For each file, review the conflict markers (<<<<<<<, =======, >>>>>>>) and choos
               next.set(newChatId, false);
               return next;
             });
+            clearPreviewForChat(setStreamingPreviewByChatId, newChatId);
             isResolvingRef.current = false;
             setIsResolving(false);
             invalidateChats();
@@ -178,6 +192,7 @@ For each file, review the conflict markers (<<<<<<<, =======, >>>>>>>) and choos
               next.set(newChatId, false);
               return next;
             });
+            clearPreviewForChat(setStreamingPreviewByChatId, newChatId);
             isResolvingRef.current = false;
             setIsResolving(false);
             invalidateChats();
@@ -212,6 +227,7 @@ For each file, review the conflict markers (<<<<<<<, =======, >>>>>>>) and choos
     setMessagesById,
     setIsStreamingById,
     setStreamCountById,
+    setStreamingPreviewByChatId,
     navigate,
     invalidateChats,
     refreshApp,

--- a/src/hooks/useStreamChat.ts
+++ b/src/hooks/useStreamChat.ts
@@ -247,6 +247,13 @@ export function useStreamChat({
         });
       };
 
+      const finalizeStream = (chatId: number) => {
+        pendingStreamChatIds.delete(chatId);
+        latestChunkByChatId.delete(chatId);
+        cancelAckTimer(chatId);
+        clearStreamingPreviewForChat(chatId);
+      };
+
       try {
         const cachedChat =
           requestedChatMode === null
@@ -357,10 +364,7 @@ export function useStreamChat({
               }
             },
             onEnd: (response: ChatResponseEnd) => {
-              pendingStreamChatIds.delete(chatId);
-              latestChunkByChatId.delete(chatId);
-              cancelAckTimer(chatId);
-              clearStreamingPreviewForChat(chatId);
+              finalizeStream(chatId);
               void (async () => {
                 // Only mark as successful if NOT cancelled - wasCancelled flag is set
                 // by the backend when user cancels the stream
@@ -535,10 +539,7 @@ export function useStreamChat({
             },
             onError: ({ error: errorMessage, warningMessages }) => {
               // Remove from pending set now that stream ended with error
-              pendingStreamChatIds.delete(chatId);
-              latestChunkByChatId.delete(chatId);
-              cancelAckTimer(chatId);
-              clearStreamingPreviewForChat(chatId);
+              finalizeStream(chatId);
 
               for (const warningMessage of warningMessages ?? []) {
                 showWarning(warningMessage);
@@ -573,10 +574,7 @@ export function useStreamChat({
         );
       } catch (error) {
         // Remove from pending set on exception
-        pendingStreamChatIds.delete(chatId);
-        latestChunkByChatId.delete(chatId);
-        cancelAckTimer(chatId);
-        clearStreamingPreviewForChat(chatId);
+        finalizeStream(chatId);
 
         console.error("[CHAT] Exception during streaming setup:", error);
         setIsStreamingById((prev) => {

--- a/src/hooks/useStreamChat.ts
+++ b/src/hooks/useStreamChat.ts
@@ -26,6 +26,10 @@ import { useChats } from "./useChats";
 import { useLoadApp } from "./useLoadApp";
 import { applyStreamingPatch } from "@/lib/applyStreamingPatch";
 import {
+  applyPreviewChunk,
+  clearPreviewForChat,
+} from "@/lib/streamingPreviewSync";
+import {
   triggerResync,
   syncChatFromDb,
   mergeResyncMessages,
@@ -238,20 +242,11 @@ export function useStreamChat({
       const targetAppId =
         appId ?? resolvedAppIdFromChat ?? selectedAppId ?? null;
 
-      const clearStreamingPreviewForChat = (chatId: number) => {
-        setStreamingPreviewByChatId((prev) => {
-          if (!prev.has(chatId)) return prev;
-          const next = new Map(prev);
-          next.delete(chatId);
-          return next;
-        });
-      };
-
       const finalizeStream = (chatId: number) => {
         pendingStreamChatIds.delete(chatId);
         latestChunkByChatId.delete(chatId);
         cancelAckTimer(chatId);
-        clearStreamingPreviewForChat(chatId);
+        clearPreviewForChat(setStreamingPreviewByChatId, chatId);
       };
 
       try {
@@ -308,26 +303,11 @@ export function useStreamChat({
                 hasIncrementedStreamCount = true;
               }
 
-              if (streamingPreview) {
-                // Sidecar tool-input XML overlay. Doesn't touch
-                // message.content. Empty content clears the overlay (server
-                // sends an empty preview when the tool's finalized XML is
-                // committed into fullResponse via onXmlComplete).
-                const { content } = streamingPreview;
-                setStreamingPreviewByChatId((prev) => {
-                  const existing = prev.get(chatId);
-                  if (content === "") {
-                    if (existing === undefined) return prev;
-                    const next = new Map(prev);
-                    next.delete(chatId);
-                    return next;
-                  }
-                  if (existing === content) return prev;
-                  const next = new Map(prev);
-                  next.set(chatId, content);
-                  return next;
-                });
-              }
+              applyPreviewChunk(
+                setStreamingPreviewByChatId,
+                chatId,
+                streamingPreview,
+              );
 
               if (updatedMessages) {
                 // Full messages update (initial load, post-compaction, etc.)

--- a/src/hooks/useStreamChat.ts
+++ b/src/hooks/useStreamChat.ts
@@ -13,6 +13,7 @@ import {
   recentStreamChatIdsAtom,
   queuedMessagesByIdAtom,
   streamCompletedSuccessfullyByIdAtom,
+  streamingPreviewByChatIdAtom,
   queuePausedByIdAtom,
   type QueuedMessageItem,
 } from "@/atoms/chatAtoms";
@@ -110,6 +111,7 @@ export function useStreamChat({
   const setStreamCompletedSuccessfullyById = useSetAtom(
     streamCompletedSuccessfullyByIdAtom,
   );
+  const setStreamingPreviewByChatId = useSetAtom(streamingPreviewByChatIdAtom);
   const queuePausedById = useAtomValue(queuePausedByIdAtom);
   const setQueuePausedById = useSetAtom(queuePausedByIdAtom);
 
@@ -235,6 +237,16 @@ export function useStreamChat({
       }
       const targetAppId =
         appId ?? resolvedAppIdFromChat ?? selectedAppId ?? null;
+
+      const clearStreamingPreviewForChat = (chatId: number) => {
+        setStreamingPreviewByChatId((prev) => {
+          if (!prev.has(chatId)) return prev;
+          const next = new Map(prev);
+          next.delete(chatId);
+          return next;
+        });
+      };
+
       try {
         const cachedChat =
           requestedChatMode === null
@@ -260,6 +272,7 @@ export function useStreamChat({
               messages: updatedMessages,
               streamingMessageId,
               streamingPatch,
+              streamingPreview,
               chunkSeq,
               effectiveChatMode,
               chatModeFallbackReason,
@@ -286,6 +299,27 @@ export function useStreamChat({
                   return next;
                 });
                 hasIncrementedStreamCount = true;
+              }
+
+              if (streamingPreview) {
+                // Sidecar tool-input XML overlay. Doesn't touch
+                // message.content. Empty content clears the overlay (server
+                // sends an empty preview when the tool's finalized XML is
+                // committed into fullResponse via onXmlComplete).
+                const { content } = streamingPreview;
+                setStreamingPreviewByChatId((prev) => {
+                  const existing = prev.get(chatId);
+                  if (content === "") {
+                    if (existing === undefined) return prev;
+                    const next = new Map(prev);
+                    next.delete(chatId);
+                    return next;
+                  }
+                  if (existing === content) return prev;
+                  const next = new Map(prev);
+                  next.set(chatId, content);
+                  return next;
+                });
               }
 
               if (updatedMessages) {
@@ -326,6 +360,7 @@ export function useStreamChat({
               pendingStreamChatIds.delete(chatId);
               latestChunkByChatId.delete(chatId);
               cancelAckTimer(chatId);
+              clearStreamingPreviewForChat(chatId);
               void (async () => {
                 // Only mark as successful if NOT cancelled - wasCancelled flag is set
                 // by the backend when user cancels the stream
@@ -503,6 +538,7 @@ export function useStreamChat({
               pendingStreamChatIds.delete(chatId);
               latestChunkByChatId.delete(chatId);
               cancelAckTimer(chatId);
+              clearStreamingPreviewForChat(chatId);
 
               for (const warningMessage of warningMessages ?? []) {
                 showWarning(warningMessage);
@@ -540,6 +576,7 @@ export function useStreamChat({
         pendingStreamChatIds.delete(chatId);
         latestChunkByChatId.delete(chatId);
         cancelAckTimer(chatId);
+        clearStreamingPreviewForChat(chatId);
 
         console.error("[CHAT] Exception during streaming setup:", error);
         setIsStreamingById((prev) => {
@@ -565,6 +602,7 @@ export function useStreamChat({
       setIsPreviewOpen,
       setStreamCompletedSuccessfullyById,
       setQueuePausedById,
+      setStreamingPreviewByChatId,
       selectedAppId,
       refetchUserBudget,
       settings,

--- a/src/ipc/types/chat.ts
+++ b/src/ipc/types/chat.ts
@@ -128,17 +128,40 @@ export const StreamingPatchSchema = z.object({
 export type StreamingPatch = z.infer<typeof StreamingPatchSchema>;
 
 /**
+ * Schema for a transient tool-input XML preview.
+ *
+ * Pro/Agent v2 tools stream their args as JSON deltas; the handler rebuilds
+ * a complete XML representation per delta (see `buildXml`). That output is
+ * not append-only — closing quotes and brackets shift as attribute values
+ * grow — so it cannot be expressed as a tail-only `StreamingPatch` against
+ * `message.content`. Routing it through the patch protocol forces non-tail
+ * escalations to `fullMessages` sends, which are expensive on long turns.
+ *
+ * Instead, previews ride a dedicated field. The renderer overlays the preview
+ * on the active streaming assistant message for this chunk's chat and clears it
+ * when content is empty or the stream ends.
+ */
+export const StreamingPreviewSchema = z.object({
+  content: z.string(),
+});
+export type StreamingPreview = z.infer<typeof StreamingPreviewSchema>;
+
+/**
  * Schema for chat response chunk event.
  *
- * Supports two modes:
- * 1. Full update: `messages` is set with the complete messages array
- * 2. Incremental tail patch: `streamingMessageId` + `streamingPatch`
+ * Three independent update modes that may appear separately or alongside
+ * each other:
+ * 1. Full update: `messages` set with the complete messages array.
+ * 2. Incremental tail patch: `streamingMessageId` + `streamingPatch`.
+ * 3. Tool-input XML preview overlay: `streamingPreview`. Doesn't touch
+ *    `message.content`; rendered as a sidecar block on the frontend.
  */
 export const ChatResponseChunkSchema = z.object({
   chatId: z.number(),
   messages: z.array(MessageSchema).optional(),
   streamingMessageId: z.number().optional(),
   streamingPatch: StreamingPatchSchema.optional(),
+  streamingPreview: StreamingPreviewSchema.optional(),
   // Monotonic chunk sequence used for ack-based backpressure on the canned
   // test streaming path. Real LLM streams omit this field; the renderer
   // only acks when chunkSeq is present.

--- a/src/lib/streamingPreviewSync.ts
+++ b/src/lib/streamingPreviewSync.ts
@@ -1,0 +1,59 @@
+import type { SetStateAction } from "react";
+import type { StreamingPreview } from "@/ipc/types/chat";
+
+type PreviewMap = Map<number, string>;
+type SetPreviewAtom = (update: SetStateAction<PreviewMap>) => void;
+
+/**
+ * Apply a `streamingPreview` field from a chat-stream chunk onto the
+ * sidecar overlay atom. The server uses `content === ""` as a clear
+ * signal (emitted after a tool's final XML is committed via
+ * `onXmlComplete`), so we delete the entry instead of storing an empty
+ * string.
+ *
+ * Returns identity-stable maps when nothing changed, so atom subscribers
+ * keep their `Object.is` short-circuit on no-op chunks.
+ *
+ * Used by every `ipc.chatStream.start` consumer (useStreamChat,
+ * usePlanImplementation, useResolveMergeConflictsWithAI). Without this
+ * helper, tool-XML preview streaming would only surface in the
+ * useStreamChat flow.
+ */
+export function applyPreviewChunk(
+  setStreamingPreviewByChatId: SetPreviewAtom,
+  chatId: number,
+  streamingPreview: StreamingPreview | undefined,
+): void {
+  if (!streamingPreview) return;
+  const { content } = streamingPreview;
+  setStreamingPreviewByChatId((prev) => {
+    const existing = prev.get(chatId);
+    if (content === "") {
+      if (existing === undefined) return prev;
+      const next = new Map(prev);
+      next.delete(chatId);
+      return next;
+    }
+    if (existing === content) return prev;
+    const next = new Map(prev);
+    next.set(chatId, content);
+    return next;
+  });
+}
+
+/**
+ * Clear any active preview overlay for `chatId`. Call on stream end,
+ * error, and cancellation so a stale overlay never outlives the stream
+ * that produced it.
+ */
+export function clearPreviewForChat(
+  setStreamingPreviewByChatId: SetPreviewAtom,
+  chatId: number,
+): void {
+  setStreamingPreviewByChatId((prev) => {
+    if (!prev.has(chatId)) return prev;
+    const next = new Map(prev);
+    next.delete(chatId);
+    return next;
+  });
+}

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -409,6 +409,15 @@ export async function handleLocalAgentStream(
       fullMessages,
       lastSentRef,
     );
+  // Sidecar preview send — independent of the patch protocol. The renderer
+  // overlays this string after the message's parsed blocks and clears the
+  // overlay when content is empty. Used for tool-input XML preview.
+  const sendPreview = (content: string) => {
+    safeSend(event.sender, "chat:response:chunk", {
+      chatId: req.chatId,
+      streamingPreview: { content },
+    });
+  };
   let postMidTurnCompactionStartStep: number | null = null;
 
   const appendInlineCompactionToTurn = async (
@@ -503,9 +512,12 @@ export async function handleLocalAgentStream(
       (accumulatedSummary: string) => {
         // Stream compaction summary to the frontend in real-time.
         // During mid-turn compaction, keep already streamed content visible.
+        // streamingPreview rides a separate overlay channel — do NOT mix it
+        // into message.content here; the renderer continues to show its
+        // preview overlay alongside this compaction-progress block.
         const compactionPreview = `<dyad-compaction title="Compacting conversation">\n${escapeXmlContent(accumulatedSummary)}\n</dyad-compaction>`;
         const previewContent = options?.showOnTopOfCurrentResponse
-          ? `${fullResponse}${streamingPreview ? streamingPreview : ""}\n${compactionPreview}`
+          ? `${fullResponse}\n${compactionPreview}`
           : compactionPreview;
         sendChunk(previewContent, { fullMessages: true });
       },
@@ -550,7 +562,9 @@ export async function handleLocalAgentStream(
     }
 
     if (options?.showOnTopOfCurrentResponse) {
-      sendChunk(fullResponse + streamingPreview, { fullMessages: true });
+      // streamingPreview rides the overlay channel; don't double-render it
+      // by mixing into message.content here.
+      sendChunk(fullResponse, { fullMessages: true });
     }
 
     return compactionResult.success;
@@ -617,17 +631,23 @@ export async function handleLocalAgentStream(
       fileEditTracker,
       isDyadPro: isDyadProEnabled(settings),
       onXmlStream: (accumulatedXml: string) => {
-        // Stream accumulated XML to UI without persisting
+        // Stream the in-progress tool XML as a sidecar preview overlay.
+        // Does NOT enter `message.content` or `fullResponse` — the patch
+        // protocol stays strictly append-only. buildXml output (which
+        // rewrites the prefix every JSON delta as attribute values grow)
+        // therefore can't perturb the streaming-patch base.
         streamingPreview = accumulatedXml;
-        sendChunk(fullResponse + streamingPreview);
+        sendPreview(streamingPreview);
       },
       onXmlComplete: (finalXml: string) => {
-        // Write final XML to DB and UI
+        // Commit final XML to fullResponse and clear the preview overlay.
         const xmlChunk = `${finalXml}\n`;
         fullResponse += xmlChunk;
-        streamingPreview = ""; // Clear preview
+        streamingPreview = "";
         updateResponseInDb(placeholderMessageId, fullResponse);
         sendChunk(fullResponse);
+        // Empty preview = renderer clears its overlay atom for this chat.
+        sendPreview("");
       },
       requireConsent: async (params: {
         toolName: string;
@@ -1540,6 +1560,16 @@ export async function handleLocalAgentStream(
         warningMessages.length > 0 ? [...new Set(warningMessages)] : undefined,
     });
     return false; // Error - don't consume quota
+  } finally {
+    // If an in-progress tool's XML preview was overlaid in the renderer
+    // and the stream tore down before onXmlComplete could commit and
+    // clear it (cancel, error, abort), explicitly clear the overlay so
+    // a stale XML preview doesn't persist past stream end. Idempotent
+    // when the overlay is already empty.
+    if (streamingPreview.length > 0) {
+      sendPreview("");
+      streamingPreview = "";
+    }
   }
 }
 
@@ -1689,11 +1719,31 @@ function sendResponseChunk(
     // tail-diff baseline in sync so the next streaming patch is correct.
     lastSentRef.value = fullResponse;
   } else {
+    const oldLen = lastSentRef.value.length;
     const patch = computeStreamingPatch(fullResponse, lastSentRef.value);
-    lastSentRef.value = fullResponse;
     if (!patch) {
       return;
     }
+    // Streaming patches are reserved for true append-only tail growth
+    // (offset === oldLen). When offset < oldLen the new content diverges
+    // inside the prior tail; applying the patch on the renderer would
+    // cleanly shrink visible content with no mismatch, briefly vanishing
+    // the response. Escalate to a fullMessages send so the renderer
+    // authoritatively replaces content.
+    if (patch.offset < oldLen) {
+      sendResponseChunk(
+        event,
+        chatId,
+        chat,
+        fullResponse,
+        placeholderMessageId,
+        hiddenMessageIds,
+        true,
+        lastSentRef,
+      );
+      return;
+    }
+    lastSentRef.value = fullResponse;
     safeSend(event.sender, "chat:response:chunk", {
       chatId,
       streamingMessageId: placeholderMessageId,


### PR DESCRIPTION
Cache parser state in a useRef inside DyadMarkdownParser so completed blocks keep referential identity across streaming chunks and React.memo can skip prior blocks. Only the open trailing block re-renders per chunk.

Tool-input XML preview rides a sidecar overlay channel (streamingPreviewByChatIdAtom) instead of being mixed into message.content. buildXml output rewrites its prefix on every JSON delta, which would otherwise force tail-patch escalations to fullMessages sends. The overlay is cleared on stream end / cancel / error.

sendResponseChunk escalates non-tail patches (offset < oldLen) to a fullMessages send. A streaming-patch with shrinking content would cleanly apply on the renderer with no mismatch, briefly vanishing the response.

Tests:
- src/components/chat/DyadMarkdownParser.test.tsx and the parser unit tests continue to pass.
- e2e-tests/streaming_renderer.spec.ts adds two specs:
  - closed dyad-write blocks remain mounted while later blocks are still streaming
  - in-progress dyad-write surfaces path attribute and "Writing..." pending indicator before the close tag arrives

---

Based on #3419; replaces #3418