### PR TITLE
Restore code when DB snapshot is past Neon retention window

### DIFF
--- a/src/hooks/useCheckoutVersion.ts
+++ b/src/hooks/useCheckoutVersion.ts
@@ -40,7 +40,7 @@ export function useCheckoutVersion() {
         // The code was checked out, but the database snapshot may not have been
         // restored (e.g. the version is older than Neon's retention window).
         if (result?.warningMessage) {
-          toast.warning(result.warningMessage);
+          toast.warning(result.warningMessage, { duration: 8000 });
         }
         // Invalidate queries that depend on the current version/branch
         await queryClient.invalidateQueries({

--- a/src/hooks/useCheckoutVersion.ts
+++ b/src/hooks/useCheckoutVersion.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { ipc } from "@/ipc/types";
+import { ipc, type CheckoutVersionResponse } from "@/ipc/types";
 import { useSetAtom } from "jotai";
+import { toast } from "sonner";
 import { activeCheckoutCounterAtom } from "@/store/appAtoms";
 import { queryKeys } from "@/lib/queryKeys";
 import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
@@ -19,7 +20,7 @@ export function useCheckoutVersion() {
   const { settings } = useSettings();
 
   const { isPending: isCheckingOutVersion, mutateAsync: checkoutVersion } =
-    useMutation<void, Error, CheckoutVersionVariables>({
+    useMutation<CheckoutVersionResponse, Error, CheckoutVersionVariables>({
       mutationFn: async ({ appId, versionId }) => {
         if (appId === null) {
           // Should be caught by UI logic before calling, but as a safeguard.
@@ -30,12 +31,17 @@ export function useCheckoutVersion() {
         }
         setActiveCheckouts((prev) => prev + 1); // Increment counter
         try {
-          await ipc.version.checkoutVersion({ appId, versionId });
+          return await ipc.version.checkoutVersion({ appId, versionId });
         } finally {
           setActiveCheckouts((prev) => prev - 1); // Decrement counter
         }
       },
-      onSuccess: async (_, variables) => {
+      onSuccess: async (result, variables) => {
+        // The code was checked out, but the database snapshot may not have been
+        // restored (e.g. the version is older than Neon's retention window).
+        if (result?.warningMessage) {
+          toast.warning(result.warningMessage);
+        }
         // Invalidate queries that depend on the current version/branch
         await queryClient.invalidateQueries({
           queryKey: queryKeys.branches.current({ appId: variables.appId }),

--- a/src/ipc/handlers/version_handlers.ts
+++ b/src/ipc/handlers/version_handlers.ts
@@ -600,6 +600,18 @@ export function registerVersionHandlers() {
                   "Failed to point Postgres at the development branch after a failed preview restore:",
                   getNeonErrorMessage(fallbackError),
                 );
+                // The fallback failed too, so we could not explicitly re-point
+                // the app at the development branch. The env file is left at its
+                // previous value, which is usually still the development branch
+                // but may be a stale preview branch from an earlier checkout.
+                // Overwrite the warning so the user knows the DB branch is
+                // uncertain (the earlier copy claimed it was left unchanged on
+                // the development database, which we can no longer guarantee).
+                warningMessage =
+                  "Restored your code to this version, but the database could not be " +
+                  "switched and we were unable to confirm which database branch your app " +
+                  `is connected to: ${getNeonErrorMessage(fallbackError)}. Please check ` +
+                  "your app's database connection before relying on its data.";
               }
             }
           }

--- a/src/ipc/handlers/version_handlers.ts
+++ b/src/ipc/handlers/version_handlers.ts
@@ -605,8 +605,7 @@ export function registerVersionHandlers() {
                 // previous value, which is usually still the development branch
                 // but may be a stale preview branch from an earlier checkout.
                 // Overwrite the warning so the user knows the DB branch is
-                // uncertain (the earlier copy claimed it was left unchanged on
-                // the development database, which we can no longer guarantee).
+                // uncertain.
                 warningMessage =
                   "Restored your code to this version, but the database could not be " +
                   "switched and we were unable to confirm which database branch your app " +

--- a/src/ipc/handlers/version_handlers.ts
+++ b/src/ipc/handlers/version_handlers.ts
@@ -28,6 +28,8 @@ import {
 import {
   getNeonClient,
   getNeonErrorMessage,
+  getRetentionWindowFromError,
+  isRetentionWindowError,
 } from "../../neon_admin/neon_management_client";
 import { getConnectionUri } from "../../neon_admin/neon_context";
 import {
@@ -64,6 +66,29 @@ function sanitizeDiffContent(content: string): string {
   return content;
 }
 
+/**
+ * Builds a user-facing warning for when the code was restored but the Neon
+ * database could not be. The retention-window case (the database snapshot is
+ * older than Neon keeps history for, e.g. 6 hours on the free plan) gets a
+ * dedicated explanation since it isn't an unexpected failure.
+ */
+function getDatabaseRestoreWarning(error: unknown): string {
+  if (isRetentionWindowError(error)) {
+    const window = getRetentionWindowFromError(error);
+    return (
+      "Restored your code to this version, but the database could not be restored: " +
+      `this version is older than your database's restore window${
+        window ? ` (${window})` : ""
+      }. ` +
+      "Neon's free plan only keeps a limited window of database history, so this " +
+      "snapshot has expired. Your current database was left unchanged."
+    );
+  }
+  return `Could not restore the database because of an error: ${getNeonErrorMessage(
+    error,
+  )}`;
+}
+
 async function syncCloudSandboxSnapshotBestEffort(appId: number) {
   try {
     await syncCloudSandboxSnapshot({ appId });
@@ -88,21 +113,15 @@ async function restoreBranchForPreview({
   previewBranchId: string;
   developmentBranchId: string;
 }): Promise<void> {
-  try {
-    const neonClient = await getNeonClient();
-    await retryOnLocked(
-      () =>
-        neonClient.restoreProjectBranch(neonProjectId, previewBranchId, {
-          source_branch_id: developmentBranchId,
-          source_timestamp: dbTimestamp,
-        }),
-      `Restore preview branch ${previewBranchId} for app ${appId}`,
-    );
-  } catch (error) {
-    const errorMessage = getNeonErrorMessage(error);
-    logger.error("Error in restoreBranchForPreview:", errorMessage);
-    throw new Error(errorMessage);
-  }
+  const neonClient = await getNeonClient();
+  await retryOnLocked(
+    () =>
+      neonClient.restoreProjectBranch(neonProjectId, previewBranchId, {
+        source_branch_id: developmentBranchId,
+        source_timestamp: dbTimestamp,
+      }),
+    `Restore preview branch ${previewBranchId} for app ${appId}`,
+  );
 }
 
 export function registerVersionHandlers() {
@@ -432,15 +451,19 @@ export function registerVersionHandlers() {
               const errorMessage = getNeonErrorMessage(error);
               logger.error("Error in deleteProjectBranch:", errorMessage);
             }
+            successMessage =
+              "Successfully restored to version (including database)";
           } catch (error) {
-            const errorMessage = getNeonErrorMessage(error);
-            logger.error("Error in restoreBranchForCheckout:", errorMessage);
-            warningMessage = `Could not restore database because of error: ${errorMessage}`;
-            // Do not throw, so we can finish switching the postgres branch
-            // It might throw because they picked a timestamp that's too old.
+            logger.error(
+              "Error restoring Neon development branch during revert:",
+              getNeonErrorMessage(error),
+            );
+            // Do not throw: the code has already been reverted, so we keep the
+            // current database, warn the user, and finish switching the
+            // postgres branch. This commonly happens when the picked version is
+            // older than Neon's retention window.
+            warningMessage = getDatabaseRestoreWarning(error);
           }
-          successMessage =
-            "Successfully restored to version (including database)";
         }
         await switchPostgresToDevelopmentBranch({
           neonProjectId: app.neonProjectId,
@@ -489,6 +512,7 @@ export function registerVersionHandlers() {
   createTypedHandler(versionContracts.checkoutVersion, async (_, params) => {
     const { appId, versionId: gitRef } = params;
     return withLock(appId, async () => {
+      let warningMessage = "";
       const app = await db.query.apps.findFirst({
         where: eq(apps.id, appId),
       });
@@ -529,27 +553,55 @@ export function registerVersionHandlers() {
           });
 
           if (version && version.neonDbTimestamp) {
-            // SWITCH the env var for POSTGRES_URL to the preview branch
-            const connectionUri = await getConnectionUri({
-              projectId: app.neonProjectId,
-              branchId: app.neonPreviewBranchId,
-            });
+            try {
+              // SWITCH the env var for POSTGRES_URL to the preview branch
+              const connectionUri = await getConnectionUri({
+                projectId: app.neonProjectId,
+                branchId: app.neonPreviewBranchId,
+              });
 
-            await restoreBranchForPreview({
-              appId,
-              dbTimestamp: version.neonDbTimestamp,
-              neonProjectId: app.neonProjectId,
-              previewBranchId: app.neonPreviewBranchId,
-              developmentBranchId: app.neonDevelopmentBranchId,
-            });
+              await restoreBranchForPreview({
+                appId,
+                dbTimestamp: version.neonDbTimestamp,
+                neonProjectId: app.neonProjectId,
+                previewBranchId: app.neonPreviewBranchId,
+                developmentBranchId: app.neonDevelopmentBranchId,
+              });
 
-            await updatePostgresUrlEnvVar({
-              appPath: app.path,
-              connectionUri,
-            });
-            logger.info(
-              `Switched Postgres to preview branch for app ${appId} commit ${version.commitHash} dbTimestamp=${version.neonDbTimestamp}`,
-            );
+              await updatePostgresUrlEnvVar({
+                appPath: app.path,
+                connectionUri,
+              });
+              logger.info(
+                `Switched Postgres to preview branch for app ${appId} commit ${version.commitHash} dbTimestamp=${version.neonDbTimestamp}`,
+              );
+            } catch (error) {
+              logger.error(
+                "Error restoring Neon preview branch during checkout:",
+                getNeonErrorMessage(error),
+              );
+              // Do not throw: we still want to check out the code below. This
+              // commonly happens when the picked version is older than Neon's
+              // retention window, so the database snapshot has expired.
+              warningMessage = getDatabaseRestoreWarning(error);
+              // Keep the app pointed at the live development database so the
+              // checked-out code still has a database to run against. This is
+              // best-effort and must never block the code checkout.
+              try {
+                await updatePostgresUrlEnvVar({
+                  appPath: app.path,
+                  connectionUri: await getConnectionUri({
+                    projectId: app.neonProjectId,
+                    branchId: app.neonDevelopmentBranchId,
+                  }),
+                });
+              } catch (fallbackError) {
+                logger.error(
+                  "Failed to point Postgres at the development branch after a failed preview restore:",
+                  getNeonErrorMessage(fallbackError),
+                );
+              }
+            }
           }
         }
       }
@@ -559,6 +611,10 @@ export function registerVersionHandlers() {
         ref: gitRef,
       });
       await syncCloudSandboxSnapshotBestEffort(appId);
+      if (warningMessage) {
+        return { warningMessage };
+      }
+      return {};
     });
   });
 }

--- a/src/ipc/types/index.ts
+++ b/src/ipc/types/index.ts
@@ -248,6 +248,7 @@ export type {
   RevertVersionParams,
   RevertVersionResponse,
   VersionChangedFile,
+  CheckoutVersionResponse,
 } from "./version";
 
 // Language model types

--- a/src/ipc/types/version.ts
+++ b/src/ipc/types/version.ts
@@ -72,6 +72,14 @@ export const GetVersionChangesParamsSchema = z.object({
     .regex(/^[0-9a-fA-F]{4,64}$/, "versionId must be a hex commit SHA"),
 });
 
+export const CheckoutVersionResponseSchema = z.object({
+  warningMessage: z.string().optional(),
+});
+
+export type CheckoutVersionResponse = z.infer<
+  typeof CheckoutVersionResponseSchema
+>;
+
 // =============================================================================
 // Version Contracts
 // =============================================================================
@@ -92,7 +100,7 @@ export const versionContracts = {
   checkoutVersion: defineContract({
     channel: "checkout-version",
     input: CheckoutVersionParamsSchema,
-    output: z.void(),
+    output: CheckoutVersionResponseSchema,
   }),
 
   getVersionChanges: defineContract({

--- a/src/neon_admin/neon_errors.test.ts
+++ b/src/neon_admin/neon_errors.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+  getNeonErrorMessage,
+  getRetentionWindowFromError,
+  isRetentionWindowError,
+} from "./neon_errors";
+
+// Mimics the shape of an axios error thrown by the Neon API client.
+function neonApiError({
+  message,
+  detail,
+}: {
+  message: string;
+  detail: string;
+}) {
+  return Object.assign(new Error(message), {
+    response: { status: 400, data: { message: detail } },
+  });
+}
+
+const RETENTION_ERROR = neonApiError({
+  message: "Request failed with status code 400",
+  detail:
+    'timestamp is before retention window; timestamp:"2026-06-04 00:25:59 +0000 UTC", retention_window:"6h0m0s"',
+});
+
+describe("getNeonErrorMessage", () => {
+  it("combines the error message with the API detail message", () => {
+    expect(getNeonErrorMessage(RETENTION_ERROR)).toBe(
+      'Request failed with status code 400 timestamp is before retention window; timestamp:"2026-06-04 00:25:59 +0000 UTC", retention_window:"6h0m0s"',
+    );
+  });
+
+  it("falls back to the plain error message", () => {
+    expect(getNeonErrorMessage(new Error("boom"))).toBe("boom");
+  });
+
+  it("handles nullish and string inputs", () => {
+    expect(getNeonErrorMessage(null)).toBe("Unknown Neon error");
+    expect(getNeonErrorMessage("plain string error")).toBe(
+      "plain string error",
+    );
+  });
+});
+
+describe("isRetentionWindowError", () => {
+  it("detects the retention-window error", () => {
+    expect(isRetentionWindowError(RETENTION_ERROR)).toBe(true);
+  });
+
+  it("detects it even when only the message string is present", () => {
+    expect(
+      isRetentionWindowError(
+        new Error(
+          'timestamp is before retention window; retention_window:"6h"',
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false for unrelated errors", () => {
+    expect(isRetentionWindowError(new Error("branch is locked"))).toBe(false);
+    expect(isRetentionWindowError(null)).toBe(false);
+  });
+});
+
+describe("getRetentionWindowFromError", () => {
+  it("formats a Go-style duration into human-readable text", () => {
+    expect(getRetentionWindowFromError(RETENTION_ERROR)).toBe("6 hours");
+  });
+
+  it("formats compound durations and singular units", () => {
+    expect(
+      getRetentionWindowFromError(
+        new Error('retention window exceeded; retention_window:"1h30m1s"'),
+      ),
+    ).toBe("1 hour 30 minutes 1 second");
+  });
+
+  it("returns null when there is no retention window in the message", () => {
+    expect(getRetentionWindowFromError(new Error("some other error"))).toBe(
+      null,
+    );
+  });
+});

--- a/src/neon_admin/neon_errors.ts
+++ b/src/neon_admin/neon_errors.ts
@@ -1,0 +1,101 @@
+/**
+ * Pure helpers for interpreting errors returned by the Neon management API.
+ *
+ * Kept dependency-free (no electron / settings imports) so the parsing logic
+ * can be unit-tested in isolation and reused without pulling in the full
+ * management client.
+ */
+
+export function getNeonErrorMessage(error: unknown): string {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === "object" &&
+          error !== null &&
+          "message" in error &&
+          typeof error.message === "string"
+        ? error.message
+        : null;
+  const detailedMessage =
+    typeof error === "object" &&
+    error !== null &&
+    "response" in error &&
+    typeof error.response === "object" &&
+    error.response !== null &&
+    "data" in error.response &&
+    typeof error.response.data === "object" &&
+    error.response.data !== null &&
+    "message" in error.response.data &&
+    typeof error.response.data.message === "string"
+      ? error.response.data.message
+      : null;
+
+  if (message && detailedMessage) {
+    return `${message} ${detailedMessage}`;
+  }
+  if (message) {
+    return message;
+  }
+  if (typeof error === "string" && error.trim()) {
+    return error;
+  }
+  if (error == null) {
+    return "Unknown Neon error";
+  }
+
+  try {
+    const serializedError = JSON.stringify(error);
+    return serializedError && serializedError !== "{}"
+      ? serializedError
+      : "Unknown Neon error";
+  } catch {
+    return String(error);
+  }
+}
+
+/**
+ * Returns true when the error is Neon's "timestamp is before retention window"
+ * error. This happens when restoring a branch to a point in time that is older
+ * than the project's history retention window (e.g. 6 hours on the free plan),
+ * so the requested database snapshot can no longer be recovered.
+ */
+export function isRetentionWindowError(error: unknown): boolean {
+  return getNeonErrorMessage(error).toLowerCase().includes("retention window");
+}
+
+/**
+ * Extracts the retention window from a Neon retention-window error and formats
+ * it for display (e.g. `6h0m0s` -> `6 hours`). Returns null when it can't be
+ * parsed out of the error message.
+ */
+export function getRetentionWindowFromError(error: unknown): string | null {
+  const match = getNeonErrorMessage(error).match(/retention_window:"([^"]+)"/);
+  if (!match) {
+    return null;
+  }
+  return formatGoDuration(match[1]) ?? match[1];
+}
+
+/**
+ * Formats a Go-style duration string (e.g. `6h0m0s`) into human-readable text
+ * (e.g. `6 hours`). Returns null if the input isn't a recognizable duration.
+ */
+function formatGoDuration(raw: string): string | null {
+  const match = raw.match(/^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/);
+  if (!match) {
+    return null;
+  }
+  const parts: string[] = [];
+  const units: [string | undefined, string][] = [
+    [match[1], "hour"],
+    [match[2], "minute"],
+    [match[3], "second"],
+  ];
+  for (const [value, unit] of units) {
+    const amount = value ? parseInt(value, 10) : 0;
+    if (amount > 0) {
+      parts.push(`${amount} ${unit}${amount === 1 ? "" : "s"}`);
+    }
+  }
+  return parts.length > 0 ? parts.join(" ") : null;
+}

--- a/src/neon_admin/neon_management_client.ts
+++ b/src/neon_admin/neon_management_client.ts
@@ -4,6 +4,7 @@ import { Api, createApiClient } from "@neondatabase/api-client";
 import log from "electron-log";
 import { IS_TEST_BUILD } from "../ipc/utils/test_utils";
 import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
+import { getNeonErrorMessage } from "./neon_errors";
 
 const logger = log.scope("neon_management_client");
 
@@ -414,52 +415,14 @@ export async function getNeonOrganizationId(): Promise<string> {
   }
 }
 
-export function getNeonErrorMessage(error: unknown): string {
-  const message =
-    error instanceof Error
-      ? error.message
-      : typeof error === "object" &&
-          error !== null &&
-          "message" in error &&
-          typeof error.message === "string"
-        ? error.message
-        : null;
-  const detailedMessage =
-    typeof error === "object" &&
-    error !== null &&
-    "response" in error &&
-    typeof error.response === "object" &&
-    error.response !== null &&
-    "data" in error.response &&
-    typeof error.response.data === "object" &&
-    error.response.data !== null &&
-    "message" in error.response.data &&
-    typeof error.response.data.message === "string"
-      ? error.response.data.message
-      : null;
-
-  if (message && detailedMessage) {
-    return `${message} ${detailedMessage}`;
-  }
-  if (message) {
-    return message;
-  }
-  if (typeof error === "string" && error.trim()) {
-    return error;
-  }
-  if (error == null) {
-    return "Unknown Neon error";
-  }
-
-  try {
-    const serializedError = JSON.stringify(error);
-    return serializedError && serializedError !== "{}"
-      ? serializedError
-      : "Unknown Neon error";
-  } catch {
-    return String(error);
-  }
-}
+// Pure error-parsing helpers live in ./neon_errors so they can be unit-tested
+// without importing the full management client. Re-exported here so existing
+// importers of neon_management_client keep working unchanged.
+export {
+  getNeonErrorMessage,
+  isRetentionWindowError,
+  getRetentionWindowFromError,
+} from "./neon_errors";
 
 const DEFAULT_EMAIL_PASSWORD_CONFIG = {
   enabled: false,


### PR DESCRIPTION
Reverting/checking out a version whose Neon DB snapshot is older than the retention window (6h on the free plan) made restoreProjectBranch return a 400. Checkout re-threw that error before running gitCheckout, so the whole operation failed and the code was never restored.

Now both revert and checkout always restore the code, leave the live database in place, and surface a clear warning explaining the snapshot has expired. Pure Neon error helpers are extracted into neon_errors.ts (with unit tests) so the retention-window case can be detected and the window formatted (e.g. 6h0m0s -> 6 hours).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

