### PR TITLE
feat(agent): add BM25 MCP tool search (experiment)

### DIFF
--- a/e2e-tests/fixtures/engine/local-agent/mcp-tool-search.ts
+++ b/e2e-tests/fixtures/engine/local-agent/mcp-tool-search.ts
@@ -1,0 +1,19 @@
+import type { LocalAgentFixture } from "../../../../testing/fake-llm-server/localAgentTypes";
+
+export const fixture: LocalAgentFixture = {
+  description: "Discover an MCP tool with search_mcp_tools",
+  turns: [
+    {
+      text: "Let me find an MCP tool for adding numbers.",
+      toolCalls: [
+        {
+          name: "search_mcp_tools",
+          args: { query: "add numbers" },
+        },
+      ],
+    },
+    {
+      text: "I found the calculator_add MCP tool for adding two numbers.",
+    },
+  ],
+};

--- a/e2e-tests/local_agent_advanced.spec.ts
+++ b/e2e-tests/local_agent_advanced.spec.ts
@@ -1,4 +1,5 @@
 import path from "path";
+import { expect } from "@playwright/test";
 import { testSkipIfWindows, Timeout } from "./helpers/test_helper";
 
 /**
@@ -89,6 +90,53 @@ testSkipIfWindows("local-agent - mcp tool call", async ({ po }) => {
 
   // Wait for chat to complete
   await po.chatActions.waitForChatCompletion();
+
+  await po.snapshotMessages();
+});
+
+/**
+ * Test for the MCP tool search experiment: the model discovers an MCP tool with
+ * search_mcp_tools, then calls it from execute_sandbox_script. Sandbox script
+ * execution is on by default; this turns on the experiment flag.
+ */
+testSkipIfWindows("local-agent - mcp tool search", async ({ po }) => {
+  await po.setUpDyadPro({ localAgent: true });
+  await po.navigation.goToSettingsTab();
+
+  // Configure the test MCP server.
+  await po.page.getByRole("button", { name: "Tools (MCP)" }).click();
+  await po.page
+    .getByRole("textbox", { name: "My MCP Server" })
+    .fill("testing-mcp-server");
+  await po.page.getByRole("textbox", { name: "node" }).fill("node");
+  const testMcpServerPath = path.join(
+    __dirname,
+    "..",
+    "testing",
+    "fake-stdio-mcp-server.mjs",
+  );
+  await po.page
+    .getByRole("textbox", { name: "path/to/mcp-server.js --flag" })
+    .fill(testMcpServerPath);
+  await po.page.getByRole("button", { name: "Add Server" }).click();
+  await po.settings.waitForMcpTool("testing-mcp-server", "calculator_add");
+
+  // Turn on the MCP tool search experiment (Playwright scrolls to the switch).
+  await po.page.getByRole("switch", { name: "Enable MCP tool search" }).click();
+
+  await po.navigation.goToAppsTab();
+  await po.importApp("minimal");
+  await po.chatActions.selectLocalAgentMode();
+
+  // The model searches for an MCP tool; search_mcp_tools auto-approves.
+  await po.sendPrompt("tc=local-agent/mcp-tool-search", {
+    skipWaitForCompletion: true,
+  });
+  await po.chatActions.waitForChatCompletion();
+
+  // The search card renders with the query the model searched for.
+  await expect(po.page.getByText("MCP Tools").first()).toBeVisible();
+  await expect(po.page.getByText("add numbers").first()).toBeVisible();
 
   await po.snapshotMessages();
 });

--- a/e2e-tests/snapshots/local_agent_advanced.spec.ts_local-agent---mcp-tool-search-1.aria.yml
+++ b/e2e-tests/snapshots/local_agent_advanced.spec.ts_local-agent---mcp-tool-search-1.aria.yml
@@ -1,0 +1,48 @@
+- paragraph: /Generate an AI_RULES\.md file for this app\. Describe the tech stack in 5-\d+ bullet points and describe clear rules about what libraries to use for what\./
+- button "file1.txt file1.txt Edit":
+  - img
+  - text: ""
+  - button "Edit":
+    - img
+    - text: ""
+  - img
+- paragraph: More EOM
+- button "Copy":
+  - img
+- img
+- text: Approved
+- img
+- text: claude-opus-4-5
+- img
+- text: less than a minute ago
+- img
+- text: "Version 2: (1 files changed)"
+- button "Copy Request ID":
+  - img
+  - text: ""
+- paragraph: tc=local-agent/mcp-tool-search
+- paragraph: Let me find an MCP tool for adding numbers.
+- button "MCP Tools add numbers":
+  - img
+  - text: ""
+  - img
+- paragraph: I found the calculator_add MCP tool for adding two numbers.
+- button "Copy":
+  - img
+- img
+- text: Approved
+- img
+- text: claude-opus-4-5
+- img
+- text: less than a minute ago
+- img
+- text: "Version 3: (1 files changed)"
+- button "Copy Request ID":
+  - img
+  - text: ""
+- button "Undo":
+  - img
+  - text: ""
+- button "Retry":
+  - img
+  - text: ""

--- a/src/components/chat/DyadMarkdownParser.tsx
+++ b/src/components/chat/DyadMarkdownParser.tsx
@@ -29,6 +29,7 @@ import { DyadProblemSummary } from "./DyadProblemSummary";
 import { ipc } from "@/ipc/types";
 import { DyadMcpToolCall } from "./DyadMcpToolCall";
 import { DyadMcpToolResult } from "./DyadMcpToolResult";
+import { DyadMcpToolSearch } from "./DyadMcpToolSearch";
 import { DyadWebSearchResult } from "./DyadWebSearchResult";
 import { DyadWebSearch } from "./DyadWebSearch";
 import { DyadWebCrawl } from "./DyadWebCrawl";
@@ -643,6 +644,20 @@ function renderCustomTag(
         </DyadCodebaseContext>
       );
 
+    case "dyad-mcp-tool-search":
+      return (
+        <DyadMcpToolSearch
+          node={{
+            properties: {
+              query: attributes.query || "",
+              server: attributes.server || "",
+              state: getState({ isStreaming, inProgress }),
+            },
+          }}
+        >
+          {content}
+        </DyadMcpToolSearch>
+      );
     case "dyad-mcp-tool-call":
       return (
         <DyadMcpToolCall

--- a/src/components/chat/DyadMcpToolSearch.tsx
+++ b/src/components/chat/DyadMcpToolSearch.tsx
@@ -23,8 +23,7 @@ export const DyadMcpToolSearch: React.FC<DyadMcpToolSearchProps> = ({
   node,
 }) => {
   const [isExpanded, setIsExpanded] = useState(false);
-  const query =
-    node?.properties?.query || (typeof children === "string" ? children : "");
+  const query = node?.properties?.query || "";
   const server = node?.properties?.server || "";
   const state = node?.properties?.state as CustomTagState;
   const inProgress = state === "pending";

--- a/src/components/chat/DyadMcpToolSearch.tsx
+++ b/src/components/chat/DyadMcpToolSearch.tsx
@@ -27,6 +27,11 @@ export const DyadMcpToolSearch: React.FC<DyadMcpToolSearchProps> = ({
   const server = node?.properties?.server || "";
   const state = node?.properties?.state as CustomTagState;
   const inProgress = state === "pending";
+  const resultText = typeof children === "string" ? children.trimEnd() : "";
+  // No-match results start with "No MCP"; "Matching tools:" would mislabel them.
+  const resultsLabel = resultText.startsWith("No MCP")
+    ? "Results:"
+    : "Matching tools:";
 
   return (
     <DyadCard
@@ -63,10 +68,10 @@ export const DyadMcpToolSearch: React.FC<DyadMcpToolSearchProps> = ({
           {children && (
             <div>
               <span className="text-xs font-medium text-muted-foreground">
-                Matching tools:
+                {resultsLabel}
               </span>
               <pre className="mt-0.5 whitespace-pre-wrap font-mono text-xs text-foreground overflow-x-auto">
-                {typeof children === "string" ? children.trimEnd() : children}
+                {resultText || children}
               </pre>
             </div>
           )}

--- a/src/components/chat/DyadMcpToolSearch.tsx
+++ b/src/components/chat/DyadMcpToolSearch.tsx
@@ -66,7 +66,7 @@ export const DyadMcpToolSearch: React.FC<DyadMcpToolSearchProps> = ({
                 Matching tools:
               </span>
               <pre className="mt-0.5 whitespace-pre-wrap font-mono text-xs text-foreground overflow-x-auto">
-                {children}
+                {typeof children === "string" ? children.trimEnd() : children}
               </pre>
             </div>
           )}

--- a/src/components/chat/DyadMcpToolSearch.tsx
+++ b/src/components/chat/DyadMcpToolSearch.tsx
@@ -1,0 +1,78 @@
+import type React from "react";
+import { useState, type ReactNode } from "react";
+import { Wrench } from "lucide-react";
+import { CustomTagState } from "./stateTypes";
+import {
+  DyadCard,
+  DyadCardHeader,
+  DyadBadge,
+  DyadExpandIcon,
+  DyadStateIndicator,
+  DyadCardContent,
+} from "./DyadCardPrimitives";
+
+interface DyadMcpToolSearchProps {
+  children?: ReactNode;
+  node?: {
+    properties?: { query?: string; server?: string; state?: CustomTagState };
+  };
+}
+
+export const DyadMcpToolSearch: React.FC<DyadMcpToolSearchProps> = ({
+  children,
+  node,
+}) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const query =
+    node?.properties?.query || (typeof children === "string" ? children : "");
+  const server = node?.properties?.server || "";
+  const state = node?.properties?.state as CustomTagState;
+  const inProgress = state === "pending";
+
+  return (
+    <DyadCard
+      state={state}
+      accentColor="indigo"
+      onClick={() => setIsExpanded(!isExpanded)}
+      isExpanded={isExpanded}
+    >
+      <DyadCardHeader icon={<Wrench size={15} />} accentColor="indigo">
+        <DyadBadge color="indigo">MCP Tools</DyadBadge>
+        {server && <DyadBadge color="sky">{server}</DyadBadge>}
+        {!isExpanded && query && (
+          <span className="text-sm text-muted-foreground italic truncate">
+            {query}
+          </span>
+        )}
+        {inProgress && (
+          <DyadStateIndicator state="pending" pendingLabel="Searching..." />
+        )}
+        <div className="ml-auto">
+          <DyadExpandIcon isExpanded={isExpanded} />
+        </div>
+      </DyadCardHeader>
+      <DyadCardContent isExpanded={isExpanded}>
+        <div className="text-sm text-muted-foreground space-y-2">
+          {query && (
+            <div>
+              <span className="text-xs font-medium text-muted-foreground">
+                Query:
+              </span>
+              <div className="italic mt-0.5 text-foreground">{query}</div>
+            </div>
+          )}
+          {children && (
+            <div>
+              <span className="text-xs font-medium text-muted-foreground">
+                Matching tools:
+              </span>
+              <pre className="mt-0.5 whitespace-pre-wrap font-mono text-xs text-foreground overflow-x-auto">
+                {children}
+              </pre>
+            </div>
+          )}
+        </div>
+      </DyadCardContent>
+    </DyadCard>
+  );
+};

--- a/src/components/chat/DyadMcpToolSearch.tsx
+++ b/src/components/chat/DyadMcpToolSearch.tsx
@@ -40,7 +40,7 @@ export const DyadMcpToolSearch: React.FC<DyadMcpToolSearchProps> = ({
         <DyadBadge color="indigo">MCP Tools</DyadBadge>
         {server && <DyadBadge color="sky">{server}</DyadBadge>}
         {!isExpanded && query && (
-          <span className="text-sm text-muted-foreground italic truncate">
+          <span className="text-sm text-muted-foreground italic truncate min-w-0">
             {query}
           </span>
         )}

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -360,6 +360,7 @@ const BaseUserSettingsFields = {
   enableNativeGit: z.boolean().optional(),
   enableSandboxScriptExecution: z.boolean().optional(),
   enableMcpServersForBuildMode: z.boolean().optional(),
+  enableMcpToolSearch: z.boolean().optional(),
   enableAutoUpdate: z.boolean(),
   releaseChannel: ReleaseChannelSchema,
   runtimeMode2: RuntimeMode2Schema.optional(),

--- a/src/lib/settingsSearchIndex.test.ts
+++ b/src/lib/settingsSearchIndex.test.ts
@@ -102,16 +102,8 @@ describe("SETTINGS_SEARCH_INDEX", () => {
       id: SETTING_IDS.enableMcpToolSearch,
       label: "Enable MCP tool search",
       description:
-        "Let the agent search for MCP tools on demand instead of listing every tool in its context",
-      keywords: [
-        "mcp",
-        "search",
-        "tools",
-        "bm25",
-        "agent",
-        "sandbox",
-        "context",
-      ],
+        "Let the agent search for MCP tools on demand instead of listing every tool in its context. Requires sandbox script execution",
+      keywords: ["mcp", "search", "tools", "agent", "sandbox", "context"],
       sectionId: SECTION_IDS.experiments,
       sectionLabel: "Experiments",
     });

--- a/src/lib/settingsSearchIndex.test.ts
+++ b/src/lib/settingsSearchIndex.test.ts
@@ -92,4 +92,28 @@ describe("SETTINGS_SEARCH_INDEX", () => {
       sectionLabel: "Advanced",
     });
   });
+
+  it("includes the MCP tool search setting", () => {
+    expect(
+      SETTINGS_SEARCH_INDEX.find(
+        (item) => item.id === SETTING_IDS.enableMcpToolSearch,
+      ),
+    ).toEqual({
+      id: SETTING_IDS.enableMcpToolSearch,
+      label: "Enable MCP tool search",
+      description:
+        "Let the agent search for MCP tools on demand instead of listing every tool in its context",
+      keywords: [
+        "mcp",
+        "search",
+        "tools",
+        "bm25",
+        "agent",
+        "sandbox",
+        "context",
+      ],
+      sectionId: SECTION_IDS.experiments,
+      sectionLabel: "Experiments",
+    });
+  });
 });

--- a/src/lib/settingsSearchIndex.ts
+++ b/src/lib/settingsSearchIndex.ts
@@ -43,6 +43,7 @@ export const SETTING_IDS = {
   enablePnpmMinimumReleaseAgeWarning:
     "setting-enable-pnpm-minimum-release-age-warning",
   enableMcpServersForBuildMode: "setting-enable-mcp-servers-for-build-mode",
+  enableMcpToolSearch: "setting-enable-mcp-tool-search",
   enableSelectAppFromHomeChatInput:
     "setting-enable-select-app-from-home-chat-input",
   reset: "setting-reset",
@@ -431,6 +432,15 @@ export const SETTINGS_SEARCH_INDEX: SearchableSettingItem[] = [
     keywords: ["mcp", "build", "agent", "tools", "server"],
     sectionId: SECTION_IDS.advanced,
     sectionLabel: "Advanced",
+  },
+  {
+    id: SETTING_IDS.enableMcpToolSearch,
+    label: "Enable MCP tool search",
+    description:
+      "Let the agent search for MCP tools on demand instead of listing every tool in its context",
+    keywords: ["mcp", "search", "tools", "bm25", "agent", "sandbox", "context"],
+    sectionId: SECTION_IDS.experiments,
+    sectionLabel: "Experiments",
   },
 
   // Experiments

--- a/src/lib/settingsSearchIndex.ts
+++ b/src/lib/settingsSearchIndex.ts
@@ -456,8 +456,8 @@ export const SETTINGS_SEARCH_INDEX: SearchableSettingItem[] = [
     id: SETTING_IDS.enableMcpToolSearch,
     label: "Enable MCP tool search",
     description:
-      "Let the agent search for MCP tools on demand instead of listing every tool in its context",
-    keywords: ["mcp", "search", "tools", "bm25", "agent", "sandbox", "context"],
+      "Let the agent search for MCP tools on demand instead of listing every tool in its context. Requires sandbox script execution",
+    keywords: ["mcp", "search", "tools", "agent", "sandbox", "context"],
     sectionId: SECTION_IDS.experiments,
     sectionLabel: "Experiments",
   },

--- a/src/lib/settingsSearchIndex.ts
+++ b/src/lib/settingsSearchIndex.ts
@@ -433,15 +433,6 @@ export const SETTINGS_SEARCH_INDEX: SearchableSettingItem[] = [
     sectionId: SECTION_IDS.advanced,
     sectionLabel: "Advanced",
   },
-  {
-    id: SETTING_IDS.enableMcpToolSearch,
-    label: "Enable MCP tool search",
-    description:
-      "Let the agent search for MCP tools on demand instead of listing every tool in its context",
-    keywords: ["mcp", "search", "tools", "bm25", "agent", "sandbox", "context"],
-    sectionId: SECTION_IDS.experiments,
-    sectionLabel: "Experiments",
-  },
 
   // Experiments
   {
@@ -458,6 +449,15 @@ export const SETTINGS_SEARCH_INDEX: SearchableSettingItem[] = [
       "credits",
       "secure",
     ],
+    sectionId: SECTION_IDS.experiments,
+    sectionLabel: "Experiments",
+  },
+  {
+    id: SETTING_IDS.enableMcpToolSearch,
+    label: "Enable MCP tool search",
+    description:
+      "Let the agent search for MCP tools on demand instead of listing every tool in its context",
+    keywords: ["mcp", "search", "tools", "bm25", "agent", "sandbox", "context"],
     sectionId: SECTION_IDS.experiments,
     sectionLabel: "Experiments",
   },

--- a/src/lib/streamingMessageParser.ts
+++ b/src/lib/streamingMessageParser.ts
@@ -50,6 +50,7 @@ const DYAD_CUSTOM_TAG_NAMES = [
   "dyad-command",
   "dyad-mcp-tool-call",
   "dyad-mcp-tool-result",
+  "dyad-mcp-tool-search",
   "dyad-list-files",
   "dyad-database-schema",
   "dyad-db-table-schema",

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -294,6 +294,11 @@ export default function SettingsPage() {
                   listing every tool's definition in its context. Requires
                   sandbox script execution.
                 </div>
+                {!settings?.enableSandboxScriptExecution && (
+                  <div className="text-xs text-amber-500">
+                    Enable sandbox script execution first.
+                  </div>
+                )}
               </div>
               <div
                 id={SETTING_IDS.enablePnpmMinimumReleaseAgeWarning}

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -278,7 +278,10 @@ export default function SettingsPage() {
                     id="enable-mcp-tool-search"
                     aria-label="Enable MCP tool search"
                     disabled={!settings?.enableSandboxScriptExecution}
-                    checked={!!settings?.enableMcpToolSearch}
+                    checked={
+                      !!settings?.enableMcpToolSearch &&
+                      !!settings?.enableSandboxScriptExecution
+                    }
                     onCheckedChange={(checked) => {
                       updateSettings({
                         enableMcpToolSearch: checked,

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -299,7 +299,7 @@ export default function SettingsPage() {
                 </div>
                 {!settings?.enableSandboxScriptExecution && (
                   <div className="text-xs text-amber-500">
-                    Cannot be enabled until sandbox script execution is on.
+                    Cannot be enabled unless sandbox script execution is on.
                   </div>
                 )}
               </div>

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -299,7 +299,7 @@ export default function SettingsPage() {
                 </div>
                 {!settings?.enableSandboxScriptExecution && (
                   <div className="text-xs text-amber-500">
-                    Enable sandbox script execution first.
+                    Cannot be enabled until sandbox script execution is on.
                   </div>
                 )}
               </div>

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -270,6 +270,31 @@ export default function SettingsPage() {
                 <CloudSandboxExperimentSwitch />
               </div>
               <div
+                id={SETTING_IDS.enableMcpToolSearch}
+                className="space-y-1 mt-4"
+              >
+                <div className="flex items-center space-x-2">
+                  <Switch
+                    id="enable-mcp-tool-search"
+                    aria-label="Enable MCP tool search"
+                    checked={!!settings?.enableMcpToolSearch}
+                    onCheckedChange={(checked) => {
+                      updateSettings({
+                        enableMcpToolSearch: checked,
+                      });
+                    }}
+                  />
+                  <Label htmlFor="enable-mcp-tool-search">
+                    Enable MCP tool search
+                  </Label>
+                </div>
+                <div className="text-sm text-gray-500 dark:text-gray-400">
+                  In Agent mode, let the model search for MCP tools instead of
+                  listing every tool's definition in its context. Requires
+                  sandbox script execution.
+                </div>
+              </div>
+              <div
                 id={SETTING_IDS.enablePnpmMinimumReleaseAgeWarning}
                 className="space-y-1 mt-4"
               >

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -277,6 +277,7 @@ export default function SettingsPage() {
                   <Switch
                     id="enable-mcp-tool-search"
                     aria-label="Enable MCP tool search"
+                    disabled={!settings?.enableSandboxScriptExecution}
                     checked={!!settings?.enableMcpToolSearch}
                     onCheckedChange={(checked) => {
                       updateSettings({

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.test.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.test.ts
@@ -268,6 +268,7 @@ vi.mock("@/ipc/utils/mcp_manager", () => ({
 vi.mock("@/pro/main/ipc/handlers/local_agent/tool_definitions", () => ({
   TOOL_DEFINITIONS: [],
   buildAgentToolSet: vi.fn(() => ({})),
+  shouldIncludeTool: vi.fn(() => false),
   requireAgentToolConsent: vi.fn(async () => true),
   clearPendingConsentsForChat: vi.fn(),
 }));

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -688,18 +688,9 @@ export async function handleLocalAgentStream(
       abortSignal: abortController.signal,
     };
 
-    // Pre-compute whether MCP-in-sandbox is active so tools registered inside
-    // buildAgentToolSet (e.g. search_mcp_tools) can gate on `ctx.mcpToolsEnabled`.
-    // Mirrors the authoritative `mcpInSandboxEnabled` derived below from the
-    // built tool set; `getAgentToolConsent` accounts for the same "never"
-    // consent that would keep execute_sandbox_script out of the set.
-    //
-    // This only mirrors the readOnly, planMode, isEnabled and "never"-consent
-    // filters. It does not mirror buildAgentToolSet's basicAgentMode
-    // (PRO_AGENT_ONLY_TOOLS) or enableAppBlueprint (APP_BLUEPRINT_TOOLS) filters,
-    // because execute_sandbox_script is in none of those sets. If that changes,
-    // mirror the relevant filter here; the dev-only divergence check below flags
-    // the mismatch in the meantime.
+    // Set before buildAgentToolSet so search_mcp_tools.isEnabled can read it
+    // mid-build, then replaced with the authoritative value once the set exists.
+    // The dev-only check below flags any drift between the two.
     const preComputedMcpToolsEnabled =
       !readOnly &&
       !planModeOnly &&

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -42,9 +42,9 @@ import {
 import {
   AgentToolName,
   buildAgentToolSet,
+  shouldIncludeTool,
   requireAgentToolConsent,
   clearPendingConsentsForChat,
-  getAgentToolConsent,
 } from "./tool_definitions";
 import {
   questionnaireResolver,
@@ -688,60 +688,41 @@ export async function handleLocalAgentStream(
       abortSignal: abortController.signal,
     };
 
-    // Set before buildAgentToolSet so search_mcp_tools.isEnabled can read it
-    // mid-build, then replaced with the authoritative value once the set exists.
-    // The dev-only check below flags any drift between the two.
-    const preComputedMcpToolsEnabled =
-      !readOnly &&
-      !planModeOnly &&
-      (executeSandboxScriptTool.isEnabled?.(ctx) ?? true) &&
-      getAgentToolConsent(executeSandboxScriptTool.name) !== "never";
-    ctx.mcpToolsEnabled = preComputedMcpToolsEnabled;
-
-    // Build tool set (agent tools + MCP tools)
-    // In read-only mode, only include read-only tools and skip MCP tools
-    // (since we can't determine if MCP tools modify state)
-    // In plan mode, only include planning tools (read + questionnaire/plan tools)
-    const agentTools = buildAgentToolSet(ctx, {
+    // Build the tool set (agent tools + MCP tools).
+    // In read-only mode, only include read-only tools and skip MCP tools (we
+    // can't tell whether MCP tools modify state). In plan mode, only include
+    // planning tools (read + questionnaire/plan tools).
+    const buildOptions = {
       readOnly,
       planModeOnly,
       basicAgentMode: !readOnly && !planModeOnly && isBasicAgentMode(settings),
       enableAppBlueprint:
         settings.enableAppBlueprint && chat.app.needsAppBlueprint,
-    });
-    // MCP tool exposure depends on whether `execute_sandbox_script` is
-    // available this turn (which already accounts for the sandbox-script
-    // experiment AND `isSandboxSupportedPlatform()` via the tool's
-    // `isEnabled` check):
-    //   - Sandbox tool present and not read-only/plan-mode: MCP tools are
-    //     NOT registered individually with the LLM. Instead, they're
-    //     exposed as host functions inside `execute_sandbox_script`'s
-    //     MustardScript sandbox so the model can chain MCP calls and file
-    //     reads in one script. The tool's description is built per-turn so
-    //     the type declarations reflect the currently enabled MCP servers.
-    //   - Otherwise (experiment off, platform unsupported, read-only, or
-    //     plan mode): fall back to the pre-branch behavior of registering
-    //     each MCP tool individually with the LLM, so users do not lose
-    //     access to their MCP servers on a platform that cannot run the
-    //     sandbox.
+    };
+    // search_mcp_tools.isEnabled reads ctx.mcpToolsEnabled while
+    // buildAgentToolSet is still running, so compute the value up front from the
+    // same predicate the builder uses. MCP-in-sandbox stays off in read-only and
+    // plan mode regardless of whether execute_sandbox_script survives the other
+    // filters.
     const mcpInSandboxEnabled =
       !readOnly &&
       !planModeOnly &&
-      agentTools.execute_sandbox_script !== undefined;
-    // The pre-computed gate above mirrors only a subset of buildAgentToolSet's
-    // filters. If they ever diverge (e.g. a new filter drops
-    // execute_sandbox_script from the set), search_mcp_tools could be
-    // registered against a stale `ctx.mcpToolsEnabled`. Surface that in dev
-    // rather than shipping a silent inconsistency.
-    if (
-      process.env.NODE_ENV !== "production" &&
-      preComputedMcpToolsEnabled !== mcpInSandboxEnabled
-    ) {
-      logger.error(
-        `mcpToolsEnabled pre-compute (${preComputedMcpToolsEnabled}) diverged from authoritative value (${mcpInSandboxEnabled}); search_mcp_tools gating may be stale.`,
-      );
-    }
+      shouldIncludeTool(executeSandboxScriptTool, ctx, buildOptions);
     ctx.mcpToolsEnabled = mcpInSandboxEnabled;
+
+    const agentTools = buildAgentToolSet(ctx, buildOptions);
+    // MCP tool exposure depends on whether execute_sandbox_script is available
+    // this turn (which accounts for the sandbox-script experiment AND
+    // isSandboxSupportedPlatform() via the tool's isEnabled check):
+    //   - Sandbox tool present and not read-only/plan mode: MCP tools are NOT
+    //     registered individually with the LLM. They're exposed as host
+    //     functions inside execute_sandbox_script's MustardScript sandbox so the
+    //     model can chain MCP calls and file reads in one script. The tool's
+    //     description is built per-turn so the type declarations reflect the
+    //     currently enabled MCP servers.
+    //   - Otherwise (experiment off, platform unsupported, read-only, or plan
+    //     mode): register each MCP tool individually with the LLM so users keep
+    //     access to their MCP servers on a platform that cannot run the sandbox.
     // When the tool-search experiment is on, the sandbox description points
     // the model at `search_mcp_tools` instead of inlining every MCP tool's
     // declarations. `ctx.mcpToolDefs` still holds ALL defs below, so the

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -44,6 +44,7 @@ import {
   buildAgentToolSet,
   requireAgentToolConsent,
   clearPendingConsentsForChat,
+  getAgentToolConsent,
 } from "./tool_definitions";
 import {
   questionnaireResolver,
@@ -82,7 +83,10 @@ import {
   parseAiMessagesJson,
   type DbMessageForParsing,
 } from "@/ipc/utils/ai_messages_utils";
-import { buildExecuteSandboxScriptDescription } from "./tools/execute_sandbox_script";
+import {
+  buildExecuteSandboxScriptDescription,
+  executeSandboxScriptTool,
+} from "./tools/execute_sandbox_script";
 import { collectMcpToolDefs } from "./tools/mcp_type_defs";
 import { addIntegrationTool } from "./tools/add_integration";
 import { writePlanTool } from "./tools/write_plan";
@@ -684,6 +688,17 @@ export async function handleLocalAgentStream(
       abortSignal: abortController.signal,
     };
 
+    // Pre-compute whether MCP-in-sandbox is active so tools registered inside
+    // buildAgentToolSet (e.g. search_mcp_tools) can gate on `ctx.mcpToolsEnabled`.
+    // Mirrors the authoritative `mcpInSandboxEnabled` derived below from the
+    // built tool set; `getAgentToolConsent` accounts for the same "never"
+    // consent that would keep execute_sandbox_script out of the set.
+    ctx.mcpToolsEnabled =
+      !readOnly &&
+      !planModeOnly &&
+      (executeSandboxScriptTool.isEnabled?.(ctx) ?? true) &&
+      getAgentToolConsent(executeSandboxScriptTool.name) !== "never";
+
     // Build tool set (agent tools + MCP tools)
     // In read-only mode, only include read-only tools and skip MCP tools
     // (since we can't determine if MCP tools modify state)
@@ -715,6 +730,12 @@ export async function handleLocalAgentStream(
       !planModeOnly &&
       agentTools.execute_sandbox_script !== undefined;
     ctx.mcpToolsEnabled = mcpInSandboxEnabled;
+    // When the tool-search experiment is on, the sandbox description points
+    // the model at `search_mcp_tools` instead of inlining every MCP tool's
+    // declarations. `ctx.mcpToolDefs` still holds ALL defs below, so the
+    // sandbox capability map can resolve whatever the model finds.
+    const useMcpToolSearch =
+      mcpInSandboxEnabled && !!settings.enableMcpToolSearch;
     const mcpToolsForRegistration: ToolSet =
       !readOnly && !planModeOnly && !mcpInSandboxEnabled
         ? await getMcpTools(event, ctx)
@@ -725,7 +746,9 @@ export async function handleLocalAgentStream(
       // the syntax + file-inspection docs (rather than the one-line
       // placeholder from the tool definition).
       agentTools.execute_sandbox_script.description =
-        await buildExecuteSandboxScriptDescription([]);
+        await buildExecuteSandboxScriptDescription([], {
+          useSearch: useMcpToolSearch,
+        });
       if (mcpInSandboxEnabled) {
         try {
           // Collect MCP defs once per turn and reuse for both the
@@ -735,7 +758,9 @@ export async function handleLocalAgentStream(
           const defs = await collectMcpToolDefs();
           ctx.mcpToolDefs = defs;
           agentTools.execute_sandbox_script.description =
-            await buildExecuteSandboxScriptDescription(defs);
+            await buildExecuteSandboxScriptDescription(defs, {
+              useSearch: useMcpToolSearch,
+            });
         } catch (e) {
           logger.warn(
             "Failed to build dynamic execute_sandbox_script description",

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -712,12 +712,12 @@ export async function handleLocalAgentStream(
     const useMcpToolSearch =
       mcpInSandboxEnabled &&
       !!settings.enableMcpToolSearch &&
-      agentTools.search_mcp_tools !== undefined;
+      agentTools.search_mcp_tools != undefined;
     const mcpToolsForRegistration: ToolSet =
       !readOnly && !planModeOnly && !mcpInSandboxEnabled
         ? await getMcpTools(event, ctx)
         : {};
-    if (agentTools.execute_sandbox_script !== undefined) {
+    if (agentTools.execute_sandbox_script != undefined) {
       // Initialize with the MustardScript-only preamble so even a
       // failure in the MCP collection path below leaves the model with
       // the syntax + file-inspection docs (rather than the one-line

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -693,6 +693,13 @@ export async function handleLocalAgentStream(
     // Mirrors the authoritative `mcpInSandboxEnabled` derived below from the
     // built tool set; `getAgentToolConsent` accounts for the same "never"
     // consent that would keep execute_sandbox_script out of the set.
+    //
+    // This only mirrors the readOnly, planMode, isEnabled and "never"-consent
+    // filters. It does not mirror buildAgentToolSet's basicAgentMode
+    // (PRO_AGENT_ONLY_TOOLS) or enableAppBlueprint (APP_BLUEPRINT_TOOLS) filters,
+    // because execute_sandbox_script is in none of those sets. If that changes,
+    // mirror the relevant filter here; the dev-only divergence check below flags
+    // the mismatch in the meantime.
     const preComputedMcpToolsEnabled =
       !readOnly &&
       !planModeOnly &&

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -688,10 +688,8 @@ export async function handleLocalAgentStream(
       abortSignal: abortController.signal,
     };
 
-    // Build the tool set (agent tools + MCP tools).
-    // In read-only mode, only include read-only tools and skip MCP tools (we
-    // can't tell whether MCP tools modify state). In plan mode, only include
-    // planning tools (read + questionnaire/plan tools).
+    // Read-only mode includes only read-only tools (MCP tools are skipped since
+    // we can't tell if they modify state); plan mode includes only planning tools.
     const buildOptions = {
       readOnly,
       planModeOnly,
@@ -699,11 +697,8 @@ export async function handleLocalAgentStream(
       enableAppBlueprint:
         settings.enableAppBlueprint && chat.app.needsAppBlueprint,
     };
-    // search_mcp_tools.isEnabled reads ctx.mcpToolsEnabled while
-    // buildAgentToolSet is still running, so compute the value up front from the
-    // same predicate the builder uses. MCP-in-sandbox stays off in read-only and
-    // plan mode regardless of whether execute_sandbox_script survives the other
-    // filters.
+    // search_mcp_tools.isEnabled reads this during the build, so set it up front
+    // from the same predicate the builder uses. Off in read-only and plan mode.
     const mcpInSandboxEnabled =
       !readOnly &&
       !planModeOnly &&
@@ -711,25 +706,9 @@ export async function handleLocalAgentStream(
     ctx.mcpToolsEnabled = mcpInSandboxEnabled;
 
     const agentTools = buildAgentToolSet(ctx, buildOptions);
-    // MCP tool exposure depends on whether execute_sandbox_script is available
-    // this turn (which accounts for the sandbox-script experiment AND
-    // isSandboxSupportedPlatform() via the tool's isEnabled check):
-    //   - Sandbox tool present and not read-only/plan mode: MCP tools are NOT
-    //     registered individually with the LLM. They're exposed as host
-    //     functions inside execute_sandbox_script's MustardScript sandbox so the
-    //     model can chain MCP calls and file reads in one script. The tool's
-    //     description is built per-turn so the type declarations reflect the
-    //     currently enabled MCP servers.
-    //   - Otherwise (experiment off, platform unsupported, read-only, or plan
-    //     mode): register each MCP tool individually with the LLM so users keep
-    //     access to their MCP servers on a platform that cannot run the sandbox.
-    // When the tool-search experiment is on, the sandbox description points
-    // the model at `search_mcp_tools` instead of inlining every MCP tool's
-    // declarations. `ctx.mcpToolDefs` still holds ALL defs below, so the
-    // sandbox capability map can resolve whatever the model finds. Gate on the
-    // tool actually being in `agentTools`: if its consent is set to "never",
-    // buildAgentToolSet drops it, and we must keep inlining the declarations so
-    // enabled MCP tools stay discoverable.
+    // When execute_sandbox_script is active, MCP tools become sandbox host
+    // functions instead of individual LLM tools. With tool-search on, the sandbox
+    // description points the model at search_mcp_tools instead of inlining them.
     const useMcpToolSearch =
       mcpInSandboxEnabled &&
       !!settings.enableMcpToolSearch &&

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -693,11 +693,12 @@ export async function handleLocalAgentStream(
     // Mirrors the authoritative `mcpInSandboxEnabled` derived below from the
     // built tool set; `getAgentToolConsent` accounts for the same "never"
     // consent that would keep execute_sandbox_script out of the set.
-    ctx.mcpToolsEnabled =
+    const preComputedMcpToolsEnabled =
       !readOnly &&
       !planModeOnly &&
       (executeSandboxScriptTool.isEnabled?.(ctx) ?? true) &&
       getAgentToolConsent(executeSandboxScriptTool.name) !== "never";
+    ctx.mcpToolsEnabled = preComputedMcpToolsEnabled;
 
     // Build tool set (agent tools + MCP tools)
     // In read-only mode, only include read-only tools and skip MCP tools
@@ -729,13 +730,31 @@ export async function handleLocalAgentStream(
       !readOnly &&
       !planModeOnly &&
       agentTools.execute_sandbox_script !== undefined;
+    // The pre-computed gate above mirrors only a subset of buildAgentToolSet's
+    // filters. If they ever diverge (e.g. a new filter drops
+    // execute_sandbox_script from the set), search_mcp_tools could be
+    // registered against a stale `ctx.mcpToolsEnabled`. Surface that in dev
+    // rather than shipping a silent inconsistency.
+    if (
+      process.env.NODE_ENV !== "production" &&
+      preComputedMcpToolsEnabled !== mcpInSandboxEnabled
+    ) {
+      logger.error(
+        `mcpToolsEnabled pre-compute (${preComputedMcpToolsEnabled}) diverged from authoritative value (${mcpInSandboxEnabled}); search_mcp_tools gating may be stale.`,
+      );
+    }
     ctx.mcpToolsEnabled = mcpInSandboxEnabled;
     // When the tool-search experiment is on, the sandbox description points
     // the model at `search_mcp_tools` instead of inlining every MCP tool's
     // declarations. `ctx.mcpToolDefs` still holds ALL defs below, so the
-    // sandbox capability map can resolve whatever the model finds.
+    // sandbox capability map can resolve whatever the model finds. Gate on the
+    // tool actually being in `agentTools`: if its consent is set to "never",
+    // buildAgentToolSet drops it, and we must keep inlining the declarations so
+    // enabled MCP tools stay discoverable.
     const useMcpToolSearch =
-      mcpInSandboxEnabled && !!settings.enableMcpToolSearch;
+      mcpInSandboxEnabled &&
+      !!settings.enableMcpToolSearch &&
+      agentTools.search_mcp_tools !== undefined;
     const mcpToolsForRegistration: ToolSet =
       !readOnly && !planModeOnly && !mcpInSandboxEnabled
         ? await getMcpTools(event, ctx)

--- a/src/pro/main/ipc/handlers/local_agent/tool_definitions.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tool_definitions.ts
@@ -36,6 +36,7 @@ import { writePlanTool } from "./tools/write_plan";
 import { exitPlanTool } from "./tools/exit_plan";
 import { readGuideTool } from "./tools/read_guide";
 import { executeSandboxScriptTool } from "./tools/execute_sandbox_script";
+import { searchMcpToolsTool } from "./tools/search_mcp_tools";
 import { writeAppBlueprintTool } from "./tools/write_app_blueprint";
 import type { LanguageModelV3ToolResultOutput } from "@ai-sdk/provider";
 import {
@@ -98,6 +99,7 @@ export const TOOL_DEFINITIONS: readonly ToolDefinition[] = [
   runTypeChecksTool,
   readGuideTool,
   executeSandboxScriptTool,
+  searchMcpToolsTool,
   // Plan mode tools
   planningQuestionnaireTool,
   writePlanTool,

--- a/src/pro/main/ipc/handlers/local_agent/tool_definitions.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tool_definitions.ts
@@ -412,6 +412,53 @@ const PRO_AGENT_ONLY_TOOLS = new Set<string>();
 const APP_BLUEPRINT_TOOLS = new Set<string>(["write_app_blueprint"]);
 
 /**
+ * Whether a tool belongs in this turn's tool set. Single source of truth for
+ * inclusion, so a caller that needs the answer before the set is built (e.g. a
+ * tool whose availability depends on another tool) can ask the same question
+ * the builder does.
+ */
+export function shouldIncludeTool(
+  tool: (typeof TOOL_DEFINITIONS)[number],
+  ctx: AgentContext,
+  options: BuildAgentToolSetOptions = {},
+): boolean {
+  if (getAgentToolConsent(tool.name) === "never") {
+    return false;
+  }
+  // In plan mode, skip state-modifying tools unless they're planning-specific.
+  if (
+    options.planModeOnly &&
+    tool.modifiesState &&
+    !PLANNING_SPECIFIC_TOOLS.has(tool.name)
+  ) {
+    return false;
+  }
+  // Skip plan-mode-only tools when NOT in plan mode.
+  if (!options.planModeOnly && PLAN_MODE_ONLY_TOOLS.has(tool.name)) {
+    return false;
+  }
+  // Skip Pro-only tools in basic agent mode.
+  if (options.basicAgentMode && PRO_AGENT_ONLY_TOOLS.has(tool.name)) {
+    return false;
+  }
+  // Skip app blueprint tools when the feature is disabled.
+  if (
+    options.enableAppBlueprint === false &&
+    APP_BLUEPRINT_TOOLS.has(tool.name)
+  ) {
+    return false;
+  }
+  // In read-only mode, skip tools that modify state.
+  if (options.readOnly && tool.modifiesState) {
+    return false;
+  }
+  if (tool.isEnabled && !tool.isEnabled(ctx)) {
+    return false;
+  }
+  return true;
+}
+
+/**
  * Build ToolSet for AI SDK from tool definitions
  */
 export function buildAgentToolSet(
@@ -421,44 +468,7 @@ export function buildAgentToolSet(
   const toolSet: Record<string, any> = {};
 
   for (const tool of TOOL_DEFINITIONS) {
-    const consent = getAgentToolConsent(tool.name);
-    if (consent === "never") {
-      continue;
-    }
-
-    // In plan mode, skip state-modifying tools unless they're planning-specific
-    if (
-      options.planModeOnly &&
-      tool.modifiesState &&
-      !PLANNING_SPECIFIC_TOOLS.has(tool.name)
-    ) {
-      continue;
-    }
-
-    // Skip plan-mode-only tools when NOT in plan mode
-    if (!options.planModeOnly && PLAN_MODE_ONLY_TOOLS.has(tool.name)) {
-      continue;
-    }
-
-    // Skip Pro-only tools in basic agent mode
-    if (options.basicAgentMode && PRO_AGENT_ONLY_TOOLS.has(tool.name)) {
-      continue;
-    }
-
-    // Skip app blueprint tools when the feature is disabled
-    if (
-      options.enableAppBlueprint === false &&
-      APP_BLUEPRINT_TOOLS.has(tool.name)
-    ) {
-      continue;
-    }
-
-    // In read-only mode, skip tools that modify state
-    if (options.readOnly && tool.modifiesState) {
-      continue;
-    }
-
-    if (tool.isEnabled && !tool.isEnabled(ctx)) {
+    if (!shouldIncludeTool(tool, ctx, options)) {
       continue;
     }
 

--- a/src/pro/main/ipc/handlers/local_agent/tools/bm25.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/bm25.spec.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import {
+  tokenize,
+  buildToolDocument,
+  bm25Ranker,
+  type ToolRanker,
+} from "./bm25";
+import type { McpToolDef } from "./mcp_type_defs";
+
+function def(
+  overrides: Partial<McpToolDef> & { toolName: string },
+): McpToolDef {
+  return {
+    jsName: overrides.toolName,
+    toolKey: `srv__${overrides.toolName}`,
+    serverId: 1,
+    serverName: "srv",
+    description: undefined,
+    inputSchema: { type: "object" },
+    ...overrides,
+  };
+}
+
+describe("tokenize", () => {
+  it("splits camelCase and snake_case into parts", () => {
+    expect(tokenize("createIssue")).toEqual(["create", "issue"]);
+    expect(tokenize("list_repositories")).toEqual(["list", "repository"]);
+  });
+
+  it("folds -ies plurals to singular so queries match", () => {
+    expect(tokenize("repositories")).toEqual(tokenize("repository"));
+  });
+
+  it("splits letter/digit boundaries", () => {
+    expect(tokenize("listV2Repos")).toEqual(
+      expect.arrayContaining(["list", "v", "2", "repo"]),
+    );
+  });
+
+  it("folds simple plurals but leaves short tokens intact", () => {
+    expect(tokenize("issues")).toEqual(["issue"]);
+    expect(tokenize("ls")).toEqual(["ls"]);
+    expect(tokenize("address")).toEqual(["address"]); // -ss not stripped
+  });
+
+  it("returns empty for empty input", () => {
+    expect(tokenize("")).toEqual([]);
+    expect(tokenize("   ")).toEqual([]);
+  });
+});
+
+describe("buildToolDocument", () => {
+  it("includes server, names, description, and property names/descriptions", () => {
+    const doc = buildToolDocument(
+      def({
+        toolName: "create_issue",
+        serverName: "github",
+        description: "Open a new issue",
+        inputSchema: {
+          type: "object",
+          properties: {
+            title: { type: "string", description: "The issue title" },
+            labels: { type: "array" },
+          },
+        },
+      }),
+    );
+    expect(doc).toContain("github");
+    expect(doc).toContain("create_issue");
+    expect(doc).toContain("Open a new issue");
+    expect(doc).toContain("title");
+    expect(doc).toContain("The issue title");
+    expect(doc).toContain("labels");
+  });
+});
+
+describe("bm25Ranker", () => {
+  const tools = [
+    def({
+      toolName: "create_issue",
+      serverName: "github",
+      description: "Create a new issue in a repository",
+    }),
+    def({
+      toolName: "send_message",
+      serverName: "slack",
+      description: "Post a message to a channel",
+    }),
+    def({
+      toolName: "list_repositories",
+      serverName: "github",
+      description: "List repositories for the user",
+    }),
+  ];
+
+  it("ranks the most lexically relevant tool first", () => {
+    const ranked = bm25Ranker("create github issue", tools);
+    expect(ranked.length).toBeGreaterThan(0);
+    expect(ranked[0].def.toolName).toBe("create_issue");
+  });
+
+  it("matches on description vocabulary, not just the name", () => {
+    const ranked = bm25Ranker("post channel", tools);
+    expect(ranked[0].def.toolName).toBe("send_message");
+  });
+
+  it("returns matches sorted by descending score", () => {
+    const ranked = bm25Ranker("repository", tools);
+    for (let i = 1; i < ranked.length; i++) {
+      expect(ranked[i - 1].score).toBeGreaterThanOrEqual(ranked[i].score);
+    }
+  });
+
+  it("omits non-matching tools (score 0)", () => {
+    const ranked = bm25Ranker("create issue", tools);
+    expect(ranked.every((r) => r.score > 0)).toBe(true);
+    expect(ranked.some((r) => r.def.toolName === "send_message")).toBe(false);
+  });
+
+  it("returns empty for an empty query or empty corpus", () => {
+    expect(bm25Ranker("", tools)).toEqual([]);
+    expect(bm25Ranker("anything", [])).toEqual([]);
+  });
+
+  it("conforms to the ToolRanker type", () => {
+    const ranker: ToolRanker = bm25Ranker;
+    expect(typeof ranker).toBe("function");
+  });
+});

--- a/src/pro/main/ipc/handlers/local_agent/tools/bm25.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/bm25.ts
@@ -42,7 +42,9 @@ export function tokenize(text: string): string[] {
     .replace(/([0-9])([A-Za-z])/g, "$1 $2");
   const raw = withBoundaries
     .toLowerCase()
-    .split(/[^a-z0-9]+/)
+    // Split on any non-letter/non-number so words in non-Latin scripts
+    // (accented, Cyrillic, CJK, etc.) survive instead of being stripped.
+    .split(/[^\p{L}\p{N}]+/u)
     .filter(Boolean);
   return raw.map(stem);
 }

--- a/src/pro/main/ipc/handlers/local_agent/tools/bm25.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/bm25.ts
@@ -1,0 +1,154 @@
+/**
+ * BM25 ranking for MCP tool search.
+ *
+ * The `ToolRanker` type is the stable seam: `search_mcp_tools` depends only
+ * on it, so the scoring details below (tokenization, corpus weighting, BM25
+ * constants) can be reworked freely without touching the tool, prompt, or
+ * capability wiring.
+ */
+
+import type { McpToolDef } from "./mcp_type_defs";
+
+export interface RankedTool {
+  def: McpToolDef;
+  /** BM25 score. Higher is a better match. Always > 0 for returned entries. */
+  score: number;
+}
+
+/**
+ * Given a free-text query and a set of candidate tools, return the tools that
+ * match the query, ranked best-first. Non-matching tools (score 0) are
+ * omitted.
+ */
+export type ToolRanker = (query: string, defs: McpToolDef[]) => RankedTool[];
+
+// Standard BM25 free parameters.
+const K1 = 1.5;
+const B = 0.75;
+
+/**
+ * Split text into lowercased terms. Splits on non-alphanumerics and on
+ * camelCase / digit boundaries so identifiers like `createIssue` and
+ * `listV2Repos` contribute their parts. Trailing plural "s" is folded so a
+ * query for "repository" matches "repositories" and "repos" reasonably often.
+ */
+export function tokenize(text: string): string[] {
+  if (!text) return [];
+  const withBoundaries = text
+    // camelCase / PascalCase boundary: fooBar -> foo Bar
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    // letter/digit boundary: v2 -> v 2, 2fa -> 2 fa
+    .replace(/([A-Za-z])([0-9])/g, "$1 $2")
+    .replace(/([0-9])([A-Za-z])/g, "$1 $2");
+  const raw = withBoundaries
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+  return raw.map(stem);
+}
+
+function stem(token: string): string {
+  // Naive plural folding only — keep short tokens intact so we don't collapse
+  // meaningful words (e.g. "ls", "is"). Handles the common cases that show up
+  // in tool/param names: "repositories" -> "repository", "issues" -> "issue".
+  if (token.length > 4 && token.endsWith("ies")) {
+    return `${token.slice(0, -3)}y`;
+  }
+  if (token.length > 3 && token.endsWith("s") && !token.endsWith("ss")) {
+    return token.slice(0, -1);
+  }
+  return token;
+}
+
+/**
+ * Build the searchable document for a tool from everything a model might key
+ * off: server name, tool name (raw + JS identifier), description, and the
+ * input schema's top-level property names and descriptions.
+ */
+export function buildToolDocument(def: McpToolDef): string {
+  const parts: string[] = [
+    def.serverName ?? "",
+    def.toolName ?? "",
+    def.jsName ?? "",
+    def.description ?? "",
+  ];
+
+  const schema = def.inputSchema as
+    | { properties?: Record<string, unknown> }
+    | undefined;
+  const properties = schema?.properties;
+  if (properties && typeof properties === "object") {
+    for (const [propName, propSchema] of Object.entries(properties)) {
+      parts.push(propName);
+      const desc =
+        propSchema &&
+        typeof propSchema === "object" &&
+        "description" in propSchema
+          ? (propSchema as { description?: unknown }).description
+          : undefined;
+      if (typeof desc === "string") {
+        parts.push(desc);
+      }
+    }
+  }
+
+  return parts.join(" ");
+}
+
+interface IndexedDoc {
+  def: McpToolDef;
+  termFreqs: Map<string, number>;
+  length: number;
+}
+
+export const bm25Ranker: ToolRanker = (query, defs) => {
+  const queryTerms = tokenize(query);
+  if (queryTerms.length === 0 || defs.length === 0) {
+    return [];
+  }
+
+  const docs: IndexedDoc[] = defs.map((def) => {
+    const terms = tokenize(buildToolDocument(def));
+    const termFreqs = new Map<string, number>();
+    for (const term of terms) {
+      termFreqs.set(term, (termFreqs.get(term) ?? 0) + 1);
+    }
+    return { def, termFreqs, length: terms.length };
+  });
+
+  const totalLength = docs.reduce((sum, doc) => sum + doc.length, 0);
+  const avgdl = totalLength / docs.length || 1;
+
+  // Document frequency per unique query term.
+  const uniqueQueryTerms = [...new Set(queryTerms)];
+  const docFreq = new Map<string, number>();
+  for (const term of uniqueQueryTerms) {
+    let df = 0;
+    for (const doc of docs) {
+      if (doc.termFreqs.has(term)) df += 1;
+    }
+    docFreq.set(term, df);
+  }
+
+  const N = docs.length;
+  const ranked: RankedTool[] = [];
+  for (const doc of docs) {
+    let score = 0;
+    for (const term of uniqueQueryTerms) {
+      const f = doc.termFreqs.get(term);
+      if (!f) continue;
+      const df = docFreq.get(term) ?? 0;
+      // BM25 idf with the standard +0.5 smoothing. Clamped at 0 so a term
+      // present in every document doesn't push scores negative.
+      const idf = Math.max(0, Math.log((N - df + 0.5) / (df + 0.5) + 1));
+      const denom = f + K1 * (1 - B + (B * doc.length) / avgdl);
+      score += idf * ((f * (K1 + 1)) / denom);
+    }
+    if (score > 0) {
+      ranked.push({ def: doc.def, score });
+    }
+  }
+
+  ranked.sort((a, b) => b.score - a.score);
+  return ranked;
+};

--- a/src/pro/main/ipc/handlers/local_agent/tools/bm25.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/bm25.ts
@@ -53,6 +53,9 @@ function stem(token: string): string {
   // Naive plural folding only — keep short tokens intact so we don't collapse
   // meaningful words (e.g. "ls", "is"). Handles the common cases that show up
   // in tool/param names: "repositories" -> "repository", "issues" -> "issue".
+  // Verb suffixes (-ing/-ed/-er) and abbreviations aren't folded, so "creating"
+  // and "create" stay distinct; swap in a real stemmer if recall gets poor as
+  // tool sets grow.
   if (token.length > 4 && token.endsWith("ies")) {
     return `${token.slice(0, -3)}y`;
   }

--- a/src/pro/main/ipc/handlers/local_agent/tools/bm25.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/bm25.ts
@@ -140,8 +140,9 @@ export const bm25Ranker: ToolRanker = (query, defs) => {
       const f = doc.termFreqs.get(term);
       if (!f) continue;
       const df = docFreq.get(term) ?? 0;
-      // BM25 idf with the standard +0.5 smoothing. Clamped at 0 so a term
-      // present in every document doesn't push scores negative.
+      // BM25 idf with +0.5 smoothing, using the log(1 + x) form (as in Lucene)
+      // rather than the classic Okapi log so the weight is always >= 0 even for
+      // a term present in every document. Math.max keeps that floor explicit.
       const idf = Math.max(0, Math.log((N - df + 0.5) / (df + 0.5) + 1));
       const denom = f + K1 * (1 - B + (B * doc.length) / avgdl);
       score += idf * ((f * (K1 + 1)) / denom);

--- a/src/pro/main/ipc/handlers/local_agent/tools/execute_sandbox_script.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/execute_sandbox_script.spec.ts
@@ -4,10 +4,12 @@ import { runSandboxScript } from "@/ipc/utils/sandbox/runner";
 import { sendTelemetryEvent } from "@/ipc/utils/telemetry";
 import { readSettings } from "@/main/settings";
 import {
+  buildExecuteSandboxScriptDescription,
   executeSandboxScriptTool,
   isSandboxScriptExecutionEnabled,
 } from "./execute_sandbox_script";
 import type { AgentContext } from "./types";
+import type { McpToolDef } from "./mcp_type_defs";
 
 vi.mock("@/ipc/utils/sandbox/execution", () => ({
   isSandboxSupportedPlatform: vi.fn(() => true),
@@ -181,5 +183,37 @@ describe("executeSandboxScriptTool", () => {
       "sandbox.script.completed",
       expect.objectContaining({ executionThread: "worker" }),
     );
+  });
+});
+
+describe("buildExecuteSandboxScriptDescription (search mode)", () => {
+  function def(serverName: string, toolName: string): McpToolDef {
+    return {
+      jsName: `${serverName}__${toolName}`,
+      toolKey: `${serverName}__${toolName}`,
+      serverId: 1,
+      serverName,
+      toolName,
+      inputSchema: { type: "object" } as any,
+    };
+  }
+
+  it("lists connected servers with tool counts instead of inlining signatures", async () => {
+    const desc = await buildExecuteSandboxScriptDescription(
+      [
+        def("Sentry", "get_issue"),
+        def("Sentry", "list_issues"),
+        def("Linear", "create_issue"),
+      ],
+      { useSearch: true },
+    );
+
+    expect(desc).toContain("Connected MCP servers:");
+    expect(desc).toContain("Sentry (2 tools)");
+    expect(desc).toContain("Linear (1 tool)");
+    expect(desc).toContain("search_mcp_tools");
+    // Search mode must NOT inline the per-tool MCP signatures (the whole
+    // point of search is to keep them out of context).
+    expect(desc).not.toContain("Sentry__get_issue");
   });
 });

--- a/src/pro/main/ipc/handlers/local_agent/tools/execute_sandbox_script.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/execute_sandbox_script.ts
@@ -201,6 +201,35 @@ ${typeDefsBlock}
 \`\`\``;
 }
 
+// Search-mode addendum: used when the `enableMcpToolSearch` experiment is on.
+// The per-tool declarations are NOT listed here to keep context lean; the
+// model discovers them via `search_mcp_tools` and then calls the returned
+// host functions from inside the script.
+function buildServerInventory(defs: McpToolDef[]): string {
+  const counts = new Map<string, number>();
+  for (const def of defs) {
+    const name = def.serverName;
+    if (!name) continue;
+    counts.set(name, (counts.get(name) ?? 0) + 1);
+  }
+  if (counts.size === 0) return "";
+  const list = [...counts.entries()]
+    .map(([name, n]) => `${name} (${n} tool${n === 1 ? "" : "s"})`)
+    .join(", ");
+  return `\nConnected MCP servers: ${list}. Search within one with the \`server\` param, or across all by omitting it.`;
+}
+
+function buildMcpSearchAddendum(defs: McpToolDef[]): string {
+  return `
+
+MCP tools can also be invoked from inside the script. To use one:
+1. Call the \`search_mcp_tools\` tool with keywords (optionally a \`server\`) to get the TypeScript declarations of the tools you need.
+2. Call those declared host functions inside this script, exactly as declared.
+${buildServerInventory(defs)}
+- Each MCP tool invocation may trigger a user consent prompt. A denied call throws.
+- MCP host functions are only available on the 'main' execution thread. They are NOT available on the 'worker' thread — if you need both heavy compute and MCP calls, split into two scripts (worker for the compute, then main for the MCP follow-up).`;
+}
+
 /**
  * Build the full tool description, appending the MCP host-function
  * declarations and usage notes when any MCP server is enabled. The
@@ -213,10 +242,17 @@ ${typeDefsBlock}
  */
 export async function buildExecuteSandboxScriptDescription(
   precomputedDefs?: McpToolDef[],
+  options?: { useSearch?: boolean },
 ): Promise<string> {
   const defs = precomputedDefs ?? (await collectMcpToolDefs());
   if (defs.length === 0) {
     return FILES_ONLY_PREAMBLE;
+  }
+  // Search mode (experiment on): point the model at `search_mcp_tools`
+  // instead of inlining every tool's declarations. The full per-tool block is
+  // only embedded when search is off.
+  if (options?.useSearch) {
+    return FILES_ONLY_PREAMBLE + buildMcpSearchAddendum(defs);
   }
   return FILES_ONLY_PREAMBLE + buildMcpAddendum(buildMcpTypeDefsBlock(defs));
 }

--- a/src/pro/main/ipc/handlers/local_agent/tools/search_mcp_tools.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/search_mcp_tools.spec.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { searchMcpToolsTool } from "./search_mcp_tools";
+import type { McpToolDef } from "./mcp_type_defs";
+import type { AgentContext } from "./types";
+
+const readSettingsMock = vi.fn();
+
+vi.mock("@/main/settings", () => ({
+  readSettings: () => readSettingsMock(),
+}));
+
+// Avoid touching the DB if the tool ever falls back to a fresh collection.
+vi.mock("./mcp_type_defs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./mcp_type_defs")>();
+  return { ...actual, collectMcpToolDefs: vi.fn(async () => []) };
+});
+
+function def(
+  overrides: Partial<McpToolDef> & { toolName: string },
+): McpToolDef {
+  return {
+    jsName: overrides.toolName,
+    toolKey: `${overrides.serverName ?? "srv"}__${overrides.toolName}`,
+    serverId: 1,
+    serverName: "srv",
+    description: undefined,
+    inputSchema: { type: "object" },
+    ...overrides,
+  };
+}
+
+const TOOLS: McpToolDef[] = [
+  def({
+    toolName: "create_issue",
+    serverName: "github",
+    description: "Create a new issue in a repository",
+    inputSchema: {
+      type: "object",
+      properties: { title: { type: "string" } },
+      required: ["title"],
+    },
+  }),
+  def({
+    toolName: "send_message",
+    serverName: "slack",
+    description: "Post a message to a channel",
+  }),
+  def({
+    toolName: "list_repositories",
+    serverName: "github",
+    description: "List repositories",
+  }),
+];
+
+function makeCtx(defs: McpToolDef[] | undefined): AgentContext {
+  return {
+    mcpToolsEnabled: true,
+    mcpToolDefs: defs,
+    onXmlComplete: vi.fn(),
+    onXmlStream: vi.fn(),
+  } as unknown as AgentContext;
+}
+
+beforeEach(() => {
+  readSettingsMock.mockReturnValue({
+    enableMcpToolSearch: true,
+    enableSandboxScriptExecution: true,
+  });
+});
+
+describe("searchMcpToolsTool.isEnabled", () => {
+  const baseCtx = { mcpToolsEnabled: true } as unknown as AgentContext;
+
+  it("is enabled when sandbox + experiment + mcpToolsEnabled are all on", () => {
+    expect(searchMcpToolsTool.isEnabled?.(baseCtx)).toBe(true);
+  });
+
+  it("is disabled when the experiment flag is off", () => {
+    readSettingsMock.mockReturnValue({
+      enableMcpToolSearch: false,
+      enableSandboxScriptExecution: true,
+    });
+    expect(searchMcpToolsTool.isEnabled?.(baseCtx)).toBe(false);
+  });
+
+  it("is disabled when sandbox script execution is off", () => {
+    readSettingsMock.mockReturnValue({
+      enableMcpToolSearch: true,
+      enableSandboxScriptExecution: false,
+    });
+    expect(searchMcpToolsTool.isEnabled?.(baseCtx)).toBe(false);
+  });
+
+  it("is disabled when MCP-in-sandbox is not active for the turn", () => {
+    expect(
+      searchMcpToolsTool.isEnabled?.({
+        mcpToolsEnabled: false,
+      } as unknown as AgentContext),
+    ).toBe(false);
+  });
+});
+
+describe("searchMcpToolsTool.execute", () => {
+  it("returns TypeScript declarations for the best match", async () => {
+    const ctx = makeCtx(TOOLS);
+    const result = await searchMcpToolsTool.execute(
+      { query: "create github issue" },
+      ctx,
+    );
+    expect(result).toContain("declare function create_issue");
+    expect(result).not.toContain("declare function send_message");
+    expect(ctx.onXmlComplete).toHaveBeenCalledOnce();
+  });
+
+  it("filters to a single server when `server` is given", async () => {
+    const ctx = makeCtx(TOOLS);
+    const result = await searchMcpToolsTool.execute(
+      { query: "list", server: "github" },
+      ctx,
+    );
+    expect(result).toContain("declare function list_repositories");
+    expect(result).not.toContain("send_message");
+  });
+
+  it("reports available servers when the server name is unknown", async () => {
+    const ctx = makeCtx(TOOLS);
+    const result = await searchMcpToolsTool.execute(
+      { query: "anything", server: "does-not-exist" },
+      ctx,
+    );
+    expect(result).toContain("No MCP server named");
+    expect(result).toContain("github");
+    expect(result).toContain("slack");
+  });
+
+  it("returns a helpful message when nothing matches the query", async () => {
+    const ctx = makeCtx(TOOLS);
+    const result = await searchMcpToolsTool.execute(
+      { query: "zzzznomatch" },
+      ctx,
+    );
+    expect(result).toContain('No MCP tools matched "zzzznomatch"');
+  });
+
+  it("includes a refine footer when more tools match than are returned", async () => {
+    // Build 8 similar tools so more than MAX_RESULTS (5) match the query.
+    const many: McpToolDef[] = Array.from({ length: 8 }, (_, i) =>
+      def({
+        toolName: `search_thing_${i}`,
+        serverName: "srv",
+        description: "search for a thing",
+      }),
+    );
+    const ctx = makeCtx(many);
+    const result = await searchMcpToolsTool.execute(
+      { query: "search thing" },
+      ctx,
+    );
+    expect(result).toMatch(/more tool\(s\) matched/);
+  });
+});

--- a/src/pro/main/ipc/handlers/local_agent/tools/search_mcp_tools.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/search_mcp_tools.spec.ts
@@ -83,14 +83,6 @@ describe("searchMcpToolsTool.isEnabled", () => {
     expect(searchMcpToolsTool.isEnabled?.(baseCtx)).toBe(false);
   });
 
-  it("is disabled when sandbox script execution is off", () => {
-    readSettingsMock.mockReturnValue({
-      enableMcpToolSearch: true,
-      enableSandboxScriptExecution: false,
-    });
-    expect(searchMcpToolsTool.isEnabled?.(baseCtx)).toBe(false);
-  });
-
   it("is disabled when MCP-in-sandbox is not active for the turn", () => {
     expect(
       searchMcpToolsTool.isEnabled?.({

--- a/src/pro/main/ipc/handlers/local_agent/tools/search_mcp_tools.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/search_mcp_tools.spec.ts
@@ -142,6 +142,16 @@ describe("searchMcpToolsTool.execute", () => {
     expect(result).toContain('No MCP tools matched "zzzznomatch"');
   });
 
+  it("reports tools unavailable when the handler did not populate defs", async () => {
+    const ctx = makeCtx(undefined);
+    const result = await searchMcpToolsTool.execute(
+      { query: "create github issue" },
+      ctx,
+    );
+    expect(result).toContain("temporarily unavailable");
+    expect(result).not.toContain("declare function");
+  });
+
   it("includes a refine footer when more tools match than are returned", async () => {
     // Build 8 similar tools so more than MAX_RESULTS (5) match the query.
     const many: McpToolDef[] = Array.from({ length: 8 }, (_, i) =>

--- a/src/pro/main/ipc/handlers/local_agent/tools/search_mcp_tools.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/search_mcp_tools.ts
@@ -74,9 +74,8 @@ export const searchMcpToolsTool: ToolDefinition<SearchMcpToolsArgs> = {
   inputSchema: searchMcpToolsSchema,
   defaultConsent: "always",
 
-  // ctx.mcpToolsEnabled is derived from shouldIncludeTool(executeSandboxScriptTool),
-  // so it already implies sandbox-script execution is on this turn. Only the
-  // experiment flag needs a separate check here.
+  // ctx.mcpToolsEnabled already implies sandbox-script execution is on, so only
+  // the experiment flag needs a separate check.
   isEnabled: (ctx) =>
     !!ctx.mcpToolsEnabled && !!readSettings().enableMcpToolSearch,
 
@@ -99,10 +98,8 @@ export const searchMcpToolsTool: ToolDefinition<SearchMcpToolsArgs> = {
       return result;
     };
 
-    // The handler populates `ctx.mcpToolDefs` with the same defs used to build
-    // the sandbox capability map. If it's missing, the sandbox has no MCP host
-    // functions this turn, so returning declarations here would point the model
-    // at functions it can't call. Surface that instead of guessing.
+    // No defs means the handler's collection failed and the sandbox has no MCP
+    // host functions this turn, so don't hand the model tools it can't call.
     if (ctx.mcpToolDefs === undefined) {
       return finish("MCP tools are temporarily unavailable. Try again.");
     }

--- a/src/pro/main/ipc/handlers/local_agent/tools/search_mcp_tools.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/search_mcp_tools.ts
@@ -5,11 +5,7 @@ import {
   escapeXmlAttr,
   escapeXmlContent,
 } from "./types";
-import {
-  collectMcpToolDefs,
-  buildMcpTypeDefsBlock,
-  type McpToolDef,
-} from "./mcp_type_defs";
+import { buildMcpTypeDefsBlock, type McpToolDef } from "./mcp_type_defs";
 import { bm25Ranker, type ToolRanker } from "./bm25";
 import { sanitizeMcpName } from "@/ipc/utils/mcp_tool_utils";
 import { isSandboxScriptExecutionEnabled } from "./execute_sandbox_script";
@@ -105,21 +101,25 @@ export const searchMcpToolsTool: ToolDefinition<SearchMcpToolsArgs> = {
   },
 
   execute: async (args: SearchMcpToolsArgs, ctx: AgentContext) => {
-    // Prefer the per-turn defs collected by the handler so search and the
-    // sandbox capability map agree on which tools exist; fall back to a fresh
-    // collection if the handler didn't populate them.
-    const allDefs = ctx.mcpToolDefs ?? (await collectMcpToolDefs());
-
-    const scoped = args.server
-      ? allDefs.filter((d) => matchesServer(d, args.server!))
-      : allDefs;
-
     const finish = (result: string) => {
       ctx.onXmlComplete(
         `<dyad-mcp-tool-search${buildSearchAttributes(args)}>${escapeXmlContent(result)}</dyad-mcp-tool-search>`,
       );
       return result;
     };
+
+    // The handler populates `ctx.mcpToolDefs` with the same defs used to build
+    // the sandbox capability map. If it's missing, the sandbox has no MCP host
+    // functions this turn, so returning declarations here would point the model
+    // at functions it can't call. Surface that instead of guessing.
+    if (ctx.mcpToolDefs === undefined) {
+      return finish("MCP tools are temporarily unavailable. Try again.");
+    }
+    const allDefs = ctx.mcpToolDefs;
+
+    const scoped = args.server
+      ? allDefs.filter((d) => matchesServer(d, args.server!))
+      : allDefs;
 
     if (scoped.length === 0) {
       const servers = uniqueServerNames(allDefs);

--- a/src/pro/main/ipc/handlers/local_agent/tools/search_mcp_tools.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/search_mcp_tools.ts
@@ -8,7 +8,6 @@ import {
 import { buildMcpTypeDefsBlock, type McpToolDef } from "./mcp_type_defs";
 import { bm25Ranker, type ToolRanker } from "./bm25";
 import { sanitizeMcpName } from "@/ipc/utils/mcp_tool_utils";
-import { isSandboxScriptExecutionEnabled } from "./execute_sandbox_script";
 import { readSettings } from "@/main/settings";
 
 /**
@@ -75,19 +74,11 @@ export const searchMcpToolsTool: ToolDefinition<SearchMcpToolsArgs> = {
   inputSchema: searchMcpToolsSchema,
   defaultConsent: "always",
 
-  isEnabled: (ctx) => {
-    // `ctx.mcpToolsEnabled` is set by the handler only when
-    // execute_sandbox_script is registered for the turn, which already implies
-    // sandbox-script execution is on. The explicit isSandboxScriptExecutionEnabled
-    // check is kept as defense-in-depth so this tool can never be enabled without
-    // the sandbox, independent of how `ctx.mcpToolsEnabled` was derived.
-    const settings = readSettings();
-    return (
-      !!ctx.mcpToolsEnabled &&
-      !!isSandboxScriptExecutionEnabled(settings) &&
-      !!settings.enableMcpToolSearch
-    );
-  },
+  // ctx.mcpToolsEnabled is derived from shouldIncludeTool(executeSandboxScriptTool),
+  // so it already implies sandbox-script execution is on this turn. Only the
+  // experiment flag needs a separate check here.
+  isEnabled: (ctx) =>
+    !!ctx.mcpToolsEnabled && !!readSettings().enableMcpToolSearch,
 
   getConsentPreview: (args) =>
     args.server

--- a/src/pro/main/ipc/handlers/local_agent/tools/search_mcp_tools.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/search_mcp_tools.ts
@@ -1,0 +1,149 @@
+import { z } from "zod";
+import {
+  ToolDefinition,
+  AgentContext,
+  escapeXmlAttr,
+  escapeXmlContent,
+} from "./types";
+import {
+  collectMcpToolDefs,
+  buildMcpTypeDefsBlock,
+  type McpToolDef,
+} from "./mcp_type_defs";
+import { bm25Ranker, type ToolRanker } from "./bm25";
+import { sanitizeMcpName } from "@/ipc/utils/mcp_tool_utils";
+import { isSandboxScriptExecutionEnabled } from "./execute_sandbox_script";
+import { readSettings } from "@/main/settings";
+
+/**
+ * Number of matching tools whose full TypeScript declarations are returned.
+ * Kept small on purpose: the point of search is to keep context lean. The
+ * model can refine its query (or pass a `server`) to reach the rest.
+ */
+const MAX_RESULTS = 5;
+
+const searchMcpToolsSchema = z.object({
+  query: z
+    .string()
+    .describe(
+      "Keywords describing the MCP tool you need (e.g. 'create github issue', 'send slack message').",
+    ),
+  server: z
+    .string()
+    .optional()
+    .describe(
+      "Optional. Restrict the search to a single MCP server by name. Omit to search across all enabled servers.",
+    ),
+});
+
+type SearchMcpToolsArgs = z.infer<typeof searchMcpToolsSchema>;
+
+function matchesServer(def: McpToolDef, server: string): boolean {
+  const a = def.serverName ?? "";
+  return (
+    a.toLowerCase() === server.toLowerCase() ||
+    sanitizeMcpName(a) === sanitizeMcpName(server)
+  );
+}
+
+function uniqueServerNames(defs: McpToolDef[]): string[] {
+  return [...new Set(defs.map((d) => d.serverName).filter(Boolean))];
+}
+
+function buildSearchAttributes(args: Partial<SearchMcpToolsArgs>): string {
+  const queryAttr = args.query ? ` query="${escapeXmlAttr(args.query)}"` : "";
+  const serverAttr = args.server
+    ? ` server="${escapeXmlAttr(args.server)}"`
+    : "";
+  return `${queryAttr}${serverAttr}`;
+}
+
+/**
+ * Discover MCP tools by keyword instead of listing every tool in the prompt.
+ * Returns the TypeScript `declare function` block (same shape used inside
+ * `execute_sandbox_script`) for the best matches, which the model then calls
+ * as host functions from a sandbox script.
+ *
+ * Only registered when MCP-in-sandbox is active for the turn AND the
+ * `enableMcpToolSearch` experiment is on (see `isEnabled`). When off, the
+ * full type-defs block is embedded in `execute_sandbox_script` as before and
+ * this tool is absent.
+ */
+export const searchMcpToolsTool: ToolDefinition<SearchMcpToolsArgs> = {
+  name: "search_mcp_tools",
+  description:
+    "Search for MCP tools by keyword and get their TypeScript signatures. " +
+    "Use this before calling an MCP tool from execute_sandbox_script: search " +
+    "for what you need, then call the returned host functions inside a script. " +
+    "Pass `server` to restrict the search to one MCP server.",
+  inputSchema: searchMcpToolsSchema,
+  defaultConsent: "always",
+
+  isEnabled: (ctx) =>
+    !!ctx.mcpToolsEnabled &&
+    !!isSandboxScriptExecutionEnabled(readSettings()) &&
+    !!readSettings().enableMcpToolSearch,
+
+  getConsentPreview: (args) =>
+    args.server
+      ? `Search MCP tools for "${args.query}" (server: ${args.server})`
+      : `Search MCP tools for "${args.query}"`,
+
+  buildXml: (args, isComplete) => {
+    if (!args.query) return undefined;
+    if (isComplete) return undefined;
+    return `<dyad-mcp-tool-search${buildSearchAttributes(args)}>Searching...`;
+  },
+
+  execute: async (args: SearchMcpToolsArgs, ctx: AgentContext) => {
+    // Prefer the per-turn defs collected by the handler so search and the
+    // sandbox capability map agree on which tools exist; fall back to a fresh
+    // collection if the handler didn't populate them.
+    const allDefs = ctx.mcpToolDefs ?? (await collectMcpToolDefs());
+
+    const scoped = args.server
+      ? allDefs.filter((d) => matchesServer(d, args.server!))
+      : allDefs;
+
+    const finish = (result: string) => {
+      ctx.onXmlComplete(
+        `<dyad-mcp-tool-search${buildSearchAttributes(args)}>${escapeXmlContent(result)}</dyad-mcp-tool-search>`,
+      );
+      return result;
+    };
+
+    if (scoped.length === 0) {
+      const servers = uniqueServerNames(allDefs);
+      const hint =
+        args.server && servers.length > 0
+          ? ` No MCP server named "${args.server}". Available servers: ${servers.join(", ")}.`
+          : servers.length > 0
+            ? ` Available servers: ${servers.join(", ")}.`
+            : " No MCP servers are enabled.";
+      return finish(`No MCP tools available to search.${hint}`);
+    }
+
+    const ranker: ToolRanker = bm25Ranker;
+    const ranked = ranker(args.query, scoped);
+
+    if (ranked.length === 0) {
+      const servers = uniqueServerNames(scoped);
+      return finish(
+        `No MCP tools matched "${args.query}". Try different keywords. ` +
+          `Searched ${scoped.length} tool(s) across: ${servers.join(", ")}.`,
+      );
+    }
+
+    const top = ranked.slice(0, MAX_RESULTS).map((r) => r.def);
+    const block = buildMcpTypeDefsBlock(top);
+    const remaining = ranked.length - top.length;
+    const footer =
+      remaining > 0
+        ? `\n\n// ${remaining} more tool(s) matched "${args.query}". Refine the query or pass \`server\` to narrow.`
+        : "";
+
+    return finish(
+      `Top ${top.length} MCP tool(s) for "${args.query}". Call these as host functions inside execute_sandbox_script:\n\n${block}${footer}`,
+    );
+  },
+};

--- a/src/pro/main/ipc/handlers/local_agent/tools/search_mcp_tools.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/search_mcp_tools.ts
@@ -79,10 +79,19 @@ export const searchMcpToolsTool: ToolDefinition<SearchMcpToolsArgs> = {
   inputSchema: searchMcpToolsSchema,
   defaultConsent: "always",
 
-  isEnabled: (ctx) =>
-    !!ctx.mcpToolsEnabled &&
-    !!isSandboxScriptExecutionEnabled(readSettings()) &&
-    !!readSettings().enableMcpToolSearch,
+  isEnabled: (ctx) => {
+    // `ctx.mcpToolsEnabled` is set by the handler only when
+    // execute_sandbox_script is registered for the turn, which already implies
+    // sandbox-script execution is on. The explicit isSandboxScriptExecutionEnabled
+    // check is kept as defense-in-depth so this tool can never be enabled without
+    // the sandbox, independent of how `ctx.mcpToolsEnabled` was derived.
+    const settings = readSettings();
+    return (
+      !!ctx.mcpToolsEnabled &&
+      !!isSandboxScriptExecutionEnabled(settings) &&
+      !!settings.enableMcpToolSearch
+    );
+  },
 
   getConsentPreview: (args) =>
     args.server


### PR DESCRIPTION
Search MCP tools by keyword from execute_sandbox_script instead of inlining every tool's signature, keeping context lean.

- Render search results in a dedicated dyad-mcp-tool-search card.
- List connected MCP servers (with tool counts) in search-mode prompt so the model knows what it can reach before searching.

Other notes:
- This does add an experiment in the settings, and the experiment is not enabled by default. None of the changes in this PR apply unless the experiment is enabled.
- Uses BM25.
- I haven't evaluated this thoroughly yet, but I have done some basic testing and it appears to me to work well enough for the time being.