### PR TITLE
Shard self-hosted macOS E2E across four runners

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -56,7 +56,7 @@ flowchart TD
 | `draft-stale-prs.yml`        | `Draft stale PRs`              | Converts inactive open PRs to draft after 7 days without meaningful activity.                                   | Daily cron (`0 0 * * *`) or `workflow_dispatch`.                                                                     | None.                                                                                                                                                                                               |
 | `label-rebase-prs.yml`       | `Label PRs needing rebase`     | Finds conflicting open PRs from allowed authors and flags them for rebase.                                      | `push` to `main`.                                                                                                    | Adds `cc:rebase` when eligible PR is conflicted (`mergeable_state == dirty`) and not already in rebase states.                                                                                      |
 | `merge-pr.yml`               | `Merge PR when ready`          | Auto-merges eligible PRs after successful CI when all checks pass.                                              | `workflow_run` for `CI` on `completed` (successful PR-triggered CI only).                                            | None (reads `merge-when-ready`, does not set labels).                                                                                                                                               |
-| `nightly-runner-cleanup.yml` | `Nightly Runner Cleanup`       | Safely frees disk space on self-hosted runner ci1 (caches, npm, runner \_work).                                 | Daily cron (4 AM PST); or `workflow_dispatch`.                                                                       | None.                                                                                                                                                                                               |
+| `nightly-runner-cleanup.yml` | `Nightly Runner Cleanup`       | Safely frees disk space on self-hosted macOS runners ci1-ci4 (caches, npm, runner \_work).                      | Daily cron (4 AM PST); or `workflow_dispatch`.                                                                       | None.                                                                                                                                                                                               |
 | `playwright-comment.yml`     | `Playwright Report Comment`    | Posts a Playwright summary comment on the PR tied to a completed CI run.                                        | `workflow_run` for `CI` on `completed`.                                                                              | None.                                                                                                                                                                                               |
 | `pr-review-responder.yml`    | `PR Review Responder`          | Runs Claude fix loops for trusted PRs, retriggers checks/reviews, and advances request-state labels.            | `pull_request_target` on `labeled` (only `cc:request:now`); `workflow_run` for `CI` on `completed`.                  | `cc:request`/`cc:request:N` -> `cc:pending`; then `cc:request:N+1` on pushed commits, `cc:done` on clean finish, `cc:failed` on failure; may add `needs-human:review-issue` when retries exhausted. |
 | `pr-status-labeler.yml`      | `PR Status Labeler`            | Applies human-attention labels based on CI outcome and review freshness/verdict.                                | `workflow_run` for `CI` on `completed`.                                                                              | Swaps between `needs-human:final-check` (clean + passing) and `needs-human:review-issue` (failing/stale/missing/issueful review).                                                                   |
@@ -64,13 +64,13 @@ flowchart TD
 
 ## Nightly Runner Cleanup
 
-The `nightly-runner-cleanup.yml` workflow runs at 4:00 AM PST on self-hosted macOS runner `ci1` to reclaim disk space. It only runs when `RUNNER_NAME == ci1`; other runners skip cleanup.
+The `nightly-runner-cleanup.yml` workflow runs at 4:00 AM PST on self-hosted macOS runners `ci1` through `ci4` to reclaim disk space.
 
 **Validation (manual run):**
 
 1. Go to Actions → Nightly Runner Cleanup → Run workflow.
-2. Confirm the run completes successfully and logs show "Running cleanup on runner: ci1".
+2. Confirm the run completes successfully and logs show cleanup running on each runner.
 3. Check logs for "Disk before" and "Disk after" to verify space reclaimed.
-4. On non-ci1 runners, logs should show "Skipping cleanup" and exit successfully.
+4. Confirm each runner re-registers and the verify job prints post-reboot disk space.
 
 **Expected behavior:** Deletes only allowlisted paths (npm cache, Playwright browsers, runner \_work dirs older than 2 days, Library/Caches subdirs). Never removes runner binaries, config, or user data outside caches.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,12 +114,9 @@ jobs:
       # can produce the correct label(s) for both GitHub-hosted and self-hosted runners.
       #
       # Privileged authors (wwwillchen, keppo-bot/keppo-bot[bot], dyad-assistant, azizmejri1, ryangroch):
-      #   - Self-hosted macOS ARM64 runners, no Windows, no sharding.
+      #   - Self-hosted macOS ARM64 runners, no Windows, 4 shards.
       #
-      #   build (macOS self-hosted) ──> e2e-tests (macOS self-hosted, shard 1/1)
-      #                                          │
-      #                                          v
-      #                                    merge-reports
+      #   build (macOS self-hosted) ──> e2e-tests (macOS self-hosted, shards 1-4) ──> merge-reports
       #
       # All other authors:
       #   - GitHub-hosted runners for macOS + Windows, 4 shards each.
@@ -134,8 +131,8 @@ jobs:
           if [ "${{ steps.author-check.outputs.is_privileged }}" = "true" ]; then
             echo 'build_os=[{"name":"macos","image":"[\"self-hosted\",\"macOS\",\"ARM64\"]"}]' >> $GITHUB_OUTPUT
             echo 'e2e_os=[{"name":"macos","image":"[\"self-hosted\",\"macOS\",\"ARM64\"]"}]' >> $GITHUB_OUTPUT
-            echo 'e2e_shard=[1,2]' >> $GITHUB_OUTPUT
-            echo 'e2e_shard_total=[2]' >> $GITHUB_OUTPUT
+            echo 'e2e_shard=[1,2,3,4]' >> $GITHUB_OUTPUT
+            echo 'e2e_shard_total=[4]' >> $GITHUB_OUTPUT
           else
             echo 'build_os=[{"name":"windows","image":"[\"windows-latest\"]"},{"name":"macos","image":"[\"macos-latest\"]"}]' >> $GITHUB_OUTPUT
             echo 'e2e_os=[{"name":"windows","image":"[\"windows-latest\"]"},{"name":"macos","image":"[\"macos-latest\"]"}]' >> $GITHUB_OUTPUT

--- a/.github/workflows/nightly-runner-cleanup.yml
+++ b/.github/workflows/nightly-runner-cleanup.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [ci1, ci2]
+        runner: [ci1, ci2, ci3, ci4]
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout (for cleanup script)
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [ci1, ci2]
+        runner: [ci1, ci2, ci3, ci4]
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Print available disk space


### PR DESCRIPTION
## Summary
- Shard privileged self-hosted macOS E2E CI across four Playwright shards.
- Extend nightly runner cleanup coverage to ci1-ci4 and refresh workflow docs.

## Test plan
- npm run fmt && npm run lint:fix && npm run ts
- npm test

#skip-bugbot

Generated with Claude Code