### PR TITLE
[codex] Reduce release workflow approval gates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,6 @@ jobs:
   prepare-release:
     name: Prepare Release Tag
     runs-on: ubuntu-latest
-    environment: release
     outputs:
       tag: ${{ steps.prepare.outputs.tag }}
       version: ${{ steps.prepare.outputs.version }}
@@ -153,7 +152,6 @@ jobs:
     name: Publish Release
     needs: build
     runs-on: ubuntu-latest
-    environment: release
     steps:
       - name: Github checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5


### PR DESCRIPTION
Summary
- Remove the release environment approval gate from prepare-release.
- Remove the release environment approval gate from publish.
- Keep the release environment gate on the build matrix, where signing credentials are used.

Validation
- npm run fmt:check
- npm run lint (passes with two existing no-thenable warnings in json_schema_to_ts.spec.ts)

#skip-bugbot

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release CI governance by allowing tag preparation and publishing without environment approval, though credential-heavy signing still runs only behind the release environment on build.
> 
> **Overview**
> **Release workflow** no longer requires the **`release` GitHub Environment** (and its approval rules) on **`prepare-release`** or **`publish`**, so tag prep and GitHub release upload can run without extra manual approvals.
> 
> The **`build`** job **still** uses **`environment: release`**, so jobs that consume macOS/Windows signing and related secrets remain behind the existing gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e868c05394313ef7938a7d55d43fd957582776e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->