### PR TITLE
Pin all setup-node GitHub Actions to Node v24.13.1

### DIFF
--- a/.github/workflows/claude-deflake-e2e.yml
+++ b/.github/workflows/claude-deflake-e2e.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Initialize environment
         uses: actions/setup-node@v4
         with:
-          node-version-file: package.json
+          node-version: v24.13.1
           cache: npm
           cache-dependency-path: package-lock.json
 

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: v24.13.1
 
       - name: Build PR review context
         id: context

--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: v24.13.1
 
       - name: Render triage prompt
         id: render-prompt

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: v24.13.1
 
       - name: Build PR review context
         id: context

--- a/.github/workflows/flakiness-upload.yml
+++ b/.github/workflows/flakiness-upload.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: v24.13.1
 
       # Download each shard's flakiness report separately to preserve structure
       - name: Download flakiness reports

--- a/.github/workflows/github-security-advisory-alerts.yml
+++ b/.github/workflows/github-security-advisory-alerts.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: v24.13.1
 
       - name: Send advisory alert email
         env:

--- a/.github/workflows/playwright-comment.yml
+++ b/.github/workflows/playwright-comment.yml
@@ -73,7 +73,7 @@ jobs:
         if: ${{ steps.pr.outputs.number != '' }}
         uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: v24.13.1
 
       - name: Download Playwright HTML report
         if: ${{ steps.pr.outputs.number != '' }}

--- a/.github/workflows/pr-review-alerts.yml
+++ b/.github/workflows/pr-review-alerts.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: v24.13.1
 
       - name: Send PR review alert email
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
-          node-version-file: package.json
+          node-version: v24.13.1
           package-manager-cache: false # Do NOT use GitHub Actions cache in release builds: https://adnanthekhan.com/2024/12/21/cacheract-the-monster-in-your-build-cache/
       - name: Install npm 11.8.0
         run: npm install -g npm@11.8.0
@@ -133,7 +133,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
-          node-version-file: package.json
+          node-version: v24.13.1
           package-manager-cache: false # Do NOT use GitHub Actions cache in release builds: https://adnanthekhan.com/2024/12/21/cacheract-the-monster-in-your-build-cache/
       - name: Install npm 11.8.0
         run: npm install -g npm@11.8.0
@@ -167,7 +167,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
-          node-version-file: package.json
+          node-version: v24.13.1
           package-manager-cache: false # Do NOT use GitHub Actions cache in release builds: https://adnanthekhan.com/2024/12/21/cacheract-the-monster-in-your-build-cache/
       - name: Verify all release assets are uploaded
         env:


### PR DESCRIPTION
## Summary
- Pin every `actions/setup-node` step across GitHub workflows to `node-version: v24.13.1`
- Replaces mixed sources (`package.json`, `lts/*`, and Node 22) for consistent CI behavior

## Test plan
- [x] `npm run fmt && npm run lint:fix && npm run ts`
- [x] `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)