### PR TITLE
Reduce renderer memory

### DIFF
--- a/src/__tests__/streamingChunk.test.ts
+++ b/src/__tests__/streamingChunk.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from "vitest";
+import type { StreamingPatch } from "@/ipc/types";
+import { hashPrefix } from "@/lib/prefixHash";
+import { applyStreamingChunk } from "@/lib/streamingChunk";
+import { initialParserState } from "@/lib/streamingMessageParser";
+
+function patch(
+  offset: number,
+  content: string,
+  fullPrefix?: string,
+): StreamingPatch {
+  return {
+    offset,
+    content,
+    prefixHash:
+      fullPrefix !== undefined && offset > 0
+        ? hashPrefix(fullPrefix, offset)
+        : undefined,
+  };
+}
+
+describe("applyStreamingChunk", () => {
+  it("applies a fresh patch and runs the parser", () => {
+    const result = applyStreamingChunk({
+      prevContent: "",
+      prevParserState: undefined,
+      prevDroppedBytes: 0,
+      patch: patch(0, "Hello "),
+    });
+    expect(result.kind).toBe("applied");
+    if (result.kind !== "applied") return;
+    // Markdown open block starts at offset 0; trim is a no-op when cutAt
+    // would be 0. Content is preserved, droppedBytes stays zero.
+    expect(result.droppedBytes).toBe(0);
+    expect(result.content).toBe("Hello ");
+    expect(result.parserState.cursor).toBe(6);
+    expect(result.parserState.openBlock?.kind).toBe("markdown");
+  });
+
+  it("trims after a custom-tag closes (state lands in clean prose)", () => {
+    const result = applyStreamingChunk({
+      prevContent: "",
+      prevParserState: undefined,
+      prevDroppedBytes: 0,
+      patch: patch(0, '<dyad-write path="a.ts">body-a</dyad-write>'),
+    });
+    expect(result.kind).toBe("applied");
+    if (result.kind !== "applied") return;
+    // After the closing tag the parser is in clean prose with no open
+    // block; trimContent cuts at cursor and drops the whole local content.
+    expect(result.content).toBe("");
+    expect(result.droppedBytes).toBe(
+      '<dyad-write path="a.ts">body-a</dyad-write>'.length,
+    );
+    expect(result.parserState.blocks).toHaveLength(1);
+    expect(result.parserState.openBlock).toBeNull();
+  });
+
+  it("preserves committed blocks across a sequence of patches", () => {
+    let state = applyStreamingChunk({
+      prevContent: "",
+      prevParserState: undefined,
+      prevDroppedBytes: 0,
+      patch: patch(0, '<dyad-write path="a.ts">body-a</dyad-write>'),
+    });
+    expect(state.kind).toBe("applied");
+    if (state.kind !== "applied") return;
+    expect(state.parserState.blocks.length).toBe(1);
+    expect(state.parserState.blocks[0].kind).toBe("custom-tag");
+
+    // Second patch appends another full custom-tag.
+    const fullSoFar =
+      '<dyad-write path="a.ts">body-a</dyad-write><dyad-write path="b.ts">body-b</dyad-write>';
+    const patch2 = patch(
+      // Server-absolute offset = end of first tag; renderer-local content is
+      // empty after the previous trim, so the splice base is the absolute
+      // length minus the cumulative dropped bytes.
+      state.droppedBytes,
+      '<dyad-write path="b.ts">body-b</dyad-write>',
+      fullSoFar,
+    );
+    state = applyStreamingChunk({
+      prevContent: state.content,
+      prevParserState: state.parserState,
+      prevDroppedBytes: state.droppedBytes,
+      patch: patch2,
+    });
+    expect(state.kind).toBe("applied");
+    if (state.kind !== "applied") return;
+    expect(state.parserState.blocks.length).toBe(2);
+    const paths = state.parserState.blocks
+      .filter(
+        (b): b is Extract<typeof b, { kind: "custom-tag" }> =>
+          b.kind === "custom-tag",
+      )
+      .map((b) => b.attributes.path);
+    expect(paths).toEqual(["a.ts", "b.ts"]);
+  });
+
+  it("keeps an in-progress custom-tag as the open block and trims around it", () => {
+    let state = applyStreamingChunk({
+      prevContent: "",
+      prevParserState: undefined,
+      prevDroppedBytes: 0,
+      patch: patch(0, '<dyad-write path="a.ts">body-a</dyad-write>'),
+    });
+    expect(state.kind).toBe("applied");
+    if (state.kind !== "applied") return;
+
+    const fullSoFar =
+      '<dyad-write path="a.ts">body-a</dyad-write><dyad-write path="b.ts">par';
+    state = applyStreamingChunk({
+      prevContent: state.content,
+      prevParserState: state.parserState,
+      prevDroppedBytes: state.droppedBytes,
+      patch: patch(
+        state.droppedBytes,
+        '<dyad-write path="b.ts">par',
+        fullSoFar,
+      ),
+    });
+    expect(state.kind).toBe("applied");
+    if (state.kind !== "applied") return;
+    // a.ts committed, b.ts is the open block.
+    expect(state.parserState.blocks.length).toBe(1);
+    expect(state.parserState.openBlock?.kind).toBe("custom-tag");
+    if (state.parserState.openBlock?.kind !== "custom-tag") return;
+    expect(state.parserState.openBlock.attributes.path).toBe("b.ts");
+    // Local content starts at the open block's '<'.
+    expect(state.content.startsWith('<dyad-write path="b.ts">par')).toBe(true);
+    expect(state.parserState.openBlockStartOffset).toBe(0);
+  });
+
+  it("returns mismatch when the offset is beyond the local content", () => {
+    const result = applyStreamingChunk({
+      prevContent: "abc",
+      prevParserState: initialParserState(),
+      prevDroppedBytes: 0,
+      patch: patch(99, "tail"),
+    });
+    expect(result.kind).toBe("mismatch");
+  });
+
+  it("returns mismatch when prefix hash disagrees with local content", () => {
+    const result = applyStreamingChunk({
+      prevContent: "abc",
+      prevParserState: initialParserState(),
+      prevDroppedBytes: 0,
+      patch: { offset: 3, content: "tail", prefixHash: 0xdeadbeef },
+    });
+    expect(result.kind).toBe("mismatch");
+  });
+
+  it("skips the prefix hash check after bytes have been dropped", () => {
+    // priorBytesDropped > 0 means the renderer no longer holds the agreed
+    // prefix; the pipeline must accept the patch despite a stale hash.
+    const result = applyStreamingChunk({
+      prevContent: "open-block-tail",
+      prevParserState: initialParserState(),
+      prevDroppedBytes: 100,
+      // server-absolute offset = 100 + 15 (length of prevContent)
+      patch: { offset: 115, content: "more", prefixHash: 0xdeadbeef },
+    });
+    expect(result.kind).toBe("applied");
+    if (result.kind !== "applied") return;
+    expect(result.content.endsWith("more")).toBe(true);
+  });
+
+  it("returns noop when the patch produces identical content", () => {
+    const init = applyStreamingChunk({
+      prevContent: "",
+      prevParserState: undefined,
+      prevDroppedBytes: 0,
+      patch: patch(0, "Hello "),
+    });
+    expect(init.kind).toBe("applied");
+    if (init.kind !== "applied") return;
+    // markdown openBlock at offset 0 → no trim → content preserved.
+    expect(init.content).toBe("Hello ");
+
+    // An empty-tail patch at the current end produces identical content
+    // (idempotent retransmit). Pipeline returns noop so the caller can
+    // skip atom writes.
+    const replay = applyStreamingChunk({
+      prevContent: init.content,
+      prevParserState: init.parserState,
+      prevDroppedBytes: init.droppedBytes,
+      patch: {
+        offset: init.droppedBytes + init.content.length,
+        content: "",
+      },
+    });
+    expect(replay.kind).toBe("noop");
+  });
+
+  it("droppedBytes is monotonically non-decreasing across patches", () => {
+    let state = applyStreamingChunk({
+      prevContent: "",
+      prevParserState: undefined,
+      prevDroppedBytes: 0,
+      patch: patch(0, "intro text "),
+    });
+    expect(state.kind).toBe("applied");
+    if (state.kind !== "applied") return;
+    let prevDropped = state.droppedBytes;
+
+    const segments = [
+      '<dyad-write path="f0.ts">b0</dyad-write>',
+      '\n<dyad-write path="f1.ts">b1</dyad-write>',
+      '\n<dyad-write path="f2.ts">b2</dyad-write>',
+    ];
+    let absoluteContent = "intro text ";
+    for (const seg of segments) {
+      const newAbsolute = absoluteContent + seg;
+      const result = applyStreamingChunk({
+        prevContent: state.content,
+        prevParserState: state.parserState,
+        prevDroppedBytes: state.droppedBytes,
+        patch: patch(absoluteContent.length, seg, absoluteContent),
+      });
+      expect(result.kind).toBe("applied");
+      if (result.kind !== "applied") return;
+      expect(result.droppedBytes).toBeGreaterThanOrEqual(prevDropped);
+      prevDropped = result.droppedBytes;
+      state = result;
+      absoluteContent = newAbsolute;
+    }
+    // After three full custom-tag commits all completed, the parser is in
+    // clean prose with no open block; everything has been trimmed.
+    expect(state.content).toBe("");
+    expect(state.parserState.blocks.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/src/__tests__/streamingMessageParser.test.ts
+++ b/src/__tests__/streamingMessageParser.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect, it } from "vitest";
+import {
+  advanceParser,
+  getParserBlocks,
+  initialParserState,
+  parseFullMessage,
+  trimToLastNBlocks,
+  type Block,
+} from "@/lib/streamingMessageParser";
+
+function blocksToShape(blocks: Block[]) {
+  return blocks.map((b) => {
+    if (b.kind === "markdown") {
+      return { kind: "markdown", content: b.content, complete: b.complete };
+    }
+    return {
+      kind: "custom-tag",
+      tag: b.tag,
+      attributes: b.attributes,
+      content: b.content,
+      complete: b.complete,
+      inProgress: b.inProgress,
+    };
+  });
+}
+
+function feedAll(content: string, splits: number[]) {
+  let state = initialParserState();
+  let prev = 0;
+  for (const at of splits) {
+    state = advanceParser(state, content.slice(0, at));
+    prev = at;
+  }
+  if (prev < content.length) {
+    state = advanceParser(state, content);
+  }
+  return state;
+}
+
+describe("streamingMessageParser", () => {
+  it("parses pure markdown as a single block", () => {
+    const content = "Hello **world**\n\nSecond paragraph";
+    const { blocks } = parseFullMessage(content);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({
+      kind: "markdown",
+      content,
+    });
+  });
+
+  it("parses a single dyad-write tag", () => {
+    const content =
+      'Before\n<dyad-write path="src/foo.ts" description="foo">code here</dyad-write>\nAfter';
+    const { blocks } = parseFullMessage(content);
+    expect(blocksToShape(blocks)).toEqual([
+      { kind: "markdown", content: "Before\n", complete: true },
+      {
+        kind: "custom-tag",
+        tag: "dyad-write",
+        attributes: { path: "src/foo.ts", description: "foo" },
+        content: "code here",
+        complete: true,
+        inProgress: false,
+      },
+      { kind: "markdown", content: "\nAfter", complete: false },
+    ]);
+  });
+
+  it("handles xml-escaped attribute and content values", () => {
+    const content =
+      '<dyad-write path="a.ts" description="A &amp; B">if (a &lt; b) {}</dyad-write>';
+    const { blocks } = parseFullMessage(content);
+    expect(blocks).toHaveLength(1);
+    const tag = blocks[0];
+    if (tag.kind !== "custom-tag") throw new Error("expected custom-tag");
+    expect(tag.attributes.description).toBe("A & B");
+    expect(tag.content).toBe("if (a < b) {}");
+  });
+
+  it("treats unclosed opening tag as in-progress", () => {
+    const content = '<dyad-write path="x.ts">partial';
+    const { blocks } = parseFullMessage(content);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({
+      kind: "custom-tag",
+      tag: "dyad-write",
+      content: "partial",
+      complete: false,
+      inProgress: true,
+    });
+  });
+
+  it("treats non-dyad < as text", () => {
+    const content = "use <html>tag</html> in markdown";
+    const { blocks } = parseFullMessage(content);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({
+      kind: "markdown",
+      content,
+    });
+  });
+
+  it("incremental parse equals full parse for any split sequence", () => {
+    const content = `Intro line.
+
+<dyad-write path="src/foo.ts" description="foo &amp; bar">
+const x = 1;
+if (a &lt; b) { console.log("&amp;"); }
+</dyad-write>
+
+Some prose between blocks.
+
+<think>step by step</think>
+
+<dyad-add-dependency packages="react"></dyad-add-dependency>
+
+Final words.`;
+
+    const fullBlocks = parseFullMessage(content).blocks;
+
+    // Try every single-split point.
+    for (let i = 0; i <= content.length; i++) {
+      let state = initialParserState();
+      state = advanceParser(state, content.slice(0, i));
+      state = advanceParser(state, content);
+      const incBlocks = getParserBlocks(state);
+      expect(blocksToShape(incBlocks)).toEqual(blocksToShape(fullBlocks));
+    }
+
+    // Try a handful of multi-split sequences (deterministic).
+    const multiSplits = [
+      [10, 25, 60, 120, 200],
+      [1, 2, 3, 4, 5, 50, 100, 150],
+      [content.length - 1],
+      [5, 5, 5, 50, 50],
+    ];
+    for (const splits of multiSplits) {
+      const state = feedAll(
+        content,
+        splits.filter((s) => s <= content.length),
+      );
+      const incBlocks = getParserBlocks(state);
+      expect(blocksToShape(incBlocks)).toEqual(blocksToShape(fullBlocks));
+    }
+  });
+
+  it("preserves committed block refs across updates", () => {
+    const part1 =
+      'Before\n<dyad-write path="x.ts">done</dyad-write>\n<dyad-write path="y.ts">in';
+    const part2 = part1 + "progress";
+    let state = initialParserState();
+    state = advanceParser(state, part1);
+    const blocks1 = getParserBlocks(state);
+    state = advanceParser(state, part2);
+    const blocks2 = getParserBlocks(state);
+    // Completed dyad-write for x.ts should keep its identity.
+    const xBefore = blocks1.find(
+      (b) => b.kind === "custom-tag" && b.attributes.path === "x.ts",
+    );
+    const xAfter = blocks2.find(
+      (b) => b.kind === "custom-tag" && b.attributes.path === "x.ts",
+    );
+    expect(xBefore).toBeDefined();
+    expect(xBefore).toBe(xAfter);
+
+    // The open in-progress block must get a new ref because its content grew —
+    // that's how React.memo on ref equality knows to re-render only it.
+    const yBefore = blocks1.find(
+      (b) => b.kind === "custom-tag" && b.attributes.path === "y.ts",
+    );
+    const yAfter = blocks2.find(
+      (b) => b.kind === "custom-tag" && b.attributes.path === "y.ts",
+    );
+    expect(yBefore).toBeDefined();
+    expect(yAfter).toBeDefined();
+    expect(yBefore).not.toBe(yAfter);
+  });
+
+  it("only the open block changes ref across many small chunks (O(chunk) renderer guarantee)", () => {
+    // 50 completed dyad-write blocks followed by one open block.
+    const completedSegments: string[] = [];
+    for (let i = 0; i < 50; i++) {
+      completedSegments.push(
+        `<dyad-write path="f${i}.ts">content ${i}</dyad-write>`,
+      );
+    }
+    const baseContent =
+      completedSegments.join("\n") + '\n<dyad-write path="open.ts">';
+
+    let state = initialParserState();
+    state = advanceParser(state, baseContent);
+    const completedRefs = getParserBlocks(state)
+      .filter(
+        (b) => b.kind === "custom-tag" && b.attributes.path?.startsWith("f"),
+      )
+      .map((b) => b);
+    expect(completedRefs).toHaveLength(50);
+
+    let content = baseContent;
+    for (let chunk = 0; chunk < 20; chunk++) {
+      content += `chunk-${chunk}-payload `;
+      state = advanceParser(state, content);
+      const after = getParserBlocks(state);
+      // All 50 completed blocks must keep the SAME ref. If even one changes,
+      // React.memo would mis-trigger and the per-chunk render cost balloons
+      // past the open block.
+      for (let i = 0; i < 50; i++) {
+        const a = completedRefs[i];
+        const b = after.find(
+          (x) => x.kind === "custom-tag" && x.attributes.path === `f${i}.ts`,
+        );
+        expect(b).toBe(a);
+      }
+    }
+  });
+
+  it("handles a closing-tag that doesn't match the open tag as content", () => {
+    const content = '<dyad-write path="a.ts">foo</dyad-edit>still</dyad-write>';
+    const { blocks } = parseFullMessage(content);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({
+      kind: "custom-tag",
+      tag: "dyad-write",
+      content: "foo</dyad-edit>still",
+      complete: true,
+    });
+  });
+
+  it("random-split fuzz: incremental matches full parse for many seeds", () => {
+    const content = `Hello.
+<dyad-write path="a.ts" description="x">code &lt;tag&gt; here</dyad-write>
+mid prose
+<dyad-add-dependency packages="react vue"></dyad-add-dependency>
+<think>analysis &amp; plan</think>
+<dyad-write path="b.ts">b body
+multi-line
+content</dyad-write>
+trailing`;
+
+    const fullBlocks = blocksToShape(parseFullMessage(content).blocks);
+
+    // Deterministic LCG.
+    let seed = 12345;
+    const rand = () => {
+      seed = (seed * 1664525 + 1013904223) >>> 0;
+      return seed / 0x100000000;
+    };
+
+    for (let trial = 0; trial < 50; trial++) {
+      const splitCount = 3 + Math.floor(rand() * 12);
+      const splits = new Set<number>();
+      for (let k = 0; k < splitCount; k++) {
+        splits.add(Math.floor(rand() * content.length));
+      }
+      const sorted = [...splits].sort((a, b) => a - b);
+      let state = initialParserState();
+      for (const s of sorted) {
+        state = advanceParser(state, content.slice(0, s));
+      }
+      state = advanceParser(state, content);
+      expect(blocksToShape(getParserBlocks(state))).toEqual(fullBlocks);
+    }
+  });
+
+  it("trimToLastNBlocks drops oldest blocks and shifts coordinates", () => {
+    const segments: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      segments.push(`<dyad-write path="f${i}.ts">body${i}</dyad-write>`);
+    }
+    const fullContent = segments.join("\n") + '\n<dyad-write path="open.ts">in';
+    let state = advanceParser(initialParserState(), fullContent);
+
+    // Closed blocks include both dyad-write and the "\n" markdown blocks
+    // between them. Keep last 3 → most recent dyad-write + "\n" markdown
+    // before/after it.
+    const trimmed = trimToLastNBlocks(state, fullContent, 3);
+    expect(trimmed.bytesDropped).toBeGreaterThan(0);
+    expect(trimmed.state.blocks.length).toBe(3);
+
+    // Trimmed content must be reparseable. The most recent dyad-write
+    // (f4.ts) must still be present plus the open one (open.ts).
+    const reparsed = parseFullMessage(trimmed.content).blocks;
+    const tagPaths = reparsed
+      .filter(
+        (b): b is Extract<Block, { kind: "custom-tag" }> =>
+          b.kind === "custom-tag",
+      )
+      .map((b) => b.attributes.path);
+    expect(tagPaths).toContain("f4.ts");
+    expect(tagPaths).toContain("open.ts");
+    // Older blocks dropped.
+    expect(tagPaths).not.toContain("f0.ts");
+    expect(tagPaths).not.toContain("f1.ts");
+
+    // After trimming, cursor matches new content length so the renderer's
+    // cache-hit guard succeeds.
+    expect(trimmed.state.cursor).toBe(trimmed.content.length);
+
+    // Subsequent advance with more bytes appended works on local coordinates.
+    const moreContent = trimmed.content + "progress";
+    state = advanceParser(trimmed.state, moreContent);
+    const open = getParserBlocks(state).find(
+      (b) => b.kind === "custom-tag" && b.attributes.path === "open.ts",
+    );
+    expect(open?.kind).toBe("custom-tag");
+    if (open?.kind === "custom-tag") {
+      expect(open.content).toBe("inprogress");
+    }
+  });
+
+  it("resets when content shrinks (resync)", () => {
+    let state = initialParserState();
+    state = advanceParser(state, '<dyad-write path="a.ts">old</dyad-write>');
+    expect(getParserBlocks(state)).toHaveLength(1);
+    state = advanceParser(state, "<dyad-write");
+    // Resync caused full reparse — synthesized markdown for partial tag.
+    const blocks = getParserBlocks(state);
+    expect(blocks.length).toBeGreaterThanOrEqual(0);
+    state = advanceParser(state, '<dyad-write path="b.ts">new</dyad-write>');
+    const finalBlocks = getParserBlocks(state);
+    expect(finalBlocks).toHaveLength(1);
+    if (finalBlocks[0].kind !== "custom-tag")
+      throw new Error("expected custom-tag");
+    expect(finalBlocks[0].attributes.path).toBe("b.ts");
+    expect(finalBlocks[0].content).toBe("new");
+  });
+});

--- a/src/__tests__/streamingMessageParser.test.ts
+++ b/src/__tests__/streamingMessageParser.test.ts
@@ -4,6 +4,7 @@ import {
   getParserBlocks,
   initialParserState,
   parseFullMessage,
+  trimToLastNBlocks,
   type Block,
 } from "@/lib/streamingMessageParser";
 
@@ -258,6 +259,52 @@ trailing`;
       }
       state = advanceParser(state, content);
       expect(blocksToShape(getParserBlocks(state))).toEqual(fullBlocks);
+    }
+  });
+
+  it("trimToLastNBlocks drops oldest blocks and shifts coordinates", () => {
+    const segments: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      segments.push(`<dyad-write path="f${i}.ts">body${i}</dyad-write>`);
+    }
+    const fullContent = segments.join("\n") + '\n<dyad-write path="open.ts">in';
+    let state = advanceParser(initialParserState(), fullContent);
+
+    // Closed blocks include both dyad-write and the "\n" markdown blocks
+    // between them. Keep last 3 → most recent dyad-write + "\n" markdown
+    // before/after it.
+    const trimmed = trimToLastNBlocks(state, fullContent, 3);
+    expect(trimmed.bytesDropped).toBeGreaterThan(0);
+    expect(trimmed.state.blocks.length).toBe(3);
+
+    // Trimmed content must be reparseable. The most recent dyad-write
+    // (f4.ts) must still be present plus the open one (open.ts).
+    const reparsed = parseFullMessage(trimmed.content).blocks;
+    const tagPaths = reparsed
+      .filter(
+        (b): b is Extract<Block, { kind: "custom-tag" }> =>
+          b.kind === "custom-tag",
+      )
+      .map((b) => b.attributes.path);
+    expect(tagPaths).toContain("f4.ts");
+    expect(tagPaths).toContain("open.ts");
+    // Older blocks dropped.
+    expect(tagPaths).not.toContain("f0.ts");
+    expect(tagPaths).not.toContain("f1.ts");
+
+    // After trimming, cursor matches new content length so the renderer's
+    // cache-hit guard succeeds.
+    expect(trimmed.state.cursor).toBe(trimmed.content.length);
+
+    // Subsequent advance with more bytes appended works on local coordinates.
+    const moreContent = trimmed.content + "progress";
+    state = advanceParser(trimmed.state, moreContent);
+    const open = getParserBlocks(state).find(
+      (b) => b.kind === "custom-tag" && b.attributes.path === "open.ts",
+    );
+    expect(open?.kind).toBe("custom-tag");
+    if (open?.kind === "custom-tag") {
+      expect(open.content).toBe("inprogress");
     }
   });
 

--- a/src/__tests__/streamingMessageParser.test.ts
+++ b/src/__tests__/streamingMessageParser.test.ts
@@ -4,7 +4,6 @@ import {
   getParserBlocks,
   initialParserState,
   parseFullMessage,
-  trimToLastNBlocks,
   type Block,
 } from "@/lib/streamingMessageParser";
 
@@ -259,52 +258,6 @@ trailing`;
       }
       state = advanceParser(state, content);
       expect(blocksToShape(getParserBlocks(state))).toEqual(fullBlocks);
-    }
-  });
-
-  it("trimToLastNBlocks drops oldest blocks and shifts coordinates", () => {
-    const segments: string[] = [];
-    for (let i = 0; i < 5; i++) {
-      segments.push(`<dyad-write path="f${i}.ts">body${i}</dyad-write>`);
-    }
-    const fullContent = segments.join("\n") + '\n<dyad-write path="open.ts">in';
-    let state = advanceParser(initialParserState(), fullContent);
-
-    // Closed blocks include both dyad-write and the "\n" markdown blocks
-    // between them. Keep last 3 → most recent dyad-write + "\n" markdown
-    // before/after it.
-    const trimmed = trimToLastNBlocks(state, fullContent, 3);
-    expect(trimmed.bytesDropped).toBeGreaterThan(0);
-    expect(trimmed.state.blocks.length).toBe(3);
-
-    // Trimmed content must be reparseable. The most recent dyad-write
-    // (f4.ts) must still be present plus the open one (open.ts).
-    const reparsed = parseFullMessage(trimmed.content).blocks;
-    const tagPaths = reparsed
-      .filter(
-        (b): b is Extract<Block, { kind: "custom-tag" }> =>
-          b.kind === "custom-tag",
-      )
-      .map((b) => b.attributes.path);
-    expect(tagPaths).toContain("f4.ts");
-    expect(tagPaths).toContain("open.ts");
-    // Older blocks dropped.
-    expect(tagPaths).not.toContain("f0.ts");
-    expect(tagPaths).not.toContain("f1.ts");
-
-    // After trimming, cursor matches new content length so the renderer's
-    // cache-hit guard succeeds.
-    expect(trimmed.state.cursor).toBe(trimmed.content.length);
-
-    // Subsequent advance with more bytes appended works on local coordinates.
-    const moreContent = trimmed.content + "progress";
-    state = advanceParser(trimmed.state, moreContent);
-    const open = getParserBlocks(state).find(
-      (b) => b.kind === "custom-tag" && b.attributes.path === "open.ts",
-    );
-    expect(open?.kind).toBe("custom-tag");
-    if (open?.kind === "custom-tag") {
-      expect(open.content).toBe("inprogress");
     }
   });
 

--- a/src/__tests__/streamingMessageParser.test.ts
+++ b/src/__tests__/streamingMessageParser.test.ts
@@ -4,7 +4,7 @@ import {
   getParserBlocks,
   initialParserState,
   parseFullMessage,
-  trimToLastNBlocks,
+  trimContent,
   type Block,
 } from "@/lib/streamingMessageParser";
 
@@ -262,48 +262,46 @@ trailing`;
     }
   });
 
-  it("trimToLastNBlocks drops oldest blocks and shifts coordinates", () => {
+  it("trimContent shortens the content string at the open-block boundary", () => {
     const segments: string[] = [];
     for (let i = 0; i < 5; i++) {
       segments.push(`<dyad-write path="f${i}.ts">body${i}</dyad-write>`);
     }
     const fullContent = segments.join("\n") + '\n<dyad-write path="open.ts">in';
-    let state = advanceParser(initialParserState(), fullContent);
+    const state = advanceParser(initialParserState(), fullContent);
 
-    // Closed blocks include both dyad-write and the "\n" markdown blocks
-    // between them. Keep last 3 → most recent dyad-write + "\n" markdown
-    // before/after it.
-    const trimmed = trimToLastNBlocks(state, fullContent, 3);
+    // Closed blocks (5 dyad-write + 5 newline markdowns) plus one open
+    // custom-tag for "open.ts".
+    expect(state.blocks.length).toBe(10);
+    expect(state.openBlock?.kind).toBe("custom-tag");
+
+    const trimmed = trimContent(state, fullContent);
     expect(trimmed.bytesDropped).toBeGreaterThan(0);
-    expect(trimmed.state.blocks.length).toBe(3);
 
-    // Trimmed content must be reparseable. The most recent dyad-write
-    // (f4.ts) must still be present plus the open one (open.ts).
-    const reparsed = parseFullMessage(trimmed.content).blocks;
-    const tagPaths = reparsed
+    // Closed blocks survive the trim — they live in state.blocks.
+    expect(trimmed.state.blocks.length).toBe(10);
+    const closedPaths = trimmed.state.blocks
       .filter(
         (b): b is Extract<Block, { kind: "custom-tag" }> =>
           b.kind === "custom-tag",
       )
       .map((b) => b.attributes.path);
-    expect(tagPaths).toContain("f4.ts");
-    expect(tagPaths).toContain("open.ts");
-    // Older blocks dropped.
-    expect(tagPaths).not.toContain("f0.ts");
-    expect(tagPaths).not.toContain("f1.ts");
+    expect(closedPaths).toEqual(["f0.ts", "f1.ts", "f2.ts", "f3.ts", "f4.ts"]);
 
-    // After trimming, cursor matches new content length so the renderer's
-    // cache-hit guard succeeds.
+    // Trimmed content begins at the open block's '<'.
+    expect(trimmed.content.startsWith('<dyad-write path="open.ts">in')).toBe(
+      true,
+    );
     expect(trimmed.state.cursor).toBe(trimmed.content.length);
+    expect(trimmed.state.openBlockStartOffset).toBe(0);
 
     // Subsequent advance with more bytes appended works on local coordinates.
     const moreContent = trimmed.content + "progress";
-    state = advanceParser(trimmed.state, moreContent);
-    const open = getParserBlocks(state).find(
-      (b) => b.kind === "custom-tag" && b.attributes.path === "open.ts",
-    );
+    const advanced = advanceParser(trimmed.state, moreContent);
+    const open = advanced.openBlock;
     expect(open?.kind).toBe("custom-tag");
     if (open?.kind === "custom-tag") {
+      expect(open.attributes.path).toBe("open.ts");
       expect(open.content).toBe("inprogress");
     }
   });

--- a/src/atoms/chatAtoms.ts
+++ b/src/atoms/chatAtoms.ts
@@ -274,3 +274,13 @@ export const queuePausedByIdAtom = atom<Map<number, boolean>>(new Map());
 export const streamingBlocksByMessageIdAtom = atom<Map<number, ParserState>>(
   new Map(),
 );
+
+// Cumulative bytes dropped from the front of the renderer-local
+// message.content for each message, while a stream is in progress. The
+// chunk handler trims old completed blocks from memory after every patch;
+// the count translates server-side patch offsets (which are absolute) into
+// local-content offsets used by applyStreamingPatch. Cleared on stream end
+// (full content is re-fetched from the database).
+export const contentBytesDroppedByMessageIdAtom = atom<Map<number, number>>(
+  new Map(),
+);

--- a/src/atoms/chatAtoms.ts
+++ b/src/atoms/chatAtoms.ts
@@ -7,6 +7,53 @@ import type {
 import type { ListedApp } from "@/ipc/types/app";
 import type { Getter, Setter } from "jotai";
 import { atom } from "jotai";
+import type { ReactElement } from "react";
+import type { ParserState } from "@/lib/streamingMessageParser";
+
+/**
+ * Per-message cache of pre-rendered React elements for committed (closed)
+ * blocks. Built at chunk-handle time so the renderer never re-creates them
+ * during render.
+ */
+export interface CachedClosedBlock {
+  /** Stable React key. Mirrors the parser block id. */
+  id: number;
+  /** The pre-built React element (key already set, props frozen). */
+  element: ReactElement;
+  /** Pre-extracted error message (for FixAllErrorsButton aggregation). */
+  errorMessage?: string;
+  /**
+   * Approximate char weight for cap accounting. For markdown blocks this
+   * is `block.content.length`; for tool-call blocks (dyad-write etc.) it
+   * is the same — the file source counts toward the total even after
+   * the block is closed.
+   */
+  bytes: number;
+  /** "tool-call" if the block's tag is in TOOL_CALL_TAGS, else "markdown". */
+  category: "markdown" | "tool-call";
+  /** The custom-tag name (e.g. "dyad-write"). Set only when category === "tool-call". */
+  toolTag?: string;
+}
+
+/** Running totals for blocks that have been evicted from the JSX cache. */
+export interface DroppedSummary {
+  markdown: number;
+  toolCalls: number;
+  /** Per-tool counts, keyed by dyad-* tag name. Subset of TOOL_CALL_TAGS. */
+  byToolTag: Record<string, number>;
+}
+
+/**
+ * Bundled JSX cache + cap-accounting state for a streaming message. Stored
+ * as a single atom value so the entries list, total-char counter, and
+ * dropped-summary update atomically per chunk.
+ */
+export interface MessageJsxState {
+  entries: CachedClosedBlock[];
+  /** Sum of `bytes` across `entries`. Maintained on push and shift. */
+  totalChars: number;
+  dropped: DroppedSummary;
+}
 
 // Per-chat atoms implemented with maps keyed by chatId
 export const chatMessagesByIdAtom = atom<Map<number, Message[]>>(new Map());
@@ -263,3 +310,31 @@ export const streamCompletedSuccessfullyByIdAtom = atom<Map<number, boolean>>(
 
 // Tracks if the queue is paused for each chat (Map<chatId, isPaused>)
 export const queuePausedByIdAtom = atom<Map<number, boolean>>(new Map());
+
+// Cache of incremental parser state per assistant message id. The renderer
+// reads from this map when present; otherwise it falls back to a one-shot
+// parse from message.content. Updated in the streaming chunk handler so
+// committed blocks keep stable refs across patches and only the open
+// trailing block changes shape per chunk.
+export const streamingBlocksByMessageIdAtom = atom<Map<number, ParserState>>(
+  new Map(),
+);
+
+// Cumulative bytes dropped from the front of the renderer-local
+// message.content for each message, while a stream is in progress. The
+// chunk handler trims old completed blocks from memory once the count
+// exceeds a threshold; the count translates server-side patch offsets
+// (which are absolute) into local-content offsets used by
+// applyStreamingPatch. Cleared on stream end (full content is re-fetched
+// from the database).
+export const contentBytesDroppedByMessageIdAtom = atom<Map<number, number>>(
+  new Map(),
+);
+
+// Per-message JSX cache + cap-accounting state. Each chunk handler appends
+// pre-rendered React elements for any newly-committed closed blocks, then
+// evicts entries from the front while the cap is exceeded (configured by
+// MAX_BLOCKS / MAX_CHARS / MIN_BLOCKS in useStreamChat). Cleared on stream
+// end so the renderer falls back to a one-shot parse of the full DB
+// content (and the omitted-blocks summary disappears).
+export const messageJsxByIdAtom = atom<Map<number, MessageJsxState>>(new Map());

--- a/src/atoms/chatAtoms.ts
+++ b/src/atoms/chatAtoms.ts
@@ -7,34 +7,7 @@ import type {
 import type { ListedApp } from "@/ipc/types/app";
 import type { Getter, Setter } from "jotai";
 import { atom } from "jotai";
-import type { ReactElement } from "react";
-import type { ParserState } from "@/lib/streamingMessageParser";
-
-/**
- * Per-message cache of pre-rendered React elements for committed (closed)
- * blocks. Built at chunk-handle time so the renderer never re-creates them
- * during render. Closed-block visibility relies on this cache because the
- * chunk handler trims closed blocks out of the parser state and
- * message.content (see KEEP_COMMITTED_BLOCKS in useStreamChat).
- */
-export interface CachedClosedBlock {
-  /** Stable React key. Mirrors the parser block id. */
-  id: number;
-  /** The pre-built React element (key already set, props frozen). */
-  element: ReactElement;
-  /** Pre-extracted error message (for FixAllErrorsButton aggregation). */
-  errorMessage?: string;
-}
-
-/**
- * Per-message JSX cache. The full response lives here as pre-rendered
- * React elements; nothing is ever evicted while a stream is active. Cleared
- * on stream end so the renderer falls back to a one-shot parse of the full
- * DB content.
- */
-export interface MessageJsxState {
-  entries: CachedClosedBlock[];
-}
+import type { Block, ParserState } from "@/lib/streamingMessageParser";
 
 // Per-chat atoms implemented with maps keyed by chatId
 export const chatMessagesByIdAtom = atom<Map<number, Message[]>>(new Map());
@@ -312,10 +285,15 @@ export const contentBytesDroppedByMessageIdAtom = atom<Map<number, number>>(
   new Map(),
 );
 
-// Per-message JSX cache. The chunk handler appends pre-rendered React
-// elements for any newly-committed closed blocks; nothing is evicted while
-// a stream is active. Required for closed-block visibility because the
-// trim drops closed blocks out of the parser state and message.content.
+// Per-message accumulator of committed (closed) parser blocks. The chunk
+// handler immutable-appends newly-closed blocks every patch; the parser
+// state itself is trimmed (state.blocks is wiped) so blocks survive the
+// trim only by living here. Block object refs are stable across chunks so
+// the renderer's per-block React.memo skips unchanged children. The array
+// ref changes only when a block closes, letting a wrapper memo skip the
+// whole closed-block subtree on chunks that just extend the open block.
 // Cleared on stream end so the renderer falls back to a one-shot parse of
 // the full DB content.
-export const messageJsxByIdAtom = atom<Map<number, MessageJsxState>>(new Map());
+export const closedBlocksByMessageIdAtom = atom<Map<number, Block[]>>(
+  new Map(),
+);

--- a/src/atoms/chatAtoms.ts
+++ b/src/atoms/chatAtoms.ts
@@ -7,7 +7,7 @@ import type {
 import type { ListedApp } from "@/ipc/types/app";
 import type { Getter, Setter } from "jotai";
 import { atom } from "jotai";
-import type { Block, ParserState } from "@/lib/streamingMessageParser";
+import type { ParserState } from "@/lib/streamingMessageParser";
 
 // Per-chat atoms implemented with maps keyed by chatId
 export const chatMessagesByIdAtom = atom<Map<number, Message[]>>(new Map());
@@ -277,23 +277,10 @@ export const streamingBlocksByMessageIdAtom = atom<Map<number, ParserState>>(
 
 // Cumulative bytes dropped from the front of the renderer-local
 // message.content for each message, while a stream is in progress. The
-// chunk handler trims old completed blocks from memory after every patch;
+// chunk handler trims content past the open-block boundary every patch;
 // the count translates server-side patch offsets (which are absolute) into
 // local-content offsets used by applyStreamingPatch. Cleared on stream end
 // (full content is re-fetched from the database).
 export const contentBytesDroppedByMessageIdAtom = atom<Map<number, number>>(
-  new Map(),
-);
-
-// Per-message accumulator of committed (closed) parser blocks. The chunk
-// handler immutable-appends newly-closed blocks every patch; the parser
-// state itself is trimmed (state.blocks is wiped) so blocks survive the
-// trim only by living here. Block object refs are stable across chunks so
-// the renderer's per-block React.memo skips unchanged children. The array
-// ref changes only when a block closes, letting a wrapper memo skip the
-// whole closed-block subtree on chunks that just extend the open block.
-// Cleared on stream end so the renderer falls back to a one-shot parse of
-// the full DB content.
-export const closedBlocksByMessageIdAtom = atom<Map<number, Block[]>>(
   new Map(),
 );

--- a/src/atoms/chatAtoms.ts
+++ b/src/atoms/chatAtoms.ts
@@ -7,7 +7,34 @@ import type {
 import type { ListedApp } from "@/ipc/types/app";
 import type { Getter, Setter } from "jotai";
 import { atom } from "jotai";
+import type { ReactElement } from "react";
 import type { ParserState } from "@/lib/streamingMessageParser";
+
+/**
+ * Per-message cache of pre-rendered React elements for committed (closed)
+ * blocks. Built at chunk-handle time so the renderer never re-creates them
+ * during render. Closed-block visibility relies on this cache because the
+ * chunk handler trims closed blocks out of the parser state and
+ * message.content (see KEEP_COMMITTED_BLOCKS in useStreamChat).
+ */
+export interface CachedClosedBlock {
+  /** Stable React key. Mirrors the parser block id. */
+  id: number;
+  /** The pre-built React element (key already set, props frozen). */
+  element: ReactElement;
+  /** Pre-extracted error message (for FixAllErrorsButton aggregation). */
+  errorMessage?: string;
+}
+
+/**
+ * Per-message JSX cache. The full response lives here as pre-rendered
+ * React elements; nothing is ever evicted while a stream is active. Cleared
+ * on stream end so the renderer falls back to a one-shot parse of the full
+ * DB content.
+ */
+export interface MessageJsxState {
+  entries: CachedClosedBlock[];
+}
 
 // Per-chat atoms implemented with maps keyed by chatId
 export const chatMessagesByIdAtom = atom<Map<number, Message[]>>(new Map());
@@ -284,3 +311,11 @@ export const streamingBlocksByMessageIdAtom = atom<Map<number, ParserState>>(
 export const contentBytesDroppedByMessageIdAtom = atom<Map<number, number>>(
   new Map(),
 );
+
+// Per-message JSX cache. The chunk handler appends pre-rendered React
+// elements for any newly-committed closed blocks; nothing is evicted while
+// a stream is active. Required for closed-block visibility because the
+// trim drops closed blocks out of the parser state and message.content.
+// Cleared on stream end so the renderer falls back to a one-shot parse of
+// the full DB content.
+export const messageJsxByIdAtom = atom<Map<number, MessageJsxState>>(new Map());

--- a/src/atoms/chatAtoms.ts
+++ b/src/atoms/chatAtoms.ts
@@ -7,32 +7,7 @@ import type {
 import type { ListedApp } from "@/ipc/types/app";
 import type { Getter, Setter } from "jotai";
 import { atom } from "jotai";
-import type { ReactElement } from "react";
 import type { ParserState } from "@/lib/streamingMessageParser";
-
-/**
- * Per-message cache of pre-rendered React elements for committed (closed)
- * blocks. Built at chunk-handle time so the renderer never re-creates them
- * during render.
- */
-export interface CachedClosedBlock {
-  /** Stable React key. Mirrors the parser block id. */
-  id: number;
-  /** The pre-built React element (key already set, props frozen). */
-  element: ReactElement;
-  /** Pre-extracted error message (for FixAllErrorsButton aggregation). */
-  errorMessage?: string;
-}
-
-/**
- * Per-message JSX cache. The full response lives here as pre-rendered
- * React elements; nothing is ever evicted while a stream is active. Cleared
- * on stream end so the renderer falls back to a one-shot parse of the full
- * DB content.
- */
-export interface MessageJsxState {
-  entries: CachedClosedBlock[];
-}
 
 // Per-chat atoms implemented with maps keyed by chatId
 export const chatMessagesByIdAtom = atom<Map<number, Message[]>>(new Map());
@@ -294,26 +269,8 @@ export const queuePausedByIdAtom = atom<Map<number, boolean>>(new Map());
 // reads from this map when present; otherwise it falls back to a one-shot
 // parse from message.content. Updated in the streaming chunk handler so
 // committed blocks keep stable refs across patches and only the open
-// trailing block changes shape per chunk.
+// trailing block changes shape per chunk. Cleared on stream end / full
+// message replace so the renderer reparses from the finalized DB content.
 export const streamingBlocksByMessageIdAtom = atom<Map<number, ParserState>>(
   new Map(),
 );
-
-// Cumulative bytes dropped from the front of the renderer-local
-// message.content for each message, while a stream is in progress. The
-// chunk handler trims old completed blocks from memory once the count
-// exceeds a threshold; the count translates server-side patch offsets
-// (which are absolute) into local-content offsets used by
-// applyStreamingPatch. Cleared on stream end (full content is re-fetched
-// from the database).
-export const contentBytesDroppedByMessageIdAtom = atom<Map<number, number>>(
-  new Map(),
-);
-
-// Per-message JSX cache + cap-accounting state. Each chunk handler appends
-// pre-rendered React elements for any newly-committed closed blocks, then
-// evicts entries from the front while the cap is exceeded (configured by
-// MAX_BLOCKS / MAX_CHARS / MIN_BLOCKS in useStreamChat). Cleared on stream
-// end so the renderer falls back to a one-shot parse of the full DB
-// content (and the omitted-blocks summary disappears).
-export const messageJsxByIdAtom = atom<Map<number, MessageJsxState>>(new Map());

--- a/src/atoms/chatAtoms.ts
+++ b/src/atoms/chatAtoms.ts
@@ -22,37 +22,16 @@ export interface CachedClosedBlock {
   element: ReactElement;
   /** Pre-extracted error message (for FixAllErrorsButton aggregation). */
   errorMessage?: string;
-  /**
-   * Approximate char weight for cap accounting. For markdown blocks this
-   * is `block.content.length`; for tool-call blocks (dyad-write etc.) it
-   * is the same — the file source counts toward the total even after
-   * the block is closed.
-   */
-  bytes: number;
-  /** "tool-call" if the block's tag is in TOOL_CALL_TAGS, else "markdown". */
-  category: "markdown" | "tool-call";
-  /** The custom-tag name (e.g. "dyad-write"). Set only when category === "tool-call". */
-  toolTag?: string;
-}
-
-/** Running totals for blocks that have been evicted from the JSX cache. */
-export interface DroppedSummary {
-  markdown: number;
-  toolCalls: number;
-  /** Per-tool counts, keyed by dyad-* tag name. Subset of TOOL_CALL_TAGS. */
-  byToolTag: Record<string, number>;
 }
 
 /**
- * Bundled JSX cache + cap-accounting state for a streaming message. Stored
- * as a single atom value so the entries list, total-char counter, and
- * dropped-summary update atomically per chunk.
+ * Per-message JSX cache. The full response lives here as pre-rendered
+ * React elements; nothing is ever evicted while a stream is active. Cleared
+ * on stream end so the renderer falls back to a one-shot parse of the full
+ * DB content.
  */
 export interface MessageJsxState {
   entries: CachedClosedBlock[];
-  /** Sum of `bytes` across `entries`. Maintained on push and shift. */
-  totalChars: number;
-  dropped: DroppedSummary;
 }
 
 // Per-chat atoms implemented with maps keyed by chatId

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -197,7 +197,10 @@ const ChatMessage = ({
               >
                 {message.role === "assistant" ? (
                   <>
-                    <DyadMarkdownParser content={assistantTextContent} />
+                    <DyadMarkdownParser
+                      content={assistantTextContent}
+                      messageId={message.id}
+                    />
                     {isLastMessage && isStreaming && (
                       <StreamingLoadingAnimation variant="streaming" />
                     )}

--- a/src/components/chat/DyadMarkdownParser.tsx
+++ b/src/components/chat/DyadMarkdownParser.tsx
@@ -24,7 +24,6 @@ import {
   streamingBlocksByMessageIdAtom,
   messageJsxByIdAtom,
   type CachedClosedBlock,
-  type DroppedSummary,
 } from "@/atoms/chatAtoms";
 import { CustomTagState } from "./stateTypes";
 import { DyadOutput } from "./DyadOutput";
@@ -55,11 +54,7 @@ import { DyadReadGuide } from "./DyadReadGuide";
 import { mapActionToButton } from "./ChatInput";
 import { SuggestedAction } from "@/lib/schemas";
 import { FixAllErrorsButton } from "./FixAllErrorsButton";
-import {
-  type Block,
-  parseFullMessage,
-  TOOL_CALL_TAGS,
-} from "@/lib/streamingMessageParser";
+import { type Block, parseFullMessage } from "@/lib/streamingMessageParser";
 
 interface DyadMarkdownParserProps {
   content: string;
@@ -168,9 +163,6 @@ export const DyadMarkdownParser: React.FC<DyadMarkdownParserProps> = ({
 
   return (
     <>
-      {cachedJsx && hasDropped(cachedJsx.dropped) && (
-        <DroppedSummaryBlock dropped={cachedJsx.dropped} />
-      )}
       {cachedJsx ? (
         <MemoCachedClosedBlocks entries={cachedJsx.entries} />
       ) : fallbackBlocks ? (
@@ -200,50 +192,9 @@ export const DyadMarkdownParser: React.FC<DyadMarkdownParserProps> = ({
   );
 };
 
-function hasDropped(dropped: DroppedSummary): boolean {
-  return dropped.markdown > 0 || dropped.toolCalls > 0;
-}
-
-/**
- * Header block summarizing what was evicted from the JSX cache while the
- * stream was running. Disappears automatically once the stream ends and the
- * cache is cleared (renderer falls back to a one-shot parse of the full DB
- * content). Suppresses any sub-count that is zero.
- */
-const DroppedSummaryBlock: React.FC<{ dropped: DroppedSummary }> = ({
-  dropped,
-}) => {
-  const parts: string[] = [];
-  if (dropped.markdown > 0) {
-    const noun = dropped.markdown === 1 ? "block" : "blocks";
-    parts.push(`${dropped.markdown} markdown ${noun}`);
-  }
-  if (dropped.toolCalls > 0) {
-    const writes = dropped.byToolTag["dyad-write"] ?? 0;
-    const searchReplaces = dropped.byToolTag["dyad-search-replace"] ?? 0;
-    const breakdown: string[] = [];
-    if (writes > 0) {
-      breakdown.push(`${writes} write_file`);
-    }
-    if (searchReplaces > 0) {
-      breakdown.push(`${searchReplaces} search_replace`);
-    }
-    const detail = breakdown.length > 0 ? ` (${breakdown.join(", ")})` : "";
-    const noun = dropped.toolCalls === 1 ? "call" : "calls";
-    parts.push(`${dropped.toolCalls} tool ${noun}${detail}`);
-  }
-  if (parts.length === 0) return null;
-  return (
-    <div className="mb-3 px-3 py-2 rounded-md border border-dashed border-border bg-muted/40 text-xs text-muted-foreground">
-      Earlier in this response: omitted {parts.join(" and ")}.
-    </div>
-  );
-};
-
 // Memoized renderer for the closed-block JSX cache. Skips re-rendering its
 // subtree entirely when the entries array reference is unchanged. The chunk
-// handler creates a new array reference only when blocks are appended or
-// evicted.
+// handler creates a new array reference only when blocks are appended.
 const MemoCachedClosedBlocks = React.memo(function MemoCachedClosedBlocks({
   entries,
 }: {
@@ -316,8 +267,6 @@ export function buildClosedBlockJsx(block: Block): CachedClosedBlock {
     return {
       id: block.id,
       element: <MemoMarkdown key={`m${block.id}`} content={block.content} />,
-      bytes: block.content.length,
-      category: "markdown",
     };
   }
   let errorMessage: string | undefined;
@@ -325,7 +274,6 @@ export function buildClosedBlockJsx(block: Block): CachedClosedBlock {
     const trimmed = block.attributes.message?.trim();
     if (trimmed) errorMessage = trimmed;
   }
-  const isToolCall = TOOL_CALL_TAGS.has(block.tag);
   return {
     id: block.id,
     element: (
@@ -336,9 +284,6 @@ export function buildClosedBlockJsx(block: Block): CachedClosedBlock {
       />
     ),
     errorMessage,
-    bytes: block.content.length,
-    category: isToolCall ? "tool-call" : "markdown",
-    toolTag: isToolCall ? block.tag : undefined,
   };
 }
 

--- a/src/components/chat/DyadMarkdownParser.tsx
+++ b/src/components/chat/DyadMarkdownParser.tsx
@@ -18,7 +18,14 @@ import { DyadCodebaseContext } from "./DyadCodebaseContext";
 import { DyadThink } from "./DyadThink";
 import { CodeHighlight } from "./CodeHighlight";
 import { useAtomValue } from "jotai";
-import { isStreamingByIdAtom, selectedChatIdAtom } from "@/atoms/chatAtoms";
+import {
+  isStreamingByIdAtom,
+  selectedChatIdAtom,
+  streamingBlocksByMessageIdAtom,
+  messageJsxByIdAtom,
+  type CachedClosedBlock,
+  type DroppedSummary,
+} from "@/atoms/chatAtoms";
 import { CustomTagState } from "./stateTypes";
 import { DyadOutput } from "./DyadOutput";
 import { DyadProblemSummary } from "./DyadProblemSummary";
@@ -48,70 +55,22 @@ import { DyadReadGuide } from "./DyadReadGuide";
 import { mapActionToButton } from "./ChatInput";
 import { SuggestedAction } from "@/lib/schemas";
 import { FixAllErrorsButton } from "./FixAllErrorsButton";
-import { unescapeXmlAttr, unescapeXmlContent } from "../../../shared/xmlEscape";
-
-const DYAD_CUSTOM_TAGS = [
-  "dyad-write",
-  "dyad-rename",
-  "dyad-delete",
-  "dyad-add-dependency",
-  "dyad-execute-sql",
-  "dyad-read-logs",
-  "dyad-add-integration",
-  "dyad-enable-nitro",
-  "dyad-output",
-  "dyad-problem-report",
-  "dyad-chat-summary",
-  "dyad-edit",
-  "dyad-grep",
-  "dyad-search-replace",
-  "dyad-codebase-context",
-  "dyad-web-search-result",
-  "dyad-web-search",
-  "dyad-web-crawl",
-  "dyad-web-fetch",
-  "dyad-code-search-result",
-  "dyad-code-search",
-  "dyad-read",
-  "think",
-  "dyad-command",
-  "dyad-mcp-tool-call",
-  "dyad-mcp-tool-result",
-  "dyad-list-files",
-  "dyad-database-schema",
-  "dyad-db-table-schema",
-  "dyad-supabase-table-schema",
-  "dyad-supabase-project-info",
-  "dyad-neon-project-info",
-  "dyad-neon-table-schema",
-  "dyad-read-guide",
-  "dyad-status",
-  "dyad-compaction",
-  "dyad-copy",
-  "dyad-image-generation",
-  // Plan mode tags
-  "dyad-write-plan",
-  "dyad-exit-plan",
-  "dyad-questionnaire",
-  // Step limit notification
-  "dyad-step-limit",
-];
+import {
+  type Block,
+  parseFullMessage,
+  TOOL_CALL_TAGS,
+} from "@/lib/streamingMessageParser";
 
 interface DyadMarkdownParserProps {
   content: string;
+  /**
+   * The id of the assistant message this content belongs to. Enables the
+   * renderer to read the cached incremental parser state from the streaming
+   * blocks atom; without it, the renderer falls back to a full reparse on
+   * every content change.
+   */
+  messageId?: number;
 }
-
-type CustomTagInfo = {
-  tag: string;
-  attributes: Record<string, string>;
-  content: string;
-  fullMatch: string;
-  inProgress?: boolean;
-};
-
-type ContentPiece =
-  | { type: "markdown"; content: string }
-  | { type: "custom-tag"; tagInfo: CustomTagInfo };
 
 const customLink = ({
   node: _node,
@@ -147,74 +106,157 @@ export const VanillaMarkdownParser = ({ content }: { content: string }) => {
 };
 
 /**
- * Custom component to parse markdown content with Dyad-specific tags
+ * Custom component to parse markdown content with Dyad-specific tags.
+ *
+ * The block list is sourced from an incremental parser (see
+ * src/lib/streamingMessageParser.ts) so completed blocks keep referential
+ * identity across streaming chunks. That lets React.memo skip every prior
+ * block, leaving only the open trailing block to re-render per chunk.
  */
 export const DyadMarkdownParser: React.FC<DyadMarkdownParserProps> = ({
   content,
+  messageId,
 }) => {
   const chatId = useAtomValue(selectedChatIdAtom);
   const isStreaming = useAtomValue(isStreamingByIdAtom).get(chatId!) ?? false;
   const deferredContent = useDeferredValue(content);
   const contentToParse = isStreaming ? deferredContent : content;
 
-  // Extract content pieces (markdown and custom tags)
-  const contentPieces = useMemo(() => {
-    return parseCustomTags(contentToParse);
-  }, [contentToParse]);
+  const streamingStates = useAtomValue(streamingBlocksByMessageIdAtom);
+  const cachedState =
+    messageId !== undefined ? streamingStates.get(messageId) : undefined;
 
-  // Extract error messages and track positions
-  const { errorMessages, lastErrorIndex, errorCount } = useMemo(() => {
+  const messageJsxMap = useAtomValue(messageJsxByIdAtom);
+  const cachedJsx =
+    messageId !== undefined ? messageJsxMap.get(messageId) : undefined;
+
+  // Open block (in-progress) is sourced from the parser state. Closed blocks
+  // come from the JSX cache when present. Falls back to one-shot parse for
+  // history / non-streaming messages with no cache entry.
+  const openBlock = cachedState?.openBlock ?? null;
+
+  // Fallback path: no JSX cache (history, post-DB-restore). One-shot parse.
+  const fallbackBlocks = useMemo<Block[] | null>(() => {
+    if (cachedJsx !== undefined) return null;
+    return parseFullMessage(contentToParse).blocks;
+  }, [cachedJsx, contentToParse]);
+
+  // Aggregate error messages for the FixAllErrorsButton.
+  const { errorMessages, errorCount } = useMemo(() => {
     const errors: string[] = [];
-    let lastIndex = -1;
-    let count = 0;
-
-    contentPieces.forEach((piece, index) => {
-      if (
-        piece.type === "custom-tag" &&
-        piece.tagInfo.tag === "dyad-output" &&
-        piece.tagInfo.attributes.type === "error"
-      ) {
-        const errorMessage = piece.tagInfo.attributes.message;
-        if (errorMessage?.trim()) {
-          errors.push(errorMessage.trim());
-          count++;
-          lastIndex = index;
+    if (cachedJsx) {
+      for (const entry of cachedJsx.entries) {
+        if (entry.errorMessage) errors.push(entry.errorMessage);
+      }
+    } else if (fallbackBlocks) {
+      for (const block of fallbackBlocks) {
+        if (
+          block.kind === "custom-tag" &&
+          block.tag === "dyad-output" &&
+          block.attributes.type === "error"
+        ) {
+          const msg = block.attributes.message?.trim();
+          if (msg) errors.push(msg);
         }
       }
-    });
+    }
+    return { errorMessages: errors, errorCount: errors.length };
+  }, [cachedJsx, fallbackBlocks]);
 
-    return {
-      errorMessages: errors,
-      lastErrorIndex: lastIndex,
-      errorCount: count,
-    };
-  }, [contentPieces]);
+  const showFixAll =
+    errorCount > 1 && !isStreaming && chatId !== null && chatId !== undefined;
 
   return (
     <>
-      {contentPieces.map((piece, index) => (
-        <React.Fragment key={index}>
-          {piece.type === "markdown" ? (
-            piece.content && <MemoMarkdown content={piece.content} />
-          ) : (
-            <MemoCustomTag tagInfo={piece.tagInfo} isStreaming={isStreaming} />
-          )}
-          {index === lastErrorIndex &&
-            errorCount > 1 &&
-            !isStreaming &&
-            chatId && (
-              <div className="mt-3 w-full flex">
-                <FixAllErrorsButton
-                  errorMessages={errorMessages}
-                  chatId={chatId}
-                />
-              </div>
+      {cachedJsx && hasDropped(cachedJsx.dropped) && (
+        <DroppedSummaryBlock dropped={cachedJsx.dropped} />
+      )}
+      {cachedJsx ? (
+        <MemoCachedClosedBlocks entries={cachedJsx.entries} />
+      ) : fallbackBlocks ? (
+        fallbackBlocks.map((block) => (
+          <React.Fragment key={block.id}>
+            {block.kind === "markdown" ? (
+              block.content && <MemoMarkdown content={block.content} />
+            ) : (
+              <MemoBlockCustomTag block={block} isStreaming={isStreaming} />
             )}
-        </React.Fragment>
-      ))}
+          </React.Fragment>
+        ))
+      ) : null}
+      {openBlock ? (
+        openBlock.kind === "markdown" ? (
+          openBlock.content && <MemoMarkdown content={openBlock.content} />
+        ) : (
+          <MemoBlockCustomTag block={openBlock} isStreaming={isStreaming} />
+        )
+      ) : null}
+      {showFixAll && (
+        <div className="mt-3 w-full flex">
+          <FixAllErrorsButton errorMessages={errorMessages} chatId={chatId!} />
+        </div>
+      )}
     </>
   );
 };
+
+function hasDropped(dropped: DroppedSummary): boolean {
+  return dropped.markdown > 0 || dropped.toolCalls > 0;
+}
+
+/**
+ * Header block summarizing what was evicted from the JSX cache while the
+ * stream was running. Disappears automatically once the stream ends and the
+ * cache is cleared (renderer falls back to a one-shot parse of the full DB
+ * content). Suppresses any sub-count that is zero.
+ */
+const DroppedSummaryBlock: React.FC<{ dropped: DroppedSummary }> = ({
+  dropped,
+}) => {
+  const parts: string[] = [];
+  if (dropped.markdown > 0) {
+    const noun = dropped.markdown === 1 ? "block" : "blocks";
+    parts.push(`${dropped.markdown} markdown ${noun}`);
+  }
+  if (dropped.toolCalls > 0) {
+    const writes = dropped.byToolTag["dyad-write"] ?? 0;
+    const searchReplaces = dropped.byToolTag["dyad-search-replace"] ?? 0;
+    const breakdown: string[] = [];
+    if (writes > 0) {
+      breakdown.push(`${writes} write_file`);
+    }
+    if (searchReplaces > 0) {
+      breakdown.push(`${searchReplaces} search_replace`);
+    }
+    const detail = breakdown.length > 0 ? ` (${breakdown.join(", ")})` : "";
+    const noun = dropped.toolCalls === 1 ? "call" : "calls";
+    parts.push(`${dropped.toolCalls} tool ${noun}${detail}`);
+  }
+  if (parts.length === 0) return null;
+  return (
+    <div className="mb-3 px-3 py-2 rounded-md border border-dashed border-border bg-muted/40 text-xs text-muted-foreground">
+      Earlier in this response: omitted {parts.join(" and ")}.
+    </div>
+  );
+};
+
+// Memoized renderer for the closed-block JSX cache. Skips re-rendering its
+// subtree entirely when the entries array reference is unchanged. The chunk
+// handler creates a new array reference only when blocks are appended or
+// evicted.
+const MemoCachedClosedBlocks = React.memo(function MemoCachedClosedBlocks({
+  entries,
+}: {
+  entries: CachedClosedBlock[];
+}) {
+  return (
+    <>
+      {entries.map((entry) => (
+        <React.Fragment key={entry.id}>{entry.element}</React.Fragment>
+      ))}
+    </>
+  );
+});
 
 // Module-level constants so MemoMarkdown never gets fresh refs for these
 // props, which would defeat ReactMarkdown's internal prop-equality checks.
@@ -222,9 +264,7 @@ const REMARK_PLUGINS = [remarkGfm];
 const MARKDOWN_COMPONENTS = { code: CodeHighlight, a: customLink };
 
 // Memoized markdown piece. Without this, ReactMarkdown re-parses every
-// completed segment's text into an AST on every streaming chunk —
-// the dominant per-render cost during long streams. Memoizing on
-// `content` lets completed segments skip that re-parse entirely.
+// completed segment's text into an AST on every streaming chunk.
 const MemoMarkdown = React.memo(function MemoMarkdown({
   content,
 }: {
@@ -240,169 +280,66 @@ const MemoMarkdown = React.memo(function MemoMarkdown({
   );
 });
 
-function tagInfoEqual(a: CustomTagInfo, b: CustomTagInfo): boolean {
-  if (a.tag !== b.tag) return false;
-  if (a.content !== b.content) return false;
-  if (a.inProgress !== b.inProgress) return false;
-  const aKeys = Object.keys(a.attributes);
-  const bKeys = Object.keys(b.attributes);
-  if (aKeys.length !== bKeys.length) return false;
-  for (const k of aKeys) {
-    if (a.attributes[k] !== b.attributes[k]) return false;
-  }
-  // fullMatch intentionally omitted: renderCustomTag never reads it, so two
-  // tagInfo objects that differ only in fullMatch produce identical output.
-  return true;
-}
+type CustomTagBlock = Extract<Block, { kind: "custom-tag" }>;
 
-// Memoized custom-tag piece. parseCustomTags rebuilds tagInfo objects on
-// every chunk (new refs), so React.memo's default referential equality
-// would never hit. The custom comparator deep-checks the fields that
-// actually affect the rendered output, so completed dyad tags skip
-// renderCustomTag and the React subtree rebuild when only later pieces
-// change.
-const MemoCustomTag = React.memo(
-  function MemoCustomTag({
-    tagInfo,
+// Memoized custom-tag block. The incremental parser preserves the Block
+// reference for any completed (closed) tag across streaming patches, so
+// referential equality on `block` is sufficient — completed blocks
+// short-circuit and skip renderCustomTag entirely.
+const MemoBlockCustomTag = React.memo(
+  function MemoBlockCustomTag({
+    block,
     isStreaming,
   }: {
-    tagInfo: CustomTagInfo;
+    block: CustomTagBlock;
     isStreaming: boolean;
   }) {
-    return <>{renderCustomTag(tagInfo, { isStreaming })}</>;
+    return <>{renderCustomTag(block, { isStreaming })}</>;
   },
   (prev, next) =>
-    tagInfoEqual(prev.tagInfo, next.tagInfo) &&
-    // Completed tags don't use isStreaming (getState returns "finished"
-    // regardless), so skip the check to avoid a one-time re-render of every
+    prev.block === next.block &&
+    // Completed tags ignore isStreaming (getState returns "finished"
+    // regardless), so skip the check to avoid one-time re-renders of every
     // completed tag when streaming ends.
-    (prev.tagInfo.inProgress === false ||
-      prev.isStreaming === next.isStreaming),
+    (prev.block.inProgress === false || prev.isStreaming === next.isStreaming),
 );
 
 /**
- * Pre-process content to handle unclosed custom tags
- * Adds closing tags at the end of the content for any unclosed custom tags
- * Assumes the opening tags are complete and valid
- * Returns the processed content and a map of in-progress tags
+ * Build a React element for a committed (closed) block. Called from the
+ * chunk handler on commit so the renderer stores a fully-built element
+ * and never re-creates it across renders. The element is wrapped in a
+ * memoized component so React.memo's ref equality skips re-rendering for
+ * unchanged blocks even if the parent re-renders.
  */
-function preprocessUnclosedTags(content: string): {
-  processedContent: string;
-  inProgressTags: Map<string, Set<number>>;
-} {
-  let processedContent = content;
-  // Map to track which tags are in progress and their positions
-  const inProgressTags = new Map<string, Set<number>>();
-
-  // For each tag type, check if there are unclosed tags
-  for (const tagName of DYAD_CUSTOM_TAGS) {
-    // Count opening and closing tags
-    const openTagPattern = new RegExp(`<${tagName}(?:\\s[^>]*)?>`, "g");
-    const closeTagPattern = new RegExp(`</${tagName}>`, "g");
-
-    // Track the positions of opening tags
-    const openingMatches: RegExpExecArray[] = [];
-    let match;
-
-    // Reset regex lastIndex to start from the beginning
-    openTagPattern.lastIndex = 0;
-
-    while ((match = openTagPattern.exec(processedContent)) !== null) {
-      openingMatches.push({ ...match });
-    }
-
-    const openCount = openingMatches.length;
-    const closeCount = (processedContent.match(closeTagPattern) || []).length;
-
-    // If we have more opening than closing tags
-    const missingCloseTags = openCount - closeCount;
-    if (missingCloseTags > 0) {
-      // Add the required number of closing tags at the end
-      processedContent += Array(missingCloseTags)
-        .fill(`</${tagName}>`)
-        .join("");
-
-      // Mark the last N tags as in progress where N is the number of missing closing tags
-      const inProgressIndexes = new Set<number>();
-      const startIndex = openCount - missingCloseTags;
-      for (let i = startIndex; i < openCount; i++) {
-        inProgressIndexes.add(openingMatches[i].index);
-      }
-      inProgressTags.set(tagName, inProgressIndexes);
-    }
+export function buildClosedBlockJsx(block: Block): CachedClosedBlock {
+  if (block.kind === "markdown") {
+    return {
+      id: block.id,
+      element: <MemoMarkdown key={`m${block.id}`} content={block.content} />,
+      bytes: block.content.length,
+      category: "markdown",
+    };
   }
-
-  return { processedContent, inProgressTags };
-}
-
-/**
- * Parse the content to extract custom tags and markdown sections into a unified array
- */
-function parseCustomTags(content: string): ContentPiece[] {
-  const { processedContent, inProgressTags } = preprocessUnclosedTags(content);
-
-  // Sort tags longest-first so e.g. "dyad-read-guide" is tried before "dyad-read".
-  // The (?=[\s>]) lookahead ensures a tag name like "dyad-read" won't prefix-match
-  // "dyad-read-guide" (the char after must be whitespace or '>').
-  const sortedTags = [...DYAD_CUSTOM_TAGS].sort((a, b) => b.length - a.length);
-  const tagPattern = new RegExp(
-    `<(${sortedTags.join("|")})(?=[\\s>])\\s*([^>]*)>(.*?)<\\/\\1>`,
-    "gs",
-  );
-
-  const contentPieces: ContentPiece[] = [];
-  let lastIndex = 0;
-  let match;
-
-  // Find all custom tags
-  while ((match = tagPattern.exec(processedContent)) !== null) {
-    const [fullMatch, tag, attributesStr, tagContent] = match;
-    const startIndex = match.index;
-
-    // Add the markdown content before this tag
-    if (startIndex > lastIndex) {
-      contentPieces.push({
-        type: "markdown",
-        content: processedContent.substring(lastIndex, startIndex),
-      });
-    }
-
-    // Parse attributes and unescape values
-    const attributes: Record<string, string> = {};
-    const attrPattern = /([\w-]+)="([^"]*)"/g;
-    let attrMatch;
-    while ((attrMatch = attrPattern.exec(attributesStr)) !== null) {
-      attributes[attrMatch[1]] = unescapeXmlAttr(attrMatch[2]);
-    }
-
-    // Check if this tag was marked as in progress
-    const tagInProgressSet = inProgressTags.get(tag);
-    const isInProgress = tagInProgressSet?.has(startIndex);
-
-    // Add the tag info with unescaped content
-    contentPieces.push({
-      type: "custom-tag",
-      tagInfo: {
-        tag,
-        attributes,
-        content: unescapeXmlContent(tagContent),
-        fullMatch,
-        inProgress: isInProgress || false,
-      },
-    });
-
-    lastIndex = startIndex + fullMatch.length;
+  let errorMessage: string | undefined;
+  if (block.tag === "dyad-output" && block.attributes.type === "error") {
+    const trimmed = block.attributes.message?.trim();
+    if (trimmed) errorMessage = trimmed;
   }
-
-  // Add the remaining markdown content
-  if (lastIndex < processedContent.length) {
-    contentPieces.push({
-      type: "markdown",
-      content: processedContent.substring(lastIndex),
-    });
-  }
-
-  return contentPieces;
+  const isToolCall = TOOL_CALL_TAGS.has(block.tag);
+  return {
+    id: block.id,
+    element: (
+      <MemoBlockCustomTag
+        key={`t${block.id}`}
+        block={block}
+        isStreaming={false}
+      />
+    ),
+    errorMessage,
+    bytes: block.content.length,
+    category: isToolCall ? "tool-call" : "markdown",
+    toolTag: isToolCall ? block.tag : undefined,
+  };
 }
 
 function getState({
@@ -430,10 +367,10 @@ function getState({
  * Render a custom tag based on its type
  */
 function renderCustomTag(
-  tagInfo: CustomTagInfo,
+  block: CustomTagBlock,
   { isStreaming }: { isStreaming: boolean },
 ): React.ReactNode {
-  const { tag, attributes, content, inProgress } = tagInfo;
+  const { tag, attributes, content, inProgress } = block;
 
   switch (tag) {
     case "dyad-read":

--- a/src/components/chat/DyadMarkdownParser.tsx
+++ b/src/components/chat/DyadMarkdownParser.tsx
@@ -22,8 +22,7 @@ import {
   isStreamingByIdAtom,
   selectedChatIdAtom,
   streamingBlocksByMessageIdAtom,
-  messageJsxByIdAtom,
-  type CachedClosedBlock,
+  closedBlocksByMessageIdAtom,
 } from "@/atoms/chatAtoms";
 import { CustomTagState } from "./stateTypes";
 import { DyadOutput } from "./DyadOutput";
@@ -118,54 +117,56 @@ export const DyadMarkdownParser: React.FC<DyadMarkdownParserProps> = ({
   const contentToParse = isStreaming ? deferredContent : content;
 
   const streamingStates = useAtomValue(streamingBlocksByMessageIdAtom);
-  const cachedState =
+  const parserState =
     messageId !== undefined ? streamingStates.get(messageId) : undefined;
 
-  const messageJsxMap = useAtomValue(messageJsxByIdAtom);
-  const cachedJsx =
-    messageId !== undefined ? messageJsxMap.get(messageId) : undefined;
+  const closedBlocksMap = useAtomValue(closedBlocksByMessageIdAtom);
+  const closedBlocks =
+    messageId !== undefined ? closedBlocksMap.get(messageId) : undefined;
 
-  // Open block (in-progress) is sourced from the parser state. Closed blocks
-  // come from the JSX cache when present (the chunk handler trims closed
-  // blocks out of the parser state, so this is the only place they survive).
-  // Falls back to one-shot parse for history / non-streaming messages.
-  const openBlock = cachedState?.openBlock ?? null;
+  // While streaming, closed blocks live in closedBlocksByMessageIdAtom and
+  // the open block lives in the parser state. The closed-blocks array ref
+  // is stable across chunks that don't close a block, so MemoClosedBlocks
+  // skips its subtree entirely on those chunks (O(1) per chunk).
+  const openBlock = parserState?.openBlock ?? null;
 
-  // Fallback path: no JSX cache (history, post-DB-restore). One-shot parse.
+  // Fallback path: no closed-block accumulator (history, post-DB-restore).
+  // One-shot parse of the full content.
   const fallbackBlocks = useMemo<Block[] | null>(() => {
-    if (cachedJsx !== undefined) return null;
+    if (closedBlocks !== undefined) return null;
     return parseFullMessage(contentToParse).blocks;
-  }, [cachedJsx, contentToParse]);
+  }, [closedBlocks, contentToParse]);
 
-  // Aggregate error messages for the FixAllErrorsButton.
+  // Aggregate error messages for the FixAllErrorsButton. Recomputes only
+  // when one of the input arrays gets a new ref (closed blocks: on commit;
+  // fallback: on content change).
   const { errorMessages, errorCount } = useMemo(() => {
     const errors: string[] = [];
-    if (cachedJsx) {
-      for (const entry of cachedJsx.entries) {
-        if (entry.errorMessage) errors.push(entry.errorMessage);
+    const collectFrom = (block: Block) => {
+      if (
+        block.kind === "custom-tag" &&
+        block.tag === "dyad-output" &&
+        block.attributes.type === "error"
+      ) {
+        const msg = block.attributes.message?.trim();
+        if (msg) errors.push(msg);
       }
+    };
+    if (closedBlocks) {
+      for (const block of closedBlocks) collectFrom(block);
     } else if (fallbackBlocks) {
-      for (const block of fallbackBlocks) {
-        if (
-          block.kind === "custom-tag" &&
-          block.tag === "dyad-output" &&
-          block.attributes.type === "error"
-        ) {
-          const msg = block.attributes.message?.trim();
-          if (msg) errors.push(msg);
-        }
-      }
+      for (const block of fallbackBlocks) collectFrom(block);
     }
     return { errorMessages: errors, errorCount: errors.length };
-  }, [cachedJsx, fallbackBlocks]);
+  }, [closedBlocks, fallbackBlocks]);
 
   const showFixAll =
     errorCount > 1 && !isStreaming && chatId !== null && chatId !== undefined;
 
   return (
     <>
-      {cachedJsx ? (
-        <MemoCachedClosedBlocks entries={cachedJsx.entries} />
+      {closedBlocks ? (
+        <MemoClosedBlocks blocks={closedBlocks} isStreaming={isStreaming} />
       ) : fallbackBlocks ? (
         fallbackBlocks.map((block) => (
           <React.Fragment key={block.id}>
@@ -193,18 +194,29 @@ export const DyadMarkdownParser: React.FC<DyadMarkdownParserProps> = ({
   );
 };
 
-// Memoized renderer for the closed-block JSX cache. Skips re-rendering its
-// subtree entirely when the entries array reference is unchanged. The chunk
-// handler creates a new array reference only when blocks are appended.
-const MemoCachedClosedBlocks = React.memo(function MemoCachedClosedBlocks({
-  entries,
+// Memoized wrapper for closed blocks. Memo hits when the `blocks` array ref
+// is unchanged (chunks that just extend the open block) so the entire
+// closed-block subtree is skipped — O(1) per chunk in the common case.
+// On commit chunks, the wrapper re-renders and reconciles N child fibers,
+// but each child is also memoed on `prev.block === next.block` so closed
+// children short-circuit and never re-render their subtrees.
+const MemoClosedBlocks = React.memo(function MemoClosedBlocks({
+  blocks,
+  isStreaming,
 }: {
-  entries: CachedClosedBlock[];
+  blocks: Block[];
+  isStreaming: boolean;
 }) {
   return (
     <>
-      {entries.map((entry) => (
-        <React.Fragment key={entry.id}>{entry.element}</React.Fragment>
+      {blocks.map((block) => (
+        <React.Fragment key={block.id}>
+          {block.kind === "markdown" ? (
+            block.content && <MemoMarkdown content={block.content} />
+          ) : (
+            <MemoBlockCustomTag block={block} isStreaming={isStreaming} />
+          )}
+        </React.Fragment>
       ))}
     </>
   );
@@ -255,38 +267,6 @@ const MemoBlockCustomTag = React.memo(
     // completed tag when streaming ends.
     (prev.block.inProgress === false || prev.isStreaming === next.isStreaming),
 );
-
-/**
- * Build a React element for a committed (closed) block. Called from the
- * chunk handler on commit so the renderer stores a fully-built element
- * and never re-creates it across renders. The element is wrapped in a
- * memoized component so React.memo's ref equality skips re-rendering for
- * unchanged blocks even if the parent re-renders.
- */
-export function buildClosedBlockJsx(block: Block): CachedClosedBlock {
-  if (block.kind === "markdown") {
-    return {
-      id: block.id,
-      element: <MemoMarkdown key={`m${block.id}`} content={block.content} />,
-    };
-  }
-  let errorMessage: string | undefined;
-  if (block.tag === "dyad-output" && block.attributes.type === "error") {
-    const trimmed = block.attributes.message?.trim();
-    if (trimmed) errorMessage = trimmed;
-  }
-  return {
-    id: block.id,
-    element: (
-      <MemoBlockCustomTag
-        key={`t${block.id}`}
-        block={block}
-        isStreaming={false}
-      />
-    ),
-    errorMessage,
-  };
-}
 
 function getState({
   isStreaming,

--- a/src/components/chat/DyadMarkdownParser.tsx
+++ b/src/components/chat/DyadMarkdownParser.tsx
@@ -22,8 +22,6 @@ import {
   isStreamingByIdAtom,
   selectedChatIdAtom,
   streamingBlocksByMessageIdAtom,
-  messageJsxByIdAtom,
-  type CachedClosedBlock,
 } from "@/atoms/chatAtoms";
 import { CustomTagState } from "./stateTypes";
 import { DyadOutput } from "./DyadOutput";
@@ -54,15 +52,19 @@ import { DyadReadGuide } from "./DyadReadGuide";
 import { mapActionToButton } from "./ChatInput";
 import { SuggestedAction } from "@/lib/schemas";
 import { FixAllErrorsButton } from "./FixAllErrorsButton";
-import { type Block, parseFullMessage } from "@/lib/streamingMessageParser";
+import {
+  type Block,
+  getParserBlocks,
+  parseFullMessage,
+} from "@/lib/streamingMessageParser";
 
 interface DyadMarkdownParserProps {
   content: string;
   /**
-   * The id of the assistant message this content belongs to. Enables the
-   * renderer to read the cached incremental parser state from the streaming
-   * blocks atom; without it, the renderer falls back to a full reparse on
-   * every content change.
+   * Assistant message id. When present, the renderer reads the incremental
+   * parser state from streamingBlocksByMessageIdAtom so completed blocks
+   * keep referential identity across streaming chunks. Without it the
+   * renderer falls back to a one-shot parse of `content`.
    */
   messageId?: number;
 }
@@ -118,96 +120,67 @@ export const DyadMarkdownParser: React.FC<DyadMarkdownParserProps> = ({
   const contentToParse = isStreaming ? deferredContent : content;
 
   const streamingStates = useAtomValue(streamingBlocksByMessageIdAtom);
-  const cachedState =
+  const parserState =
     messageId !== undefined ? streamingStates.get(messageId) : undefined;
 
-  const messageJsxMap = useAtomValue(messageJsxByIdAtom);
-  const cachedJsx =
-    messageId !== undefined ? messageJsxMap.get(messageId) : undefined;
-
-  // Open block (in-progress) is sourced from the parser state. Closed blocks
-  // come from the JSX cache when present. Falls back to one-shot parse for
-  // history / non-streaming messages with no cache entry.
-  const openBlock = cachedState?.openBlock ?? null;
-
-  // Fallback path: no JSX cache (history, post-DB-restore). One-shot parse.
-  const fallbackBlocks = useMemo<Block[] | null>(() => {
-    if (cachedJsx !== undefined) return null;
+  // Source the visible block list from the incremental parser when present;
+  // closed blocks share refs across chunks so MemoBlockCustomTag /
+  // MemoMarkdown skip every prior block via React.memo. For history /
+  // non-streaming messages with no parser state, fall back to a one-shot
+  // parse of the full content.
+  const blocks = useMemo<Block[]>(() => {
+    if (parserState) return getParserBlocks(parserState);
     return parseFullMessage(contentToParse).blocks;
-  }, [cachedJsx, contentToParse]);
+  }, [parserState, contentToParse]);
 
-  // Aggregate error messages for the FixAllErrorsButton.
-  const { errorMessages, errorCount } = useMemo(() => {
+  const { errorMessages, lastErrorIndex, errorCount } = useMemo(() => {
     const errors: string[] = [];
-    if (cachedJsx) {
-      for (const entry of cachedJsx.entries) {
-        if (entry.errorMessage) errors.push(entry.errorMessage);
-      }
-    } else if (fallbackBlocks) {
-      for (const block of fallbackBlocks) {
-        if (
-          block.kind === "custom-tag" &&
-          block.tag === "dyad-output" &&
-          block.attributes.type === "error"
-        ) {
-          const msg = block.attributes.message?.trim();
-          if (msg) errors.push(msg);
+    let lastIndex = -1;
+    blocks.forEach((block, index) => {
+      if (
+        block.kind === "custom-tag" &&
+        block.tag === "dyad-output" &&
+        block.attributes.type === "error"
+      ) {
+        const msg = block.attributes.message?.trim();
+        if (msg) {
+          errors.push(msg);
+          lastIndex = index;
         }
       }
-    }
-    return { errorMessages: errors, errorCount: errors.length };
-  }, [cachedJsx, fallbackBlocks]);
-
-  const showFixAll =
-    errorCount > 1 && !isStreaming && chatId !== null && chatId !== undefined;
+    });
+    return {
+      errorMessages: errors,
+      lastErrorIndex: lastIndex,
+      errorCount: errors.length,
+    };
+  }, [blocks]);
 
   return (
     <>
-      {cachedJsx ? (
-        <MemoCachedClosedBlocks entries={cachedJsx.entries} />
-      ) : fallbackBlocks ? (
-        fallbackBlocks.map((block) => (
-          <React.Fragment key={block.id}>
-            {block.kind === "markdown" ? (
-              block.content && <MemoMarkdown content={block.content} />
-            ) : (
-              <MemoBlockCustomTag block={block} isStreaming={isStreaming} />
+      {blocks.map((block, index) => (
+        <React.Fragment key={block.id}>
+          {block.kind === "markdown" ? (
+            block.content && <MemoMarkdown content={block.content} />
+          ) : (
+            <MemoBlockCustomTag block={block} isStreaming={isStreaming} />
+          )}
+          {index === lastErrorIndex &&
+            errorCount > 1 &&
+            !isStreaming &&
+            chatId && (
+              <div className="mt-3 w-full flex">
+                <FixAllErrorsButton
+                  errorMessages={errorMessages}
+                  chatId={chatId}
+                />
+              </div>
             )}
-          </React.Fragment>
-        ))
-      ) : null}
-      {openBlock ? (
-        openBlock.kind === "markdown" ? (
-          openBlock.content && <MemoMarkdown content={openBlock.content} />
-        ) : (
-          <MemoBlockCustomTag block={openBlock} isStreaming={isStreaming} />
-        )
-      ) : null}
-      {showFixAll && (
-        <div className="mt-3 w-full flex">
-          <FixAllErrorsButton errorMessages={errorMessages} chatId={chatId!} />
-        </div>
-      )}
-    </>
-  );
-};
-
-// Memoized renderer for the closed-block JSX cache. Skips re-rendering its
-// subtree entirely when the entries array reference is unchanged. The chunk
-// handler creates a new array reference only when blocks are appended.
-const MemoCachedClosedBlocks = React.memo(function MemoCachedClosedBlocks({
-  entries,
-}: {
-  entries: CachedClosedBlock[];
-}) {
-  return (
-    <>
-      {entries.map((entry) => (
-        <React.Fragment key={entry.id}>{entry.element}</React.Fragment>
+        </React.Fragment>
       ))}
     </>
   );
-});
+};
 
 // Module-level constants so MemoMarkdown never gets fresh refs for these
 // props, which would defeat ReactMarkdown's internal prop-equality checks.
@@ -254,38 +227,6 @@ const MemoBlockCustomTag = React.memo(
     // completed tag when streaming ends.
     (prev.block.inProgress === false || prev.isStreaming === next.isStreaming),
 );
-
-/**
- * Build a React element for a committed (closed) block. Called from the
- * chunk handler on commit so the renderer stores a fully-built element
- * and never re-creates it across renders. The element is wrapped in a
- * memoized component so React.memo's ref equality skips re-rendering for
- * unchanged blocks even if the parent re-renders.
- */
-export function buildClosedBlockJsx(block: Block): CachedClosedBlock {
-  if (block.kind === "markdown") {
-    return {
-      id: block.id,
-      element: <MemoMarkdown key={`m${block.id}`} content={block.content} />,
-    };
-  }
-  let errorMessage: string | undefined;
-  if (block.tag === "dyad-output" && block.attributes.type === "error") {
-    const trimmed = block.attributes.message?.trim();
-    if (trimmed) errorMessage = trimmed;
-  }
-  return {
-    id: block.id,
-    element: (
-      <MemoBlockCustomTag
-        key={`t${block.id}`}
-        block={block}
-        isStreaming={false}
-      />
-    ),
-    errorMessage,
-  };
-}
 
 function getState({
   isStreaming,

--- a/src/components/chat/DyadMarkdownParser.tsx
+++ b/src/components/chat/DyadMarkdownParser.tsx
@@ -22,7 +22,6 @@ import {
   isStreamingByIdAtom,
   selectedChatIdAtom,
   streamingBlocksByMessageIdAtom,
-  closedBlocksByMessageIdAtom,
 } from "@/atoms/chatAtoms";
 import { CustomTagState } from "./stateTypes";
 import { DyadOutput } from "./DyadOutput";
@@ -53,7 +52,11 @@ import { DyadReadGuide } from "./DyadReadGuide";
 import { mapActionToButton } from "./ChatInput";
 import { SuggestedAction } from "@/lib/schemas";
 import { FixAllErrorsButton } from "./FixAllErrorsButton";
-import { type Block, parseFullMessage } from "@/lib/streamingMessageParser";
+import {
+  type Block,
+  getOpenBlock,
+  parseFullMessage,
+} from "@/lib/streamingMessageParser";
 
 interface DyadMarkdownParserProps {
   content: string;
@@ -120,22 +123,20 @@ export const DyadMarkdownParser: React.FC<DyadMarkdownParserProps> = ({
   const parserState =
     messageId !== undefined ? streamingStates.get(messageId) : undefined;
 
-  const closedBlocksMap = useAtomValue(closedBlocksByMessageIdAtom);
-  const closedBlocks =
-    messageId !== undefined ? closedBlocksMap.get(messageId) : undefined;
+  // While streaming, closed blocks live in parserState.blocks (immutable-
+  // appended on commit) and the open block comes from getOpenBlock. The
+  // closed-blocks array ref is stable across chunks that don't close a
+  // block, so MemoClosedBlocks skips its subtree entirely on those chunks
+  // (O(1) per chunk).
+  const closedBlocks = parserState?.blocks;
+  const openBlock = parserState ? getOpenBlock(parserState) : null;
 
-  // While streaming, closed blocks live in closedBlocksByMessageIdAtom and
-  // the open block lives in the parser state. The closed-blocks array ref
-  // is stable across chunks that don't close a block, so MemoClosedBlocks
-  // skips its subtree entirely on those chunks (O(1) per chunk).
-  const openBlock = parserState?.openBlock ?? null;
-
-  // Fallback path: no closed-block accumulator (history, post-DB-restore).
-  // One-shot parse of the full content.
+  // Fallback path: no parser state (history, post-DB-restore). One-shot
+  // parse of the full content.
   const fallbackBlocks = useMemo<Block[] | null>(() => {
-    if (closedBlocks !== undefined) return null;
+    if (parserState !== undefined) return null;
     return parseFullMessage(contentToParse).blocks;
-  }, [closedBlocks, contentToParse]);
+  }, [parserState, contentToParse]);
 
   // Aggregate error messages for the FixAllErrorsButton. Recomputes only
   // when one of the input arrays gets a new ref (closed blocks: on commit;

--- a/src/components/chat/DyadMarkdownParser.tsx
+++ b/src/components/chat/DyadMarkdownParser.tsx
@@ -22,6 +22,8 @@ import {
   isStreamingByIdAtom,
   selectedChatIdAtom,
   streamingBlocksByMessageIdAtom,
+  messageJsxByIdAtom,
+  type CachedClosedBlock,
 } from "@/atoms/chatAtoms";
 import { CustomTagState } from "./stateTypes";
 import { DyadOutput } from "./DyadOutput";
@@ -52,11 +54,7 @@ import { DyadReadGuide } from "./DyadReadGuide";
 import { mapActionToButton } from "./ChatInput";
 import { SuggestedAction } from "@/lib/schemas";
 import { FixAllErrorsButton } from "./FixAllErrorsButton";
-import {
-  type Block,
-  getParserBlocks,
-  parseFullMessage,
-} from "@/lib/streamingMessageParser";
+import { type Block, parseFullMessage } from "@/lib/streamingMessageParser";
 
 interface DyadMarkdownParserProps {
   content: string;
@@ -120,67 +118,97 @@ export const DyadMarkdownParser: React.FC<DyadMarkdownParserProps> = ({
   const contentToParse = isStreaming ? deferredContent : content;
 
   const streamingStates = useAtomValue(streamingBlocksByMessageIdAtom);
-  const parserState =
+  const cachedState =
     messageId !== undefined ? streamingStates.get(messageId) : undefined;
 
-  // Source the visible block list from the incremental parser when present;
-  // closed blocks share refs across chunks so MemoBlockCustomTag /
-  // MemoMarkdown skip every prior block via React.memo. For history /
-  // non-streaming messages with no parser state, fall back to a one-shot
-  // parse of the full content.
-  const blocks = useMemo<Block[]>(() => {
-    if (parserState) return getParserBlocks(parserState);
-    return parseFullMessage(contentToParse).blocks;
-  }, [parserState, contentToParse]);
+  const messageJsxMap = useAtomValue(messageJsxByIdAtom);
+  const cachedJsx =
+    messageId !== undefined ? messageJsxMap.get(messageId) : undefined;
 
-  const { errorMessages, lastErrorIndex, errorCount } = useMemo(() => {
+  // Open block (in-progress) is sourced from the parser state. Closed blocks
+  // come from the JSX cache when present (the chunk handler trims closed
+  // blocks out of the parser state, so this is the only place they survive).
+  // Falls back to one-shot parse for history / non-streaming messages.
+  const openBlock = cachedState?.openBlock ?? null;
+
+  // Fallback path: no JSX cache (history, post-DB-restore). One-shot parse.
+  const fallbackBlocks = useMemo<Block[] | null>(() => {
+    if (cachedJsx !== undefined) return null;
+    return parseFullMessage(contentToParse).blocks;
+  }, [cachedJsx, contentToParse]);
+
+  // Aggregate error messages for the FixAllErrorsButton.
+  const { errorMessages, errorCount } = useMemo(() => {
     const errors: string[] = [];
-    let lastIndex = -1;
-    blocks.forEach((block, index) => {
-      if (
-        block.kind === "custom-tag" &&
-        block.tag === "dyad-output" &&
-        block.attributes.type === "error"
-      ) {
-        const msg = block.attributes.message?.trim();
-        if (msg) {
-          errors.push(msg);
-          lastIndex = index;
+    if (cachedJsx) {
+      for (const entry of cachedJsx.entries) {
+        if (entry.errorMessage) errors.push(entry.errorMessage);
+      }
+    } else if (fallbackBlocks) {
+      for (const block of fallbackBlocks) {
+        if (
+          block.kind === "custom-tag" &&
+          block.tag === "dyad-output" &&
+          block.attributes.type === "error"
+        ) {
+          const msg = block.attributes.message?.trim();
+          if (msg) errors.push(msg);
         }
       }
-    });
-    return {
-      errorMessages: errors,
-      lastErrorIndex: lastIndex,
-      errorCount: errors.length,
-    };
-  }, [blocks]);
+    }
+    return { errorMessages: errors, errorCount: errors.length };
+  }, [cachedJsx, fallbackBlocks]);
+
+  const showFixAll =
+    errorCount > 1 && !isStreaming && chatId !== null && chatId !== undefined;
 
   return (
     <>
-      {blocks.map((block, index) => (
-        <React.Fragment key={block.id}>
-          {block.kind === "markdown" ? (
-            block.content && <MemoMarkdown content={block.content} />
-          ) : (
-            <MemoBlockCustomTag block={block} isStreaming={isStreaming} />
-          )}
-          {index === lastErrorIndex &&
-            errorCount > 1 &&
-            !isStreaming &&
-            chatId && (
-              <div className="mt-3 w-full flex">
-                <FixAllErrorsButton
-                  errorMessages={errorMessages}
-                  chatId={chatId}
-                />
-              </div>
+      {cachedJsx ? (
+        <MemoCachedClosedBlocks entries={cachedJsx.entries} />
+      ) : fallbackBlocks ? (
+        fallbackBlocks.map((block) => (
+          <React.Fragment key={block.id}>
+            {block.kind === "markdown" ? (
+              block.content && <MemoMarkdown content={block.content} />
+            ) : (
+              <MemoBlockCustomTag block={block} isStreaming={isStreaming} />
             )}
-        </React.Fragment>
-      ))}
+          </React.Fragment>
+        ))
+      ) : null}
+      {openBlock ? (
+        openBlock.kind === "markdown" ? (
+          openBlock.content && <MemoMarkdown content={openBlock.content} />
+        ) : (
+          <MemoBlockCustomTag block={openBlock} isStreaming={isStreaming} />
+        )
+      ) : null}
+      {showFixAll && (
+        <div className="mt-3 w-full flex">
+          <FixAllErrorsButton errorMessages={errorMessages} chatId={chatId!} />
+        </div>
+      )}
     </>
   );
 };
+
+// Memoized renderer for the closed-block JSX cache. Skips re-rendering its
+// subtree entirely when the entries array reference is unchanged. The chunk
+// handler creates a new array reference only when blocks are appended.
+const MemoCachedClosedBlocks = React.memo(function MemoCachedClosedBlocks({
+  entries,
+}: {
+  entries: CachedClosedBlock[];
+}) {
+  return (
+    <>
+      {entries.map((entry) => (
+        <React.Fragment key={entry.id}>{entry.element}</React.Fragment>
+      ))}
+    </>
+  );
+});
 
 // Module-level constants so MemoMarkdown never gets fresh refs for these
 // props, which would defeat ReactMarkdown's internal prop-equality checks.
@@ -227,6 +255,38 @@ const MemoBlockCustomTag = React.memo(
     // completed tag when streaming ends.
     (prev.block.inProgress === false || prev.isStreaming === next.isStreaming),
 );
+
+/**
+ * Build a React element for a committed (closed) block. Called from the
+ * chunk handler on commit so the renderer stores a fully-built element
+ * and never re-creates it across renders. The element is wrapped in a
+ * memoized component so React.memo's ref equality skips re-rendering for
+ * unchanged blocks even if the parent re-renders.
+ */
+export function buildClosedBlockJsx(block: Block): CachedClosedBlock {
+  if (block.kind === "markdown") {
+    return {
+      id: block.id,
+      element: <MemoMarkdown key={`m${block.id}`} content={block.content} />,
+    };
+  }
+  let errorMessage: string | undefined;
+  if (block.tag === "dyad-output" && block.attributes.type === "error") {
+    const trimmed = block.attributes.message?.trim();
+    if (trimmed) errorMessage = trimmed;
+  }
+  return {
+    id: block.id,
+    element: (
+      <MemoBlockCustomTag
+        key={`t${block.id}`}
+        block={block}
+        isStreaming={false}
+      />
+    ),
+    errorMessage,
+  };
+}
 
 function getState({
   isStreaming,

--- a/src/hooks/useStreamChat.ts
+++ b/src/hooks/useStreamChat.ts
@@ -17,7 +17,6 @@ import {
   contentBytesDroppedByMessageIdAtom,
   messageJsxByIdAtom,
   type CachedClosedBlock,
-  type DroppedSummary,
   type MessageJsxState,
   queuePausedByIdAtom,
   type QueuedMessageItem,
@@ -29,88 +28,24 @@ import {
 } from "@/lib/streamingMessageParser";
 import { buildClosedBlockJsx } from "@/components/chat/DyadMarkdownParser";
 
-// Tail-only render caps. Each closed block is rendered to JSX once and held
-// in messageJsxByIdAtom. Cap accounting evicts entries from the FRONT of
-// that list while the user response is being streamed:
-//   - count > MAX_BLOCKS  -> evict
-//   - totalChars > MAX_CHARS -> evict
-//   - never evict if remaining count <= MIN_BLOCKS (UX floor)
-// Parser state and renderer-local message.content are unconditionally
-// trimmed to the open block (KEEP_COMMITTED_BLOCKS = 0); the JSX cache is
-// the only place closed-block content lives during a stream.
-const MAX_BLOCKS = 50;
-const MIN_BLOCKS = 10;
-const MAX_CHARS = 200_000;
+// Renderer-local message.content is trimmed to the open block on every
+// chunk. Closed blocks live in messageJsxByIdAtom as pre-rendered React
+// elements — never evicted during a stream so the user sees the full
+// response. The cache is cleared on stream end (renderer falls back to a
+// one-shot parse of the full DB content).
 const KEEP_COMMITTED_BLOCKS = 0;
 
-const EMPTY_DROPPED: DroppedSummary = {
-  markdown: 0,
-  toolCalls: 0,
-  byToolTag: {},
-};
-
-const EMPTY_JSX_STATE: MessageJsxState = {
-  entries: [],
-  totalChars: 0,
-  dropped: EMPTY_DROPPED,
-};
-
 /**
- * Append newly-committed closed-block JSX to the per-message cache and
- * evict from the front until the caps hold. MIN_BLOCKS is a hard floor —
- * never drop below it even if MAX_CHARS is still exceeded. Returns a fresh
- * MessageJsxState with the updated entries, totalChars, and dropped
- * counters; callers wrap it in the atom map.
+ * Append newly-committed closed-block JSX to the per-message cache. No
+ * eviction — the full response is preserved as pre-rendered React elements.
  */
-function appendAndEnforceCaps(
+function appendJsxEntries(
   prev: MessageJsxState | undefined,
   newEntries: CachedClosedBlock[],
 ): MessageJsxState {
-  const base = prev ?? EMPTY_JSX_STATE;
-  const entries = [...base.entries, ...newEntries];
-  let totalChars = base.totalChars;
-  for (const e of newEntries) totalChars += e.bytes;
-
-  let droppedMd = base.dropped.markdown;
-  let droppedTools = base.dropped.toolCalls;
-  let byTagMutated: Record<string, number> | null = null;
-
-  while (
-    entries.length > MIN_BLOCKS &&
-    (entries.length > MAX_BLOCKS || totalChars > MAX_CHARS)
-  ) {
-    const head = entries.shift()!;
-    totalChars -= head.bytes;
-    if (head.category === "markdown") {
-      droppedMd++;
-    } else {
-      droppedTools++;
-      if (byTagMutated === null) {
-        byTagMutated = { ...base.dropped.byToolTag };
-      }
-      const tag = head.toolTag ?? "unknown";
-      byTagMutated[tag] = (byTagMutated[tag] ?? 0) + 1;
-    }
-  }
-
-  if (
-    droppedMd === base.dropped.markdown &&
-    droppedTools === base.dropped.toolCalls &&
-    byTagMutated === null &&
-    newEntries.length > 0
-  ) {
-    return { entries, totalChars, dropped: base.dropped };
-  }
-
-  return {
-    entries,
-    totalChars,
-    dropped: {
-      markdown: droppedMd,
-      toolCalls: droppedTools,
-      byToolTag: byTagMutated ?? base.dropped.byToolTag,
-    },
-  };
+  if (newEntries.length === 0) return prev ?? { entries: [] };
+  const base = prev ?? { entries: [] };
+  return { entries: [...base.entries, ...newEntries] };
 }
 import { ipc } from "@/ipc/types";
 import { isPreviewOpenAtom } from "@/atoms/viewAtoms";
@@ -456,10 +391,7 @@ export function useStreamChat({
                           newClosed.map(buildClosedBlockJsx);
                         setMessageJsxById((prevMap) => {
                           const cur2 = prevMap.get(streamingMessageId);
-                          const updated = appendAndEnforceCaps(
-                            cur2,
-                            newEntries,
-                          );
+                          const updated = appendJsxEntries(cur2, newEntries);
                           const out = new Map(prevMap);
                           out.set(streamingMessageId, updated);
                           return out;

--- a/src/hooks/useStreamChat.ts
+++ b/src/hooks/useStreamChat.ts
@@ -18,11 +18,7 @@ import {
   queuePausedByIdAtom,
   type QueuedMessageItem,
 } from "@/atoms/chatAtoms";
-import {
-  advanceParser,
-  initialParserState,
-  trimContent,
-} from "@/lib/streamingMessageParser";
+import { applyStreamingChunk } from "@/lib/streamingChunk";
 import { ipc } from "@/ipc/types";
 import { isPreviewOpenAtom } from "@/atoms/viewAtoms";
 import { pendingScreenshotAppIdAtom } from "@/atoms/previewAtoms";
@@ -30,7 +26,6 @@ import type { ChatResponseEnd, App, Chat } from "@/ipc/types";
 import type { ChatSummary } from "@/lib/schemas";
 import { useChats } from "./useChats";
 import { useLoadApp } from "./useLoadApp";
-import { applyStreamingPatch } from "@/lib/applyStreamingPatch";
 import {
   triggerResync,
   syncChatFromDb,
@@ -328,62 +323,55 @@ export function useStreamChat({
                 streamingMessageId !== undefined &&
                 streamingPatch !== undefined
               ) {
-                const priorDropped =
-                  store
-                    .get(contentBytesDroppedByMessageIdAtom)
-                    .get(streamingMessageId) ?? 0;
-                const applied = applyStreamingPatch(
-                  setMessagesById,
-                  chatId,
-                  streamingMessageId,
-                  streamingPatch,
-                  priorDropped,
-                );
-                if (applied) {
-                  const messages = store.get(chatMessagesByIdAtom).get(chatId);
-                  const msg = messages?.find(
-                    (m) => m.id === streamingMessageId,
-                  );
-                  if (msg) {
-                    const newContent = msg.content ?? "";
-                    setStreamingBlocksById((prev) => {
-                      const cur =
-                        prev.get(streamingMessageId) ?? initialParserState();
-                      if (newContent.length === cur.cursor && cur.cursor > 0) {
-                        return prev;
-                      }
-                      // Trim message.content past the open-block boundary.
-                      // Closed blocks remain in parser state; only the raw
-                      // string is shortened so applyStreamingPatch's per-
-                      // chunk slice/concat stays bounded.
-                      const advanced = advanceParser(cur, newContent);
-                      const trim = trimContent(advanced, newContent);
-                      if (trim.bytesDropped > 0) {
-                        setMessagesById((prevMap) => {
-                          const list = prevMap.get(chatId);
-                          if (!list) return prevMap;
-                          const updated = list.map((m) =>
-                            m.id === streamingMessageId
-                              ? { ...m, content: trim.content }
-                              : m,
-                          );
-                          const out = new Map(prevMap);
-                          out.set(chatId, updated);
-                          return out;
-                        });
-                        setContentBytesDroppedById((prevMap) => {
-                          const cur2 = prevMap.get(streamingMessageId) ?? 0;
-                          const out = new Map(prevMap);
-                          out.set(streamingMessageId, cur2 + trim.bytesDropped);
-                          return out;
-                        });
-                      }
-                      const next = new Map(prev);
-                      next.set(streamingMessageId, trim.state);
-                      return next;
-                    });
-                  }
-                } else {
+                // Read prior atom values, run the pure pipeline, write
+                // results in a single set per atom.
+                const messages = store.get(chatMessagesByIdAtom).get(chatId);
+                const msg = messages?.find((m) => m.id === streamingMessageId);
+                const result = msg
+                  ? applyStreamingChunk({
+                      prevContent: msg.content ?? "",
+                      prevParserState: store
+                        .get(streamingBlocksByMessageIdAtom)
+                        .get(streamingMessageId),
+                      prevDroppedBytes:
+                        store
+                          .get(contentBytesDroppedByMessageIdAtom)
+                          .get(streamingMessageId) ?? 0,
+                      patch: streamingPatch,
+                    })
+                  : ({ kind: "mismatch" } as const);
+
+                if (result.kind === "applied") {
+                  const newContent = result.content;
+                  setMessagesById((prev) => {
+                    const list = prev.get(chatId);
+                    if (!list) return prev;
+                    const updated = list.map((m) =>
+                      m.id === streamingMessageId
+                        ? { ...m, content: newContent }
+                        : m,
+                    );
+                    const next = new Map(prev);
+                    next.set(chatId, updated);
+                    return next;
+                  });
+                  setStreamingBlocksById((prev) => {
+                    const next = new Map(prev);
+                    next.set(streamingMessageId, result.parserState);
+                    return next;
+                  });
+                  setContentBytesDroppedById((prev) => {
+                    if (
+                      (prev.get(streamingMessageId) ?? 0) ===
+                      result.droppedBytes
+                    ) {
+                      return prev;
+                    }
+                    const next = new Map(prev);
+                    next.set(streamingMessageId, result.droppedBytes);
+                    return next;
+                  });
+                } else if (result.kind === "mismatch") {
                   triggerResync(chatId, setMessagesById, store);
                   // Drop parser state and dropped-byte counter for this
                   // message so the renderer re-parses from the resynced
@@ -397,6 +385,7 @@ export function useStreamChat({
                   setStreamingBlocksById(dropForMessage);
                   setContentBytesDroppedById(dropForMessage);
                 }
+                // result.kind === "noop" → no atom writes needed.
               }
 
               // Ack-based backpressure for the canned test stream. Real

--- a/src/hooks/useStreamChat.ts
+++ b/src/hooks/useStreamChat.ts
@@ -379,13 +379,14 @@ export function useStreamChat({
                       if (newContent.length === cur.cursor && cur.cursor > 0) {
                         return prev;
                       }
+                      // advanceParser shares `cur.blocks` by reference and
+                      // pushes new closed blocks onto it, so capture the
+                      // count BEFORE the call — otherwise the post-advance
+                      // length equals advanced.blocks.length and the slice
+                      // below is always empty.
+                      const priorBlockCount = cur.blocks.length;
                       let advanced = advanceParser(cur, newContent);
-                      // Render any newly-committed closed blocks to JSX and
-                      // append to the message-JSX cache, then evict from the
-                      // front while the cap is exceeded.
-                      const newClosed = advanced.blocks.slice(
-                        cur.blocks.length,
-                      );
+                      const newClosed = advanced.blocks.slice(priorBlockCount);
                       if (newClosed.length > 0) {
                         const newEntries: CachedClosedBlock[] =
                           newClosed.map(buildClosedBlockJsx);

--- a/src/hooks/useStreamChat.ts
+++ b/src/hooks/useStreamChat.ts
@@ -14,13 +14,22 @@ import {
   queuedMessagesByIdAtom,
   streamCompletedSuccessfullyByIdAtom,
   streamingBlocksByMessageIdAtom,
+  contentBytesDroppedByMessageIdAtom,
   queuePausedByIdAtom,
   type QueuedMessageItem,
 } from "@/atoms/chatAtoms";
 import {
   advanceParser,
   initialParserState,
+  trimToLastNBlocks,
 } from "@/lib/streamingMessageParser";
+
+// Renderer-local message.content is trimmed to the open block on every
+// chunk. Closed blocks live only in the parser-state atom (block refs are
+// stable so React.memo skips them). The trim keeps `message.content`
+// bounded to the size of the current open block, which keeps each per-chunk
+// applyStreamingPatch slice/concat allocation small.
+const KEEP_COMMITTED_BLOCKS = 0;
 import { ipc } from "@/ipc/types";
 import { isPreviewOpenAtom } from "@/atoms/viewAtoms";
 import { pendingScreenshotAppIdAtom } from "@/atoms/previewAtoms";
@@ -116,6 +125,9 @@ export function useStreamChat({
     streamCompletedSuccessfullyByIdAtom,
   );
   const setStreamingBlocksById = useSetAtom(streamingBlocksByMessageIdAtom);
+  const setContentBytesDroppedById = useSetAtom(
+    contentBytesDroppedByMessageIdAtom,
+  );
   const queuePausedById = useAtomValue(queuePausedByIdAtom);
   const setQueuePausedById = useSetAtom(queuePausedByIdAtom);
 
@@ -301,10 +313,11 @@ export function useStreamChat({
                   next.set(chatId, updatedMessages);
                   return next;
                 });
-                // Drop parser states for messages that aren't in the new
-                // payload; the renderer reparses replaced messages one-shot.
+                // Drop parser states / dropped-byte counters for messages
+                // that aren't in the new payload; the renderer reparses
+                // replaced messages one-shot.
                 const validIds = new Set(updatedMessages.map((m) => m.id));
-                setStreamingBlocksById((prev) => {
+                const pruneByMessageId = <V>(prev: Map<number, V>) => {
                   if (prev.size === 0) return prev;
                   let changed = false;
                   const next = new Map(prev);
@@ -315,16 +328,23 @@ export function useStreamChat({
                     }
                   }
                   return changed ? next : prev;
-                });
+                };
+                setStreamingBlocksById(pruneByMessageId);
+                setContentBytesDroppedById(pruneByMessageId);
               } else if (
                 streamingMessageId !== undefined &&
                 streamingPatch !== undefined
               ) {
+                const priorDropped =
+                  store
+                    .get(contentBytesDroppedByMessageIdAtom)
+                    .get(streamingMessageId) ?? 0;
                 const applied = applyStreamingPatch(
                   setMessagesById,
                   chatId,
                   streamingMessageId,
                   streamingPatch,
+                  priorDropped,
                 );
                 if (applied) {
                   const messages = store.get(chatMessagesByIdAtom).get(chatId);
@@ -339,7 +359,46 @@ export function useStreamChat({
                       if (newContent.length === cur.cursor && cur.cursor > 0) {
                         return prev;
                       }
-                      const advanced = advanceParser(cur, newContent);
+                      let advanced = advanceParser(cur, newContent);
+                      // Aggressive trim: drop ALL closed blocks from parser
+                      // state and from message.content. Closed blocks still
+                      // render via stable refs in the parser-state atom's
+                      // `blocks` array; only the open block needs to be
+                      // alive in parser state + message.content.
+                      let trimmedContent: string | null = null;
+                      let dropDelta = 0;
+                      if (advanced.blocks.length > KEEP_COMMITTED_BLOCKS) {
+                        const trim = trimToLastNBlocks(
+                          advanced,
+                          newContent,
+                          KEEP_COMMITTED_BLOCKS,
+                        );
+                        if (trim.bytesDropped > 0) {
+                          advanced = trim.state;
+                          trimmedContent = trim.content;
+                          dropDelta = trim.bytesDropped;
+                        }
+                      }
+                      if (trimmedContent !== null) {
+                        setMessagesById((prevMap) => {
+                          const list = prevMap.get(chatId);
+                          if (!list) return prevMap;
+                          const updated = list.map((m) =>
+                            m.id === streamingMessageId
+                              ? { ...m, content: trimmedContent! }
+                              : m,
+                          );
+                          const out = new Map(prevMap);
+                          out.set(chatId, updated);
+                          return out;
+                        });
+                        setContentBytesDroppedById((prevMap) => {
+                          const cur2 = prevMap.get(streamingMessageId) ?? 0;
+                          const out = new Map(prevMap);
+                          out.set(streamingMessageId, cur2 + dropDelta);
+                          return out;
+                        });
+                      }
                       const next = new Map(prev);
                       next.set(streamingMessageId, advanced);
                       return next;
@@ -347,14 +406,17 @@ export function useStreamChat({
                   }
                 } else {
                   triggerResync(chatId, setMessagesById, store);
-                  // Drop parser state for this message so the renderer
-                  // re-parses from the resynced (full DB) content.
-                  setStreamingBlocksById((prev) => {
+                  // Drop parser state and dropped-byte counter for this
+                  // message so the renderer re-parses from the resynced
+                  // (full DB) content.
+                  const dropForMessage = <V>(prev: Map<number, V>) => {
                     if (!prev.has(streamingMessageId)) return prev;
                     const next = new Map(prev);
                     next.delete(streamingMessageId);
                     return next;
-                  });
+                  };
+                  setStreamingBlocksById(dropForMessage);
+                  setContentBytesDroppedById(dropForMessage);
                 }
               }
 
@@ -517,13 +579,14 @@ export function useStreamChat({
                         next.set(chatId, merged);
                         return next;
                       });
-                      // Stream ended successfully — drop parser states for
-                      // finalized messages so the renderer falls back to a
-                      // one-shot parse of the merged DB content.
+                      // Stream ended successfully — drop parser states and
+                      // dropped-byte counters for finalized messages so the
+                      // renderer falls back to a one-shot parse of the
+                      // merged DB content.
                       const finalizedIds = new Set(
                         latestChat.messages.map((m) => m.id),
                       );
-                      setStreamingBlocksById((prev) => {
+                      const dropFinalized = <V>(prev: Map<number, V>) => {
                         if (prev.size === 0) return prev;
                         let changed = false;
                         const next = new Map(prev);
@@ -534,7 +597,9 @@ export function useStreamChat({
                           }
                         }
                         return changed ? next : prev;
-                      });
+                      };
+                      setStreamingBlocksById(dropFinalized);
+                      setContentBytesDroppedById(dropFinalized);
                     }
                   } catch (error) {
                     console.warn(

--- a/src/hooks/useStreamChat.ts
+++ b/src/hooks/useStreamChat.ts
@@ -14,39 +14,13 @@ import {
   queuedMessagesByIdAtom,
   streamCompletedSuccessfullyByIdAtom,
   streamingBlocksByMessageIdAtom,
-  contentBytesDroppedByMessageIdAtom,
-  messageJsxByIdAtom,
-  type CachedClosedBlock,
-  type MessageJsxState,
   queuePausedByIdAtom,
   type QueuedMessageItem,
 } from "@/atoms/chatAtoms";
 import {
   advanceParser,
   initialParserState,
-  trimToLastNBlocks,
 } from "@/lib/streamingMessageParser";
-import { buildClosedBlockJsx } from "@/components/chat/DyadMarkdownParser";
-
-// Renderer-local message.content is trimmed to the open block on every
-// chunk. Closed blocks live in messageJsxByIdAtom as pre-rendered React
-// elements — never evicted during a stream so the user sees the full
-// response. The cache is cleared on stream end (renderer falls back to a
-// one-shot parse of the full DB content).
-const KEEP_COMMITTED_BLOCKS = 0;
-
-/**
- * Append newly-committed closed-block JSX to the per-message cache. No
- * eviction — the full response is preserved as pre-rendered React elements.
- */
-function appendJsxEntries(
-  prev: MessageJsxState | undefined,
-  newEntries: CachedClosedBlock[],
-): MessageJsxState {
-  if (newEntries.length === 0) return prev ?? { entries: [] };
-  const base = prev ?? { entries: [] };
-  return { entries: [...base.entries, ...newEntries] };
-}
 import { ipc } from "@/ipc/types";
 import { isPreviewOpenAtom } from "@/atoms/viewAtoms";
 import { pendingScreenshotAppIdAtom } from "@/atoms/previewAtoms";
@@ -142,10 +116,6 @@ export function useStreamChat({
     streamCompletedSuccessfullyByIdAtom,
   );
   const setStreamingBlocksById = useSetAtom(streamingBlocksByMessageIdAtom);
-  const setContentBytesDroppedById = useSetAtom(
-    contentBytesDroppedByMessageIdAtom,
-  );
-  const setMessageJsxById = useSetAtom(messageJsxByIdAtom);
   const queuePausedById = useAtomValue(queuePausedByIdAtom);
   const setQueuePausedById = useSetAtom(queuePausedByIdAtom);
 
@@ -331,12 +301,10 @@ export function useStreamChat({
                   next.set(chatId, updatedMessages);
                   return next;
                 });
-                // Drop any cached parser states / dropped-byte counters /
-                // JSX caches that don't correspond to messages in the new
-                // payload. The renderer falls back to one-shot parsing for
-                // the replaced messages.
+                // Drop parser states for messages that aren't in the new
+                // payload; the renderer reparses replaced messages one-shot.
                 const validIds = new Set(updatedMessages.map((m) => m.id));
-                const pruneByMessageId = <V>(prev: Map<number, V>) => {
+                setStreamingBlocksById((prev) => {
                   if (prev.size === 0) return prev;
                   let changed = false;
                   const next = new Map(prev);
@@ -347,24 +315,16 @@ export function useStreamChat({
                     }
                   }
                   return changed ? next : prev;
-                };
-                setStreamingBlocksById(pruneByMessageId);
-                setContentBytesDroppedById(pruneByMessageId);
-                setMessageJsxById(pruneByMessageId);
+                });
               } else if (
                 streamingMessageId !== undefined &&
                 streamingPatch !== undefined
               ) {
-                const priorDropped =
-                  store
-                    .get(contentBytesDroppedByMessageIdAtom)
-                    .get(streamingMessageId) ?? 0;
                 const applied = applyStreamingPatch(
                   setMessagesById,
                   chatId,
                   streamingMessageId,
                   streamingPatch,
-                  priorDropped,
                 );
                 if (applied) {
                   const messages = store.get(chatMessagesByIdAtom).get(chatId);
@@ -379,63 +339,7 @@ export function useStreamChat({
                       if (newContent.length === cur.cursor && cur.cursor > 0) {
                         return prev;
                       }
-                      // advanceParser shares `cur.blocks` by reference and
-                      // pushes new closed blocks onto it, so capture the
-                      // count BEFORE the call — otherwise the post-advance
-                      // length equals advanced.blocks.length and the slice
-                      // below is always empty.
-                      const priorBlockCount = cur.blocks.length;
-                      let advanced = advanceParser(cur, newContent);
-                      const newClosed = advanced.blocks.slice(priorBlockCount);
-                      if (newClosed.length > 0) {
-                        const newEntries: CachedClosedBlock[] =
-                          newClosed.map(buildClosedBlockJsx);
-                        setMessageJsxById((prevMap) => {
-                          const cur2 = prevMap.get(streamingMessageId);
-                          const updated = appendJsxEntries(cur2, newEntries);
-                          const out = new Map(prevMap);
-                          out.set(streamingMessageId, updated);
-                          return out;
-                        });
-                      }
-                      // Aggressive trim: drop ALL closed blocks from parser
-                      // state and from message.content. Renderer pulls closed
-                      // blocks from the JSX cache; only the open block needs
-                      // to be alive in parser state + content.
-                      let trimmedContent: string | null = null;
-                      let dropDelta = 0;
-                      if (advanced.blocks.length > KEEP_COMMITTED_BLOCKS) {
-                        const trim = trimToLastNBlocks(
-                          advanced,
-                          newContent,
-                          KEEP_COMMITTED_BLOCKS,
-                        );
-                        if (trim.bytesDropped > 0) {
-                          advanced = trim.state;
-                          trimmedContent = trim.content;
-                          dropDelta = trim.bytesDropped;
-                        }
-                      }
-                      if (trimmedContent !== null) {
-                        setMessagesById((prevMap) => {
-                          const list = prevMap.get(chatId);
-                          if (!list) return prevMap;
-                          const updated = list.map((m) =>
-                            m.id === streamingMessageId
-                              ? { ...m, content: trimmedContent! }
-                              : m,
-                          );
-                          const out = new Map(prevMap);
-                          out.set(chatId, updated);
-                          return out;
-                        });
-                        setContentBytesDroppedById((prevMap) => {
-                          const cur2 = prevMap.get(streamingMessageId) ?? 0;
-                          const out = new Map(prevMap);
-                          out.set(streamingMessageId, cur2 + dropDelta);
-                          return out;
-                        });
-                      }
+                      const advanced = advanceParser(cur, newContent);
                       const next = new Map(prev);
                       next.set(streamingMessageId, advanced);
                       return next;
@@ -443,18 +347,14 @@ export function useStreamChat({
                   }
                 } else {
                   triggerResync(chatId, setMessagesById, store);
-                  // Drop parser state, dropped-byte counter, and JSX cache
-                  // for this message so the renderer re-parses from the
-                  // resynced (full DB) content.
-                  const dropForMessage = <V>(prev: Map<number, V>) => {
+                  // Drop parser state for this message so the renderer
+                  // re-parses from the resynced (full DB) content.
+                  setStreamingBlocksById((prev) => {
                     if (!prev.has(streamingMessageId)) return prev;
                     const next = new Map(prev);
                     next.delete(streamingMessageId);
                     return next;
-                  };
-                  setStreamingBlocksById(dropForMessage);
-                  setContentBytesDroppedById(dropForMessage);
-                  setMessageJsxById(dropForMessage);
+                  });
                 }
               }
 
@@ -617,16 +517,13 @@ export function useStreamChat({
                         next.set(chatId, merged);
                         return next;
                       });
-                      // Stream ended successfully — full message content
-                      // was just merged from the DB into the messages atom.
-                      // Drop the JSX cache, parser state, and dropped-byte
-                      // counters for finalized messages so the renderer
-                      // falls back to a one-shot parse of the full content
-                      // and the omitted-blocks summary disappears.
+                      // Stream ended successfully — drop parser states for
+                      // finalized messages so the renderer falls back to a
+                      // one-shot parse of the merged DB content.
                       const finalizedIds = new Set(
                         latestChat.messages.map((m) => m.id),
                       );
-                      const dropFinalized = <V>(prev: Map<number, V>) => {
+                      setStreamingBlocksById((prev) => {
                         if (prev.size === 0) return prev;
                         let changed = false;
                         const next = new Map(prev);
@@ -637,10 +534,7 @@ export function useStreamChat({
                           }
                         }
                         return changed ? next : prev;
-                      };
-                      setMessageJsxById(dropFinalized);
-                      setStreamingBlocksById(dropFinalized);
-                      setContentBytesDroppedById(dropFinalized);
+                      });
                     }
                   } catch (error) {
                     console.warn(

--- a/src/hooks/useStreamChat.ts
+++ b/src/hooks/useStreamChat.ts
@@ -15,6 +15,9 @@ import {
   streamCompletedSuccessfullyByIdAtom,
   streamingBlocksByMessageIdAtom,
   contentBytesDroppedByMessageIdAtom,
+  messageJsxByIdAtom,
+  type CachedClosedBlock,
+  type MessageJsxState,
   queuePausedByIdAtom,
   type QueuedMessageItem,
 } from "@/atoms/chatAtoms";
@@ -23,13 +26,27 @@ import {
   initialParserState,
   trimToLastNBlocks,
 } from "@/lib/streamingMessageParser";
+import { buildClosedBlockJsx } from "@/components/chat/DyadMarkdownParser";
 
 // Renderer-local message.content is trimmed to the open block on every
-// chunk. Closed blocks live only in the parser-state atom (block refs are
-// stable so React.memo skips them). The trim keeps `message.content`
-// bounded to the size of the current open block, which keeps each per-chunk
-// applyStreamingPatch slice/concat allocation small.
+// chunk. Closed blocks live in messageJsxByIdAtom as pre-rendered React
+// elements — never evicted during a stream so the user sees the full
+// response. Cleared on stream end (renderer falls back to a one-shot
+// parse of the full DB content).
 const KEEP_COMMITTED_BLOCKS = 0;
+
+/**
+ * Append newly-committed closed-block JSX to the per-message cache. No
+ * eviction — the full response is preserved as pre-rendered React elements.
+ */
+function appendJsxEntries(
+  prev: MessageJsxState | undefined,
+  newEntries: CachedClosedBlock[],
+): MessageJsxState {
+  if (newEntries.length === 0) return prev ?? { entries: [] };
+  const base = prev ?? { entries: [] };
+  return { entries: [...base.entries, ...newEntries] };
+}
 import { ipc } from "@/ipc/types";
 import { isPreviewOpenAtom } from "@/atoms/viewAtoms";
 import { pendingScreenshotAppIdAtom } from "@/atoms/previewAtoms";
@@ -128,6 +145,7 @@ export function useStreamChat({
   const setContentBytesDroppedById = useSetAtom(
     contentBytesDroppedByMessageIdAtom,
   );
+  const setMessageJsxById = useSetAtom(messageJsxByIdAtom);
   const queuePausedById = useAtomValue(queuePausedByIdAtom);
   const setQueuePausedById = useSetAtom(queuePausedByIdAtom);
 
@@ -313,9 +331,9 @@ export function useStreamChat({
                   next.set(chatId, updatedMessages);
                   return next;
                 });
-                // Drop parser states / dropped-byte counters for messages
-                // that aren't in the new payload; the renderer reparses
-                // replaced messages one-shot.
+                // Drop parser states / dropped-byte counters / JSX caches
+                // for messages that aren't in the new payload; the renderer
+                // reparses replaced messages one-shot.
                 const validIds = new Set(updatedMessages.map((m) => m.id));
                 const pruneByMessageId = <V>(prev: Map<number, V>) => {
                   if (prev.size === 0) return prev;
@@ -331,6 +349,7 @@ export function useStreamChat({
                 };
                 setStreamingBlocksById(pruneByMessageId);
                 setContentBytesDroppedById(pruneByMessageId);
+                setMessageJsxById(pruneByMessageId);
               } else if (
                 streamingMessageId !== undefined &&
                 streamingPatch !== undefined
@@ -359,12 +378,30 @@ export function useStreamChat({
                       if (newContent.length === cur.cursor && cur.cursor > 0) {
                         return prev;
                       }
+                      // advanceParser shares `cur.blocks` by reference and
+                      // pushes new closed blocks onto it, so capture the
+                      // count BEFORE the call — otherwise the post-advance
+                      // length equals advanced.blocks.length and the slice
+                      // below is always empty.
+                      const priorBlockCount = cur.blocks.length;
                       let advanced = advanceParser(cur, newContent);
+                      const newClosed = advanced.blocks.slice(priorBlockCount);
+                      if (newClosed.length > 0) {
+                        const newEntries: CachedClosedBlock[] =
+                          newClosed.map(buildClosedBlockJsx);
+                        setMessageJsxById((prevMap) => {
+                          const cur2 = prevMap.get(streamingMessageId);
+                          const updated = appendJsxEntries(cur2, newEntries);
+                          const out = new Map(prevMap);
+                          out.set(streamingMessageId, updated);
+                          return out;
+                        });
+                      }
                       // Aggressive trim: drop ALL closed blocks from parser
-                      // state and from message.content. Closed blocks still
-                      // render via stable refs in the parser-state atom's
-                      // `blocks` array; only the open block needs to be
-                      // alive in parser state + message.content.
+                      // state and from message.content. Closed blocks
+                      // continue to render from the JSX cache appended
+                      // above; only the open block needs to be alive in
+                      // parser state + message.content.
                       let trimmedContent: string | null = null;
                       let dropDelta = 0;
                       if (advanced.blocks.length > KEEP_COMMITTED_BLOCKS) {
@@ -406,9 +443,9 @@ export function useStreamChat({
                   }
                 } else {
                   triggerResync(chatId, setMessagesById, store);
-                  // Drop parser state and dropped-byte counter for this
-                  // message so the renderer re-parses from the resynced
-                  // (full DB) content.
+                  // Drop parser state, dropped-byte counter, and JSX cache
+                  // for this message so the renderer re-parses from the
+                  // resynced (full DB) content.
                   const dropForMessage = <V>(prev: Map<number, V>) => {
                     if (!prev.has(streamingMessageId)) return prev;
                     const next = new Map(prev);
@@ -417,6 +454,7 @@ export function useStreamChat({
                   };
                   setStreamingBlocksById(dropForMessage);
                   setContentBytesDroppedById(dropForMessage);
+                  setMessageJsxById(dropForMessage);
                 }
               }
 
@@ -579,10 +617,10 @@ export function useStreamChat({
                         next.set(chatId, merged);
                         return next;
                       });
-                      // Stream ended successfully — drop parser states and
-                      // dropped-byte counters for finalized messages so the
-                      // renderer falls back to a one-shot parse of the
-                      // merged DB content.
+                      // Stream ended successfully — drop parser states,
+                      // dropped-byte counters, and JSX caches for finalized
+                      // messages so the renderer falls back to a one-shot
+                      // parse of the merged DB content.
                       const finalizedIds = new Set(
                         latestChat.messages.map((m) => m.id),
                       );
@@ -600,6 +638,7 @@ export function useStreamChat({
                       };
                       setStreamingBlocksById(dropFinalized);
                       setContentBytesDroppedById(dropFinalized);
+                      setMessageJsxById(dropFinalized);
                     }
                   } catch (error) {
                     console.warn(

--- a/src/hooks/useStreamChat.ts
+++ b/src/hooks/useStreamChat.ts
@@ -15,9 +15,7 @@ import {
   streamCompletedSuccessfullyByIdAtom,
   streamingBlocksByMessageIdAtom,
   contentBytesDroppedByMessageIdAtom,
-  messageJsxByIdAtom,
-  type CachedClosedBlock,
-  type MessageJsxState,
+  closedBlocksByMessageIdAtom,
   queuePausedByIdAtom,
   type QueuedMessageItem,
 } from "@/atoms/chatAtoms";
@@ -25,28 +23,15 @@ import {
   advanceParser,
   initialParserState,
   trimToLastNBlocks,
+  type Block,
 } from "@/lib/streamingMessageParser";
-import { buildClosedBlockJsx } from "@/components/chat/DyadMarkdownParser";
 
 // Renderer-local message.content is trimmed to the open block on every
-// chunk. Closed blocks live in messageJsxByIdAtom as pre-rendered React
-// elements — never evicted during a stream so the user sees the full
-// response. Cleared on stream end (renderer falls back to a one-shot
-// parse of the full DB content).
+// chunk; the parser's state.blocks is wiped at the same time. Closed blocks
+// survive in closedBlocksByMessageIdAtom (immutable append). Cleared on
+// stream end (renderer falls back to a one-shot parse of the full DB
+// content).
 const KEEP_COMMITTED_BLOCKS = 0;
-
-/**
- * Append newly-committed closed-block JSX to the per-message cache. No
- * eviction — the full response is preserved as pre-rendered React elements.
- */
-function appendJsxEntries(
-  prev: MessageJsxState | undefined,
-  newEntries: CachedClosedBlock[],
-): MessageJsxState {
-  if (newEntries.length === 0) return prev ?? { entries: [] };
-  const base = prev ?? { entries: [] };
-  return { entries: [...base.entries, ...newEntries] };
-}
 import { ipc } from "@/ipc/types";
 import { isPreviewOpenAtom } from "@/atoms/viewAtoms";
 import { pendingScreenshotAppIdAtom } from "@/atoms/previewAtoms";
@@ -145,7 +130,7 @@ export function useStreamChat({
   const setContentBytesDroppedById = useSetAtom(
     contentBytesDroppedByMessageIdAtom,
   );
-  const setMessageJsxById = useSetAtom(messageJsxByIdAtom);
+  const setClosedBlocksById = useSetAtom(closedBlocksByMessageIdAtom);
   const queuePausedById = useAtomValue(queuePausedByIdAtom);
   const setQueuePausedById = useSetAtom(queuePausedByIdAtom);
 
@@ -331,9 +316,9 @@ export function useStreamChat({
                   next.set(chatId, updatedMessages);
                   return next;
                 });
-                // Drop parser states / dropped-byte counters / JSX caches
-                // for messages that aren't in the new payload; the renderer
-                // reparses replaced messages one-shot.
+                // Drop parser states / dropped-byte counters / closed-block
+                // accumulators for messages that aren't in the new payload;
+                // the renderer reparses replaced messages one-shot.
                 const validIds = new Set(updatedMessages.map((m) => m.id));
                 const pruneByMessageId = <V>(prev: Map<number, V>) => {
                   if (prev.size === 0) return prev;
@@ -349,7 +334,7 @@ export function useStreamChat({
                 };
                 setStreamingBlocksById(pruneByMessageId);
                 setContentBytesDroppedById(pruneByMessageId);
-                setMessageJsxById(pruneByMessageId);
+                setClosedBlocksById(pruneByMessageId);
               } else if (
                 streamingMessageId !== undefined &&
                 streamingPatch !== undefined
@@ -378,30 +363,28 @@ export function useStreamChat({
                       if (newContent.length === cur.cursor && cur.cursor > 0) {
                         return prev;
                       }
-                      // advanceParser shares `cur.blocks` by reference and
-                      // pushes new closed blocks onto it, so capture the
-                      // count BEFORE the call — otherwise the post-advance
-                      // length equals advanced.blocks.length and the slice
-                      // below is always empty.
+                      // Capture block count before advance so the slice
+                      // below isolates blocks closed during this advance.
                       const priorBlockCount = cur.blocks.length;
                       let advanced = advanceParser(cur, newContent);
-                      const newClosed = advanced.blocks.slice(priorBlockCount);
+                      const newClosed: Block[] =
+                        advanced.blocks.slice(priorBlockCount);
                       if (newClosed.length > 0) {
-                        const newEntries: CachedClosedBlock[] =
-                          newClosed.map(buildClosedBlockJsx);
-                        setMessageJsxById((prevMap) => {
-                          const cur2 = prevMap.get(streamingMessageId);
-                          const updated = appendJsxEntries(cur2, newEntries);
+                        // Immutable append: new array ref → renderer's
+                        // closed-block memo wrapper invalidates exactly on
+                        // chunks that close a block.
+                        setClosedBlocksById((prevMap) => {
+                          const cur2 = prevMap.get(streamingMessageId) ?? [];
                           const out = new Map(prevMap);
-                          out.set(streamingMessageId, updated);
+                          out.set(streamingMessageId, [...cur2, ...newClosed]);
                           return out;
                         });
                       }
                       // Aggressive trim: drop ALL closed blocks from parser
                       // state and from message.content. Closed blocks
-                      // continue to render from the JSX cache appended
-                      // above; only the open block needs to be alive in
-                      // parser state + message.content.
+                      // continue to render from closedBlocksByMessageIdAtom
+                      // appended above; only the open block needs to be
+                      // alive in parser state + message.content.
                       let trimmedContent: string | null = null;
                       let dropDelta = 0;
                       if (advanced.blocks.length > KEEP_COMMITTED_BLOCKS) {
@@ -443,9 +426,9 @@ export function useStreamChat({
                   }
                 } else {
                   triggerResync(chatId, setMessagesById, store);
-                  // Drop parser state, dropped-byte counter, and JSX cache
-                  // for this message so the renderer re-parses from the
-                  // resynced (full DB) content.
+                  // Drop parser state, dropped-byte counter, and closed-
+                  // block accumulator for this message so the renderer
+                  // re-parses from the resynced (full DB) content.
                   const dropForMessage = <V>(prev: Map<number, V>) => {
                     if (!prev.has(streamingMessageId)) return prev;
                     const next = new Map(prev);
@@ -454,7 +437,7 @@ export function useStreamChat({
                   };
                   setStreamingBlocksById(dropForMessage);
                   setContentBytesDroppedById(dropForMessage);
-                  setMessageJsxById(dropForMessage);
+                  setClosedBlocksById(dropForMessage);
                 }
               }
 
@@ -618,9 +601,9 @@ export function useStreamChat({
                         return next;
                       });
                       // Stream ended successfully — drop parser states,
-                      // dropped-byte counters, and JSX caches for finalized
-                      // messages so the renderer falls back to a one-shot
-                      // parse of the merged DB content.
+                      // dropped-byte counters, and closed-block accumulators
+                      // for finalized messages so the renderer falls back
+                      // to a one-shot parse of the merged DB content.
                       const finalizedIds = new Set(
                         latestChat.messages.map((m) => m.id),
                       );
@@ -638,7 +621,7 @@ export function useStreamChat({
                       };
                       setStreamingBlocksById(dropFinalized);
                       setContentBytesDroppedById(dropFinalized);
-                      setMessageJsxById(dropFinalized);
+                      setClosedBlocksById(dropFinalized);
                     }
                   } catch (error) {
                     console.warn(

--- a/src/hooks/useStreamChat.ts
+++ b/src/hooks/useStreamChat.ts
@@ -15,23 +15,14 @@ import {
   streamCompletedSuccessfullyByIdAtom,
   streamingBlocksByMessageIdAtom,
   contentBytesDroppedByMessageIdAtom,
-  closedBlocksByMessageIdAtom,
   queuePausedByIdAtom,
   type QueuedMessageItem,
 } from "@/atoms/chatAtoms";
 import {
   advanceParser,
   initialParserState,
-  trimToLastNBlocks,
-  type Block,
+  trimContent,
 } from "@/lib/streamingMessageParser";
-
-// Renderer-local message.content is trimmed to the open block on every
-// chunk; the parser's state.blocks is wiped at the same time. Closed blocks
-// survive in closedBlocksByMessageIdAtom (immutable append). Cleared on
-// stream end (renderer falls back to a one-shot parse of the full DB
-// content).
-const KEEP_COMMITTED_BLOCKS = 0;
 import { ipc } from "@/ipc/types";
 import { isPreviewOpenAtom } from "@/atoms/viewAtoms";
 import { pendingScreenshotAppIdAtom } from "@/atoms/previewAtoms";
@@ -130,7 +121,6 @@ export function useStreamChat({
   const setContentBytesDroppedById = useSetAtom(
     contentBytesDroppedByMessageIdAtom,
   );
-  const setClosedBlocksById = useSetAtom(closedBlocksByMessageIdAtom);
   const queuePausedById = useAtomValue(queuePausedByIdAtom);
   const setQueuePausedById = useSetAtom(queuePausedByIdAtom);
 
@@ -316,9 +306,9 @@ export function useStreamChat({
                   next.set(chatId, updatedMessages);
                   return next;
                 });
-                // Drop parser states / dropped-byte counters / closed-block
-                // accumulators for messages that aren't in the new payload;
-                // the renderer reparses replaced messages one-shot.
+                // Drop parser states / dropped-byte counters for messages
+                // that aren't in the new payload; the renderer reparses
+                // replaced messages one-shot.
                 const validIds = new Set(updatedMessages.map((m) => m.id));
                 const pruneByMessageId = <V>(prev: Map<number, V>) => {
                   if (prev.size === 0) return prev;
@@ -334,7 +324,6 @@ export function useStreamChat({
                 };
                 setStreamingBlocksById(pruneByMessageId);
                 setContentBytesDroppedById(pruneByMessageId);
-                setClosedBlocksById(pruneByMessageId);
               } else if (
                 streamingMessageId !== undefined &&
                 streamingPatch !== undefined
@@ -363,49 +352,19 @@ export function useStreamChat({
                       if (newContent.length === cur.cursor && cur.cursor > 0) {
                         return prev;
                       }
-                      // Capture block count before advance so the slice
-                      // below isolates blocks closed during this advance.
-                      const priorBlockCount = cur.blocks.length;
-                      let advanced = advanceParser(cur, newContent);
-                      const newClosed: Block[] =
-                        advanced.blocks.slice(priorBlockCount);
-                      if (newClosed.length > 0) {
-                        // Immutable append: new array ref → renderer's
-                        // closed-block memo wrapper invalidates exactly on
-                        // chunks that close a block.
-                        setClosedBlocksById((prevMap) => {
-                          const cur2 = prevMap.get(streamingMessageId) ?? [];
-                          const out = new Map(prevMap);
-                          out.set(streamingMessageId, [...cur2, ...newClosed]);
-                          return out;
-                        });
-                      }
-                      // Aggressive trim: drop ALL closed blocks from parser
-                      // state and from message.content. Closed blocks
-                      // continue to render from closedBlocksByMessageIdAtom
-                      // appended above; only the open block needs to be
-                      // alive in parser state + message.content.
-                      let trimmedContent: string | null = null;
-                      let dropDelta = 0;
-                      if (advanced.blocks.length > KEEP_COMMITTED_BLOCKS) {
-                        const trim = trimToLastNBlocks(
-                          advanced,
-                          newContent,
-                          KEEP_COMMITTED_BLOCKS,
-                        );
-                        if (trim.bytesDropped > 0) {
-                          advanced = trim.state;
-                          trimmedContent = trim.content;
-                          dropDelta = trim.bytesDropped;
-                        }
-                      }
-                      if (trimmedContent !== null) {
+                      // Trim message.content past the open-block boundary.
+                      // Closed blocks remain in parser state; only the raw
+                      // string is shortened so applyStreamingPatch's per-
+                      // chunk slice/concat stays bounded.
+                      const advanced = advanceParser(cur, newContent);
+                      const trim = trimContent(advanced, newContent);
+                      if (trim.bytesDropped > 0) {
                         setMessagesById((prevMap) => {
                           const list = prevMap.get(chatId);
                           if (!list) return prevMap;
                           const updated = list.map((m) =>
                             m.id === streamingMessageId
-                              ? { ...m, content: trimmedContent! }
+                              ? { ...m, content: trim.content }
                               : m,
                           );
                           const out = new Map(prevMap);
@@ -415,20 +374,20 @@ export function useStreamChat({
                         setContentBytesDroppedById((prevMap) => {
                           const cur2 = prevMap.get(streamingMessageId) ?? 0;
                           const out = new Map(prevMap);
-                          out.set(streamingMessageId, cur2 + dropDelta);
+                          out.set(streamingMessageId, cur2 + trim.bytesDropped);
                           return out;
                         });
                       }
                       const next = new Map(prev);
-                      next.set(streamingMessageId, advanced);
+                      next.set(streamingMessageId, trim.state);
                       return next;
                     });
                   }
                 } else {
                   triggerResync(chatId, setMessagesById, store);
-                  // Drop parser state, dropped-byte counter, and closed-
-                  // block accumulator for this message so the renderer
-                  // re-parses from the resynced (full DB) content.
+                  // Drop parser state and dropped-byte counter for this
+                  // message so the renderer re-parses from the resynced
+                  // (full DB) content.
                   const dropForMessage = <V>(prev: Map<number, V>) => {
                     if (!prev.has(streamingMessageId)) return prev;
                     const next = new Map(prev);
@@ -437,7 +396,6 @@ export function useStreamChat({
                   };
                   setStreamingBlocksById(dropForMessage);
                   setContentBytesDroppedById(dropForMessage);
-                  setClosedBlocksById(dropForMessage);
                 }
               }
 
@@ -600,10 +558,10 @@ export function useStreamChat({
                         next.set(chatId, merged);
                         return next;
                       });
-                      // Stream ended successfully — drop parser states,
-                      // dropped-byte counters, and closed-block accumulators
-                      // for finalized messages so the renderer falls back
-                      // to a one-shot parse of the merged DB content.
+                      // Stream ended successfully — drop parser states and
+                      // dropped-byte counters for finalized messages so the
+                      // renderer falls back to a one-shot parse of the
+                      // merged DB content.
                       const finalizedIds = new Set(
                         latestChat.messages.map((m) => m.id),
                       );
@@ -621,7 +579,6 @@ export function useStreamChat({
                       };
                       setStreamingBlocksById(dropFinalized);
                       setContentBytesDroppedById(dropFinalized);
-                      setClosedBlocksById(dropFinalized);
                     }
                   } catch (error) {
                     console.warn(

--- a/src/hooks/useStreamChat.ts
+++ b/src/hooks/useStreamChat.ts
@@ -13,9 +13,105 @@ import {
   recentStreamChatIdsAtom,
   queuedMessagesByIdAtom,
   streamCompletedSuccessfullyByIdAtom,
+  streamingBlocksByMessageIdAtom,
+  contentBytesDroppedByMessageIdAtom,
+  messageJsxByIdAtom,
+  type CachedClosedBlock,
+  type DroppedSummary,
+  type MessageJsxState,
   queuePausedByIdAtom,
   type QueuedMessageItem,
 } from "@/atoms/chatAtoms";
+import {
+  advanceParser,
+  initialParserState,
+  trimToLastNBlocks,
+} from "@/lib/streamingMessageParser";
+import { buildClosedBlockJsx } from "@/components/chat/DyadMarkdownParser";
+
+// Tail-only render caps. Each closed block is rendered to JSX once and held
+// in messageJsxByIdAtom. Cap accounting evicts entries from the FRONT of
+// that list while the user response is being streamed:
+//   - count > MAX_BLOCKS  -> evict
+//   - totalChars > MAX_CHARS -> evict
+//   - never evict if remaining count <= MIN_BLOCKS (UX floor)
+// Parser state and renderer-local message.content are unconditionally
+// trimmed to the open block (KEEP_COMMITTED_BLOCKS = 0); the JSX cache is
+// the only place closed-block content lives during a stream.
+const MAX_BLOCKS = 50;
+const MIN_BLOCKS = 10;
+const MAX_CHARS = 200_000;
+const KEEP_COMMITTED_BLOCKS = 0;
+
+const EMPTY_DROPPED: DroppedSummary = {
+  markdown: 0,
+  toolCalls: 0,
+  byToolTag: {},
+};
+
+const EMPTY_JSX_STATE: MessageJsxState = {
+  entries: [],
+  totalChars: 0,
+  dropped: EMPTY_DROPPED,
+};
+
+/**
+ * Append newly-committed closed-block JSX to the per-message cache and
+ * evict from the front until the caps hold. MIN_BLOCKS is a hard floor —
+ * never drop below it even if MAX_CHARS is still exceeded. Returns a fresh
+ * MessageJsxState with the updated entries, totalChars, and dropped
+ * counters; callers wrap it in the atom map.
+ */
+function appendAndEnforceCaps(
+  prev: MessageJsxState | undefined,
+  newEntries: CachedClosedBlock[],
+): MessageJsxState {
+  const base = prev ?? EMPTY_JSX_STATE;
+  const entries = [...base.entries, ...newEntries];
+  let totalChars = base.totalChars;
+  for (const e of newEntries) totalChars += e.bytes;
+
+  let droppedMd = base.dropped.markdown;
+  let droppedTools = base.dropped.toolCalls;
+  let byTagMutated: Record<string, number> | null = null;
+
+  while (
+    entries.length > MIN_BLOCKS &&
+    (entries.length > MAX_BLOCKS || totalChars > MAX_CHARS)
+  ) {
+    const head = entries.shift()!;
+    totalChars -= head.bytes;
+    if (head.category === "markdown") {
+      droppedMd++;
+    } else {
+      droppedTools++;
+      if (byTagMutated === null) {
+        byTagMutated = { ...base.dropped.byToolTag };
+      }
+      const tag = head.toolTag ?? "unknown";
+      byTagMutated[tag] = (byTagMutated[tag] ?? 0) + 1;
+    }
+  }
+
+  if (
+    droppedMd === base.dropped.markdown &&
+    droppedTools === base.dropped.toolCalls &&
+    byTagMutated === null &&
+    newEntries.length > 0
+  ) {
+    return { entries, totalChars, dropped: base.dropped };
+  }
+
+  return {
+    entries,
+    totalChars,
+    dropped: {
+      markdown: droppedMd,
+      toolCalls: droppedTools,
+      byToolTag: byTagMutated ?? base.dropped.byToolTag,
+    },
+  };
+}
 import { ipc } from "@/ipc/types";
 import { isPreviewOpenAtom } from "@/atoms/viewAtoms";
 import { pendingScreenshotAppIdAtom } from "@/atoms/previewAtoms";
@@ -110,6 +206,11 @@ export function useStreamChat({
   const setStreamCompletedSuccessfullyById = useSetAtom(
     streamCompletedSuccessfullyByIdAtom,
   );
+  const setStreamingBlocksById = useSetAtom(streamingBlocksByMessageIdAtom);
+  const setContentBytesDroppedById = useSetAtom(
+    contentBytesDroppedByMessageIdAtom,
+  );
+  const setMessageJsxById = useSetAtom(messageJsxByIdAtom);
   const queuePausedById = useAtomValue(queuePausedByIdAtom);
   const setQueuePausedById = useSetAtom(queuePausedByIdAtom);
 
@@ -295,18 +396,132 @@ export function useStreamChat({
                   next.set(chatId, updatedMessages);
                   return next;
                 });
+                // Drop any cached parser states / dropped-byte counters /
+                // JSX caches that don't correspond to messages in the new
+                // payload. The renderer falls back to one-shot parsing for
+                // the replaced messages.
+                const validIds = new Set(updatedMessages.map((m) => m.id));
+                const pruneByMessageId = <V>(prev: Map<number, V>) => {
+                  if (prev.size === 0) return prev;
+                  let changed = false;
+                  const next = new Map(prev);
+                  for (const id of prev.keys()) {
+                    if (!validIds.has(id)) {
+                      next.delete(id);
+                      changed = true;
+                    }
+                  }
+                  return changed ? next : prev;
+                };
+                setStreamingBlocksById(pruneByMessageId);
+                setContentBytesDroppedById(pruneByMessageId);
+                setMessageJsxById(pruneByMessageId);
               } else if (
                 streamingMessageId !== undefined &&
                 streamingPatch !== undefined
               ) {
+                const priorDropped =
+                  store
+                    .get(contentBytesDroppedByMessageIdAtom)
+                    .get(streamingMessageId) ?? 0;
                 const applied = applyStreamingPatch(
                   setMessagesById,
                   chatId,
                   streamingMessageId,
                   streamingPatch,
+                  priorDropped,
                 );
-                if (!applied) {
+                if (applied) {
+                  const messages = store.get(chatMessagesByIdAtom).get(chatId);
+                  const msg = messages?.find(
+                    (m) => m.id === streamingMessageId,
+                  );
+                  if (msg) {
+                    const newContent = msg.content ?? "";
+                    setStreamingBlocksById((prev) => {
+                      const cur =
+                        prev.get(streamingMessageId) ?? initialParserState();
+                      if (newContent.length === cur.cursor && cur.cursor > 0) {
+                        return prev;
+                      }
+                      let advanced = advanceParser(cur, newContent);
+                      // Render any newly-committed closed blocks to JSX and
+                      // append to the message-JSX cache, then evict from the
+                      // front while the cap is exceeded.
+                      const newClosed = advanced.blocks.slice(
+                        cur.blocks.length,
+                      );
+                      if (newClosed.length > 0) {
+                        const newEntries: CachedClosedBlock[] =
+                          newClosed.map(buildClosedBlockJsx);
+                        setMessageJsxById((prevMap) => {
+                          const cur2 = prevMap.get(streamingMessageId);
+                          const updated = appendAndEnforceCaps(
+                            cur2,
+                            newEntries,
+                          );
+                          const out = new Map(prevMap);
+                          out.set(streamingMessageId, updated);
+                          return out;
+                        });
+                      }
+                      // Aggressive trim: drop ALL closed blocks from parser
+                      // state and from message.content. Renderer pulls closed
+                      // blocks from the JSX cache; only the open block needs
+                      // to be alive in parser state + content.
+                      let trimmedContent: string | null = null;
+                      let dropDelta = 0;
+                      if (advanced.blocks.length > KEEP_COMMITTED_BLOCKS) {
+                        const trim = trimToLastNBlocks(
+                          advanced,
+                          newContent,
+                          KEEP_COMMITTED_BLOCKS,
+                        );
+                        if (trim.bytesDropped > 0) {
+                          advanced = trim.state;
+                          trimmedContent = trim.content;
+                          dropDelta = trim.bytesDropped;
+                        }
+                      }
+                      if (trimmedContent !== null) {
+                        setMessagesById((prevMap) => {
+                          const list = prevMap.get(chatId);
+                          if (!list) return prevMap;
+                          const updated = list.map((m) =>
+                            m.id === streamingMessageId
+                              ? { ...m, content: trimmedContent! }
+                              : m,
+                          );
+                          const out = new Map(prevMap);
+                          out.set(chatId, updated);
+                          return out;
+                        });
+                        setContentBytesDroppedById((prevMap) => {
+                          const cur2 = prevMap.get(streamingMessageId) ?? 0;
+                          const out = new Map(prevMap);
+                          out.set(streamingMessageId, cur2 + dropDelta);
+                          return out;
+                        });
+                      }
+                      const next = new Map(prev);
+                      next.set(streamingMessageId, advanced);
+                      return next;
+                    });
+                  }
+                } else {
                   triggerResync(chatId, setMessagesById, store);
+                  // Drop parser state, dropped-byte counter, and JSX cache
+                  // for this message so the renderer re-parses from the
+                  // resynced (full DB) content.
+                  const dropForMessage = <V>(prev: Map<number, V>) => {
+                    if (!prev.has(streamingMessageId)) return prev;
+                    const next = new Map(prev);
+                    next.delete(streamingMessageId);
+                    return next;
+                  };
+                  setStreamingBlocksById(dropForMessage);
+                  setContentBytesDroppedById(dropForMessage);
+                  setMessageJsxById(dropForMessage);
                 }
               }
 
@@ -469,6 +684,30 @@ export function useStreamChat({
                         next.set(chatId, merged);
                         return next;
                       });
+                      // Stream ended successfully — full message content
+                      // was just merged from the DB into the messages atom.
+                      // Drop the JSX cache, parser state, and dropped-byte
+                      // counters for finalized messages so the renderer
+                      // falls back to a one-shot parse of the full content
+                      // and the omitted-blocks summary disappears.
+                      const finalizedIds = new Set(
+                        latestChat.messages.map((m) => m.id),
+                      );
+                      const dropFinalized = <V>(prev: Map<number, V>) => {
+                        if (prev.size === 0) return prev;
+                        let changed = false;
+                        const next = new Map(prev);
+                        for (const id of prev.keys()) {
+                          if (finalizedIds.has(id)) {
+                            next.delete(id);
+                            changed = true;
+                          }
+                        }
+                        return changed ? next : prev;
+                      };
+                      setMessageJsxById(dropFinalized);
+                      setStreamingBlocksById(dropFinalized);
+                      setContentBytesDroppedById(dropFinalized);
                     }
                   } catch (error) {
                     console.warn(

--- a/src/lib/applyStreamingPatch.ts
+++ b/src/lib/applyStreamingPatch.ts
@@ -5,13 +5,21 @@ import { hashPrefix } from "@/lib/prefixHash";
  * Applies a tail-only streaming patch to the messages-by-id map atom.
  * Reconstructs the streaming message content as `current.slice(0, offset) + content`.
  *
+ * `priorBytesDropped` is the cumulative number of bytes that the renderer
+ * has discarded from the front of the local message.content (see
+ * trimToLastNBlocks). Server-side patch offsets are absolute, so the local
+ * effective offset is `offset - priorBytesDropped`. When dropped > 0 the
+ * prefixHash check is skipped — we no longer have the full prefix bytes to
+ * recompute the hash, and the trim is renderer-only / never round-tripped.
+ *
  * Returns false when the patch cannot be applied cleanly:
  *   - chatId has no local messages yet (missing placeholder)
  *   - streamingMessageId is not found in local messages
- *   - local renderer content is shorter than patch offset (stale DB overwrite dropped bytes)
- *   - djb2 hash of the local prefix disagrees with prefixHash (stale DB content
- *     has same length but different prefix, e.g. a cleanFullResponse < → ＜
- *     rewrite anywhere in the prefix after the DB write)
+ *   - patch offset is below the dropped boundary (impossible without a rewind)
+ *   - local renderer content is shorter than effective offset (stale DB
+ *     overwrite dropped bytes)
+ *   - djb2 hash of the local prefix disagrees with prefixHash (only checked
+ *     when priorBytesDropped === 0)
  * The caller should resync on false instead of splicing a new tail onto the wrong base.
  */
 export function applyStreamingPatch(
@@ -21,6 +29,7 @@ export function applyStreamingPatch(
   chatId: number,
   streamingMessageId: number,
   streamingPatch: StreamingPatch,
+  priorBytesDropped = 0,
 ): boolean {
   const { offset, content, prefixHash } = streamingPatch;
   let baseMismatch = false;
@@ -35,19 +44,34 @@ export function applyStreamingPatch(
       if (msg.id !== streamingMessageId) return msg;
       found = true;
       const currentContent = msg.content ?? "";
-      if (currentContent.length < offset) {
+      // Server-side absolute offset → renderer-local offset.
+      const effectiveOffset = offset - priorBytesDropped;
+      if (effectiveOffset < 0) {
         baseMismatch = true;
         return msg;
       }
+      if (currentContent.length < effectiveOffset) {
+        baseMismatch = true;
+        return msg;
+      }
+      // Skip prefix-hash check after we've dropped bytes — we no longer have
+      // the full prefix to recompute against. cleanFullResponse rewrites
+      // past the drop boundary become invisible, but the resync path on
+      // applied=false still rescues us if the tail divergence is detectable
+      // any other way.
       if (
+        priorBytesDropped === 0 &&
         prefixHash !== undefined &&
-        offset > 0 &&
-        hashPrefix(currentContent, offset) !== prefixHash
+        effectiveOffset > 0 &&
+        hashPrefix(currentContent, effectiveOffset) !== prefixHash
       ) {
         baseMismatch = true;
         return msg;
       }
-      return { ...msg, content: currentContent.slice(0, offset) + content };
+      return {
+        ...msg,
+        content: currentContent.slice(0, effectiveOffset) + content,
+      };
     });
     if (!found) {
       baseMismatch = true;

--- a/src/lib/applyStreamingPatch.ts
+++ b/src/lib/applyStreamingPatch.ts
@@ -5,21 +5,13 @@ import { hashPrefix } from "@/lib/prefixHash";
  * Applies a tail-only streaming patch to the messages-by-id map atom.
  * Reconstructs the streaming message content as `current.slice(0, offset) + content`.
  *
- * `priorBytesDropped` is the cumulative number of bytes that the renderer
- * has discarded from the front of the local message.content (see
- * trimToLastNBlocks). Server-side patch offsets are absolute, so the local
- * effective offset is `offset - priorBytesDropped`. When dropped > 0 the
- * prefixHash check is skipped — we no longer have the full prefix bytes to
- * recompute the hash, and the trim is renderer-only / never round-tripped.
- *
  * Returns false when the patch cannot be applied cleanly:
  *   - chatId has no local messages yet (missing placeholder)
  *   - streamingMessageId is not found in local messages
- *   - patch offset is below the dropped boundary (impossible without a rewind)
- *   - local renderer content is shorter than effective offset (stale DB
- *     overwrite dropped bytes)
- *   - djb2 hash of the local prefix disagrees with prefixHash (only checked
- *     when priorBytesDropped === 0)
+ *   - local renderer content is shorter than patch offset (stale DB overwrite dropped bytes)
+ *   - djb2 hash of the local prefix disagrees with prefixHash (stale DB content
+ *     has same length but different prefix, e.g. a cleanFullResponse < → ＜
+ *     rewrite anywhere in the prefix after the DB write)
  * The caller should resync on false instead of splicing a new tail onto the wrong base.
  */
 export function applyStreamingPatch(
@@ -29,7 +21,6 @@ export function applyStreamingPatch(
   chatId: number,
   streamingMessageId: number,
   streamingPatch: StreamingPatch,
-  priorBytesDropped = 0,
 ): boolean {
   const { offset, content, prefixHash } = streamingPatch;
   let baseMismatch = false;
@@ -44,34 +35,19 @@ export function applyStreamingPatch(
       if (msg.id !== streamingMessageId) return msg;
       found = true;
       const currentContent = msg.content ?? "";
-      // Server-side absolute offset → renderer-local offset.
-      const effectiveOffset = offset - priorBytesDropped;
-      if (effectiveOffset < 0) {
+      if (currentContent.length < offset) {
         baseMismatch = true;
         return msg;
       }
-      if (currentContent.length < effectiveOffset) {
-        baseMismatch = true;
-        return msg;
-      }
-      // Skip prefix-hash check after we've dropped bytes — we no longer have
-      // the full prefix to recompute against. cleanFullResponse rewrites
-      // past the drop boundary become invisible, but the resync path on
-      // applied=false still rescues us if the tail divergence is detectable
-      // any other way.
       if (
-        priorBytesDropped === 0 &&
         prefixHash !== undefined &&
-        effectiveOffset > 0 &&
-        hashPrefix(currentContent, effectiveOffset) !== prefixHash
+        offset > 0 &&
+        hashPrefix(currentContent, offset) !== prefixHash
       ) {
         baseMismatch = true;
         return msg;
       }
-      return {
-        ...msg,
-        content: currentContent.slice(0, effectiveOffset) + content,
-      };
+      return { ...msg, content: currentContent.slice(0, offset) + content };
     });
     if (!found) {
       baseMismatch = true;

--- a/src/lib/applyStreamingPatch.ts
+++ b/src/lib/applyStreamingPatch.ts
@@ -2,25 +2,51 @@ import type { Message, StreamingPatch } from "@/ipc/types";
 import { hashPrefix } from "@/lib/prefixHash";
 
 /**
+ * Pure splice. Validates a tail-only streaming patch against the current
+ * renderer-local content and returns the new content (or a mismatch).
+ *
+ * `priorBytesDropped` is the cumulative number of bytes the renderer has
+ * discarded from the front of message.content (see trimContent). Server-
+ * side patch offsets are absolute, so the local effective offset is
+ * `offset - priorBytesDropped`. When dropped > 0 the prefixHash check is
+ * skipped — we no longer have the full prefix bytes to recompute the hash,
+ * and the trim is renderer-only / never round-tripped.
+ *
+ * Mismatches:
+ *   - effective offset is negative (impossible without a rewind)
+ *   - current content is shorter than the effective offset (stale base)
+ *   - djb2 hash of the local prefix disagrees with prefixHash (only
+ *     checked when priorBytesDropped === 0)
+ */
+export function applyStreamingPatchPure(
+  currentContent: string,
+  patch: StreamingPatch,
+  priorBytesDropped = 0,
+): { applied: true; content: string } | { applied: false } {
+  const { offset, content, prefixHash } = patch;
+  const effectiveOffset = offset - priorBytesDropped;
+  if (effectiveOffset < 0) return { applied: false };
+  if (currentContent.length < effectiveOffset) return { applied: false };
+  if (
+    priorBytesDropped === 0 &&
+    prefixHash !== undefined &&
+    effectiveOffset > 0 &&
+    hashPrefix(currentContent, effectiveOffset) !== prefixHash
+  ) {
+    return { applied: false };
+  }
+  return {
+    applied: true,
+    content: currentContent.slice(0, effectiveOffset) + content,
+  };
+}
+
+/**
  * Applies a tail-only streaming patch to the messages-by-id map atom.
- * Reconstructs the streaming message content as `current.slice(0, offset) + content`.
- *
- * `priorBytesDropped` is the cumulative number of bytes that the renderer
- * has discarded from the front of the local message.content (see
- * trimToLastNBlocks). Server-side patch offsets are absolute, so the local
- * effective offset is `offset - priorBytesDropped`. When dropped > 0 the
- * prefixHash check is skipped — we no longer have the full prefix bytes to
- * recompute the hash, and the trim is renderer-only / never round-tripped.
- *
- * Returns false when the patch cannot be applied cleanly:
- *   - chatId has no local messages yet (missing placeholder)
- *   - streamingMessageId is not found in local messages
- *   - patch offset is below the dropped boundary (impossible without a rewind)
- *   - local renderer content is shorter than effective offset (stale DB
- *     overwrite dropped bytes)
- *   - djb2 hash of the local prefix disagrees with prefixHash (only checked
- *     when priorBytesDropped === 0)
- * The caller should resync on false instead of splicing a new tail onto the wrong base.
+ * Thin atom-writing wrapper around applyStreamingPatchPure for callers
+ * that don't need the incremental parser pipeline (plan implementation,
+ * merge-conflict resolution). Returns false on mismatch; the caller
+ * should resync rather than splice onto the wrong base.
  */
 export function applyStreamingPatch(
   setMessagesById: (
@@ -31,56 +57,25 @@ export function applyStreamingPatch(
   streamingPatch: StreamingPatch,
   priorBytesDropped = 0,
 ): boolean {
-  const { offset, content, prefixHash } = streamingPatch;
-  let baseMismatch = false;
+  let applied = false;
   setMessagesById((prev) => {
     const existingMessages = prev.get(chatId);
-    if (!existingMessages) {
-      baseMismatch = true;
-      return prev;
-    }
-    let found = false;
-    const updated = existingMessages.map((msg) => {
-      if (msg.id !== streamingMessageId) return msg;
-      found = true;
-      const currentContent = msg.content ?? "";
-      // Server-side absolute offset → renderer-local offset.
-      const effectiveOffset = offset - priorBytesDropped;
-      if (effectiveOffset < 0) {
-        baseMismatch = true;
-        return msg;
-      }
-      if (currentContent.length < effectiveOffset) {
-        baseMismatch = true;
-        return msg;
-      }
-      // Skip prefix-hash check after we've dropped bytes — we no longer have
-      // the full prefix to recompute against. cleanFullResponse rewrites
-      // past the drop boundary become invisible, but the resync path on
-      // applied=false still rescues us if the tail divergence is detectable
-      // any other way.
-      if (
-        priorBytesDropped === 0 &&
-        prefixHash !== undefined &&
-        effectiveOffset > 0 &&
-        hashPrefix(currentContent, effectiveOffset) !== prefixHash
-      ) {
-        baseMismatch = true;
-        return msg;
-      }
-      return {
-        ...msg,
-        content: currentContent.slice(0, effectiveOffset) + content,
-      };
-    });
-    if (!found) {
-      baseMismatch = true;
-      return prev;
-    }
-    if (baseMismatch) return prev;
+    if (!existingMessages) return prev;
+    const msg = existingMessages.find((m) => m.id === streamingMessageId);
+    if (!msg) return prev;
+    const result = applyStreamingPatchPure(
+      msg.content ?? "",
+      streamingPatch,
+      priorBytesDropped,
+    );
+    if (!result.applied) return prev;
+    applied = true;
+    const updated = existingMessages.map((m) =>
+      m.id === streamingMessageId ? { ...m, content: result.content } : m,
+    );
     const next = new Map(prev);
     next.set(chatId, updated);
     return next;
   });
-  return !baseMismatch;
+  return applied;
 }

--- a/src/lib/streamingChunk.ts
+++ b/src/lib/streamingChunk.ts
@@ -1,0 +1,75 @@
+import type { StreamingPatch } from "@/ipc/types";
+import { applyStreamingPatchPure } from "@/lib/applyStreamingPatch";
+import {
+  advanceParser,
+  initialParserState,
+  trimContent,
+  type ParserState,
+} from "@/lib/streamingMessageParser";
+
+export interface StreamingChunkInput {
+  /** Renderer-local message.content before this patch. */
+  prevContent: string;
+  /** Cached parser state from the previous chunk, or undefined on the first patch. */
+  prevParserState: ParserState | undefined;
+  /** Cumulative bytes the renderer has trimmed off the front of content. */
+  prevDroppedBytes: number;
+  /** Incoming streaming patch. */
+  patch: StreamingPatch;
+}
+
+export type StreamingChunkResult =
+  | {
+      kind: "applied";
+      /** New content after splice + trim. */
+      content: string;
+      /** New parser state (cursor / openBlock / blocks shifted to new origin). */
+      parserState: ParserState;
+      /** New cumulative dropped-bytes count. */
+      droppedBytes: number;
+    }
+  | {
+      /** Patch could not be applied cleanly — caller should resync. */
+      kind: "mismatch";
+    }
+  | {
+      /** Patch produced identical content. Caller can skip atom writes. */
+      kind: "noop";
+    };
+
+/**
+ * Pure streaming-chunk pipeline. Splices the patch into prevContent, runs
+ * the incremental parser, and trims content past the open-block boundary
+ * in one step. The chunk handler reads atoms, calls this, and writes the
+ * result back. No side effects, no atom access — fully unit-testable.
+ *
+ * The trim is content-only: parser state.blocks is preserved so the
+ * renderer keeps showing committed blocks. Returned droppedBytes feeds
+ * the next call's offset translation.
+ */
+export function applyStreamingChunk({
+  prevContent,
+  prevParserState,
+  prevDroppedBytes,
+  patch,
+}: StreamingChunkInput): StreamingChunkResult {
+  const patched = applyStreamingPatchPure(prevContent, patch, prevDroppedBytes);
+  if (!patched.applied) return { kind: "mismatch" };
+
+  // Idempotent retransmit / no-op patch: skip parser advance and atom
+  // writes. Parser state is unchanged.
+  if (patched.content === prevContent && prevParserState !== undefined) {
+    return { kind: "noop" };
+  }
+
+  const baseState = prevParserState ?? initialParserState();
+  const advanced = advanceParser(baseState, patched.content);
+  const trim = trimContent(advanced, patched.content);
+
+  return {
+    kind: "applied",
+    content: trim.content,
+    parserState: trim.state,
+    droppedBytes: prevDroppedBytes + trim.bytesDropped,
+  };
+}

--- a/src/lib/streamingMessageParser.ts
+++ b/src/lib/streamingMessageParser.ts
@@ -183,11 +183,17 @@ function appendToMarkdownOpen(state: ParserState, text: string): void {
 function commitOpenMarkdown(state: ParserState, endOffset: number): void {
   if (state.openBlock && state.openBlock.kind === "markdown") {
     if (state.openBlock.content.length > 0) {
-      state.blocks.push({
-        ...state.openBlock,
-        complete: true,
-        endOffset,
-      });
+      // Immutable append: new array ref on commit so the renderer's
+      // closed-block memo wrapper invalidates exactly when a block closes
+      // and stays stable across "open block extends" chunks.
+      state.blocks = [
+        ...state.blocks,
+        {
+          ...state.openBlock,
+          complete: true,
+          endOffset,
+        },
+      ];
     }
     state.openBlock = null;
   }
@@ -198,16 +204,21 @@ function commitOpenMarkdown(state: ParserState, endOffset: number): void {
  * If `content` is shorter than state.cursor (a rewrite/resync), the parser
  * is reset and re-runs from scratch.
  *
- * Returns a NEW state object. Committed blocks share refs with the previous
- * state; the open block is rebuilt only when its content changes.
+ * Returns a NEW state object. Individual committed Block objects share refs
+ * with the previous state (so per-block React.memo hits); the blocks array
+ * gets a new ref only when a block closes during this advance, so the
+ * renderer's closed-block wrapper memo can short-circuit on chunks that
+ * just extend the open block. The open block is rebuilt only when its
+ * content changes.
  */
 export function advanceParser(prev: ParserState, content: string): ParserState {
   let state: ParserState;
   if (content.length < prev.cursor) {
     state = initialParserState();
   } else {
-    // Shallow clone — we mutate locally then return it. Committed blocks
-    // array reference is reused (we only push, never mutate prior entries).
+    // Shallow clone — we mutate locally then return it. The blocks array
+    // is reassigned (immutable append) on each commit, so prior refs are
+    // preserved on chunks that don't close any block.
     state = {
       cursor: prev.cursor,
       mode: prev.mode,
@@ -364,17 +375,21 @@ export function advanceParser(prev: ParserState, content: string): ParserState {
         const closing = state.pendingCloseName;
         if (state.currentTag && closing === state.currentTag.tag) {
           // Finalize the custom-tag block. End offset is one past the '>'.
+          // Immutable append (see commitOpenMarkdown).
           const finalContent = unescapeXmlContent(state.currentTag.rawContent);
-          state.blocks.push({
-            kind: "custom-tag",
-            id: state.currentTag.blockId,
-            tag: state.currentTag.tag,
-            attributes: state.currentTag.attributes,
-            content: finalContent,
-            complete: true,
-            inProgress: false,
-            endOffset: i + 1,
-          });
+          state.blocks = [
+            ...state.blocks,
+            {
+              kind: "custom-tag",
+              id: state.currentTag.blockId,
+              tag: state.currentTag.tag,
+              attributes: state.currentTag.attributes,
+              content: finalContent,
+              complete: true,
+              inProgress: false,
+              endOffset: i + 1,
+            },
+          ];
           state.currentTag = null;
           state.openBlock = null;
           state.pending = "";

--- a/src/lib/streamingMessageParser.ts
+++ b/src/lib/streamingMessageParser.ts
@@ -73,8 +73,6 @@ export type Block =
       id: number;
       content: string;
       complete: boolean;
-      /** Byte offset (in the parser's local content) at which this block ends. Set on commit. */
-      endOffset?: number;
     }
   | {
       kind: "custom-tag";
@@ -85,8 +83,6 @@ export type Block =
       complete: boolean;
       /** True when the closing tag has not yet been seen. */
       inProgress: boolean;
-      /** Byte offset (in the parser's local content) at which this block ends. Set on commit. */
-      endOffset?: number;
     };
 
 type Mode =
@@ -122,10 +118,16 @@ export interface ParserState {
   currentTag: OpenTag | null;
   /**
    * Byte offset of the '<' that started the most recent tag candidate.
-   * Valid while mode is tag-open / tag-attrs / tag-close-* — used to set
-   * the endOffset of the markdown block that preceded a real tag.
+   * Valid while mode is tag-open / tag-attrs — captured so a successful
+   * tag-attrs commit can record the new custom-tag block's start offset.
    */
   tagStartOffset: number;
+  /**
+   * Byte offset (in the parser's local content) where the current open
+   * block starts. Used by trimContent to cut the content string at the
+   * open block boundary. Stale when openBlock is null.
+   */
+  openBlockStartOffset: number;
   /** Open trailing block — markdown while in prose modes, custom-tag while in tag-content/close. */
   openBlock: Block | null;
   /** Committed (closed) blocks. Refs stable across updates. */
@@ -143,6 +145,7 @@ export function initialParserState(): ParserState {
     pendingCloseName: "",
     currentTag: null,
     tagStartOffset: 0,
+    openBlockStartOffset: 0,
     openBlock: null,
     blocks: [],
     nextBlockId: 0,
@@ -161,7 +164,11 @@ function parseAttributes(attrsStr: string): Record<string, string> {
   return out;
 }
 
-function appendToMarkdownOpen(state: ParserState, text: string): void {
+function appendToMarkdownOpen(
+  state: ParserState,
+  text: string,
+  startOffset: number,
+): void {
   if (!text) return;
   if (state.openBlock && state.openBlock.kind === "markdown") {
     state.openBlock = {
@@ -177,10 +184,11 @@ function appendToMarkdownOpen(state: ParserState, text: string): void {
       content: text,
       complete: false,
     };
+    state.openBlockStartOffset = startOffset;
   }
 }
 
-function commitOpenMarkdown(state: ParserState, endOffset: number): void {
+function commitOpenMarkdown(state: ParserState): void {
   if (state.openBlock && state.openBlock.kind === "markdown") {
     if (state.openBlock.content.length > 0) {
       // Immutable append: new array ref on commit so the renderer's
@@ -191,7 +199,6 @@ function commitOpenMarkdown(state: ParserState, endOffset: number): void {
         {
           ...state.openBlock,
           complete: true,
-          endOffset,
         },
       ];
     }
@@ -228,6 +235,7 @@ export function advanceParser(prev: ParserState, content: string): ParserState {
       pendingCloseName: prev.pendingCloseName,
       currentTag: prev.currentTag,
       tagStartOffset: prev.tagStartOffset,
+      openBlockStartOffset: prev.openBlockStartOffset,
       openBlock: prev.openBlock,
       blocks: prev.blocks,
       nextBlockId: prev.nextBlockId,
@@ -250,7 +258,7 @@ export function advanceParser(prev: ParserState, content: string): ParserState {
         // Fast-forward over a run of non-'<' chars; cheaper than per-char append.
         let j = i + 1;
         while (j < len && content[j] !== "<") j++;
-        appendToMarkdownOpen(state, content.slice(i, j));
+        appendToMarkdownOpen(state, content.slice(i, j), i);
         i = j;
       }
       continue;
@@ -277,7 +285,7 @@ export function advanceParser(prev: ParserState, content: string): ParserState {
         continue;
       }
       // Not a custom tag. Flush the buffered "<NAME" to markdown and resume.
-      appendToMarkdownOpen(state, state.pending);
+      appendToMarkdownOpen(state, state.pending, state.tagStartOffset);
       state.pending = "";
       state.mode = "prose";
       // Re-process current char in prose mode.
@@ -288,9 +296,8 @@ export function advanceParser(prev: ParserState, content: string): ParserState {
       if (ch === ">") {
         const attrs = parseAttributes(state.pendingAttrs);
         // Commit the prior markdown block (if any) so the new tag block
-        // becomes the trailing open block. The markdown block ends at the
-        // '<' that began this tag.
-        commitOpenMarkdown(state, state.tagStartOffset);
+        // becomes the trailing open block.
+        commitOpenMarkdown(state);
         state.currentTag = {
           tag: state.pendingTagName,
           attributes: attrs,
@@ -306,6 +313,8 @@ export function advanceParser(prev: ParserState, content: string): ParserState {
           complete: false,
           inProgress: true,
         };
+        // Custom-tag block starts at the '<' that opened it.
+        state.openBlockStartOffset = state.tagStartOffset;
         state.pendingTagName = "";
         state.pendingAttrs = "";
         state.mode = "tag-content";
@@ -374,8 +383,7 @@ export function advanceParser(prev: ParserState, content: string): ParserState {
       if (ch === ">") {
         const closing = state.pendingCloseName;
         if (state.currentTag && closing === state.currentTag.tag) {
-          // Finalize the custom-tag block. End offset is one past the '>'.
-          // Immutable append (see commitOpenMarkdown).
+          // Finalize the custom-tag block. Immutable append (see commitOpenMarkdown).
           const finalContent = unescapeXmlContent(state.currentTag.rawContent);
           state.blocks = [
             ...state.blocks,
@@ -387,7 +395,6 @@ export function advanceParser(prev: ParserState, content: string): ParserState {
               content: finalContent,
               complete: true,
               inProgress: false,
-              endOffset: i + 1,
             },
           ];
           state.currentTag = null;
@@ -448,14 +455,12 @@ export function advanceParser(prev: ParserState, content: string): ParserState {
 }
 
 /**
- * Materialize the current visible block list. Pending bytes mid-tag-name
- * are surfaced as appended markdown text so they show as raw text while
- * the next byte is awaited (matches the existing parseCustomTags behavior
+ * The currently-visible open (trailing) block, or null if there is none.
+ * Pending bytes mid-tag-name are surfaced as appended markdown text so the
+ * user sees them streaming (matches the existing parseCustomTags behavior
  * for unfinished opening tags without a '>').
  */
-export function getParserBlocks(state: ParserState): Block[] {
-  // When mid-disambiguation of a possible opening tag, surface the pending
-  // bytes as raw markdown text so the user sees them streaming.
+export function getOpenBlock(state: ParserState): Block | null {
   let synthesized = "";
   if (state.mode === "tag-open") {
     synthesized = state.pending;
@@ -465,30 +470,35 @@ export function getParserBlocks(state: ParserState): Block[] {
 
   if (state.openBlock) {
     if (synthesized && state.openBlock.kind === "markdown") {
-      return [
-        ...state.blocks,
-        {
-          kind: "markdown",
-          id: state.openBlock.id,
-          content: state.openBlock.content + synthesized,
-          complete: false,
-        },
-      ];
+      return {
+        kind: "markdown",
+        id: state.openBlock.id,
+        content: state.openBlock.content + synthesized,
+        complete: false,
+      };
     }
-    return [...state.blocks, state.openBlock];
+    return state.openBlock;
   }
   if (synthesized) {
-    return [
-      ...state.blocks,
-      {
-        kind: "markdown",
-        id: state.nextBlockId,
-        content: synthesized,
-        complete: false,
-      },
-    ];
+    return {
+      kind: "markdown",
+      id: state.nextBlockId,
+      content: synthesized,
+      complete: false,
+    };
   }
-  return state.blocks;
+  return null;
+}
+
+/**
+ * Materialize the full current block list (closed + open). Used for
+ * one-shot parses (parseFullMessage) and tests; the streaming renderer
+ * reads state.blocks and getOpenBlock(state) directly so the closed-block
+ * array ref stays stable across non-commit chunks.
+ */
+export function getParserBlocks(state: ParserState): Block[] {
+  const open = getOpenBlock(state);
+  return open ? [...state.blocks, open] : state.blocks;
 }
 
 /**
@@ -504,42 +514,40 @@ export function parseFullMessage(content: string): {
 }
 
 /**
- * Drop the oldest committed blocks beyond `keepLastN`, slicing the content
- * string at the byte boundary of the last dropped block. Returns adjusted
- * state and content. The open block (if any) and parser scan position
- * are shifted to the new origin so subsequent advanceParser calls keep
- * working in local coordinates.
+ * Trim the front of the local content string up to the open block's start
+ * (or up to cursor when there is no open block and the parser is in clean
+ * prose). Closed blocks remain in state.blocks for the renderer; only the
+ * raw content string and the parser's scan offsets shift to a new origin.
+ *
+ * Skipped (no-op) when the parser is mid-disambiguation (tag-open /
+ * tag-attrs / tag-close-*) with no open block — the next chunk usually
+ * resolves the disambiguation, after which trim works again.
  *
  * Caller is responsible for tracking the cumulative `bytesDropped` so
  * incoming streaming patches (which carry server-side offsets) can be
  * translated to local coordinates.
  */
-export function trimToLastNBlocks(
+export function trimContent(
   state: ParserState,
   content: string,
-  keepLastN: number,
 ): { state: ParserState; content: string; bytesDropped: number } {
-  if (state.blocks.length <= keepLastN) {
+  let cutAt: number;
+  if (state.openBlock !== null) {
+    cutAt = state.openBlockStartOffset;
+  } else if (state.mode === "prose") {
+    cutAt = state.cursor;
+  } else {
     return { state, content, bytesDropped: 0 };
   }
-  const dropCount = state.blocks.length - keepLastN;
-  const lastDropped = state.blocks[dropCount - 1];
-  // Every committed block must have an endOffset (parser sets it on commit).
-  // If somehow absent (forward-compat), bail out instead of corrupting state.
-  if (lastDropped.endOffset === undefined) {
+  if (cutAt <= 0) {
     return { state, content, bytesDropped: 0 };
   }
-  const cutAt = lastDropped.endOffset;
   const newContent = content.slice(cutAt);
-  const remaining = state.blocks.slice(dropCount).map((b) => ({
-    ...b,
-    endOffset: b.endOffset !== undefined ? b.endOffset - cutAt : b.endOffset,
-  }));
   const newState: ParserState = {
     ...state,
     cursor: state.cursor - cutAt,
-    tagStartOffset: Math.max(0, state.tagStartOffset - cutAt),
-    blocks: remaining,
+    tagStartOffset: 0,
+    openBlockStartOffset: 0,
   };
   return { state: newState, content: newContent, bytesDropped: cutAt };
 }

--- a/src/lib/streamingMessageParser.ts
+++ b/src/lib/streamingMessageParser.ts
@@ -1,0 +1,566 @@
+import { unescapeXmlAttr, unescapeXmlContent } from "../../shared/xmlEscape";
+
+/**
+ * Incremental dyad-tag parser.
+ *
+ * Goal: feed the message content as it grows and emit a list of stable
+ * block objects for the renderer. Completed blocks keep referential
+ * identity across updates so React.memo can skip them. Only the open
+ * trailing block changes refs while bytes are arriving.
+ *
+ * The visible block list (getParserBlocks) is identical to what
+ * parseCustomTags produced on the same final string, with one streaming-only
+ * caveat: pending bytes between an unrecognized "<" / partial opening tag
+ * and its disambiguating character are temporarily attached to the trailing
+ * markdown block, then re-shaped if the bytes turn into a real opening tag.
+ *
+ * The parser does NOT decide between "in-progress" vs "aborted" — that's
+ * the renderer's call based on whether the chat is still streaming. We only
+ * mark blocks as `complete` (closing tag seen) vs not.
+ */
+
+// Mirror of DYAD_CUSTOM_TAGS in DyadMarkdownParser. Kept here as the source
+// of truth so the parser doesn't depend on the renderer file.
+const DYAD_CUSTOM_TAG_NAMES = [
+  "dyad-write",
+  "dyad-rename",
+  "dyad-delete",
+  "dyad-add-dependency",
+  "dyad-execute-sql",
+  "dyad-read-logs",
+  "dyad-add-integration",
+  "dyad-enable-nitro",
+  "dyad-output",
+  "dyad-problem-report",
+  "dyad-chat-summary",
+  "dyad-edit",
+  "dyad-grep",
+  "dyad-search-replace",
+  "dyad-codebase-context",
+  "dyad-web-search-result",
+  "dyad-web-search",
+  "dyad-web-crawl",
+  "dyad-web-fetch",
+  "dyad-code-search-result",
+  "dyad-code-search",
+  "dyad-read",
+  "think",
+  "dyad-command",
+  "dyad-mcp-tool-call",
+  "dyad-mcp-tool-result",
+  "dyad-list-files",
+  "dyad-database-schema",
+  "dyad-db-table-schema",
+  "dyad-supabase-table-schema",
+  "dyad-supabase-project-info",
+  "dyad-neon-project-info",
+  "dyad-neon-table-schema",
+  "dyad-read-guide",
+  "dyad-status",
+  "dyad-compaction",
+  "dyad-copy",
+  "dyad-image-generation",
+  "dyad-write-plan",
+  "dyad-exit-plan",
+  "dyad-questionnaire",
+  "dyad-step-limit",
+];
+const DYAD_CUSTOM_TAG_SET = new Set(DYAD_CUSTOM_TAG_NAMES);
+
+/**
+ * Tags that represent a tool call (i.e. the LLM interacting with its
+ * environment). Sourced from `pro/main/ipc/handlers/local_agent/tools/`:
+ * any tool whose `buildXml` emits one of these dyad-* tags is a tool call.
+ * Used by the renderer's tail-only cap to bucket dropped blocks into
+ * "markdown" vs "tool-call" for the omitted-blocks summary.
+ */
+export const TOOL_CALL_TAGS: ReadonlySet<string> = new Set([
+  "dyad-write",
+  "dyad-rename",
+  "dyad-delete",
+  "dyad-add-dependency",
+  "dyad-execute-sql",
+  "dyad-read-logs",
+  "dyad-add-integration",
+  "dyad-enable-nitro",
+  "dyad-grep",
+  "dyad-search-replace",
+  "dyad-web-search",
+  "dyad-web-crawl",
+  "dyad-web-fetch",
+  "dyad-code-search",
+  "dyad-read",
+  "dyad-list-files",
+  "dyad-db-table-schema",
+  "dyad-supabase-project-info",
+  "dyad-neon-project-info",
+  "dyad-read-guide",
+  "dyad-status",
+  "dyad-copy",
+  "dyad-image-generation",
+  "dyad-write-plan",
+  "dyad-exit-plan",
+  "dyad-questionnaire",
+]);
+
+export type Block =
+  | {
+      kind: "markdown";
+      id: number;
+      content: string;
+      complete: boolean;
+      /** Byte offset (in the parser's local content) at which this block ends. Set on commit. */
+      endOffset?: number;
+    }
+  | {
+      kind: "custom-tag";
+      id: number;
+      tag: string;
+      attributes: Record<string, string>;
+      content: string;
+      complete: boolean;
+      /** True when the closing tag has not yet been seen. */
+      inProgress: boolean;
+      /** Byte offset (in the parser's local content) at which this block ends. Set on commit. */
+      endOffset?: number;
+    };
+
+type Mode =
+  | "prose" // looking for "<" that may begin a custom tag
+  | "tag-open" // saw "<", reading a name
+  | "tag-attrs" // saw "<NAME ", reading attributes until ">"
+  | "tag-content" // inside a tag's content
+  | "tag-close-start" // saw "<" inside tag content
+  | "tag-close-name"; // saw "</", reading closing name until ">"
+
+interface OpenTag {
+  tag: string;
+  attributes: Record<string, string>;
+  /** Block id assigned when opening. */
+  blockId: number;
+  /** Accumulated raw (still escaped) content. */
+  rawContent: string;
+}
+
+export interface ParserState {
+  /** Bytes from `content` already consumed. */
+  cursor: number;
+  mode: Mode;
+  /** Bytes seen but not yet committed (e.g. partial "<dyad-..."). */
+  pending: string;
+  /** While in tag-attrs, the tag name. */
+  pendingTagName: string;
+  /** While in tag-attrs, raw chars between name and '>'. */
+  pendingAttrs: string;
+  /** While in tag-close-name, raw chars after "</". */
+  pendingCloseName: string;
+  /** The currently-open custom tag, if mode is tag-content / tag-close-*. */
+  currentTag: OpenTag | null;
+  /**
+   * Byte offset of the '<' that started the most recent tag candidate.
+   * Valid while mode is tag-open / tag-attrs / tag-close-* — used to set
+   * the endOffset of the markdown block that preceded a real tag.
+   */
+  tagStartOffset: number;
+  /** Open trailing block — markdown while in prose modes, custom-tag while in tag-content/close. */
+  openBlock: Block | null;
+  /** Committed (closed) blocks. Refs stable across updates. */
+  blocks: Block[];
+  nextBlockId: number;
+}
+
+export function initialParserState(): ParserState {
+  return {
+    cursor: 0,
+    mode: "prose",
+    pending: "",
+    pendingTagName: "",
+    pendingAttrs: "",
+    pendingCloseName: "",
+    currentTag: null,
+    tagStartOffset: 0,
+    openBlock: null,
+    blocks: [],
+    nextBlockId: 0,
+  };
+}
+
+const NAME_CHAR = /[A-Za-z0-9-]/;
+
+function parseAttributes(attrsStr: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  const re = /([\w-]+)="([^"]*)"/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(attrsStr)) !== null) {
+    out[m[1]] = unescapeXmlAttr(m[2]);
+  }
+  return out;
+}
+
+function appendToMarkdownOpen(state: ParserState, text: string): void {
+  if (!text) return;
+  if (state.openBlock && state.openBlock.kind === "markdown") {
+    state.openBlock = {
+      kind: "markdown",
+      id: state.openBlock.id,
+      content: state.openBlock.content + text,
+      complete: false,
+    };
+  } else {
+    state.openBlock = {
+      kind: "markdown",
+      id: state.nextBlockId++,
+      content: text,
+      complete: false,
+    };
+  }
+}
+
+function commitOpenMarkdown(state: ParserState, endOffset: number): void {
+  if (state.openBlock && state.openBlock.kind === "markdown") {
+    if (state.openBlock.content.length > 0) {
+      state.blocks.push({
+        ...state.openBlock,
+        complete: true,
+        endOffset,
+      });
+    }
+    state.openBlock = null;
+  }
+}
+
+/**
+ * Advance the parser through `content` starting from state.cursor.
+ * If `content` is shorter than state.cursor (a rewrite/resync), the parser
+ * is reset and re-runs from scratch.
+ *
+ * Returns a NEW state object. Committed blocks share refs with the previous
+ * state; the open block is rebuilt only when its content changes.
+ */
+export function advanceParser(prev: ParserState, content: string): ParserState {
+  let state: ParserState;
+  if (content.length < prev.cursor) {
+    state = initialParserState();
+  } else {
+    // Shallow clone — we mutate locally then return it. Committed blocks
+    // array reference is reused (we only push, never mutate prior entries).
+    state = {
+      cursor: prev.cursor,
+      mode: prev.mode,
+      pending: prev.pending,
+      pendingTagName: prev.pendingTagName,
+      pendingAttrs: prev.pendingAttrs,
+      pendingCloseName: prev.pendingCloseName,
+      currentTag: prev.currentTag,
+      tagStartOffset: prev.tagStartOffset,
+      openBlock: prev.openBlock,
+      blocks: prev.blocks,
+      nextBlockId: prev.nextBlockId,
+    };
+  }
+
+  const len = content.length;
+  let i = state.cursor;
+
+  while (i < len) {
+    const ch = content[i];
+
+    if (state.mode === "prose") {
+      if (ch === "<") {
+        state.pending = "<";
+        state.tagStartOffset = i;
+        state.mode = "tag-open";
+        i++;
+      } else {
+        // Fast-forward over a run of non-'<' chars; cheaper than per-char append.
+        let j = i + 1;
+        while (j < len && content[j] !== "<") j++;
+        appendToMarkdownOpen(state, content.slice(i, j));
+        i = j;
+      }
+      continue;
+    }
+
+    if (state.mode === "tag-open") {
+      if (NAME_CHAR.test(ch)) {
+        state.pending += ch;
+        i++;
+        continue;
+      }
+      // Disambiguator. The pending buffer is "<NAME". To be a real custom
+      // tag, NAME must be in the set AND the next char must be ws or '>'.
+      const name = state.pending.slice(1);
+      if (
+        DYAD_CUSTOM_TAG_SET.has(name) &&
+        (ch === " " || ch === "\t" || ch === "\n" || ch === "\r" || ch === ">")
+      ) {
+        state.pendingTagName = name;
+        state.pendingAttrs = "";
+        state.pending = "";
+        state.mode = "tag-attrs";
+        // Don't advance i — let tag-attrs see this char (handles '>' immediately).
+        continue;
+      }
+      // Not a custom tag. Flush the buffered "<NAME" to markdown and resume.
+      appendToMarkdownOpen(state, state.pending);
+      state.pending = "";
+      state.mode = "prose";
+      // Re-process current char in prose mode.
+      continue;
+    }
+
+    if (state.mode === "tag-attrs") {
+      if (ch === ">") {
+        const attrs = parseAttributes(state.pendingAttrs);
+        // Commit the prior markdown block (if any) so the new tag block
+        // becomes the trailing open block. The markdown block ends at the
+        // '<' that began this tag.
+        commitOpenMarkdown(state, state.tagStartOffset);
+        state.currentTag = {
+          tag: state.pendingTagName,
+          attributes: attrs,
+          blockId: state.nextBlockId++,
+          rawContent: "",
+        };
+        state.openBlock = {
+          kind: "custom-tag",
+          id: state.currentTag.blockId,
+          tag: state.currentTag.tag,
+          attributes: state.currentTag.attributes,
+          content: "",
+          complete: false,
+          inProgress: true,
+        };
+        state.pendingTagName = "";
+        state.pendingAttrs = "";
+        state.mode = "tag-content";
+        i++;
+        continue;
+      }
+      // Fast-forward attribute bytes.
+      let j = i;
+      while (j < len && content[j] !== ">") j++;
+      state.pendingAttrs += content.slice(i, j);
+      i = j;
+      continue;
+    }
+
+    if (state.mode === "tag-content") {
+      if (ch === "<") {
+        state.pending = "<";
+        state.mode = "tag-close-start";
+        i++;
+        continue;
+      }
+      // Fast-forward run of non-'<' content into rawContent.
+      let j = i + 1;
+      while (j < len && content[j] !== "<") j++;
+      const chunk = content.slice(i, j);
+      if (state.currentTag) {
+        state.currentTag.rawContent += chunk;
+        const open = state.openBlock;
+        if (open && open.kind === "custom-tag") {
+          state.openBlock = {
+            ...open,
+            content: unescapeXmlContent(state.currentTag.rawContent),
+          };
+        }
+      }
+      i = j;
+      continue;
+    }
+
+    if (state.mode === "tag-close-start") {
+      if (ch === "/") {
+        state.pending += "/";
+        state.pendingCloseName = "";
+        state.mode = "tag-close-name";
+        i++;
+        continue;
+      }
+      // Not a closing tag — '<' was content. Push pending into rawContent and resume.
+      if (state.currentTag) {
+        state.currentTag.rawContent += state.pending;
+        const open = state.openBlock;
+        if (open && open.kind === "custom-tag") {
+          state.openBlock = {
+            ...open,
+            content: unescapeXmlContent(state.currentTag.rawContent),
+          };
+        }
+      }
+      state.pending = "";
+      state.mode = "tag-content";
+      // Reprocess current char in tag-content (handles consecutive "<").
+      continue;
+    }
+
+    if (state.mode === "tag-close-name") {
+      if (ch === ">") {
+        const closing = state.pendingCloseName;
+        if (state.currentTag && closing === state.currentTag.tag) {
+          // Finalize the custom-tag block. End offset is one past the '>'.
+          const finalContent = unescapeXmlContent(state.currentTag.rawContent);
+          state.blocks.push({
+            kind: "custom-tag",
+            id: state.currentTag.blockId,
+            tag: state.currentTag.tag,
+            attributes: state.currentTag.attributes,
+            content: finalContent,
+            complete: true,
+            inProgress: false,
+            endOffset: i + 1,
+          });
+          state.currentTag = null;
+          state.openBlock = null;
+          state.pending = "";
+          state.pendingCloseName = "";
+          state.mode = "prose";
+          i++;
+          continue;
+        }
+        // Mismatched closing — treat the buffered "</NAME>" as raw content.
+        // state.pending already contains "</NAME"; just append the closing '>'.
+        const buffered = state.pending + ">";
+        if (state.currentTag) {
+          state.currentTag.rawContent += buffered;
+          const open = state.openBlock;
+          if (open && open.kind === "custom-tag") {
+            state.openBlock = {
+              ...open,
+              content: unescapeXmlContent(state.currentTag.rawContent),
+            };
+          }
+        }
+        state.pending = "";
+        state.pendingCloseName = "";
+        state.mode = "tag-content";
+        i++;
+        continue;
+      }
+      if (NAME_CHAR.test(ch)) {
+        state.pendingCloseName += ch;
+        state.pending += ch;
+        i++;
+        continue;
+      }
+      // Unexpected char inside closing name — treat the buffer as raw content.
+      const buffered = state.pending;
+      if (state.currentTag) {
+        state.currentTag.rawContent += buffered;
+        const open = state.openBlock;
+        if (open && open.kind === "custom-tag") {
+          state.openBlock = {
+            ...open,
+            content: unescapeXmlContent(state.currentTag.rawContent),
+          };
+        }
+      }
+      state.pending = "";
+      state.pendingCloseName = "";
+      state.mode = "tag-content";
+      // Reprocess this char as content.
+      continue;
+    }
+  }
+
+  state.cursor = len;
+  return state;
+}
+
+/**
+ * Materialize the current visible block list. Pending bytes mid-tag-name
+ * are surfaced as appended markdown text so they show as raw text while
+ * the next byte is awaited (matches the existing parseCustomTags behavior
+ * for unfinished opening tags without a '>').
+ */
+export function getParserBlocks(state: ParserState): Block[] {
+  // When mid-disambiguation of a possible opening tag, surface the pending
+  // bytes as raw markdown text so the user sees them streaming.
+  let synthesized = "";
+  if (state.mode === "tag-open") {
+    synthesized = state.pending;
+  } else if (state.mode === "tag-attrs") {
+    synthesized = "<" + state.pendingTagName + state.pendingAttrs;
+  }
+
+  if (state.openBlock) {
+    if (synthesized && state.openBlock.kind === "markdown") {
+      return [
+        ...state.blocks,
+        {
+          kind: "markdown",
+          id: state.openBlock.id,
+          content: state.openBlock.content + synthesized,
+          complete: false,
+        },
+      ];
+    }
+    return [...state.blocks, state.openBlock];
+  }
+  if (synthesized) {
+    return [
+      ...state.blocks,
+      {
+        kind: "markdown",
+        id: state.nextBlockId,
+        content: synthesized,
+        complete: false,
+      },
+    ];
+  }
+  return state.blocks;
+}
+
+/**
+ * One-shot parse of `content`. Used for non-streaming messages (history,
+ * post-completion) so the renderer's block-list pipeline is uniform.
+ */
+export function parseFullMessage(content: string): {
+  state: ParserState;
+  blocks: Block[];
+} {
+  const state = advanceParser(initialParserState(), content);
+  return { state, blocks: getParserBlocks(state) };
+}
+
+/**
+ * Drop the oldest committed blocks beyond `keepLastN`, slicing the content
+ * string at the byte boundary of the last dropped block. Returns adjusted
+ * state and content. The open block (if any) and parser scan position
+ * are shifted to the new origin so subsequent advanceParser calls keep
+ * working in local coordinates.
+ *
+ * Caller is responsible for tracking the cumulative `bytesDropped` so
+ * incoming streaming patches (which carry server-side offsets) can be
+ * translated to local coordinates.
+ */
+export function trimToLastNBlocks(
+  state: ParserState,
+  content: string,
+  keepLastN: number,
+): { state: ParserState; content: string; bytesDropped: number } {
+  if (state.blocks.length <= keepLastN) {
+    return { state, content, bytesDropped: 0 };
+  }
+  const dropCount = state.blocks.length - keepLastN;
+  const lastDropped = state.blocks[dropCount - 1];
+  // Every committed block must have an endOffset (parser sets it on commit).
+  // If somehow absent (forward-compat), bail out instead of corrupting state.
+  if (lastDropped.endOffset === undefined) {
+    return { state, content, bytesDropped: 0 };
+  }
+  const cutAt = lastDropped.endOffset;
+  const newContent = content.slice(cutAt);
+  const remaining = state.blocks.slice(dropCount).map((b) => ({
+    ...b,
+    endOffset: b.endOffset !== undefined ? b.endOffset - cutAt : b.endOffset,
+  }));
+  const newState: ParserState = {
+    ...state,
+    cursor: state.cursor - cutAt,
+    tagStartOffset: Math.max(0, state.tagStartOffset - cutAt),
+    blocks: remaining,
+  };
+  return { state: newState, content: newContent, bytesDropped: cutAt };
+}

--- a/src/lib/streamingMessageParser.ts
+++ b/src/lib/streamingMessageParser.ts
@@ -67,50 +67,12 @@ const DYAD_CUSTOM_TAG_NAMES = [
 ];
 const DYAD_CUSTOM_TAG_SET = new Set(DYAD_CUSTOM_TAG_NAMES);
 
-/**
- * Tags that represent a tool call (i.e. the LLM interacting with its
- * environment). Sourced from `pro/main/ipc/handlers/local_agent/tools/`:
- * any tool whose `buildXml` emits one of these dyad-* tags is a tool call.
- * Used by the renderer's tail-only cap to bucket dropped blocks into
- * "markdown" vs "tool-call" for the omitted-blocks summary.
- */
-export const TOOL_CALL_TAGS: ReadonlySet<string> = new Set([
-  "dyad-write",
-  "dyad-rename",
-  "dyad-delete",
-  "dyad-add-dependency",
-  "dyad-execute-sql",
-  "dyad-read-logs",
-  "dyad-add-integration",
-  "dyad-enable-nitro",
-  "dyad-grep",
-  "dyad-search-replace",
-  "dyad-web-search",
-  "dyad-web-crawl",
-  "dyad-web-fetch",
-  "dyad-code-search",
-  "dyad-read",
-  "dyad-list-files",
-  "dyad-db-table-schema",
-  "dyad-supabase-project-info",
-  "dyad-neon-project-info",
-  "dyad-read-guide",
-  "dyad-status",
-  "dyad-copy",
-  "dyad-image-generation",
-  "dyad-write-plan",
-  "dyad-exit-plan",
-  "dyad-questionnaire",
-]);
-
 export type Block =
   | {
       kind: "markdown";
       id: number;
       content: string;
       complete: boolean;
-      /** Byte offset (in the parser's local content) at which this block ends. Set on commit. */
-      endOffset?: number;
     }
   | {
       kind: "custom-tag";
@@ -121,8 +83,6 @@ export type Block =
       complete: boolean;
       /** True when the closing tag has not yet been seen. */
       inProgress: boolean;
-      /** Byte offset (in the parser's local content) at which this block ends. Set on commit. */
-      endOffset?: number;
     };
 
 type Mode =
@@ -156,12 +116,6 @@ export interface ParserState {
   pendingCloseName: string;
   /** The currently-open custom tag, if mode is tag-content / tag-close-*. */
   currentTag: OpenTag | null;
-  /**
-   * Byte offset of the '<' that started the most recent tag candidate.
-   * Valid while mode is tag-open / tag-attrs / tag-close-* — used to set
-   * the endOffset of the markdown block that preceded a real tag.
-   */
-  tagStartOffset: number;
   /** Open trailing block — markdown while in prose modes, custom-tag while in tag-content/close. */
   openBlock: Block | null;
   /** Committed (closed) blocks. Refs stable across updates. */
@@ -178,7 +132,6 @@ export function initialParserState(): ParserState {
     pendingAttrs: "",
     pendingCloseName: "",
     currentTag: null,
-    tagStartOffset: 0,
     openBlock: null,
     blocks: [],
     nextBlockId: 0,
@@ -216,13 +169,12 @@ function appendToMarkdownOpen(state: ParserState, text: string): void {
   }
 }
 
-function commitOpenMarkdown(state: ParserState, endOffset: number): void {
+function commitOpenMarkdown(state: ParserState): void {
   if (state.openBlock && state.openBlock.kind === "markdown") {
     if (state.openBlock.content.length > 0) {
       state.blocks.push({
         ...state.openBlock,
         complete: true,
-        endOffset,
       });
     }
     state.openBlock = null;
@@ -252,7 +204,6 @@ export function advanceParser(prev: ParserState, content: string): ParserState {
       pendingAttrs: prev.pendingAttrs,
       pendingCloseName: prev.pendingCloseName,
       currentTag: prev.currentTag,
-      tagStartOffset: prev.tagStartOffset,
       openBlock: prev.openBlock,
       blocks: prev.blocks,
       nextBlockId: prev.nextBlockId,
@@ -268,7 +219,6 @@ export function advanceParser(prev: ParserState, content: string): ParserState {
     if (state.mode === "prose") {
       if (ch === "<") {
         state.pending = "<";
-        state.tagStartOffset = i;
         state.mode = "tag-open";
         i++;
       } else {
@@ -313,9 +263,8 @@ export function advanceParser(prev: ParserState, content: string): ParserState {
       if (ch === ">") {
         const attrs = parseAttributes(state.pendingAttrs);
         // Commit the prior markdown block (if any) so the new tag block
-        // becomes the trailing open block. The markdown block ends at the
-        // '<' that began this tag.
-        commitOpenMarkdown(state, state.tagStartOffset);
+        // becomes the trailing open block.
+        commitOpenMarkdown(state);
         state.currentTag = {
           tag: state.pendingTagName,
           attributes: attrs,
@@ -399,7 +348,7 @@ export function advanceParser(prev: ParserState, content: string): ParserState {
       if (ch === ">") {
         const closing = state.pendingCloseName;
         if (state.currentTag && closing === state.currentTag.tag) {
-          // Finalize the custom-tag block. End offset is one past the '>'.
+          // Finalize the custom-tag block.
           const finalContent = unescapeXmlContent(state.currentTag.rawContent);
           state.blocks.push({
             kind: "custom-tag",
@@ -409,7 +358,6 @@ export function advanceParser(prev: ParserState, content: string): ParserState {
             content: finalContent,
             complete: true,
             inProgress: false,
-            endOffset: i + 1,
           });
           state.currentTag = null;
           state.openBlock = null;
@@ -522,45 +470,4 @@ export function parseFullMessage(content: string): {
 } {
   const state = advanceParser(initialParserState(), content);
   return { state, blocks: getParserBlocks(state) };
-}
-
-/**
- * Drop the oldest committed blocks beyond `keepLastN`, slicing the content
- * string at the byte boundary of the last dropped block. Returns adjusted
- * state and content. The open block (if any) and parser scan position
- * are shifted to the new origin so subsequent advanceParser calls keep
- * working in local coordinates.
- *
- * Caller is responsible for tracking the cumulative `bytesDropped` so
- * incoming streaming patches (which carry server-side offsets) can be
- * translated to local coordinates.
- */
-export function trimToLastNBlocks(
-  state: ParserState,
-  content: string,
-  keepLastN: number,
-): { state: ParserState; content: string; bytesDropped: number } {
-  if (state.blocks.length <= keepLastN) {
-    return { state, content, bytesDropped: 0 };
-  }
-  const dropCount = state.blocks.length - keepLastN;
-  const lastDropped = state.blocks[dropCount - 1];
-  // Every committed block must have an endOffset (parser sets it on commit).
-  // If somehow absent (forward-compat), bail out instead of corrupting state.
-  if (lastDropped.endOffset === undefined) {
-    return { state, content, bytesDropped: 0 };
-  }
-  const cutAt = lastDropped.endOffset;
-  const newContent = content.slice(cutAt);
-  const remaining = state.blocks.slice(dropCount).map((b) => ({
-    ...b,
-    endOffset: b.endOffset !== undefined ? b.endOffset - cutAt : b.endOffset,
-  }));
-  const newState: ParserState = {
-    ...state,
-    cursor: state.cursor - cutAt,
-    tagStartOffset: Math.max(0, state.tagStartOffset - cutAt),
-    blocks: remaining,
-  };
-  return { state: newState, content: newContent, bytesDropped: cutAt };
 }

--- a/src/lib/streamingMessageParser.ts
+++ b/src/lib/streamingMessageParser.ts
@@ -73,6 +73,8 @@ export type Block =
       id: number;
       content: string;
       complete: boolean;
+      /** Byte offset (in the parser's local content) at which this block ends. Set on commit. */
+      endOffset?: number;
     }
   | {
       kind: "custom-tag";
@@ -83,6 +85,8 @@ export type Block =
       complete: boolean;
       /** True when the closing tag has not yet been seen. */
       inProgress: boolean;
+      /** Byte offset (in the parser's local content) at which this block ends. Set on commit. */
+      endOffset?: number;
     };
 
 type Mode =
@@ -116,6 +120,12 @@ export interface ParserState {
   pendingCloseName: string;
   /** The currently-open custom tag, if mode is tag-content / tag-close-*. */
   currentTag: OpenTag | null;
+  /**
+   * Byte offset of the '<' that started the most recent tag candidate.
+   * Valid while mode is tag-open / tag-attrs / tag-close-* — used to set
+   * the endOffset of the markdown block that preceded a real tag.
+   */
+  tagStartOffset: number;
   /** Open trailing block — markdown while in prose modes, custom-tag while in tag-content/close. */
   openBlock: Block | null;
   /** Committed (closed) blocks. Refs stable across updates. */
@@ -132,6 +142,7 @@ export function initialParserState(): ParserState {
     pendingAttrs: "",
     pendingCloseName: "",
     currentTag: null,
+    tagStartOffset: 0,
     openBlock: null,
     blocks: [],
     nextBlockId: 0,
@@ -169,12 +180,13 @@ function appendToMarkdownOpen(state: ParserState, text: string): void {
   }
 }
 
-function commitOpenMarkdown(state: ParserState): void {
+function commitOpenMarkdown(state: ParserState, endOffset: number): void {
   if (state.openBlock && state.openBlock.kind === "markdown") {
     if (state.openBlock.content.length > 0) {
       state.blocks.push({
         ...state.openBlock,
         complete: true,
+        endOffset,
       });
     }
     state.openBlock = null;
@@ -204,6 +216,7 @@ export function advanceParser(prev: ParserState, content: string): ParserState {
       pendingAttrs: prev.pendingAttrs,
       pendingCloseName: prev.pendingCloseName,
       currentTag: prev.currentTag,
+      tagStartOffset: prev.tagStartOffset,
       openBlock: prev.openBlock,
       blocks: prev.blocks,
       nextBlockId: prev.nextBlockId,
@@ -219,6 +232,7 @@ export function advanceParser(prev: ParserState, content: string): ParserState {
     if (state.mode === "prose") {
       if (ch === "<") {
         state.pending = "<";
+        state.tagStartOffset = i;
         state.mode = "tag-open";
         i++;
       } else {
@@ -263,8 +277,9 @@ export function advanceParser(prev: ParserState, content: string): ParserState {
       if (ch === ">") {
         const attrs = parseAttributes(state.pendingAttrs);
         // Commit the prior markdown block (if any) so the new tag block
-        // becomes the trailing open block.
-        commitOpenMarkdown(state);
+        // becomes the trailing open block. The markdown block ends at the
+        // '<' that began this tag.
+        commitOpenMarkdown(state, state.tagStartOffset);
         state.currentTag = {
           tag: state.pendingTagName,
           attributes: attrs,
@@ -348,7 +363,7 @@ export function advanceParser(prev: ParserState, content: string): ParserState {
       if (ch === ">") {
         const closing = state.pendingCloseName;
         if (state.currentTag && closing === state.currentTag.tag) {
-          // Finalize the custom-tag block.
+          // Finalize the custom-tag block. End offset is one past the '>'.
           const finalContent = unescapeXmlContent(state.currentTag.rawContent);
           state.blocks.push({
             kind: "custom-tag",
@@ -358,6 +373,7 @@ export function advanceParser(prev: ParserState, content: string): ParserState {
             content: finalContent,
             complete: true,
             inProgress: false,
+            endOffset: i + 1,
           });
           state.currentTag = null;
           state.openBlock = null;
@@ -470,4 +486,45 @@ export function parseFullMessage(content: string): {
 } {
   const state = advanceParser(initialParserState(), content);
   return { state, blocks: getParserBlocks(state) };
+}
+
+/**
+ * Drop the oldest committed blocks beyond `keepLastN`, slicing the content
+ * string at the byte boundary of the last dropped block. Returns adjusted
+ * state and content. The open block (if any) and parser scan position
+ * are shifted to the new origin so subsequent advanceParser calls keep
+ * working in local coordinates.
+ *
+ * Caller is responsible for tracking the cumulative `bytesDropped` so
+ * incoming streaming patches (which carry server-side offsets) can be
+ * translated to local coordinates.
+ */
+export function trimToLastNBlocks(
+  state: ParserState,
+  content: string,
+  keepLastN: number,
+): { state: ParserState; content: string; bytesDropped: number } {
+  if (state.blocks.length <= keepLastN) {
+    return { state, content, bytesDropped: 0 };
+  }
+  const dropCount = state.blocks.length - keepLastN;
+  const lastDropped = state.blocks[dropCount - 1];
+  // Every committed block must have an endOffset (parser sets it on commit).
+  // If somehow absent (forward-compat), bail out instead of corrupting state.
+  if (lastDropped.endOffset === undefined) {
+    return { state, content, bytesDropped: 0 };
+  }
+  const cutAt = lastDropped.endOffset;
+  const newContent = content.slice(cutAt);
+  const remaining = state.blocks.slice(dropCount).map((b) => ({
+    ...b,
+    endOffset: b.endOffset !== undefined ? b.endOffset - cutAt : b.endOffset,
+  }));
+  const newState: ParserState = {
+    ...state,
+    cursor: state.cursor - cutAt,
+    tagStartOffset: Math.max(0, state.tagStartOffset - cutAt),
+    blocks: remaining,
+  };
+  return { state: newState, content: newContent, bytesDropped: cutAt };
 }


### PR DESCRIPTION
Throwaway, do not merge

---

As for which parts specifically relate to the trimming of `message.content`:

 1. src/lib/streamingMessageParser.ts — the trim primitive
  - trimContent(state, content) (line 530) — the actual trim. Cuts content at openBlockStartOffset (or cursor in prose), returns bytesDropped.
  Adjusts cursor, leaves blocks/openBlock intact.
  - openBlockStartOffset field in ParserState (line ~127) + how advanceParser sets it — defines the cut boundary.

  2. src/atoms/chatAtoms.ts — the two state holders (lines ~267–286)
  - streamingBlocksByMessageIdAtom — cached parser state.
  - contentBytesDroppedByMessageIdAtom — cumulative dropped bytes (offset translation).

  3. src/lib/applyStreamingPatch.ts — offset translation
  - applyStreamingPatchPure(content, patch, droppedBytes) — subtracts droppedBytes so absolute server offsets map onto trimmed local content. This
  is what makes trimming correct (without it, patches splice at wrong position). The mismatch path matters here.
  
  4. src/lib/streamingChunk.ts — the pipeline gluing it together
  - applyStreamingChunk(...) — splice → advanceParser → trimContent. Returns applied/mismatch/noop. Whole file is small, read it all.
  
  5. src/hooks/useStreamChat.ts — wiring (the +93 in cffa1fe0)
  - Chunk handler ~line 75: reads both atoms, calls applyStreamingChunk, writes back result.droppedBytes + parser state.
  - Cleanup .delete()/.clear() on stream end / full replace (lines ~51, 126, 153) — both atoms cleared so renderer reparses DB content.

  Tests: src/__tests__/streamingMessageParser.test.ts (trim cases), src/__tests__/streamingChunk.test.ts (pipeline, mismatch/noop).
