### PR TITLE
fix(chat): stop AnimatePresence from freezing the streaming loader

### DIFF
--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -299,7 +299,7 @@ export function ChatPanel({
       <div className="flex flex-1 overflow-hidden">
         {!isVersionPaneOpen && (
           <div className="relative flex-1 min-w-0 overflow-hidden">
-            <AnimatePresence initial={false}>
+            <AnimatePresence>
               {!showTerminalDrawer && (
                 <motion.div
                   key="chat"


### PR DESCRIPTION
The streaming loading animation froze while the model generated a response.

PR #3452 (the in-chat terminal drawer) wrapped the chat message layer in an \<AnimatePresence initial={false}\>. initial={false} blocks the initial animation of every motion component present on the first render and propagates through context to the whole subtree, including the streaming loader nested inside. For a looping keyframe animation a blocked initial animation is set statically to its final keyframe instead of starting, so the loader sat frozen. (Toggling the terminal re-added the chat after the first render, which is not blocked, so the loop started: that is why opening and closing the terminal unfroze it.)

Drop initial={false} from the chat's AnimatePresence so the loader's animation is no longer blocked. The chat now plays its enter animation on first render, which initial={false} had been suppressing.

---

Essentially, I noticed that the orbs/bars animation when streaming is frozen unless I open the terminal, which most users probably won't do. This is a one-line fix.