### PR TITLE
Bypass Corepack project pnpm pins for install policy

### DIFF
--- a/rules/electron-ipc.md
+++ b/rules/electron-ipc.md
@@ -143,6 +143,8 @@ When changing install-policy constants or helpers in `src/ipc/utils/socket_firew
 
 Do not treat "pnpm is available but older than the minimumReleaseAge-supporting version" the same as "pnpm is unavailable." `PNPM_INSTALL_POLICY_ARGS` currently use `--config.*` flags, which pnpm 10.15.0 and 9.0.0 accept on `pnpm install`; keep using pnpm with those flags when it is present, and only fall back to npm when the pnpm binary cannot be run.
 
+When running Dyad-managed pnpm install/add commands from inside an app directory, use `getPnpmCommandEnv()` so Corepack ignores stale project `packageManager` pins via `COREPACK_ENABLE_PROJECT_SPEC=0`. Apply this to `npx sfw ... pnpm ...` wrappers too, since the wrapped pnpm inherits the parent env; avoid forcing it onto user-authored custom commands unless intentionally changing their package-manager semantics.
+
 When generating `pnpm-workspace.yaml` for install policy (`allowBuilds`, `minimumReleaseAge`), include a top-level `packages:` block such as `packages: ["." ]` if one does not already exist. pnpm 9 treats `pnpm-workspace.yaml` as a workspace manifest and fails with `packages field missing or empty` when the file only contains config keys.
 
 Automated `pnpm add` commands that run in an app root with a generated `pnpm-workspace.yaml` must pass `--ignore-workspace-root-check`. Otherwise older pnpm versions can fail with `ERR_PNPM_ADDING_TO_ROOT` even though Dyad intentionally installs into that app root.

--- a/rules/electron-ipc.md
+++ b/rules/electron-ipc.md
@@ -143,7 +143,7 @@ When changing install-policy constants or helpers in `src/ipc/utils/socket_firew
 
 Do not treat "pnpm is available but older than the minimumReleaseAge-supporting version" the same as "pnpm is unavailable." `PNPM_INSTALL_POLICY_ARGS` currently use `--config.*` flags, which pnpm 10.15.0 and 9.0.0 accept on `pnpm install`; keep using pnpm with those flags when it is present, and only fall back to npm when the pnpm binary cannot be run.
 
-When running Dyad-managed pnpm install/add commands from inside an app directory, use `getPnpmCommandEnv()` so Corepack ignores stale project `packageManager` pins via `COREPACK_ENABLE_PROJECT_SPEC=0`. Apply this to `npx sfw ... pnpm ...` wrappers too, since the wrapped pnpm inherits the parent env; avoid forcing it onto user-authored custom commands unless intentionally changing their package-manager semantics.
+When running Dyad-managed package-manager install/add/probe commands from inside an app directory, use `getPackageManagerCommandEnv()` so Corepack ignores stale project `packageManager` pins via `COREPACK_ENABLE_PROJECT_SPEC=0`. Apply this to `pnpm --version` probes and `npx sfw ...` wrappers too, since the wrapped package manager inherits the parent env; avoid forcing it onto user-authored custom commands unless intentionally changing their package-manager semantics.
 
 When generating `pnpm-workspace.yaml` for install policy (`allowBuilds`, `minimumReleaseAge`), include a top-level `packages:` block such as `packages: ["." ]` if one does not already exist. pnpm 9 treats `pnpm-workspace.yaml` as a workspace manifest and fails with `packages field missing or empty` when the file only contains config keys.
 

--- a/src/ipc/handlers/app_upgrade_handlers.ts
+++ b/src/ipc/handlers/app_upgrade_handlers.ts
@@ -11,6 +11,7 @@ import { spawn } from "node:child_process";
 import { gitAddAll, gitCommit } from "../utils/git_utils";
 import { simpleSpawn } from "../utils/simpleSpawn";
 import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
+import { getPackageManagerCommandEnv } from "@/ipc/utils/socket_firewall";
 
 export const logger = log.scope("app_upgrade_handlers");
 const handle = createLoggedHandler(logger);
@@ -161,6 +162,7 @@ async function applyComponentTagger(appPath: string) {
       "pnpm add --ignore-workspace-root-check -D @dyad-sh/react-vite-component-tagger || npm install --save-dev --legacy-peer-deps @dyad-sh/react-vite-component-tagger",
       {
         cwd: appPath,
+        env: getPackageManagerCommandEnv(),
         shell: true,
         stdio: "pipe",
       },

--- a/src/ipc/handlers/debug_handlers.ts
+++ b/src/ipc/handlers/debug_handlers.ts
@@ -26,6 +26,7 @@ import { eq } from "drizzle-orm";
 import { getDyadAppPath } from "../../paths/paths";
 import { validateChatContext } from "../utils/context_paths_utils";
 import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
+import { getPackageManagerCommandEnv } from "@/ipc/utils/socket_firewall";
 
 // Shared function to get system debug info
 async function getSystemDebugInfo({
@@ -48,7 +49,9 @@ async function getSystemDebugInfo({
   }
 
   try {
-    pnpmVersion = await runShellCommand("pnpm --version");
+    pnpmVersion = await runShellCommand("pnpm --version", {
+      env: getPackageManagerCommandEnv(),
+    });
   } catch (err) {
     console.error("Failed to get pnpm version:", err);
   }
@@ -295,7 +298,9 @@ export function registerDebugHandlers() {
       // Get runtime info in parallel
       const [nodeVersion, pnpmVersion, nodePathResult] = await Promise.all([
         runShellCommand("node --version").catch(() => null),
-        runShellCommand("pnpm --version").catch(() => null),
+        runShellCommand("pnpm --version", {
+          env: getPackageManagerCommandEnv(),
+        }).catch(() => null),
         (platform() === "win32"
           ? runShellCommand("where.exe node")
           : runShellCommand("which node")

--- a/src/ipc/handlers/node_handlers.ts
+++ b/src/ipc/handlers/node_handlers.ts
@@ -13,6 +13,7 @@ import { IS_TEST_BUILD } from "../utils/test_utils";
 import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
 import {
   getCommandExecutionDisplayDetails,
+  getPackageManagerCommandEnv,
   PNPM_GLOBAL_INSTALL_PACKAGE,
   runCommand,
 } from "@/ipc/utils/socket_firewall";
@@ -128,6 +129,7 @@ export function registerNodeHandlers() {
       // If both fail, then pnpm is not available.
       runShellCommand(
         `pnpm --version || (corepack enable pnpm && pnpm --version) || (npm install -g ${PNPM_GLOBAL_INSTALL_PACKAGE} && pnpm --version)`,
+        { env: getPackageManagerCommandEnv() },
       ),
     ]);
     return { nodeVersion, pnpmVersion, nodeDownloadUrl };
@@ -146,15 +148,18 @@ export function registerNodeHandlers() {
 
       // Use --force in case pnpm is already installed, but user
       // wants to upgrade.
-      await runCommand("npm", [
-        "install",
-        "-g",
-        "--force",
-        PNPM_GLOBAL_INSTALL_PACKAGE,
-      ]);
+      await runCommand(
+        "npm",
+        ["install", "-g", "--force", PNPM_GLOBAL_INSTALL_PACKAGE],
+        {
+          env: getPackageManagerCommandEnv(),
+        },
+      );
       reloadNodePath();
 
-      const result = await runCommand("pnpm", ["--version"]);
+      const result = await runCommand("pnpm", ["--version"], {
+        env: getPackageManagerCommandEnv(),
+      });
       const pnpmVersion = result.stdout.trim();
       if (!pnpmVersion) {
         throw new Error(

--- a/src/ipc/processors/executeAddDependency.test.ts
+++ b/src/ipc/processors/executeAddDependency.test.ts
@@ -382,6 +382,9 @@ describe("executeAddDependency", () => {
       ],
       {
         cwd: "/tmp/app",
+        env: expect.objectContaining({
+          COREPACK_ENABLE_PROJECT_SPEC: "0",
+        }),
         timeoutMs: ADD_DEPENDENCY_INSTALL_TIMEOUT_MS,
       },
     );

--- a/src/ipc/processors/executeAddDependency.test.ts
+++ b/src/ipc/processors/executeAddDependency.test.ts
@@ -431,6 +431,9 @@ describe("executeAddDependency", () => {
       ["install", "--legacy-peer-deps", "react"],
       {
         cwd: "/tmp/app",
+        env: expect.objectContaining({
+          COREPACK_ENABLE_PROJECT_SPEC: "0",
+        }),
         timeoutMs: ADD_DEPENDENCY_INSTALL_TIMEOUT_MS,
       },
     );

--- a/src/ipc/processors/executeAddDependency.ts
+++ b/src/ipc/processors/executeAddDependency.ts
@@ -10,6 +10,7 @@ import {
   commitPnpmAllowBuildsConfigIfChanged,
   ensureSocketFirewallInstalled,
   getCommandExecutionDisplayDetails,
+  getPnpmCommandEnv,
   getPnpmMinimumReleaseAgeSupport,
   runCommand,
 } from "@/ipc/utils/socket_firewall";
@@ -139,10 +140,18 @@ async function runAddDependencyCommand(
   lastError: unknown;
 }> {
   try {
-    const { stdout, stderr } = await runCommand(command.command, command.args, {
+    const usesPnpm =
+      command.command === "pnpm" || command.args.includes("pnpm");
+    const options = {
       cwd: appPath,
       timeoutMs: ADD_DEPENDENCY_INSTALL_TIMEOUT_MS,
-    });
+      ...(usesPnpm ? { env: getPnpmCommandEnv() } : {}),
+    };
+    const { stdout, stderr } = await runCommand(
+      command.command,
+      command.args,
+      options,
+    );
     return {
       succeeded: true,
       installResults: stdout + (stderr ? `\n${stderr}` : ""),

--- a/src/ipc/processors/executeAddDependency.ts
+++ b/src/ipc/processors/executeAddDependency.ts
@@ -10,7 +10,7 @@ import {
   commitPnpmAllowBuildsConfigIfChanged,
   ensureSocketFirewallInstalled,
   getCommandExecutionDisplayDetails,
-  getPnpmCommandEnv,
+  getPackageManagerCommandEnv,
   getPnpmMinimumReleaseAgeSupport,
   runCommand,
 } from "@/ipc/utils/socket_firewall";
@@ -140,12 +140,10 @@ async function runAddDependencyCommand(
   lastError: unknown;
 }> {
   try {
-    const usesPnpm =
-      command.command === "pnpm" || command.args.includes("pnpm");
     const options = {
       cwd: appPath,
+      env: getPackageManagerCommandEnv(),
       timeoutMs: ADD_DEPENDENCY_INSTALL_TIMEOUT_MS,
-      ...(usesPnpm ? { env: getPnpmCommandEnv() } : {}),
     };
     const { stdout, stderr } = await runCommand(
       command.command,

--- a/src/ipc/services/app_runtime_service.test.ts
+++ b/src/ipc/services/app_runtime_service.test.ts
@@ -71,6 +71,10 @@ vi.mock("@/ipc/utils/safe_sender", () => ({
 vi.mock("@/ipc/utils/socket_firewall", () => ({
   ensurePnpmAllowBuildsConfigured: (args: unknown) =>
     ensurePnpmAllowBuildsConfiguredMock(args),
+  getPnpmCommandEnv: () => ({
+    ...process.env,
+    COREPACK_ENABLE_PROJECT_SPEC: "0",
+  }),
   getPnpmMinimumReleaseAgeSupport: () => getPnpmMinimumReleaseAgeSupportMock(),
   PNPM_INSTALL_POLICY_ARGS: ["--minimum-release-age=1440"],
 }));
@@ -231,6 +235,9 @@ describe("executeApp", () => {
       [],
       expect.objectContaining({
         cwd: "/tmp/app",
+        env: expect.objectContaining({
+          COREPACK_ENABLE_PROJECT_SPEC: "0",
+        }),
         shell: true,
       }),
     );

--- a/src/ipc/services/app_runtime_service.test.ts
+++ b/src/ipc/services/app_runtime_service.test.ts
@@ -71,7 +71,7 @@ vi.mock("@/ipc/utils/safe_sender", () => ({
 vi.mock("@/ipc/utils/socket_firewall", () => ({
   ensurePnpmAllowBuildsConfigured: (args: unknown) =>
     ensurePnpmAllowBuildsConfiguredMock(args),
-  getPnpmCommandEnv: () => ({
+  getPackageManagerCommandEnv: () => ({
     ...process.env,
     COREPACK_ENABLE_PROJECT_SPEC: "0",
   }),

--- a/src/ipc/services/app_runtime_service.test.ts
+++ b/src/ipc/services/app_runtime_service.test.ts
@@ -127,6 +127,23 @@ function createEvent(): Electron.IpcMainInvokeEvent {
   return { sender } as IpcMainInvokeEvent;
 }
 
+async function withCorepackProjectSpecEnv<T>(
+  value: string,
+  callback: () => Promise<T>,
+): Promise<T> {
+  const originalValue = process.env.COREPACK_ENABLE_PROJECT_SPEC;
+  process.env.COREPACK_ENABLE_PROJECT_SPEC = value;
+  try {
+    return await callback();
+  } finally {
+    if (originalValue === undefined) {
+      delete process.env.COREPACK_ENABLE_PROJECT_SPEC;
+    } else {
+      process.env.COREPACK_ENABLE_PROJECT_SPEC = originalValue;
+    }
+  }
+}
+
 describe("executeApp", () => {
   beforeEach(() => {
     runningApps.clear();
@@ -252,6 +269,63 @@ describe("executeApp", () => {
         message: "Install pnpm 10.16.0 or newer for the strongest protection",
       }),
     );
+  });
+
+  it("does not disable Corepack project specs for npm fallback commands", async () => {
+    await withCorepackProjectSpecEnv("1", async () => {
+      const process = new FakeChildProcess(101);
+      spawnMock.mockReturnValueOnce(process);
+
+      await executeApp({
+        appPath: "/tmp/app",
+        appId: 1,
+        event: createEvent(),
+        isNeon: false,
+      });
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        "(npm install --legacy-peer-deps && npm run dev -- --port 32101)",
+        [],
+        expect.objectContaining({
+          cwd: "/tmp/app",
+          env: expect.objectContaining({
+            COREPACK_ENABLE_PROJECT_SPEC: "1",
+          }),
+          shell: true,
+        }),
+      );
+      expect(ensurePnpmAllowBuildsConfiguredMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it("does not disable Corepack project specs for custom commands", async () => {
+    await withCorepackProjectSpecEnv("1", async () => {
+      const process = new FakeChildProcess(101);
+      spawnMock.mockReturnValueOnce(process);
+
+      await executeApp({
+        appPath: "/tmp/app",
+        appId: 1,
+        event: createEvent(),
+        isNeon: false,
+        installCommand: "pnpm install --frozen-lockfile",
+        startCommand: "pnpm run preview -- --port 32101",
+      });
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        "pnpm install --frozen-lockfile && pnpm run preview -- --port 32101",
+        [],
+        expect.objectContaining({
+          cwd: "/tmp/app",
+          env: expect.objectContaining({
+            COREPACK_ENABLE_PROJECT_SPEC: "1",
+          }),
+          shell: true,
+        }),
+      );
+      expect(getPnpmMinimumReleaseAgeSupportMock).not.toHaveBeenCalled();
+      expect(ensurePnpmAllowBuildsConfiguredMock).not.toHaveBeenCalled();
+    });
   });
 
   it("starts the proxy on the deterministic port without killing the occupant", async () => {

--- a/src/ipc/services/app_runtime_service.ts
+++ b/src/ipc/services/app_runtime_service.ts
@@ -34,6 +34,7 @@ import {
 } from "@/ipc/utils/process_manager";
 import {
   ensurePnpmAllowBuildsConfigured,
+  getPnpmCommandEnv,
   getPnpmMinimumReleaseAgeSupport,
   PNPM_INSTALL_POLICY_ARGS,
 } from "@/ipc/utils/socket_firewall";
@@ -345,8 +346,10 @@ async function executeAppLocalNode({
     onPnpmMinimumReleaseAgeWarning: (message) =>
       emitPnpmMinimumReleaseAgeWarning({ appId, event, message }),
   });
+  const hasCustomCommands = !!installCommand?.trim() && !!startCommand?.trim();
   const spawnedProcess = spawn(command, [], {
     cwd: appPath,
+    env: hasCustomCommands ? process.env : getPnpmCommandEnv(),
     shell: true,
     stdio: "pipe",
     detached: false,

--- a/src/ipc/services/app_runtime_service.ts
+++ b/src/ipc/services/app_runtime_service.ts
@@ -34,7 +34,7 @@ import {
 } from "@/ipc/utils/process_manager";
 import {
   ensurePnpmAllowBuildsConfigured,
-  getPnpmCommandEnv,
+  getPackageManagerCommandEnv,
   getPnpmMinimumReleaseAgeSupport,
   PNPM_INSTALL_POLICY_ARGS,
 } from "@/ipc/utils/socket_firewall";
@@ -349,7 +349,7 @@ async function executeAppLocalNode({
   const hasCustomCommands = !!installCommand?.trim() && !!startCommand?.trim();
   const spawnedProcess = spawn(command, [], {
     cwd: appPath,
-    env: hasCustomCommands ? process.env : getPnpmCommandEnv(),
+    env: hasCustomCommands ? process.env : getPackageManagerCommandEnv(),
     shell: true,
     stdio: "pipe",
     detached: false,

--- a/src/ipc/services/app_runtime_service.ts
+++ b/src/ipc/services/app_runtime_service.ts
@@ -36,6 +36,7 @@ import {
   ensurePnpmAllowBuildsConfigured,
   getPackageManagerCommandEnv,
   getPnpmMinimumReleaseAgeSupport,
+  type PackageManager,
   PNPM_INSTALL_POLICY_ARGS,
 } from "@/ipc/utils/socket_firewall";
 
@@ -83,6 +84,12 @@ function getNpmInstallCommand(): string {
   return "npm install --legacy-peer-deps";
 }
 
+interface AppRuntimeCommand {
+  command: string;
+  isCustom: boolean;
+  packageManager: PackageManager | null;
+}
+
 async function getDefaultCommand({
   runtimeMode,
   appId,
@@ -93,26 +100,37 @@ async function getDefaultCommand({
   appId: number;
   appPath: string;
   onPnpmMinimumReleaseAgeWarning?: (message: string) => void;
-}): Promise<string> {
+}): Promise<AppRuntimeCommand> {
   const port = getAppPort(appId);
   if (runtimeMode === "docker") {
     await ensurePnpmAllowBuildsConfigured({ appPath });
-    return `${getPnpmInstallCommand()} && pnpm run dev --port ${port}`;
+    return {
+      command: `${getPnpmInstallCommand()} && pnpm run dev --port ${port}`,
+      isCustom: false,
+      packageManager: "pnpm",
+    };
   }
 
   const pnpmSupport = await getPnpmMinimumReleaseAgeSupport();
-  const npmCommand = `(${getNpmInstallCommand()} && npm run dev -- --port ${port})`;
 
   if (!pnpmSupport.minimumReleaseAgeSupported && pnpmSupport.warningMessage) {
     onPnpmMinimumReleaseAgeWarning?.(pnpmSupport.warningMessage);
   }
 
   if (!pnpmSupport.available) {
-    return npmCommand;
+    return {
+      command: `(${getNpmInstallCommand()} && npm run dev -- --port ${port})`,
+      isCustom: false,
+      packageManager: "npm",
+    };
   }
 
   await ensurePnpmAllowBuildsConfigured({ appPath });
-  return `${getPnpmInstallCommand()} && pnpm run dev --port ${port}`;
+  return {
+    command: `${getPnpmInstallCommand()} && pnpm run dev --port ${port}`,
+    isCustom: false,
+    packageManager: "pnpm",
+  };
 }
 
 async function getCommand({
@@ -129,10 +147,14 @@ async function getCommand({
   installCommand?: string | null;
   startCommand?: string | null;
   onPnpmMinimumReleaseAgeWarning?: (message: string) => void;
-}): Promise<string> {
+}): Promise<AppRuntimeCommand> {
   const hasCustomCommands = !!installCommand?.trim() && !!startCommand?.trim();
   if (hasCustomCommands) {
-    return `${installCommand!.trim()} && ${startCommand!.trim()}`;
+    return {
+      command: `${installCommand!.trim()} && ${startCommand!.trim()}`,
+      isCustom: true,
+      packageManager: null,
+    };
   }
 
   return getDefaultCommand({
@@ -346,10 +368,14 @@ async function executeAppLocalNode({
     onPnpmMinimumReleaseAgeWarning: (message) =>
       emitPnpmMinimumReleaseAgeWarning({ appId, event, message }),
   });
-  const hasCustomCommands = !!installCommand?.trim() && !!startCommand?.trim();
-  const spawnedProcess = spawn(command, [], {
+  let env = { ...process.env };
+  if (!command.isCustom && command.packageManager === "pnpm") {
+    env = getPackageManagerCommandEnv();
+  }
+
+  const spawnedProcess = spawn(command.command, [], {
     cwd: appPath,
-    env: hasCustomCommands ? process.env : getPackageManagerCommandEnv(),
+    env,
     shell: true,
     stdio: "pipe",
     detached: false,
@@ -383,7 +409,7 @@ async function executeAppLocalNode({
       .join(", ");
 
     logger.error(
-      `Failed to spawn process for app ${appId}. Command="${command}", CWD="${appPath}", ${details}\nSTDERR:\n${
+      `Failed to spawn process for app ${appId}. Command="${command.command}", CWD="${appPath}", ${details}\nSTDERR:\n${
         errorOutput || "(empty)"
       }`,
     );
@@ -747,15 +773,17 @@ RUN npm install -g pnpm
       `dyad-app-${appId}`,
       "sh",
       "-c",
-      await getCommand({
-        runtimeMode: "docker",
-        appId,
-        appPath,
-        installCommand,
-        startCommand,
-        onPnpmMinimumReleaseAgeWarning: (message) =>
-          emitPnpmMinimumReleaseAgeWarning({ appId, event, message }),
-      }),
+      (
+        await getCommand({
+          runtimeMode: "docker",
+          appId,
+          appPath,
+          installCommand,
+          startCommand,
+          onPnpmMinimumReleaseAgeWarning: (message) =>
+            emitPnpmMinimumReleaseAgeWarning({ appId, event, message }),
+        })
+      ).command,
     ],
     {
       stdio: "pipe",

--- a/src/ipc/utils/runShellCommand.ts
+++ b/src/ipc/utils/runShellCommand.ts
@@ -3,11 +3,15 @@ import log from "electron-log";
 
 const logger = log.scope("runShellCommand");
 
-export function runShellCommand(command: string): Promise<string | null> {
+export function runShellCommand(
+  command: string,
+  options: { env?: NodeJS.ProcessEnv } = {},
+): Promise<string | null> {
   logger.log(`Running command: ${command}`);
   return new Promise((resolve) => {
     let output = "";
     const process = spawn(command, {
+      env: options.env,
       shell: true,
       stdio: ["ignore", "pipe", "pipe"], // ignore stdin, pipe stdout/stderr
     });

--- a/src/ipc/utils/socket_firewall.test.ts
+++ b/src/ipc/utils/socket_firewall.test.ts
@@ -26,6 +26,7 @@ import {
   DYAD_ALLOW_BUILDS_CACHE_TTL_MS,
   ensurePnpmAllowBuildsConfigured,
   ensureSocketFirewallInstalled,
+  getPnpmCommandEnv,
   getPnpmMinimumReleaseAgeSupport,
   PACKAGE_MANAGER_PROBE_TIMEOUT_MS,
   resolveExecutableName,
@@ -59,6 +60,16 @@ async function withPlatform<T>(
 
 beforeEach(() => {
   vi.clearAllMocks();
+});
+
+describe("getPnpmCommandEnv", () => {
+  it("disables Corepack project packageManager pins while preserving the rest of the env", () => {
+    expect(getPnpmCommandEnv({ PATH: "/bin", FOO: "bar" })).toEqual({
+      PATH: "/bin",
+      FOO: "bar",
+      COREPACK_ENABLE_PROJECT_SPEC: "0",
+    });
+  });
 });
 
 describe("detectPreferredPackageManager", () => {

--- a/src/ipc/utils/socket_firewall.test.ts
+++ b/src/ipc/utils/socket_firewall.test.ts
@@ -26,7 +26,7 @@ import {
   DYAD_ALLOW_BUILDS_CACHE_TTL_MS,
   ensurePnpmAllowBuildsConfigured,
   ensureSocketFirewallInstalled,
-  getPnpmCommandEnv,
+  getPackageManagerCommandEnv,
   getPnpmMinimumReleaseAgeSupport,
   PACKAGE_MANAGER_PROBE_TIMEOUT_MS,
   resolveExecutableName,
@@ -62,9 +62,9 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe("getPnpmCommandEnv", () => {
+describe("getPackageManagerCommandEnv", () => {
   it("disables Corepack project packageManager pins while preserving the rest of the env", () => {
-    expect(getPnpmCommandEnv({ PATH: "/bin", FOO: "bar" })).toEqual({
+    expect(getPackageManagerCommandEnv({ PATH: "/bin", FOO: "bar" })).toEqual({
       PATH: "/bin",
       FOO: "bar",
       COREPACK_ENABLE_PROJECT_SPEC: "0",
@@ -80,6 +80,9 @@ describe("detectPreferredPackageManager", () => {
 
     await expect(detectPreferredPackageManager(runner)).resolves.toBe("pnpm");
     expect(runner).toHaveBeenCalledWith("pnpm", ["--version"], {
+      env: expect.objectContaining({
+        COREPACK_ENABLE_PROJECT_SPEC: "0",
+      }),
       timeoutMs: PACKAGE_MANAGER_PROBE_TIMEOUT_MS,
     });
   });
@@ -91,6 +94,9 @@ describe("detectPreferredPackageManager", () => {
 
     await expect(detectPreferredPackageManager(runner)).resolves.toBe("npm");
     expect(runner).toHaveBeenCalledWith("pnpm", ["--version"], {
+      env: expect.objectContaining({
+        COREPACK_ENABLE_PROJECT_SPEC: "0",
+      }),
       timeoutMs: PACKAGE_MANAGER_PROBE_TIMEOUT_MS,
     });
   });
@@ -102,6 +108,9 @@ describe("detectPreferredPackageManager", () => {
 
     await expect(detectPreferredPackageManager(runner)).resolves.toBe("pnpm");
     expect(runner).toHaveBeenCalledWith("pnpm", ["--version"], {
+      env: expect.objectContaining({
+        COREPACK_ENABLE_PROJECT_SPEC: "0",
+      }),
       timeoutMs: PACKAGE_MANAGER_PROBE_TIMEOUT_MS,
     });
   });
@@ -713,6 +722,9 @@ describe("ensureSocketFirewallInstalled", () => {
       "npx",
       ["--prefer-offline", "--yes", "sfw@2.0.4", "--help"],
       {
+        env: expect.objectContaining({
+          COREPACK_ENABLE_PROJECT_SPEC: "0",
+        }),
         timeoutMs: SOCKET_FIREWALL_PROBE_TIMEOUT_MS,
       },
     );
@@ -732,6 +744,9 @@ describe("ensureSocketFirewallInstalled", () => {
       "npx",
       ["--prefer-offline", "--yes", "sfw@2.0.4", "--help"],
       {
+        env: expect.objectContaining({
+          COREPACK_ENABLE_PROJECT_SPEC: "0",
+        }),
         timeoutMs: SOCKET_FIREWALL_PROBE_TIMEOUT_MS,
       },
     );

--- a/src/ipc/utils/socket_firewall.ts
+++ b/src/ipc/utils/socket_firewall.ts
@@ -16,6 +16,7 @@ export const SOCKET_FIREWALL_WARNING_MESSAGE =
   "the npm firewall could not be installed. Warning: can not check if npm packages are safe";
 export const PNPM_MINIMUM_RELEASE_AGE_VERSION = "10.16.0";
 export const PNPM_GLOBAL_INSTALL_PACKAGE = "pnpm@latest-11";
+export const COREPACK_ENABLE_PROJECT_SPEC_DISABLED_ENV = "0";
 const MINIMUM_PACKAGE_RELEASE_AGE_DAYS = 1;
 export const MINIMUM_PACKAGE_RELEASE_AGE_MINUTES =
   MINIMUM_PACKAGE_RELEASE_AGE_DAYS * 24 * 60;
@@ -99,6 +100,15 @@ export type CommandRunner = (
   args: string[],
   options?: CommandExecutionOptions,
 ) => Promise<CommandExecutionResult>;
+
+export function getPnpmCommandEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  return {
+    ...env,
+    COREPACK_ENABLE_PROJECT_SPEC: COREPACK_ENABLE_PROJECT_SPEC_DISABLED_ENV,
+  };
+}
 
 export type PackageManager = "pnpm" | "npm";
 type AllowBuildsChannel = "local" | "remote";

--- a/src/ipc/utils/socket_firewall.ts
+++ b/src/ipc/utils/socket_firewall.ts
@@ -101,7 +101,7 @@ export type CommandRunner = (
   options?: CommandExecutionOptions,
 ) => Promise<CommandExecutionResult>;
 
-export function getPnpmCommandEnv(
+export function getPackageManagerCommandEnv(
   env: NodeJS.ProcessEnv = process.env,
 ): NodeJS.ProcessEnv {
   return {
@@ -711,6 +711,7 @@ export async function ensureSocketFirewallInstalled(
 }> {
   try {
     await runner("npx", [...SOCKET_FIREWALL_NPX_ARGS, "--help"], {
+      env: getPackageManagerCommandEnv(),
       timeoutMs: SOCKET_FIREWALL_PROBE_TIMEOUT_MS,
     });
     return { available: true };
@@ -758,6 +759,7 @@ export async function getPnpmMinimumReleaseAgeSupport(
 
   try {
     const result = await runner("pnpm", ["--version"], {
+      env: getPackageManagerCommandEnv(),
       timeoutMs: PACKAGE_MANAGER_PROBE_TIMEOUT_MS,
     });
     const version = result.stdout.trim();


### PR DESCRIPTION
## Summary
- Disable Corepack project packageManager pin resolution for Dyad-managed pnpm installs so stale app pins cannot bypass install policy.
- Apply the env to add-dependency, app startup, and migration dependency installs when pnpm is used.
- Add unit coverage for the Corepack env helper and command env propagation.

## Test plan
- npm run fmt && npm run lint:fix && npm run ts
- npm test