### PR TITLE
Filter missing TypeScript setup errors from PostHog telemetry

### DIFF
--- a/src/ipc/processors/tsc.test.ts
+++ b/src/ipc/processors/tsc.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
+import { shouldFilterTelemetryException } from "@/ipc/utils/telemetry";
+import { toProblemReportError } from "./tsc";
+
+describe("toProblemReportError", () => {
+  it("classifies missing TypeScript as a filtered precondition error", () => {
+    const error = toProblemReportError(
+      new Error(
+        "Failed to load TypeScript from C:\\Users\\jazzm\\dyad-apps\\wandering-koala-nudge because of Error: Cannot find module 'typescript'",
+      ),
+    );
+
+    expect(error).toBeInstanceOf(DyadError);
+    expect((error as DyadError).kind).toBe(DyadErrorKind.Precondition);
+    expect(shouldFilterTelemetryException(error)).toBe(true);
+  });
+
+  it("classifies missing tsconfig as a filtered precondition error", () => {
+    const error = toProblemReportError(
+      new Error(
+        "No TypeScript configuration file found in /app. Expected one of: tsconfig.app.json, tsconfig.json",
+      ),
+    );
+
+    expect(error).toBeInstanceOf(DyadError);
+    expect((error as DyadError).kind).toBe(DyadErrorKind.Precondition);
+    expect(shouldFilterTelemetryException(error)).toBe(true);
+  });
+
+  it("preserves unexpected worker failures for telemetry", () => {
+    const error = toProblemReportError(
+      new Error("TypeScript config error: invalid compiler option"),
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).not.toBeInstanceOf(DyadError);
+    expect(shouldFilterTelemetryException(error)).toBe(false);
+  });
+});

--- a/src/ipc/processors/tsc.ts
+++ b/src/ipc/processors/tsc.ts
@@ -1,6 +1,7 @@
 import * as path from "node:path";
 import { Worker } from "node:worker_threads";
 
+import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
 import { ProblemReport } from "@/ipc/types";
 import log from "electron-log";
 import { WorkerInput, WorkerOutput } from "../../../shared/tsc_types";
@@ -13,6 +14,29 @@ import {
 import { getTypeScriptCachePath } from "@/paths/paths";
 
 const logger = log.scope("tsc");
+
+/**
+ * Map expected type-check setup failures to DyadError so they are not sent to
+ * PostHog as `$exception` events (missing deps, no tsconfig, etc.).
+ */
+export function toProblemReportError(error: unknown): Error {
+  if (error instanceof DyadError) {
+    return error;
+  }
+
+  const message =
+    error instanceof Error ? error.message : String(error ?? "Unknown error");
+
+  if (
+    message.startsWith("Failed to load TypeScript from") ||
+    message.includes("Cannot find module 'typescript'") ||
+    message.startsWith("No TypeScript configuration file found")
+  ) {
+    return new DyadError(message, DyadErrorKind.Precondition);
+  }
+
+  return error instanceof Error ? error : new Error(message);
+}
 
 export async function generateProblemReport({
   fullResponse,
@@ -39,7 +63,11 @@ export async function generateProblemReport({
         resolve(output.data);
       } else {
         logger.error(`TSC worker failed for app ${appPath}: ${output.error}`);
-        reject(new Error(output.error || "Unknown worker error"));
+        reject(
+          toProblemReportError(
+            new Error(output.error || "Unknown worker error"),
+          ),
+        );
       }
     });
 
@@ -47,14 +75,16 @@ export async function generateProblemReport({
     worker.on("error", (error) => {
       logger.error(`TSC worker error for app ${appPath}:`, error);
       worker.terminate();
-      reject(error);
+      reject(toProblemReportError(error));
     });
 
     // Handle worker exit
     worker.on("exit", (code) => {
       if (code !== 0) {
         logger.error(`TSC worker exited with code ${code} for app ${appPath}`);
-        reject(new Error(`Worker exited with code ${code}`));
+        reject(
+          toProblemReportError(new Error(`Worker exited with code ${code}`)),
+        );
       }
     });
 


### PR DESCRIPTION
## Summary
- Classify expected TSC worker failures (missing `typescript` package or tsconfig) as `DyadError` with `Precondition` kind in `generateProblemReport`.
- Prevents `check-problems` IPC failures from being sent to PostHog as `$exception` events for apps that are not set up for type checking yet.
- Adds unit tests for the error classification and telemetry filtering behavior.

## Test plan
- [x] `npm test -- src/ipc/processors/tsc.test.ts`
- [x] Full `npm test` suite passes
- [x] `npm run fmt && npm run lint:fix && npm run ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)