### PR TITLE
Pin release tag during dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,36 @@ permissions:
 name: Release app
 on:
   workflow_dispatch:
+
+concurrency:
+  group: release-app-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
+  prepare-release:
+    name: Prepare Release Tag
+    runs-on: ubuntu-latest
+    environment: release
+    outputs:
+      tag: ${{ steps.prepare.outputs.tag }}
+      version: ${{ steps.prepare.outputs.version }}
+      release-state: ${{ steps.prepare.outputs.release_state }}
+    steps:
+      - name: Github checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - name: Use Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: v24.13.1
+          package-manager-cache: false # Do NOT use GitHub Actions cache in release builds: https://adnanthekhan.com/2024/12/21/cacheract-the-monster-in-your-build-cache/
+      - name: Create or update unpublished release tag
+        id: prepare
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/prepare-release-tag.js prepare
+
   build:
+    needs: prepare-release
     environment: release
     strategy:
       # Continue building other platforms even if one fails
@@ -168,6 +196,8 @@ jobs:
         with:
           node-version: v24.13.1
           package-manager-cache: false # Do NOT use GitHub Actions cache in release builds: https://adnanthekhan.com/2024/12/21/cacheract-the-monster-in-your-build-cache/
+      - name: Verify release tag still points to this workflow commit
+        run: node scripts/prepare-release-tag.js verify
       - name: Verify all release assets are uploaded
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -13,8 +13,19 @@ import { VitePlugin } from "@electron-forge/plugin-vite";
 import { FusesPlugin } from "@electron-forge/plugin-fuses";
 import { FuseV1Options, FuseVersion } from "@electron/fuses";
 import { AutoUnpackNativesPlugin } from "@electron-forge/plugin-auto-unpack-natives";
+import { readFileSync } from "fs";
+import { createRequire } from "module";
 
 console.log("AZURE_CODE_SIGNING_DLIB", process.env.AZURE_CODE_SIGNING_DLIB);
+
+const require = createRequire(import.meta.url);
+const { isPrereleaseVersion } =
+  require("./scripts/release-version-utils.js") as {
+    isPrereleaseVersion: (version: string) => boolean;
+  };
+const packageJson = JSON.parse(
+  readFileSync(new URL("./package.json", import.meta.url), "utf8"),
+) as { version: string };
 
 const pgRuntimeDependencies = [
   "pg",
@@ -208,7 +219,7 @@ const config: ForgeConfig = {
         },
         draft: true,
         force: true,
-        prerelease: true,
+        prerelease: isPrereleaseVersion(packageJson.version),
       },
     },
   ],

--- a/scripts/prepare-release-tag.js
+++ b/scripts/prepare-release-tag.js
@@ -7,6 +7,16 @@ const { execFileSync } = require("child_process");
 const DEFAULT_OWNER = "dyad-sh";
 const DEFAULT_REPO = "dyad";
 
+class GithubRequestError extends Error {
+  constructor({ path, response, text }) {
+    super(
+      `GitHub API GET ${path} failed: ${response.status} ${response.statusText}\n${text}`,
+    );
+    this.name = "GithubRequestError";
+    this.status = response.status;
+  }
+}
+
 function readPackageVersion(packageJsonPath) {
   const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
   if (typeof packageJson.version !== "string" || !packageJson.version) {
@@ -31,15 +41,26 @@ async function githubRequest({ owner, path, repo, token }) {
 
   if (!response.ok) {
     const text = await response.text();
-    throw new Error(
-      `GitHub API GET ${path} failed: ${response.status} ${response.statusText}\n${text}`,
-    );
+    throw new GithubRequestError({ path, response, text });
   }
 
   return response.json();
 }
 
 async function findReleaseByTag({ owner, repo, tagName, token }) {
+  try {
+    return await githubRequest({
+      owner,
+      path: `/releases/tags/${tagName}`,
+      repo,
+      token,
+    });
+  } catch (error) {
+    if (error.status !== 404) {
+      throw error;
+    }
+  }
+
   for (let page = 1; page <= 5; page += 1) {
     const releases = await githubRequest({
       owner,
@@ -80,6 +101,26 @@ function pushTagToSha({ currentSha, tagName }) {
   runGit(["push", "origin", `refs/tags/${tagName}`, "--force"]);
 }
 
+function getRemoteTagShaFromOutput({ output, tagName }) {
+  const lines = output
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const dereferencedLine = lines.find((line) =>
+    line.endsWith(`refs/tags/${tagName}^{}`),
+  );
+  const tagLine =
+    dereferencedLine ??
+    lines.find((line) => line.endsWith(`refs/tags/${tagName}`));
+
+  if (!tagLine) {
+    return null;
+  }
+
+  const [sha] = tagLine.split(/\s+/);
+  return sha || null;
+}
+
 function getRemoteTagSha(tagName) {
   const output = runGit([
     "ls-remote",
@@ -91,8 +132,7 @@ function getRemoteTagSha(tagName) {
     return null;
   }
 
-  const [sha] = output.split(/\s+/);
-  return sha || null;
+  return getRemoteTagShaFromOutput({ output, tagName });
 }
 
 function verifyRemoteTagSha({ currentSha, tagName }) {
@@ -116,7 +156,15 @@ function writeGithubOutputs({ outputPath, outputs }) {
   fs.appendFileSync(
     outputPath,
     Object.entries(outputs)
-      .map(([key, value]) => `${key}=${value}`)
+      .map(([key, value]) => {
+        const stringValue = String(value);
+        if (stringValue.includes("\n")) {
+          throw new Error(
+            `GitHub output values must not contain newlines: ${key}`,
+          );
+        }
+        return `${key}=${stringValue}`;
+      })
       .join("\n") + "\n",
   );
 }
@@ -225,7 +273,10 @@ module.exports = {
   findReleaseByTag,
   getRepoParts,
   getRemoteTagSha,
+  getRemoteTagShaFromOutput,
+  GithubRequestError,
   prepareReleaseTag,
   readPackageVersion,
   verifyPreparedReleaseTag,
+  writeGithubOutputs,
 };

--- a/scripts/prepare-release-tag.js
+++ b/scripts/prepare-release-tag.js
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+const { execFileSync } = require("child_process");
+
+const DEFAULT_OWNER = "dyad-sh";
+const DEFAULT_REPO = "dyad";
+
+function readPackageVersion(packageJsonPath) {
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+  if (typeof packageJson.version !== "string" || !packageJson.version) {
+    throw new Error(`No package.json version found at ${packageJsonPath}`);
+  }
+  return packageJson.version;
+}
+
+async function githubRequest({ owner, path, repo, token }) {
+  const response = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}${path}`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "Content-Type": "application/json",
+        "User-Agent": "dyad-release-tag-preparer",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    },
+  );
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(
+      `GitHub API GET ${path} failed: ${response.status} ${response.statusText}\n${text}`,
+    );
+  }
+
+  return response.json();
+}
+
+async function findReleaseByTag({ owner, repo, tagName, token }) {
+  for (let page = 1; page <= 5; page += 1) {
+    const releases = await githubRequest({
+      owner,
+      path: `/releases?per_page=100&page=${page}`,
+      repo,
+      token,
+    });
+    const release = releases.find(
+      (candidate) => candidate.tag_name === tagName,
+    );
+
+    if (release) {
+      return release;
+    }
+
+    if (releases.length < 100) {
+      break;
+    }
+  }
+
+  return null;
+}
+
+function assertReleaseCanMoveTag({ release, tagName }) {
+  if (release && !release.draft) {
+    throw new Error(
+      `Release ${tagName} is already published; refusing to move its tag.`,
+    );
+  }
+}
+
+function runGit(args) {
+  return execFileSync("git", args, { encoding: "utf8", stdio: "pipe" }).trim();
+}
+
+function pushTagToSha({ currentSha, tagName }) {
+  runGit(["tag", "-f", tagName, currentSha]);
+  runGit(["push", "origin", `refs/tags/${tagName}`, "--force"]);
+}
+
+function getRemoteTagSha(tagName) {
+  const output = runGit([
+    "ls-remote",
+    "--tags",
+    "origin",
+    `refs/tags/${tagName}`,
+  ]);
+  if (!output) {
+    return null;
+  }
+
+  const [sha] = output.split(/\s+/);
+  return sha || null;
+}
+
+function verifyRemoteTagSha({ currentSha, tagName }) {
+  const tagSha = getRemoteTagSha(tagName);
+  if (!tagSha) {
+    throw new Error(`Remote tag ${tagName} was not found.`);
+  }
+
+  if (tagSha !== currentSha) {
+    throw new Error(
+      `Remote tag ${tagName} points to ${tagSha}, expected ${currentSha}.`,
+    );
+  }
+}
+
+function writeGithubOutputs({ outputPath, outputs }) {
+  if (!outputPath) {
+    return;
+  }
+
+  fs.appendFileSync(
+    outputPath,
+    Object.entries(outputs)
+      .map(([key, value]) => `${key}=${value}`)
+      .join("\n") + "\n",
+  );
+}
+
+function getRepoParts(repository) {
+  if (!repository) {
+    return { owner: DEFAULT_OWNER, repo: DEFAULT_REPO };
+  }
+
+  const [owner, repo] = repository.split("/");
+  if (!owner || !repo) {
+    throw new Error(`Invalid GITHUB_REPOSITORY value: ${repository}`);
+  }
+  return { owner, repo };
+}
+
+async function prepareReleaseTag({
+  currentSha,
+  owner,
+  packageJsonPath = path.join(__dirname, "..", "package.json"),
+  repo,
+  token,
+}) {
+  if (!currentSha) {
+    throw new Error("GITHUB_SHA environment variable is required");
+  }
+  if (!token) {
+    throw new Error("GITHUB_TOKEN environment variable is required");
+  }
+
+  const version = readPackageVersion(packageJsonPath);
+  const tagName = `v${version}`;
+  const release = await findReleaseByTag({ owner, repo, tagName, token });
+  assertReleaseCanMoveTag({ release, tagName });
+  pushTagToSha({ currentSha, tagName });
+
+  return {
+    releaseState: release ? "draft" : "missing",
+    tagName,
+    version,
+  };
+}
+
+function verifyPreparedReleaseTag({
+  currentSha,
+  packageJsonPath = path.join(__dirname, "..", "package.json"),
+}) {
+  if (!currentSha) {
+    throw new Error("GITHUB_SHA environment variable is required");
+  }
+
+  const version = readPackageVersion(packageJsonPath);
+  const tagName = `v${version}`;
+  verifyRemoteTagSha({ currentSha, tagName });
+
+  return { tagName, version };
+}
+
+async function main() {
+  const mode = process.argv[2] ?? "prepare";
+  const { owner, repo } = getRepoParts(process.env.GITHUB_REPOSITORY);
+
+  if (mode === "prepare") {
+    const result = await prepareReleaseTag({
+      currentSha: process.env.GITHUB_SHA,
+      owner,
+      repo,
+      token: process.env.GITHUB_TOKEN,
+    });
+    writeGithubOutputs({
+      outputPath: process.env.GITHUB_OUTPUT,
+      outputs: {
+        release_state: result.releaseState,
+        tag: result.tagName,
+        version: result.version,
+      },
+    });
+    console.log(
+      `Pinned ${result.tagName} to ${process.env.GITHUB_SHA}; release state was ${result.releaseState}.`,
+    );
+    return;
+  }
+
+  if (mode === "verify") {
+    const result = verifyPreparedReleaseTag({
+      currentSha: process.env.GITHUB_SHA,
+    });
+    console.log(
+      `Verified ${result.tagName} points to ${process.env.GITHUB_SHA}.`,
+    );
+    return;
+  }
+
+  throw new Error(`Unknown mode: ${mode}`);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error("Failed to prepare release tag:", error.message);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  assertReleaseCanMoveTag,
+  findReleaseByTag,
+  getRepoParts,
+  getRemoteTagSha,
+  prepareReleaseTag,
+  readPackageVersion,
+  verifyPreparedReleaseTag,
+};

--- a/scripts/release-version-utils.js
+++ b/scripts/release-version-utils.js
@@ -1,5 +1,6 @@
 function isPrereleaseVersion(version) {
-  return version.includes("-");
+  const [coreAndPrerelease] = version.split("+", 1);
+  return coreAndPrerelease.includes("-");
 }
 
 module.exports = {

--- a/scripts/release-version-utils.js
+++ b/scripts/release-version-utils.js
@@ -1,0 +1,7 @@
+function isPrereleaseVersion(version) {
+  return version.includes("-");
+}
+
+module.exports = {
+  isPrereleaseVersion,
+};

--- a/scripts/verify-release-assets.js
+++ b/scripts/verify-release-assets.js
@@ -2,6 +2,7 @@
 
 const fs = require("fs");
 const path = require("path");
+const { isPrereleaseVersion } = require("./release-version-utils.js");
 
 /**
  * Verifies that all expected binary assets are present in the GitHub release
@@ -58,6 +59,13 @@ async function verifyReleaseAssets() {
 
     console.log(`📦 Found ${assets.length} assets in release ${tagName}`);
     console.log(`📄 Release status: ${release.draft ? "DRAFT" : "PUBLISHED"}`);
+
+    const expectedPrerelease = isPrereleaseVersion(version);
+    if (release.prerelease !== expectedPrerelease) {
+      throw new Error(
+        `Release ${tagName} prerelease flag is ${release.prerelease}, expected ${expectedPrerelease}`,
+      );
+    }
 
     // Handle different beta naming conventions across platforms
     const normalizeVersionForPlatform = (version, platform) => {

--- a/src/__tests__/prepare_release_tag_script.test.ts
+++ b/src/__tests__/prepare_release_tag_script.test.ts
@@ -1,15 +1,22 @@
 // @vitest-environment node
 
 import { createRequire } from "module";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 const require = createRequire(import.meta.url);
 const {
   assertReleaseCanMoveTag,
+  findReleaseByTag,
   getRepoParts,
+  getRemoteTagShaFromOutput,
+  writeGithubOutputs,
 } = require("../../scripts/prepare-release-tag.js");
 
 describe("prepare release tag script", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("allows missing or draft releases to move a tag", () => {
     expect(() =>
       assertReleaseCanMoveTag({ release: null, tagName: "v1.3.0" }),
@@ -36,5 +43,106 @@ describe("prepare release tag script", () => {
       owner: "dyad-sh",
       repo: "dyad",
     });
+  });
+
+  it("fetches published releases by tag before falling back to listed drafts", async () => {
+    const release = { draft: false, tag_name: "v1.3.0" };
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => release,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      findReleaseByTag({
+        owner: "dyad-sh",
+        repo: "dyad",
+        tagName: "v1.3.0",
+        token: "token",
+      }),
+    ).resolves.toBe(release);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock.mock.calls[0][0]).toContain("/releases/tags/v1.3.0");
+  });
+
+  it("falls back to listed releases when direct tag lookup returns 404", async () => {
+    const draftRelease = { draft: true, tag_name: "v1.3.0" };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+        text: async () => "not found",
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [draftRelease],
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      findReleaseByTag({
+        owner: "dyad-sh",
+        repo: "dyad",
+        tagName: "v1.3.0",
+        token: "token",
+      }),
+    ).resolves.toBe(draftRelease);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1][0]).toContain(
+      "/releases?per_page=100&page=1",
+    );
+  });
+
+  it("keeps non-404 GitHub API errors from direct tag lookup", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: "Server Error",
+        text: async () => "server error",
+      }),
+    );
+
+    await expect(
+      findReleaseByTag({
+        owner: "dyad-sh",
+        repo: "dyad",
+        tagName: "v1.3.0",
+        token: "token",
+      }),
+    ).rejects.toMatchObject({ status: 500 });
+  });
+
+  it("prefers dereferenced SHAs for annotated remote tags", () => {
+    expect(
+      getRemoteTagShaFromOutput({
+        output: [
+          "tag-object-sha\trefs/tags/v1.3.0",
+          "commit-sha\trefs/tags/v1.3.0^{}",
+        ].join("\n"),
+        tagName: "v1.3.0",
+      }),
+    ).toBe("commit-sha");
+  });
+
+  it("falls back to the tag SHA for lightweight remote tags", () => {
+    expect(
+      getRemoteTagShaFromOutput({
+        output: "commit-sha\trefs/tags/v1.3.0",
+        tagName: "v1.3.0",
+      }),
+    ).toBe("commit-sha");
+  });
+
+  it("rejects multiline GitHub output values", () => {
+    expect(() =>
+      writeGithubOutputs({
+        outputPath: "unused",
+        outputs: { tag: "v1.3.0\nmalformed=true" },
+      }),
+    ).toThrow("GitHub output values must not contain newlines: tag");
   });
 });

--- a/src/__tests__/prepare_release_tag_script.test.ts
+++ b/src/__tests__/prepare_release_tag_script.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment node
+
+import { createRequire } from "module";
+import { describe, expect, it } from "vitest";
+
+const require = createRequire(import.meta.url);
+const {
+  assertReleaseCanMoveTag,
+  getRepoParts,
+} = require("../../scripts/prepare-release-tag.js");
+
+describe("prepare release tag script", () => {
+  it("allows missing or draft releases to move a tag", () => {
+    expect(() =>
+      assertReleaseCanMoveTag({ release: null, tagName: "v1.3.0" }),
+    ).not.toThrow();
+    expect(() =>
+      assertReleaseCanMoveTag({
+        release: { draft: true },
+        tagName: "v1.3.0",
+      }),
+    ).not.toThrow();
+  });
+
+  it("refuses to move a tag for a published release", () => {
+    expect(() =>
+      assertReleaseCanMoveTag({
+        release: { draft: false },
+        tagName: "v1.3.0",
+      }),
+    ).toThrow("Release v1.3.0 is already published");
+  });
+
+  it("parses GitHub repository coordinates", () => {
+    expect(getRepoParts("dyad-sh/dyad")).toEqual({
+      owner: "dyad-sh",
+      repo: "dyad",
+    });
+  });
+});

--- a/src/__tests__/release_version_utils_script.test.ts
+++ b/src/__tests__/release_version_utils_script.test.ts
@@ -1,0 +1,17 @@
+// @vitest-environment node
+
+import { createRequire } from "module";
+import { describe, expect, it } from "vitest";
+
+const require = createRequire(import.meta.url);
+const {
+  isPrereleaseVersion,
+} = require("../../scripts/release-version-utils.js");
+
+describe("release version utils script", () => {
+  it("detects prerelease package versions", () => {
+    expect(isPrereleaseVersion("1.3.0-beta.1")).toBe(true);
+    expect(isPrereleaseVersion("1.3.0-rc.1")).toBe(true);
+    expect(isPrereleaseVersion("1.3.0")).toBe(false);
+  });
+});

--- a/src/__tests__/release_version_utils_script.test.ts
+++ b/src/__tests__/release_version_utils_script.test.ts
@@ -13,5 +13,7 @@ describe("release version utils script", () => {
     expect(isPrereleaseVersion("1.3.0-beta.1")).toBe(true);
     expect(isPrereleaseVersion("1.3.0-rc.1")).toBe(true);
     expect(isPrereleaseVersion("1.3.0")).toBe(false);
+    expect(isPrereleaseVersion("1.3.0+build-1")).toBe(false);
+    expect(isPrereleaseVersion("1.3.0-rc.1+build-1")).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Add a prepare-release workflow job that pins the version tag to the workflow commit before release builds start.
- Allow reruns to move tags while the release is missing or draft, but refuse to move tags for published releases.
- Configure prerelease flags from package versions and verify release metadata during asset checks.

## Test plan
- npm run fmt && npm run lint:fix && npm run ts
- npm test
- actionlint .github/workflows/release.yml

#skip-bugbot