### PR TITLE
Fix generated pnpm workspace config

### DIFF
--- a/rules/electron-ipc.md
+++ b/rules/electron-ipc.md
@@ -143,6 +143,8 @@ When changing install-policy constants or helpers in `src/ipc/utils/socket_firew
 
 Do not treat "pnpm is available but older than the minimumReleaseAge-supporting version" the same as "pnpm is unavailable." `PNPM_INSTALL_POLICY_ARGS` currently use `--config.*` flags, which pnpm 10.15.0 and 9.0.0 accept on `pnpm install`; keep using pnpm with those flags when it is present, and only fall back to npm when the pnpm binary cannot be run.
 
+When generating `pnpm-workspace.yaml` for install policy (`allowBuilds`, `minimumReleaseAge`), include a top-level `packages:` block such as `packages: ["." ]` if one does not already exist. pnpm 9 treats `pnpm-workspace.yaml` as a workspace manifest and fails with `packages field missing or empty` when the file only contains config keys.
+
 ## React + IPC integration pattern
 
 When creating hooks/components that call IPC handlers:

--- a/src/ipc/utils/socket_firewall.test.ts
+++ b/src/ipc/utils/socket_firewall.test.ts
@@ -137,9 +137,6 @@ describe("updatePnpmAllowBuildsConfigContent", () => {
   it("creates allowBuilds config when no config exists", () => {
     expect(updatePnpmAllowBuildsConfigContent("", allowBuildsText)).toBe(
       [
-        "packages:",
-        "  - .",
-        "",
         "allowBuilds:",
         "  # dyad-default-allow-builds begin",
         "  # dyad-default-allow-builds-schema=v1",
@@ -148,6 +145,9 @@ describe("updatePnpmAllowBuildsConfigContent", () => {
         '  "@swc/core": true',
         "  sharp: true",
         "  # dyad-default-allow-builds end",
+        "",
+        "packages:",
+        "  - .",
         "minimumReleaseAge: 1440",
         "",
       ].join("\n"),
@@ -164,9 +164,6 @@ describe("updatePnpmAllowBuildsConfigContent", () => {
       ),
     ).toBe(
       [
-        "packages:",
-        "  - .",
-        "",
         "storeDir: /tmp/pnpm-store",
         "allowBuilds:",
         "  # dyad-default-allow-builds begin",
@@ -176,6 +173,9 @@ describe("updatePnpmAllowBuildsConfigContent", () => {
         '  "@swc/core": true',
         "  # dyad-default-allow-builds end",
         "  sharp: false",
+        "",
+        "packages:",
+        "  - .",
         "minimumReleaseAge: 1440",
         "",
       ].join("\n"),
@@ -190,9 +190,6 @@ describe("updatePnpmAllowBuildsConfigContent", () => {
       ),
     ).toBe(
       [
-        "packages:",
-        "  - .",
-        "",
         "minimumReleaseAge: 60",
         "allowBuilds:",
         "  # dyad-default-allow-builds begin",
@@ -202,6 +199,9 @@ describe("updatePnpmAllowBuildsConfigContent", () => {
         '  "@swc/core": true',
         "  # dyad-default-allow-builds end",
         "  sharp: false",
+        "",
+        "packages:",
+        "  - .",
         "",
       ].join("\n"),
     );
@@ -223,9 +223,6 @@ describe("updatePnpmAllowBuildsConfigContent", () => {
       ),
     ).toBe(
       [
-        "packages:",
-        "  - .",
-        "",
         "allowBuilds:",
         "  # dyad-default-allow-builds begin",
         "  # dyad-default-allow-builds-schema=v1",
@@ -234,6 +231,9 @@ describe("updatePnpmAllowBuildsConfigContent", () => {
         '  "@swc/core": true',
         "  sharp: true",
         "  # dyad-default-allow-builds end",
+        "",
+        "packages:",
+        "  - .",
         "minimumReleaseAge: 1440",
         "",
       ].join("\n"),
@@ -253,9 +253,6 @@ describe("updatePnpmAllowBuildsConfigContent", () => {
       ),
     ).toBe(
       [
-        "packages:",
-        "  - .",
-        "",
         "allowBuilds:",
         "  # dyad-default-allow-builds begin",
         "  # dyad-default-allow-builds-schema=v1",
@@ -264,6 +261,9 @@ describe("updatePnpmAllowBuildsConfigContent", () => {
         '  "@swc/core": true',
         "  sharp: true",
         "  # dyad-default-allow-builds end",
+        "",
+        "packages:",
+        "  - .",
         "minimumReleaseAge: 1440",
         "",
       ].join("\n"),
@@ -301,6 +301,40 @@ describe("updatePnpmAllowBuildsConfigContent", () => {
     );
   });
 
+  it("does not move YAML directives or document markers when adding packages", () => {
+    expect(
+      updatePnpmAllowBuildsConfigContent(
+        [
+          "%YAML 1.2",
+          "---",
+          "# existing config",
+          "allowBuilds:",
+          "  sharp: false",
+        ].join("\n"),
+        allowBuildsText,
+      ),
+    ).toBe(
+      [
+        "%YAML 1.2",
+        "---",
+        "# existing config",
+        "allowBuilds:",
+        "  # dyad-default-allow-builds begin",
+        "  # dyad-default-allow-builds-schema=v1",
+        "  # dyad-default-allow-builds-data-version=2026-05-21.1",
+        "  # dyad-default-allow-builds-channel=local",
+        '  "@swc/core": true',
+        "  # dyad-default-allow-builds end",
+        "  sharp: false",
+        "",
+        "packages:",
+        "  - .",
+        "minimumReleaseAge: 1440",
+        "",
+      ].join("\n"),
+    );
+  });
+
   it("writes project pnpm-workspace.yaml atomically", async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "dyad-pnpm-config-"));
     try {
@@ -315,9 +349,6 @@ describe("updatePnpmAllowBuildsConfigContent", () => {
         readFile(path.join(tempDir, "pnpm-workspace.yaml"), "utf8"),
       ).resolves.toBe(
         [
-          "packages:",
-          "  - .",
-          "",
           "allowBuilds:",
           "  # dyad-default-allow-builds begin",
           "  # dyad-default-allow-builds-schema=v1",
@@ -326,6 +357,9 @@ describe("updatePnpmAllowBuildsConfigContent", () => {
           '  "@swc/core": true',
           "  sharp: true",
           "  # dyad-default-allow-builds end",
+          "",
+          "packages:",
+          "  - .",
           "minimumReleaseAge: 1440",
           "",
         ].join("\n"),

--- a/src/ipc/utils/socket_firewall.test.ts
+++ b/src/ipc/utils/socket_firewall.test.ts
@@ -137,6 +137,9 @@ describe("updatePnpmAllowBuildsConfigContent", () => {
   it("creates allowBuilds config when no config exists", () => {
     expect(updatePnpmAllowBuildsConfigContent("", allowBuildsText)).toBe(
       [
+        "packages:",
+        "  - .",
+        "",
         "allowBuilds:",
         "  # dyad-default-allow-builds begin",
         "  # dyad-default-allow-builds-schema=v1",
@@ -161,6 +164,9 @@ describe("updatePnpmAllowBuildsConfigContent", () => {
       ),
     ).toBe(
       [
+        "packages:",
+        "  - .",
+        "",
         "storeDir: /tmp/pnpm-store",
         "allowBuilds:",
         "  # dyad-default-allow-builds begin",
@@ -184,6 +190,9 @@ describe("updatePnpmAllowBuildsConfigContent", () => {
       ),
     ).toBe(
       [
+        "packages:",
+        "  - .",
+        "",
         "minimumReleaseAge: 60",
         "allowBuilds:",
         "  # dyad-default-allow-builds begin",
@@ -214,6 +223,9 @@ describe("updatePnpmAllowBuildsConfigContent", () => {
       ),
     ).toBe(
       [
+        "packages:",
+        "  - .",
+        "",
         "allowBuilds:",
         "  # dyad-default-allow-builds begin",
         "  # dyad-default-allow-builds-schema=v1",
@@ -241,6 +253,9 @@ describe("updatePnpmAllowBuildsConfigContent", () => {
       ),
     ).toBe(
       [
+        "packages:",
+        "  - .",
+        "",
         "allowBuilds:",
         "  # dyad-default-allow-builds begin",
         "  # dyad-default-allow-builds-schema=v1",
@@ -261,6 +276,31 @@ describe("updatePnpmAllowBuildsConfigContent", () => {
     ).toThrow("Invalid default pnpm allow-builds list");
   });
 
+  it("preserves an existing packages config", () => {
+    expect(
+      updatePnpmAllowBuildsConfigContent(
+        ["packages:", "  - apps/*", "", "allowBuilds:"].join("\n"),
+        allowBuildsText,
+      ),
+    ).toBe(
+      [
+        "packages:",
+        "  - apps/*",
+        "",
+        "allowBuilds:",
+        "  # dyad-default-allow-builds begin",
+        "  # dyad-default-allow-builds-schema=v1",
+        "  # dyad-default-allow-builds-data-version=2026-05-21.1",
+        "  # dyad-default-allow-builds-channel=local",
+        '  "@swc/core": true',
+        "  sharp: true",
+        "  # dyad-default-allow-builds end",
+        "minimumReleaseAge: 1440",
+        "",
+      ].join("\n"),
+    );
+  });
+
   it("writes project pnpm-workspace.yaml atomically", async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "dyad-pnpm-config-"));
     try {
@@ -275,6 +315,9 @@ describe("updatePnpmAllowBuildsConfigContent", () => {
         readFile(path.join(tempDir, "pnpm-workspace.yaml"), "utf8"),
       ).resolves.toBe(
         [
+          "packages:",
+          "  - .",
+          "",
           "allowBuilds:",
           "  # dyad-default-allow-builds begin",
           "  # dyad-default-allow-builds-schema=v1",
@@ -434,6 +477,9 @@ describe("updatePnpmAllowBuildsConfigContent", () => {
     );
     const configPath = path.join(tempDir, "pnpm-workspace.yaml");
     const existingConfig = [
+      "packages:",
+      "  - .",
+      "",
       "allowBuilds:",
       "  # dyad-default-allow-builds begin",
       "  # dyad-default-allow-builds-schema=v1",

--- a/src/ipc/utils/socket_firewall.ts
+++ b/src/ipc/utils/socket_firewall.ts
@@ -341,7 +341,10 @@ function hasTopLevelConfigKey(lines: string[], key: string): boolean {
 
 function formatPnpmWorkspaceConfigContent(lines: string[]): string {
   if (!hasTopLevelConfigKey(lines, "packages")) {
-    lines.unshift("packages:", "  - .", "");
+    if (lines.length > 0 && lines.at(-1) !== "") {
+      lines.push("");
+    }
+    lines.push("packages:", "  - .");
   }
 
   if (!hasTopLevelConfigKey(lines, "minimumReleaseAge")) {

--- a/src/ipc/utils/socket_firewall.ts
+++ b/src/ipc/utils/socket_firewall.ts
@@ -340,6 +340,10 @@ function hasTopLevelConfigKey(lines: string[], key: string): boolean {
 }
 
 function formatPnpmWorkspaceConfigContent(lines: string[]): string {
+  if (!hasTopLevelConfigKey(lines, "packages")) {
+    lines.unshift("packages:", "  - .", "");
+  }
+
   if (!hasTopLevelConfigKey(lines, "minimumReleaseAge")) {
     lines.push(`minimumReleaseAge: ${MINIMUM_PACKAGE_RELEASE_AGE_MINUTES}`);
   }


### PR DESCRIPTION
## Summary
- Add a default `packages: ['.']` block when Dyad generates pnpm workspace config.
- Preserve existing workspace package patterns when updating allow-builds config.
- Update socket firewall tests for pnpm 9-compatible workspace output.

## Test plan
- `npm run fmt`
- `npm run lint:fix`
- `npm run ts`
- `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)