### PR TITLE
Trim Windows package artifacts

### DIFF
--- a/src/__tests__/packaging_cleanup.test.ts
+++ b/src/__tests__/packaging_cleanup.test.ts
@@ -49,6 +49,19 @@ describe("removeUnusedAppPackageFiles", () => {
       nodePtyPath,
       "build/Release/obj.target/pty/src/unix/pty.o",
     );
+    const windowsBuildDepsArtifact = path.join(
+      nodePtyPath,
+      "build/deps/winpty/src/Release/obj/winpty-agent/Agent.obj",
+    );
+    const windowsDebugArtifacts = [
+      "build/Release/winpty-agent.iobj",
+      "build/Release/winpty-agent.ipdb",
+      "build/Release/winpty-agent.tlog",
+      "build/Release/pty.vcxproj",
+      "build/Release/pty.vcxproj.filters",
+      "build/Release/winpty.lib",
+      "build/Release/winpty.exp",
+    ].map((file) => path.join(nodePtyPath, file));
 
     await Promise.all([
       writeFixtureFile(supportedBinary),
@@ -57,6 +70,8 @@ describe("removeUnusedAppPackageFiles", () => {
       writeFixtureFile(rebuiltBinary),
       writeFixtureFile(spawnHelper),
       writeFixtureFile(buildIntermediate),
+      writeFixtureFile(windowsBuildDepsArtifact),
+      ...windowsDebugArtifacts.map((file) => writeFixtureFile(file)),
       writeFixtureFile(path.join(nodePtyPath, "src/index.ts")),
       writeFixtureFile(path.join(nodePtyPath, "lib/index.js.map")),
     ]);
@@ -69,6 +84,8 @@ describe("removeUnusedAppPackageFiles", () => {
     await expectMissing(unsupportedBinary);
     await expectMissing(debugSymbols);
     await expectMissing(buildIntermediate);
+    await expectMissing(windowsBuildDepsArtifact);
+    await Promise.all(windowsDebugArtifacts.map((file) => expectMissing(file)));
     await expectMissing(path.join(nodePtyPath, "src/index.ts"));
     await expectMissing(path.join(nodePtyPath, "lib/index.js.map"));
   });
@@ -97,6 +114,14 @@ describe("removeUnusedAppPackageFiles", () => {
       betterSqlitePath,
       "build/Release/obj.target/sqlite3/sqlite3.o",
     );
+    const windowsBuildArtifacts = [
+      "build/Release/better_sqlite3.iobj",
+      "build/Release/better_sqlite3.ipdb",
+      "build/Release/better_sqlite3.pdb",
+      "build/Release/sqlite3.lib",
+      "build/Release/test_extension.pdb",
+      "build/Release/test_extension.node",
+    ].map((file) => path.join(betterSqlitePath, file));
 
     await Promise.all([
       writeFixtureFile(runtimeJs),
@@ -104,6 +129,7 @@ describe("removeUnusedAppPackageFiles", () => {
       writeFixtureFile(sqliteSource),
       writeFixtureFile(staticLibrary),
       writeFixtureFile(buildObject),
+      ...windowsBuildArtifacts.map((file) => writeFixtureFile(file)),
       writeFixtureFile(path.join(betterSqlitePath, "src/addon.cpp")),
     ]);
 
@@ -114,6 +140,7 @@ describe("removeUnusedAppPackageFiles", () => {
     await expectMissing(sqliteSource);
     await expectMissing(staticLibrary);
     await expectMissing(buildObject);
+    await Promise.all(windowsBuildArtifacts.map((file) => expectMissing(file)));
     await expectMissing(path.join(betterSqlitePath, "src/addon.cpp"));
   });
 });
@@ -257,6 +284,7 @@ describe("removeUnusedCopiedResources", () => {
       "libSkiaSharp.dll",
       "HarfBuzzSharp.dll",
       "msalruntime_x86.dll",
+      "scalar.exe",
     ].map((file) => path.join(binPath, file));
 
     const keptFiles = [
@@ -269,10 +297,11 @@ describe("removeUnusedCopiedResources", () => {
     ].map((file) => path.join(binPath, file));
 
     const gitLfs = path.join(gitPath, "mingw64/libexec/git-core/git-lfs.exe");
+    const cmdScalar = path.join(gitPath, "cmd/scalar.exe");
     const gitconfig = path.join(gitPath, "etc/gitconfig");
 
     await Promise.all([
-      ...[...removedFiles, ...keptFiles, gitLfs].map((file) =>
+      ...[...removedFiles, ...keptFiles, gitLfs, cmdScalar].map((file) =>
         writeFixtureFile(file),
       ),
       writeFixtureFile(
@@ -285,6 +314,7 @@ describe("removeUnusedCopiedResources", () => {
 
     await Promise.all(removedFiles.map((file) => expectMissing(file)));
     await expectMissing(gitLfs);
+    await expectMissing(cmdScalar);
     for (const file of keptFiles) {
       await expect(fs.readFile(file, "utf8")).resolves.toBe("fixture");
     }

--- a/src/lib/packaging_cleanup.ts
+++ b/src/lib/packaging_cleanup.ts
@@ -36,6 +36,7 @@ const NODE_PTY_ALWAYS_REMOVE_RELATIVE_PATHS = [
   "build/Makefile",
   "build/binding.Makefile",
   "build/config.gypi",
+  "build/deps",
   "build/gyp-mac-tool",
   "build/Release/.deps",
   "build/Release/obj.target",
@@ -58,6 +59,27 @@ const BETTER_SQLITE3_REMOVE_RELATIVE_PATHS = [
   "build/Release/obj",
   "build/Release/sqlite3.a",
 ] as const;
+
+const NATIVE_BUILD_ARTIFACT_EXTENSIONS = new Set([
+  ".exp",
+  ".iobj",
+  ".ipdb",
+  ".lastbuildstate",
+  ".lib",
+  ".obj",
+  ".pdb",
+  ".recipe",
+  ".tlog",
+  ".vcxproj",
+]);
+
+function hasNativeBuildArtifactExtension(name: string): boolean {
+  const lowerName = name.toLowerCase();
+  return (
+    NATIVE_BUILD_ARTIFACT_EXTENSIONS.has(path.extname(lowerName)) ||
+    lowerName.endsWith(".vcxproj.filters")
+  );
+}
 
 async function rmIfExists(absolutePath: string): Promise<void> {
   try {
@@ -133,7 +155,9 @@ async function pruneNodePty(
   await removeFilesMatching(
     nodePtyPath,
     ({ name }) =>
-      name.endsWith(".pdb") || name.endsWith(".map") || name.includes(".test."),
+      hasNativeBuildArtifactExtension(name) ||
+      name.endsWith(".map") ||
+      name.includes(".test."),
   );
 
   const keepPrebuild = NODE_PTY_KEEP_PREBUILDS_BY_TARGET[`${platform}-${arch}`];
@@ -159,6 +183,13 @@ async function pruneBetterSqlite3(betterSqlite3Path: string): Promise<void> {
   await removeRelativePaths(
     betterSqlite3Path,
     BETTER_SQLITE3_REMOVE_RELATIVE_PATHS,
+  );
+
+  await removeFilesMatching(
+    betterSqlite3Path,
+    ({ name }) =>
+      hasNativeBuildArtifactExtension(name) ||
+      name.startsWith("test_extension."),
   );
 }
 
@@ -336,11 +367,15 @@ async function pruneGitCredentialManagerWindows(
 ): Promise<void> {
   await Promise.all(
     WINDOWS_MINGW_SUBFOLDERS.map((subfolder) =>
-      removeFilesMatching(path.join(gitPath, subfolder, "bin"), ({ name }) =>
-        WINDOWS_GCM_FILE_PATTERNS.some((pattern) => pattern.test(name)),
+      removeFilesMatching(
+        path.join(gitPath, subfolder, "bin"),
+        ({ name }) =>
+          name === "scalar.exe" ||
+          WINDOWS_GCM_FILE_PATTERNS.some((pattern) => pattern.test(name)),
       ),
     ),
   );
+  await rmIfExists(path.join(gitPath, "cmd", "scalar.exe"));
 
   // minGit's system gitconfig sets credential.helper=manager; drop the line so
   // git does not warn about (or attempt to launch) the removed helper.


### PR DESCRIPTION
## Summary
- prune native build/debug artifacts from packaged node-pty and better-sqlite3 while preserving runtime binaries
- remove unused Git for Windows scalar executables from copied dugite resources
- extend packaging cleanup tests for the Windows artifact cases

## Verification
- npm test -- src/__tests__/packaging_cleanup.test.ts
- npm run lint
- npm run ts
- npm run build
- npx oxfmt --check src/lib/packaging_cleanup.ts src/__tests__/packaging_cleanup.test.ts

Windows package measurement after build: out/dyad-win32-x64 is ~396.02 MB unpacked, down from the prior ~496.15 MB baseline.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect post-build file pruning in packaged apps; runtime binaries and core Git DLLs are explicitly preserved in tests.
> 
> **Overview**
> Expands **packaging cleanup** so shipped Windows builds drop more build-only weight while keeping runtime native modules and Git binaries.
> 
> **node-pty** and **better-sqlite3** now strip MSVC-style artifacts (`.iobj`, `.ipdb`, `.lib`, `.obj`, `.vcxproj`, etc.) via a shared extension helper; **node-pty** also removes **`build/deps`**. **better-sqlite3** additionally drops **`test_extension.*`** files.
> 
> For bundled **Git on Windows**, **`scalar.exe`** is removed from **`mingw*/bin`** and **`cmd/scalar.exe`**, alongside existing GCM pruning. Tests cover these Windows artifact paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05759aca9cc873e27ffe7415f34ef8ea3b252730. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

