### PR TITLE
feat(crash): add Upload Chat Session button to force-close dialog

### DIFF
--- a/e2e-tests/crash_upload_button.spec.ts
+++ b/e2e-tests/crash_upload_button.spec.ts
@@ -1,0 +1,70 @@
+import { expect } from "@playwright/test";
+import { Timeout, testWithConfig } from "./helpers/test_helper";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+// The force-close dialog offers a one-click "Upload Chat Session" button for the
+// chat that was streaming at crash time. That chat id is captured in the crash
+// sentinel (session.lock) at stream start. These tests mock the sentinel (the
+// same approach as the force-close performance test) to verify the button is
+// shown when an activeChatId is present and hidden when it isn't.
+
+const SETTINGS = {
+  hasRunBefore: true,
+  enableAutoUpdate: false,
+  releaseChannel: "stable",
+};
+
+function writeCrashScenario(userDataDir: string, sentinel: string) {
+  fs.mkdirSync(userDataDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(userDataDir, "user-settings.json"),
+    JSON.stringify(SETTINGS, null, 2),
+  );
+  fs.writeFileSync(path.join(userDataDir, "session.lock"), sentinel);
+}
+
+testWithConfig({
+  preLaunchHook: async ({ userDataDir }) => {
+    // Sentinel carries the chat that was streaming at crash time.
+    writeCrashScenario(
+      userDataDir,
+      JSON.stringify({ ts: Date.now(), activeChatId: 1 }),
+    );
+  },
+})(
+  "force-close dialog shows Upload Chat Session button when a chat was active",
+  async ({ po }) => {
+    await expect(po.chatActions.getHomeChatInputContainer()).toBeVisible({
+      timeout: Timeout.LONG,
+    });
+    await expect(
+      po.page.getByRole("heading", { name: "Force Close Detected" }),
+    ).toBeVisible({ timeout: Timeout.MEDIUM });
+
+    await expect(
+      po.page.getByRole("button", { name: "Upload Chat Session" }),
+    ).toBeVisible();
+  },
+);
+
+testWithConfig({
+  preLaunchHook: async ({ userDataDir }) => {
+    // Sentinel with no activeChatId (no stream ran this session).
+    writeCrashScenario(userDataDir, JSON.stringify({ ts: Date.now() }));
+  },
+})(
+  "force-close dialog hides Upload Chat Session button when no chat was active",
+  async ({ po }) => {
+    await expect(po.chatActions.getHomeChatInputContainer()).toBeVisible({
+      timeout: Timeout.LONG,
+    });
+    await expect(
+      po.page.getByRole("heading", { name: "Force Close Detected" }),
+    ).toBeVisible({ timeout: Timeout.MEDIUM });
+
+    await expect(
+      po.page.getByRole("button", { name: "Upload Chat Session" }),
+    ).not.toBeVisible();
+  },
+);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,6 +23,7 @@ import { LanguageSchema } from "@/lib/schemas";
 import { useShortcut } from "@/hooks/useShortcut";
 import { useIsMac } from "@/hooks/useChatModeToggle";
 import { ReleaseNotesDialog } from "@/components/ReleaseNotesDialog";
+import { ForceCloseDialog } from "@/components/ForceCloseDialog";
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   const { refreshAppIframe } = useRunApp();
@@ -141,6 +142,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
               duration={settings?.isTestMode ? 500 : undefined}
             />
             <ReleaseNotesDialog />
+            <ForceCloseDialog />
           </SidebarProvider>
         </DeepLinkProvider>
       </ThemeProvider>

--- a/src/atoms/helpDialogAtom.ts
+++ b/src/atoms/helpDialogAtom.ts
@@ -1,0 +1,11 @@
+import { atom } from "jotai";
+
+export interface HelpDialogState {
+  open: boolean;
+  // When set, the Help dialog opens directly into the chat-session upload
+  // (review) flow for this chat instead of the main help screen. Used by the
+  // crash dialog to skip straight to uploading the chat that was last active.
+  uploadChatId?: number;
+}
+
+export const helpDialogAtom = atom<HelpDialogState>({ open: false });

--- a/src/components/ForceCloseDialog.tsx
+++ b/src/components/ForceCloseDialog.tsx
@@ -1,4 +1,6 @@
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useSetAtom } from "jotai";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -8,27 +10,53 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { AlertTriangle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { AlertTriangle, Upload } from "lucide-react";
+import { ipc } from "@/ipc/types";
+import { helpDialogAtom } from "@/atoms/helpDialogAtom";
 
-interface ForceCloseDialogProps {
-  isOpen: boolean;
-  onClose: () => void;
-  performanceData?: {
-    timestamp: number;
-    memoryUsageMB: number;
-    cpuUsagePercent?: number;
-    systemMemoryUsageMB?: number;
-    systemMemoryTotalMB?: number;
-    systemCpuPercent?: number;
-  };
+interface ForceClosePerformanceData {
+  timestamp: number;
+  memoryUsageMB: number;
+  cpuUsagePercent?: number;
+  systemMemoryUsageMB?: number;
+  systemMemoryTotalMB?: number;
+  systemCpuPercent?: number;
 }
 
-export function ForceCloseDialog({
-  isOpen,
-  onClose,
-  performanceData,
-}: ForceCloseDialogProps) {
+// Self-contained: subscribes to the force-close event and owns its open state.
+// Mounted in the root layout so it appears regardless of the current route,
+// e.g. when the app restores a chat on startup.
+export function ForceCloseDialog() {
   const { t } = useTranslation(["home", "common"]);
+  const setHelpDialog = useSetAtom(helpDialogAtom);
+  const [isOpen, setIsOpen] = useState(false);
+  const [performanceData, setPerformanceData] = useState<
+    ForceClosePerformanceData | undefined
+  >(undefined);
+  // The chat that was streaming at crash time (from the crash sentinel). When
+  // present, we offer a one-click upload of that session.
+  const [activeChatId, setActiveChatId] = useState<number | undefined>(
+    undefined,
+  );
+
+  useEffect(() => {
+    const unsubscribe = ipc.events.system.onForceCloseDetected((data) => {
+      setPerformanceData(data.performanceData);
+      setActiveChatId(data.activeChatId);
+      setIsOpen(true);
+    });
+    return () => unsubscribe();
+  }, []);
+
+  const onClose = () => setIsOpen(false);
+
+  const handleUploadChatSession = () => {
+    if (activeChatId == null) return;
+    onClose();
+    setHelpDialog({ open: true, uploadChatId: activeChatId });
+  };
+
   const formatTimestamp = (timestamp: number) => {
     return new Date(timestamp).toLocaleString();
   };
@@ -129,6 +157,12 @@ export function ForceCloseDialog({
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
+          {activeChatId != null && (
+            <Button variant="outline" onClick={handleUploadChatSession}>
+              <Upload className="h-4 w-4" />
+              {t("home:help.uploadChatSession")}
+            </Button>
+          )}
           <AlertDialogAction onClick={onClose}>
             {t("common:ok")}
           </AlertDialogAction>

--- a/src/components/HelpDialog.tsx
+++ b/src/components/HelpDialog.tsx
@@ -33,6 +33,7 @@ import { selectedChatIdAtom } from "@/atoms/chatAtoms";
 import { helpDialogAtom } from "@/atoms/helpDialogAtom";
 import { type SessionDebugBundle, type SystemDebugInfo } from "@/ipc/types";
 import { showError } from "@/lib/toast";
+import { useTranslation } from "react-i18next";
 import { HelpBotDialog } from "./HelpBotDialog";
 import { useSettings } from "@/hooks/useSettings";
 import { BugScreenshotDialog } from "./BugScreenshotDialog";
@@ -242,6 +243,7 @@ function CopyButton({ text }: { text: string }) {
 // =============================================================================
 
 export function HelpDialog() {
+  const { t } = useTranslation(["home"]);
   const [helpDialog, setHelpDialog] = useAtom(helpDialogAtom);
   const isOpen = helpDialog.open;
   const onClose = () => setHelpDialog({ open: false });
@@ -307,12 +309,15 @@ export function HelpDialog() {
       .then((bundle) => {
         if (!active) return;
         setDebugBundle(bundle);
+        // Clear uploadChatId once loaded so canceling from review back to the
+        // main screen doesn't keep rendering the preload spinner.
+        setHelpDialog({ open: true });
         navigateTo("review");
       })
       .catch((error) => {
         if (!active) return;
         console.error("Failed to load chat session:", error);
-        alert(
+        showError(
           "Failed to load chat session. Please try again or report manually.",
         );
         onClose();
@@ -716,7 +721,7 @@ ${formatLogsSection(debugInfo)}
     >
       <div className="flex flex-col items-center justify-center gap-3 py-12 text-muted-foreground">
         <Loader2Icon className="h-6 w-6 animate-spin" />
-        <span>Preparing upload...</span>
+        <span>{t("home:help.preparingUpload")}</span>
       </div>
     </AnimatedScreen>
   );

--- a/src/components/HelpDialog.tsx
+++ b/src/components/HelpDialog.tsx
@@ -27,8 +27,9 @@ import {
   useRef,
   useCallback,
 } from "react";
-import { useAtomValue } from "jotai";
+import { useAtom, useAtomValue } from "jotai";
 import { selectedChatIdAtom } from "@/atoms/chatAtoms";
+import { helpDialogAtom } from "@/atoms/helpDialogAtom";
 import { type SessionDebugBundle, type SystemDebugInfo } from "@/ipc/types";
 import { showError } from "@/lib/toast";
 import { HelpBotDialog } from "./HelpBotDialog";
@@ -239,12 +240,10 @@ function CopyButton({ text }: { text: string }) {
 // Main component
 // =============================================================================
 
-interface HelpDialogProps {
-  isOpen: boolean;
-  onClose: () => void;
-}
-
-export function HelpDialog({ isOpen, onClose }: HelpDialogProps) {
+export function HelpDialog() {
+  const [helpDialog, setHelpDialog] = useAtom(helpDialogAtom);
+  const isOpen = helpDialog.open;
+  const onClose = () => setHelpDialog({ open: false });
   const [isLoading, setIsLoading] = useState(false);
   const [isUploading, setIsUploading] = useState(false);
   const [screen, setScreen] = useState<DialogScreen>("main");
@@ -256,6 +255,9 @@ export function HelpDialog({ isOpen, onClose }: HelpDialogProps) {
   const [isHelpBotOpen, setIsHelpBotOpen] = useState(false);
   const [isBugScreenshotOpen, setIsBugScreenshotOpen] = useState(false);
   const hasNavigated = useRef(false);
+  // Tracks which chat (if any) we've already preloaded for the crash-triggered
+  // upload flow, so the preload effect fires once per open.
+  const preloadedChatId = useRef<number | null>(null);
   const selectedChatId = useAtomValue(selectedChatIdAtom);
   const { settings } = useSettings();
   const { userBudget } = useUserBudgetInfo();
@@ -281,11 +283,37 @@ export function HelpDialog({ isOpen, onClose }: HelpDialogProps) {
     setDebugBundle(null);
     setSessionId("");
     hasNavigated.current = false;
+    preloadedChatId.current = null;
   };
 
   useEffect(() => {
     if (!isOpen) resetDialogState();
   }, [isOpen]);
+
+  // Crash-triggered upload: when opened with a uploadChatId, skip the main
+  // screen, preload that chat's debug bundle, and jump straight to review.
+  useEffect(() => {
+    if (!isOpen) return;
+    const chatId = helpDialog.uploadChatId;
+    if (chatId == null || preloadedChatId.current === chatId) return;
+    preloadedChatId.current = chatId;
+    setIsUploading(true);
+    ipc.misc
+      .getSessionDebugBundle(chatId)
+      .then((bundle) => {
+        setDebugBundle(bundle);
+        navigateTo("review");
+      })
+      .catch((error) => {
+        console.error("Failed to load chat session:", error);
+        alert(
+          "Failed to load chat session. Please try again or report manually.",
+        );
+        onClose();
+      })
+      .finally(() => setIsUploading(false));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, helpDialog.uploadChatId]);
 
   const handleClose = () => onClose();
 

--- a/src/components/HelpDialog.tsx
+++ b/src/components/HelpDialog.tsx
@@ -18,6 +18,7 @@ import {
   AlertCircleIcon,
   MessageSquareIcon,
   CopyIcon,
+  Loader2Icon,
 } from "lucide-react";
 import { ipc } from "@/ipc/types";
 import {
@@ -298,20 +299,30 @@ export function HelpDialog() {
     if (chatId == null || preloadedChatId.current === chatId) return;
     preloadedChatId.current = chatId;
     setIsUploading(true);
+    // Guard against the dialog closing before the bundle resolves, which would
+    // otherwise leave it on the review screen with a stale bundle.
+    let active = true;
     ipc.misc
       .getSessionDebugBundle(chatId)
       .then((bundle) => {
+        if (!active) return;
         setDebugBundle(bundle);
         navigateTo("review");
       })
       .catch((error) => {
+        if (!active) return;
         console.error("Failed to load chat session:", error);
         alert(
           "Failed to load chat session. Please try again or report manually.",
         );
         onClose();
       })
-      .finally(() => setIsUploading(false));
+      .finally(() => {
+        if (active) setIsUploading(false);
+      });
+    return () => {
+      active = false;
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen, helpDialog.uploadChatId]);
 
@@ -694,9 +705,27 @@ ${formatLogsSection(debugInfo)}
     </AnimatedScreen>
   );
 
+  // Shown while a crash-triggered upload preloads its bundle, so the user who
+  // clicked "Upload Chat Session" sees a spinner instead of the main help menu
+  // before the review screen appears.
+  const renderPreloadingScreen = () => (
+    <AnimatedScreen
+      screenKey="main"
+      direction={direction}
+      skipInitial={!hasNavigated.current}
+    >
+      <div className="flex flex-col items-center justify-center gap-3 py-12 text-muted-foreground">
+        <Loader2Icon className="h-6 w-6 animate-spin" />
+        <span>Preparing upload...</span>
+      </div>
+    </AnimatedScreen>
+  );
+
   // ---------------------------------------------------------------------------
   // Render
   // ---------------------------------------------------------------------------
+
+  const isCrashPreloading = helpDialog.uploadChatId != null;
 
   return (
     <>
@@ -709,7 +738,10 @@ ${formatLogsSection(debugInfo)}
           }
         >
           <AnimatePresence mode="wait" custom={direction}>
-            {screen === "main" && renderMainScreen()}
+            {screen === "main" &&
+              (isCrashPreloading
+                ? renderPreloadingScreen()
+                : renderMainScreen())}
             {screen === "review" && renderReviewScreen()}
             {screen === "upload-complete" && renderUploadCompleteScreen()}
           </AnimatePresence>

--- a/src/components/HelpDialog.tsx
+++ b/src/components/HelpDialog.tsx
@@ -317,9 +317,7 @@ export function HelpDialog() {
       .catch((error) => {
         if (!active) return;
         console.error("Failed to load chat session:", error);
-        showError(
-          "Failed to load chat session. Please try again or report manually.",
-        );
+        showError(t("home:help.failedToLoadChatSession"));
         onClose();
       })
       .finally(() => {

--- a/src/components/HelpDialog.tsx
+++ b/src/components/HelpDialog.tsx
@@ -243,7 +243,7 @@ function CopyButton({ text }: { text: string }) {
 // =============================================================================
 
 export function HelpDialog() {
-  const { t } = useTranslation(["home"]);
+  const { t } = useTranslation(["home", "common"]);
   const [helpDialog, setHelpDialog] = useAtom(helpDialogAtom);
   const isOpen = helpDialog.open;
   const onClose = () => setHelpDialog({ open: false });
@@ -312,7 +312,12 @@ export function HelpDialog() {
         // Clear uploadChatId once loaded so canceling from review back to the
         // main screen doesn't keep rendering the preload spinner.
         setHelpDialog({ open: true });
-        navigateTo("review");
+        // Move to review with an explicit forward direction. The preload only
+        // runs from the main screen, so we set the transition directly rather
+        // than reading the screen value asynchronously via navigateTo.
+        setDirection(1);
+        setScreen("review");
+        hasNavigated.current = true;
       })
       .catch((error) => {
         if (!active) return;
@@ -720,6 +725,9 @@ ${formatLogsSection(debugInfo)}
       <div className="flex flex-col items-center justify-center gap-3 py-12 text-muted-foreground">
         <Loader2Icon className="h-6 w-6 animate-spin" />
         <span>{t("home:help.preparingUpload")}</span>
+        <Button variant="outline" size="sm" onClick={handleClose}>
+          {t("common:cancel")}
+        </Button>
       </div>
     </AnimatedScreen>
   );

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -29,7 +29,8 @@ import {
 import { cn } from "@/lib/utils";
 import { ChatList } from "./ChatList";
 import { AppList } from "./AppList";
-import { HelpDialog } from "./HelpDialog"; // Import the new dialog
+import { HelpDialog } from "./HelpDialog";
+import { helpDialogAtom } from "@/atoms/helpDialogAtom";
 import { SettingsList } from "./SettingsList";
 import { LibraryList } from "./LibraryList";
 import {
@@ -147,7 +148,7 @@ export function AppSidebar() {
   const [hoverState, setHoverState] =
     useState<AppSidebarHoverState>("no-hover");
   const expandedByHover = useRef(false);
-  const [isHelpDialogOpen, setIsHelpDialogOpen] = useState(false);
+  const setHelpDialog = useSetAtom(helpDialogAtom);
   const [isDropdownOpen] = useAtom(dropdownOpenAtom);
   const selectedAppId = useAtomValue(selectedAppIdAtom);
   const setSelectedAppId = useSetAtom(selectedAppIdAtom);
@@ -266,12 +267,9 @@ export function AppSidebar() {
               icon={HelpCircle}
               label="Help"
               isExpanded={state === "expanded"}
-              onClick={() => setIsHelpDialogOpen(true)}
+              onClick={() => setHelpDialog({ open: true })}
             />
-            <HelpDialog
-              isOpen={isHelpDialogOpen}
-              onClose={() => setIsHelpDialogOpen(false)}
-            />
+            <HelpDialog />
           </SidebarMenuItem>
         </SidebarMenu>
       </SidebarFooter>

--- a/src/i18n/locales/en/home.json
+++ b/src/i18n/locales/en/home.json
@@ -153,6 +153,7 @@
     "uploadChatSession": "Upload Chat Session",
     "uploadChatDescription": "Share chat logs and code for troubleshooting. Data is used only to resolve your issue and auto-deleted after a limited time.",
     "preparingUpload": "Preparing Upload...",
+    "failedToLoadChatSession": "Failed to load chat session. Please try again or report manually.",
     "helpBotTitle": "Dyad Help Bot",
     "askQuestion": "Ask a question about using Dyad.",
     "conversationLogged": "This conversation may be logged and used to improve the product. Please do not put any sensitive information in here.",

--- a/src/i18n/locales/es/home.json
+++ b/src/i18n/locales/es/home.json
@@ -153,6 +153,7 @@
     "uploadChatSession": "Subir Sesión de Chat",
     "uploadChatDescription": "Comparte registros de chat y código para solucionar problemas. Los datos se utilizan solo para resolver tu problema y se eliminan automáticamente después de un tiempo limitado.",
     "preparingUpload": "Preparando Subida...",
+    "failedToLoadChatSession": "No se pudo cargar la sesión de chat. Vuelve a intentarlo o repórtalo manualmente.",
     "helpBotTitle": "Bot de Ayuda de Dyad",
     "askQuestion": "Haz una pregunta sobre el uso de Dyad.",
     "conversationLogged": "Esta conversación puede ser registrada y utilizada para mejorar el producto. Por favor, no introduzcas información confidencial aquí.",

--- a/src/i18n/locales/pt-BR/home.json
+++ b/src/i18n/locales/pt-BR/home.json
@@ -150,6 +150,7 @@
     "uploadChatSession": "Enviar Sessão de Chat",
     "uploadChatDescription": "Compartilhe logs de chat e código para solução de problemas. Os dados são usados apenas para resolver seu problema e excluídos automaticamente após um tempo limitado.",
     "preparingUpload": "Preparando Envio...",
+    "failedToLoadChatSession": "Falha ao carregar a sessão de chat. Tente novamente ou reporte manualmente.",
     "helpBotTitle": "Bot de Ajuda do Dyad",
     "askQuestion": "Faça uma pergunta sobre o uso do Dyad.",
     "conversationLogged": "Esta conversa pode ser registrada e usada para melhorar o produto. Por favor, não insira informações sensíveis aqui.",

--- a/src/i18n/locales/zh-CN/home.json
+++ b/src/i18n/locales/zh-CN/home.json
@@ -150,6 +150,7 @@
     "uploadChatSession": "上传聊天会话",
     "uploadChatDescription": "分享聊天日志和代码以进行故障排除。数据仅用于解决您的问题，并在限定时间后自动删除。",
     "preparingUpload": "正在准备上传...",
+    "failedToLoadChatSession": "无法加载聊天会话。请重试或手动报告。",
     "helpBotTitle": "Dyad 帮助机器人",
     "askQuestion": "关于使用 Dyad 的问题。",
     "conversationLogged": "此对话可能会被记录并用于改进产品。请勿在此输入敏感信息。",

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -280,9 +280,13 @@ export function registerChatStreamHandlers() {
         );
       }
 
-      // Record the streaming chat in the crash sentinel so that if this session
-      // crashes, the force-close dialog can offer to upload this chat. Cleared
-      // automatically on clean exit.
+      // Record the streaming chat in the crash sentinel so a later force-close
+      // can offer to upload it. We intentionally don't clear this when the
+      // stream ends: the chat of the most recent stream stays the most likely
+      // crash culprit even afterwards (its output stays mounted, and the
+      // apply/build/preview steps run after the stream), so it remains the best
+      // guess until the next stream replaces it. The latest stream wins, and the
+      // value is cleared on clean exit.
       setSentinelActiveChat(req.chatId);
 
       // Handle redo option: remove the most recent messages if needed

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -133,7 +133,7 @@ import {
   VersionedFiles,
 } from "../utils/versioned_codebase_context";
 import { getAiMessagesJsonIfWithinLimit } from "../utils/ai_messages_utils";
-import { readSettings } from "@/main/settings";
+import { readSettings, setSentinelActiveChat } from "@/main/settings";
 import {
   buildLocalAgentAttachmentInfo,
   getInlineImageMimeType,
@@ -261,6 +261,11 @@ export function registerChatStreamHandlers() {
 
       // Notify renderer that stream is starting
       safeSend(event.sender, "chat:stream:start", { chatId: req.chatId });
+
+      // Record the streaming chat in the crash sentinel so that if this session
+      // crashes, the force-close dialog can offer to upload this chat. Cleared
+      // automatically on clean exit.
+      setSentinelActiveChat(req.chatId);
 
       // Get the chat to check for existing messages
       const chat = await db.query.chats.findFirst({

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -262,11 +262,6 @@ export function registerChatStreamHandlers() {
       // Notify renderer that stream is starting
       safeSend(event.sender, "chat:stream:start", { chatId: req.chatId });
 
-      // Record the streaming chat in the crash sentinel so that if this session
-      // crashes, the force-close dialog can offer to upload this chat. Cleared
-      // automatically on clean exit.
-      setSentinelActiveChat(req.chatId);
-
       // Get the chat to check for existing messages
       const chat = await db.query.chats.findFirst({
         where: eq(chats.id, req.chatId),
@@ -284,6 +279,11 @@ export function registerChatStreamHandlers() {
           DyadErrorKind.NotFound,
         );
       }
+
+      // Record the streaming chat in the crash sentinel so that if this session
+      // crashes, the force-close dialog can offer to upload this chat. Cleared
+      // automatically on clean exit.
+      setSentinelActiveChat(req.chatId);
 
       // Handle redo option: remove the most recent messages if needed
       if (req.redo) {

--- a/src/ipc/types/system.ts
+++ b/src/ipc/types/system.ts
@@ -109,6 +109,9 @@ export const ForceCloseDetectedPayloadSchema = z.object({
       systemCpuPercent: z.number().optional(),
     })
     .optional(),
+  // Chat that was streaming at crash time, captured in the crash sentinel.
+  // Present only if a stream ran this session; enables one-click upload.
+  activeChatId: z.number().optional(),
 });
 
 // =============================================================================

--- a/src/main.ts
+++ b/src/main.ts
@@ -478,6 +478,7 @@ const createWindow = () => {
       });
 
       pendingForceCloseData = null;
+      pendingActiveChatId = null;
       pendingCrashDetected = false;
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,7 @@ import {
   writeCrashSentinel,
   clearCrashSentinel,
   crashSentinelExists,
+  readCrashSentinel,
   recordRendererCrash,
   readRendererCrashRecord,
   clearRendererCrashRecord,
@@ -232,6 +233,10 @@ export async function onReady() {
       logger.warn("Last known performance:", settings.lastKnownPerformance);
       pendingForceCloseData = settings.lastKnownPerformance;
     }
+
+    // The chat that was streaming when the crash happened, if any, so the
+    // dialog can offer a one-click upload of it.
+    pendingActiveChatId = readCrashSentinel()?.activeChatId ?? null;
   }
 
   // TODO: Remove legacyIsRunningCrash migration path after a few releases
@@ -373,6 +378,7 @@ declare global {
 
 let mainWindow: BrowserWindow | null = null;
 let pendingForceCloseData: any = null;
+let pendingActiveChatId: number | null = null;
 let pendingCrashDetected = false;
 let isAppQuitting = false;
 
@@ -445,6 +451,9 @@ const createWindow = () => {
         windowRef?.webContents.send("force-close-detected", {
           ...(pendingForceCloseData && {
             performanceData: pendingForceCloseData,
+          }),
+          ...(pendingActiveChatId != null && {
+            activeChatId: pendingActiveChatId,
           }),
         });
       }

--- a/src/main/settings.test.ts
+++ b/src/main/settings.test.ts
@@ -12,6 +12,9 @@ import {
   encrypt,
   decrypt,
   notifyRendererErrorToastListenerReady,
+  writeCrashSentinel,
+  setSentinelActiveChat,
+  readCrashSentinel,
 } from "@/main/settings";
 import { getUserDataPath } from "@/paths/paths";
 import { UserSettings } from "@/lib/schemas";
@@ -908,3 +911,53 @@ function scrubSettings(result: UserSettings) {
     telemetryUserId: "[scrubbed]",
   };
 }
+
+describe("crash sentinel", () => {
+  const mockUserDataPath = "/mock/user/data";
+  const sentinelPath = `${mockUserDataPath}/session.lock`;
+  let store: Record<string, string>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUserDataPath.mockReturnValue(mockUserDataPath);
+    mockPath.join.mockImplementation((...args: string[]) => args.join("/"));
+    store = {};
+    mockFs.writeFileSync.mockImplementation((p, data) => {
+      store[p as string] = data as string;
+    });
+    mockFs.readFileSync.mockImplementation((p) => {
+      const value = store[p as string];
+      if (value === undefined) {
+        const err = new Error("ENOENT") as NodeJS.ErrnoException;
+        err.code = "ENOENT";
+        throw err;
+      }
+      return value;
+    });
+  });
+
+  it("writeCrashSentinel writes JSON with a timestamp and no active chat", () => {
+    writeCrashSentinel();
+    const data = readCrashSentinel();
+    expect(typeof data?.ts).toBe("number");
+    expect(data?.activeChatId).toBeUndefined();
+  });
+
+  it("setSentinelActiveChat records the chat id, preserving the timestamp", () => {
+    writeCrashSentinel();
+    const ts = readCrashSentinel()?.ts;
+    setSentinelActiveChat(42);
+    const data = readCrashSentinel();
+    expect(data?.activeChatId).toBe(42);
+    expect(data?.ts).toBe(ts);
+  });
+
+  it("readCrashSentinel returns null for the legacy bare-timestamp format", () => {
+    store[sentinelPath] = "1700000000000";
+    expect(readCrashSentinel()).toBeNull();
+  });
+
+  it("readCrashSentinel returns null when the sentinel is missing", () => {
+    expect(readCrashSentinel()).toBeNull();
+  });
+});

--- a/src/main/settings.test.ts
+++ b/src/main/settings.test.ts
@@ -960,4 +960,14 @@ describe("crash sentinel", () => {
   it("readCrashSentinel returns null when the sentinel is missing", () => {
     expect(readCrashSentinel()).toBeNull();
   });
+
+  it("readCrashSentinel returns null when ts is not a number", () => {
+    store[sentinelPath] = JSON.stringify({ ts: "nope", activeChatId: 1 });
+    expect(readCrashSentinel()).toBeNull();
+  });
+
+  it("readCrashSentinel ignores a non-numeric activeChatId", () => {
+    store[sentinelPath] = JSON.stringify({ ts: 123, activeChatId: "nope" });
+    expect(readCrashSentinel()).toEqual({ ts: 123, activeChatId: undefined });
+  });
 });

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -98,11 +98,35 @@ function getCrashSentinelPath(): string {
   return path.join(getUserDataPath(), CRASH_SENTINEL_FILE);
 }
 
+interface CrashSentinelData {
+  ts: number;
+  // The chat that was last streaming this session, captured at stream start so
+  // the crash dialog can offer to upload it. Absent if no stream ran.
+  activeChatId?: number;
+}
+
 export function writeCrashSentinel(): void {
   try {
-    fs.writeFileSync(getCrashSentinelPath(), String(Date.now()));
+    const data: CrashSentinelData = { ts: Date.now() };
+    fs.writeFileSync(getCrashSentinelPath(), JSON.stringify(data));
   } catch (error) {
     logger.error("Error writing crash sentinel:", error);
+  }
+}
+
+// Records the chat that just started streaming into the existing sentinel,
+// preserving its timestamp. The sentinel's lifecycle (created at startup,
+// deleted on clean exit) scopes this to the current session automatically.
+export function setSentinelActiveChat(chatId: number): void {
+  try {
+    const existing = readCrashSentinel();
+    const data: CrashSentinelData = {
+      ts: existing?.ts ?? Date.now(),
+      activeChatId: chatId,
+    };
+    fs.writeFileSync(getCrashSentinelPath(), JSON.stringify(data));
+  } catch (error) {
+    logger.error("Error updating crash sentinel active chat:", error);
   }
 }
 
@@ -118,6 +142,22 @@ export function clearCrashSentinel(): void {
 
 export function crashSentinelExists(): boolean {
   return fs.existsSync(getCrashSentinelPath());
+}
+
+// Reads and parses the sentinel. Returns null if missing or not a JSON object
+// (e.g. the legacy bare-timestamp format from older builds). That's harmless:
+// crash detection is existence-based, and only activeChatId is consumed, so a
+// null here just means no chat to offer for upload.
+export function readCrashSentinel(): CrashSentinelData | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(getCrashSentinelPath(), "utf-8"));
+    if (typeof parsed !== "object" || parsed === null) {
+      return null;
+    }
+    return { ts: parsed.ts, activeChatId: parsed.activeChatId };
+  } catch {
+    return null;
+  }
 }
 
 export type RendererCrashPerformanceSnapshot = NonNullable<

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -154,7 +154,12 @@ export function readCrashSentinel(): CrashSentinelData | null {
     if (typeof parsed !== "object" || parsed === null) {
       return null;
     }
-    return { ts: parsed.ts, activeChatId: parsed.activeChatId };
+    if (typeof parsed.ts !== "number") {
+      return null;
+    }
+    const activeChatId =
+      typeof parsed.activeChatId === "number" ? parsed.activeChatId : undefined;
+    return { ts: parsed.ts, activeChatId };
   } catch {
     return null;
   }

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -20,7 +20,6 @@ import { showError } from "@/lib/toast";
 import { invalidateAppQuery } from "@/hooks/useLoadApp";
 import { useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "@/lib/queryKeys";
-import { ForceCloseDialog } from "@/components/ForceCloseDialog";
 import { useSelectChat } from "@/hooks/useSelectChat";
 import { FeaturedAppShowcase } from "@/components/FeaturedAppShowcase";
 
@@ -57,20 +56,9 @@ export default function HomePage() {
   const { selectChat } = useSelectChat();
   const [isLoading, setIsLoading] = useState(false);
   const [loadingMode, setLoadingMode] = useState<"new" | "existing">("new");
-  const [forceCloseDialogOpen, setForceCloseDialogOpen] = useState(false);
-  const [performanceData, setPerformanceData] = useState<any>(undefined);
   const { streamMessage } = useStreamChat({ hasChatId: false });
   const posthog = usePostHog();
   const queryClient = useQueryClient();
-
-  // Listen for force-close events
-  useEffect(() => {
-    const unsubscribe = ipc.events.system.onForceCloseDetected((data) => {
-      setPerformanceData(data.performanceData);
-      setForceCloseDialogOpen(true);
-    });
-    return () => unsubscribe();
-  }, []);
 
   // Get the appId from search params
   const appId = search.appId ? Number(search.appId) : null;
@@ -236,11 +224,6 @@ export default function HomePage() {
             <SetupDyadProButton />
           )}
         </div>
-        <ForceCloseDialog
-          isOpen={forceCloseDialogOpen}
-          onClose={() => setForceCloseDialogOpen(false)}
-          performanceData={performanceData}
-        />
         <SetupBanner />
 
         <div className="w-full">


### PR DESCRIPTION
Reduce friction between a crash and uploading the relevant chat session. The force-close dialog now offers a one-click "Upload Chat Session" button for the chat that was streaming when the crash happened.

- Capture the streaming chat id in the crash sentinel at stream start. The sentinel format changes from a bare timestamp to JSON ({ ts, activeChatId }). Detection stays existence-based, and reads tolerate the legacy bare-timestamp format (treated as no chat), so upgrade/downgrade and corrupt files are safe.
- Surface the id in the force-close event; the dialog shows the button only when a stream ran this session, and opens the existing Help dialog upload flow (review -> submit) preloaded with that chat.
- Move ForceCloseDialog from the home page into the root layout so it appears regardless of route. Previously it was missed when the app restored a chat on startup (same fix the release-notes dialog received).

Tests: unit tests for the sentinel read/write/legacy parsing, e2e for the button showing/hiding based on the sentinel.