### PR TITLE
Show release notes when restoring chat on startup

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,6 +22,7 @@ import i18n from "@/i18n";
 import { LanguageSchema } from "@/lib/schemas";
 import { useShortcut } from "@/hooks/useShortcut";
 import { useIsMac } from "@/hooks/useChatModeToggle";
+import { ReleaseNotesDialog } from "@/components/ReleaseNotesDialog";
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   const { refreshAppIframe } = useRunApp();
@@ -139,6 +140,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
               expand
               duration={settings?.isTestMode ? 500 : undefined}
             />
+            <ReleaseNotesDialog />
           </SidebarProvider>
         </DeepLinkProvider>
       </ThemeProvider>

--- a/src/components/ReleaseNotesDialog.test.tsx
+++ b/src/components/ReleaseNotesDialog.test.tsx
@@ -1,0 +1,140 @@
+import type { ReactNode } from "react";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type Settings = {
+  lastShownReleaseNotesVersion?: string;
+};
+
+describe("ReleaseNotesDialog", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("shows release notes after an upgrade and records the shown version", async () => {
+    const updateSettings = vi.fn();
+    const doesReleaseNoteExist = vi.fn().mockResolvedValue({
+      exists: true,
+      url: "about:blank",
+    });
+
+    await renderReleaseNotesDialog({
+      settings: { lastShownReleaseNotesVersion: "1.2.0" },
+      updateSettings,
+      doesReleaseNoteExist,
+    });
+
+    expect(await screen.findByText("What's new in v1.3.0?")).toBeTruthy();
+    expect(doesReleaseNoteExist).toHaveBeenCalledWith({ version: "1.3.0" });
+    await waitFor(() => {
+      expect(updateSettings).toHaveBeenCalledWith({
+        lastShownReleaseNotesVersion: "1.3.0",
+      });
+    });
+  });
+
+  it("records the current version without fetching release notes on first run", async () => {
+    const updateSettings = vi.fn();
+    const doesReleaseNoteExist = vi.fn();
+
+    await renderReleaseNotesDialog({
+      settings: {},
+      updateSettings,
+      doesReleaseNoteExist,
+    });
+
+    await waitFor(() => {
+      expect(updateSettings).toHaveBeenCalledWith({
+        lastShownReleaseNotesVersion: "1.3.0",
+      });
+    });
+    expect(doesReleaseNoteExist).not.toHaveBeenCalled();
+    expect(screen.queryByText("What's new in v1.3.0?")).toBeNull();
+  });
+
+  it("does not record the current version when no release note exists", async () => {
+    const updateSettings = vi.fn();
+    const doesReleaseNoteExist = vi.fn().mockResolvedValue({
+      exists: false,
+    });
+
+    await renderReleaseNotesDialog({
+      settings: { lastShownReleaseNotesVersion: "1.2.0" },
+      updateSettings,
+      doesReleaseNoteExist,
+    });
+
+    await waitFor(() => {
+      expect(doesReleaseNoteExist).toHaveBeenCalledWith({ version: "1.3.0" });
+    });
+    expect(updateSettings).not.toHaveBeenCalled();
+    expect(screen.queryByText("What's new in v1.3.0?")).toBeNull();
+  });
+});
+
+async function renderReleaseNotesDialog({
+  settings,
+  updateSettings,
+  doesReleaseNoteExist,
+}: {
+  settings: Settings;
+  updateSettings: ReturnType<typeof vi.fn>;
+  doesReleaseNoteExist: ReturnType<typeof vi.fn>;
+}) {
+  vi.doMock("react-i18next", () => ({
+    useTranslation: () => ({
+      t: (key: string, params?: { version?: string }) => {
+        if (key === "whatsNew") {
+          return `What's new in v${params?.version}?`;
+        }
+        if (key === "releaseNotesTitle") {
+          return `Release notes for v${params?.version}`;
+        }
+        return key;
+      },
+    }),
+  }));
+  vi.doMock("@/hooks/useAppVersion", () => ({
+    useAppVersion: () => "1.3.0",
+  }));
+  vi.doMock("@/hooks/useSettings", () => ({
+    useSettings: () => ({
+      settings,
+      updateSettings,
+    }),
+  }));
+  vi.doMock("@/contexts/ThemeContext", () => ({
+    useTheme: () => ({ theme: "light" }),
+  }));
+  vi.doMock("@/ipc/types", () => ({
+    ipc: {
+      system: {
+        doesReleaseNoteExist,
+      },
+    },
+  }));
+  vi.doMock("@/components/ui/dialog", () => {
+    return {
+      Dialog: ({ open, children }: { open: boolean; children: ReactNode }) =>
+        open ? <div data-testid="dialog">{children}</div> : null,
+      DialogContent: ({ children }: { children: ReactNode }) => (
+        <div>{children}</div>
+      ),
+      DialogHeader: ({ children }: { children: ReactNode }) => (
+        <div>{children}</div>
+      ),
+      DialogTitle: ({ children }: { children: ReactNode }) => (
+        <h2>{children}</h2>
+      ),
+    };
+  });
+
+  const { ReleaseNotesDialog } = await import("./ReleaseNotesDialog");
+  let result: ReturnType<typeof render> | undefined;
+  await act(async () => {
+    result = render(<ReleaseNotesDialog />);
+    await Promise.resolve();
+  });
+  return result;
+}

--- a/src/components/ReleaseNotesDialog.tsx
+++ b/src/components/ReleaseNotesDialog.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { ExternalLink } from "lucide-react";
+
+import { useAppVersion } from "@/hooks/useAppVersion";
+import { useSettings } from "@/hooks/useSettings";
+import { useTheme } from "@/contexts/ThemeContext";
+import { ipc } from "@/ipc/types";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+// Track whether we've already checked release notes this session.
+let hasCheckedReleaseNotes = false;
+
+export function ReleaseNotesDialog() {
+  const { t } = useTranslation("home");
+  const appVersion = useAppVersion();
+  const { settings, updateSettings } = useSettings();
+  const { theme } = useTheme();
+  const [releaseNotesOpen, setReleaseNotesOpen] = useState(false);
+  const [releaseUrl, setReleaseUrl] = useState("");
+
+  useEffect(() => {
+    const checkReleaseNotes = async () => {
+      if (
+        hasCheckedReleaseNotes ||
+        !appVersion ||
+        !settings ||
+        settings.lastShownReleaseNotesVersion === appVersion
+      ) {
+        return;
+      }
+      hasCheckedReleaseNotes = true;
+
+      const shouldShowReleaseNotes = !!settings.lastShownReleaseNotesVersion;
+
+      // It feels spammy to show release notes if it's the user's very first time.
+      if (!shouldShowReleaseNotes) {
+        await updateSettings({
+          lastShownReleaseNotesVersion: appVersion,
+        });
+        return;
+      }
+
+      try {
+        const result = await ipc.system.doesReleaseNoteExist({
+          version: appVersion,
+        });
+
+        if (result.exists && result.url) {
+          setReleaseUrl(`${result.url}?hideHeader=true&theme=${theme}`);
+          setReleaseNotesOpen(true);
+          await updateSettings({
+            lastShownReleaseNotesVersion: appVersion,
+          });
+        }
+      } catch (err) {
+        console.warn(
+          "Unable to check if release note exists for: " + appVersion,
+          err,
+        );
+      }
+    };
+    checkReleaseNotes();
+  }, [appVersion, settings, updateSettings, theme]);
+
+  return (
+    <Dialog open={releaseNotesOpen} onOpenChange={setReleaseNotesOpen}>
+      <DialogContent className="max-w-4xl bg-(--docs-bg) pr-0 pt-4 pl-4 gap-1">
+        <DialogHeader>
+          <DialogTitle>{t("whatsNew", { version: appVersion })}</DialogTitle>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="absolute right-10 top-2 focus-visible:ring-0 focus-visible:ring-offset-0"
+            onClick={() =>
+              window.open(
+                releaseUrl.replace(`?hideHeader=true&theme=${theme}`, ""),
+                "_blank",
+              )
+            }
+          >
+            <ExternalLink className="w-4 h-4" />
+          </Button>
+        </DialogHeader>
+        <div className="overflow-auto h-[70vh] flex flex-col ">
+          {releaseUrl && (
+            <div className="flex-1">
+              <iframe
+                src={releaseUrl}
+                className="w-full h-full border-0 rounded-lg"
+                title={t("releaseNotesTitle", { version: appVersion })}
+              />
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -14,17 +14,7 @@ import { HomeChatInput } from "@/components/chat/HomeChatInput";
 import { usePostHog } from "posthog-js/react";
 import { PrivacyBanner } from "@/components/TelemetryBanner";
 import { INSPIRATION_PROMPTS } from "@/prompts/inspiration_prompts";
-import { useAppVersion } from "@/hooks/useAppVersion";
 
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { useTheme } from "@/contexts/ThemeContext";
-import { Button } from "@/components/ui/button";
-import { ExternalLink } from "lucide-react";
 import { ImportAppButton } from "@/components/ImportAppButton";
 import { showError } from "@/lib/toast";
 import { invalidateAppQuery } from "@/hooks/useLoadApp";
@@ -46,10 +36,6 @@ import {
 import { hasDyadProKey, getEffectiveDefaultChatMode } from "@/lib/schemas";
 import { useFreeAgentQuota } from "@/hooks/useFreeAgentQuota";
 import { useInitialChatMode } from "@/hooks/useInitialChatMode";
-
-// Track whether we've already checked release notes this session (module-scoped
-// so it persists across component unmount/remount cycles).
-let hasCheckedReleaseNotes = false;
 
 // Adding an export for attachments
 export interface HomeSubmitOptions {
@@ -75,10 +61,6 @@ export default function HomePage() {
   const [performanceData, setPerformanceData] = useState<any>(undefined);
   const { streamMessage } = useStreamChat({ hasChatId: false });
   const posthog = usePostHog();
-  const appVersion = useAppVersion();
-  const [releaseNotesOpen, setReleaseNotesOpen] = useState(false);
-  const [releaseUrl, setReleaseUrl] = useState("");
-  const { theme } = useTheme();
   const queryClient = useQueryClient();
 
   // Listen for force-close events
@@ -89,47 +71,6 @@ export default function HomePage() {
     });
     return () => unsubscribe();
   }, []);
-
-  useEffect(() => {
-    const updateLastVersionLaunched = async () => {
-      if (
-        hasCheckedReleaseNotes ||
-        !appVersion ||
-        !settings ||
-        settings.lastShownReleaseNotesVersion === appVersion
-      ) {
-        return;
-      }
-      hasCheckedReleaseNotes = true;
-
-      const shouldShowReleaseNotes = !!settings.lastShownReleaseNotesVersion;
-      await updateSettings({
-        lastShownReleaseNotesVersion: appVersion,
-      });
-      // It feels spammy to show release notes if it's
-      // the users very first time.
-      if (!shouldShowReleaseNotes) {
-        return;
-      }
-
-      try {
-        const result = await ipc.system.doesReleaseNoteExist({
-          version: appVersion,
-        });
-
-        if (result.exists && result.url) {
-          setReleaseUrl(result.url + "?hideHeader=true&theme=" + theme);
-          setReleaseNotesOpen(true);
-        }
-      } catch (err) {
-        console.warn(
-          "Unable to check if release note exists for: " + appVersion,
-          err,
-        );
-      }
-    };
-    updateLastVersionLaunched();
-  }, [appVersion, settings, updateSettings, theme]);
 
   // Get the appId from search params
   const appId = search.appId ? Number(search.appId) : null;
@@ -367,41 +308,6 @@ export default function HomePage() {
           <ProBanner />
         </div>
         <PrivacyBanner />
-
-        {/* Release Notes Dialog */}
-        <Dialog open={releaseNotesOpen} onOpenChange={setReleaseNotesOpen}>
-          <DialogContent className="max-w-4xl bg-(--docs-bg) pr-0 pt-4 pl-4 gap-1">
-            <DialogHeader>
-              <DialogTitle>
-                {t("whatsNew", { version: appVersion })}
-              </DialogTitle>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="absolute right-10 top-2 focus-visible:ring-0 focus-visible:ring-offset-0"
-                onClick={() =>
-                  window.open(
-                    releaseUrl.replace("?hideHeader=true&theme=" + theme, ""),
-                    "_blank",
-                  )
-                }
-              >
-                <ExternalLink className="w-4 h-4" />
-              </Button>
-            </DialogHeader>
-            <div className="overflow-auto h-[70vh] flex flex-col ">
-              {releaseUrl && (
-                <div className="flex-1">
-                  <iframe
-                    src={releaseUrl}
-                    className="w-full h-full border-0 rounded-lg"
-                    title={t("releaseNotesTitle", { version: appVersion })}
-                  />
-                </div>
-              )}
-            </div>
-          </DialogContent>
-        </Dialog>
       </div>
       <FeaturedAppShowcase />
     </div>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only refactor with localized settings behavior change when no release note exists; covered by new unit tests.
> 
> **Overview**
> **Release notes now run from the root layout** instead of the home page, so the “What’s new” dialog can appear when the app opens on chat or other routes—not only on home.
> 
> The logic lives in a new **`ReleaseNotesDialog`** component mounted next to the global toaster. It still checks once per session, skips the modal on first launch (but records the current version), and opens an iframe when `ipc.system.doesReleaseNoteExist` returns a URL. **Settings are only updated when notes are shown or on that first-run baseline**; if there is no release note for the version, `lastShownReleaseNotesVersion` is left unchanged (unlike the previous home-page flow, which always wrote the version before deciding whether to show the dialog).
> 
> Home page release-notes state, effects, and dialog markup were removed. **Vitest coverage** was added for upgrade, first-run, and missing-note cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14842adeef6e15904f48a529b38d1bb298c8fcde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->