### PR TITLE
fix(agent-consent): show full SQL preview and restore "Show more"

### DIFF
--- a/src/components/chat/AgentConsentBanner.tsx
+++ b/src/components/chat/AgentConsentBanner.tsx
@@ -40,6 +40,8 @@ export function AgentConsentBanner({
   const [isInputExpanded, setIsInputExpanded] = React.useState(false);
   const [inputHasOverflow, setInputHasOverflow] = React.useState(false);
   const inputRef = React.useRef<HTMLDivElement | null>(null);
+  const isExpandedRef = React.useRef(isInputExpanded);
+  isExpandedRef.current = isInputExpanded;
 
   React.useEffect(() => {
     if (!inputPreview) {
@@ -50,9 +52,10 @@ export function AgentConsentBanner({
     const element = inputRef.current;
     if (!element) return;
 
-    // The collapsed preview is clipped to whole lines via CSS line-clamp, so
-    // overflow just means the full content is taller than the clamped box.
+    // Only measure while collapsed; the expanded box has different dimensions.
+    // Overflow means the full content is taller than the clamped preview.
     const compute = () => {
+      if (isExpandedRef.current) return;
       setInputHasOverflow(element.scrollHeight > element.clientHeight + 1);
     };
 

--- a/src/components/chat/AgentConsentBanner.tsx
+++ b/src/components/chat/AgentConsentBanner.tsx
@@ -40,9 +40,9 @@ export function AgentConsentBanner({
   const [isInputExpanded, setIsInputExpanded] = React.useState(false);
   const [inputHasOverflow, setInputHasOverflow] = React.useState(false);
   const inputRef = React.useRef<HTMLDivElement | null>(null);
-  const isExpandedRef = React.useRef(isInputExpanded);
-  isExpandedRef.current = isInputExpanded;
 
+  // Measure overflow only while collapsed; the expanded box has different
+  // dimensions. Re-runs on collapse so the flag refreshes once the box shrinks.
   React.useEffect(() => {
     if (!inputPreview) {
       setInputHasOverflow(false);
@@ -52,17 +52,15 @@ export function AgentConsentBanner({
     const element = inputRef.current;
     if (!element) return;
 
-    // Only measure while collapsed; the expanded box has different dimensions.
-    // Overflow means the full content is taller than the clamped preview.
     const compute = () => {
-      if (isExpandedRef.current) return;
+      if (isInputExpanded) return;
       setInputHasOverflow(element.scrollHeight > element.clientHeight + 1);
     };
 
     compute();
     window.addEventListener("resize", compute);
     return () => window.removeEventListener("resize", compute);
-  }, [inputPreview]);
+  }, [inputPreview, isInputExpanded]);
 
   return (
     <div className="border-b border-border bg-muted/50">
@@ -111,7 +109,7 @@ export function AgentConsentBanner({
                 className={`text-sm whitespace-pre-wrap ${
                   isInputExpanded
                     ? "max-h-[40vh] overflow-auto"
-                    : "line-clamp-4 overflow-hidden"
+                    : "line-clamp-6 overflow-hidden"
                 }`}
               >
                 {inputPreview}

--- a/src/components/chat/AgentConsentBanner.tsx
+++ b/src/components/chat/AgentConsentBanner.tsx
@@ -18,6 +18,9 @@ import {
 } from "../ui/tooltip";
 import { useTranslation } from "react-i18next";
 
+const INPUT_PREVIEW_COLLAPSED_LINES = 6;
+const INPUT_PREVIEW_EXPANDED_MAX_HEIGHT = "40vh";
+
 interface AgentConsentBannerProps {
   consent: PendingAgentConsent;
   onDecision: (decision: "accept-once" | "accept-always" | "decline") => void;
@@ -38,11 +41,11 @@ export function AgentConsentBanner({
 
   // Collapsible input preview state
   const [isInputExpanded, setIsInputExpanded] = React.useState(false);
+  const [inputCollapsedMaxHeight, setInputCollapsedMaxHeight] =
+    React.useState<number>();
   const [inputHasOverflow, setInputHasOverflow] = React.useState(false);
   const inputRef = React.useRef<HTMLDivElement | null>(null);
 
-  // Measure overflow only while collapsed; the expanded box has different
-  // dimensions. Re-runs on collapse so the flag refreshes once the box shrinks.
   React.useLayoutEffect(() => {
     if (!inputPreview) {
       setInputHasOverflow(false);
@@ -53,14 +56,23 @@ export function AgentConsentBanner({
     if (!element) return;
 
     const compute = () => {
-      if (isInputExpanded) return;
-      setInputHasOverflow(element.scrollHeight > element.clientHeight + 1);
+      const computedStyle = window.getComputedStyle(element);
+      const parsedLineHeight = Number.parseFloat(computedStyle.lineHeight);
+      const lineHeight = Number.isFinite(parsedLineHeight)
+        ? parsedLineHeight
+        : 20;
+      const collapsedMaxHeight = Math.round(
+        lineHeight * INPUT_PREVIEW_COLLAPSED_LINES,
+      );
+
+      setInputCollapsedMaxHeight(collapsedMaxHeight);
+      setInputHasOverflow(element.scrollHeight > collapsedMaxHeight + 1);
     };
 
     compute();
     window.addEventListener("resize", compute);
     return () => window.removeEventListener("resize", compute);
-  }, [inputPreview, isInputExpanded]);
+  }, [inputPreview]);
 
   return (
     <div className="border-b border-border bg-muted/50">
@@ -103,14 +115,17 @@ export function AgentConsentBanner({
                 <span>{t("changesDatabaseSchema")}</span>
               </div>
             )}
-            <div className="bg-muted p-1.5 rounded">
+            <div className="rounded bg-muted p-1.5">
               <div
                 ref={inputRef}
-                className={`text-sm whitespace-pre-wrap break-words ${
-                  isInputExpanded
-                    ? "max-h-[40vh] overflow-auto"
-                    : "line-clamp-6 overflow-hidden"
+                className={`text-sm whitespace-pre-wrap break-words transition-[max-height] duration-200 ease-out motion-reduce:transition-none ${
+                  isInputExpanded ? "overflow-auto" : "overflow-hidden"
                 }`}
+                style={{
+                  maxHeight: isInputExpanded
+                    ? INPUT_PREVIEW_EXPANDED_MAX_HEIGHT
+                    : inputCollapsedMaxHeight,
+                }}
               >
                 {inputPreview}
               </div>

--- a/src/components/chat/AgentConsentBanner.tsx
+++ b/src/components/chat/AgentConsentBanner.tsx
@@ -43,7 +43,7 @@ export function AgentConsentBanner({
 
   // Measure overflow only while collapsed; the expanded box has different
   // dimensions. Re-runs on collapse so the flag refreshes once the box shrinks.
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     if (!inputPreview) {
       setInputHasOverflow(false);
       return;
@@ -106,7 +106,7 @@ export function AgentConsentBanner({
             <div className="bg-muted p-1.5 rounded">
               <div
                 ref={inputRef}
-                className={`text-sm whitespace-pre-wrap ${
+                className={`text-sm whitespace-pre-wrap break-words ${
                   isInputExpanded
                     ? "max-h-[40vh] overflow-auto"
                     : "line-clamp-6 overflow-hidden"

--- a/src/components/chat/AgentConsentBanner.tsx
+++ b/src/components/chat/AgentConsentBanner.tsx
@@ -38,8 +38,6 @@ export function AgentConsentBanner({
 
   // Collapsible input preview state
   const [isInputExpanded, setIsInputExpanded] = React.useState(false);
-  const [inputCollapsedMaxHeight, setInputCollapsedMaxHeight] =
-    React.useState<number>(0);
   const [inputHasOverflow, setInputHasOverflow] = React.useState(false);
   const inputRef = React.useRef<HTMLDivElement | null>(null);
 
@@ -52,22 +50,15 @@ export function AgentConsentBanner({
     const element = inputRef.current;
     if (!element) return;
 
+    // The collapsed preview is clipped to whole lines via CSS line-clamp, so
+    // overflow just means the full content is taller than the clamped box.
     const compute = () => {
-      const computedStyle = window.getComputedStyle(element);
-      const parsedLineHeight = parseFloat(computedStyle.lineHeight || "16");
-      const lineHeight = Number.isFinite(parsedLineHeight)
-        ? parsedLineHeight
-        : 16;
-      const maxLines = 6;
-      const maxHeightPx = Math.max(0, Math.round(lineHeight * maxLines));
-      setInputCollapsedMaxHeight(maxHeightPx);
-      setInputHasOverflow(element.scrollHeight > maxHeightPx + 1);
+      setInputHasOverflow(element.scrollHeight > element.clientHeight + 1);
     };
 
     compute();
-    const onResize = () => compute();
-    window.addEventListener("resize", onResize);
-    return () => window.removeEventListener("resize", onResize);
+    window.addEventListener("resize", compute);
+    return () => window.removeEventListener("resize", compute);
   }, [inputPreview]);
 
   return (
@@ -111,15 +102,17 @@ export function AgentConsentBanner({
                 <span>{t("changesDatabaseSchema")}</span>
               </div>
             )}
-            <div
-              ref={inputRef}
-              className="bg-muted p-1.5 rounded text-sm whitespace-pre-wrap"
-              style={{
-                maxHeight: isInputExpanded ? "40vh" : inputCollapsedMaxHeight,
-                overflow: isInputExpanded ? "auto" : "hidden",
-              }}
-            >
-              {inputPreview}
+            <div className="bg-muted p-1.5 rounded">
+              <div
+                ref={inputRef}
+                className={`text-sm whitespace-pre-wrap ${
+                  isInputExpanded
+                    ? "max-h-[40vh] overflow-auto"
+                    : "line-clamp-4 overflow-hidden"
+                }`}
+              >
+                {inputPreview}
+              </div>
             </div>
             {inputHasOverflow && (
               <button

--- a/src/pro/main/ipc/handlers/local_agent/tools/execute_sql.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/execute_sql.spec.ts
@@ -51,14 +51,8 @@ describe("executeSqlTool", () => {
   });
 
   it("returns the full query as the consent preview", () => {
-    const query = "SELECT * FROM users WHERE id = 1;";
-    expect(executeSqlTool.getConsentPreview?.({ query })).toBe(query);
-  });
-
-  it("caps an oversized consent preview with an ellipsis", () => {
     const query = "a".repeat(5000);
-    const preview = executeSqlTool.getConsentPreview?.({ query });
-    expect(preview).toBe("a".repeat(2000) + "…");
+    expect(executeSqlTool.getConsentPreview?.({ query })).toBe(query);
   });
 
   it("writes a Supabase migration file for schema-mutating SQL", async () => {

--- a/src/pro/main/ipc/handlers/local_agent/tools/execute_sql.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/execute_sql.spec.ts
@@ -50,6 +50,17 @@ describe("executeSqlTool", () => {
     ).toEqual({ sqlMutatesSchema: false });
   });
 
+  it("returns the full query as the consent preview", () => {
+    const query = "SELECT * FROM users WHERE id = 1;";
+    expect(executeSqlTool.getConsentPreview?.({ query })).toBe(query);
+  });
+
+  it("caps an oversized consent preview with an ellipsis", () => {
+    const query = "a".repeat(5000);
+    const preview = executeSqlTool.getConsentPreview?.({ query });
+    expect(preview).toBe("a".repeat(2000) + "…");
+  });
+
   it("writes a Supabase migration file for schema-mutating SQL", async () => {
     await executeSqlTool.execute(
       {

--- a/src/pro/main/ipc/handlers/local_agent/tools/execute_sql.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/execute_sql.ts
@@ -17,6 +17,10 @@ const executeSqlSchema = z.object({
   description: z.string().optional().describe("Brief description of the query"),
 });
 
+// Bound the consent preview so a pathological query can't push a huge string
+// through IPC and React state. The banner scrolls within this anyway.
+const MAX_CONSENT_PREVIEW_CHARS = 2000;
+
 export const executeSqlTool: ToolDefinition<z.infer<typeof executeSqlSchema>> =
   {
     name: "execute_sql",
@@ -29,7 +33,10 @@ export const executeSqlTool: ToolDefinition<z.infer<typeof executeSqlSchema>> =
       !!ctx.supabaseProjectId ||
       (!!ctx.neonProjectId && !!ctx.neonActiveBranchId),
 
-    getConsentPreview: (args) => args.query,
+    getConsentPreview: (args) =>
+      args.query.length > MAX_CONSENT_PREVIEW_CHARS
+        ? args.query.slice(0, MAX_CONSENT_PREVIEW_CHARS) + "…"
+        : args.query,
 
     getConsentMetadata: (args) => ({
       sqlMutatesSchema: doesSqlMutateSchema(args.query),

--- a/src/pro/main/ipc/handlers/local_agent/tools/execute_sql.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/execute_sql.ts
@@ -29,8 +29,7 @@ export const executeSqlTool: ToolDefinition<z.infer<typeof executeSqlSchema>> =
       !!ctx.supabaseProjectId ||
       (!!ctx.neonProjectId && !!ctx.neonActiveBranchId),
 
-    getConsentPreview: (args) =>
-      args.query.slice(0, 100) + (args.query.length > 100 ? "..." : ""),
+    getConsentPreview: (args) => args.query,
 
     getConsentMetadata: (args) => ({
       sqlMutatesSchema: doesSqlMutateSchema(args.query),

--- a/src/pro/main/ipc/handlers/local_agent/tools/execute_sql.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/execute_sql.ts
@@ -17,10 +17,6 @@ const executeSqlSchema = z.object({
   description: z.string().optional().describe("Brief description of the query"),
 });
 
-// Bound the consent preview so a pathological query can't push a huge string
-// through IPC and React state. The banner scrolls within this anyway.
-const MAX_CONSENT_PREVIEW_CHARS = 2000;
-
 export const executeSqlTool: ToolDefinition<z.infer<typeof executeSqlSchema>> =
   {
     name: "execute_sql",
@@ -33,10 +29,7 @@ export const executeSqlTool: ToolDefinition<z.infer<typeof executeSqlSchema>> =
       !!ctx.supabaseProjectId ||
       (!!ctx.neonProjectId && !!ctx.neonActiveBranchId),
 
-    getConsentPreview: (args) =>
-      args.query.length > MAX_CONSENT_PREVIEW_CHARS
-        ? args.query.slice(0, MAX_CONSENT_PREVIEW_CHARS) + "…"
-        : args.query,
+    getConsentPreview: (args) => args.query,
 
     getConsentMetadata: (args) => ({
       sqlMutatesSchema: doesSqlMutateSchema(args.query),


### PR DESCRIPTION
The execute_sql consent preview was truncated to 100 characters before being handed to the consent banner. The banner decides whether to render its "Show more" button by checking if the preview overflows the collapsed box, so the 100-character cap kept the content short enough that it never overflowed. As a result "Show more" never appeared for SQL previews and longer queries were silently cut off with no way to see the rest.

Drop the character truncation and pass the full query. Replace the banner's JavaScript line measurement (getComputedStyle line-height, padding and box-sizing math) with a CSS line-clamp, so the collapsed preview clips cleanly on whole-line boundaries and "Show more" shows whenever the content actually overflows. Overflow detection is now a plain scrollHeight vs clientHeight check.

The banner is shared by all local-agent tool consents, but in practice only execute_sql and set_chat_summary produce previews long enough to overflow; every other tool renders a short one-line summary, so their appearance is unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

