### PR TITLE
fix(lmstudio): list vlm and other generative models, not just llm

### DIFF
--- a/src/ipc/handlers/local_model_lmstudio_handler.test.ts
+++ b/src/ipc/handlers/local_model_lmstudio_handler.test.ts
@@ -1,0 +1,99 @@
+import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
+import { fetchLMStudioModels } from "@/ipc/handlers/local_model_lmstudio_handler";
+import { afterEach, describe, it, expect, vi } from "vitest";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+function stubFetchWith(data: unknown[]) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ data, object: "list" }),
+    }),
+  );
+}
+
+describe("fetchLMStudioModels", () => {
+  it("includes generative models (llm and vlm) and drops embedding models", async () => {
+    // Example response shape taken from LM Studio's /api/v0/models endpoint.
+    stubFetchWith([
+      {
+        id: "google/gemma-4-e4b",
+        object: "model",
+        type: "vlm",
+        publisher: "google",
+        state: "loaded",
+      },
+      {
+        id: "qwen/qwen3-8b",
+        object: "model",
+        type: "llm",
+        publisher: "qwen",
+        state: "loaded",
+      },
+      {
+        id: "text-embedding-nomic-embed-text-v1.5",
+        object: "model",
+        type: "embeddings",
+        publisher: "nomic-ai",
+        state: "not-loaded",
+      },
+    ]);
+
+    const { models } = await fetchLMStudioModels();
+
+    expect(models.map((model) => model.modelName)).toEqual([
+      "google/gemma-4-e4b",
+      "qwen/qwen3-8b",
+    ]);
+    expect(models).toEqual([
+      {
+        modelName: "google/gemma-4-e4b",
+        displayName: "google/gemma-4-e4b",
+        provider: "lmstudio",
+      },
+      {
+        modelName: "qwen/qwen3-8b",
+        displayName: "qwen/qwen3-8b",
+        provider: "lmstudio",
+      },
+    ]);
+  });
+
+  it("also drops the legacy singular 'embedding' type", async () => {
+    stubFetchWith([
+      { id: "chat-model", object: "model", type: "llm", state: "loaded" },
+      {
+        id: "legacy-embedding",
+        object: "model",
+        type: "embedding",
+        state: "loaded",
+      },
+    ]);
+
+    const { models } = await fetchLMStudioModels();
+
+    expect(models.map((model) => model.modelName)).toEqual(["chat-model"]);
+  });
+
+  it("throws an external DyadError when the response is not ok", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        statusText: "Service Unavailable",
+      }),
+    );
+
+    await expect(fetchLMStudioModels()).rejects.toEqual(
+      new DyadError(
+        "Failed to fetch models from LM Studio",
+        DyadErrorKind.External,
+      ),
+    );
+  });
+});

--- a/src/ipc/handlers/local_model_lmstudio_handler.ts
+++ b/src/ipc/handlers/local_model_lmstudio_handler.ts
@@ -7,8 +7,15 @@ import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
 
 const logger = log.scope("lmstudio_handler");
 
+// LM Studio's /api/v0/models endpoint returns both generative models and
+// embedding models. Only generative models can be used for chat, so the
+// embedding types are excluded. Excluding non-chat types (rather than
+// allow-listing "llm") keeps multimodal/vision models such as "vlm" usable
+// and lets future chat-capable types surface without another code change.
+const NON_CHAT_LM_STUDIO_MODEL_TYPES = new Set(["embeddings", "embedding"]);
+
 export interface LMStudioModel {
-  type: "llm" | "embedding" | string;
+  type: "llm" | "vlm" | "embeddings" | string;
   id: string;
   object: string;
   publisher: string;
@@ -33,8 +40,8 @@ export async function fetchLMStudioModels(): Promise<{ models: LocalModel[] }> {
   const modelsJson = await modelsResponse.json();
   const downloadedModels = modelsJson.data as LMStudioModel[];
   const models: LocalModel[] = downloadedModels
-    .filter((model: any) => model.type === "llm")
-    .map((model: any) => ({
+    .filter((model) => !NON_CHAT_LM_STUDIO_MODEL_TYPES.has(model.type))
+    .map((model) => ({
       modelName: model.id,
       displayName: model.id,
       provider: "lmstudio",


### PR DESCRIPTION
## Problem

Fixes #3668.

LM Studio's `/api/v0/models` endpoint reports model `type` as `"llm"`, `"vlm"` (multimodal/vision-capable chat models), or `"embeddings"`. The handler filtered with:

```ts
.filter((model) => model.type === "llm")
```

So any chat model tagged `"vlm"` was dropped. A user whose loaded models are all multimodal ends up with an empty list and this log line:

```
(lmstudio_handler) Successfully fetched 0 models from LM Studio
```

This is the same root cause as the previously reported #3263.

## Solution

Exclude embedding model types instead of allow-listing `"llm"`:

```ts
const NON_CHAT_LM_STUDIO_MODEL_TYPES = new Set(["embeddings", "embedding"]);
...
.filter((model) => !NON_CHAT_LM_STUDIO_MODEL_TYPES.has(model.type))
```

Both `"embeddings"` (current API value) and the legacy singular `"embedding"` (already declared in the `LMStudioModel` type) are excluded. Allow-listing `"llm"` was the bug; blocking only the non-chat (embedding) types keeps `vlm` and any future chat-capable type usable without another code change, while embedding models stay hidden. The `LMStudioModel` `type` union is also updated to match the values the endpoint actually returns.

## Testing

Added `local_model_lmstudio_handler.test.ts` (mirrors the existing Ollama handler test, stubs `fetch`):

- a mixed list of `vlm` + `llm` + `embeddings` returns only the two generative models
- the legacy singular `embedding` type is also dropped
- a non-ok response still throws an external `DyadError`

```
✓ src/ipc/handlers/local_model_lmstudio_handler.test.ts (3 tests)
```

Reverting the filter to `type === "llm"` makes the vlm case fail, confirming the test guards the fix. `oxlint` and `tsgo` type-check are clean on the changed files.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

