### PR TITLE
Preserve chat drafts when submitting annotator screenshots

### DIFF
--- a/e2e-tests/annotator.spec.ts
+++ b/e2e-tests/annotator.spec.ts
@@ -10,6 +10,10 @@ testSkipIfWindows(
     // Create a basic app
     await po.sendPrompt("basic");
 
+    const existingPrompt = "Make the primary button easier to find";
+    await po.chatActions.getChatInput().fill(existingPrompt);
+    await expect(po.chatActions.getChatInput()).toContainText(existingPrompt);
+
     // Click the annotator button to activate annotator mode
     await po.previewPanel.clickPreviewAnnotatorButton();
 
@@ -19,6 +23,7 @@ testSkipIfWindows(
     // Submit the screenshot to chat
     await po.previewPanel.clickAnnotatorSubmit();
 
+    await expect(po.chatActions.getChatInput()).toContainText(existingPrompt);
     await expect(po.chatActions.getChatInput()).toContainText(
       "Please update the UI based on these screenshots",
     );

--- a/src/pro/ui/components/Annotator/Annotator.tsx
+++ b/src/pro/ui/components/Annotator/Annotator.tsx
@@ -151,7 +151,13 @@ export const Annotator = ({
       });
 
       onSubmit([file], "chat-context");
-      setChatInput("Please update the UI based on these screenshots");
+      const screenshotPrompt =
+        "Please update the UI based on these screenshots";
+      setChatInput((prev) =>
+        prev.trim()
+          ? `${prev.trimEnd()}\n\n${screenshotPrompt}`
+          : screenshotPrompt,
+      );
       handleAnnotatorClick();
     } catch (error) {
       console.error("Failed to export annotated image:", error);


### PR DESCRIPTION
 ## Summary
  - Appends the annotator follow-up prompt to an existing chat draft with a blank-line separator, while keeping empty-draft behavior unchanged.
  - Extends the existing annotator E2E flow so prompt preservation and screenshot attachment stay covered together.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UX fix in chat input handling with a matching E2E update; no auth, data, or backend changes.
> 
> **Overview**
> Submitting an annotated screenshot from the preview **no longer wipes** the chat input. The follow-up line *"Please update the UI based on these screenshots"* is **appended** after any non-empty draft (with a blank line between); an empty input still gets only that prompt.
> 
> The annotator E2E flow now **pre-fills** the chat, submits a screenshot, and asserts both the user draft and the screenshot prompt remain, alongside the existing attachment checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1ce43f940c5d9fcc8896fd20944b12698ad3270. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->