### PR TITLE
Setting needsAppBlueprint to false when starting an app with a plan

### DIFF
--- a/src/pro/main/ipc/handlers/local_agent/tools/exit_plan.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/exit_plan.ts
@@ -1,8 +1,11 @@
 import { z } from "zod";
 import log from "electron-log";
+import { eq } from "drizzle-orm";
 import { ToolDefinition, AgentContext } from "./types";
 import { safeSend } from "@/ipc/utils/safe_sender";
 import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
+import { db } from "@/db";
+import { apps } from "@/db/schema";
 
 const logger = log.scope("exit_plan");
 
@@ -62,6 +65,18 @@ export const exitPlanTool: ToolDefinition<z.infer<typeof exitPlanSchema>> = {
     }
 
     logger.log("Exiting plan mode, transitioning to implementation");
+
+    try {
+      await db
+        .update(apps)
+        .set({ needsAppBlueprint: false })
+        .where(eq(apps.id, ctx.appId));
+    } catch (error) {
+      logger.warn(
+        `Failed to clear needsAppBlueprint for app ${ctx.appId} on plan exit`,
+        error,
+      );
+    }
 
     safeSend(ctx.event.sender, "plan:exit", {
       chatId: ctx.chatId,


### PR DESCRIPTION
When starting a new app with a plan , `needsAppBlueprint` is still set to true so after approving the plan the user still needs to approve the app blueprint , which is creating an unnecessary friction for the users .

if `needsAppBlueprint` is set to true it usually means :

- new app
- no blueprint was approved , therefore the app was not developed since most tools will be blocked

in both cases the plan should act as a replacement for the app blueprint so we set `needsAppBlueprint` to false after the user has accepted the plan