### PR TITLE
Split sandbox VM timeout from host time

### DIFF
--- a/src/ipc/utils/sandbox/capabilities.ts
+++ b/src/ipc/utils/sandbox/capabilities.ts
@@ -8,10 +8,7 @@ import {
   toAttachmentLogicalPath,
 } from "@/ipc/utils/media_path_utils";
 import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
-import {
-  SANDBOX_HOST_CALL_TIMEOUT_MS,
-  SANDBOX_READ_FILE_LIMIT_BYTES,
-} from "./limits";
+import { SANDBOX_READ_FILE_LIMIT_BYTES } from "./limits";
 
 type StructuredObject = { [key: string]: unknown };
 
@@ -175,32 +172,6 @@ function isTextPath(filePath: string): boolean {
   return TEXT_EXTENSIONS.has(path.extname(filePath).toLowerCase());
 }
 
-async function withHostCallTimeout<T>(
-  description: string,
-  fn: () => Promise<T>,
-): Promise<T> {
-  let timer: NodeJS.Timeout | undefined;
-  try {
-    return await Promise.race([
-      fn(),
-      new Promise<never>((_, reject) => {
-        timer = setTimeout(() => {
-          reject(
-            new DyadError(
-              `${description} timed out after ${SANDBOX_HOST_CALL_TIMEOUT_MS}ms.`,
-              DyadErrorKind.External,
-            ),
-          );
-        }, SANDBOX_HOST_CALL_TIMEOUT_MS);
-      }),
-    ]);
-  } finally {
-    if (timer) {
-      clearTimeout(timer);
-    }
-  }
-}
-
 async function resolveSandboxPath(params: {
   appPath: string;
   guestPath: string;
@@ -279,125 +250,119 @@ export async function sandboxReadFile(
   guestPath: string,
   rawOptions?: unknown,
 ): Promise<string> {
-  return withHostCallTimeout("read_file", async () => {
-    const options = parseReadOptions(rawOptions);
-    const resolved = await resolveSandboxPath({ appPath, guestPath });
-    await assertResolvedPathAllowed({ appPath, ...resolved });
+  const options = parseReadOptions(rawOptions);
+  const resolved = await resolveSandboxPath({ appPath, guestPath });
+  await assertResolvedPathAllowed({ appPath, ...resolved });
 
-    const stat = await fs.stat(resolved.filePath);
-    if (!stat.isFile()) {
-      throw new DyadError(
-        `Path is not a file: ${resolved.displayPath}`,
-        DyadErrorKind.Validation,
-      );
-    }
+  const stat = await fs.stat(resolved.filePath);
+  if (!stat.isFile()) {
+    throw new DyadError(
+      `Path is not a file: ${resolved.displayPath}`,
+      DyadErrorKind.Validation,
+    );
+  }
 
-    const start = options.start ?? 0;
-    if (
-      options.length !== undefined &&
-      options.length > SANDBOX_READ_FILE_LIMIT_BYTES
-    ) {
-      throw new DyadError(
-        `read_file length ${options.length} exceeds the ${SANDBOX_READ_FILE_LIMIT_BYTES} byte limit. Read the file in chunks with start and length instead.`,
-        DyadErrorKind.Validation,
-      );
-    }
-    if (start > stat.size) {
-      return "";
-    }
-    const remainingBytes = stat.size - start;
-    const length = options.length ?? remainingBytes;
-    if (length > SANDBOX_READ_FILE_LIMIT_BYTES) {
-      throw new DyadError(
-        `read_file would read ${length} bytes from ${resolved.displayPath}, exceeding the ${SANDBOX_READ_FILE_LIMIT_BYTES} byte limit. Use file_stats to get the size, then read bounded chunks with start and length.`,
-        DyadErrorKind.Validation,
-      );
-    }
+  const start = options.start ?? 0;
+  if (
+    options.length !== undefined &&
+    options.length > SANDBOX_READ_FILE_LIMIT_BYTES
+  ) {
+    throw new DyadError(
+      `read_file length ${options.length} exceeds the ${SANDBOX_READ_FILE_LIMIT_BYTES} byte limit. Read the file in chunks with start and length instead.`,
+      DyadErrorKind.Validation,
+    );
+  }
+  if (start > stat.size) {
+    return "";
+  }
+  const remainingBytes = stat.size - start;
+  const length = options.length ?? remainingBytes;
+  if (length > SANDBOX_READ_FILE_LIMIT_BYTES) {
+    throw new DyadError(
+      `read_file would read ${length} bytes from ${resolved.displayPath}, exceeding the ${SANDBOX_READ_FILE_LIMIT_BYTES} byte limit. Use file_stats to get the size, then read bounded chunks with start and length.`,
+      DyadErrorKind.Validation,
+    );
+  }
 
-    const handle = await fs.open(resolved.filePath, "r");
-    try {
-      const bytesToRead = Math.min(length, remainingBytes);
-      const buffer = Buffer.alloc(bytesToRead);
-      const { bytesRead } = await handle.read(buffer, 0, bytesToRead, start);
-      const bytes = buffer.subarray(0, bytesRead);
-      return (options.encoding ?? "utf8") === "base64"
-        ? bytes.toString("base64")
-        : bytes.toString("utf8");
-    } finally {
-      await handle.close();
-    }
-  });
+  const handle = await fs.open(resolved.filePath, "r");
+  try {
+    const bytesToRead = Math.min(length, remainingBytes);
+    const buffer = Buffer.alloc(bytesToRead);
+    const { bytesRead } = await handle.read(buffer, 0, bytesToRead, start);
+    const bytes = buffer.subarray(0, bytesRead);
+    return (options.encoding ?? "utf8") === "base64"
+      ? bytes.toString("base64")
+      : bytes.toString("utf8");
+  } finally {
+    await handle.close();
+  }
 }
 
 export async function sandboxFileStats(
   appPath: string,
   guestPath: string,
 ): Promise<SandboxFileStats> {
-  return withHostCallTimeout("file_stats", async () => {
-    const resolved = await resolveSandboxPath({ appPath, guestPath });
-    await assertResolvedPathAllowed({ appPath, ...resolved });
-    const stat = await fs.stat(resolved.filePath);
-    if (!stat.isFile()) {
-      throw new DyadError(
-        `Path is not a file: ${resolved.displayPath}`,
-        DyadErrorKind.Validation,
-      );
-    }
-    return {
-      size: stat.size,
-      isText: isTextPath(resolved.filePath),
-      mtime: stat.mtime.toISOString(),
-    };
-  });
+  const resolved = await resolveSandboxPath({ appPath, guestPath });
+  await assertResolvedPathAllowed({ appPath, ...resolved });
+  const stat = await fs.stat(resolved.filePath);
+  if (!stat.isFile()) {
+    throw new DyadError(
+      `Path is not a file: ${resolved.displayPath}`,
+      DyadErrorKind.Validation,
+    );
+  }
+  return {
+    size: stat.size,
+    isText: isTextPath(resolved.filePath),
+    mtime: stat.mtime.toISOString(),
+  };
 }
 
 export async function sandboxListFiles(
   appPath: string,
   guestDir?: string,
 ): Promise<string[]> {
-  return withHostCallTimeout("list_files", async () => {
-    const dir = guestDir ?? ".";
-    if (dir === "attachments:" || dir === "attachments") {
-      const attachments = await listStoredAttachments(appPath);
-      return attachments.map((attachment) =>
-        toAttachmentLogicalPath(attachment.logicalName),
-      );
-    }
+  const dir = guestDir ?? ".";
+  if (dir === "attachments:" || dir === "attachments") {
+    const attachments = await listStoredAttachments(appPath);
+    return attachments.map((attachment) =>
+      toAttachmentLogicalPath(attachment.logicalName),
+    );
+  }
 
-    assertAllowedGuestPath(dir);
-    const dirPath = safeJoin(appPath, dir);
-    const realAppPath = await fs.realpath(appPath);
-    let realDirPath: string;
-    try {
-      realDirPath = await fs.realpath(dirPath);
-    } catch (error) {
-      if (isNodeErrorWithCode(error, "ENOENT")) {
-        throw new DyadError(
-          `Directory not found: ${dir}`,
-          DyadErrorKind.NotFound,
-        );
-      }
-      throw error;
-    }
-    const relative = path.relative(realAppPath, realDirPath);
-    if (relative.startsWith("..") || path.isAbsolute(relative)) {
+  assertAllowedGuestPath(dir);
+  const dirPath = safeJoin(appPath, dir);
+  const realAppPath = await fs.realpath(appPath);
+  let realDirPath: string;
+  try {
+    realDirPath = await fs.realpath(dirPath);
+  } catch (error) {
+    if (isNodeErrorWithCode(error, "ENOENT")) {
       throw new DyadError(
-        `Sandbox scripts cannot list files outside the app: ${dir}`,
-        DyadErrorKind.Precondition,
+        `Directory not found: ${dir}`,
+        DyadErrorKind.NotFound,
       );
     }
-    const entries = await fs.readdir(realDirPath, { withFileTypes: true });
-    return entries
-      .filter((entry) => !DENIED_PATH_PATTERNS.some((p) => p.test(entry.name)))
-      .map((entry) => {
-        const relativePath = path
-          .join(relative, entry.name)
-          .split(path.sep)
-          .join("/");
-        return entry.isDirectory() ? `${relativePath}/` : relativePath;
-      })
-      .sort();
-  });
+    throw error;
+  }
+  const relative = path.relative(realAppPath, realDirPath);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new DyadError(
+      `Sandbox scripts cannot list files outside the app: ${dir}`,
+      DyadErrorKind.Precondition,
+    );
+  }
+  const entries = await fs.readdir(realDirPath, { withFileTypes: true });
+  return entries
+    .filter((entry) => !DENIED_PATH_PATTERNS.some((p) => p.test(entry.name)))
+    .map((entry) => {
+      const relativePath = path
+        .join(relative, entry.name)
+        .split(path.sep)
+        .join("/");
+      return entry.isDirectory() ? `${relativePath}/` : relativePath;
+    })
+    .sort();
 }
 
 export function buildSandboxCapabilities(appPath: string) {

--- a/src/ipc/utils/sandbox/execution.ts
+++ b/src/ipc/utils/sandbox/execution.ts
@@ -9,6 +9,7 @@ import {
   type SandboxHostCallObserver,
 } from "./capabilities";
 import {
+  clampSandboxWallClockTimeoutMs,
   clampSandboxTimeoutMs,
   SANDBOX_ALLOCATION_BUDGET,
   SANDBOX_CALL_DEPTH_LIMIT,
@@ -37,8 +38,12 @@ export interface SandboxExecutionParams {
   appPath: string;
   script: string;
   timeoutMs?: number;
+  wallClockTimeoutMs?: number;
   persistFullOutput?: boolean;
   onHostCall?: SandboxHostCallObserver;
+  onVmBudgetStart?: () => void;
+  onVmBudgetPause?: () => void;
+  onVmBudgetResume?: () => void;
   capabilities?: Record<string, (...args: unknown[]) => unknown>;
 }
 
@@ -127,6 +132,155 @@ async function spillOutput(params: {
   return outputPath;
 }
 
+function createVmRuntimeBudget(timeoutMs: number): {
+  signal: AbortSignal;
+  start: () => void;
+  pause: () => void;
+  resume: () => void;
+  stop: () => void;
+  abort: () => void;
+  getElapsedMs: () => number;
+} {
+  const abortController = new AbortController();
+  let elapsedMs = 0;
+  let runningSince: number | undefined;
+  let timer: NodeJS.Timeout | undefined;
+  let pauseDepth = 0;
+
+  function clearTimer() {
+    if (timer) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+  }
+
+  function abortIfExpired() {
+    if (elapsedMs >= timeoutMs && !abortController.signal.aborted) {
+      abortController.abort();
+    }
+  }
+
+  function scheduleTimer() {
+    clearTimer();
+    if (abortController.signal.aborted || pauseDepth > 0) {
+      return;
+    }
+    const remainingMs = timeoutMs - elapsedMs;
+    if (remainingMs <= 0) {
+      abortIfExpired();
+      return;
+    }
+    timer = setTimeout(() => {
+      if (runningSince !== undefined) {
+        elapsedMs += Date.now() - runningSince;
+        runningSince = Date.now();
+      }
+      abortIfExpired();
+      if (!abortController.signal.aborted) {
+        scheduleTimer();
+      }
+    }, remainingMs);
+  }
+
+  function start() {
+    if (runningSince === undefined && !abortController.signal.aborted) {
+      runningSince = Date.now();
+      scheduleTimer();
+    }
+  }
+
+  function pause() {
+    if (runningSince !== undefined) {
+      elapsedMs += Date.now() - runningSince;
+      runningSince = undefined;
+    }
+    pauseDepth += 1;
+    clearTimer();
+    abortIfExpired();
+  }
+
+  function resume() {
+    if (pauseDepth === 0) {
+      return;
+    }
+    pauseDepth -= 1;
+    if (pauseDepth > 0 || abortController.signal.aborted) {
+      return;
+    }
+    runningSince = Date.now();
+    scheduleTimer();
+  }
+
+  function stop() {
+    if (runningSince !== undefined) {
+      elapsedMs += Date.now() - runningSince;
+      runningSince = undefined;
+    }
+    clearTimer();
+  }
+
+  return {
+    signal: abortController.signal,
+    start,
+    pause,
+    resume,
+    stop,
+    abort: () => abortController.abort(),
+    getElapsedMs: () =>
+      runningSince === undefined
+        ? elapsedMs
+        : elapsedMs + Date.now() - runningSince,
+  };
+}
+
+function wrapCapabilitiesWithVmBudget(
+  capabilities: Record<string, (...args: unknown[]) => unknown>,
+  budget: Pick<
+    ReturnType<typeof createVmRuntimeBudget>,
+    "pause" | "resume" | "signal"
+  >,
+  hooks: Pick<SandboxExecutionParams, "onVmBudgetPause" | "onVmBudgetResume">,
+): Record<string, (...args: unknown[]) => unknown> {
+  return Object.fromEntries(
+    Object.entries(capabilities).map(([name, capability]) => [
+      name,
+      (...args: unknown[]) => {
+        budget.pause();
+        hooks.onVmBudgetPause?.();
+        if (budget.signal.aborted) {
+          hooks.onVmBudgetResume?.();
+          budget.resume();
+          throw new DyadError(
+            "Sandbox script timed out before host call execution.",
+            DyadErrorKind.External,
+          );
+        }
+        try {
+          const result = capability(...args);
+          if (
+            result !== null &&
+            typeof result === "object" &&
+            "then" in result &&
+            typeof result.then === "function"
+          ) {
+            return Promise.resolve(result).finally(() => {
+              hooks.onVmBudgetResume?.();
+              budget.resume();
+            });
+          }
+          hooks.onVmBudgetResume?.();
+          budget.resume();
+          return result;
+        } catch (error) {
+          hooks.onVmBudgetResume?.();
+          budget.resume();
+          throw error;
+        }
+      },
+    ]),
+  );
+}
+
 export async function executeSandboxScriptInProcess(
   params: SandboxExecutionParams,
 ): Promise<SandboxRunResult> {
@@ -140,16 +294,24 @@ export async function executeSandboxScriptInProcess(
   }
 
   const timeoutMs = clampSandboxTimeoutMs(params.timeoutMs);
-  const started = Date.now();
+  const wallClockTimeoutMs = clampSandboxWallClockTimeoutMs(
+    params.wallClockTimeoutMs,
+  );
   const { Mustard, ExecutionContext } = await loadMustard();
-  const abortController = new AbortController();
-  const timeout = setTimeout(() => abortController.abort(), timeoutMs);
+  const vmBudget = createVmRuntimeBudget(timeoutMs);
+  let wallClockTimeout: NodeJS.Timeout | undefined;
+  let wallClockTimeoutError: DyadError | undefined;
 
   try {
     const program = new Mustard(params.script);
-    const capabilityMap =
+    const rawCapabilityMap =
       params.capabilities ??
       buildSandboxCapabilitiesWithObserver(params.appPath, params.onHostCall);
+    const capabilityMap = wrapCapabilitiesWithVmBudget(
+      rawCapabilityMap,
+      vmBudget,
+      params,
+    );
     const context = new ExecutionContext({
       capabilities: capabilityMap as unknown as Record<string, Capability>,
       limits: {
@@ -162,10 +324,30 @@ export async function executeSandboxScriptInProcess(
       snapshotKey: `dyad-sandbox:${params.appPath}`,
     });
 
-    const result = await program.run({
-      context,
-      signal: abortController.signal,
-    });
+    vmBudget.start();
+    params.onVmBudgetStart?.();
+    const result = await Promise.race([
+      program.run({
+        context,
+        signal: vmBudget.signal,
+      }),
+      new Promise<never>((_, reject) => {
+        wallClockTimeout = setTimeout(() => {
+          wallClockTimeoutError = new DyadError(
+            `Sandbox host execution timed out after ${wallClockTimeoutMs}ms.`,
+            DyadErrorKind.External,
+          );
+          vmBudget.abort();
+          reject(wallClockTimeoutError);
+        }, wallClockTimeoutMs);
+      }),
+    ]);
+    if (wallClockTimeout) {
+      clearTimeout(wallClockTimeout);
+      wallClockTimeout = undefined;
+    }
+    vmBudget.stop();
+    const executionMs = vmBudget.getElapsedMs();
     const output = stringifyStructuredValue(result);
     const truncated =
       Buffer.byteLength(output, "utf8") > SANDBOX_LLM_OUTPUT_LIMIT_BYTES;
@@ -180,17 +362,23 @@ export async function executeSandboxScriptInProcess(
         : output,
       truncated,
       fullOutputPath,
-      executionMs: Date.now() - started,
+      executionMs,
     };
   } catch (error) {
-    if (abortController.signal.aborted) {
+    vmBudget.stop();
+    if (wallClockTimeoutError) {
+      throw error === wallClockTimeoutError ? error : wallClockTimeoutError;
+    }
+    if (vmBudget.signal.aborted) {
       throw new DyadError(
-        `Sandbox script timed out after ${timeoutMs}ms.`,
+        `Sandbox script timed out after ${timeoutMs}ms of VM execution.`,
         DyadErrorKind.External,
       );
     }
     throw error;
   } finally {
-    clearTimeout(timeout);
+    if (wallClockTimeout) {
+      clearTimeout(wallClockTimeout);
+    }
   }
 }

--- a/src/ipc/utils/sandbox/limits.ts
+++ b/src/ipc/utils/sandbox/limits.ts
@@ -5,7 +5,7 @@ export const SANDBOX_READ_FILE_LIMIT_BYTES = 20 * 1024 * 1024;
 
 export const DEFAULT_SANDBOX_TIMEOUT_MS = 60_000;
 export const MAX_SANDBOX_TIMEOUT_MS = 60_000;
-export const SANDBOX_HOST_CALL_TIMEOUT_MS = 2_000;
+export const SANDBOX_WALL_CLOCK_TIMEOUT_MS = 5 * 60_000;
 
 // Avoid running out of instructions (e.g. parsing large CSV file)
 // Note: we have a sandbox timeout and run it off main thread, so
@@ -23,5 +23,17 @@ export function clampSandboxTimeoutMs(timeoutMs: number | undefined): number {
   return Math.min(
     Math.max(Math.floor(timeoutMs ?? DEFAULT_SANDBOX_TIMEOUT_MS), 1),
     MAX_SANDBOX_TIMEOUT_MS,
+  );
+}
+
+export function clampSandboxWallClockTimeoutMs(
+  timeoutMs: number | undefined,
+): number {
+  if (!Number.isFinite(timeoutMs)) {
+    return SANDBOX_WALL_CLOCK_TIMEOUT_MS;
+  }
+  return Math.min(
+    Math.max(Math.floor(timeoutMs ?? SANDBOX_WALL_CLOCK_TIMEOUT_MS), 1),
+    SANDBOX_WALL_CLOCK_TIMEOUT_MS,
   );
 }

--- a/src/ipc/utils/sandbox/runner.ts
+++ b/src/ipc/utils/sandbox/runner.ts
@@ -9,8 +9,10 @@ import {
   type SandboxRunResult,
 } from "./execution";
 import {
+  clampSandboxWallClockTimeoutMs,
   clampSandboxTimeoutMs,
   SANDBOX_SCRIPT_SOURCE_LIMIT_BYTES,
+  SANDBOX_WALL_CLOCK_TIMEOUT_MS,
 } from "./limits";
 import {
   deserializeSandboxWorkerError,
@@ -20,6 +22,8 @@ import {
 
 export { isSandboxSupportedPlatform };
 export type { SandboxRunResult };
+
+const WORKER_WALL_CLOCK_TIMEOUT_MARGIN_MS = 5_000;
 
 function isTestRuntime(): boolean {
   return (
@@ -65,21 +69,92 @@ function runSandboxScriptInWorker(params: {
   return new Promise((resolve, reject) => {
     let settled = false;
     const worker = new Worker(workerPath, { workerData: input });
-    const timeout = setTimeout(() => {
+    const wallClockTimeoutMs = clampSandboxWallClockTimeoutMs(undefined);
+    const wallClockTimeout = setTimeout(() => {
       settle(
         () =>
           reject(
             new DyadError(
-              `Sandbox script timed out after ${params.timeoutMs}ms.`,
+              `Sandbox host execution timed out after ${SANDBOX_WALL_CLOCK_TIMEOUT_MS}ms.`,
               DyadErrorKind.External,
             ),
           ),
         true,
       );
-    }, params.timeoutMs);
+    }, wallClockTimeoutMs + WORKER_WALL_CLOCK_TIMEOUT_MARGIN_MS);
+
+    let vmElapsedMs = 0;
+    let vmRunningSince: number | undefined;
+    let vmPauseDepth = 0;
+    let vmTimeout: NodeJS.Timeout | undefined;
+
+    function clearVmTimeout() {
+      if (vmTimeout) {
+        clearTimeout(vmTimeout);
+        vmTimeout = undefined;
+      }
+    }
+
+    function scheduleVmTimeout() {
+      clearVmTimeout();
+      if (vmPauseDepth > 0 || vmRunningSince === undefined) {
+        return;
+      }
+      const remainingMs = params.timeoutMs - vmElapsedMs;
+      if (remainingMs <= 0) {
+        settle(
+          () =>
+            reject(
+              new DyadError(
+                `Sandbox script timed out after ${params.timeoutMs}ms of VM execution.`,
+                DyadErrorKind.External,
+              ),
+            ),
+          true,
+        );
+        return;
+      }
+      vmTimeout = setTimeout(() => {
+        if (vmRunningSince !== undefined) {
+          vmElapsedMs += Date.now() - vmRunningSince;
+          vmRunningSince = Date.now();
+        }
+        scheduleVmTimeout();
+      }, remainingMs);
+    }
+
+    function startVmBudget() {
+      if (vmRunningSince !== undefined) {
+        return;
+      }
+      vmRunningSince = Date.now();
+      scheduleVmTimeout();
+    }
+
+    function pauseVmBudget() {
+      if (vmRunningSince !== undefined) {
+        vmElapsedMs += Date.now() - vmRunningSince;
+        vmRunningSince = undefined;
+      }
+      vmPauseDepth += 1;
+      clearVmTimeout();
+    }
+
+    function resumeVmBudget() {
+      if (vmPauseDepth === 0) {
+        return;
+      }
+      vmPauseDepth -= 1;
+      if (vmPauseDepth > 0 || vmRunningSince !== undefined) {
+        return;
+      }
+      vmRunningSince = Date.now();
+      scheduleVmTimeout();
+    }
 
     function cleanup() {
-      clearTimeout(timeout);
+      clearTimeout(wallClockTimeout);
+      clearVmTimeout();
       worker.removeAllListeners();
     }
 
@@ -97,6 +172,21 @@ function runSandboxScriptInWorker(params: {
 
     worker.on("message", (message: SandboxWorkerMessage) => {
       if (settled) {
+        return;
+      }
+
+      if (message.type === "vmBudgetStart") {
+        startVmBudget();
+        return;
+      }
+
+      if (message.type === "vmBudgetPause") {
+        pauseVmBudget();
+        return;
+      }
+
+      if (message.type === "vmBudgetResume") {
+        resumeVmBudget();
         return;
       }
 

--- a/src/ipc/utils/sandbox/sandbox.test.ts
+++ b/src/ipc/utils/sandbox/sandbox.test.ts
@@ -20,11 +20,14 @@ import {
   isSandboxSupportedPlatform,
   runSandboxScript,
 } from "@/ipc/utils/sandbox/runner";
+import { executeSandboxScriptInProcess } from "@/ipc/utils/sandbox/execution";
 import {
   SANDBOX_LLM_OUTPUT_LIMIT_BYTES,
   SANDBOX_READ_FILE_LIMIT_BYTES,
   SANDBOX_UI_OUTPUT_LIMIT_BYTES,
 } from "@/ipc/utils/sandbox/limits";
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 describe("sandbox capabilities", () => {
   let appPath: string;
@@ -385,5 +388,59 @@ describe("sandbox capabilities", () => {
     await expect(
       fs.readFile(result.fullOutputPath!, "utf8"),
     ).resolves.toHaveLength(SANDBOX_UI_OUTPUT_LIMIT_BYTES);
+  });
+
+  it("excludes host capability time from the VM timeout budget", async () => {
+    if (!isSandboxSupportedPlatform()) {
+      return;
+    }
+
+    const hostDelayMs = 150;
+    const result = await executeSandboxScriptInProcess({
+      appPath,
+      script: `
+        async function main() {
+          return await slow_host_call();
+        }
+        main();
+      `,
+      timeoutMs: 100,
+      wallClockTimeoutMs: 1_000,
+      capabilities: {
+        slow_host_call: async () => {
+          await delay(hostDelayMs);
+          return "done";
+        },
+      },
+    });
+
+    expect(result.value).toBe("done");
+    expect(result.executionMs).toBeLessThan(100);
+  });
+
+  it("bounds host execution with a wall-clock timeout", async () => {
+    if (!isSandboxSupportedPlatform()) {
+      return;
+    }
+
+    await expect(
+      executeSandboxScriptInProcess({
+        appPath,
+        script: `
+          async function main() {
+            return await slow_host_call();
+          }
+          main();
+        `,
+        timeoutMs: 1_000,
+        wallClockTimeoutMs: 10,
+        capabilities: {
+          slow_host_call: async () => {
+            await delay(100);
+            return "done";
+          },
+        },
+      }),
+    ).rejects.toThrow("Sandbox host execution timed out after 10ms");
   });
 });

--- a/src/ipc/utils/sandbox/sandbox_worker.ts
+++ b/src/ipc/utils/sandbox/sandbox_worker.ts
@@ -28,6 +28,21 @@ async function run() {
         hostCall,
       } satisfies SandboxWorkerMessage);
     },
+    onVmBudgetStart: () => {
+      port.postMessage({
+        type: "vmBudgetStart",
+      } satisfies SandboxWorkerMessage);
+    },
+    onVmBudgetPause: () => {
+      port.postMessage({
+        type: "vmBudgetPause",
+      } satisfies SandboxWorkerMessage);
+    },
+    onVmBudgetResume: () => {
+      port.postMessage({
+        type: "vmBudgetResume",
+      } satisfies SandboxWorkerMessage);
+    },
   });
 
   port.postMessage({

--- a/src/ipc/utils/sandbox/worker_protocol.ts
+++ b/src/ipc/utils/sandbox/worker_protocol.ts
@@ -22,6 +22,9 @@ export interface SerializedSandboxWorkerError {
 }
 
 export type SandboxWorkerMessage =
+  | { type: "vmBudgetStart" }
+  | { type: "vmBudgetPause" }
+  | { type: "vmBudgetResume" }
   | { type: "hostCall"; hostCall: SandboxWorkerHostCall }
   | { type: "result"; result: SandboxRunResult }
   | { type: "error"; error: SerializedSandboxWorkerError };


### PR DESCRIPTION
## Summary
- Measure sandbox timeout against time spent executing inside the MustardScript VM instead of wall-clock host capability time.
- Add a separate 5-minute host execution wall-clock cap for worker and in-process sandbox runs.
- Cover host-time exclusion and wall-clock timeout behavior in sandbox tests.

## Test plan
- npm run fmt
- npm run lint:fix
- npm run ts
- npm test

🤖 Generated with [Claude Code](https://claude.com/claude-code)