### PR TITLE
Filter community templates in app blueprint dropdown

### DIFF
--- a/rules/chat-message-indicators.md
+++ b/rules/chat-message-indicators.md
@@ -10,4 +10,4 @@ Content here
 
 Valid states: `"finished"`, `"in-progress"`, `"aborted"`
 
-- Renderer unit tests that import `DyadMarkdownParser` should mock `../preview_panel/FileEditor`; otherwise the `DyadWrite` import initializes Monaco and Happy DOM may try to fetch `cdn.jsdelivr.net`, causing offline `ENOTFOUND` failures.
+- Renderer unit tests that import chat components can initialize Monaco through the file editor tree, leading to Happy DOM errors like `moduleId: 'vs/editor/editor.main'` or offline `cdn.jsdelivr.net` failures. For pure helper logic, extract the helper into a small `.ts` module and test that directly; when testing `DyadMarkdownParser`, mock `../preview_panel/FileEditor`.

--- a/src/components/chat/DyadAppBlueprintCard.test.ts
+++ b/src/components/chat/DyadAppBlueprintCard.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import type { Template } from "@/shared/templates";
+import { getAppBlueprintTemplateOptions } from "./appBlueprintTemplateOptions";
+
+const templates: Template[] = [
+  {
+    id: "react",
+    title: "React.js Template",
+    description: "Official React template",
+    imageUrl: "react.png",
+    isOfficial: true,
+  },
+  {
+    id: "dyad-sh/community-template",
+    title: "Community Template",
+    description: "Community template",
+    imageUrl: "community.png",
+    isOfficial: false,
+  },
+  {
+    id: "dyad-sh/selected-community-template",
+    title: "Selected Community Template",
+    description: "Selected community template",
+    imageUrl: "selected-community.png",
+    isOfficial: false,
+  },
+];
+
+describe("getAppBlueprintTemplateOptions", () => {
+  it("hides community templates when the current template is official", () => {
+    expect(
+      getAppBlueprintTemplateOptions(templates, "react").map(
+        (template) => template.id,
+      ),
+    ).toEqual(["react"]);
+  });
+
+  it("keeps the current community template visible", () => {
+    expect(
+      getAppBlueprintTemplateOptions(
+        templates,
+        "dyad-sh/selected-community-template",
+      ).map((template) => template.id),
+    ).toEqual(["react", "dyad-sh/selected-community-template"]);
+  });
+});

--- a/src/components/chat/DyadAppBlueprintCard.tsx
+++ b/src/components/chat/DyadAppBlueprintCard.tsx
@@ -31,6 +31,7 @@ import { queryKeys } from "@/lib/queryKeys";
 import { AppBlueprintUserPrompt } from "./AppBlueprintUserPrompt";
 import { AppBlueprintDesignDirection } from "./AppBlueprintDesignDirection";
 import { AppBlueprintVisuals } from "./AppBlueprintVisuals";
+import { getAppBlueprintTemplateOptions } from "./appBlueprintTemplateOptions";
 import type { CustomTagState } from "./stateTypes";
 
 interface DyadAppBlueprintCardProps {
@@ -115,6 +116,7 @@ export const DyadAppBlueprintCard: React.FC<DyadAppBlueprintCardProps> = ({
   const primaryColorTextFieldId = `${inputIdPrefix}-primary-color-text`;
   const primaryColorPickerFieldId = `${inputIdPrefix}-primary-color-picker`;
   const statusId = `${inputIdPrefix}-status`;
+  const templateOptions = getAppBlueprintTemplateOptions(templates, templateId);
 
   const [editingName, setEditingName] = useState(false);
   const [nameValue, setNameValue] = useState(appName);
@@ -684,7 +686,7 @@ export const DyadAppBlueprintCard: React.FC<DyadAppBlueprintCardProps> = ({
                     Unknown template ({templateId})
                   </option>
                 )}
-                {(templates ?? []).map((t) => (
+                {templateOptions.map((t) => (
                   <option key={t.id} value={t.id}>
                     {t.title}
                   </option>

--- a/src/components/chat/appBlueprintTemplateOptions.ts
+++ b/src/components/chat/appBlueprintTemplateOptions.ts
@@ -1,0 +1,10 @@
+import type { Template } from "@/shared/templates";
+
+export function getAppBlueprintTemplateOptions(
+  templates: Template[] | undefined,
+  currentTemplateId: string,
+): Template[] {
+  return (templates ?? []).filter(
+    (template) => template.isOfficial || template.id === currentTemplateId,
+  );
+}


### PR DESCRIPTION
## Summary
- Filter the app blueprint template dropdown to show official templates by default.
- Keep the currently selected community template visible so existing blueprint selections remain editable.
- Add focused unit coverage for the template option filtering.

## Test plan
- npm run fmt && npm run lint:fix && npm run ts
- npm test