### PR TITLE
Allow shader files in codebase context

### DIFF
--- a/src/__tests__/codebase.test.ts
+++ b/src/__tests__/codebase.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { extractCodebase } from "@/utils/codebase";
+
+vi.mock("electron-log", () => ({
+  default: {
+    scope: () => ({
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      log: vi.fn(),
+      warn: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock("@/main/settings", () => ({
+  readSettings: vi.fn(() => ({
+    enableNativeGit: false,
+    enableDyadPro: false,
+    enableProSmartFilesContextMode: false,
+  })),
+}));
+
+vi.mock("@/ipc/utils/git_utils", () => ({
+  gitIsIgnoredIso: vi.fn(async () => false),
+  gitListFilesNative: vi.fn(async () => []),
+}));
+
+describe("extractCodebase", () => {
+  let appDir: string | undefined;
+
+  afterEach(async () => {
+    if (appDir) {
+      await fs.promises.rm(appDir, { recursive: true, force: true });
+      appDir = undefined;
+    }
+  });
+
+  it("includes shader source file contents", async () => {
+    appDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "codebase-"));
+    await fs.promises.mkdir(path.join(appDir, "src", "shaders"), {
+      recursive: true,
+    });
+
+    await fs.promises.writeFile(
+      path.join(appDir, "src", "shaders", "scene.wgsl"),
+      "fn vertexMain() -> void {}",
+    );
+    await fs.promises.writeFile(
+      path.join(appDir, "src", "shaders", "material.frag"),
+      "void main() { gl_FragColor = vec4(1.0); }",
+    );
+    await fs.promises.writeFile(
+      path.join(appDir, "src", "notes.shader"),
+      "custom shader notes",
+    );
+
+    const result = await extractCodebase({
+      appPath: appDir,
+      chatContext: {
+        contextPaths: [],
+        smartContextAutoIncludes: [],
+      },
+    });
+
+    expect(result.files).toContainEqual({
+      path: "src/shaders/scene.wgsl",
+      content: "fn vertexMain() -> void {}",
+      force: false,
+    });
+    expect(result.files).toContainEqual({
+      path: "src/shaders/material.frag",
+      content: "void main() { gl_FragColor = vec4(1.0); }",
+      force: false,
+    });
+    expect(result.files).toContainEqual({
+      path: "src/notes.shader",
+      content: "// File contents excluded from context",
+      force: false,
+    });
+  });
+});

--- a/src/utils/codebase.ts
+++ b/src/utils/codebase.ts
@@ -29,6 +29,14 @@ const ALLOWED_EXTENSIONS = [
   ".scss",
   ".sass",
   ".less",
+  // Shader source files for WebGL/WebGPU/Three.js projects
+  ".glsl",
+  ".wgsl",
+  ".vert",
+  ".frag",
+  ".vs",
+  ".fs",
+  ".comp",
   // Oftentimes used as config (e.g. package.json, vercel.json) or data files (e.g. translations)
   ".json",
   // GitHub Actions


### PR DESCRIPTION
## Summary
- Include common GLSL and WGSL shader source extensions in codebase context extraction.
- Add a regression test covering included shader files and an omitted non-allowlisted shader-like extension.

## Test plan
- npm test -- src/__tests__/codebase.test.ts
- npm run fmt
- npm run lint:fix
- npm run ts
- npm test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive change to the extension allowlist with a focused unit test; no auth, data, or extraction logic changes beyond inclusion rules.
> 
> **Overview**
> Extends codebase context extraction so **shader sources** (GLSL/WGSL and common vertex/fragment/compute extensions) are read into chat context instead of being listed with the omitted placeholder.
> 
> Adds **`src/__tests__/codebase.test.ts`** to assert `.wgsl` and `.frag` ship real contents while a non-allowlisted `.shader` file still gets `// File contents excluded from context`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4472f91cfa9152bdde638f74181ccc702d5161d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->