### PR TITLE
[codex] Pin release Windows runner to 2022

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - { name: "windows", image: "windows-latest" }
+          - { name: "windows", image: "windows-2022" }
           # See https://github.com/dyad-sh/dyad/issues/96
           - { name: "linux", image: "ubuntu-22.04" }
           - { name: "macos-intel", image: "macos-15-intel" }


### PR DESCRIPTION
Summary
- Pin the Release app Windows build runner to windows-2022.
- Avoid windows-latest moving to Windows Server 2025 / Visual Studio 2026, which breaks native rebuilds for better-sqlite3 via electron node-gyp.

Validation
- npm run fmt:check
- npm run lint (passes with two existing no-thenable warnings in json_schema_to_ts.spec.ts)

#skip-bugbot

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI matrix image change for release Windows builds only; no application or runtime code changes.
> 
> **Overview**
> The **Release app** workflow’s Windows matrix job now uses **`windows-2022`** instead of **`windows-latest`**, so the release build stays on a known Windows/Visual Studio stack.
> 
> This avoids **`windows-latest`** rolling forward (e.g. Windows Server 2025 / Visual Studio 2026) and breaking native **`better-sqlite3`** rebuilds via Electron **`node-gyp`**. Linux and macOS matrix entries are unchanged; CI workflows still use **`windows-latest`** elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b58a055aa9e34a9f547dcfc6b5299e188b0541fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->