### PR TITLE
Filter generic TypeError fetch failed from PostHog telemetry

### DIFF
--- a/rules/dyad-errors.md
+++ b/rules/dyad-errors.md
@@ -37,7 +37,7 @@ Most IPC/main paths and shared utilities (`git_utils`, Supabase admin, local age
 
 **Do not** import `DyadError` inside preload (`src/preload.ts`) without verifying the preload bundle; preload continues to use plain `Error` for invalid channels.
 
-**Legacy:** `FILTERED_EXCEPTION_MESSAGES` and `RateLimitError` (429) handling in `telemetry.ts` remain for any plain `Error` paths not yet migrated.
+**Legacy:** `FILTERED_EXCEPTION_MESSAGES`, `RateLimitError` (429) handling in `telemetry.ts`, and bare `TypeError: fetch failed` (via `isGenericFetchFailedError` in `posthogTelemetry.ts`) remain for plain `Error` paths not yet migrated. Renderer PostHog `before_send` uses `shouldFilterPostHogExceptionEvent` for the same fetch noise from autocapture.
 
 ## Automation pitfalls
 

--- a/src/__tests__/posthogTelemetry.test.ts
+++ b/src/__tests__/posthogTelemetry.test.ts
@@ -3,6 +3,7 @@ import {
   createExceptionFromTelemetry,
   getExceptionTelemetryContext,
   shouldBypassNonProTelemetrySampling,
+  shouldFilterPostHogExceptionEvent,
 } from "@/lib/posthogTelemetry";
 
 describe("createExceptionFromTelemetry", () => {
@@ -24,6 +25,44 @@ describe("createExceptionFromTelemetry", () => {
 
     expect(error.name).toBe("Error");
     expect(error.message).toBe("Unknown IPC exception");
+  });
+});
+
+describe("shouldFilterPostHogExceptionEvent", () => {
+  it("filters generic TypeError fetch failed from main-process telemetry", () => {
+    expect(
+      shouldFilterPostHogExceptionEvent({
+        event: "$exception",
+        properties: {
+          exception_name: "TypeError",
+          exception_message: "fetch failed",
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("filters generic TypeError fetch failed from PostHog autocapture", () => {
+    expect(
+      shouldFilterPostHogExceptionEvent({
+        event: "$exception",
+        properties: {
+          $exception_type: "TypeError",
+          $exception_message: "fetch failed",
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("does not filter fetch failures with actionable messages", () => {
+    expect(
+      shouldFilterPostHogExceptionEvent({
+        event: "$exception",
+        properties: {
+          exception_name: "TypeError",
+          exception_message: "fetch failed: ECONNREFUSED",
+        },
+      }),
+    ).toBe(false);
   });
 });
 

--- a/src/__tests__/telemetry.test.ts
+++ b/src/__tests__/telemetry.test.ts
@@ -20,6 +20,12 @@ describe("shouldFilterTelemetryException", () => {
     expect(shouldFilterTelemetryException(error)).toBe(true);
   });
 
+  it("filters generic TypeError fetch failed network noise", () => {
+    const error = new TypeError("fetch failed");
+
+    expect(shouldFilterTelemetryException(error)).toBe(true);
+  });
+
   it("does not filter non-429 RateLimitError variants", () => {
     const error = new Error("Rate limited (503): Service Unavailable");
     error.name = "RateLimitError";

--- a/src/ipc/utils/telemetry.ts
+++ b/src/ipc/utils/telemetry.ts
@@ -4,6 +4,7 @@ import {
   DyadError,
   isDyadErrorKindFilteredFromTelemetry,
 } from "@/errors/dyad_error";
+import { isGenericFetchFailedError } from "@/lib/posthogTelemetry";
 import { TelemetryEventPayload } from "@/ipc/types";
 
 const logger = log.scope("telemetry");
@@ -65,6 +66,13 @@ export function shouldFilterTelemetryException(error: unknown): boolean {
     error instanceof Error &&
     error.name === "RateLimitError" &&
     error.message.includes("(429)")
+  ) {
+    return true;
+  }
+
+  if (
+    error instanceof Error &&
+    isGenericFetchFailedError(error.name, error.message)
   ) {
     return true;
   }

--- a/src/lib/posthogTelemetry.ts
+++ b/src/lib/posthogTelemetry.ts
@@ -10,6 +10,45 @@ export type PostHogTelemetryEvent = {
  * Non-Pro telemetry sends only ~10% of events. These events are always sent.
  * Keep `sandbox.script.*` here so script instrumentation is never sampled out.
  */
+/** Node/Electron undici network failure with no actionable stack context. */
+export function isGenericFetchFailedError(
+  name: string | undefined,
+  message: string | undefined,
+): boolean {
+  return name === "TypeError" && message === "fetch failed";
+}
+
+export function shouldFilterPostHogExceptionEvent(
+  event: PostHogTelemetryEvent | null | undefined,
+): boolean {
+  const properties = event?.properties;
+  if (!properties) {
+    return false;
+  }
+
+  if (
+    isGenericFetchFailedError(
+      typeof properties.exception_name === "string"
+        ? properties.exception_name
+        : undefined,
+      typeof properties.exception_message === "string"
+        ? properties.exception_message
+        : undefined,
+    )
+  ) {
+    return true;
+  }
+
+  return isGenericFetchFailedError(
+    typeof properties.$exception_type === "string"
+      ? properties.$exception_type
+      : undefined,
+    typeof properties.$exception_message === "string"
+      ? properties.$exception_message
+      : undefined,
+  );
+}
+
 export function shouldBypassNonProTelemetrySampling(
   event: PostHogTelemetryEvent | null | undefined,
 ): boolean {

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -33,6 +33,7 @@ import {
   createExceptionFromTelemetry,
   getExceptionTelemetryContext,
   shouldBypassNonProTelemetrySampling,
+  shouldFilterPostHogExceptionEvent,
 } from "./lib/posthogTelemetry";
 
 // @ts-ignore
@@ -87,6 +88,13 @@ const posthogClient = posthog.init(
     before_send: (event) => {
       if (!isTelemetryOptedIn()) {
         console.debug("Telemetry not opted in, skipping event");
+        return null;
+      }
+
+      if (shouldFilterPostHogExceptionEvent(event)) {
+        console.debug(
+          "Filtering generic fetch failed exception from telemetry",
+        );
         return null;
       }
       const telemetryUserId = getTelemetryUserId();


### PR DESCRIPTION
## Summary
- Drop bare `TypeError: fetch failed` exceptions from main-process telemetry filtering before they reach PostHog
- Also filter the same noise in renderer PostHog `before_send` for autocaptured exceptions
- Add unit tests for both filtering paths

## Test plan
- [x] `npm test -- src/__tests__/telemetry.test.ts src/__tests__/posthogTelemetry.test.ts`
- [x] Full `npm test` suite passes
- [x] `npm run fmt && npm run lint:fix && npm run ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)