### PR TITLE
Format pr-push/SKILL.md

### DIFF
--- a/.claude/skills/pr-push/SKILL.md
+++ b/.claude/skills/pr-push/SKILL.md
@@ -155,8 +155,7 @@ Commit any uncommitted changes, run lint checks, fix any issues, and push the cu
 
    Look at the active account name in the output (e.g., `Logged in to github.com account keppo-bot[bot]`). The account is a bot if the name ends with `[bot]`.
 
-   **If the account is a bot, do NOT create the PR.** PRs *authored* by bot accounts do not trigger third-party code reviewers (Cursor Bugbot, Gemini Code Assist, cubic, Copilot), so the PR must be created by a human. Instead:
-
+   **If the account is a bot, do NOT create the PR.** PRs _authored_ by bot accounts do not trigger third-party code reviewers (Cursor Bugbot, Gemini Code Assist, cubic, Copilot), so the PR must be created by a human. Instead:
    - Construct the PR-creation link for the pushed branch: `https://github.com/<owner>/<repo>/pull/new/<branch-name>` (use the repo the branch was pushed to)
    - Write the suggested PR title and body (same format as the `gh pr create` body below) so the user can paste them in
    - In the final summary, tell the user to create the PR themselves using that link, title, and body


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only formatting with no runtime or behavioral impact.
> 
> **Overview**
> Updates **pr-push** skill wording only: the word *authored* in the bot-account PR rule now uses underscore italics (`_authored_`) instead of asterisk italics, matching common markdown style in the doc.
> 
> No changes to workflow steps, commands, or bot-vs-human PR behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf2105cfe6925c20ae287f50320b40863f247e19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

