### PR TITLE
Filter Ollama connection telemetry

### DIFF
--- a/rules/dyad-errors.md
+++ b/rules/dyad-errors.md
@@ -30,6 +30,7 @@ Prefer **`DyadError`** over growing `FILTERED_EXCEPTION_MESSAGES` in `telemetry.
 
 - **`createTypedHandler` / `createLoggedTypedHandler`** rethrow the original error after telemetry — `DyadError` is preserved.
 - **`createLoggedHandler` (`safe_handle.ts`)** rethrows `DyadError` unchanged so the renderer keeps `instanceof DyadError`.
+- In broad `catch` blocks that convert unknown failures to `DyadError`, first rethrow existing `DyadError` instances. Otherwise an already-classified error (for example `Precondition` or `External`) can be wrapped as the wrong kind and change telemetry filtering.
 
 ## Migration
 

--- a/src/__tests__/parseOllamaHost.test.ts
+++ b/src/__tests__/parseOllamaHost.test.ts
@@ -1,5 +1,14 @@
-import { parseOllamaHost } from "@/ipc/handlers/local_model_ollama_handler";
-import { describe, it, expect } from "vitest";
+import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
+import {
+  fetchOllamaModels,
+  parseOllamaHost,
+} from "@/ipc/handlers/local_model_ollama_handler";
+import { afterEach, describe, it, expect, vi } from "vitest";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
 
 describe("parseOllamaHost", () => {
   it("should return default URL when no host is provided", () => {
@@ -143,5 +152,37 @@ describe("parseOllamaHost", () => {
       const result = parseOllamaHost(input);
       expect(result).toBe("http://example.com:443");
     });
+  });
+});
+
+describe("fetchOllamaModels", () => {
+  it("classifies Ollama connection failures as filtered precondition errors", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new TypeError("fetch failed")),
+    );
+
+    await expect(fetchOllamaModels()).rejects.toMatchObject({
+      message:
+        "Could not connect to Ollama. Make sure it's running at http://localhost:11434",
+      kind: DyadErrorKind.Precondition,
+    });
+  });
+
+  it("preserves classified Ollama response errors", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        statusText: "Service Unavailable",
+      }),
+    );
+
+    await expect(fetchOllamaModels()).rejects.toEqual(
+      new DyadError(
+        "Failed to fetch model: Service Unavailable",
+        DyadErrorKind.External,
+      ),
+    );
   });
 });

--- a/src/ipc/handlers/local_model_ollama_handler.ts
+++ b/src/ipc/handlers/local_model_ollama_handler.ts
@@ -97,7 +97,7 @@ export async function fetchOllamaModels(): Promise<{ models: LocalModel[] }> {
       (error as Error).message.includes("fetch failed")
     ) {
       throw new DyadError(
-        "Could not connect to Ollama. Make sure it's running at http://localhost:11434",
+        "Could not connect to Ollama. Make sure it's running at " + getOllamaApiUrl(),
         DyadErrorKind.Precondition,
       );
     }

--- a/src/ipc/handlers/local_model_ollama_handler.ts
+++ b/src/ipc/handlers/local_model_ollama_handler.ts
@@ -89,12 +89,16 @@ export async function fetchOllamaModels(): Promise<{ models: LocalModel[] }> {
     logger.info(`Successfully fetched ${models.length} models from Ollama`);
     return { models };
   } catch (error) {
+    if (error instanceof DyadError) {
+      throw error;
+    }
     if (
       error instanceof TypeError &&
       (error as Error).message.includes("fetch failed")
     ) {
-      throw new Error(
+      throw new DyadError(
         "Could not connect to Ollama. Make sure it's running at http://localhost:11434",
+        DyadErrorKind.Precondition,
       );
     }
     throw new DyadError(

--- a/src/ipc/handlers/local_model_ollama_handler.ts
+++ b/src/ipc/handlers/local_model_ollama_handler.ts
@@ -97,7 +97,8 @@ export async function fetchOllamaModels(): Promise<{ models: LocalModel[] }> {
       (error as Error).message.includes("fetch failed")
     ) {
       throw new DyadError(
-        "Could not connect to Ollama. Make sure it's running at " + getOllamaApiUrl(),
+        "Could not connect to Ollama. Make sure it's running at " +
+          getOllamaApiUrl(),
         DyadErrorKind.Precondition,
       );
     }


### PR DESCRIPTION
## Summary
- Classify Ollama fetch connection failures as filtered precondition errors.
- Preserve existing classified Ollama errors instead of wrapping them.
- Add unit coverage for the connection failure and response error paths.

## Test plan
- npm run fmt && npm run lint:fix && npm run ts
- npm test

Generated with Claude Code