### PR TITLE
Enrich app:initial-load telemetry and stop sampling it for non-Pro users

### DIFF
--- a/rules/electron-ipc.md
+++ b/rules/electron-ipc.md
@@ -152,3 +152,4 @@ When creating hooks/components that call IPC handlers:
 - Wrap reads in `useQuery`, using keys from `queryKeys` factory (see above), async `queryFn` that calls the relevant domain client (e.g., `appClient.getApp(...)`) or unified `ipc` namespace, and conditionally use `enabled`/`initialData`/`meta` as needed.
 - Wrap writes in `useMutation`; validate inputs locally, call the domain client, and invalidate related queries on success. Use shared utilities (e.g., toast helpers) in `onError`.
 - Synchronize TanStack Query data with any global state (like Jotai atoms) via `useEffect` only if required.
+- For renderer launch telemetry that needs first-run state, do not infer it from `settings.hasRunBefore` after startup. `onFirstRunMaybe` flips that setting before `createWindow()`, so expose the pre-write value through an IPC/query context instead.

--- a/src/__tests__/posthogTelemetry.test.ts
+++ b/src/__tests__/posthogTelemetry.test.ts
@@ -108,7 +108,7 @@ describe("getInitialLoadTelemetryProperties", () => {
     });
   });
 
-  it("marks first sessions and falls back to selected chat mode", () => {
+  it("marks first sessions and leaves unset default chat mode as null", () => {
     expect(
       getInitialLoadTelemetryProperties({
         settings: makeSettings({
@@ -125,7 +125,7 @@ describe("getInitialLoadTelemetryProperties", () => {
       releaseChannel: "stable",
       isFirstSession: true,
       modelProvider: "auto",
-      defaultChatMode: "plan",
+      defaultChatMode: null,
       runtimeMode2: "host",
     });
   });

--- a/src/__tests__/posthogTelemetry.test.ts
+++ b/src/__tests__/posthogTelemetry.test.ts
@@ -88,13 +88,13 @@ describe("getInitialLoadTelemetryProperties", () => {
           defaultChatMode: "ask",
           selectedChatMode: "build",
           runtimeMode2: "docker",
-          hasRunBefore: true,
           providerSettings: {
             auto: { apiKey: { value: "secret" } },
           },
         }),
         appVersion: "1.1.0",
         platform: "darwin",
+        isFirstSession: false,
       }),
     ).toEqual({
       isPro: true,
@@ -113,10 +113,10 @@ describe("getInitialLoadTelemetryProperties", () => {
       getInitialLoadTelemetryProperties({
         settings: makeSettings({
           selectedChatMode: "plan",
-          hasRunBefore: false,
         }),
         appVersion: "1.1.0",
         platform: null,
+        isFirstSession: true,
       }),
     ).toEqual({
       isPro: false,

--- a/src/__tests__/posthogTelemetry.test.ts
+++ b/src/__tests__/posthogTelemetry.test.ts
@@ -88,7 +88,7 @@ describe("getInitialLoadTelemetryProperties", () => {
           defaultChatMode: "ask",
           selectedChatMode: "build",
           runtimeMode2: "docker",
-          lastShownReleaseNotesVersion: "1.0.0",
+          hasRunBefore: true,
           providerSettings: {
             auto: { apiKey: { value: "secret" } },
           },
@@ -113,6 +113,7 @@ describe("getInitialLoadTelemetryProperties", () => {
       getInitialLoadTelemetryProperties({
         settings: makeSettings({
           selectedChatMode: "plan",
+          hasRunBefore: false,
         }),
         appVersion: "1.1.0",
         platform: null,
@@ -125,7 +126,7 @@ describe("getInitialLoadTelemetryProperties", () => {
       isFirstSession: true,
       modelProvider: "auto",
       defaultChatMode: "plan",
-      runtimeMode2: null,
+      runtimeMode2: "host",
     });
   });
 });

--- a/src/__tests__/posthogTelemetry.test.ts
+++ b/src/__tests__/posthogTelemetry.test.ts
@@ -2,9 +2,22 @@ import { describe, expect, it } from "vitest";
 import {
   createExceptionFromTelemetry,
   getExceptionTelemetryContext,
+  getInitialLoadTelemetryProperties,
   shouldBypassNonProTelemetrySampling,
   shouldFilterPostHogExceptionEvent,
 } from "@/lib/posthogTelemetry";
+import type { UserSettings } from "@/lib/schemas";
+
+function makeSettings(overrides: Partial<UserSettings> = {}): UserSettings {
+  return {
+    selectedModel: { provider: "auto", name: "auto" },
+    providerSettings: {},
+    selectedTemplateId: "react",
+    enableAutoUpdate: true,
+    releaseChannel: "stable",
+    ...overrides,
+  } as UserSettings;
+}
 
 describe("createExceptionFromTelemetry", () => {
   it("uses exception telemetry fields when present", () => {
@@ -66,6 +79,57 @@ describe("shouldFilterPostHogExceptionEvent", () => {
   });
 });
 
+describe("getInitialLoadTelemetryProperties", () => {
+  it("includes high-value launch properties from settings", () => {
+    expect(
+      getInitialLoadTelemetryProperties({
+        settings: makeSettings({
+          releaseChannel: "beta",
+          defaultChatMode: "ask",
+          selectedChatMode: "build",
+          runtimeMode2: "docker",
+          lastShownReleaseNotesVersion: "1.0.0",
+          providerSettings: {
+            auto: { apiKey: { value: "secret" } },
+          },
+        }),
+        appVersion: "1.1.0",
+        platform: "darwin",
+      }),
+    ).toEqual({
+      isPro: true,
+      appVersion: "1.1.0",
+      platform: "darwin",
+      releaseChannel: "beta",
+      isFirstSession: false,
+      modelProvider: "auto",
+      defaultChatMode: "ask",
+      runtimeMode2: "docker",
+    });
+  });
+
+  it("marks first sessions and falls back to selected chat mode", () => {
+    expect(
+      getInitialLoadTelemetryProperties({
+        settings: makeSettings({
+          selectedChatMode: "plan",
+        }),
+        appVersion: "1.1.0",
+        platform: null,
+      }),
+    ).toEqual({
+      isPro: false,
+      appVersion: "1.1.0",
+      platform: null,
+      releaseChannel: "stable",
+      isFirstSession: true,
+      modelProvider: "auto",
+      defaultChatMode: "plan",
+      runtimeMode2: null,
+    });
+  });
+});
+
 describe("shouldBypassNonProTelemetrySampling", () => {
   it("always sends sandbox.script.* events for non-Pro sampling", () => {
     expect(
@@ -90,6 +154,15 @@ describe("shouldBypassNonProTelemetrySampling", () => {
       shouldBypassNonProTelemetrySampling({
         event: "sandbox.script.timeout",
         properties: { error: "Script timed out" },
+      }),
+    ).toBe(true);
+  });
+
+  it("always sends app:initial-load for non-Pro sampling", () => {
+    expect(
+      shouldBypassNonProTelemetrySampling({
+        event: "app:initial-load",
+        properties: { isPro: false, appVersion: "1.0.0" },
       }),
     ).toBe(true);
   });

--- a/src/__tests__/readSettings.test.ts
+++ b/src/__tests__/readSettings.test.ts
@@ -146,6 +146,22 @@ describe("readSettings", () => {
       expect(result.releaseChannel).toBe("stable");
     });
 
+    it("should treat existing settings files without hasRunBefore as already run", () => {
+      const mockFileContent = {
+        selectedModel: {
+          name: "gpt-4",
+          provider: "openai",
+        },
+      };
+
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readFileSync.mockReturnValue(JSON.stringify(mockFileContent));
+
+      const result = readSettings();
+
+      expect(result.hasRunBefore).toBe(true);
+    });
+
     it("should decrypt encrypted provider API keys", () => {
       const mockFileContent = {
         providerSettings: {

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -4,6 +4,7 @@ import { userSettingsAtom, envVarsAtom } from "@/atoms/appAtoms";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { ipc } from "@/ipc/types";
 import { type UserSettings, hasDyadProKey } from "@/lib/schemas";
+import { getInitialLoadTelemetryProperties } from "@/lib/posthogTelemetry";
 import { usePostHog } from "posthog-js/react";
 import { useAppVersion } from "./useAppVersion";
 import { queryKeys } from "@/lib/queryKeys";
@@ -47,19 +48,39 @@ export function useSettings() {
 
   // Process telemetry side effects when settings load/change
   useEffect(() => {
-    if (settingsQuery.data) {
-      processSettingsForTelemetry(settingsQuery.data);
-      const isPro = hasDyadProKey(settingsQuery.data);
-      posthog.people.set({ isPro });
-      if (!isInitialLoad && appVersion) {
-        posthog.capture("app:initial-load", {
-          isPro,
-          appVersion,
-        });
-        isInitialLoad = true;
-      }
-      setSettingsAtom(settingsQuery.data);
+    if (!settingsQuery.data) {
+      return;
     }
+
+    processSettingsForTelemetry(settingsQuery.data);
+    const isPro = hasDyadProKey(settingsQuery.data);
+    posthog.people.set({ isPro });
+    setSettingsAtom(settingsQuery.data);
+
+    if (isInitialLoad || !appVersion) {
+      return;
+    }
+
+    isInitialLoad = true;
+    const settings = settingsQuery.data;
+
+    void (async () => {
+      let platform: string | null = null;
+      try {
+        platform = await ipc.system.getSystemPlatform();
+      } catch (error) {
+        console.warn("Failed to get system platform for telemetry", error);
+      }
+
+      posthog.capture(
+        "app:initial-load",
+        getInitialLoadTelemetryProperties({
+          settings,
+          appVersion,
+          platform,
+        }),
+      );
+    })();
   }, [settingsQuery.data, appVersion, posthog, setSettingsAtom]);
 
   // Sync env vars to Jotai atom

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -25,7 +25,7 @@ export function isDyadProUser(): boolean {
   return window.localStorage.getItem(DYAD_PRO_STATUS_KEY) === "true";
 }
 
-let initialLoadTelemetryState: "idle" | "pending" | "sent" = "idle";
+let initialLoadTelemetryState: "idle" | "sent" = "idle";
 
 export function useSettings() {
   const posthog = usePostHog();
@@ -46,6 +46,16 @@ export function useSettings() {
     queryFn: () => ipc.misc.getEnvVars(),
   });
 
+  const {
+    data: platform,
+    error: platformError,
+    isLoading: isPlatformLoading,
+  } = useQuery({
+    queryKey: queryKeys.system.platform,
+    queryFn: () => ipc.system.getSystemPlatform(),
+    staleTime: Infinity,
+  });
+
   // Process telemetry side effects when settings load/change
   useEffect(() => {
     if (!settingsQuery.data) {
@@ -57,48 +67,41 @@ export function useSettings() {
     posthog?.people?.set({ isPro });
     setSettingsAtom(settingsQuery.data);
 
-    if (initialLoadTelemetryState !== "idle" || !appVersion || !posthog) {
+    if (
+      initialLoadTelemetryState !== "idle" ||
+      !appVersion ||
+      !posthog ||
+      isPlatformLoading
+    ) {
       return;
     }
 
-    initialLoadTelemetryState = "pending";
-    let cancelled = false;
-    const settings = settingsQuery.data;
-
-    void (async () => {
-      let platform: string | null = null;
-      try {
-        platform = await queryClient.ensureQueryData({
-          queryKey: queryKeys.system.platform,
-          queryFn: () => ipc.system.getSystemPlatform(),
-          staleTime: Infinity,
-        });
-      } catch (error) {
-        console.warn("Failed to get system platform for telemetry", error);
-      }
-
-      if (cancelled) {
-        return;
-      }
-
-      posthog.capture(
-        "app:initial-load",
-        getInitialLoadTelemetryProperties({
-          settings,
-          appVersion,
-          platform,
-        }),
+    if (platformError) {
+      console.warn(
+        "Failed to get system platform for telemetry",
+        platformError,
       );
-      initialLoadTelemetryState = "sent";
-    })();
+    }
 
-    return () => {
-      cancelled = true;
-      if (initialLoadTelemetryState === "pending") {
-        initialLoadTelemetryState = "idle";
-      }
-    };
-  }, [settingsQuery.data, appVersion, posthog, queryClient, setSettingsAtom]);
+    const settings = settingsQuery.data;
+    posthog.capture(
+      "app:initial-load",
+      getInitialLoadTelemetryProperties({
+        settings,
+        appVersion,
+        platform: platform ?? null,
+      }),
+    );
+    initialLoadTelemetryState = "sent";
+  }, [
+    settingsQuery.data,
+    appVersion,
+    posthog,
+    isPlatformLoading,
+    platform,
+    platformError,
+    setSettingsAtom,
+  ]);
 
   // Sync env vars to Jotai atom
   useEffect(() => {

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -56,6 +56,15 @@ export function useSettings() {
     staleTime: Infinity,
   });
 
+  const {
+    data: initialLoadTelemetryContext,
+    isLoading: isInitialLoadTelemetryContextLoading,
+  } = useQuery({
+    queryKey: queryKeys.system.initialLoadTelemetryContext,
+    queryFn: () => ipc.system.getInitialLoadTelemetryContext(),
+    staleTime: Infinity,
+  });
+
   // Process telemetry side effects when settings load/change
   useEffect(() => {
     if (!settingsQuery.data) {
@@ -71,7 +80,9 @@ export function useSettings() {
       initialLoadTelemetryState !== "idle" ||
       !appVersion ||
       !posthog ||
-      isPlatformLoading
+      isPlatformLoading ||
+      isInitialLoadTelemetryContextLoading ||
+      !initialLoadTelemetryContext
     ) {
       return;
     }
@@ -90,6 +101,7 @@ export function useSettings() {
         settings,
         appVersion,
         platform: platform ?? null,
+        isFirstSession: initialLoadTelemetryContext.isFirstSession,
       }),
     );
     initialLoadTelemetryState = "sent";
@@ -98,8 +110,10 @@ export function useSettings() {
     appVersion,
     posthog,
     isPlatformLoading,
+    isInitialLoadTelemetryContextLoading,
     platform,
     platformError,
+    initialLoadTelemetryContext,
     setSettingsAtom,
   ]);
 

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -25,7 +25,7 @@ export function isDyadProUser(): boolean {
   return window.localStorage.getItem(DYAD_PRO_STATUS_KEY) === "true";
 }
 
-let isInitialLoad = false;
+let initialLoadTelemetryState: "idle" | "pending" | "sent" = "idle";
 
 export function useSettings() {
   const posthog = usePostHog();
@@ -54,22 +54,31 @@ export function useSettings() {
 
     processSettingsForTelemetry(settingsQuery.data);
     const isPro = hasDyadProKey(settingsQuery.data);
-    posthog.people.set({ isPro });
+    posthog?.people?.set({ isPro });
     setSettingsAtom(settingsQuery.data);
 
-    if (isInitialLoad || !appVersion) {
+    if (initialLoadTelemetryState !== "idle" || !appVersion || !posthog) {
       return;
     }
 
-    isInitialLoad = true;
+    initialLoadTelemetryState = "pending";
+    let cancelled = false;
     const settings = settingsQuery.data;
 
     void (async () => {
       let platform: string | null = null;
       try {
-        platform = await ipc.system.getSystemPlatform();
+        platform = await queryClient.ensureQueryData({
+          queryKey: queryKeys.system.platform,
+          queryFn: () => ipc.system.getSystemPlatform(),
+          staleTime: Infinity,
+        });
       } catch (error) {
         console.warn("Failed to get system platform for telemetry", error);
+      }
+
+      if (cancelled) {
+        return;
       }
 
       posthog.capture(
@@ -80,8 +89,16 @@ export function useSettings() {
           platform,
         }),
       );
+      initialLoadTelemetryState = "sent";
     })();
-  }, [settingsQuery.data, appVersion, posthog, setSettingsAtom]);
+
+    return () => {
+      cancelled = true;
+      if (initialLoadTelemetryState === "pending") {
+        initialLoadTelemetryState = "idle";
+      }
+    };
+  }, [settingsQuery.data, appVersion, posthog, queryClient, setSettingsAtom]);
 
   // Sync env vars to Jotai atom
   useEffect(() => {
@@ -98,7 +115,7 @@ export function useSettings() {
     onSuccess: (updatedSettings) => {
       queryClient.setQueryData(queryKeys.settings.user, updatedSettings);
       processSettingsForTelemetry(updatedSettings);
-      posthog.people.set({ isPro: hasDyadProKey(updatedSettings) });
+      posthog?.people?.set({ isPro: hasDyadProKey(updatedSettings) });
       setSettingsAtom(updatedSettings);
     },
     meta: { showErrorToast: true },

--- a/src/ipc/handlers/window_handlers.ts
+++ b/src/ipc/handlers/window_handlers.ts
@@ -3,6 +3,7 @@ import log from "electron-log";
 import { platform } from "os";
 import { createTypedHandler } from "./base";
 import { systemContracts } from "../types/system";
+import { getInitialLoadIsFirstSession } from "@/main/settings";
 
 const logger = log.scope("window-handlers");
 
@@ -56,4 +57,13 @@ export function registerWindowHandlers() {
   createTypedHandler(systemContracts.getSystemPlatform, async () => {
     return platform();
   });
+
+  createTypedHandler(
+    systemContracts.getInitialLoadTelemetryContext,
+    async () => {
+      return {
+        isFirstSession: getInitialLoadIsFirstSession(),
+      };
+    },
+  );
 }

--- a/src/ipc/types/system.ts
+++ b/src/ipc/types/system.ts
@@ -149,6 +149,14 @@ export const systemContracts = {
     output: z.string(),
   }),
 
+  getInitialLoadTelemetryContext: defineContract({
+    channel: "get-initial-load-telemetry-context",
+    input: z.void(),
+    output: z.object({
+      isFirstSession: z.boolean(),
+    }),
+  }),
+
   getSystemDebugInfo: defineContract({
     channel: "get-system-debug-info",
     input: z.void(),

--- a/src/lib/posthogTelemetry.ts
+++ b/src/lib/posthogTelemetry.ts
@@ -18,11 +18,11 @@ export function getInitialLoadTelemetryProperties({
     appVersion,
     platform,
     releaseChannel: settings.releaseChannel,
-    isFirstSession: !settings.lastShownReleaseNotesVersion,
+    isFirstSession: settings.hasRunBefore === false,
     modelProvider: settings.selectedModel.provider,
     defaultChatMode:
       settings.defaultChatMode ?? settings.selectedChatMode ?? null,
-    runtimeMode2: settings.runtimeMode2 ?? null,
+    runtimeMode2: settings.runtimeMode2 ?? "host",
   };
 }
 

--- a/src/lib/posthogTelemetry.ts
+++ b/src/lib/posthogTelemetry.ts
@@ -20,8 +20,7 @@ export function getInitialLoadTelemetryProperties({
     releaseChannel: settings.releaseChannel,
     isFirstSession: settings.hasRunBefore === false,
     modelProvider: settings.selectedModel.provider,
-    defaultChatMode:
-      settings.defaultChatMode ?? settings.selectedChatMode ?? null,
+    defaultChatMode: settings.defaultChatMode ?? null,
     runtimeMode2: settings.runtimeMode2 ?? "host",
   };
 }

--- a/src/lib/posthogTelemetry.ts
+++ b/src/lib/posthogTelemetry.ts
@@ -6,19 +6,21 @@ export type InitialLoadTelemetryInput = {
   settings: UserSettings;
   appVersion: string;
   platform: string | null;
+  isFirstSession: boolean;
 };
 
 export function getInitialLoadTelemetryProperties({
   settings,
   appVersion,
   platform,
+  isFirstSession,
 }: InitialLoadTelemetryInput) {
   return {
     isPro: hasDyadProKey(settings),
     appVersion,
     platform,
     releaseChannel: settings.releaseChannel,
-    isFirstSession: settings.hasRunBefore === false,
+    isFirstSession,
     modelProvider: settings.selectedModel.provider,
     defaultChatMode: settings.defaultChatMode ?? null,
     runtimeMode2: settings.runtimeMode2 ?? "host",

--- a/src/lib/posthogTelemetry.ts
+++ b/src/lib/posthogTelemetry.ts
@@ -1,4 +1,30 @@
+import { hasDyadProKey, type UserSettings } from "@/lib/schemas";
+
 type TelemetryProperties = Record<string, unknown> | undefined;
+
+export type InitialLoadTelemetryInput = {
+  settings: UserSettings;
+  appVersion: string;
+  platform: string | null;
+};
+
+export function getInitialLoadTelemetryProperties({
+  settings,
+  appVersion,
+  platform,
+}: InitialLoadTelemetryInput) {
+  return {
+    isPro: hasDyadProKey(settings),
+    appVersion,
+    platform,
+    releaseChannel: settings.releaseChannel,
+    isFirstSession: !settings.lastShownReleaseNotesVersion,
+    modelProvider: settings.selectedModel.provider,
+    defaultChatMode:
+      settings.defaultChatMode ?? settings.selectedChatMode ?? null,
+    runtimeMode2: settings.runtimeMode2 ?? null,
+  };
+}
 
 /** PostHog event shape used by renderer `before_send` sampling. */
 export type PostHogTelemetryEvent = {
@@ -56,6 +82,10 @@ export function shouldBypassNonProTelemetrySampling(
   const properties = event?.properties;
 
   if (eventName?.startsWith("sandbox.script.")) {
+    return true;
+  }
+
+  if (eventName === "app:initial-load") {
     return true;
   }
 

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -23,6 +23,10 @@ export const queryKeys = {
     appVersion: ["system", "appVersion"] as const,
     nodejsStatus: ["system", "nodejsStatus"] as const,
     platform: ["system", "platform"] as const,
+    initialLoadTelemetryContext: [
+      "system",
+      "initialLoadTelemetryContext",
+    ] as const,
   },
 
   // ─────────────────────────────────────────────────────────────────────────────

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,7 @@ import {
   recordRendererCrash,
   readRendererCrashRecord,
   clearRendererCrashRecord,
+  setInitialLoadIsFirstSession,
 } from "./main/settings";
 import { sendTelemetryEvent } from "./ipc/utils/telemetry";
 import { handleSupabaseOAuthReturn } from "./supabase_admin/supabase_return_handler";
@@ -323,7 +324,10 @@ export async function onReady() {
 }
 
 export async function onFirstRunMaybe(settings: UserSettings) {
-  if (!settings.hasRunBefore) {
+  const isFirstSession = settings.hasRunBefore === false;
+  setInitialLoadIsFirstSession(isFirstSession);
+
+  if (isFirstSession) {
     await promptMoveToApplicationsFolder();
     writeSettings({
       hasRunBefore: true,

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -336,6 +336,7 @@ function readExistingSettingsFile(filePath: string): UserSettings {
   const combinedSettings: UserSettings = {
     ...DEFAULT_SETTINGS,
     ...rawSettings,
+    hasRunBefore: rawSettings.hasRunBefore ?? true,
   };
   const supabase = combinedSettings.supabase;
   if (supabase) {

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -67,6 +67,16 @@ const RENDERER_CRASH_FILE = "renderer-crash.json";
 const SETTINGS_FILE = "user-settings.json";
 const RESTORE_SETTINGS_DOCS_URL =
   "https://www.dyad.sh/docs/guides/migrate-restore#restoring-settings-from-backup";
+let initialLoadIsFirstSession = false;
+
+export function setInitialLoadIsFirstSession(value: boolean): void {
+  initialLoadIsFirstSession = value;
+}
+
+export function getInitialLoadIsFirstSession(): boolean {
+  return initialLoadIsFirstSession;
+}
+
 interface RendererErrorToast {
   message: string;
   action?: {

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -106,8 +106,8 @@ const posthogClient = posthog.init(
         event.properties["$ip"] = null;
       }
 
-      // For non-Pro users, only send 10% of events (but always send errors and
-      // sandbox.script.* instrumentation — see shouldBypassNonProTelemetrySampling).
+      // For non-Pro users, only send 10% of events (but always send errors,
+      // app:initial-load, and sandbox.script.* — see shouldBypassNonProTelemetrySampling).
       if (!isDyadProUser()) {
         if (
           !shouldBypassNonProTelemetrySampling(event) &&


### PR DESCRIPTION
## Summary
- Expand `app:initial-load` with platform, release channel, first-session, model provider, default chat mode, and runtime mode properties
- Bypass 10% non-Pro sampling for `app:initial-load` so launch metrics are reliable for DAU cohort analysis
- Add unit tests for the new telemetry helper

## Test plan
- [x] `npm test -- src/__tests__/posthogTelemetry.test.ts`
- [x] `npm test`
- [x] `npm run fmt && npm run lint:fix && npm run ts`


Made with [Cursor](https://cursor.com)