### PR TITLE
Fix preview AI action gating on app exit failure

### DIFF
--- a/src/atoms/appAtoms.ts
+++ b/src/atoms/appAtoms.ts
@@ -19,6 +19,12 @@ export const selectedVersionIdAtom = atom<string | null>(null);
 
 export const appConsoleEntriesAtom = atom<ConsoleEntry[]>([]);
 export const previewRunStartedAtAtom = atom<number | null>(null);
+export type PreviewAppExit = {
+  appId: number;
+  exitCode: number | null;
+  timestamp: number;
+};
+export const previewAppExitAtom = atom<PreviewAppExit | null>(null);
 export const appUrlAtom = atom<
   | {
       appUrl: string;

--- a/src/components/preview_panel/PreviewLoadingScreen.test.ts
+++ b/src/components/preview_panel/PreviewLoadingScreen.test.ts
@@ -5,6 +5,7 @@ import {
   getPreviewLoadingSessionStartedAt,
   isWarningMessage,
   sanitizePreviewErrorForPrompt,
+  shouldShowPreviewErrorBanner,
 } from "./PreviewLoadingScreen";
 
 const entry = (
@@ -116,6 +117,38 @@ describe("PreviewLoadingScreen helpers", () => {
           sessionStartedAt: 100,
         }),
       ).toBe(false);
+    });
+  });
+
+  describe("shouldShowPreviewErrorBanner", () => {
+    it("hides the banner when errors are logged before the command exits", () => {
+      expect(
+        shouldShowPreviewErrorBanner({
+          errorMessages: ["Error: still compiling"],
+          previewAppExit: null,
+          sessionStartedAt: 100,
+        }),
+      ).toBe(false);
+    });
+
+    it("hides the banner when the command exits successfully", () => {
+      expect(
+        shouldShowPreviewErrorBanner({
+          errorMessages: ["Error: noisy stderr"],
+          previewAppExit: { appId: 1, exitCode: 0, timestamp: 200 },
+          sessionStartedAt: 100,
+        }),
+      ).toBe(false);
+    });
+
+    it("shows the banner only when the current command exits non-zero with errors", () => {
+      expect(
+        shouldShowPreviewErrorBanner({
+          errorMessages: ["Error: Cannot find module 'react'"],
+          previewAppExit: { appId: 1, exitCode: 1, timestamp: 200 },
+          sessionStartedAt: 100,
+        }),
+      ).toBe(true);
     });
   });
 });

--- a/src/components/preview_panel/PreviewLoadingScreen.test.ts
+++ b/src/components/preview_panel/PreviewLoadingScreen.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { ConsoleEntry } from "@/ipc/types";
 import {
+  didPreviewCommandFail,
   getPreviewLoadingSessionStartedAt,
   isWarningMessage,
   sanitizePreviewErrorForPrompt,
@@ -84,5 +85,37 @@ describe("PreviewLoadingScreen helpers", () => {
     expect(sanitized).not.toContain("\u0000");
     expect(sanitized).toContain("[truncated]");
     expect(sanitized.length).toBeLessThan(message.length);
+  });
+
+  describe("didPreviewCommandFail", () => {
+    it("returns true only for a non-zero exit in the current loading session", () => {
+      expect(
+        didPreviewCommandFail({
+          previewAppExit: { appId: 1, exitCode: 1, timestamp: 200 },
+          sessionStartedAt: 100,
+        }),
+      ).toBe(true);
+
+      expect(
+        didPreviewCommandFail({
+          previewAppExit: { appId: 1, exitCode: 0, timestamp: 200 },
+          sessionStartedAt: 100,
+        }),
+      ).toBe(false);
+
+      expect(
+        didPreviewCommandFail({
+          previewAppExit: { appId: 1, exitCode: 1, timestamp: 50 },
+          sessionStartedAt: 100,
+        }),
+      ).toBe(false);
+
+      expect(
+        didPreviewCommandFail({
+          previewAppExit: { appId: 1, exitCode: null, timestamp: 200 },
+          sessionStartedAt: 100,
+        }),
+      ).toBe(false);
+    });
   });
 });

--- a/src/components/preview_panel/PreviewLoadingScreen.test.ts
+++ b/src/components/preview_panel/PreviewLoadingScreen.test.ts
@@ -94,6 +94,7 @@ describe("PreviewLoadingScreen helpers", () => {
         didPreviewCommandFail({
           previewAppExit: { appId: 1, exitCode: 1, timestamp: 200 },
           sessionStartedAt: 100,
+          currentAppId: 1,
         }),
       ).toBe(true);
 
@@ -101,6 +102,7 @@ describe("PreviewLoadingScreen helpers", () => {
         didPreviewCommandFail({
           previewAppExit: { appId: 1, exitCode: 0, timestamp: 200 },
           sessionStartedAt: 100,
+          currentAppId: 1,
         }),
       ).toBe(false);
 
@@ -108,6 +110,7 @@ describe("PreviewLoadingScreen helpers", () => {
         didPreviewCommandFail({
           previewAppExit: { appId: 1, exitCode: 1, timestamp: 50 },
           sessionStartedAt: 100,
+          currentAppId: 1,
         }),
       ).toBe(false);
 
@@ -115,6 +118,17 @@ describe("PreviewLoadingScreen helpers", () => {
         didPreviewCommandFail({
           previewAppExit: { appId: 1, exitCode: null, timestamp: 200 },
           sessionStartedAt: 100,
+          currentAppId: 1,
+        }),
+      ).toBe(false);
+    });
+
+    it("returns false when the exit belongs to a different app", () => {
+      expect(
+        didPreviewCommandFail({
+          previewAppExit: { appId: 1, exitCode: 1, timestamp: 200 },
+          sessionStartedAt: 100,
+          currentAppId: 2,
         }),
       ).toBe(false);
     });
@@ -127,6 +141,7 @@ describe("PreviewLoadingScreen helpers", () => {
           errorMessages: ["Error: still compiling"],
           previewAppExit: null,
           sessionStartedAt: 100,
+          currentAppId: 1,
         }),
       ).toBe(false);
     });
@@ -137,6 +152,7 @@ describe("PreviewLoadingScreen helpers", () => {
           errorMessages: ["Error: noisy stderr"],
           previewAppExit: { appId: 1, exitCode: 0, timestamp: 200 },
           sessionStartedAt: 100,
+          currentAppId: 1,
         }),
       ).toBe(false);
     });
@@ -147,8 +163,20 @@ describe("PreviewLoadingScreen helpers", () => {
           errorMessages: ["Error: Cannot find module 'react'"],
           previewAppExit: { appId: 1, exitCode: 1, timestamp: 200 },
           sessionStartedAt: 100,
+          currentAppId: 1,
         }),
       ).toBe(true);
+    });
+
+    it("hides the banner when the exit belongs to a different app", () => {
+      expect(
+        shouldShowPreviewErrorBanner({
+          errorMessages: ["Error: Cannot find module 'react'"],
+          previewAppExit: { appId: 1, exitCode: 1, timestamp: 200 },
+          sessionStartedAt: 100,
+          currentAppId: 2,
+        }),
+      ).toBe(false);
     });
   });
 });

--- a/src/components/preview_panel/PreviewLoadingScreen.tsx
+++ b/src/components/preview_panel/PreviewLoadingScreen.tsx
@@ -104,6 +104,21 @@ export function didPreviewCommandFail({
   );
 }
 
+export function shouldShowPreviewErrorBanner({
+  errorMessages,
+  previewAppExit,
+  sessionStartedAt,
+}: {
+  errorMessages: string[];
+  previewAppExit: PreviewAppExit | null;
+  sessionStartedAt: number;
+}) {
+  return (
+    errorMessages.length > 0 &&
+    didPreviewCommandFail({ previewAppExit, sessionStartedAt })
+  );
+}
+
 interface PreviewLoadingScreenProps {
   // True while the app is being spawned/restarted (useRunApp).
   loading: boolean;
@@ -253,8 +268,8 @@ export function PreviewLoadingScreen({
 
   if (!shouldRender) return null;
 
-  const showErrorBanner = errorMessages.length > 0;
-  const showFixErrorsWithAi = didPreviewCommandFail({
+  const showErrorBanner = shouldShowPreviewErrorBanner({
+    errorMessages,
     previewAppExit,
     sessionStartedAt,
   });
@@ -376,18 +391,16 @@ export function PreviewLoadingScreen({
                 <Cog size={14} />
                 <span>{t("preview.rebuild")}</span>
               </button>
-              {showFixErrorsWithAi && (
-                <button
-                  type="button"
-                  onClick={handleFixAllErrors}
-                  disabled={isStreaming || !selectedChatId}
-                  className="cursor-pointer flex items-center gap-1 px-2.5 py-1 bg-red-600 hover:bg-red-700 dark:bg-red-600 dark:hover:bg-red-500 text-white rounded text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                  data-testid="preview-loading-fix-errors-button"
-                >
-                  <Sparkles size={14} />
-                  <span>Fix {errorCount} error(s) with AI</span>
-                </button>
-              )}
+              <button
+                type="button"
+                onClick={handleFixAllErrors}
+                disabled={isStreaming || !selectedChatId}
+                className="cursor-pointer flex items-center gap-1 px-2.5 py-1 bg-red-600 hover:bg-red-700 dark:bg-red-600 dark:hover:bg-red-500 text-white rounded text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                data-testid="preview-loading-fix-errors-button"
+              >
+                <Sparkles size={14} />
+                <span>Fix {errorCount} error(s) with AI</span>
+              </button>
             </div>
           </div>
         )}

--- a/src/components/preview_panel/PreviewLoadingScreen.tsx
+++ b/src/components/preview_panel/PreviewLoadingScreen.tsx
@@ -14,6 +14,7 @@ import {
   appConsoleEntriesAtom,
   previewAppExitAtom,
   previewRunStartedAtAtom,
+  selectedAppIdAtom,
 } from "@/atoms/appAtoms";
 import type { PreviewAppExit } from "@/atoms/appAtoms";
 import { selectedChatIdAtom } from "@/atoms/chatAtoms";
@@ -92,12 +93,15 @@ export function sanitizePreviewErrorForPrompt(message: string) {
 export function didPreviewCommandFail({
   previewAppExit,
   sessionStartedAt,
+  currentAppId,
 }: {
   previewAppExit: PreviewAppExit | null;
   sessionStartedAt: number;
+  currentAppId: number | null;
 }) {
   return (
     previewAppExit !== null &&
+    previewAppExit.appId === currentAppId &&
     previewAppExit.timestamp >= sessionStartedAt &&
     previewAppExit.exitCode !== null &&
     previewAppExit.exitCode !== 0
@@ -108,14 +112,16 @@ export function shouldShowPreviewErrorBanner({
   errorMessages,
   previewAppExit,
   sessionStartedAt,
+  currentAppId,
 }: {
   errorMessages: string[];
   previewAppExit: PreviewAppExit | null;
   sessionStartedAt: number;
+  currentAppId: number | null;
 }) {
   return (
     errorMessages.length > 0 &&
-    didPreviewCommandFail({ previewAppExit, sessionStartedAt })
+    didPreviewCommandFail({ previewAppExit, sessionStartedAt, currentAppId })
   );
 }
 
@@ -142,6 +148,7 @@ export function PreviewLoadingScreen({
   const consoleEntries = useAtomValue(appConsoleEntriesAtom);
   const previewAppExit = useAtomValue(previewAppExitAtom);
   const previewRunStartedAt = useAtomValue(previewRunStartedAtAtom);
+  const selectedAppId = useAtomValue(selectedAppIdAtom);
   const selectedChatId = useAtomValue(selectedChatIdAtom);
   const { streamMessage, isStreaming } = useStreamChat();
   const { restartApp } = useRunApp();
@@ -272,6 +279,7 @@ export function PreviewLoadingScreen({
     errorMessages,
     previewAppExit,
     sessionStartedAt,
+    currentAppId: selectedAppId,
   });
   const errorCount = errorMessages.length;
 

--- a/src/components/preview_panel/PreviewLoadingScreen.tsx
+++ b/src/components/preview_panel/PreviewLoadingScreen.tsx
@@ -12,8 +12,10 @@ import { useTranslation } from "react-i18next";
 import type { ConsoleEntry } from "@/ipc/types";
 import {
   appConsoleEntriesAtom,
+  previewAppExitAtom,
   previewRunStartedAtAtom,
 } from "@/atoms/appAtoms";
+import type { PreviewAppExit } from "@/atoms/appAtoms";
 import { selectedChatIdAtom } from "@/atoms/chatAtoms";
 import { useRunApp } from "@/hooks/useRunApp";
 import { useStreamChat } from "@/hooks/useStreamChat";
@@ -87,6 +89,21 @@ export function sanitizePreviewErrorForPrompt(message: string) {
     : withoutControlChars;
 }
 
+export function didPreviewCommandFail({
+  previewAppExit,
+  sessionStartedAt,
+}: {
+  previewAppExit: PreviewAppExit | null;
+  sessionStartedAt: number;
+}) {
+  return (
+    previewAppExit !== null &&
+    previewAppExit.timestamp >= sessionStartedAt &&
+    previewAppExit.exitCode !== null &&
+    previewAppExit.exitCode !== 0
+  );
+}
+
 interface PreviewLoadingScreenProps {
   // True while the app is being spawned/restarted (useRunApp).
   loading: boolean;
@@ -108,6 +125,7 @@ export function PreviewLoadingScreen({
 }: PreviewLoadingScreenProps) {
   const { t } = useTranslation("home");
   const consoleEntries = useAtomValue(appConsoleEntriesAtom);
+  const previewAppExit = useAtomValue(previewAppExitAtom);
   const previewRunStartedAt = useAtomValue(previewRunStartedAtAtom);
   const selectedChatId = useAtomValue(selectedChatIdAtom);
   const { streamMessage, isStreaming } = useStreamChat();
@@ -236,6 +254,10 @@ export function PreviewLoadingScreen({
   if (!shouldRender) return null;
 
   const showErrorBanner = errorMessages.length > 0;
+  const showFixErrorsWithAi = didPreviewCommandFail({
+    previewAppExit,
+    sessionStartedAt,
+  });
   const errorCount = errorMessages.length;
 
   return (
@@ -354,16 +376,18 @@ export function PreviewLoadingScreen({
                 <Cog size={14} />
                 <span>{t("preview.rebuild")}</span>
               </button>
-              <button
-                type="button"
-                onClick={handleFixAllErrors}
-                disabled={isStreaming || !selectedChatId}
-                className="cursor-pointer flex items-center gap-1 px-2.5 py-1 bg-red-600 hover:bg-red-700 dark:bg-red-600 dark:hover:bg-red-500 text-white rounded text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                data-testid="preview-loading-fix-errors-button"
-              >
-                <Sparkles size={14} />
-                <span>Fix {errorCount} error(s) with AI</span>
-              </button>
+              {showFixErrorsWithAi && (
+                <button
+                  type="button"
+                  onClick={handleFixAllErrors}
+                  disabled={isStreaming || !selectedChatId}
+                  className="cursor-pointer flex items-center gap-1 px-2.5 py-1 bg-red-600 hover:bg-red-700 dark:bg-red-600 dark:hover:bg-red-500 text-white rounded text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  data-testid="preview-loading-fix-errors-button"
+                >
+                  <Sparkles size={14} />
+                  <span>Fix {errorCount} error(s) with AI</span>
+                </button>
+              )}
             </div>
           </div>
         )}

--- a/src/hooks/useRunApp.test.tsx
+++ b/src/hooks/useRunApp.test.tsx
@@ -4,6 +4,7 @@ import type { PropsWithChildren } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   appConsoleEntriesAtom,
+  previewAppExitAtom,
   previewErrorMessageAtom,
   selectedAppIdAtom,
 } from "@/atoms/appAtoms";
@@ -215,6 +216,34 @@ describe("useAppOutputSubscription", () => {
     expect(appOutputBatchSubscribeMock).toHaveBeenCalledTimes(1);
     expect(appOutputListeners.size).toBe(1);
     expect(appOutputBatchListeners.size).toBe(1);
+
+    unmount();
+  });
+
+  it("tracks app process exit without adding an extra console log", () => {
+    const { store, Wrapper } = makeWrapper(1);
+    const { unmount } = renderHook(() => useAppOutputSubscription(), {
+      wrapper: Wrapper,
+    });
+
+    act(() => {
+      for (const listener of appOutputListeners) {
+        listener({
+          type: "app-exit",
+          message: "App process exited with code 1",
+          appId: 1,
+          exitCode: 1,
+          timestamp: 123,
+        });
+      }
+    });
+
+    expect(store.get(previewAppExitAtom)).toEqual({
+      appId: 1,
+      exitCode: 1,
+      timestamp: 123,
+    });
+    expect(store.get(appConsoleEntriesAtom)).toEqual([]);
 
     unmount();
   });

--- a/src/hooks/useRunApp.ts
+++ b/src/hooks/useRunApp.ts
@@ -5,6 +5,7 @@ import {
   appConsoleEntriesAtom,
   appUrlAtom,
   currentAppAtom,
+  previewAppExitAtom,
   previewPanelKeyAtom,
   previewErrorMessageAtom,
   previewRunStartedAtAtom,
@@ -55,6 +56,7 @@ export function useRebuildAppAfterPnpmInstall() {
   const setPreviewPanelKey = useSetAtom(previewPanelKeyAtom);
   const setPreservedUrls = useSetAtom(previewCurrentUrlAtom);
   const setPreviewRunStartedAt = useSetAtom(previewRunStartedAtAtom);
+  const setPreviewAppExit = useSetAtom(previewAppExitAtom);
   const setLoading = useSetAtom(useRunAppLoadingAtom);
   const appId = useAtomValue(selectedAppIdAtom);
   const selectedAppIdRef = useRef(appId);
@@ -70,6 +72,7 @@ export function useRebuildAppAfterPnpmInstall() {
       const wasActiveAppAtStart = isActiveApp();
       if (wasActiveAppAtStart) {
         setPreviewRunStartedAt(startedAt);
+        setPreviewAppExit(null);
         setLoading(true);
       }
 
@@ -144,6 +147,7 @@ export function useRebuildAppAfterPnpmInstall() {
       setPreviewErrorMessage,
       setPreviewPanelKey,
       setPreviewRunStartedAt,
+      setPreviewAppExit,
     ],
   );
 }
@@ -159,6 +163,7 @@ export function useAppOutputSubscription() {
   const [, setAppUrlObj] = useAtom(appUrlAtom);
   const [, setPreviewErrorMessage] = useAtom(previewErrorMessageAtom);
   const setPreviewPanelKey = useSetAtom(previewPanelKeyAtom);
+  const setPreviewAppExit = useSetAtom(previewAppExitAtom);
   const appId = useAtomValue(selectedAppIdAtom);
   const rebuildAppAfterPnpmInstall = useRebuildAppAfterPnpmInstall();
   const pnpmWarningSettingRef = useRef({
@@ -259,6 +264,15 @@ export function useAppOutputSubscription() {
         );
       }
 
+      if (output.type === "app-exit") {
+        setPreviewAppExit({
+          appId: output.appId,
+          exitCode: output.exitCode ?? null,
+          timestamp: output.timestamp ?? Date.now(),
+        });
+        return null;
+      }
+
       if (
         output.type === "package-manager-warning" &&
         pnpmWarningSettingRef.current.hasSettings &&
@@ -310,6 +324,7 @@ export function useAppOutputSubscription() {
       onHotModuleReload,
       processProxyServerOutput,
       rebuildAppAfterPnpmInstall,
+      setPreviewAppExit,
       setPreviewErrorMessage,
       updateSettings,
     ],
@@ -362,12 +377,14 @@ export function useRunApp() {
   const setPreviewPanelKey = useSetAtom(previewPanelKeyAtom);
   const setPreservedUrls = useSetAtom(previewCurrentUrlAtom);
   const setPreviewRunStartedAt = useSetAtom(previewRunStartedAtAtom);
+  const setPreviewAppExit = useSetAtom(previewAppExitAtom);
   const appId = useAtomValue(selectedAppIdAtom);
   const setPreviewErrorMessage = useSetAtom(previewErrorMessageAtom);
 
   const runApp = useCallback(async (appId: number) => {
     const startedAt = Date.now();
     setPreviewRunStartedAt(startedAt);
+    setPreviewAppExit(null);
     setLoading(true);
     try {
       console.debug("Running app", appId);
@@ -447,6 +464,7 @@ export function useRunApp() {
       }
       const startedAt = Date.now();
       setPreviewRunStartedAt(startedAt);
+      setPreviewAppExit(null);
       setLoading(true);
       try {
         console.debug(
@@ -515,6 +533,7 @@ export function useRunApp() {
       setAppUrlObj,
       setPreviewPanelKey,
       setPreviewRunStartedAt,
+      setPreviewAppExit,
       setPreservedUrls,
     ],
   );

--- a/src/ipc/services/app_runtime_service.test.ts
+++ b/src/ipc/services/app_runtime_service.test.ts
@@ -1,0 +1,165 @@
+import { EventEmitter } from "node:events";
+import type { ChildProcess } from "node:child_process";
+import type { IpcMainInvokeEvent, WebContents } from "electron";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { safeSendMock, spawnMock } = vi.hoisted(() => ({
+  safeSendMock: vi.fn(),
+  spawnMock: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  default: {
+    spawn: spawnMock,
+  },
+  spawn: spawnMock,
+}));
+
+vi.mock("electron-log", () => ({
+  default: {
+    scope: () => ({
+      log: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock("fix-path", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("kill-port", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("@/main/settings", () => ({
+  readSettings: () => ({
+    runtimeMode2: "host",
+  }),
+}));
+
+vi.mock("@/ipc/utils/safe_sender", () => ({
+  safeSend: (...args: unknown[]) => safeSendMock(...args),
+}));
+
+vi.mock("@/ipc/utils/socket_firewall", () => ({
+  ensurePnpmAllowBuildsConfigured: vi.fn(),
+  getPnpmMinimumReleaseAgeSupport: vi.fn(async () => ({
+    supported: false,
+  })),
+  PNPM_INSTALL_POLICY_ARGS: ["--minimum-release-age=1440"],
+}));
+
+vi.mock("@/ipc/utils/cloud_sandbox_provider", () => ({
+  buildCloudSandboxFileMap: vi.fn(),
+  CloudSandboxApiError: class CloudSandboxApiError extends Error {
+    code?: string;
+    status?: number;
+  },
+  createCloudSandbox: vi.fn(),
+  destroyCloudSandbox: vi.fn(),
+  registerRunningCloudSandbox: vi.fn(),
+  setCloudSandboxSyncUpdateListener: vi.fn(),
+  stopCloudSandboxFileSync: vi.fn(),
+  streamCloudSandboxLogs: vi.fn(),
+  unregisterRunningCloudSandbox: vi.fn(),
+  uploadCloudSandboxFiles: vi.fn(),
+}));
+
+import { executeApp } from "./app_runtime_service";
+import { processCounter, runningApps } from "@/ipc/utils/process_manager";
+
+class FakeChildProcess extends EventEmitter {
+  pid: number;
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  stdin = {
+    write: vi.fn(),
+  };
+
+  constructor(pid: number) {
+    super();
+    this.pid = pid;
+  }
+}
+
+function createEvent(): Electron.IpcMainInvokeEvent {
+  const sender = {
+    isDestroyed: () => false,
+    isCrashed: () => false,
+    send: vi.fn(),
+  } as unknown as WebContents;
+
+  return { sender } as IpcMainInvokeEvent;
+}
+
+describe("executeApp", () => {
+  beforeEach(() => {
+    runningApps.clear();
+    processCounter.value = 0;
+    safeSendMock.mockReset();
+    spawnMock.mockReset();
+  });
+
+  it("does not emit app-exit when a replaced process closes later", async () => {
+    const firstProcess = new FakeChildProcess(101);
+    const secondProcess = new FakeChildProcess(102);
+    spawnMock
+      .mockReturnValueOnce(firstProcess)
+      .mockReturnValueOnce(secondProcess);
+
+    await executeApp({
+      appPath: "/tmp/app",
+      appId: 1,
+      event: createEvent(),
+      isNeon: false,
+    });
+    await executeApp({
+      appPath: "/tmp/app",
+      appId: 1,
+      event: createEvent(),
+      isNeon: false,
+    });
+
+    firstProcess.emit("close", 1, null);
+
+    expect(safeSendMock).not.toHaveBeenCalledWith(
+      expect.anything(),
+      "app:output",
+      expect.objectContaining({ type: "app-exit" }),
+    );
+    expect(runningApps.get(1)?.process).toBe(
+      secondProcess as unknown as ChildProcess,
+    );
+  });
+
+  it("emits app-exit when the current process closes", async () => {
+    const process = new FakeChildProcess(101);
+    spawnMock.mockReturnValueOnce(process);
+
+    const event = createEvent();
+    await executeApp({
+      appPath: "/tmp/app",
+      appId: 1,
+      event,
+      isNeon: false,
+    });
+
+    process.emit("close", 1, null);
+
+    expect(safeSendMock).toHaveBeenCalledWith(
+      event.sender,
+      "app:output",
+      expect.objectContaining({
+        type: "app-exit",
+        appId: 1,
+        exitCode: 1,
+        signal: null,
+      }),
+    );
+    expect(runningApps.has(1)).toBe(false);
+  });
+});

--- a/src/ipc/services/app_runtime_service.ts
+++ b/src/ipc/services/app_runtime_service.ts
@@ -574,6 +574,12 @@ function listenToProcess({
       `App ${appId} (PID: ${spawnedProcess.pid}) process closed with code ${code}, signal ${signal}.`,
     );
     flushAllAppOutputs();
+    const currentAppInfo = runningApps.get(appId);
+    if (!currentAppInfo || currentAppInfo.process !== spawnedProcess) {
+      removeAppIfCurrentProcess(appId, spawnedProcess);
+      return;
+    }
+
     safeSend(event.sender, "app:output", {
       type: "app-exit",
       message: `App process exited with code ${code ?? "null"}`,

--- a/src/ipc/services/app_runtime_service.ts
+++ b/src/ipc/services/app_runtime_service.ts
@@ -574,6 +574,14 @@ function listenToProcess({
       `App ${appId} (PID: ${spawnedProcess.pid}) process closed with code ${code}, signal ${signal}.`,
     );
     flushAllAppOutputs();
+    safeSend(event.sender, "app:output", {
+      type: "app-exit",
+      message: `App process exited with code ${code ?? "null"}`,
+      appId,
+      exitCode: code,
+      signal,
+      timestamp: Date.now(),
+    });
     removeAppIfCurrentProcess(appId, spawnedProcess);
   });
 

--- a/src/ipc/types/misc.ts
+++ b/src/ipc/types/misc.ts
@@ -304,10 +304,13 @@ export const AppOutputSchema = z.object({
     "package-manager-warning",
     "sync-error",
     "sync-recovered",
+    "app-exit",
   ]),
   message: z.string(),
   appId: z.number(),
   timestamp: z.number().optional(),
+  exitCode: z.number().nullable().optional(),
+  signal: z.string().nullable().optional(),
 });
 
 export type AppOutput = z.infer<typeof AppOutputSchema>;


### PR DESCRIPTION
## Summary
- Track preview app process exits from the app output IPC stream.
- Reset exit state when starting or rebuilding the preview app.
- Show the preview Fix errors with AI action only after the current run exits with a non-zero code.

## Test plan
- npm run fmt && npm run lint:fix && npm run ts
- npm test

🤖 Generated with [Claude Code](https://claude.com/claude-code)