### PR TITLE
Reject enum value reuse in Neon transaction migrations

### DIFF
--- a/packages/ts-pg-schema-diff/README.md
+++ b/packages/ts-pg-schema-diff/README.md
@@ -46,7 +46,7 @@ type SchemaDiffResult = {
 ```
 
 Execute statements sequentially against `currentDatabaseUrl` to move it toward `desiredDatabaseUrl`.
-Do not wrap the whole result in one transaction: PostgreSQL rejects `CREATE INDEX CONCURRENTLY` and `DROP INDEX CONCURRENTLY` inside transaction blocks. If your executor requires a single transaction, call `generateSchemaDiff({ currentDatabaseUrl, desiredDatabaseUrl, noConcurrentIndexOperations: true })` and review the stronger locking behavior before applying.
+Do not wrap the whole result in one transaction: PostgreSQL rejects `CREATE INDEX CONCURRENTLY` and `DROP INDEX CONCURRENTLY` inside transaction blocks. If your executor requires a single transaction, call `generateSchemaDiff({ currentDatabaseUrl, desiredDatabaseUrl, noConcurrentIndexOperations: true, rejectEnumValueUsageInSameTransaction: true })` and review the stronger locking behavior before applying. The enum guard rejects plans that add a new enum value and use that value in a later statement, because PostgreSQL does not allow the value to be used until the transaction that added it commits.
 
 Connection options are passed to the underlying `pg` pool for both databases. The default pool size is `1` per database because introspection only needs one checked-out connection per side.
 

--- a/packages/ts-pg-schema-diff/src/generators/schema.ts
+++ b/packages/ts-pg-schema-diff/src/generators/schema.ts
@@ -578,8 +578,17 @@ function checkConstraintUsesAddedEnumLabel(
   constraint: CheckConstraint,
   addition: EnumValueAddition,
 ): string | null {
+  const enumColumnNames = new Set(
+    table.columns
+      .filter((column) => columnUsesType(column, addition.typeNames))
+      .map((column) => column.name),
+  );
+  if (enumColumnNames.size === 0) {
+    return null;
+  }
   if (
-    !table.columns.some((column) => columnUsesType(column, addition.typeNames))
+    constraint.keyColumns.length > 0 &&
+    !constraint.keyColumns.some((columnName) => enumColumnNames.has(columnName))
   ) {
     return null;
   }

--- a/packages/ts-pg-schema-diff/src/generators/schema.ts
+++ b/packages/ts-pg-schema-diff/src/generators/schema.ts
@@ -587,9 +587,12 @@ function checkConstraintUsesAddedEnumLabel(
 }
 
 function findAddedLabelReference(
-  expression: string,
+  expression: string | null | undefined,
   labels: readonly string[],
 ): string | null {
+  if (expression == null) {
+    return null;
+  }
   for (const label of labels) {
     if (expression.includes(`'${escapeStringLiteral(label)}'`)) {
       return label;

--- a/packages/ts-pg-schema-diff/src/generators/schema.ts
+++ b/packages/ts-pg-schema-diff/src/generators/schema.ts
@@ -108,7 +108,7 @@ export function generateStatements(
   for (const viewDiff of diff.materializedViewDiffs.alters) {
     assertMaterializedViewCanBeRecreated(viewDiff.old, diff);
   }
-  return orderStatementSections([
+  const statements = orderStatementSections([
     {
       id: "named-schema:add",
       statements: diff.namedSchemaDiffs.adds.map(addNamedSchema),
@@ -285,6 +285,12 @@ export function generateStatements(
       statements: diff.namedSchemaDiffs.deletes.map(deleteNamedSchema),
     },
   ]);
+
+  if (options.rejectEnumValueUsageInSameTransaction === true) {
+    assertNoEnumValueUsageInSameTransaction(diff);
+  }
+
+  return statements;
 }
 
 type StatementSection = {
@@ -429,6 +435,167 @@ function assertEnumCanBeRecreated(schemaEnum: Enum, diff: SchemaDiff): void {
       `removing labels from enum ${fqName(schemaEnum.name)} is not supported because it is used by table ${fqName(referencingTable.name)}`,
     );
   }
+}
+
+type EnumValueAddition = {
+  readonly schemaEnum: Enum;
+  readonly labels: readonly string[];
+  readonly typeNames: ReadonlySet<string>;
+};
+
+function assertNoEnumValueUsageInSameTransaction(diff: SchemaDiff): void {
+  const additions = enumValueAdditions(diff);
+  if (additions.length === 0) {
+    return;
+  }
+
+  for (const addition of additions) {
+    const usage = findSameTransactionEnumValueUsage(diff, addition);
+    if (usage === null) {
+      continue;
+    }
+    throw new NotImplementedMigrationError(
+      `adding enum value ${usage.label} to ${fqName(addition.schemaEnum.name)} and using it in ${usage.location} is not supported in a single transaction. Apply the enum value change first, then regenerate the migration preview.`,
+    );
+  }
+}
+
+function enumValueAdditions(diff: SchemaDiff): readonly EnumValueAddition[] {
+  return diff.enumDiffs.alters
+    .map((enumDiff) => {
+      const oldLabels = new Set(enumDiff.old.labels);
+      const labels = enumDiff.next.labels.filter(
+        (label) => !oldLabels.has(label),
+      );
+      return {
+        schemaEnum: enumDiff.next,
+        labels,
+        typeNames: enumTypeNameCandidates(enumDiff.next),
+      };
+    })
+    .filter((addition) => addition.labels.length > 0);
+}
+
+function findSameTransactionEnumValueUsage(
+  diff: SchemaDiff,
+  addition: EnumValueAddition,
+): { readonly label: string; readonly location: string } | null {
+  for (const table of diff.tableDiffs.adds) {
+    const usage = findEnumValueUsageInTable(table, addition);
+    if (usage !== null) {
+      return { ...usage, location: `${fqName(table.name)} ${usage.location}` };
+    }
+  }
+
+  for (const tableDiff of diff.tableDiffs.alters) {
+    for (const column of tableDiff.columnsDiff.adds) {
+      const label = enumColumnDefaultUsesAddedLabel(column, addition);
+      if (label !== null) {
+        return {
+          label,
+          location: `${fqName(tableDiff.next.name)} column ${escapeIdentifier(column.name)} default`,
+        };
+      }
+    }
+
+    for (const columnDiff of tableDiff.columnsDiff.alters) {
+      const label = enumColumnDefaultUsesAddedLabel(columnDiff.next, addition);
+      if (
+        label !== null &&
+        columnDiff.old.default !== columnDiff.next.default
+      ) {
+        return {
+          label,
+          location: `${fqName(tableDiff.next.name)} column ${escapeIdentifier(columnDiff.next.name)} default`,
+        };
+      }
+    }
+
+    for (const constraint of [
+      ...tableDiff.checkConstraintDiff.adds,
+      ...tableDiff.checkConstraintDiff.alters.map(
+        (constraintDiff) => constraintDiff.next,
+      ),
+    ]) {
+      const label = checkConstraintUsesAddedEnumLabel(
+        tableDiff.next,
+        constraint,
+        addition,
+      );
+      if (label !== null) {
+        return {
+          label,
+          location: `${fqName(tableDiff.next.name)} check constraint ${escapeIdentifier(constraint.name)}`,
+        };
+      }
+    }
+  }
+
+  return null;
+}
+
+function findEnumValueUsageInTable(
+  table: Table,
+  addition: EnumValueAddition,
+): { readonly label: string; readonly location: string } | null {
+  for (const column of table.columns) {
+    const label = enumColumnDefaultUsesAddedLabel(column, addition);
+    if (label !== null) {
+      return {
+        label,
+        location: `column ${escapeIdentifier(column.name)} default`,
+      };
+    }
+  }
+  for (const constraint of table.checkConstraints) {
+    const label = checkConstraintUsesAddedEnumLabel(
+      table,
+      constraint,
+      addition,
+    );
+    if (label !== null) {
+      return {
+        label,
+        location: `check constraint ${escapeIdentifier(constraint.name)}`,
+      };
+    }
+  }
+  return null;
+}
+
+function enumColumnDefaultUsesAddedLabel(
+  column: Column,
+  addition: EnumValueAddition,
+): string | null {
+  if (!columnUsesType(column, addition.typeNames)) {
+    return null;
+  }
+  return findAddedLabelReference(column.default, addition.labels);
+}
+
+function checkConstraintUsesAddedEnumLabel(
+  table: Table,
+  constraint: CheckConstraint,
+  addition: EnumValueAddition,
+): string | null {
+  if (
+    !table.columns.some((column) => columnUsesType(column, addition.typeNames))
+  ) {
+    return null;
+  }
+  return findAddedLabelReference(constraint.expression, addition.labels);
+}
+
+function findAddedLabelReference(
+  expression: string,
+  labels: readonly string[],
+): string | null {
+  for (const label of labels) {
+    if (expression.includes(`'${escapeStringLiteral(label)}'`)) {
+      return label;
+    }
+  }
+  return null;
 }
 
 function columnUsesType(

--- a/packages/ts-pg-schema-diff/src/index.ts
+++ b/packages/ts-pg-schema-diff/src/index.ts
@@ -24,6 +24,7 @@ export type GenerateSchemaDiffOptions = {
   readonly includeSchemas?: readonly string[];
   readonly excludeSchemas?: readonly string[];
   readonly noConcurrentIndexOperations?: boolean;
+  readonly rejectEnumValueUsageInSameTransaction?: boolean;
   readonly connection?: DatabaseConnectionOptions;
 };
 
@@ -41,10 +42,17 @@ export async function generateSchemaDiff(
     readSchema("desired", options.desiredDatabaseUrl, options),
   ]);
 
-  const planOptions: GeneratePlanOptions =
-    options.noConcurrentIndexOperations === undefined
+  const planOptions: GeneratePlanOptions = {
+    ...(options.noConcurrentIndexOperations === undefined
       ? {}
-      : { noConcurrentIndexOperations: options.noConcurrentIndexOperations };
+      : { noConcurrentIndexOperations: options.noConcurrentIndexOperations }),
+    ...(options.rejectEnumValueUsageInSameTransaction === undefined
+      ? {}
+      : {
+          rejectEnumValueUsageInSameTransaction:
+            options.rejectEnumValueUsageInSameTransaction,
+        }),
+  };
   return toSchemaDiffResult(
     generatePlan(currentSchema, desiredSchema, planOptions),
   );

--- a/packages/ts-pg-schema-diff/src/plan/generate.ts
+++ b/packages/ts-pg-schema-diff/src/plan/generate.ts
@@ -7,6 +7,7 @@ import type { InternalStatement, SchemaDiffResult } from "./types.js";
 
 export type GeneratePlanOptions = {
   readonly noConcurrentIndexOperations?: boolean;
+  readonly rejectEnumValueUsageInSameTransaction?: boolean;
 };
 
 export type InternalPlan = {

--- a/packages/ts-pg-schema-diff/test/unit.test.ts
+++ b/packages/ts-pg-schema-diff/test/unit.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../src/schema/identifiers.js";
 import {
   emptySchema,
+  type CheckConstraint,
   type Column,
   type ForeignKeyConstraint,
   type FunctionSchema,
@@ -178,6 +179,92 @@ describe("generatePlan", () => {
     ).toThrow(
       'adding enum value ok to "public"."mood" and using it in "public"."messages" column "mood" default is not supported in a single transaction',
     );
+  });
+
+  it("rejects enum value additions used by a later check constraint", () => {
+    const current: Schema = {
+      ...emptySchema(),
+      enums: [
+        {
+          kind: "enum",
+          name: schemaQualifiedName("public", "mood"),
+          labels: ["sad"],
+        },
+      ],
+      tables: [table("messages", [column("mood", "mood", false)])],
+    };
+    const desired: Schema = {
+      ...emptySchema(),
+      enums: [
+        {
+          kind: "enum",
+          name: schemaQualifiedName("public", "mood"),
+          labels: ["sad", "ok"],
+        },
+      ],
+      tables: [
+        {
+          ...table("messages", [column("mood", "mood", false)]),
+          checkConstraints: [
+            checkConstraint("messages_mood_check", ["mood"], "mood = 'ok'"),
+          ],
+        },
+      ],
+    };
+
+    expect(() =>
+      generatePlan(current, desired, {
+        rejectEnumValueUsageInSameTransaction: true,
+      }),
+    ).toThrow(
+      'adding enum value ok to "public"."mood" and using it in "public"."messages" check constraint "messages_mood_check" is not supported in a single transaction',
+    );
+  });
+
+  it("ignores unrelated check constraints when guarding enum value additions", () => {
+    const current: Schema = {
+      ...emptySchema(),
+      enums: [
+        {
+          kind: "enum",
+          name: schemaQualifiedName("public", "mood"),
+          labels: ["sad"],
+        },
+      ],
+      tables: [
+        table("messages", [
+          column("mood", "mood", false),
+          column("note", "text", false),
+        ]),
+      ],
+    };
+    const desired: Schema = {
+      ...emptySchema(),
+      enums: [
+        {
+          kind: "enum",
+          name: schemaQualifiedName("public", "mood"),
+          labels: ["sad", "ok"],
+        },
+      ],
+      tables: [
+        {
+          ...table("messages", [
+            column("mood", "mood", false),
+            column("note", "text", false),
+          ]),
+          checkConstraints: [
+            checkConstraint("messages_note_check", ["note"], "note <> 'ok'"),
+          ],
+        },
+      ],
+    };
+
+    expect(() =>
+      generatePlan(current, desired, {
+        rejectEnumValueUsageInSameTransaction: true,
+      }),
+    ).not.toThrow();
   });
 
   it("renames a replaced index before creating the new index and dropping the old one", () => {
@@ -861,6 +948,22 @@ function table(name: string, columns: readonly Column[]): Table {
     partitionKeyDef: "",
     parentTable: null,
     forValues: "",
+  };
+}
+
+function checkConstraint(
+  name: string,
+  keyColumns: readonly string[],
+  expression: string,
+): CheckConstraint {
+  return {
+    kind: "checkConstraint",
+    name,
+    keyColumns,
+    expression,
+    isValid: true,
+    isInheritable: true,
+    dependsOnFunctions: [],
   };
 }
 

--- a/packages/ts-pg-schema-diff/test/unit.test.ts
+++ b/packages/ts-pg-schema-diff/test/unit.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest";
 import { buildPoolConfig } from "../src/db/connect.js";
 import { assertSupportedPostgresVersion } from "../src/db/introspect.js";
 import { diffLists } from "../src/diff/listDiff.js";
-import { DuplicateIdentifierError } from "../src/errors.js";
+import {
+  DuplicateIdentifierError,
+  NotImplementedMigrationError,
+} from "../src/errors.js";
 import { toPublicStatement } from "../src/plan/classify.js";
 import { generatePlan, toSchemaDiffResult } from "../src/plan/generate.js";
 import type { InternalStatement, MigrationHazard } from "../src/plan/types.js";
@@ -123,6 +126,58 @@ describe("generatePlan", () => {
         type: "destructive",
       },
     ]);
+  });
+
+  it("rejects enum value additions used by a later statement in one transaction", () => {
+    const current: Schema = {
+      ...emptySchema(),
+      enums: [
+        {
+          kind: "enum",
+          name: schemaQualifiedName("public", "mood"),
+          labels: ["sad"],
+        },
+      ],
+      tables: [
+        table("messages", [
+          {
+            ...column("mood", "mood", false),
+            default: "'sad'::mood",
+          },
+        ]),
+      ],
+    };
+    const desired: Schema = {
+      ...emptySchema(),
+      enums: [
+        {
+          kind: "enum",
+          name: schemaQualifiedName("public", "mood"),
+          labels: ["sad", "ok"],
+        },
+      ],
+      tables: [
+        table("messages", [
+          {
+            ...column("mood", "mood", false),
+            default: "'ok'::mood",
+          },
+        ]),
+      ],
+    };
+
+    expect(() =>
+      generatePlan(current, desired, {
+        rejectEnumValueUsageInSameTransaction: true,
+      }),
+    ).toThrow(NotImplementedMigrationError);
+    expect(() =>
+      generatePlan(current, desired, {
+        rejectEnumValueUsageInSameTransaction: true,
+      }),
+    ).toThrow(
+      'adding enum value ok to "public"."mood" and using it in "public"."messages" column "mood" default is not supported in a single transaction',
+    );
   });
 
   it("renames a replaced index before creating the new index and dropping the old one", () => {

--- a/src/ipc/utils/migration_utils.test.ts
+++ b/src/ipc/utils/migration_utils.test.ts
@@ -55,6 +55,7 @@ describe("generateNeonMigrationStatements", () => {
       desiredDatabaseUrl: "postgresql://dev",
       includeSchemas: MIGRATION_SCHEMA_DIFF_INCLUDE_SCHEMAS,
       noConcurrentIndexOperations: true,
+      rejectEnumValueUsageInSameTransaction: true,
       connection: MIGRATION_SCHEMA_DIFF_CONNECTION_OPTIONS,
     });
   });

--- a/src/ipc/utils/migration_utils.ts
+++ b/src/ipc/utils/migration_utils.ts
@@ -169,6 +169,7 @@ export async function generateNeonMigrationStatements({
       desiredDatabaseUrl,
       includeSchemas: MIGRATION_SCHEMA_DIFF_INCLUDE_SCHEMAS,
       noConcurrentIndexOperations: true,
+      rejectEnumValueUsageInSameTransaction: true,
       connection: MIGRATION_SCHEMA_DIFF_CONNECTION_OPTIONS,
     });
     return diff.statements;


### PR DESCRIPTION
## Summary
- add an opt-in ts-pg-schema-diff guard that rejects plans which add a PostgreSQL enum value and use that new label later in the same transaction
- enable the guard for Dyad Neon migration previews, where apply runs the statement list in one transaction
- document the transactional enum caveat and cover the default-value regression path

## Why
PostgreSQL does not allow a newly added enum value to be used until the transaction that added it commits. Dyad currently applies Neon migration previews as one transaction, so plans like ALTER TYPE ADD VALUE followed by an ALTER TABLE SET DEFAULT using that value can look valid in preview and then fail at apply time. This turns that case into an early, clear precondition error that tells the user to apply the enum label change first and regenerate the preview.

Closes #3520

## Tests
- npm --prefix packages/ts-pg-schema-diff test
- npm --prefix packages/ts-pg-schema-diff run typecheck
- npm test -- src/ipc/utils/migration_utils.test.ts
- npm run fmt:check
- npm run ts