### PR TITLE
feat: add experiment to auto-approve non-schema SQL in agent mode

### DIFF
--- a/src/components/AutoApproveSqlExperimentSwitch.tsx
+++ b/src/components/AutoApproveSqlExperimentSwitch.tsx
@@ -1,0 +1,32 @@
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { useSettings } from "@/hooks/useSettings";
+
+export function AutoApproveSqlExperimentSwitch() {
+  const { settings, updateSettings } = useSettings();
+  const isEnabled = !!settings?.autoApproveNonSchemaSql;
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center space-x-2">
+        <Switch
+          id="enable-auto-approve-non-schema-sql"
+          aria-label="Auto-approve non-schema SQL"
+          checked={isEnabled}
+          onCheckedChange={(checked) => {
+            updateSettings({
+              autoApproveNonSchemaSql: checked,
+            });
+          }}
+        />
+        <Label htmlFor="enable-auto-approve-non-schema-sql">
+          Auto-approve non-schema SQL
+        </Label>
+      </div>
+      <div className="text-sm text-gray-500 dark:text-gray-400">
+        In Agent mode, skip the consent prompt when running SQL that does not
+        change the database schema. Schema changes still require approval.
+      </div>
+    </div>
+  );
+}

--- a/src/components/AutoApproveSqlSwitch.tsx
+++ b/src/components/AutoApproveSqlSwitch.tsx
@@ -11,7 +11,7 @@ export function AutoApproveSqlSwitch() {
       <div className="flex items-center space-x-2">
         <Switch
           id="enable-auto-approve-non-schema-sql"
-          aria-label="Auto-approve non-schema SQL"
+          aria-label="Skip consent for non-schema SQL"
           checked={isEnabled}
           onCheckedChange={(checked) => {
             updateSettings({
@@ -20,7 +20,7 @@ export function AutoApproveSqlSwitch() {
           }}
         />
         <Label htmlFor="enable-auto-approve-non-schema-sql">
-          Auto-approve non-schema SQL
+          Skip consent for non-schema SQL
         </Label>
       </div>
       <div className="text-sm text-gray-500 dark:text-gray-400">

--- a/src/components/AutoApproveSqlSwitch.tsx
+++ b/src/components/AutoApproveSqlSwitch.tsx
@@ -2,7 +2,7 @@ import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { useSettings } from "@/hooks/useSettings";
 
-export function AutoApproveSqlExperimentSwitch() {
+export function AutoApproveSqlSwitch() {
   const { settings, updateSettings } = useSettings();
   const isEnabled = !!settings?.autoApproveNonSchemaSql;
 

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -344,6 +344,7 @@ const BaseUserSettingsFields = {
   selectedTemplateId: z.string(),
   selectedThemeId: z.string().optional(),
   enableSupabaseWriteSqlMigration: z.boolean().optional(),
+  autoApproveNonSchemaSql: z.boolean().optional(),
   skipPruneEdgeFunctions: z.boolean().optional(),
   acceptedCommunityCode: z.boolean().optional(),
   zoomLevel: ZoomLevelSchema.optional(),

--- a/src/lib/settingsSearchIndex.ts
+++ b/src/lib/settingsSearchIndex.ts
@@ -435,6 +435,24 @@ export const SETTINGS_SEARCH_INDEX: SearchableSettingItem[] = [
     sectionId: SECTION_IDS.advanced,
     sectionLabel: "Advanced",
   },
+  {
+    id: SETTING_IDS.autoApproveNonSchemaSql,
+    label: "Auto-approve non-schema SQL",
+    description:
+      "In Agent mode, skip the consent prompt when running SQL that does not change the database schema. Schema changes still require approval",
+    keywords: [
+      "sql",
+      "database",
+      "consent",
+      "approve",
+      "schema",
+      "agent",
+      "supabase",
+      "neon",
+    ],
+    sectionId: SECTION_IDS.advanced,
+    sectionLabel: "Advanced",
+  },
 
   // Experiments
   {
@@ -450,24 +468,6 @@ export const SETTINGS_SEARCH_INDEX: SearchableSettingItem[] = [
       "pro",
       "credits",
       "secure",
-    ],
-    sectionId: SECTION_IDS.experiments,
-    sectionLabel: "Experiments",
-  },
-  {
-    id: SETTING_IDS.autoApproveNonSchemaSql,
-    label: "Auto-approve non-schema SQL",
-    description:
-      "In Agent mode, skip the consent prompt when running SQL that does not change the database schema. Schema changes still require approval",
-    keywords: [
-      "sql",
-      "database",
-      "consent",
-      "approve",
-      "schema",
-      "agent",
-      "supabase",
-      "neon",
     ],
     sectionId: SECTION_IDS.experiments,
     sectionLabel: "Experiments",

--- a/src/lib/settingsSearchIndex.ts
+++ b/src/lib/settingsSearchIndex.ts
@@ -437,7 +437,7 @@ export const SETTINGS_SEARCH_INDEX: SearchableSettingItem[] = [
   },
   {
     id: SETTING_IDS.autoApproveNonSchemaSql,
-    label: "Auto-approve non-schema SQL",
+    label: "Skip consent for non-schema SQL",
     description:
       "In Agent mode, skip the consent prompt when running SQL that does not change the database schema. Schema changes still require approval",
     keywords: [

--- a/src/lib/settingsSearchIndex.ts
+++ b/src/lib/settingsSearchIndex.ts
@@ -38,6 +38,7 @@ export const SETTING_IDS = {
   neon: "setting-neon",
   nativeGit: "setting-native-git",
   enableCloudSandbox: "setting-enable-cloud-sandbox",
+  autoApproveNonSchemaSql: "setting-auto-approve-non-schema-sql",
   enableSandboxScriptExecution: "setting-enable-sandbox-script-execution",
   blockUnsafeNpmPackages: "setting-block-unsafe-npm-packages",
   enablePnpmMinimumReleaseAgeWarning:
@@ -449,6 +450,24 @@ export const SETTINGS_SEARCH_INDEX: SearchableSettingItem[] = [
       "pro",
       "credits",
       "secure",
+    ],
+    sectionId: SECTION_IDS.experiments,
+    sectionLabel: "Experiments",
+  },
+  {
+    id: SETTING_IDS.autoApproveNonSchemaSql,
+    label: "Auto-approve non-schema SQL",
+    description:
+      "In Agent mode, skip the consent prompt when running SQL that does not change the database schema. Schema changes still require approval",
+    keywords: [
+      "sql",
+      "database",
+      "consent",
+      "approve",
+      "schema",
+      "agent",
+      "supabase",
+      "neon",
     ],
     sectionId: SECTION_IDS.experiments,
     sectionLabel: "Experiments",

--- a/src/main/settings.test.ts
+++ b/src/main/settings.test.ts
@@ -88,6 +88,7 @@ describe("readSettings", () => {
       );
       expect(scrubSettings(result)).toMatchInlineSnapshot(`
         {
+          "autoApproveNonSchemaSql": true,
           "autoExpandPreviewPanel": true,
           "enableAppBlueprint": true,
           "enableAutoFixProblems": false,
@@ -501,6 +502,7 @@ describe("readSettings", () => {
 
       expect(scrubSettings(result)).toMatchInlineSnapshot(`
         {
+          "autoApproveNonSchemaSql": true,
           "autoExpandPreviewPanel": true,
           "enableAppBlueprint": true,
           "enableAutoFixProblems": false,

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -61,6 +61,7 @@ export const DEFAULT_SETTINGS: UserSettings = {
   enableNativeGit: true,
   enableSandboxScriptExecution: true,
   enableCodeExplorer: true,
+  autoApproveNonSchemaSql: true,
   autoExpandPreviewPanel: true,
   enableContextCompaction: true,
   enablePnpmMinimumReleaseAgeWarning: false,

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -36,6 +36,7 @@ import { DefaultChatModeSelector } from "@/components/DefaultChatModeSelector";
 import { ContextCompactionSwitch } from "@/components/ContextCompactionSwitch";
 import { BlockUnsafeNpmPackagesSwitch } from "@/components/BlockUnsafeNpmPackagesSwitch";
 import { CloudSandboxExperimentSwitch } from "@/components/CloudSandboxExperimentSwitch";
+import { AutoApproveSqlExperimentSwitch } from "@/components/AutoApproveSqlExperimentSwitch";
 import { useSetAtom } from "jotai";
 import { activeSettingsSectionAtom } from "@/atoms/viewAtoms";
 import { SECTION_IDS, SETTING_IDS } from "@/lib/settingsSearchIndex";
@@ -268,6 +269,12 @@ export default function SettingsPage() {
             <div className="space-y-4">
               <div id={SETTING_IDS.enableCloudSandbox} className="space-y-1">
                 <CloudSandboxExperimentSwitch />
+              </div>
+              <div
+                id={SETTING_IDS.autoApproveNonSchemaSql}
+                className="space-y-1 mt-4"
+              >
+                <AutoApproveSqlExperimentSwitch />
               </div>
               <div
                 id={SETTING_IDS.enableMcpToolSearch}

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -36,7 +36,7 @@ import { DefaultChatModeSelector } from "@/components/DefaultChatModeSelector";
 import { ContextCompactionSwitch } from "@/components/ContextCompactionSwitch";
 import { BlockUnsafeNpmPackagesSwitch } from "@/components/BlockUnsafeNpmPackagesSwitch";
 import { CloudSandboxExperimentSwitch } from "@/components/CloudSandboxExperimentSwitch";
-import { AutoApproveSqlExperimentSwitch } from "@/components/AutoApproveSqlExperimentSwitch";
+import { AutoApproveSqlSwitch } from "@/components/AutoApproveSqlSwitch";
 import { useSetAtom } from "jotai";
 import { activeSettingsSectionAtom } from "@/atoms/viewAtoms";
 import { SECTION_IDS, SETTING_IDS } from "@/lib/settingsSearchIndex";
@@ -249,6 +249,12 @@ export default function SettingsPage() {
                   servers are always enabled in Agent mode.
                 </div>
               </div>
+              <div
+                id={SETTING_IDS.autoApproveNonSchemaSql}
+                className="space-y-1 mt-4"
+              >
+                <AutoApproveSqlSwitch />
+              </div>
             </div>
           </div>
 
@@ -269,12 +275,6 @@ export default function SettingsPage() {
             <div className="space-y-4">
               <div id={SETTING_IDS.enableCloudSandbox} className="space-y-1">
                 <CloudSandboxExperimentSwitch />
-              </div>
-              <div
-                id={SETTING_IDS.autoApproveNonSchemaSql}
-                className="space-y-1 mt-4"
-              >
-                <AutoApproveSqlExperimentSwitch />
               </div>
               <div
                 id={SETTING_IDS.enableMcpToolSearch}

--- a/src/pro/main/ipc/handlers/local_agent/auto_approve_sql.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/auto_approve_sql.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { shouldAutoApproveAgentTool } from "./tool_definitions";
+
+describe("shouldAutoApproveAgentTool", () => {
+  it("auto-approves execute_sql that does not mutate schema when enabled", () => {
+    expect(
+      shouldAutoApproveAgentTool({
+        toolName: "execute_sql",
+        metadata: { sqlMutatesSchema: false },
+        autoApproveNonSchemaSql: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("still asks for schema-mutating execute_sql when enabled", () => {
+    expect(
+      shouldAutoApproveAgentTool({
+        toolName: "execute_sql",
+        metadata: { sqlMutatesSchema: true },
+        autoApproveNonSchemaSql: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not auto-approve when the setting is off", () => {
+    expect(
+      shouldAutoApproveAgentTool({
+        toolName: "execute_sql",
+        metadata: { sqlMutatesSchema: false },
+        autoApproveNonSchemaSql: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldAutoApproveAgentTool({
+        toolName: "execute_sql",
+        metadata: { sqlMutatesSchema: false },
+        autoApproveNonSchemaSql: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not auto-approve when schema-mutation metadata is missing", () => {
+    expect(
+      shouldAutoApproveAgentTool({
+        toolName: "execute_sql",
+        metadata: null,
+        autoApproveNonSchemaSql: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("never auto-approves a tool other than execute_sql", () => {
+    expect(
+      shouldAutoApproveAgentTool({
+        toolName: "write_file",
+        metadata: { sqlMutatesSchema: false },
+        autoApproveNonSchemaSql: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/pro/main/ipc/handlers/local_agent/tool_definitions.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tool_definitions.ts
@@ -179,6 +179,23 @@ export function getDefaultConsent(toolName: AgentToolName): AgentToolConsent {
   return tool?.defaultConsent ?? "ask";
 }
 
+/**
+ * When autoApproveNonSchemaSql is enabled, execute_sql calls that the schema
+ * classifier determines do not mutate the schema run without a consent prompt.
+ * Schema-mutating SQL still requires consent.
+ */
+export function shouldAutoApproveAgentTool(params: {
+  toolName: AgentToolName;
+  metadata?: { sqlMutatesSchema?: boolean } | null;
+  autoApproveNonSchemaSql: boolean | undefined;
+}): boolean {
+  return (
+    params.toolName === "execute_sql" &&
+    params.metadata?.sqlMutatesSchema === false &&
+    params.autoApproveNonSchemaSql === true
+  );
+}
+
 export function getAgentToolConsent(toolName: AgentToolName): AgentToolConsent {
   const settings = readSettings();
   const stored = settings.agentToolConsents?.[toolName];
@@ -234,6 +251,16 @@ export async function requireAgentToolConsent(
       "Should not ask for consent for a tool marked as 'never'",
       DyadErrorKind.Internal,
     );
+
+  if (
+    shouldAutoApproveAgentTool({
+      toolName: params.toolName,
+      metadata: params.metadata,
+      autoApproveNonSchemaSql: readSettings().autoApproveNonSchemaSql,
+    })
+  ) {
+    return true;
+  }
 
   // Ask renderer for a decision via event bridge
   const requestId = `agent:${params.toolName}:${crypto.randomUUID()}`;


### PR DESCRIPTION
In agent mode, every SQL statement the agent runs produces its own consent prompt. When the user is making a lot of database changes, this means a steady stream of prompts to click through, even for routine data reads and writes that do not change the database structure.

This narrows when we ask. SQL that does not change the schema runs without a prompt, and only schema-changing SQL still asks for consent. We decide which is which using the existing SQL schema classifier, which already powers the schema-change warning on the consent banner. The classifier fails safe: multi-statement SQL is flagged if any statement changes the schema, and SQL it cannot fully parse is treated as schema-changing so it still asks.

The behavior is controlled by a new setting, `autoApproveNonSchemaSql`, which is on by default and lives in the Advanced section of the settings page. The auto-approve decision sits in `requireAgentToolConsent`, after the existing always/never checks, so explicit per-tool consent choices still win.

Per review discussion, this is on by default rather than an opt-in experiment, and it sits under Advanced rather than Experiments.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
