### PR TITLE
fix(linux): repair Supabase OAuth connect on dev, AppImage, and rpm

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -196,6 +196,7 @@ const config: ForgeConfig = {
     new MakerZIP({}, ["darwin"]),
     new MakerRpm({
       options: {
+        mimeType: ["x-scheme-handler/dyad"],
         icon: "./assets/icon/logo.png",
       },
     }),

--- a/src/main.ts
+++ b/src/main.ts
@@ -874,6 +874,8 @@ if (IS_TEST_BUILD) {
     // On a cold start the deep link arrives in this instance's argv (the
     // .desktop Exec %u), and second-instance only fires for later launches, so
     // drain the initial argv here. The queue holds it until the app is ready.
+    // This runs on every launch, so match by dyad:// prefix to ignore the
+    // normal (no-deep-link) startup args.
     const initialDeepLink = process.argv.find((arg) =>
       arg.startsWith("dyad://"),
     );

--- a/src/main.ts
+++ b/src/main.ts
@@ -72,6 +72,7 @@ import fs from "fs";
 import { gitAddSafeDirectory } from "./ipc/utils/git_utils";
 import { getDyadAppsBaseDirectory, getDyadAppPath } from "./paths/paths";
 import { createDeepLinkQueue } from "./main/deep_link_queue";
+import { registerDyadProtocolLinux } from "./main/linux_protocol_registration";
 
 log.errorHandler.startCatching();
 log.eventLogger.startLogging();
@@ -214,6 +215,10 @@ if (process.defaultApp) {
 }
 
 export async function onReady() {
+  // Linux: claim the dyad:// scheme for this build (best-effort, see module).
+  // setAsDefaultProtocolClient above is unreliable on Linux.
+  void registerDyadProtocolLinux();
+
   // Load React DevTools extension in development
   if (process.env.NODE_ENV === "development") {
     let chromeUserData: string;

--- a/src/main.ts
+++ b/src/main.ts
@@ -870,6 +870,17 @@ if (IS_TEST_BUILD) {
         deepLinkQueue.handle(url);
       }
     });
+
+    // On a cold start the deep link arrives in this instance's argv (the
+    // .desktop Exec %u), and second-instance only fires for later launches, so
+    // drain the initial argv here. The queue holds it until the app is ready.
+    const initialDeepLink = process.argv.find((arg) =>
+      arg.startsWith("dyad://"),
+    );
+    if (initialDeepLink) {
+      deepLinkQueue.handle(initialDeepLink);
+    }
+
     startAppWhenReady();
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -566,6 +566,9 @@ const createWindow = () => {
   let devToolsReloadedCount = 0;
 
   mainWindow.webContents.on("did-finish-load", () => {
+    // Must run on first load, else deep links break in dev.
+    deepLinkQueue.markReady();
+
     if (process.env.NODE_ENV === "development") {
       // In dev, wait until AFTER the DevTools-triggered reload before sending the message
       if (devToolsReloadedCount === 0) {
@@ -573,8 +576,6 @@ const createWindow = () => {
         return; // Ignore first load, we will reload momentarily
       }
     }
-
-    deepLinkQueue.markReady();
 
     // Summarize native crash minidumps before sending app:crash_detected. If
     // the main process crashed natively, that summary becomes the crash cause

--- a/src/main/linux_protocol_registration.test.ts
+++ b/src/main/linux_protocol_registration.test.ts
@@ -1,0 +1,63 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  buildDesktopFile,
+  computeExecCommand,
+} from "@/main/linux_protocol_registration";
+
+describe("computeExecCommand", () => {
+  it("uses the electron binary plus entry script in dev", () => {
+    const command = computeExecCommand({
+      defaultApp: true,
+      execPath: "/usr/lib/electron/electron",
+      argv: [
+        "/usr/lib/electron/electron",
+        "/home/user/code/dyad/.vite/main.js",
+      ],
+      appImagePath: undefined,
+    });
+
+    const script = path.resolve("/home/user/code/dyad/.vite/main.js");
+    expect(command.exec).toBe(`"/usr/lib/electron/electron" "${script}" %u`);
+    expect(command.tryExec).toBe("/usr/lib/electron/electron");
+  });
+
+  it("uses the stable APPIMAGE path, never the /tmp mount", () => {
+    const command = computeExecCommand({
+      defaultApp: false,
+      execPath: "/tmp/.mount_dyadXXXX/usr/lib/dyad/dyad",
+      argv: ["/tmp/.mount_dyadXXXX/usr/lib/dyad/dyad"],
+      appImagePath: "/home/user/AppImages/dyad.AppImage",
+    });
+
+    expect(command.exec).toBe(`"/home/user/AppImages/dyad.AppImage" %u`);
+    expect(command.tryExec).toBe("/home/user/AppImages/dyad.AppImage");
+    expect(command.exec).not.toContain("/tmp/.mount");
+  });
+
+  it("uses the installed binary for packaged deb/rpm", () => {
+    const command = computeExecCommand({
+      defaultApp: false,
+      execPath: "/opt/dyad/dyad",
+      argv: ["/opt/dyad/dyad"],
+      appImagePath: undefined,
+    });
+
+    expect(command.exec).toBe(`"/opt/dyad/dyad" %u`);
+    expect(command.tryExec).toBe("/opt/dyad/dyad");
+  });
+});
+
+describe("buildDesktopFile", () => {
+  it("includes the scheme handler, TryExec, and NoDisplay", () => {
+    const contents = buildDesktopFile({
+      exec: `"/opt/dyad/dyad" %u`,
+      tryExec: "/opt/dyad/dyad",
+    });
+
+    expect(contents).toContain("MimeType=x-scheme-handler/dyad;");
+    expect(contents).toContain(`Exec="/opt/dyad/dyad" %u`);
+    expect(contents).toContain("TryExec=/opt/dyad/dyad");
+    expect(contents).toContain("NoDisplay=true");
+  });
+});

--- a/src/main/linux_protocol_registration.test.ts
+++ b/src/main/linux_protocol_registration.test.ts
@@ -46,6 +46,19 @@ describe("computeExecCommand", () => {
     expect(command.exec).toBe(`"/opt/dyad/dyad" %u`);
     expect(command.tryExec).toBe("/opt/dyad/dyad");
   });
+
+  it("escapes characters reserved inside quoted Exec values", () => {
+    const command = computeExecCommand({
+      defaultApp: false,
+      execPath: "/opt/dyad/dyad",
+      argv: [],
+      appImagePath: `/home/u$er/My "Apps"/dyad \`v1\`.AppImage`,
+    });
+
+    expect(command.exec).toBe(
+      `"/home/u\\$er/My \\"Apps\\"/dyad \\\`v1\\\`.AppImage" %u`,
+    );
+  });
 });
 
 describe("buildDesktopFile", () => {

--- a/src/main/linux_protocol_registration.ts
+++ b/src/main/linux_protocol_registration.ts
@@ -31,10 +31,11 @@ interface ExecCommand {
   tryExec: string;
 }
 
-// Double-quote a path for a .desktop Exec/TryExec value. Field codes like
+// Double-quote a path for a .desktop Exec value. Inside the quotes the
+// characters " ` $ \ must each be escaped with a backslash. Field codes like
 // `%u` must stay outside the quotes.
 function quote(value: string): string {
-  return `"${value}"`;
+  return `"${value.replace(/(["`$\\])/g, "\\$1")}"`;
 }
 
 // The Exec target differs per packaging format. Pure so it can be unit-tested
@@ -108,7 +109,11 @@ export async function registerDyadProtocolLinux(): Promise<void> {
       appImagePath: process.env.APPIMAGE,
     });
 
-    const appsDir = path.join(os.homedir(), ".local", "share", "applications");
+    // Honor XDG_DATA_HOME so the file lands where the desktop environment
+    // actually searches; fall back to the spec default otherwise.
+    const dataHome =
+      process.env.XDG_DATA_HOME || path.join(os.homedir(), ".local", "share");
+    const appsDir = path.join(dataHome, "applications");
     const desktopPath = path.join(appsDir, DESKTOP_FILENAME);
 
     await fs.promises.mkdir(appsDir, { recursive: true });
@@ -116,16 +121,17 @@ export async function registerDyadProtocolLinux(): Promise<void> {
 
     // Refresh the desktop database cache. The update-desktop-database command
     // isn't installed on every distro; if it's missing, the xdg-mime call below
-    // still updates ~/.config/mimeapps.list on its own.
-    await execFileAsync("update-desktop-database", [appsDir]).catch((error) => {
+    // still updates ~/.config/mimeapps.list on its own. The timeout guards
+    // against either tool hanging on a stale lock or corrupt database.
+    await execFileAsync("update-desktop-database", [appsDir], {
+      timeout: 5000,
+    }).catch((error) => {
       logger.warn("update-desktop-database failed:", error);
     });
 
-    await execFileAsync("xdg-mime", [
-      "default",
-      DESKTOP_FILENAME,
-      MIME_TYPE,
-    ]).catch((error) => {
+    await execFileAsync("xdg-mime", ["default", DESKTOP_FILENAME, MIME_TYPE], {
+      timeout: 5000,
+    }).catch((error) => {
       logger.warn("xdg-mime default failed:", error);
     });
 

--- a/src/main/linux_protocol_registration.ts
+++ b/src/main/linux_protocol_registration.ts
@@ -1,0 +1,136 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import log from "electron-log";
+import { IS_TEST_BUILD } from "../ipc/utils/test_utils";
+
+const logger = log.scope("linux_protocol");
+const execFileAsync = promisify(execFile);
+
+const SCHEME = "dyad";
+const MIME_TYPE = `x-scheme-handler/${SCHEME}`;
+const DESKTOP_FILENAME = `${SCHEME}-url-handler.desktop`;
+
+interface ExecInputs {
+  // process.defaultApp: true for dev / unpackaged runs.
+  defaultApp: boolean;
+  // process.execPath: the electron binary (dev) or installed binary (deb/rpm).
+  execPath: string;
+  // process.argv: argv[1] is the app entry script in dev.
+  argv: string[];
+  // process.env.APPIMAGE: stable path to the .AppImage, set by the runtime.
+  appImagePath: string | undefined;
+}
+
+interface ExecCommand {
+  // Full Exec line including the `%u` field code that injects the URL.
+  exec: string;
+  // Bare binary for TryExec, so a stale entry self-disables if it's gone.
+  tryExec: string;
+}
+
+// Double-quote a path for a .desktop Exec/TryExec value. Field codes like
+// `%u` must stay outside the quotes.
+function quote(value: string): string {
+  return `"${value}"`;
+}
+
+// The Exec target differs per packaging format. Pure so it can be unit-tested
+// without touching the real environment.
+export function computeExecCommand(inputs: ExecInputs): ExecCommand {
+  const { defaultApp, execPath, argv, appImagePath } = inputs;
+
+  // AppImage: process.execPath points at the ephemeral /tmp/.mount_* extract
+  // that changes every launch, so it must not be used. appImagePath (from
+  // process.env.APPIMAGE) is the stable location of the .AppImage file itself.
+  if (!defaultApp && appImagePath) {
+    return {
+      exec: `${quote(appImagePath)} %u`,
+      tryExec: appImagePath,
+    };
+  }
+
+  // Dev / unpackaged: electron binary plus the app entry script.
+  if (defaultApp && argv.length >= 2) {
+    const script = path.resolve(argv[1]);
+    return {
+      exec: `${quote(execPath)} ${quote(script)} %u`,
+      tryExec: execPath,
+    };
+  }
+
+  // Packaged deb / rpm: the installed binary is stable.
+  return {
+    exec: `${quote(execPath)} %u`,
+    tryExec: execPath,
+  };
+}
+
+// Pure: render the .desktop contents. NoDisplay keeps it out of app menus
+// (it's a URL-handler shim, not a launcher).
+export function buildDesktopFile(command: ExecCommand): string {
+  return [
+    "[Desktop Entry]",
+    "Type=Application",
+    "Name=Dyad",
+    `Exec=${command.exec}`,
+    `TryExec=${command.tryExec}`,
+    `MimeType=${MIME_TYPE};`,
+    "NoDisplay=true",
+    "Terminal=false",
+    "",
+  ].join("\n");
+}
+
+// Register this build as the dyad:// handler. Linux only; best-effort.
+//
+// Electron's setAsDefaultProtocolClient doesn't reliably do this on Linux, so
+// we write the .desktop file ourselves and point the OS at it. We do it on
+// every startup so the handler always points at the build the user launched last.
+// The file goes under ~/.local/share (this user only), so it won't clash with
+// a deb/rpm system install.
+export async function registerDyadProtocolLinux(): Promise<void> {
+  if (process.platform !== "linux") {
+    return;
+  }
+  // Don't mutate the host mime database during E2E runs.
+  if (IS_TEST_BUILD) {
+    return;
+  }
+
+  try {
+    const command = computeExecCommand({
+      defaultApp: Boolean(process.defaultApp),
+      execPath: process.execPath,
+      argv: process.argv,
+      appImagePath: process.env.APPIMAGE,
+    });
+
+    const appsDir = path.join(os.homedir(), ".local", "share", "applications");
+    const desktopPath = path.join(appsDir, DESKTOP_FILENAME);
+
+    await fs.promises.mkdir(appsDir, { recursive: true });
+    await fs.promises.writeFile(desktopPath, buildDesktopFile(command));
+
+    // Refresh the desktop database cache. The update-desktop-database command
+    // isn't installed on every distro; if it's missing, the xdg-mime call below
+    // still updates ~/.config/mimeapps.list on its own.
+    await execFileAsync("update-desktop-database", [appsDir]).catch((error) => {
+      logger.warn("update-desktop-database failed:", error);
+    });
+
+    await execFileAsync("xdg-mime", [
+      "default",
+      DESKTOP_FILENAME,
+      MIME_TYPE,
+    ]).catch((error) => {
+      logger.warn("xdg-mime default failed:", error);
+    });
+
+    logger.info(`Registered ${MIME_TYPE} handler at ${desktopPath}`);
+  } catch (error) {
+    logger.warn("Failed to register dyad:// protocol handler:", error);
+  }
+}

--- a/src/main/linux_protocol_registration.ts
+++ b/src/main/linux_protocol_registration.ts
@@ -77,6 +77,7 @@ export function buildDesktopFile(command: ExecCommand): string {
     "Type=Application",
     "Name=Dyad",
     `Exec=${command.exec}`,
+    // TryExec is a bare path; the spec doesn't allow it to be quoted or escaped.
     `TryExec=${command.tryExec}`,
     `MimeType=${MIME_TYPE};`,
     "NoDisplay=true",
@@ -129,13 +130,22 @@ export async function registerDyadProtocolLinux(): Promise<void> {
       logger.warn("update-desktop-database failed:", error);
     });
 
-    await execFileAsync("xdg-mime", ["default", DESKTOP_FILENAME, MIME_TYPE], {
-      timeout: 5000,
-    }).catch((error) => {
-      logger.warn("xdg-mime default failed:", error);
-    });
+    // xdg-mime is the step that actually sets the default, so only claim
+    // success when it succeeds.
+    const registered = await execFileAsync(
+      "xdg-mime",
+      ["default", DESKTOP_FILENAME, MIME_TYPE],
+      { timeout: 5000 },
+    )
+      .then(() => true)
+      .catch((error) => {
+        logger.warn("xdg-mime default failed:", error);
+        return false;
+      });
 
-    logger.info(`Registered ${MIME_TYPE} handler at ${desktopPath}`);
+    if (registered) {
+      logger.info(`Registered ${MIME_TYPE} handler at ${desktopPath}`);
+    }
   } catch (error) {
     logger.warn("Failed to register dyad:// protocol handler:", error);
   }


### PR DESCRIPTION
Connecting to Supabase on Linux failed: after going through the OAuth flow, the dyad:// return link couldn't reach the app, so the OS showed an "open with" app picker instead of handing control back to Dyad. This affected dev builds, AppImage builds, and rpm installs, where the dyad:// scheme was either never registered or pointed at the wrong build.

The underlying cause is that Electron's setAsDefaultProtocolClient doesn't reliably register the handler on Linux. We now register it ourselves on each startup: write a user-level .desktop file and set it as the default via xdg-mime, with the Exec path computed per build type (dev uses the electron binary plus the entry script, AppImage uses the stable $APPIMAGE path, deb/rpm use the installed binary). We also add the x-scheme-handler/dyad MIME type to the rpm maker so fresh rpm installs register the scheme like deb already does.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

