### PR TITLE
Fix Neon migration preview introspection

### DIFF
--- a/rules/database-drizzle.md
+++ b/rules/database-drizzle.md
@@ -10,6 +10,12 @@ npm run db:generate
 
 IMPORTANT: Do NOT generate SQL migration files by hand! This is wrong.
 
+## Neon migration preview
+
+When diffing Neon branches with `ts-pg-schema-diff`, use unpooled connection
+URIs. Neon pooled `-pooler` hosts reject PostgreSQL startup `options` like
+`statement_timeout` with `unsupported startup parameter in options`.
+
 ## Drizzle migration conflicts during rebase
 
 When rebasing a branch that has drizzle migrations conflicting with upstream (e.g., both have `0028_*.sql`), prefer regenerating over manually editing snapshot/journal files:

--- a/src/ipc/utils/migration_utils.test.ts
+++ b/src/ipc/utils/migration_utils.test.ts
@@ -11,6 +11,7 @@ import {
   MIGRATION_SCHEMA_DIFF_CONNECTION_OPTIONS,
   MIGRATION_SCHEMA_DIFF_INCLUDE_SCHEMAS,
   deriveDestructiveReasons,
+  logger,
 } from "./migration_utils";
 import { DyadErrorKind } from "@/errors/dyad_error";
 
@@ -97,6 +98,9 @@ describe("generateNeonMigrationStatements", () => {
   });
 
   it("maps introspection failures to external errors", async () => {
+    const loggerErrorSpy = vi
+      .spyOn(logger, "error")
+      .mockImplementation(() => {});
     generateSchemaDiffMock.mockRejectedValue(
       new PgSchemaDiffError("Failed to introspect current database schema", {
         cause: new Error("connect ECONNRESET"),
@@ -111,8 +115,18 @@ describe("generateNeonMigrationStatements", () => {
     ).rejects.toMatchObject({
       kind: DyadErrorKind.External,
       message:
-        "Failed to compute migration plan: Failed to introspect current database schema",
+        "Failed to compute migration plan: Failed to introspect current database schema: Error: connect ECONNRESET",
     });
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      "Failed to compute migration plan. Cause chain:",
+      expect.stringContaining(
+        "PgSchemaDiffError: Failed to introspect current database schema",
+      ),
+    );
+    expect(loggerErrorSpy.mock.calls[0]?.[1]).toContain(
+      "caused by: Error: connect ECONNRESET",
+    );
+    loggerErrorSpy.mockRestore();
   });
 });
 

--- a/src/ipc/utils/migration_utils.ts
+++ b/src/ipc/utils/migration_utils.ts
@@ -208,10 +208,66 @@ function toMigrationDiffDyadError(error: unknown): DyadError {
     error instanceof PgSchemaDiffError || error instanceof Error
       ? error.message
       : String(error);
+  logger.error(
+    "Failed to compute migration plan. Cause chain:",
+    formatErrorCauseChain(error),
+  );
+  const causeSummary = formatErrorCauseSummary(error);
   return new DyadError(
-    `Failed to compute migration plan: ${message}`,
+    causeSummary
+      ? `Failed to compute migration plan: ${message}: ${causeSummary}`
+      : `Failed to compute migration plan: ${message}`,
     DyadErrorKind.External,
   );
+}
+
+function formatErrorCauseSummary(error: unknown): string | null {
+  const seen = new Set<unknown>();
+  const messages: string[] = [];
+  let current =
+    error instanceof Error
+      ? (error as Error & { cause?: unknown }).cause
+      : undefined;
+
+  while (current instanceof Error && !seen.has(current)) {
+    seen.add(current);
+    messages.push(`${current.name}: ${current.message}`);
+    current = (current as Error & { cause?: unknown }).cause;
+  }
+
+  if (current !== undefined && !seen.has(current)) {
+    messages.push(String(current));
+  }
+
+  return messages.length === 0 ? null : messages.join(": ");
+}
+
+function formatErrorCauseChain(error: unknown): string {
+  const seen = new Set<unknown>();
+  const lines: string[] = [];
+  let current: unknown = error;
+  while (current instanceof Error && !seen.has(current)) {
+    seen.add(current);
+    lines.push(formatErrorForLog(current));
+    current = (current as Error & { cause?: unknown }).cause;
+  }
+
+  if (current !== undefined && !seen.has(current)) {
+    lines.push(String(current));
+  }
+
+  return lines
+    .map((line, index) => (index === 0 ? line : `caused by: ${line}`))
+    .join("\n");
+}
+
+function formatErrorForLog(error: Error): string {
+  const details = [
+    error.name,
+    error.message,
+    error.stack ? `stack: ${error.stack}` : null,
+  ].filter(Boolean);
+  return details.join(": ");
 }
 
 function findErrorInCauseChain(
@@ -267,10 +323,12 @@ export async function prepareMigrationContext({
   const devUri = await getConnectionUri({
     projectId,
     branchId: devBranchId,
+    pooled: false,
   });
   const prodUri = await getConnectionUri({
     projectId,
     branchId: prodBranchId,
+    pooled: false,
   });
 
   logger.info(

--- a/src/neon_admin/neon_context.test.ts
+++ b/src/neon_admin/neon_context.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getNeonClient } from "./neon_management_client";
+import { getConnectionUri } from "./neon_context";
+
+vi.mock("./neon_management_client", () => ({
+  getNeonClient: vi.fn(),
+}));
+
+const getNeonClientMock = vi.mocked(getNeonClient);
+
+describe("getConnectionUri", () => {
+  beforeEach(() => {
+    getNeonClientMock.mockReset();
+  });
+
+  it("forwards the pooled option to Neon", async () => {
+    const neonClient = {
+      listProjectBranchRoles: vi.fn().mockResolvedValue({
+        data: { roles: [{ name: "neondb_owner", protected: false }] },
+      }),
+      listProjectBranchDatabases: vi.fn().mockResolvedValue({
+        data: { databases: [{ name: "neondb" }] },
+      }),
+      getConnectionUri: vi.fn().mockResolvedValue({
+        data: { uri: "postgresql://test" },
+      }),
+    };
+    getNeonClientMock.mockResolvedValue(
+      neonClient as unknown as Awaited<ReturnType<typeof getNeonClient>>,
+    );
+
+    await expect(
+      getConnectionUri({
+        projectId: "project-id",
+        branchId: "branch-id",
+        pooled: false,
+      }),
+    ).resolves.toBe("postgresql://test");
+
+    expect(neonClient.getConnectionUri).toHaveBeenCalledWith({
+      projectId: "project-id",
+      branch_id: "branch-id",
+      database_name: "neondb",
+      role_name: "neondb_owner",
+      pooled: false,
+    });
+  });
+});

--- a/src/neon_admin/neon_context.ts
+++ b/src/neon_admin/neon_context.ts
@@ -112,9 +112,11 @@ export async function getBranchDatabaseName({
 export async function getConnectionUri({
   projectId,
   branchId,
+  pooled,
 }: {
   projectId: string;
   branchId: string;
+  pooled?: boolean;
 }): Promise<string> {
   const neonClient = await getNeonClient();
   const [roleName, databaseName] = await Promise.all([
@@ -126,6 +128,7 @@ export async function getConnectionUri({
     branch_id: branchId,
     database_name: databaseName,
     role_name: roleName,
+    pooled,
   });
   return response.data.uri;
 }


### PR DESCRIPTION
## Summary
- Use unpooled Neon connection URIs for migration preview schema diff introspection so startup timeout options are accepted.
- Surface concise schema-diff cause details in user-facing migration preview errors while logging the full cause chain.
- Add tests for Neon pooled URI forwarding and migration diff error cause reporting.

## Test plan
- npm run fmt
- npm run lint:fix
- npm run ts
- npm test