### PR TITLE
fix: clearer error when connecting to a non-git folder

### DIFF
--- a/src/ipc/utils/git_utils.ts
+++ b/src/ipc/utils/git_utils.ts
@@ -1022,10 +1022,15 @@ export async function gitSetRemoteUrl({
         }
       } else if (result.exitCode !== 0) {
         // Handle other errors
-        throw new DyadError(
-          `Failed to add remote: ${result.stderr}`,
-          DyadErrorKind.Conflict,
-        );
+        const stderr = result.stderr || "";
+        let message = `Failed to add remote: ${stderr}`;
+        let kind: DyadErrorKind = DyadErrorKind.Conflict;
+        if (/not a git repository/i.test(stderr)) {
+          message =
+            "The selected folder is not a git repository. Initialize it with `git init` (or pick a folder that already is one) before connecting it to a remote.";
+          kind = DyadErrorKind.NotFound;
+        }
+        throw new DyadError(message, kind);
       }
     } catch (error: any) {
       logger.error("Error setting up remote:", error);


### PR DESCRIPTION
When the user picks a folder that is not a git repository and tries to connect it as an existing GitHub repo, the wrapped stderr `fatal: not a git repository (or any of the parent directories): .git` is forwarded verbatim, which is opaque (see #3552).

This detects the `not a git repository` case in `gitSetRemoteUrl` and surfaces an actionable message ("Initialize it with `git init` …") tagged as `DyadErrorKind.NotFound` instead of `Conflict`, matching the project's existing `DyadErrorKind` taxonomy. Other failure modes keep the original `Failed to add remote: …` text and Conflict kind.