### PR TITLE
Show Node download for pnpm v11 requirement

### DIFF
--- a/rules/e2e-testing.md
+++ b/rules/e2e-testing.md
@@ -121,6 +121,10 @@ If this happens:
 
 If `npm run build` fails while rebuilding native modules with `ImportError` from Homebrew Python 3.14's `pyexpat` (for example `Symbol not found: _XML_SetAllocTrackerActivationThreshold`), rerun the build with the system Python: `PYTHON=/usr/bin/python3 npm run build`.
 
+## Missing dependencies during E2E builds
+
+If `npm run build` / Electron Forge packaging fails with `Failed to locate module "<package>"` but `package.json` and `package-lock.json` already declare that package, run `npm install` to restore `node_modules` before debugging app code.
+
 ## Common flaky test patterns and fixes
 
 - **After `po.importApp(...)`**: Some imports trigger an initial assistant turn (for example `minimal` generating `AI_RULES.md`) that can leave a visible `Retry` button in the chat. If the test is about a later prompt, first wait for that import-time turn to finish, then start a new chat before calling `sendPrompt()`, or helper methods that wait on `Retry` visibility may return too early.

--- a/src/components/PnpmMinimumReleaseAgeToast.test.tsx
+++ b/src/components/PnpmMinimumReleaseAgeToast.test.tsx
@@ -136,4 +136,22 @@ describe("PnpmMinimumReleaseAgeToast", () => {
     );
     expect(onInstallPnpm).not.toHaveBeenCalled();
   });
+
+  it("treats a Node prerelease as below the final pnpm v11 minimum", async () => {
+    vi.useRealTimers();
+    getNodejsStatusMock.mockResolvedValue({
+      nodeVersion: "v22.13.0-rc.1",
+      pnpmVersion: "10.15.0",
+      nodeDownloadUrl: "https://example.com/node.pkg",
+    });
+    const onInstallPnpm = vi.fn();
+
+    renderToast({ onInstallPnpm });
+
+    await screen.findByRole("button", {
+      name: /download node\.js/i,
+    });
+
+    expect(onInstallPnpm).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/PnpmMinimumReleaseAgeToast.test.tsx
+++ b/src/components/PnpmMinimumReleaseAgeToast.test.tsx
@@ -1,7 +1,14 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
+import type { ComponentProps } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { toast } from "sonner";
 import { PnpmMinimumReleaseAgeToast } from "./PnpmMinimumReleaseAgeToast";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const { getNodejsStatusMock, openExternalUrlMock } = vi.hoisted(() => ({
+  getNodejsStatusMock: vi.fn(),
+  openExternalUrlMock: vi.fn(),
+}));
 
 vi.mock("sonner", () => ({
   toast: {
@@ -9,28 +16,59 @@ vi.mock("sonner", () => ({
   },
 }));
 
+vi.mock("@/ipc/types", () => ({
+  ipc: {
+    system: {
+      getNodejsStatus: getNodejsStatusMock,
+      openExternalUrl: openExternalUrlMock,
+    },
+  },
+}));
+
 describe("PnpmMinimumReleaseAgeToast", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.clearAllMocks();
+    getNodejsStatusMock.mockResolvedValue({
+      nodeVersion: "v22.14.0",
+      pnpmVersion: "10.15.0",
+      nodeDownloadUrl: "https://example.com/node.pkg",
+    });
   });
 
   afterEach(() => {
     vi.useRealTimers();
   });
 
+  function renderToast(
+    props: Partial<ComponentProps<typeof PnpmMinimumReleaseAgeToast>> = {},
+  ) {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <PnpmMinimumReleaseAgeToast
+          toastId="pnpm-toast"
+          message="Install pnpm 10.16.0 or newer for the strongest protection"
+          onInstallPnpm={vi.fn()}
+          onOpenDocs={vi.fn()}
+          onNeverShowAgain={vi.fn()}
+          {...props}
+        />
+      </QueryClientProvider>,
+    );
+  }
+
   it("keeps the toast open while installing and briefly shows success", async () => {
     const onInstallPnpm = vi.fn().mockResolvedValue(undefined);
 
-    render(
-      <PnpmMinimumReleaseAgeToast
-        toastId="pnpm-toast"
-        message="Install pnpm 10.16.0 or newer for the strongest protection"
-        onInstallPnpm={onInstallPnpm}
-        onOpenDocs={vi.fn()}
-        onNeverShowAgain={vi.fn()}
-      />,
-    );
+    renderToast({ onInstallPnpm });
 
     const installButton = screen.getByRole("button", {
       name: /install pnpm/i,
@@ -60,15 +98,7 @@ describe("PnpmMinimumReleaseAgeToast", () => {
       .fn()
       .mockRejectedValue(new Error("Could not install pnpm because of EACCES"));
 
-    render(
-      <PnpmMinimumReleaseAgeToast
-        toastId="pnpm-toast"
-        message="Install pnpm 10.16.0 or newer for the strongest protection"
-        onInstallPnpm={onInstallPnpm}
-        onOpenDocs={onOpenDocs}
-        onNeverShowAgain={vi.fn()}
-      />,
-    );
+    renderToast({ onInstallPnpm, onOpenDocs });
 
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: /install pnpm/i }));
@@ -83,5 +113,27 @@ describe("PnpmMinimumReleaseAgeToast", () => {
 
     expect(onOpenDocs).toHaveBeenCalledTimes(1);
     expect(toast.dismiss).not.toHaveBeenCalled();
+  });
+
+  it("shows a Node.js download action when Node is too old for pnpm v11", async () => {
+    vi.useRealTimers();
+    getNodejsStatusMock.mockResolvedValue({
+      nodeVersion: "v20.11.1",
+      pnpmVersion: "10.15.0",
+      nodeDownloadUrl: "https://example.com/node.pkg",
+    });
+    const onInstallPnpm = vi.fn();
+
+    renderToast({ onInstallPnpm });
+
+    const downloadButton = await screen.findByRole("button", {
+      name: /download node\.js/i,
+    });
+    fireEvent.click(downloadButton);
+
+    expect(openExternalUrlMock).toHaveBeenCalledWith(
+      "https://example.com/node.pkg",
+    );
+    expect(onInstallPnpm).not.toHaveBeenCalled();
   });
 });

--- a/src/components/PnpmMinimumReleaseAgeToast.tsx
+++ b/src/components/PnpmMinimumReleaseAgeToast.tsx
@@ -2,6 +2,7 @@ import { toast } from "sonner";
 import {
   ExternalLink,
   Loader2,
+  Download,
   PackageCheck,
   Shield,
   X,
@@ -9,6 +10,9 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import { Button } from "./ui/button";
+import { useQuery } from "@tanstack/react-query";
+import { ipc } from "@/ipc/types";
+import { queryKeys } from "@/lib/queryKeys";
 
 interface PnpmMinimumReleaseAgeToastProps {
   toastId: string | number;
@@ -20,8 +24,37 @@ interface PnpmMinimumReleaseAgeToastProps {
 
 const DEFAULT_MESSAGE =
   "Get the latest pnpm for the safest development experience.";
+const PNPM_11_MINIMUM_NODE_VERSION = "22.13.0";
 
 type InstallStatus = "idle" | "installing" | "success" | "error";
+
+function parseVersionParts(version: string): [number, number, number] | null {
+  const match = version.trim().match(/^v?(\d+)\.(\d+)\.(\d+)/);
+  if (!match) {
+    return null;
+  }
+
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function isVersionAtLeast(version: string, minimum: string): boolean {
+  const versionParts = parseVersionParts(version);
+  const minimumParts = parseVersionParts(minimum);
+  if (!versionParts || !minimumParts) {
+    return false;
+  }
+
+  for (let index = 0; index < versionParts.length; index += 1) {
+    if (versionParts[index] > minimumParts[index]) {
+      return true;
+    }
+    if (versionParts[index] < minimumParts[index]) {
+      return false;
+    }
+  }
+
+  return true;
+}
 
 function getInstallErrorMessage(error: unknown): string {
   if (error instanceof Error && error.message) {
@@ -40,6 +73,10 @@ export function PnpmMinimumReleaseAgeToast({
 }: PnpmMinimumReleaseAgeToastProps) {
   const [installStatus, setInstallStatus] = useState<InstallStatus>("idle");
   const [installErrorMessage, setInstallErrorMessage] = useState<string>();
+  const { data: nodeSystemInfo } = useQuery({
+    queryKey: queryKeys.system.nodejsStatus,
+    queryFn: () => ipc.system.getNodejsStatus(),
+  });
 
   const handleClose = () => {
     toast.dismiss(toastId);
@@ -64,20 +101,36 @@ export function PnpmMinimumReleaseAgeToast({
     }
   };
 
+  const isInstalling = installStatus === "installing";
+  const isError = installStatus === "error";
+  const isSuccess = installStatus === "success";
+  const showBenefits = !isSuccess && !isError;
+  const needsNodeUpgrade =
+    nodeSystemInfo !== undefined &&
+    (!nodeSystemInfo.nodeVersion ||
+      !isVersionAtLeast(
+        nodeSystemInfo.nodeVersion,
+        PNPM_11_MINIMUM_NODE_VERSION,
+      ));
   const displayMessage =
     installStatus === "success"
       ? "pnpm successfully installed"
       : installStatus === "error"
         ? `${installErrorMessage}. Please read pnpm docs for other installation options.`
-        : message || DEFAULT_MESSAGE;
-
-  const isInstalling = installStatus === "installing";
-  const isError = installStatus === "error";
-  const isSuccess = installStatus === "success";
-  const showBenefits = !isSuccess && !isError;
+        : needsNodeUpgrade
+          ? `pnpm v11 requires Node.js ${PNPM_11_MINIMUM_NODE_VERSION} or newer. Download and install the latest Node.js first.`
+          : message || DEFAULT_MESSAGE;
 
   const handleOpenDocs = () => {
     onOpenDocs();
+  };
+
+  const handleDownloadNode = () => {
+    if (!nodeSystemInfo) {
+      return;
+    }
+
+    void ipc.system.openExternalUrl(nodeSystemInfo.nodeDownloadUrl);
   };
 
   return (
@@ -137,6 +190,16 @@ export function PnpmMinimumReleaseAgeToast({
                 <Button onClick={handleOpenDocs} size="sm" variant="default">
                   <ExternalLink className="w-3.5 h-3.5" />
                   Open docs
+                </Button>
+              ) : needsNodeUpgrade ? (
+                <Button
+                  onClick={handleDownloadNode}
+                  size="sm"
+                  variant="default"
+                  disabled={isSuccess}
+                >
+                  <Download className="w-3.5 h-3.5" />
+                  Download Node.js
                 </Button>
               ) : (
                 <Button

--- a/src/components/PnpmMinimumReleaseAgeToast.tsx
+++ b/src/components/PnpmMinimumReleaseAgeToast.tsx
@@ -13,6 +13,7 @@ import { Button } from "./ui/button";
 import { useQuery } from "@tanstack/react-query";
 import { ipc } from "@/ipc/types";
 import { queryKeys } from "@/lib/queryKeys";
+import { isVersionAtLeast } from "@/shared/version_utils";
 
 interface PnpmMinimumReleaseAgeToastProps {
   toastId: string | number;
@@ -27,34 +28,6 @@ const DEFAULT_MESSAGE =
 const PNPM_11_MINIMUM_NODE_VERSION = "22.13.0";
 
 type InstallStatus = "idle" | "installing" | "success" | "error";
-
-function parseVersionParts(version: string): [number, number, number] | null {
-  const match = version.trim().match(/^v?(\d+)\.(\d+)\.(\d+)/);
-  if (!match) {
-    return null;
-  }
-
-  return [Number(match[1]), Number(match[2]), Number(match[3])];
-}
-
-function isVersionAtLeast(version: string, minimum: string): boolean {
-  const versionParts = parseVersionParts(version);
-  const minimumParts = parseVersionParts(minimum);
-  if (!versionParts || !minimumParts) {
-    return false;
-  }
-
-  for (let index = 0; index < versionParts.length; index += 1) {
-    if (versionParts[index] > minimumParts[index]) {
-      return true;
-    }
-    if (versionParts[index] < minimumParts[index]) {
-      return false;
-    }
-  }
-
-  return true;
-}
 
 function getInstallErrorMessage(error: unknown): string {
   if (error instanceof Error && error.message) {

--- a/src/ipc/handlers/node_handlers.ts
+++ b/src/ipc/handlers/node_handlers.ts
@@ -69,16 +69,16 @@ function getNodeDownloadUrl(): string {
   }
 
   // Default to mac download url.
-  let nodeDownloadUrl = "https://nodejs.org/dist/v22.14.0/node-v22.14.0.pkg";
+  let nodeDownloadUrl = "https://nodejs.org/dist/v22.22.3/node-v22.22.3.pkg";
   if (platform() == "win32") {
     if (arch() === "arm64" || arch() === "arm") {
       nodeDownloadUrl =
-        "https://nodejs.org/dist/v22.14.0/node-v22.14.0-arm64.msi";
+        "https://nodejs.org/dist/v22.22.3/node-v22.22.3-arm64.msi";
     } else {
       // x64 is the most common architecture for Windows so it's the
       // default download url.
       nodeDownloadUrl =
-        "https://nodejs.org/dist/v22.14.0/node-v22.14.0-x64.msi";
+        "https://nodejs.org/dist/v22.22.3/node-v22.22.3-x64.msi";
     }
   }
   return nodeDownloadUrl;
@@ -112,7 +112,7 @@ export function registerNodeHandlers() {
       logger.log("Using mock Node.js status:", mockNodeInstalled);
       if (mockNodeInstalled) {
         return {
-          nodeVersion: "v22.14.0",
+          nodeVersion: "v22.22.3",
           pnpmVersion: "9.0.0",
           nodeDownloadUrl,
         };

--- a/src/ipc/utils/socket_firewall.ts
+++ b/src/ipc/utils/socket_firewall.ts
@@ -10,6 +10,7 @@ import defaultApproveBuildsText from "@/data/default-approve-builds.txt?raw";
 import { gitAdd, gitCommit } from "@/ipc/utils/git_utils";
 import { PNPM_MINIMUM_RELEASE_AGE_WARNING_PREFIX } from "@/shared/packageManagerWarnings";
 import { IS_TEST_BUILD } from "@/ipc/utils/test_utils";
+import { isVersionAtLeast } from "@/shared/version_utils";
 
 export const SOCKET_FIREWALL_WARNING_MESSAGE =
   "the npm firewall could not be installed. Warning: can not check if npm packages are safe";
@@ -576,42 +577,6 @@ export async function commitPnpmAllowBuildsConfigIfChanged(
   } catch (error) {
     logger.warn("Failed to commit pnpm allowBuilds config:", error);
   }
-}
-
-function parseVersionParts(version: string): {
-  parts: [number, number, number];
-  hasPrerelease: boolean;
-} | null {
-  const match = version
-    .trim()
-    .match(/^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?/);
-  if (!match) {
-    return null;
-  }
-
-  return {
-    parts: [Number(match[1]), Number(match[2]), Number(match[3])],
-    hasPrerelease: match[4] !== undefined,
-  };
-}
-
-export function isVersionAtLeast(version: string, minimum: string): boolean {
-  const parsedVersion = parseVersionParts(version);
-  const parsedMinimum = parseVersionParts(minimum);
-  if (!parsedVersion || !parsedMinimum) {
-    return false;
-  }
-
-  for (let index = 0; index < parsedVersion.parts.length; index += 1) {
-    if (parsedVersion.parts[index] > parsedMinimum.parts[index]) {
-      return true;
-    }
-    if (parsedVersion.parts[index] < parsedMinimum.parts[index]) {
-      return false;
-    }
-  }
-
-  return !parsedVersion.hasPrerelease || parsedMinimum.hasPrerelease;
 }
 
 export function resolveExecutableName(

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -21,6 +21,7 @@ export const queryKeys = {
   system: {
     all: ["system"] as const,
     appVersion: ["system", "appVersion"] as const,
+    nodejsStatus: ["system", "nodejsStatus"] as const,
     platform: ["system", "platform"] as const,
   },
 

--- a/src/shared/version_utils.test.ts
+++ b/src/shared/version_utils.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { isVersionAtLeast } from "./version_utils";
+
+describe("isVersionAtLeast", () => {
+  it("compares major, minor, and patch versions", () => {
+    expect(isVersionAtLeast("10.16.0", "10.16.0")).toBe(true);
+    expect(isVersionAtLeast("10.16.1", "10.16.0")).toBe(true);
+    expect(isVersionAtLeast("10.15.9", "10.16.0")).toBe(false);
+    expect(isVersionAtLeast("9.99.99", "10.16.0")).toBe(false);
+  });
+
+  it("accepts node-style v prefixes", () => {
+    expect(isVersionAtLeast("v22.13.0", "22.13.0")).toBe(true);
+    expect(isVersionAtLeast("v22.12.0", "22.13.0")).toBe(false);
+  });
+
+  it("treats prereleases as lower than their final release", () => {
+    expect(isVersionAtLeast("22.13.0-rc.1", "22.13.0")).toBe(false);
+    expect(isVersionAtLeast("v22.13.0-rc.1", "22.13.0")).toBe(false);
+    expect(isVersionAtLeast("22.13.0", "22.13.0-rc.1")).toBe(true);
+  });
+
+  it("returns false for unparsable versions", () => {
+    expect(isVersionAtLeast("not-a-version", "22.13.0")).toBe(false);
+    expect(isVersionAtLeast("22.13.0", "not-a-version")).toBe(false);
+  });
+});

--- a/src/shared/version_utils.ts
+++ b/src/shared/version_utils.ts
@@ -1,0 +1,35 @@
+function parseVersionParts(version: string): {
+  parts: [number, number, number];
+  hasPrerelease: boolean;
+} | null {
+  const match = version
+    .trim()
+    .match(/^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?/);
+  if (!match) {
+    return null;
+  }
+
+  return {
+    parts: [Number(match[1]), Number(match[2]), Number(match[3])],
+    hasPrerelease: match[4] !== undefined,
+  };
+}
+
+export function isVersionAtLeast(version: string, minimum: string): boolean {
+  const parsedVersion = parseVersionParts(version);
+  const parsedMinimum = parseVersionParts(minimum);
+  if (!parsedVersion || !parsedMinimum) {
+    return false;
+  }
+
+  for (let index = 0; index < parsedVersion.parts.length; index += 1) {
+    if (parsedVersion.parts[index] > parsedMinimum.parts[index]) {
+      return true;
+    }
+    if (parsedVersion.parts[index] < parsedMinimum.parts[index]) {
+      return false;
+    }
+  }
+
+  return !parsedVersion.hasPrerelease || parsedMinimum.hasPrerelease;
+}


### PR DESCRIPTION
## Summary
- Show a Download Node.js action when the installed Node.js version cannot run pnpm v11.
- Use the existing Node.js status IPC endpoint and query key to drive the toast action.
- Add focused toast coverage for the Node.js download path.

## Test plan
- npm run fmt && npm run lint:fix && npm run ts
- npm test
- npm run build
- PLAYWRIGHT_HTML_OPEN=never npm run e2e -- e2e-tests/package_manager.spec.ts