### PR TITLE
feat(telemetry): capture and report native crashes via Crashpad

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import {
   protocol,
   net,
   session,
+  crashReporter,
 } from "electron";
 import * as path from "node:path";
 import { registerIpcHandlers } from "./ipc/ipc_host";
@@ -46,6 +47,15 @@ import {
   stopPerformanceMonitoring,
 } from "./utils/performance_monitor";
 import {
+  parseMinidumpSummary,
+  type MinidumpSummary,
+} from "./utils/minidump_summary";
+import {
+  listDumpFilesRecursive,
+  moveDump,
+  pruneDumps,
+} from "./utils/crash_dumps";
+import {
   DYAD_INTERNAL_DIR_NAME,
   DYAD_MEDIA_SUBDIR,
   DYAD_SCREENSHOT_SUBDIR,
@@ -65,7 +75,97 @@ log.errorHandler.startCatching();
 log.eventLogger.startLogging();
 log.scope.labelPadding = false;
 
+// In dev, keep minidumps under the project's ./userData (matching where Dyad
+// writes its other dev files) instead of the OS userData dir, so they don't
+// mingle with a prod install's dumps. Must run before crashReporter.start.
+if (process.env.NODE_ENV === "development") {
+  const devCrashDumps = path.resolve("./userData/Crashpad");
+  fs.mkdirSync(devCrashDumps, { recursive: true });
+  app.setPath("crashDumps", devCrashDumps);
+}
+
+// Capture native crashes (main/renderer/GPU/utility) as local minidumps. Not
+// uploaded; parsed on the next launch into a summary we send as telemetry.
+// Must start before the app is ready. globalExtra annotates every dump with
+// static context; dynamic GPU status is added in onReady.
+crashReporter.start({
+  uploadToServer: false,
+  compress: true,
+  globalExtra: {
+    app_version: app.getVersion(),
+    electron_version: process.versions.electron ?? "unknown",
+    chrome_version: process.versions.chrome ?? "unknown",
+    os: process.platform,
+    arch: process.arch,
+  },
+});
+
 const logger = log.scope("main");
+
+// Cap retained dumps so they don't accumulate indefinitely; keep only a few
+// recent ones for examination/export.
+const MAX_RETAINED_DUMPS = 5;
+let nativeCrashDumpsProcessed = false;
+let pendingNativeBrowserCrash: MinidumpSummary | null = null;
+
+// Summarize each new minidump (signal, faulting module + offset, process type —
+// no memory). A main-process crash is the app crash, so its summary is stashed
+// and attached to app:crash_detected; other (survived child) crashes are left
+// to their own paths. Each dump is then kept under a timestamped name for later
+// examination. Runs once per session.
+function processNativeCrashDumps(): void {
+  if (nativeCrashDumpsProcessed) {
+    return;
+  }
+  nativeCrashDumpsProcessed = true;
+
+  const crashDumpsDir = app.getPath("crashDumps");
+  // Where we keep dumps we've already reported, for later examination. Kept
+  // outside crashDumpsDir so it stays separate from Crashpad's own dump dirs.
+  const retainDir = path.join(
+    path.dirname(crashDumpsDir),
+    "dyad-crash-reports",
+  );
+  try {
+    fs.mkdirSync(retainDir, { recursive: true });
+  } catch (error) {
+    logger.warn("Could not create crash reports directory:", error);
+  }
+
+  for (const file of listDumpFilesRecursive(crashDumpsDir)) {
+    const summary = parseMinidumpSummary(file);
+    if (summary) {
+      logger.info(
+        "Native crash:",
+        summary.ptype,
+        summary.crashReason,
+        summary.faultingModule,
+        summary.faultingOffset,
+      );
+      if (summary.ptype === "browser" && !pendingNativeBrowserCrash) {
+        pendingNativeBrowserCrash = summary;
+      }
+    }
+    // Retain (timestamp-named) so it can be examined/exported and isn't
+    // re-summarized next launch; this also drains Crashpad's dump dirs.
+    moveDump(file, path.join(retainDir, crashReportName(file)));
+  }
+  pruneDumps(retainDir, MAX_RETAINED_DUMPS);
+}
+
+// A readable, sortable dump name from the crash time (the dump's mtime), with a
+// short id suffix to avoid collisions: crash-2026-06-07T20-41-55-123Z-9ac4d4e8.dmp
+function crashReportName(dumpPath: string): string {
+  let mtimeMs = Date.now();
+  try {
+    mtimeMs = fs.statSync(dumpPath).mtimeMs;
+  } catch {
+    // fall back to now
+  }
+  const ts = new Date(mtimeMs).toISOString().replace(/[:.]/g, "-");
+  const id = path.basename(dumpPath).slice(0, 8);
+  return `crash-${ts}-${id}.dmp`;
+}
 const deepLinkQueue = createDeepLinkQueue(handleDeepLinkReturn);
 
 // Load environment variables from .env file
@@ -244,6 +344,26 @@ export async function onReady() {
   }
 
   writeCrashSentinel();
+
+  // Record the GPU's feature status (is compositing / WebGL hardware-accelerated)
+  // on every dump written from here on. It's useful context when reading a dump,
+  // since the GPU driver can be involved in a crash. This can't go in
+  // crashReporter.start's globalExtra because the status isn't known until the
+  // app is ready; addExtraParameter adds it to all later dumps.
+  try {
+    const gpu = app.getGPUFeatureStatus();
+    crashReporter.addExtraParameter(
+      "gpu_compositing",
+      String(gpu?.gpu_compositing ?? "unknown"),
+    );
+    crashReporter.addExtraParameter(
+      "gpu_webgl",
+      String(gpu?.webgl ?? "unknown"),
+    );
+  } catch (error) {
+    logger.warn("Could not read GPU status for crash context:", error);
+  }
+  logger.info("Crash dumps directory:", app.getPath("crashDumps"));
 
   // Start performance monitoring
   startPerformanceMonitoring();
@@ -436,6 +556,11 @@ const createWindow = () => {
 
     deepLinkQueue.markReady();
 
+    // Summarize native crash minidumps before sending app:crash_detected. If
+    // the main process crashed natively, that summary becomes the crash cause
+    // reported in app:crash_detected.
+    processNativeCrashDumps();
+
     // Send force-close once after the correct load
     if (pendingCrashDetected && !forceCloseMessageSent) {
       forceCloseMessageSent = true;
@@ -448,6 +573,9 @@ const createWindow = () => {
           }),
         });
       }
+
+      const nativeCrash = pendingNativeBrowserCrash;
+      pendingNativeBrowserCrash = null;
 
       sendTelemetryEvent("app:crash_detected", {
         // Mark as error so renderer PostHog before_send sampling does not
@@ -465,6 +593,15 @@ const createWindow = () => {
           last_known_snapshot_timestamp: pendingForceCloseData.timestamp,
           time_since_last_heartbeat_ms:
             Date.now() - pendingForceCloseData.timestamp,
+        }),
+        // "native" when a main-process minidump was captured for this crash,
+        // else "unknown" (no dump: force-kill / OOM-kill / power loss / missed).
+        crash_cause: nativeCrash ? "native" : "unknown",
+        ...(nativeCrash && {
+          crash_reason: nativeCrash.crashReason,
+          exception_code: nativeCrash.exceptionCode,
+          faulting_module: nativeCrash.faultingModule,
+          faulting_offset: nativeCrash.faultingOffset,
         }),
       });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -145,6 +145,10 @@ function processNativeCrashDumps(): void {
       );
       if (summary.ptype === "browser" && !pendingNativeBrowserCrash) {
         pendingNativeBrowserCrash = summary;
+        // A browser-process dump is direct evidence of a main-process crash, so
+        // report it even if the crash sentinel wasn't written (e.g. a crash
+        // during early startup).
+        pendingCrashDetected = true;
       }
     }
     // Retain (timestamp-named) so it can be examined/exported and isn't

--- a/src/main.ts
+++ b/src/main.ts
@@ -120,12 +120,10 @@ function processNativeCrashDumps(): void {
   nativeCrashDumpsProcessed = true;
 
   const crashDumpsDir = app.getPath("crashDumps");
-  // Where we keep dumps we've already reported, for later examination. Kept
-  // outside crashDumpsDir so it stays separate from Crashpad's own dump dirs.
-  const retainDir = path.join(
-    path.dirname(crashDumpsDir),
-    "dyad-crash-reports",
-  );
+  // Where we keep dumps we've already reported, for later examination. Under
+  // userData (not inside crashDumpsDir) so it stays separate from Crashpad's
+  // own dump dirs and isn't picked up by the scan above.
+  const retainDir = path.join(app.getPath("userData"), "dyad-crash-reports");
   try {
     fs.mkdirSync(retainDir, { recursive: true });
   } catch (error) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -127,7 +127,10 @@ function processNativeCrashDumps(): void {
   try {
     fs.mkdirSync(retainDir, { recursive: true });
   } catch (error) {
+    // Without the retain dir, moving a dump would fail and drop it. Leave the
+    // dumps in place and try again on the next launch.
     logger.warn("Could not create crash reports directory:", error);
+    return;
   }
 
   for (const file of listDumpFilesRecursive(crashDumpsDir)) {

--- a/src/utils/crash_dumps.test.ts
+++ b/src/utils/crash_dumps.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  listDumpFiles,
+  listDumpFilesRecursive,
+  deleteDump,
+  moveDump,
+  pruneDumps,
+} from "@/utils/crash_dumps";
+
+describe("crash_dumps", () => {
+  let dir: string;
+
+  // Create a dump (+ .meta sidecar) with a controlled modification time so
+  // newest-first ordering is deterministic.
+  function makeDump(name: string, ageSeconds: number): string {
+    const dump = path.join(dir, name);
+    fs.writeFileSync(dump, "x");
+    fs.writeFileSync(dump.replace(/\.dmp$/, ".meta"), "m");
+    const t = Date.now() / 1000 - ageSeconds;
+    fs.utimesSync(dump, t, t);
+    return dump;
+  }
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "crash-dumps-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("lists only .dmp files, newest first", () => {
+    makeDump("a.dmp", 30);
+    makeDump("b.dmp", 10);
+    makeDump("c.dmp", 20);
+    fs.writeFileSync(path.join(dir, "notes.txt"), "ignore me");
+
+    const files = listDumpFiles(dir).map((f) => path.basename(f));
+    expect(files).toEqual(["b.dmp", "c.dmp", "a.dmp"]);
+  });
+
+  it("returns empty for a missing directory", () => {
+    expect(listDumpFiles(path.join(dir, "nope"))).toEqual([]);
+  });
+
+  it("finds .dmp files in nested subdirs (pending/ and reports/), newest first", () => {
+    // Mirror Crashpad's platform-specific layout: a dump under pending/ (Linux/
+    // macOS) and one under reports/ (Windows). Both must be found.
+    fs.mkdirSync(path.join(dir, "pending"));
+    fs.mkdirSync(path.join(dir, "reports"));
+    makeDump(path.join("pending", "a.dmp"), 30);
+    makeDump(path.join("reports", "b.dmp"), 10);
+    fs.writeFileSync(path.join(dir, "reports", "metadata"), "ignore");
+
+    const files = listDumpFilesRecursive(dir).map((f) => path.basename(f));
+    expect(files).toEqual(["b.dmp", "a.dmp"]);
+  });
+
+  it("deletes a dump and its .meta sidecar", () => {
+    const dump = makeDump("x.dmp", 1);
+    deleteDump(dump);
+    expect(fs.existsSync(dump)).toBe(false);
+    expect(fs.existsSync(dump.replace(/\.dmp$/, ".meta"))).toBe(false);
+  });
+
+  it("moves a dump and its .meta sidecar to a new name", () => {
+    const src = makeDump("a1b2c3d4.dmp", 1);
+    const dest = path.join(dir, "crash-2026-06-07T00-00-00-000Z-a1b2c3d4.dmp");
+    moveDump(src, dest);
+    expect(fs.existsSync(src)).toBe(false);
+    expect(fs.existsSync(dest)).toBe(true);
+    expect(fs.existsSync(dest.replace(/\.dmp$/, ".meta"))).toBe(true);
+  });
+
+  it("prunes to the N most-recent dumps", () => {
+    makeDump("old1.dmp", 50);
+    makeDump("old2.dmp", 40);
+    makeDump("recent1.dmp", 20);
+    makeDump("recent2.dmp", 10);
+
+    pruneDumps(dir, 2);
+
+    const remaining = listDumpFiles(dir)
+      .map((f) => path.basename(f))
+      .sort();
+    expect(remaining).toEqual(["recent1.dmp", "recent2.dmp"]);
+    // sidecars of pruned dumps are gone too
+    expect(fs.existsSync(path.join(dir, "old1.meta"))).toBe(false);
+  });
+
+  it("prune is a no-op when under the limit", () => {
+    makeDump("a.dmp", 5);
+    pruneDumps(dir, 5);
+    expect(listDumpFiles(dir)).toHaveLength(1);
+  });
+});

--- a/src/utils/crash_dumps.test.ts
+++ b/src/utils/crash_dumps.test.ts
@@ -75,6 +75,14 @@ describe("crash_dumps", () => {
     expect(fs.existsSync(dest.replace(/\.dmp$/, ".meta"))).toBe(true);
   });
 
+  it("deletes the source when the move fails, so it isn't reprocessed", () => {
+    const src = makeDump("a1b2c3d4.dmp", 1);
+    // Destination parent does not exist → rename fails. The source must still be
+    // removed so the next launch doesn't read it again.
+    moveDump(src, path.join(dir, "no-such-dir", "x.dmp"));
+    expect(fs.existsSync(src)).toBe(false);
+  });
+
   it("prunes to the N most-recent dumps", () => {
     makeDump("old1.dmp", 50);
     makeDump("old2.dmp", 40);

--- a/src/utils/crash_dumps.ts
+++ b/src/utils/crash_dumps.ts
@@ -82,20 +82,18 @@ function unlinkQuiet(p: string): void {
   }
 }
 
-// Move a file, best effort. Falls back to copy+delete across devices (EXDEV).
-// If the move can't complete, delete the source so it isn't read again on the
-// next launch.
+// Move a file, best effort. If the rename fails (cross-device, a locked file,
+// etc.), preserve the file by copying it first when possible, then remove the
+// source so it isn't read again on the next launch.
 function renameQuiet(src: string, dest: string): void {
   try {
     fs.renameSync(src, dest);
     return;
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "EXDEV") {
-      try {
-        fs.copyFileSync(src, dest);
-      } catch {
-        // fall through to deleting the source
-      }
+  } catch {
+    try {
+      fs.copyFileSync(src, dest);
+    } catch {
+      // source may be unreadable; still remove it below to avoid reprocessing
     }
   }
   unlinkQuiet(src);

--- a/src/utils/crash_dumps.ts
+++ b/src/utils/crash_dumps.ts
@@ -9,10 +9,10 @@ export function listDumpFiles(dir: string): string[] {
   } catch {
     return [];
   }
-  return entries
+  const dumps = entries
     .filter((f) => f.endsWith(".dmp"))
-    .map((f) => path.join(dir, f))
-    .sort((a, b) => mtimeMs(b) - mtimeMs(a));
+    .map((f) => path.join(dir, f));
+  return sortNewestFirst(dumps);
 }
 
 // Absolute paths of every .dmp anywhere under a directory tree, newest first.
@@ -35,7 +35,7 @@ export function listDumpFilesRecursive(dir: string): string[] {
     }
   };
   walk(dir);
-  return found.sort((a, b) => mtimeMs(b) - mtimeMs(a));
+  return sortNewestFirst(found);
 }
 
 // Delete a dump and its Crashpad metadata sidecar (best effort).
@@ -57,6 +57,15 @@ export function pruneDumps(dir: string, max: number): void {
   }
 }
 
+// Sort paths newest-first, reading each file's mtime once (not inside the
+// comparator, which would re-stat on every comparison).
+function sortNewestFirst(paths: string[]): string[] {
+  return paths
+    .map((p) => ({ p, mtime: mtimeMs(p) }))
+    .sort((a, b) => b.mtime - a.mtime)
+    .map((x) => x.p);
+}
+
 function mtimeMs(p: string): number {
   try {
     return fs.statSync(p).mtimeMs;
@@ -73,10 +82,21 @@ function unlinkQuiet(p: string): void {
   }
 }
 
+// Move a file, best effort. Falls back to copy+delete across devices (EXDEV).
+// If the move can't complete, delete the source so it isn't read again on the
+// next launch.
 function renameQuiet(src: string, dest: string): void {
   try {
     fs.renameSync(src, dest);
-  } catch {
-    // Best effort — sidecar may not exist, or the source is already gone.
+    return;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "EXDEV") {
+      try {
+        fs.copyFileSync(src, dest);
+      } catch {
+        // fall through to deleting the source
+      }
+    }
   }
+  unlinkQuiet(src);
 }

--- a/src/utils/crash_dumps.ts
+++ b/src/utils/crash_dumps.ts
@@ -1,0 +1,82 @@
+import fs from "node:fs";
+import path from "node:path";
+
+// Absolute paths of the minidump files in a directory, newest first.
+export function listDumpFiles(dir: string): string[] {
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(dir);
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((f) => f.endsWith(".dmp"))
+    .map((f) => path.join(dir, f))
+    .sort((a, b) => mtimeMs(b) - mtimeMs(a));
+}
+
+// Absolute paths of every .dmp anywhere under a directory tree, newest first.
+// Crashpad's dump location is platform-specific (pending/ on Linux/macOS,
+// reports/ on Windows), so we search the whole crashDumps tree rather than
+// assume one subdirectory.
+export function listDumpFilesRecursive(dir: string): string[] {
+  const found: string[] = [];
+  const walk = (d: string): void => {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(d, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const p = path.join(d, entry.name);
+      if (entry.isDirectory()) walk(p);
+      else if (entry.name.endsWith(".dmp")) found.push(p);
+    }
+  };
+  walk(dir);
+  return found.sort((a, b) => mtimeMs(b) - mtimeMs(a));
+}
+
+// Delete a dump and its Crashpad metadata sidecar (best effort).
+export function deleteDump(dumpPath: string): void {
+  unlinkQuiet(dumpPath);
+  unlinkQuiet(dumpPath.replace(/\.dmp$/, ".meta"));
+}
+
+// Move a dump (and its .meta sidecar) to a new path (best effort).
+export function moveDump(src: string, dest: string): void {
+  renameQuiet(src, dest);
+  renameQuiet(src.replace(/\.dmp$/, ".meta"), dest.replace(/\.dmp$/, ".meta"));
+}
+
+// Keep at most `max` most-recent dumps; delete the rest (and their sidecars).
+export function pruneDumps(dir: string, max: number): void {
+  for (const dump of listDumpFiles(dir).slice(max)) {
+    deleteDump(dump);
+  }
+}
+
+function mtimeMs(p: string): number {
+  try {
+    return fs.statSync(p).mtimeMs;
+  } catch {
+    return 0;
+  }
+}
+
+function unlinkQuiet(p: string): void {
+  try {
+    fs.unlinkSync(p);
+  } catch {
+    // Best effort — nothing actionable if the file is already gone.
+  }
+}
+
+function renameQuiet(src: string, dest: string): void {
+  try {
+    fs.renameSync(src, dest);
+  } catch {
+    // Best effort — sidecar may not exist, or the source is already gone.
+  }
+}

--- a/src/utils/minidump_summary.test.ts
+++ b/src/utils/minidump_summary.test.ts
@@ -182,6 +182,20 @@ describe("parseMinidumpBuffer", () => {
     );
   });
 
+  it("decodes a macOS Mach exception code (not a POSIX signal)", () => {
+    // On macOS, ExceptionCode is a Mach exception type: 1 is EXC_BAD_ACCESS,
+    // not signal 1 (SIGHUP).
+    const dump = buildMinidump({
+      modules: oneModule,
+      exceptionCode: 1,
+      ip: 0x10010n,
+      ipOffset: 264,
+    });
+    expect(parseMinidumpBuffer(dump, "darwin", "arm64")!.crashReason).toBe(
+      "EXC_BAD_ACCESS",
+    );
+  });
+
   it("decodes a Windows NTSTATUS code", () => {
     const dump = buildMinidump({
       modules: [{ base: 0x400000n, size: 0x1000, name: "C:\\app\\app.exe" }],

--- a/src/utils/minidump_summary.test.ts
+++ b/src/utils/minidump_summary.test.ts
@@ -24,6 +24,7 @@ function buildMinidump(opts: {
   ip: bigint;
   ipOffset: number; // where the IP sits in the CPU context: 248 (x64) / 264 (arm64)
   ptype?: string;
+  addressMask?: bigint; // Crashpad address_mask, written into the CrashpadInfo stream
 }): Buffer {
   const buf = Buffer.alloc(16384);
   const dv = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
@@ -118,10 +119,15 @@ function buildMinidump(opts: {
     dv.setUint32(cpModListRva + 12, moduleInfoRva, true);
     cursor = cpModListRva + 16;
 
-    // CrashpadInfo: module_list RVA @ +48.
+    // CrashpadInfo: module_list RVA @ +48, optional address_mask u64 @ +56.
     crashpadInfoRva = cursor;
     dv.setUint32(crashpadInfoRva + 48, cpModListRva, true);
-    cursor = crashpadInfoRva + 52;
+    if (opts.addressMask !== undefined) {
+      dv.setBigUint64(crashpadInfoRva + 56, opts.addressMask, true);
+      cursor = crashpadInfoRva + 64;
+    } else {
+      cursor = crashpadInfoRva + 52;
+    }
   }
 
   // --- Header (signature @0, stream count @8, directory RVA @12) ---
@@ -140,7 +146,7 @@ function buildMinidump(opts: {
   dv.setUint32(52, exceptionRva, true);
   if (opts.ptype !== undefined) {
     dv.setUint32(56, 0x43500001, true);
-    dv.setUint32(60, 52, true);
+    dv.setUint32(60, opts.addressMask !== undefined ? 64 : 52, true);
     dv.setUint32(64, crashpadInfoRva, true);
   }
 
@@ -194,6 +200,22 @@ describe("parseMinidumpBuffer", () => {
       exceptionCode: 11,
       ip: 0x10800n,
       ipOffset: 264,
+    });
+    const s = parseMinidumpBuffer(dump, "darwin", "arm64");
+    expect(s!.faultingModule).toBe("libc.so.6");
+    expect(s!.faultingOffset).toBe("0x800");
+  });
+
+  it("strips arm64 pointer-tag bits using the Crashpad address_mask", () => {
+    // IP carries a high tag byte (0xab...); without masking it falls outside the
+    // module. The address_mask clears the tag so it resolves to base + 0x800.
+    const dump = buildMinidump({
+      modules: oneModule,
+      exceptionCode: 11,
+      ip: 0xab00000000010800n,
+      ipOffset: 264,
+      ptype: "browser",
+      addressMask: 0x000000ffffffffffn,
     });
     const s = parseMinidumpBuffer(dump, "darwin", "arm64");
     expect(s!.faultingModule).toBe("libc.so.6");

--- a/src/utils/minidump_summary.test.ts
+++ b/src/utils/minidump_summary.test.ts
@@ -208,14 +208,15 @@ describe("parseMinidumpBuffer", () => {
 
   it("strips arm64 pointer-tag bits using the Crashpad address_mask", () => {
     // IP carries a high tag byte (0xab...); without masking it falls outside the
-    // module. The address_mask clears the tag so it resolves to base + 0x800.
+    // module. address_mask marks the tag bits — clearing them (pointer & ~mask)
+    // recovers base + 0x800.
     const dump = buildMinidump({
       modules: oneModule,
       exceptionCode: 11,
       ip: 0xab00000000010800n,
       ipOffset: 264,
       ptype: "browser",
-      addressMask: 0x000000ffffffffffn,
+      addressMask: 0xff00000000000000n,
     });
     const s = parseMinidumpBuffer(dump, "darwin", "arm64");
     expect(s!.faultingModule).toBe("libc.so.6");

--- a/src/utils/minidump_summary.test.ts
+++ b/src/utils/minidump_summary.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect } from "vitest";
+import { parseMinidumpBuffer } from "@/utils/minidump_summary";
+
+// Build a minimal but valid minidump containing only the streams the parser
+// reads (module list + exception, and optionally a CrashpadInfo stream with a
+// "ptype" annotation), with the instruction pointer placed in a synthetic CPU
+// context. Lets us assert parsing deterministically without committing a real
+// (memory-bearing) dump.
+//
+// A minidump is a header, then a stream directory (a table of contents), then
+// the stream payloads — all referenced by RVA (an absolute byte offset from the
+// start of the file). We can't write the directory until we know where each
+// payload landed, so this builds in two passes: first lay the payloads down at
+// increasing offsets (tracking each one's RVA), then fill in the header +
+// directory that point at them. `cursor` is the running write position; the
+// `& ~3` / `& ~7` expressions round it up to 4-/8-byte alignment.
+//
+// The field offsets used here (e.g. exceptionCode @ +8) are the same ones the
+// parser reads — see the struct layouts documented in minidump_summary.ts.
+function buildMinidump(opts: {
+  modules: { base: bigint; size: number; name: string }[];
+  exceptionCode: number;
+  exceptionAddress?: bigint;
+  ip: bigint;
+  ipOffset: number; // where the IP sits in the CPU context: 248 (x64) / 264 (arm64)
+  ptype?: string;
+}): Buffer {
+  const buf = Buffer.alloc(16384);
+  const dv = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+  // 2 streams (module list + exception), or 3 when a CrashpadInfo stream is
+  // included. Payloads start after the 32-byte header + the directory (one
+  // 12-byte entry per stream).
+  const streamCount = opts.ptype !== undefined ? 3 : 2;
+  let cursor = 32 + streamCount * 12;
+
+  // Writes a length-prefixed UTF-8 string (u32 byte-length + bytes) at the
+  // cursor and returns its RVA. Used for the Crashpad annotation name/value.
+  const writeUtf8 = (s: string): number => {
+    const r = cursor;
+    const b = Buffer.from(s, "utf8");
+    dv.setUint32(r, b.length, true);
+    b.copy(buf, r + 4);
+    cursor = (r + 4 + b.length + 3) & ~3;
+    return r;
+  };
+
+  // --- Module name strings (MINIDUMP_STRING: u32 byte-length + UTF-16LE) ---
+  // Written first so the module records below can point at them by RVA.
+  const nameRvas: number[] = [];
+  for (const m of opts.modules) {
+    const rva = cursor;
+    const u16 = Buffer.from(m.name, "utf16le");
+    dv.setUint32(rva, u16.length, true);
+    u16.copy(buf, rva + 4);
+    cursor = (rva + 4 + u16.length + 3) & ~3;
+    nameRvas.push(rva);
+  }
+
+  // --- Module list stream (u32 count, then one 108-byte record per module) ---
+  // Each record: base @ +0, size @ +8, name RVA @ +20.
+  const moduleListRva = cursor;
+  dv.setUint32(moduleListRva, opts.modules.length, true);
+  let mc = moduleListRva + 4;
+  opts.modules.forEach((m, i) => {
+    dv.setBigUint64(mc, m.base, true);
+    dv.setUint32(mc + 8, m.size, true);
+    dv.setUint32(mc + 20, nameRvas[i], true);
+    mc += 108;
+  });
+  const moduleListSize = mc - moduleListRva;
+  cursor = mc;
+
+  // --- CPU context ---
+  // The parser reads the instruction pointer from here. We only need the IP, so
+  // the rest is left zeroed; the IP is placed at the arch-specific ipOffset.
+  const contextRva = cursor;
+  const contextSize = opts.ipOffset + 8;
+  dv.setBigUint64(contextRva + opts.ipOffset, opts.ip, true);
+  cursor = (contextRva + contextSize + 7) & ~7;
+
+  // --- Exception stream ---
+  // exceptionCode @ +8; exceptionAddress @ +24; then a location descriptor for
+  // the CPU context above (its size @ +160, its RVA @ +164).
+  const exceptionRva = cursor;
+  dv.setUint32(exceptionRva + 8, opts.exceptionCode, true);
+  dv.setBigUint64(exceptionRva + 24, opts.exceptionAddress ?? 0n, true);
+  dv.setUint32(exceptionRva + 160, contextSize, true);
+  dv.setUint32(exceptionRva + 164, contextRva, true);
+  const exceptionSize = 168;
+  cursor = (exceptionRva + exceptionSize + 3) & ~3;
+
+  // --- Optional CrashpadInfo stream carrying one "ptype" annotation ---
+  // Mirrors the nested chain the parser walks to find ptype, built bottom-up so
+  // each level can reference the RVA of the one below it:
+  //   annotation (name + value) -> annotation_objects list -> module_info ->
+  //   module_list -> CrashpadInfo.
+  let crashpadInfoRva = 0;
+  if (opts.ptype !== undefined) {
+    const nameRva = writeUtf8("ptype");
+    const valueRva = writeUtf8(opts.ptype);
+
+    // annotation_objects: u32 count, then one 12-byte annotation
+    // (name RVA @ +0, value RVA @ +8 within the annotation).
+    const annObjectsRva = cursor;
+    dv.setUint32(annObjectsRva, 1, true);
+    dv.setUint32(annObjectsRva + 4, nameRva, true);
+    dv.setUint32(annObjectsRva + 12, valueRva, true);
+    cursor = annObjectsRva + 16;
+
+    // ModuleCrashpadInfo: annotation_objects RVA @ +24.
+    const moduleInfoRva = cursor;
+    dv.setUint32(moduleInfoRva + 24, annObjectsRva, true);
+    cursor = moduleInfoRva + 28;
+
+    // module_list: u32 count, then one 12-byte link whose module_info RVA @ +8.
+    const cpModListRva = cursor;
+    dv.setUint32(cpModListRva, 1, true);
+    dv.setUint32(cpModListRva + 12, moduleInfoRva, true);
+    cursor = cpModListRva + 16;
+
+    // CrashpadInfo: module_list RVA @ +48.
+    crashpadInfoRva = cursor;
+    dv.setUint32(crashpadInfoRva + 48, cpModListRva, true);
+    cursor = crashpadInfoRva + 52;
+  }
+
+  // --- Header (signature @0, stream count @8, directory RVA @12) ---
+  dv.setUint32(0, 0x504d444d, true); // "MDMP"
+  dv.setUint32(8, streamCount, true);
+  dv.setUint32(12, 32, true);
+
+  // --- Stream directory: one 12-byte entry per stream, each being
+  // { u32 streamType @0, u32 dataSize @4, u32 rva @8 }, starting at offset 32.
+  // [0] module list (type 4), [1] exception (type 6), [2] CrashpadInfo.
+  dv.setUint32(32, 4, true);
+  dv.setUint32(36, moduleListSize, true);
+  dv.setUint32(40, moduleListRva, true);
+  dv.setUint32(44, 6, true);
+  dv.setUint32(48, exceptionSize, true);
+  dv.setUint32(52, exceptionRva, true);
+  if (opts.ptype !== undefined) {
+    dv.setUint32(56, 0x43500001, true);
+    dv.setUint32(60, 52, true);
+    dv.setUint32(64, crashpadInfoRva, true);
+  }
+
+  return Buffer.from(buf.subarray(0, cursor));
+}
+
+const oneModule = [{ base: 0x10000n, size: 0x2000, name: "/lib/libc.so.6" }];
+
+describe("parseMinidumpBuffer", () => {
+  it("decodes a POSIX signal and resolves the faulting module via the IP", () => {
+    const dump = buildMinidump({
+      modules: oneModule,
+      exceptionCode: 11, // SIGSEGV
+      ip: 0x10500n, // inside the module (base + 0x500)
+      ipOffset: 248,
+    });
+    const s = parseMinidumpBuffer(dump, "linux", "x64");
+    expect(s).not.toBeNull();
+    expect(s!.crashReason).toBe("SIGSEGV");
+    expect(s!.faultingModule).toBe("libc.so.6");
+    expect(s!.faultingOffset).toBe("0x500");
+  });
+
+  it("decodes SIGABRT", () => {
+    const dump = buildMinidump({
+      modules: oneModule,
+      exceptionCode: 6,
+      ip: 0x10010n,
+      ipOffset: 248,
+    });
+    expect(parseMinidumpBuffer(dump, "linux", "x64")!.crashReason).toBe(
+      "SIGABRT",
+    );
+  });
+
+  it("decodes a Windows NTSTATUS code", () => {
+    const dump = buildMinidump({
+      modules: [{ base: 0x400000n, size: 0x1000, name: "C:\\app\\app.exe" }],
+      exceptionCode: 0xc0000005,
+      ip: 0x400100n,
+      ipOffset: 248,
+    });
+    const s = parseMinidumpBuffer(dump, "win32", "x64");
+    expect(s!.crashReason).toBe("ACCESS_VIOLATION");
+    expect(s!.faultingModule).toBe("app.exe");
+  });
+
+  it("reads the arm64 IP at the documented offset (264)", () => {
+    const dump = buildMinidump({
+      modules: oneModule,
+      exceptionCode: 11,
+      ip: 0x10800n,
+      ipOffset: 264,
+    });
+    const s = parseMinidumpBuffer(dump, "darwin", "arm64");
+    expect(s!.faultingModule).toBe("libc.so.6");
+    expect(s!.faultingOffset).toBe("0x800");
+  });
+
+  it("omits the module when the IP is outside every module", () => {
+    const dump = buildMinidump({
+      modules: oneModule,
+      exceptionCode: 11,
+      ip: 0x99999999n,
+      ipOffset: 248,
+    });
+    const s = parseMinidumpBuffer(dump, "linux", "x64");
+    expect(s!.crashReason).toBe("SIGSEGV");
+    expect(s!.faultingModule).toBeUndefined();
+  });
+
+  it("returns the raw code when the signal is unmapped", () => {
+    const dump = buildMinidump({
+      modules: oneModule,
+      exceptionCode: 99,
+      ip: 0x10010n,
+      ipOffset: 248,
+    });
+    const s = parseMinidumpBuffer(dump, "linux", "x64");
+    expect(s!.crashReason).toBeUndefined();
+    expect(s!.exceptionCode).toBe(99);
+  });
+
+  it("reads the crashing process type (ptype) from the CrashpadInfo stream", () => {
+    const dump = buildMinidump({
+      modules: oneModule,
+      exceptionCode: 11,
+      ip: 0x10010n,
+      ipOffset: 248,
+      ptype: "browser",
+    });
+    expect(parseMinidumpBuffer(dump, "linux", "x64")!.ptype).toBe("browser");
+  });
+
+  it("leaves ptype undefined when there is no CrashpadInfo stream", () => {
+    const dump = buildMinidump({
+      modules: oneModule,
+      exceptionCode: 11,
+      ip: 0x10010n,
+      ipOffset: 248,
+    });
+    expect(parseMinidumpBuffer(dump, "linux", "x64")!.ptype).toBeUndefined();
+  });
+
+  it("rejects a buffer without the MDMP signature", () => {
+    expect(parseMinidumpBuffer(Buffer.alloc(64), "linux", "x64")).toBeNull();
+  });
+
+  it("rejects a truncated buffer", () => {
+    expect(parseMinidumpBuffer(Buffer.alloc(8), "linux", "x64")).toBeNull();
+  });
+});

--- a/src/utils/minidump_summary.ts
+++ b/src/utils/minidump_summary.ts
@@ -213,9 +213,9 @@ export function parseMinidumpBuffer(
       }
     }
 
-    // On arm64 (Apple Silicon) the saved pointer can carry pointer-auth / top-byte
-    // tag bits. Crashpad records an address_mask to strip them; apply it before
-    // module lookup so the address falls inside its module's range.
+    // On arm64 the saved pointer can carry pointer-auth / top-byte tag bits.
+    // Crashpad records an address_mask to recover the real address before module
+    // lookup.
     if (instructionPointer !== 0n && crashpadInfoRva) {
       const mask = readAddressMask(
         view,
@@ -223,7 +223,7 @@ export function parseMinidumpBuffer(
         crashpadInfoRva,
         crashpadInfoSize,
       );
-      if (mask !== 0n) instructionPointer &= mask;
+      instructionPointer = applyAddressMask(instructionPointer, mask);
     }
 
     let faultingModule: string | undefined;
@@ -320,6 +320,15 @@ function readAddressMask(
     return 0n;
   }
   return view.getBigUint64(infoRva + CRASHPAD_ADDRESS_MASK_OFF, true);
+}
+
+// Recover a real address from a tagged arm64 pointer using Crashpad's mask. Per
+// Crashpad: clear the masked (tag) bits, or set them when bit 55 is set (the
+// pointer is in high memory). A 0 mask means no tagging — return as-is.
+function applyAddressMask(pointer: bigint, mask: bigint): bigint {
+  if (mask === 0n) return pointer;
+  const HIGH_MEMORY_BIT = 1n << 55n;
+  return (pointer & HIGH_MEMORY_BIT) !== 0n ? pointer | mask : pointer & ~mask;
 }
 
 // A u32 byte-length followed by UTF-8 bytes (MinidumpUTF8String / ByteArray).

--- a/src/utils/minidump_summary.ts
+++ b/src/utils/minidump_summary.ts
@@ -1,0 +1,332 @@
+import fs from "node:fs";
+
+// A small, symbol-free summary extracted from a minidump: enough to attribute a
+// native crash (which signal, which module faulted) without any memory contents,
+// so it is safe to send as telemetry. Not a full stack walk — just the faulting
+// frame's module + offset, which can be resolved to a function name offline
+// against public symbols using the recorded app/Electron version.
+export interface MinidumpSummary {
+  crashReason?: string; // e.g. "SIGABRT" / "SIGSEGV" (POSIX) or NTSTATUS name
+  exceptionCode: number; // raw code, in case the name table misses it
+  faultingModule?: string; // basename of the module containing the crash address
+  faultingOffset?: string; // hex offset of the crash address within that module
+  ptype?: string; // crashing process type: "browser" (main) / "renderer" / "gpu-process" / …
+}
+
+// These values are fixed by the minidump file format. The signature and stream
+// type ids come from Microsoft's MINIDUMP_HEADER / MINIDUMP_STREAM_TYPE; the
+// CrashpadInfo stream id and struct layouts come from Crashpad's headers.
+
+// First 4 bytes of every minidump: ASCII "MDMP" (little-endian).
+const MINIDUMP_SIGNATURE = 0x504d444d;
+
+// Stream type ids we read from the stream directory.
+const STREAM_MODULE_LIST = 4; // ModuleListStream
+const STREAM_EXCEPTION = 6; // ExceptionStream
+const STREAM_CRASHPAD_INFO = 0x43500001; // Crashpad's vendor extension
+
+// Each struct below is a flat C record, so a field's offset is the sum of the
+// sizes of the fields before it (u32 = 4 bytes, u64 = 8). The layout is written
+// out so every offset is derivable from it.
+
+// MINIDUMP_HEADER:
+//   u32 signature @0 | u32 version @4 | u32 streamCount @8 | u32 dirRva @12 | ...
+// The full header is 32 bytes; the stream directory follows it.
+const HEADER_STREAM_COUNT_OFF = 8;
+const HEADER_DIR_RVA_OFF = 12;
+const HEADER_SIZE = 32;
+
+// MINIDUMP_DIRECTORY entry (one per stream): a u32 stream type, then a
+// LOCATION_DESCRIPTOR { u32 dataSize @4, u32 rva @8 }. 12 bytes total.
+const DIR_ENTRY_SIZE = 12;
+const DIR_ENTRY_TYPE_OFF = 0;
+const DIR_ENTRY_RVA_OFF = 8;
+
+// MINIDUMP_EXCEPTION_STREAM, from the stream's start:
+//   u32 threadId          @0
+//   u32 alignment         @4
+//   -- MINIDUMP_EXCEPTION --
+//   u32 exceptionCode     @8
+//   u32 exceptionFlags    @12
+//   u64 exceptionRecord   @16
+//   u64 exceptionAddress  @24
+//   u32 numberParameters  @32
+//   u32 alignment         @36
+//   u64 info[15]          @40  (15 * 8 = 120 bytes, ends @160)
+//   -- thread context LOCATION_DESCRIPTOR --
+//   u32 dataSize          @160
+//   u32 rva               @164  -> file offset of the crashing thread's CPU context
+const EXC_CODE_OFF = 8;
+const EXC_CONTEXT_RVA_OFF = 164;
+
+// MINIDUMP_MODULE record: u64 base @0, u32 size @8, ... u32 nameRva @20, with
+// the whole record being 108 bytes (so module N starts at N * 108).
+const MODULE_RECORD_SIZE = 108;
+const MODULE_BASE_OFF = 0;
+const MODULE_SIZE_OFF = 8;
+const MODULE_NAME_RVA_OFF = 20;
+
+// Crashpad stores the POSIX signal number in ExceptionCode on Linux/macOS.
+const SIGNAL_NAMES: Record<number, string> = {
+  4: "SIGILL",
+  5: "SIGTRAP",
+  6: "SIGABRT",
+  7: "SIGBUS",
+  8: "SIGFPE",
+  11: "SIGSEGV",
+  15: "SIGTERM",
+};
+
+// Windows uses NTSTATUS exception codes; degrades to the raw code when unmatched.
+const NTSTATUS_NAMES: Record<number, string> = {
+  0xc0000005: "ACCESS_VIOLATION",
+  0xc000001d: "ILLEGAL_INSTRUCTION",
+  0xc0000094: "INTEGER_DIVIDE_BY_ZERO",
+  0xc00000fd: "STACK_OVERFLOW",
+  0xc0000409: "STACK_BUFFER_OVERRUN",
+  0x80000003: "BREAKPOINT",
+};
+
+interface MinidumpModule {
+  base: bigint;
+  size: number;
+  name: string;
+}
+
+// Byte offset of the instruction pointer (where the crash happened) within each
+// architecture's CPU context struct — the struct the exception stream points
+// at. Each struct is a flat C record, so the IP's offset is the sum of the sizes
+// of the fields ahead of it (u16 = 2 bytes, u32 = 4, u64 = 8). Derived below
+// from Breakpad's context structs; values match real dumps.
+//
+// x64 — rip in MDRawContextAMD64 (minidump_cpu_amd64.h):
+//     6 * u64 home params                 =  48
+//   + u32 context_flags + u32 mx_csr      =   8  ->  56
+//   + 6 * u16 segment regs + u32 eflags   =  16  ->  72
+//   + 6 * u64 debug regs (dr0..dr7)       =  48  -> 120
+//   + 16 * u64 integer regs (rax..r15)    = 128  -> 248
+//   rip is the next field                            => 248
+//
+// arm64 — pc in MDRawContextARM64 (minidump_cpu_arm64.h):
+//     u32 context_flags + u32 cpsr        =   8
+//   + 32 * u64 iregs (x0..x30, sp)        = 256  -> 264
+//   pc is iregs[32], the next register              => 264
+//
+// https://chromium.googlesource.com/breakpad/breakpad/+/main/src/google_breakpad/common/minidump_cpu_amd64.h
+// https://chromium.googlesource.com/breakpad/breakpad/+/main/src/google_breakpad/common/minidump_cpu_arm64.h
+const IP_OFFSET_IN_CONTEXT: Partial<Record<NodeJS.Architecture, number>> = {
+  x64: 248,
+  arm64: 264,
+};
+
+// Read a minidump file from disk and summarize it. Returns null if the file
+// can't be read or isn't a valid minidump.
+export function parseMinidumpSummary(
+  filePath: string,
+  platform: NodeJS.Platform = process.platform,
+  arch: NodeJS.Architecture = process.arch,
+): MinidumpSummary | null {
+  let buf: Buffer;
+  try {
+    buf = fs.readFileSync(filePath);
+  } catch {
+    return null;
+  }
+  return parseMinidumpBuffer(buf, platform, arch);
+}
+
+// Parse an in-memory minidump into a MinidumpSummary. Finds the streams it needs
+// via the directory, decodes the crash reason from the exception code, resolves
+// the faulting instruction pointer to a module + offset, and reads the process
+// type. Returns null if the buffer is not a valid minidump; individual fields
+// are left undefined when their stream is missing or malformed.
+export function parseMinidumpBuffer(
+  buf: Buffer,
+  platform: NodeJS.Platform = process.platform,
+  arch: NodeJS.Architecture = process.arch,
+): MinidumpSummary | null {
+  try {
+    const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+    if (
+      buf.length < HEADER_SIZE ||
+      view.getUint32(0, true) !== MINIDUMP_SIGNATURE
+    ) {
+      return null;
+    }
+    const numStreams = view.getUint32(HEADER_STREAM_COUNT_OFF, true);
+    const dirRva = view.getUint32(HEADER_DIR_RVA_OFF, true);
+
+    // Walk the stream directory, recording the file offset (rva) of each stream
+    // we care about.
+    let moduleListRva = 0;
+    let exceptionRva = 0;
+    let crashpadInfoRva = 0;
+    for (let i = 0; i < numStreams; i++) {
+      const entry = dirRva + i * DIR_ENTRY_SIZE;
+      if (entry + DIR_ENTRY_SIZE > buf.length) break;
+      const type = view.getUint32(entry + DIR_ENTRY_TYPE_OFF, true);
+      const rva = view.getUint32(entry + DIR_ENTRY_RVA_OFF, true);
+      if (type === STREAM_MODULE_LIST) moduleListRva = rva;
+      else if (type === STREAM_EXCEPTION) exceptionRva = rva;
+      else if (type === STREAM_CRASHPAD_INFO) crashpadInfoRva = rva;
+    }
+
+    if (exceptionRva === 0 || exceptionRva + EXC_CONTEXT_RVA_OFF > buf.length) {
+      return null;
+    }
+    const exceptionCode = view.getUint32(exceptionRva + EXC_CODE_OFF, true);
+
+    const crashReason =
+      platform === "win32"
+        ? NTSTATUS_NAMES[exceptionCode >>> 0]
+        : SIGNAL_NAMES[exceptionCode];
+
+    // The faulting CODE location is the instruction pointer from the crashing
+    // thread's CPU context — not ExceptionAddress, which on a null-deref/abort
+    // is the (zero) data fault address. The exception stream points to that
+    // context; the IP sits at an arch-specific offset within it.
+    let instructionPointer = 0n;
+    const ipOffset = IP_OFFSET_IN_CONTEXT[arch];
+    if (
+      ipOffset !== undefined &&
+      exceptionRva + EXC_CONTEXT_RVA_OFF + 4 <= buf.length
+    ) {
+      const contextRva = view.getUint32(
+        exceptionRva + EXC_CONTEXT_RVA_OFF,
+        true,
+      );
+      if (contextRva + ipOffset + 8 <= buf.length) {
+        instructionPointer = view.getBigUint64(contextRva + ipOffset, true);
+      }
+    }
+
+    let faultingModule: string | undefined;
+    let faultingOffset: string | undefined;
+    if (moduleListRva !== 0 && instructionPointer !== 0n) {
+      const module = findModule(
+        parseModules(view, buf, moduleListRva),
+        instructionPointer,
+      );
+      if (module) {
+        faultingModule = basename(module.name);
+        faultingOffset = "0x" + (instructionPointer - module.base).toString(16);
+      }
+    }
+
+    return {
+      crashReason,
+      exceptionCode,
+      faultingModule,
+      faultingOffset,
+      ptype: crashpadInfoRva
+        ? parsePtype(view, buf, crashpadInfoRva)
+        : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+// Read the "ptype" Crashpad annotation (the crashing process type) from the
+// MinidumpCrashpadInfo stream. Nested structs we walk, with the byte offset of
+// the field we read from each:
+//
+//   MinidumpCrashpadInfo        ->  module_list rva          @ +48
+//   module_list                 ->  count, then 12-byte links
+//     link                      ->  module_info rva          @ +8
+//   MinidumpModuleCrashpadInfo  ->  annotation_objects rva   @ +24
+//   annotation_objects          ->  count, then 12-byte annotations
+//     annotation                ->  name rva @ +0, value rva @ +8
+//
+// name and value are length-prefixed UTF-8; return the value named "ptype".
+function parsePtype(
+  view: DataView,
+  buf: Buffer,
+  infoRva: number,
+): string | undefined {
+  try {
+    if (infoRva + 52 > buf.length) return undefined;
+    const modListRva = view.getUint32(infoRva + 48, true);
+    if (modListRva === 0 || modListRva + 4 > buf.length) return undefined;
+    const moduleCount = view.getUint32(modListRva, true);
+    for (let i = 0; i < moduleCount; i++) {
+      const link = modListRva + 4 + i * 12;
+      if (link + 12 > buf.length) break;
+      const moduleInfoRva = view.getUint32(link + 8, true);
+      if (moduleInfoRva + 28 > buf.length) continue;
+      const objectsRva = view.getUint32(moduleInfoRva + 24, true);
+      if (objectsRva === 0 || objectsRva + 4 > buf.length) continue;
+      const objectCount = view.getUint32(objectsRva, true);
+      for (let j = 0; j < objectCount; j++) {
+        const obj = objectsRva + 4 + j * 12;
+        if (obj + 12 > buf.length) break;
+        if (
+          readLengthPrefixed(view, buf, view.getUint32(obj, true)) === "ptype"
+        ) {
+          return readLengthPrefixed(view, buf, view.getUint32(obj + 8, true));
+        }
+      }
+    }
+  } catch {
+    // best effort — ptype is optional context
+  }
+  return undefined;
+}
+
+// A u32 byte-length followed by UTF-8 bytes (MinidumpUTF8String / ByteArray).
+function readLengthPrefixed(view: DataView, buf: Buffer, rva: number): string {
+  if (rva === 0 || rva + 4 > buf.length) return "";
+  const len = view.getUint32(rva, true);
+  const start = rva + 4;
+  if (len <= 0 || start + len > buf.length) return "";
+  return buf.toString("utf8", start, start + len);
+}
+
+// Parse the module list stream into the base address, size, and name of each
+// loaded module. (MINIDUMP_MODULE_LIST: a u32 count, then `count` fixed-size
+// module records.)
+function parseModules(
+  view: DataView,
+  buf: Buffer,
+  rva: number,
+): MinidumpModule[] {
+  if (rva + 4 > buf.length) return [];
+  const count = view.getUint32(rva, true);
+  const modules: MinidumpModule[] = [];
+  for (let i = 0; i < count; i++) {
+    const m = rva + 4 + i * MODULE_RECORD_SIZE;
+    if (m + MODULE_RECORD_SIZE > buf.length) break;
+    const base = view.getBigUint64(m + MODULE_BASE_OFF, true);
+    const size = view.getUint32(m + MODULE_SIZE_OFF, true);
+    const nameRva = view.getUint32(m + MODULE_NAME_RVA_OFF, true);
+    modules.push({ base, size, name: readMinidumpString(view, buf, nameRva) });
+  }
+  return modules;
+}
+
+// Find the loaded module whose address range contains the given address (the
+// crash IP), or undefined if it falls outside every module.
+function findModule(
+  modules: MinidumpModule[],
+  address: bigint,
+): MinidumpModule | undefined {
+  return modules.find(
+    (m) => address >= m.base && address < m.base + BigInt(m.size),
+  );
+}
+
+// MINIDUMP_STRING: u32 byte-length followed by UTF-16LE.
+function readMinidumpString(view: DataView, buf: Buffer, rva: number): string {
+  if (rva === 0 || rva + 4 > buf.length) return "";
+  const byteLength = view.getUint32(rva, true);
+  const start = rva + 4;
+  if (byteLength <= 0 || start + byteLength > buf.length) return "";
+  return buf.toString("utf16le", start, start + byteLength);
+}
+
+// Last path segment of a module path, handling both / and \ separators (module
+// names are full paths, and Windows dumps use backslashes).
+function basename(p: string): string {
+  const i = Math.max(p.lastIndexOf("/"), p.lastIndexOf("\\"));
+  return i >= 0 ? p.slice(i + 1) : p;
+}

--- a/src/utils/minidump_summary.ts
+++ b/src/utils/minidump_summary.ts
@@ -40,6 +40,7 @@ const HEADER_SIZE = 32;
 // LOCATION_DESCRIPTOR { u32 dataSize @4, u32 rva @8 }. 12 bytes total.
 const DIR_ENTRY_SIZE = 12;
 const DIR_ENTRY_TYPE_OFF = 0;
+const DIR_ENTRY_SIZE_OFF = 4;
 const DIR_ENTRY_RVA_OFF = 8;
 
 // MINIDUMP_EXCEPTION_STREAM, from the stream's start:
@@ -65,6 +66,13 @@ const MODULE_RECORD_SIZE = 108;
 const MODULE_BASE_OFF = 0;
 const MODULE_SIZE_OFF = 8;
 const MODULE_NAME_RVA_OFF = 20;
+
+// MinidumpCrashpadInfo: u32 version @0 | UUID report_id (16) @4 | UUID client_id
+// (16) @20 | LOCATION_DESCRIPTOR simple_annotations (8) @36 | LOCATION_DESCRIPTOR
+// module_list (8) @44 | u32 reserved @52 | u64 address_mask @56.
+const CRASHPAD_MODULE_LIST_RVA_OFF = 48; // rva field of module_list (@44 + 4)
+const CRASHPAD_ADDRESS_MASK_OFF = 56;
+const CRASHPAD_INFO_MIN_SIZE_FOR_MASK = 64; // through the end of address_mask
 
 // Crashpad stores the POSIX signal number in ExceptionCode on Linux/macOS.
 const SIGNAL_NAMES: Record<number, string> = {
@@ -161,14 +169,19 @@ export function parseMinidumpBuffer(
     let moduleListRva = 0;
     let exceptionRva = 0;
     let crashpadInfoRva = 0;
+    let crashpadInfoSize = 0;
     for (let i = 0; i < numStreams; i++) {
       const entry = dirRva + i * DIR_ENTRY_SIZE;
       if (entry + DIR_ENTRY_SIZE > buf.length) break;
       const type = view.getUint32(entry + DIR_ENTRY_TYPE_OFF, true);
+      const size = view.getUint32(entry + DIR_ENTRY_SIZE_OFF, true);
       const rva = view.getUint32(entry + DIR_ENTRY_RVA_OFF, true);
       if (type === STREAM_MODULE_LIST) moduleListRva = rva;
       else if (type === STREAM_EXCEPTION) exceptionRva = rva;
-      else if (type === STREAM_CRASHPAD_INFO) crashpadInfoRva = rva;
+      else if (type === STREAM_CRASHPAD_INFO) {
+        crashpadInfoRva = rva;
+        crashpadInfoSize = size;
+      }
     }
 
     if (exceptionRva === 0 || exceptionRva + EXC_CONTEXT_RVA_OFF > buf.length) {
@@ -198,6 +211,19 @@ export function parseMinidumpBuffer(
       if (contextRva + ipOffset + 8 <= buf.length) {
         instructionPointer = view.getBigUint64(contextRva + ipOffset, true);
       }
+    }
+
+    // On arm64 (Apple Silicon) the saved pointer can carry pointer-auth / top-byte
+    // tag bits. Crashpad records an address_mask to strip them; apply it before
+    // module lookup so the address falls inside its module's range.
+    if (instructionPointer !== 0n && crashpadInfoRva) {
+      const mask = readAddressMask(
+        view,
+        buf,
+        crashpadInfoRva,
+        crashpadInfoSize,
+      );
+      if (mask !== 0n) instructionPointer &= mask;
     }
 
     let faultingModule: string | undefined;
@@ -245,8 +271,13 @@ function parsePtype(
   infoRva: number,
 ): string | undefined {
   try {
-    if (infoRva + 52 > buf.length) return undefined;
-    const modListRva = view.getUint32(infoRva + 48, true);
+    if (infoRva + CRASHPAD_MODULE_LIST_RVA_OFF + 4 > buf.length) {
+      return undefined;
+    }
+    const modListRva = view.getUint32(
+      infoRva + CRASHPAD_MODULE_LIST_RVA_OFF,
+      true,
+    );
     if (modListRva === 0 || modListRva + 4 > buf.length) return undefined;
     const moduleCount = view.getUint32(modListRva, true);
     for (let i = 0; i < moduleCount; i++) {
@@ -271,6 +302,24 @@ function parsePtype(
     // best effort — ptype is optional context
   }
   return undefined;
+}
+
+// Read the address_mask from the MinidumpCrashpadInfo stream, used to strip
+// pointer-tag bits from addresses (arm64). Returns 0n when absent — older dumps
+// don't have the field, so only read it when the stream is long enough.
+function readAddressMask(
+  view: DataView,
+  buf: Buffer,
+  infoRva: number,
+  infoSize: number,
+): bigint {
+  if (
+    infoSize < CRASHPAD_INFO_MIN_SIZE_FOR_MASK ||
+    infoRva + CRASHPAD_ADDRESS_MASK_OFF + 8 > buf.length
+  ) {
+    return 0n;
+  }
+  return view.getBigUint64(infoRva + CRASHPAD_ADDRESS_MASK_OFF, true);
 }
 
 // A u32 byte-length followed by UTF-8 bytes (MinidumpUTF8String / ByteArray).

--- a/src/utils/minidump_summary.ts
+++ b/src/utils/minidump_summary.ts
@@ -74,7 +74,7 @@ const CRASHPAD_MODULE_LIST_RVA_OFF = 48; // rva field of module_list (@44 + 4)
 const CRASHPAD_ADDRESS_MASK_OFF = 56;
 const CRASHPAD_INFO_MIN_SIZE_FOR_MASK = 64; // through the end of address_mask
 
-// Crashpad stores the POSIX signal number in ExceptionCode on Linux/macOS.
+// On Linux, Crashpad stores the POSIX signal number in ExceptionCode.
 const SIGNAL_NAMES: Record<number, string> = {
   4: "SIGILL",
   5: "SIGTRAP",
@@ -83,6 +83,23 @@ const SIGNAL_NAMES: Record<number, string> = {
   8: "SIGFPE",
   11: "SIGSEGV",
   15: "SIGTERM",
+};
+
+// On macOS, ExceptionCode is the Mach exception type, not a signal.
+const MACH_EXCEPTION_NAMES: Record<number, string> = {
+  1: "EXC_BAD_ACCESS",
+  2: "EXC_BAD_INSTRUCTION",
+  3: "EXC_ARITHMETIC",
+  4: "EXC_EMULATION",
+  5: "EXC_SOFTWARE",
+  6: "EXC_BREAKPOINT",
+  7: "EXC_SYSCALL",
+  8: "EXC_MACH_SYSCALL",
+  9: "EXC_RPC_ALERT",
+  10: "EXC_CRASH",
+  11: "EXC_RESOURCE",
+  12: "EXC_GUARD",
+  13: "EXC_CORPSE_NOTIFY",
 };
 
 // Windows uses NTSTATUS exception codes; degrades to the raw code when unmatched.
@@ -192,7 +209,9 @@ export function parseMinidumpBuffer(
     const crashReason =
       platform === "win32"
         ? NTSTATUS_NAMES[exceptionCode >>> 0]
-        : SIGNAL_NAMES[exceptionCode];
+        : platform === "darwin"
+          ? MACH_EXCEPTION_NAMES[exceptionCode]
+          : SIGNAL_NAMES[exceptionCode];
 
     // The faulting CODE location is the instruction pointer from the crashing
     // thread's CPU context — not ExceptionAddress, which on a null-deref/abort


### PR DESCRIPTION
Native crashes (segfaults, aborts, V8 fatal errors) currently leave no trace in our telemetry — the process dies before any JS handler runs. This turns on Electron's crashReporter to capture them as local minidumps, then reports a small, privacy-safe summary on the next launch.

From each dump we report:

- crash signal (e.g. SIGSEGV, SIGABRT) — what kind of fault it was. A bad memory access, a deliberate abort/assert, an illegal instruction, etc. all look different, so this lets us bucket crashes by type.
- faulting module + offset — which binary crashed (our code, V8, a GPU driver, a system library) and how far into it. The offset lands in the same spot for everyone on a given build, so the same offset showing up repeatedly means one shared bug. Paired with the build version, we can look the offset up offline to get the actual function name.
- process type — whether the main, renderer, or GPU process died. Tells us which part of the app failed. A main-process crash means the whole app went down, so its cause is attached to app:crash_detected (crash_cause "native", else "unknown").

This PR adds code to manually parse the minidump, which works by reading a few fixed-offset fields straight out of the dump's binary structs — the crash signal, the module list, and the crashing thread's instruction pointer — then mapping that pointer to a module + offset. There's no off-the-shelf in-process minidump reader, and we read only these header fields, never the memory the dump contains, so the result is safe to send as telemetry. The raw dump stays on disk (timestamped, max 5) for the rare deeper offline look.

---

We currently get a lot of crash reports that are difficult to make sense of. The goal of this PR is to better categorize the crashes, so it adds more information to the `app:crash_detected` telemetry event. This won't necessarily help us diagnose any individual crash, but it should hopefully produce patterns in the data that could point us in the right direction.

This PR will also leave behind crash dumps on the user's computer, opening the possibility that they could send those to us and that we could analyze them.

The dump parser is hard to read; sorry about that. It's doing a lot of individual byte manipulation on a binary file, so it's difficult to avoid magic numbers.