### PR TITLE
fix: refresh uncommitted changes banner immediately when stream ends

### DIFF
--- a/src/hooks/useStreamChat.ts
+++ b/src/hooks/useStreamChat.ts
@@ -504,6 +504,14 @@ export function useStreamChat({
                 refreshApp();
                 refreshVersions();
                 invalidateTokenCount();
+                // Refresh the uncommitted changes banner immediately rather
+                // than waiting for its 5s poll, so it reflects the changes
+                // made by this stream as soon as it ends.
+                queryClient.invalidateQueries({
+                  queryKey: queryKeys.uncommittedFiles.byApp({
+                    appId: targetAppId,
+                  }),
+                });
                 onSettled?.({
                   success: true,
                   pausedByStepLimit: response.pausePromptQueue === true,


### PR DESCRIPTION
The banner relied on a 5s poll in useUncommittedFiles, so after a chat stopped it could take up to ~5 seconds to reflect changes. Invalidate the uncommittedFiles query in the stream onEnd handler, matching the pattern already used after commit/discard.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

