### PR TITLE
Treat preview stderr deprecations and npm warns as warnings

### DIFF
--- a/src/components/preview_panel/PreviewLoadingScreen.test.ts
+++ b/src/components/preview_panel/PreviewLoadingScreen.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { ConsoleEntry } from "@/ipc/types";
 import {
   getPreviewLoadingSessionStartedAt,
+  isWarningMessage,
   sanitizePreviewErrorForPrompt,
 } from "./PreviewLoadingScreen";
 
@@ -53,6 +54,26 @@ describe("PreviewLoadingScreen helpers", () => {
         runStartedAt: 200,
       }),
     ).toBe(200);
+  });
+
+  describe("isWarningMessage", () => {
+    it.each([
+      "(node:1234) [DEP0123] DeprecationWarning: Buffer() is deprecated",
+      "Deprecation: The `punycode` module is deprecated.",
+      "npm warn deprecated inflight@1.0.6",
+      "NPM WARN deprecated glob@7.2.3",
+    ])("returns true for non-actionable stderr: %s", (message) => {
+      expect(isWarningMessage(message)).toBe(true);
+    });
+
+    it.each([
+      "Error: Cannot find module 'react'",
+      "ELIFECYCLE Command failed with exit code 1",
+      "Failed to compile",
+      "Deprecation without colon suffix",
+    ])("returns false for actionable errors: %s", (message) => {
+      expect(isWarningMessage(message)).toBe(false);
+    });
   });
 
   it("removes control characters and caps error excerpts sent to AI", () => {

--- a/src/components/preview_panel/PreviewLoadingScreen.tsx
+++ b/src/components/preview_panel/PreviewLoadingScreen.tsx
@@ -31,16 +31,19 @@ function formatTime(ts: number) {
   return d.toTimeString().slice(0, 8);
 }
 
-// Node prints DeprecationWarnings to stderr (e.g. "(node:1234) [DEP0123]
-// DeprecationWarning: ..."), so they surface here as level="error" even
-// though they aren't actionable failures. Treat them as warnings: don't
-// count them in the error banner, and render them with warn styling.
-function isDeprecationWarning(message: string): boolean {
-  return /DeprecationWarning/i.test(message);
+// Node/npm print deprecations and warnings to stderr, so they surface here as
+// level="error" even though they aren't actionable failures. Treat them as
+// warnings: don't count them in the error banner, and render with warn styling.
+export function isWarningMessage(message: string): boolean {
+  return (
+    /DeprecationWarning/i.test(message) ||
+    /Deprecation:\s/i.test(message) ||
+    /npm warn/i.test(message)
+  );
 }
 
 function displayLevel(entry: ConsoleEntry): ConsoleEntry["level"] {
-  if (entry.level === "error" && isDeprecationWarning(entry.message)) {
+  if (entry.level === "error" && isWarningMessage(entry.message)) {
     return "warn";
   }
   return entry.level;
@@ -170,7 +173,7 @@ export function PreviewLoadingScreen({
     const seen = new Set<string>();
     const result: string[] = [];
     for (const entry of sessionEntries) {
-      if (entry.level !== "error" || isDeprecationWarning(entry.message)) {
+      if (entry.level !== "error" || isWarningMessage(entry.message)) {
         continue;
       }
       const key = entry.message;


### PR DESCRIPTION
## Summary
- Downgrade non-actionable stderr lines (`DeprecationWarning`, `Deprecation:`, `npm warn`) from errors to warnings in the preview loading screen
- Exclude those messages from the startup error banner count
- Add `isWarningMessage` helper with unit tests

## Test plan
- [x] `npm test -- src/components/preview_panel/PreviewLoadingScreen.test.ts`
- [ ] Start an app with deprecation/npm warn output on stderr and confirm they show as warnings, not in the error banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)