### PR TITLE
Increase session debug log tail

### DIFF
--- a/src/ipc/handlers/debug_handlers.ts
+++ b/src/ipc/handlers/debug_handlers.ts
@@ -344,7 +344,7 @@ export function registerDebugHandlers() {
         ]);
 
       // Read logs
-      const logs = readAppLogs(1_000, "info");
+      const logs = readAppLogs(5_000, "info");
 
       // Build the bundle
       const bundle: SessionDebugBundle = {


### PR DESCRIPTION
## Summary
- Increase uploaded chat session debug bundles from the last 1,000 app log lines to 5,000.
- Preserve more context before crashes or clipped stack traces.

## Test plan
- npm run fmt && npm run lint:fix && npm run ts
- npm test

🤖 Generated with [Claude Code](https://claude.com/claude-code)