### PR TITLE
Add Advanced settings section above Experiments

### DIFF
--- a/e2e-tests/mcp.spec.ts
+++ b/e2e-tests/mcp.spec.ts
@@ -6,7 +6,7 @@ import { expect } from "@playwright/test";
 testSkipIfWindows("mcp - call calculator", async ({ po }) => {
   await po.setUp();
   await po.navigation.goToSettingsTab();
-  await po.settings.scrollToSettingsSection("experiments");
+  await po.settings.scrollToSettingsSection("advanced");
   await po.settings.toggleEnableMcpServersForBuildMode();
   await po.settings.scrollToSettingsSection("tools-mcp");
 
@@ -89,7 +89,7 @@ testSkipIfWindows("mcp - call calculator via http", async ({ po }) => {
   try {
     await po.setUp();
     await po.navigation.goToSettingsTab();
-    await po.settings.scrollToSettingsSection("experiments");
+    await po.settings.scrollToSettingsSection("advanced");
     await po.settings.toggleEnableMcpServersForBuildMode();
     await po.settings.scrollToSettingsSection("tools-mcp");
 

--- a/src/components/SettingsList.tsx
+++ b/src/components/SettingsList.tsx
@@ -22,6 +22,7 @@ const SETTINGS_SECTIONS: SettingsSection[] = [
   { id: SECTION_IDS.integrations, label: "Integrations" },
   { id: SECTION_IDS.agentPermissions, label: "Agent Permissions" },
   { id: SECTION_IDS.toolsMcp, label: "Tools (MCP)" },
+  { id: SECTION_IDS.advanced, label: "Advanced" },
   { id: SECTION_IDS.experiments, label: "Experiments" },
   { id: SECTION_IDS.dangerZone, label: "Danger Zone" },
 ];

--- a/src/lib/settingsSearchIndex.test.ts
+++ b/src/lib/settingsSearchIndex.test.ts
@@ -40,8 +40,8 @@ describe("SETTINGS_SEARCH_INDEX", () => {
       label: "Block unsafe npm packages",
       description: "Uses socket.dev to detect unsafe packages and blocks them",
       keywords: ["socket", "npm", "firewall", "package", "unsafe", "security"],
-      sectionId: SECTION_IDS.experiments,
-      sectionLabel: "Experiments",
+      sectionId: SECTION_IDS.advanced,
+      sectionLabel: "Advanced",
     });
   });
 
@@ -87,10 +87,9 @@ describe("SETTINGS_SEARCH_INDEX", () => {
         "attachments",
         "mustard",
         "agent",
-        "experiment",
       ],
-      sectionId: SECTION_IDS.experiments,
-      sectionLabel: "Experiments",
+      sectionId: SECTION_IDS.advanced,
+      sectionLabel: "Advanced",
     });
   });
 });

--- a/src/lib/settingsSearchIndex.ts
+++ b/src/lib/settingsSearchIndex.ts
@@ -7,6 +7,7 @@ export const SECTION_IDS = {
   integrations: "integrations",
   agentPermissions: "agent-permissions",
   toolsMcp: "tools-mcp",
+  advanced: "advanced",
   experiments: "experiments",
   dangerZone: "danger-zone",
 } as const;
@@ -373,16 +374,66 @@ export const SETTINGS_SEARCH_INDEX: SearchableSettingItem[] = [
     sectionLabel: "Tools (MCP)",
   },
 
-  // Experiments
+  // Advanced
+  {
+    id: SECTION_IDS.advanced,
+    label: "Advanced",
+    description: "Power-user settings for Git, sandboxing, packages, and MCP",
+    keywords: [
+      "advanced",
+      "git",
+      "sandbox",
+      "npm",
+      "mcp",
+      "security",
+      "native",
+    ],
+    sectionId: SECTION_IDS.advanced,
+    sectionLabel: "Advanced",
+  },
   {
     id: SETTING_IDS.nativeGit,
     label: "Enable Native Git",
     description:
       "Use native Git for faster performance without external installation",
-    keywords: ["git", "native", "experiment", "beta", "performance"],
-    sectionId: SECTION_IDS.experiments,
-    sectionLabel: "Experiments",
+    keywords: ["git", "native", "performance"],
+    sectionId: SECTION_IDS.advanced,
+    sectionLabel: "Advanced",
   },
+  {
+    id: SETTING_IDS.enableSandboxScriptExecution,
+    label: "Enable sandbox script execution",
+    description:
+      "Allow local-agent attachment scripts to inspect files with execute_sandbox_script",
+    keywords: [
+      "script",
+      "scripts",
+      "sandbox",
+      "attachments",
+      "mustard",
+      "agent",
+    ],
+    sectionId: SECTION_IDS.advanced,
+    sectionLabel: "Advanced",
+  },
+  {
+    id: SETTING_IDS.blockUnsafeNpmPackages,
+    label: "Block unsafe npm packages",
+    description: "Uses socket.dev to detect unsafe packages and blocks them",
+    keywords: ["socket", "npm", "firewall", "package", "unsafe", "security"],
+    sectionId: SECTION_IDS.advanced,
+    sectionLabel: "Advanced",
+  },
+  {
+    id: SETTING_IDS.enableMcpServersForBuildMode,
+    label: "Enable MCP servers for Build mode",
+    description: "Allow MCP servers to be used when in Build mode",
+    keywords: ["mcp", "build", "agent", "tools", "server"],
+    sectionId: SECTION_IDS.advanced,
+    sectionLabel: "Advanced",
+  },
+
+  // Experiments
   {
     id: SETTING_IDS.enableCloudSandbox,
     label: "Enable Cloud Sandbox (Pro)",
@@ -397,31 +448,6 @@ export const SETTINGS_SEARCH_INDEX: SearchableSettingItem[] = [
       "credits",
       "secure",
     ],
-    sectionId: SECTION_IDS.experiments,
-    sectionLabel: "Experiments",
-  },
-  {
-    id: SETTING_IDS.enableSandboxScriptExecution,
-    label: "Enable sandbox script execution",
-    description:
-      "Allow local-agent attachment scripts to inspect files with execute_sandbox_script",
-    keywords: [
-      "script",
-      "scripts",
-      "sandbox",
-      "attachments",
-      "mustard",
-      "agent",
-      "experiment",
-    ],
-    sectionId: SECTION_IDS.experiments,
-    sectionLabel: "Experiments",
-  },
-  {
-    id: SETTING_IDS.blockUnsafeNpmPackages,
-    label: "Block unsafe npm packages",
-    description: "Uses socket.dev to detect unsafe packages and blocks them",
-    keywords: ["socket", "npm", "firewall", "package", "unsafe", "security"],
     sectionId: SECTION_IDS.experiments,
     sectionLabel: "Experiments",
   },
@@ -444,14 +470,6 @@ export const SETTINGS_SEARCH_INDEX: SearchableSettingItem[] = [
     sectionLabel: "Experiments",
   },
 
-  {
-    id: SETTING_IDS.enableMcpServersForBuildMode,
-    label: "Enable MCP servers for Build mode",
-    description: "Allow MCP servers to be used when in Build mode",
-    keywords: ["mcp", "build", "agent", "tools", "experiment", "server"],
-    sectionId: SECTION_IDS.experiments,
-    sectionLabel: "Experiments",
-  },
   {
     id: SETTING_IDS.enableSelectAppFromHomeChatInput,
     label: "Enable Select App from Home Chat Input",

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -160,16 +160,22 @@ export default function SettingsPage() {
             <ToolsMcpSettings />
           </div>
 
-          {/* Experiments Section */}
+          {/* Advanced Section */}
           <div
-            id={SECTION_IDS.experiments}
+            id={SECTION_IDS.advanced}
             className="bg-white dark:bg-gray-800 rounded-xl shadow-sm p-6"
           >
-            <h2 className="text-lg font-medium text-gray-900 dark:text-white mb-4">
-              Experiments
-            </h2>
+            <div className="mb-6">
+              <h2 className="text-lg font-medium text-gray-900 dark:text-white">
+                Advanced
+              </h2>
+              <p className="text-sm text-gray-500 dark:text-gray-400 mt-1 mb-2">
+                We recommend keeping the default settings unless something is
+                not working
+              </p>
+            </div>
             <div className="space-y-4">
-              <div id={SETTING_IDS.nativeGit} className="space-y-1 mt-4">
+              <div id={SETTING_IDS.nativeGit} className="space-y-1">
                 <div className="flex items-center space-x-2">
                   <Switch
                     id="enable-native-git"
@@ -187,12 +193,6 @@ export default function SettingsPage() {
                   This doesn't require any external Git installation and offers
                   a faster, native-Git performance experience.
                 </div>
-              </div>
-              <div
-                id={SETTING_IDS.enableCloudSandbox}
-                className="space-y-1 mt-4"
-              >
-                <CloudSandboxExperimentSwitch />
               </div>
               <div
                 id={SETTING_IDS.enableSandboxScriptExecution}
@@ -225,30 +225,6 @@ export default function SettingsPage() {
                 <BlockUnsafeNpmPackagesSwitch />
               </div>
               <div
-                id={SETTING_IDS.enablePnpmMinimumReleaseAgeWarning}
-                className="space-y-1 mt-4"
-              >
-                <div className="flex items-center space-x-2">
-                  <Switch
-                    id="enable-pnpm-minimum-release-age-warning"
-                    aria-label="Enable pnpm upgrade warning"
-                    checked={!!settings?.enablePnpmMinimumReleaseAgeWarning}
-                    onCheckedChange={(checked) => {
-                      updateSettings({
-                        enablePnpmMinimumReleaseAgeWarning: checked,
-                      });
-                    }}
-                  />
-                  <Label htmlFor="enable-pnpm-minimum-release-age-warning">
-                    Enable pnpm upgrade warning
-                  </Label>
-                </div>
-                <div className="text-sm text-gray-500 dark:text-gray-400">
-                  Show the pnpm release-age warning toast and one-click pnpm
-                  upgrade action.
-                </div>
-              </div>
-              <div
                 id={SETTING_IDS.enableMcpServersForBuildMode}
                 className="space-y-1 mt-4"
               >
@@ -270,6 +246,51 @@ export default function SettingsPage() {
                 <div className="text-sm text-gray-500 dark:text-gray-400">
                   Allow MCP servers to be used when in Build mode. Note: MCP
                   servers are always enabled in Agent mode.
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Experiments Section */}
+          <div
+            id={SECTION_IDS.experiments}
+            className="bg-white dark:bg-gray-800 rounded-xl shadow-sm p-6"
+          >
+            <div className="mb-6">
+              <h2 className="text-lg font-medium text-gray-900 dark:text-white">
+                Experiments
+              </h2>
+              <p className="text-sm text-gray-500 dark:text-gray-400 mt-1 mb-2">
+                We do not recommend enabling experiments as these features may
+                not be stable
+              </p>
+            </div>
+            <div className="space-y-4">
+              <div id={SETTING_IDS.enableCloudSandbox} className="space-y-1">
+                <CloudSandboxExperimentSwitch />
+              </div>
+              <div
+                id={SETTING_IDS.enablePnpmMinimumReleaseAgeWarning}
+                className="space-y-1 mt-4"
+              >
+                <div className="flex items-center space-x-2">
+                  <Switch
+                    id="enable-pnpm-minimum-release-age-warning"
+                    aria-label="Enable pnpm upgrade warning"
+                    checked={!!settings?.enablePnpmMinimumReleaseAgeWarning}
+                    onCheckedChange={(checked) => {
+                      updateSettings({
+                        enablePnpmMinimumReleaseAgeWarning: checked,
+                      });
+                    }}
+                  />
+                  <Label htmlFor="enable-pnpm-minimum-release-age-warning">
+                    Enable pnpm upgrade warning
+                  </Label>
+                </div>
+                <div className="text-sm text-gray-500 dark:text-gray-400">
+                  Show the pnpm release-age warning toast and one-click pnpm
+                  upgrade action.
                 </div>
               </div>
               <div


### PR DESCRIPTION
## Summary
- Move power-user toggles (Native Git, sandbox scripts, unsafe npm blocking, MCP for Build mode) from Experiments into a new **Advanced** section above Experiments
- Add section subtitles with guidance for Advanced and Experiments
- Update settings search index, sidebar nav, and MCP E2E scroll target

## Test plan
- [ ] Open Settings and confirm **Advanced** appears above **Experiments** in the sidebar
- [ ] Verify the four moved toggles are under Advanced with the new subtitle
- [ ] Verify Cloud Sandbox, pnpm warning, and Select App remain under Experiments with its subtitle
- [ ] Search settings for "native git" / "MCP build" and confirm results point to Advanced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)