### PR TITLE
feat(agent): list MCP tool names in search mode

### DIFF
--- a/e2e-tests/fixtures/engine/local-agent/get-mcp-tool-schema.ts
+++ b/e2e-tests/fixtures/engine/local-agent/get-mcp-tool-schema.ts
@@ -1,0 +1,19 @@
+import type { LocalAgentFixture } from "../../../../testing/fake-llm-server/localAgentTypes";
+
+export const fixture: LocalAgentFixture = {
+  description: "Fetch an MCP tool's signature with get_mcp_tool_schema",
+  turns: [
+    {
+      text: "Let me get the schema for the calculator_add MCP tool.",
+      toolCalls: [
+        {
+          name: "get_mcp_tool_schema",
+          args: { tools: ["calculator_add"] },
+        },
+      ],
+    },
+    {
+      text: "I have the calculator_add signature and can now call it.",
+    },
+  ],
+};

--- a/e2e-tests/local_agent_advanced.spec.ts
+++ b/e2e-tests/local_agent_advanced.spec.ts
@@ -139,6 +139,12 @@ testSkipIfWindows("local-agent - mcp tool search", async ({ po }) => {
   await expect(po.page.getByText("add numbers").first()).toBeVisible();
 
   await po.snapshotMessages();
+
+  // Capture the request payload so the search-mode prompt (tool name inventory
+  // + get_mcp_tool_schema / search_mcp_tools wording) is covered, not just the
+  // rendered card.
+  await po.sendPrompt("[dump] add two numbers");
+  await po.snapshotServerDump("request");
 });
 
 /**

--- a/e2e-tests/local_agent_advanced.spec.ts
+++ b/e2e-tests/local_agent_advanced.spec.ts
@@ -142,6 +142,53 @@ testSkipIfWindows("local-agent - mcp tool search", async ({ po }) => {
 });
 
 /**
+ * Test for get_mcp_tool_schema: in search mode the model sees tools listed by
+ * name, then fetches a tool's signature with get_mcp_tool_schema before
+ * calling it. Registered behind the same "Enable MCP tool search" flag.
+ */
+testSkipIfWindows("local-agent - get mcp tool schema", async ({ po }) => {
+  await po.setUpDyadPro({ localAgent: true });
+  await po.navigation.goToSettingsTab();
+
+  // Configure the test MCP server.
+  await po.page.getByRole("button", { name: "Tools (MCP)" }).click();
+  await po.page
+    .getByRole("textbox", { name: "My MCP Server" })
+    .fill("testing-mcp-server");
+  await po.page.getByRole("textbox", { name: "node" }).fill("node");
+  const testMcpServerPath = path.join(
+    __dirname,
+    "..",
+    "testing",
+    "fake-stdio-mcp-server.mjs",
+  );
+  await po.page
+    .getByRole("textbox", { name: "path/to/mcp-server.js --flag" })
+    .fill(testMcpServerPath);
+  await po.page.getByRole("button", { name: "Add Server" }).click();
+  await po.settings.waitForMcpTool("testing-mcp-server", "calculator_add");
+
+  // Same flag that lists tool names and registers get_mcp_tool_schema.
+  await po.page.getByRole("switch", { name: "Enable MCP tool search" }).click();
+
+  await po.navigation.goToAppsTab();
+  await po.importApp("minimal");
+  await po.chatActions.selectLocalAgentMode();
+
+  // The model fetches a listed tool's signature; get_mcp_tool_schema auto-approves.
+  await po.sendPrompt("tc=local-agent/get-mcp-tool-schema", {
+    skipWaitForCompletion: true,
+  });
+  await po.chatActions.waitForChatCompletion();
+
+  // The schema card renders with the tool name the model requested.
+  await expect(po.page.getByText("MCP Tool Schema").first()).toBeVisible();
+  await expect(po.page.getByText("calculator_add").first()).toBeVisible();
+
+  await po.snapshotMessages();
+});
+
+/**
  * Test for enable_nitro tool in local-agent mode on a Vite app.
  */
 testSkipIfWindows("local-agent - enable nitro", async ({ po }) => {

--- a/e2e-tests/snapshots/local_agent_advanced.spec.ts_local-agent---get-mcp-tool-schema-1.aria.yml
+++ b/e2e-tests/snapshots/local_agent_advanced.spec.ts_local-agent---get-mcp-tool-schema-1.aria.yml
@@ -1,0 +1,14 @@
+- paragraph: "[[AI_RULES_GENERATION_PROMPT]]"
+- button "file1.txt file1.txt Edit"
+- paragraph: More EOM
+- button "Copy"
+- text: "[[Version 2: files changed]]"
+- button "Copy Request ID"
+- paragraph: tc=local-agent/get-mcp-tool-schema
+- paragraph: Let me get the schema for the calculator_add MCP tool.
+- button "MCP Tool Schema calculator_add"
+- paragraph: I have the calculator_add signature and can now call it.
+- button "Copy"
+- button "Copy Request ID"
+- button "Undo"
+- button "Retry"

--- a/e2e-tests/snapshots/local_agent_advanced.spec.ts_local-agent---mcp-tool-search-1.txt
+++ b/e2e-tests/snapshots/local_agent_advanced.spec.ts_local-agent---mcp-tool-search-1.txt
@@ -1,0 +1,826 @@
+{
+  "body": {
+    "model": "anthropic/claude-opus-4-5",
+    "max_tokens": 32000,
+    "thinking": {
+      "type": "adaptive",
+      "display": "summarized"
+    },
+    "output_config": {
+      "effort": "medium"
+    },
+    "system": [
+      {
+        "type": "text",
+        "text": "[[SYSTEM_MESSAGE]]"
+      }
+    ],
+    "messages": [
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "text",
+            "text": "Generate an AI_RULES.md file for this app. Describe the tech stack in 5-10 bullet points and describe clear rules about what libraries to use for what."
+          }
+        ]
+      },
+      {
+        "role": "assistant",
+        "content": [
+          {
+            "type": "text",
+            "text": "\n  <dyad-write path=\"file1.txt\">\n  A file (2)\n  </dyad-write>\n  More\n  EOM"
+          }
+        ]
+      },
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "text",
+            "text": "tc=local-agent/mcp-tool-search"
+          }
+        ]
+      },
+      {
+        "role": "assistant",
+        "content": [
+          {
+            "type": "text",
+            "text": "Let me find an MCP tool for adding numbers."
+          },
+          {
+            "type": "tool_use",
+            "id": "[[TOOL_CALL_0]]",
+            "name": "search_mcp_tools",
+            "input": {
+              "query": "add numbers"
+            }
+          }
+        ]
+      },
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "tool_result",
+            "tool_use_id": "[[TOOL_CALL_0]]",
+            "content": "{\"type\":\"text\",\"value\":\"Top 1 MCP tool(s) for \\\"add numbers\\\". Call these as host functions inside execute_sandbox_script:\\n\\ntype McpResult = {\\n  content: Array<\\n    | { type: \\\"text\\\"; text: string }\\n    | { type: \\\"image\\\"; data: string; mimeType: string }\\n    | { type: \\\"resource\\\"; resource: unknown }\\n  >;\\n  isError?: boolean;\\n};\\n\\n// ---- Server: testing-mcp-server ----\\n/** Add two numbers and return the sum */\\ndeclare function testing_mcp_server__calculator_add(args: {\\n  a: number;\\n  b: number;\\n}): Promise<McpResult>;\\n\"}"
+          }
+        ]
+      },
+      {
+        "role": "assistant",
+        "content": [
+          {
+            "type": "text",
+            "text": "I found the calculator_add MCP tool for adding two numbers."
+          }
+        ]
+      },
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "text",
+            "text": "[dump] add two numbers"
+          }
+        ]
+      }
+    ],
+    "tools": [
+      {
+        "name": "write_file",
+        "description": "Create or completely overwrite a file in the codebase",
+        "input_schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "string",
+              "description": "The file path relative to the app root"
+            },
+            "content": {
+              "type": "string",
+              "description": "The content to write to the file"
+            },
+            "description": {
+              "description": "Brief description of the change",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "content"
+          ],
+          "additionalProperties": false
+        },
+        "eager_input_streaming": true
+      },
+      {
+        "name": "search_replace",
+        "description": "Use this tool to propose a search and replace operation on an existing file.\n\nThe tool will replace ONE occurrence of old_string with new_string in the specified file.\n\nCRITICAL REQUIREMENTS FOR USING THIS TOOL:\n\n1. UNIQUENESS: The old_string MUST uniquely identify the specific instance you want to change. This means:\n   - Include AT LEAST 3-5 lines of context BEFORE the change point\n   - Include AT LEAST 3-5 lines of context AFTER the change point\n   - Include all whitespace, indentation, and surrounding code exactly as it appears in the file\n\n2. SINGLE INSTANCE: This tool can only change ONE instance at a time. If you need to change multiple instances:\n   - Make separate calls to this tool for each instance\n   - Each call must uniquely identify its specific instance using extensive context\n\n3. VERIFICATION: Before using this tool:\n   - If multiple instances exist, gather enough context to uniquely identify each one\n   - Plan separate tool calls for each instance\n",
+        "input_schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "properties": {
+            "file_path": {
+              "type": "string",
+              "description": "The path to the file you want to search and replace in."
+            },
+            "old_string": {
+              "type": "string",
+              "description": "The text to replace (must be unique within the file, and must match the file contents exactly, including all whitespace and indentation)"
+            },
+            "new_string": {
+              "type": "string",
+              "description": "The edited text to replace the old_string (must be different from the old_string)"
+            }
+          },
+          "required": [
+            "file_path",
+            "old_string",
+            "new_string"
+          ],
+          "additionalProperties": false
+        },
+        "eager_input_streaming": true
+      },
+      {
+        "name": "copy_file",
+        "description": "Copy a file from one location to another. Can copy uploaded attachment files (attachments:<name> or .dyad/media paths) into the codebase, or copy files within the codebase.",
+        "input_schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "properties": {
+            "from": {
+              "type": "string",
+              "description": "The source file path (can be attachments:<name>, a .dyad/media path, or a path relative to the app root)"
+            },
+            "to": {
+              "type": "string",
+              "description": "The destination file path relative to the app root"
+            },
+            "description": {
+              "description": "Brief description of why the file is being copied",
+              "type": "string"
+            }
+          },
+          "required": [
+            "from",
+            "to"
+          ],
+          "additionalProperties": false
+        },
+        "eager_input_streaming": true
+      },
+      {
+        "name": "delete_file",
+        "description": "Delete a file from the codebase",
+        "input_schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "string",
+              "description": "The file path to delete"
+            }
+          },
+          "required": [
+            "path"
+          ],
+          "additionalProperties": false
+        },
+        "eager_input_streaming": true
+      },
+      {
+        "name": "rename_file",
+        "description": "Rename or move a file in the codebase",
+        "input_schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "properties": {
+            "from": {
+              "type": "string",
+              "description": "The current file path"
+            },
+            "to": {
+              "type": "string",
+              "description": "The new file path"
+            }
+          },
+          "required": [
+            "from",
+            "to"
+          ],
+          "additionalProperties": false
+        },
+        "eager_input_streaming": true
+      },
+      {
+        "name": "add_dependency",
+        "description": "Install npm packages",
+        "input_schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "properties": {
+            "packages": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Array of package names to install"
+            }
+          },
+          "required": [
+            "packages"
+          ],
+          "additionalProperties": false
+        },
+        "eager_input_streaming": true
+      },
+      {
+        "name": "read_file",
+        "description": "Read the content of a file from the codebase or an attachment path such as attachments:notes.txt.\n  \n- You have the capability to call multiple tools in a single response. It is always better to speculatively read multiple files as a batch that are potentially useful.",
+        "input_schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "string",
+              "description": "The file path to read"
+            },
+            "app_name": {
+              "description": "Optional. Name of a referenced app (from `@app:Name` mentions in the user's prompt) to read from instead of the current app. Omit to read from the current app.",
+              "type": "string"
+            },
+            "start_line_one_indexed": {
+              "description": "The one-indexed line number to start reading from (inclusive).",
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 9007199254740991
+            },
+            "end_line_one_indexed_inclusive": {
+              "description": "The one-indexed line number to end reading at (inclusive).",
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 9007199254740991
+            }
+          },
+          "required": [
+            "path"
+          ],
+          "additionalProperties": false
+        },
+        "eager_input_streaming": true
+      },
+      {
+        "name": "list_files",
+        "description": "List files in the application directory. By default, lists only the immediate directory contents. Use recursive=true to list all files recursively. Use include_ignored=true to include git-ignored and hidden paths; recursive ignored listings require directory to be set. Results are capped at 1000 paths.",
+        "input_schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "properties": {
+            "directory": {
+              "description": "Optional subdirectory to list",
+              "type": "string"
+            },
+            "app_name": {
+              "description": "Optional. Name of a referenced app (from `@app:Name` mentions in the user's prompt) to list from instead of the current app. Omit to list the current app.",
+              "type": "string"
+            },
+            "recursive": {
+              "description": "Whether to list files recursively (default: false)",
+              "type": "boolean"
+            },
+            "include_ignored": {
+              "description": "Whether to include git-ignored and hidden files/directories such as node_modules (default: false).",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        "eager_input_streaming": true
+      },
+      {
+        "name": "grep",
+        "description": "Search for a regex pattern or exact literal text in the codebase using ripgrep.\n\n- Returns matching lines with file paths and line numbers\n- By default, the search is case-insensitive\n- Use literal=true for exact symbols/snippets with punctuation, e.g. createBooking({, import strings, route paths, or JSX tags\n- Use include_pattern to filter by file type (e.g. '*.tsx')\n- Use exclude_pattern to skip certain files (e.g. '*.test.ts')\n- Use include_ignored=true to search git-ignored and hidden files/directories such as node_modules. Pair it with include_pattern to keep searches scoped.\n- Results are limited to 100 matches by default (max 250). If results are truncated, narrow your search with include_pattern or a more specific query.",
+        "input_schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "The regex pattern to search for, or the exact text when literal is true"
+            },
+            "app_name": {
+              "description": "Optional. Name of a referenced app (from `@app:Name` mentions in the user's prompt) to search in instead of the current app. Omit to search the current app.",
+              "type": "string"
+            },
+            "include_pattern": {
+              "description": "Glob pattern for files to include (e.g. '*.ts' for TypeScript files)",
+              "type": "string"
+            },
+            "exclude_pattern": {
+              "description": "Glob pattern for files to exclude",
+              "type": "string"
+            },
+            "include_ignored": {
+              "description": "Whether to include git-ignored and hidden files/directories such as node_modules (default: false). Use include_pattern to keep this scoped.",
+              "type": "boolean"
+            },
+            "case_sensitive": {
+              "description": "Whether the search should be case sensitive (default: false)",
+              "type": "boolean"
+            },
+            "literal": {
+              "description": "Search query as exact text instead of a regex. Use this for symbols or snippets containing punctuation such as createBooking({, route paths, JSX tags, or import strings.",
+              "type": "boolean"
+            },
+            "limit": {
+              "description": "Maximum number of matches to return (default: 100, max: 250). Use include_pattern to narrow results if limit is reached.",
+              "type": "number",
+              "minimum": 1,
+              "maximum": 250
+            }
+          },
+          "required": [
+            "query"
+          ],
+          "additionalProperties": false
+        },
+        "eager_input_streaming": true
+      },
+      {
+        "name": "explore_code",
+        "description": "Ask a code reconnaissance sub-agent to explore code included in a configured TypeScript project.\n\nUse this when you need to understand how a TypeScript, TSX, JavaScript, or JSX feature, symbol, type, component, service, or flow is implemented across files. It returns a compact report: a Flow of file/line ranges with quoted evidence, optional Read targets and Search targets, a Confidence, and an Action. Treat a high- or medium-confidence report as the codebase map and follow its Action rather than rediscovering the code.\n\nSet the intent argument to what you will do with the result: explain for \"trace how\", data-flow, request-flow, or \"how is this computed/surfaced\" questions; locate for finding the best files/symbols; edit or debug when you will read exact ranges before changing code or verifying behavior.\n\nFollow the report's Action:\n\n| Action | Do next | Do NOT |\n|--------|---------|--------|\n| answer_from_report | Answer or plan directly from the report. | Re-read discovery files, grep, or call explore_code again. |\n| read_targets | explain/locate: answer from the report, citing the listed targets as jump points. edit/debug: read only the listed tight ranges before changing or verifying code. | Read targets just to confirm the map for explain/locate (unless confidence is low or the user asked for edits/debugging/exact verification). |\n| targeted_gap_search | Run only the rendered Search targets with their exact terms/scopes, then answer from the report plus those results and name any remaining gap. | Invent broader searches, open arbitrary hits, or call explore_code again. |\n| skip_explore_result | Proceed without the report; nothing relevant was found. | Treat it as a map. |\n\nIf confidence is low, inspect the listed read/search targets before relying on the report. If an Action calls for Search targets but none are rendered, answer from the observed Flow and name the remaining gap. Do not call explore_code repeatedly for the same investigation after a high- or medium-confidence report.\n\nOnly use this for files included in the app's TypeScript config. JavaScript and JSX require TypeScript config support such as allowJs. If the project does not have TypeScript installed and configured, use grep/list_files/read_file instead.",
+        "input_schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Natural-language code exploration query"
+            },
+            "app_name": {
+              "description": "Optional. Name of a referenced app (from `@app:Name` mentions in the user's prompt) to explore instead of the current app. Omit to explore the current app.",
+              "type": "string"
+            },
+            "tsconfig_path": {
+              "description": "Optional app-relative path to a TypeScript config file. Omit to use tsconfig.app.json or tsconfig.json.",
+              "type": "string"
+            },
+            "max_files": {
+              "description": "Maximum number of relevant files to return (default: 5, max: 8).",
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 8
+            },
+            "max_depth": {
+              "description": "Graph expansion depth from matching symbols (default: 2, max: 3).",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 3
+            },
+            "intent": {
+              "type": "string",
+              "enum": [
+                "explain",
+                "locate",
+                "edit",
+                "debug"
+              ],
+              "description": "Required. What the result will be used for. Use explain/locate when you will answer or point at code from the map. Use edit/debug when exact ranges will be read before changing code or verifying behavior."
+            }
+          },
+          "required": [
+            "query",
+            "intent"
+          ],
+          "additionalProperties": false
+        },
+        "eager_input_streaming": true
+      },
+      {
+        "name": "set_chat_summary",
+        "description": "Set the title/summary for this chat. Call this tool exactly once early in the turn, as soon as you understand the user's request well enough to write a short title. Do not wait until the end of the turn.",
+        "input_schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "properties": {
+            "summary": {
+              "type": "string",
+              "description": "A short summary/title for the chat"
+            }
+          },
+          "required": [
+            "summary"
+          ],
+          "additionalProperties": false
+        },
+        "eager_input_streaming": true
+      },
+      {
+        "name": "add_integration",
+        "description": "Prompt the user to choose and set up a database provider for the app. Do NOT set the provider parameter unless the user explicitly names a specific provider (e.g. 'Supabase' or 'Neon') in their message. The tool blocks until the user finishes the setup inside the chat and clicks Continue, then returns; you should then proceed with the next step.",
+        "input_schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "properties": {
+            "provider": {
+              "description": "Optional preferred database provider. Use 'none' (or omit) if the user did not explicitly name a provider. Only use 'supabase' or 'neon' if the user specifically mentions that provider name in their prompt.",
+              "type": "string",
+              "enum": [
+                "none",
+                "supabase",
+                "neon"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "eager_input_streaming": true
+      },
+      {
+        "name": "enable_nitro",
+        "description": "Add a Nitro server layer to this Vite app so it can run secure server-side code\n(API routes, database clients, secrets, webhooks).\n\nWHEN TO CALL: Before writing any code under server/, before referencing DATABASE_URL\nor any server-only env var, or when the user asks for an API route, webhook, or\nserver-side compute. Skip for client-side fetch with public/anon keys, for use\ncases fully covered by Supabase (anon key + RLS), or when the user explicitly\nsays \"static only\" / \"no backend\".\n\nDATABASE REQUESTS: If the user is asking for a database (or anything that needs\none — auth, persistence, CRUD, etc.) and no provider is set up yet, call\n`add_integration` FIRST and stop. Do NOT call `enable_nitro` in the same turn\n— the user must pick their provider first. Supabase makes Nitro unnecessary.\nNeon automatically sets up the Nitro server layer as part of its integration\nflow, so do NOT call `enable_nitro` after a Neon integration either — Nitro\nwill already be in place when the integration completes. Only call\n`enable_nitro` for non-database server-side needs (API routes, webhooks,\nserver-only secrets) when no provider is involved.",
+        "input_schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "properties": {
+            "reason": {
+              "type": "string",
+              "description": "One sentence explaining why server-side code is needed for this prompt."
+            }
+          },
+          "required": [
+            "reason"
+          ],
+          "additionalProperties": false
+        },
+        "eager_input_streaming": true
+      },
+      {
+        "name": "read_logs",
+        "description": "Read logs at the moment this tool is called. Includes client logs, server logs, edge function logs, and network requests. Use this to debug errors, investigate issues, or understand app behavior. IMPORTANT: Logs are a snapshot from when you call this tool - they will NOT update while you are writing code or making changes. Use filters (searchTerm, type, level) to narrow down relevant logs on the first call.",
+        "input_schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "properties": {
+            "type": {
+              "description": "Filter by log source type (default: all). Types: 'client' = browser console logs; 'server' = backend (including development server) logs and build output; 'edge-function' = edge function logs; 'network-requests' = HTTP requests and responses (outgoing calls and their responses).",
+              "type": "string",
+              "enum": [
+                "all",
+                "client",
+                "server",
+                "edge-function",
+                "network-requests"
+              ]
+            },
+            "level": {
+              "description": "Filter by log level (default: all)",
+              "type": "string",
+              "enum": [
+                "all",
+                "info",
+                "warn",
+                "error"
+              ]
+            },
+            "searchTerm": {
+              "description": "Search for logs containing this text (case-insensitive)",
+              "type": "string"
+            },
+            "limit": {
+              "description": "Maximum number of logs to return (default: 50, max: 200)",
+              "type": "number",
+              "minimum": 1,
+              "maximum": 200
+            }
+          },
+          "additionalProperties": false
+        },
+        "eager_input_streaming": true
+      },
+      {
+        "name": "web_search",
+        "description": "\nUse this tool to access real-time information beyond your training data cutoff.\n\nWhen to Search:\n- Current API documentation, library versions, or breaking changes\n- Latest best practices, security advisories, or bug fixes\n- Specific error messages or troubleshooting solutions\n- Recent framework updates or deprecation notices\n\nQuery Tips:\n- Be specific: Include version numbers, exact error messages, or technical terms\n- Add context: \"React 19 useEffect cleanup\" not just \"React hooks\"\n\nExamples:\n\n<example>\nOpenAI GPT-5 API model names\n</example>\n\n<example>\nNextJS 14 app router middleware auth\n</example>\n",
+        "input_schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "The search query to look up on the web"
+            }
+          },
+          "required": [
+            "query"
+          ],
+          "additionalProperties": false
+        },
+        "eager_input_streaming": true
+      },
+      {
+        "name": "web_crawl",
+        "description": "\nYou can crawl a website so you can clone it.\n\n### When You MUST Trigger a Crawl\nTrigger a crawl ONLY if BOTH conditions are true:\n\n1. The user's message shows intent to CLONE / COPY / REPLICATE / RECREATE / DUPLICATE / MIMIC a website.\n   - Keywords include: clone, copy, replicate, recreate, duplicate, mimic, build the same, make the same.\n\n2. The user's message contains a URL or something that appears to be a domain name.\n   - e.g. \"example.com\", \"https://example.com\"\n   - Do not require 'http://' or 'https://'.\n",
+        "input_schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "properties": {
+            "url": {
+              "type": "string",
+              "description": "URL to crawl"
+            }
+          },
+          "required": [
+            "url"
+          ],
+          "additionalProperties": false
+        },
+        "eager_input_streaming": true
+      },
+      {
+        "name": "web_fetch",
+        "description": "Fetch and read the content of a web page as markdown given its URL.\n\n### When to Use This Tool\nUse this tool when the user's message contains a URL (or domain name) and they want to:\n- **Read** the page's content (e.g. documentation, blog post, article)\n- **Reference** information from the page (e.g. API docs, tutorials, guides)\n- **Extract** data or context from a live web page to inform their code\n- **Follow a link** someone shared to understand its contents\n\nExamples:\n- \"Use the docs at docs.example.com/api to set up the client\"\n- \"What does this page say? https://example.com/blog/post\"\n- \"Follow the guide at example.com/tutorial\"\n\n### When NOT to Use This Tool\n- The user wants to **visually clone or replicate** a website → use `web_crawl` instead\n- The user needs to **search the web** for information without a specific URL → use `web_search` instead\n",
+        "input_schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "properties": {
+            "url": {
+              "type": "string",
+              "description": "URL to fetch content from"
+            }
+          },
+          "required": [
+            "url"
+          ],
+          "additionalProperties": false
+        },
+        "eager_input_streaming": true
+      },
+      {
+        "name": "generate_image",
+        "description": "Generate an image using AI based on a text prompt. The generated image is saved to the project's .dyad/media directory.\n\n### When to Use\n- User requests a custom image, illustration, icon, or graphic for their app\n- User wants a hero image, background, banner, or visual asset\n- Creating images that are more visually relevant than placeholder rectangles\n\n### Prompt Guidelines\nWrite detailed, descriptive prompts. Be specific about:\n- **Subject**: What is in the image (objects, people, scenes)\n- **Style**: Photography, illustration, flat design, 3D render, watercolor, etc.\n- **Composition**: Layout, perspective, framing\n- **Colors**: Specific color palette or mood\n- **Mood**: Cheerful, professional, dramatic, minimal, etc.\n\n### Examples\n- \"A modern flat illustration of a team collaborating around a laptop, using a blue and purple color palette, clean minimal style with subtle gradients, white background\"\n- \"Professional product photography of a sleek smartphone on a marble surface, soft studio lighting, shallow depth of field, warm neutral tones\"\n\n### After Generation\nThe tool returns the file path in .dyad/media. Use the copy_file tool to copy it to the appropriate location in the project (e.g., public/assets/) and reference that path in your code.\n",
+        "input_schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "properties": {
+            "prompt": {
+              "type": "string",
+              "description": "A detailed, descriptive prompt for the image to generate. Be specific about colors, composition, style, mood, and subject matter. Avoid generic or vague descriptions."
+            }
+          },
+          "required": [
+            "prompt"
+          ],
+          "additionalProperties": false
+        },
+        "eager_input_streaming": true
+      },
+      {
+        "name": "update_todos",
+        "description": "\n### When to Use This Tool\n\nUse proactively for:\n1. Complex multi-step tasks (3+ distinct steps)\n2. Non-trivial tasks requiring careful planning\n3. User explicitly requests todo list\n4. User provides multiple tasks (numbered/comma-separated)\n5. After completing tasks - mark complete with merge=true and add follow-ups\n6. When starting new tasks - mark as in_progress (ideally only one at a time)\n\n### When NOT to Use\n\nSkip for:\n1. Single, straightforward tasks\n2. Trivial tasks with no organizational benefit\n3. Tasks completable in < 3 trivial steps\n4. Purely conversational/informational requests\n5. Todo items should NOT include operational actions done in service of higher-level tasks.\n\nNEVER INCLUDE THESE IN TODOS: linting; testing; searching or examining the codebase.\n\n### Examples\n\n<example>\nUser: Add dark mode toggle to settings\nAssistant:\n- *Creates todo list:*\n1. Add state management [in_progress]\n2. Implement styles\n3. Create toggle component\n4. Update components\n- [Immediately begins working on todo 1 in the same tool call batch]\n<reasoning>\nMulti-step feature with dependencies.\n</reasoning>\n</example>\n\n<example>\n// User: Implement user registration, product catalog, shopping cart, checkout flow.\nAssistant: *Creates todo list breaking down each feature into specific tasks*\n<reasoning>\nMultiple complex features provided as list requiring organized task management.\n</reasoning>\n</example>\n\n### Task States and Management\n\n1. **Task States:**\n- pending: Not yet started\n- in_progress: Currently working on\n- completed: Finished successfully\n\n2. **Task Management:**\n- Update status in real-time\n- Mark complete IMMEDIATELY after finishing\n- Only ONE task in_progress at a time\n- Complete current tasks before starting new ones\n\n3. **Task Breakdown:**\n- Create specific, actionable items\n- Break complex tasks into manageable steps\n- Use clear, descriptive names\n\n4. **Parallel Todo Writes:**\n- Prefer creating the first todo as in_progress\n- Start working on todos by using tool calls in the same tool call batch as the todo write\n- Batch todo updates with other tool calls for better latency and lower costs for the user\n",
+        "input_schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "properties": {
+            "merge": {
+              "type": "boolean",
+              "description": "Whether to merge the todos with the existing todos. If true, the todos will be merged into the existing todos based on the id field. You can leave unchanged properties undefined. If false, the new todos will replace the existing todos."
+            },
+            "todos": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "Unique identifier for the todo item"
+                  },
+                  "content": {
+                    "description": "The description/content of the todo item",
+                    "type": "string"
+                  },
+                  "status": {
+                    "description": "The current status of the todo item",
+                    "type": "string",
+                    "enum": [
+                      "pending",
+                      "in_progress",
+                      "completed"
+                    ]
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "additionalProperties": false
+              },
+              "description": "Array of todo items. When merge is true, only include todos that need updates. When merge is false, this is the complete list."
+            }
+          },
+          "required": [
+            "merge",
+            "todos"
+          ],
+          "additionalProperties": false
+        },
+        "eager_input_streaming": true
+      },
+      {
+        "name": "run_type_checks",
+        "description": "Run TypeScript type checks on the current workspace. You can provide paths to specific files or directories, or omit the argument to get diagnostics for all files.\n\n- If a file path is provided, returns diagnostics for that file only\n- If a directory path is provided, returns diagnostics for all files within that directory\n- If no path is provided, returns diagnostics for all files in the workspace\n- This tool can return type errors that were already present before your edits, so avoid calling it with a very wide scope of files\n- NEVER call this tool on a file unless you've edited it or are about to edit it",
+        "input_schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "properties": {
+            "paths": {
+              "description": "Optional. An array of paths to files or directories to read type errors for. If provided, returns diagnostics for the specified files/directories only. If not provided, returns diagnostics for all files in the workspace.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "eager_input_streaming": true
+      },
+      {
+        "name": "read_guide",
+        "description": "Read a detailed instruction guide. Use this when the system prompt tells you to load a guide before implementing a feature.",
+        "input_schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "properties": {
+            "guide": {
+              "type": "string",
+              "description": "Name of the guide to read (e.g. 'add-authentication', 'add-email-verification', 'add-password-reset')"
+            }
+          },
+          "required": [
+            "guide"
+          ],
+          "additionalProperties": false
+        },
+        "eager_input_streaming": true
+      },
+      {
+        "name": "execute_sandbox_script",
+        "description": "Run a small program written in a strict, sandboxed subset of JavaScript (MustardScript) to inspect files.\n\nUse this when you need to slice, search, count, aggregate, or summarize file contents before answering. Return only the concise value you need.\n\nSupported language surface:\n- let/const, functions, closures, arrow functions, async/await, promises, arrays, plain objects, Map, Set, if/switch, loops, break/continue, try/catch/finally, throw, template literals, destructuring, optional chaining, nullish coalescing, JSON, Math, and conservative Array/String/Object/Date/Intl/RegExp helpers.\n- Top-level await is supported. Top-level return is not supported; return the final expression value instead, e.g. `const text = await read_file(\"attachments:data.csv\"); text.length;`.\n- The script has no ambient authority. It can only act through the host functions below.\n\nRecommendations:\n- Avoid defining nested helper functions in the main function.\n\nUnsupported / unavailable:\n- No var, import/export, require, CommonJS, npm packages, Node APIs, browser/DOM APIs, process, module, exports, global, environment variables, subprocesses, network/fetch, fetch, timers, setTimeout, setInterval, eval, Function constructor, with, classes, generators, custom iterator authoring, Symbols, WeakMap, WeakSet, typed arrays, ArrayBuffer, shared memory, atomics, Proxy, accessors, full prototype/property-descriptor semantics, or arbitrary filesystem access.\n- String.prototype.localeCompare is not supported; compare with <, >, or === instead.\n- `console.*` is not available.\n- Unsupported syntax or unsupported built-in behavior fails closed with an error. Rewrite using simpler JavaScript when that happens.\n\nAvoid returning shared references:\n\n```\nconst row = { key: \"x\", total: 1 };\n({ a: row, b: row }); // rejected\n```\n\nUse cloned/plain rows instead:\n\n```\nconst row = { key: \"x\", total: 1 };\n({\n  a: { key: row.key, total: row.total },\n  b: { key: row.key, total: row.total }\n});\n```\n\nExecution thread:\n- 'main' (default) runs in-process. Use for small / fast scripts.\n- 'worker' runs on a separate worker thread so chat streaming and other main-process work stay responsive. Use when the script is compute-heavy (parsing multi-MB CSVs, large aggregations).\n\nHost functions:\n```ts\ntype ReadFileOptions = {\n  start?: number; // zero-indexed byte offset\n  length?: number; // max bytes to read\n  encoding?: \"utf8\" | \"base64\";\n};\n\ntype FileStats = {\n  size: number;\n  isText: boolean;\n  mtime: string; // ISO timestamp\n};\n\ndeclare function read_file(\n  path: string,\n  options?: ReadFileOptions,\n): Promise<string>;\n\ndeclare function list_files(dir?: \".\" | \"attachments:\" | string): Promise<string[]>;\n\ndeclare function file_stats(path: string): Promise<FileStats>;\n```\n\nPaths are app-relative (including `.dyad/media/<stored-name>`), or attachment paths like attachments:filename.ext. Prefer range reads, filtering, aggregation, and small summaries over returning entire files.\n\nMCP tools can also be invoked from inside the script. The tools available on each connected server are listed below by name only. To use one:\n1. If you recognize the tool you need, call `get_mcp_tool_schema` with its name(s) to get its description and full TypeScript declaration.\n2. If you are not sure which tool you need, call `search_mcp_tools` with keywords (optionally a `server`) to find candidates and get their declarations.\n3. Call the declared host functions inside this script, exactly as declared.\n- Each MCP tool invocation may trigger a user consent prompt. A denied call throws.\n- MCP host functions are only available on the 'main' execution thread. They are NOT available on the 'worker' thread — if you need both heavy compute and MCP calls, split into two scripts (worker for the compute, then main for the MCP follow-up).\n\nAvailable MCP tools (call get_mcp_tool_schema for a tool's signature):\n```\n// testing-mcp-server\n- testing_mcp_server__calculator_add\n- testing_mcp_server__print_envs\n```",
+        "input_schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "properties": {
+            "script": {
+              "type": "string",
+              "maxLength": 131072,
+              "description": "Sandboxed JavaScript subset source code to execute."
+            },
+            "description": {
+              "description": "One-line human-readable summary of what the script does.",
+              "type": "string",
+              "maxLength": 160
+            },
+            "execution_thread": {
+              "default": "main",
+              "description": "Where to run the script. Default 'main' runs in-process and is the only thread that exposes MCP tools — use it for any script that calls MCP host functions, and for small / fast operations. Use 'worker' for compute-heavy work (parsing multi-MB attachments, large aggregations, anything that might take more than a few hundred milliseconds) so chat streaming and other main-process work isn't stalled. MCP host functions are NOT available on the worker thread.",
+              "type": "string",
+              "enum": [
+                "main",
+                "worker"
+              ]
+            }
+          },
+          "required": [
+            "script"
+          ],
+          "additionalProperties": false
+        },
+        "eager_input_streaming": true
+      },
+      {
+        "name": "search_mcp_tools",
+        "description": "Search for MCP tools by keyword and get their TypeScript signatures. Use this before calling an MCP tool from execute_sandbox_script: search for what you need, then call the returned host functions inside a script. Pass `server` to restrict the search to one MCP server.",
+        "input_schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "Keywords describing the MCP tool you need (e.g. 'create github issue', 'send slack message')."
+            },
+            "server": {
+              "description": "Optional. Restrict the search to a single MCP server by name. Omit to search across all enabled servers.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "query"
+          ],
+          "additionalProperties": false
+        },
+        "eager_input_streaming": true
+      },
+      {
+        "name": "get_mcp_tool_schema",
+        "description": "Get the description and full TypeScript signature of MCP tools by name. The MCP tools listed in execute_sandbox_script show only names; call this to get a tool's description and input schema before calling it as a host function inside a script. If a name is shared by tools on more than one server, the signatures for all of them are returned.",
+        "input_schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "properties": {
+            "tools": {
+              "minItems": 1,
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Names of the MCP tools to fetch full TypeScript signatures for, as listed in execute_sandbox_script (e.g. ['github__issue_write'])."
+            }
+          },
+          "required": [
+            "tools"
+          ],
+          "additionalProperties": false
+        },
+        "eager_input_streaming": true
+      },
+      {
+        "name": "planning_questionnaire",
+        "description": "Present a structured questionnaire to gather requirements from the user. The tool displays questions in the UI and waits for the user's responses, returning them as the tool result.\n\n<when_to_use>\nUse this tool when:\n- The user wants to create a NEW app or project\n- The request is vague or open-ended\n- There are multiple reasonable interpretations\nSkip when the request is a specific, concrete change.\n</when_to_use>\n\n<input_schema>\nThe tool accepts ONLY a \"questions\" array.\n\nEach question object has these fields:\n- \"question\" (string, REQUIRED): The question text shown to the user\n- \"type\" (string, REQUIRED): One of \"text\", \"radio\", or \"checkbox\"\n- \"options\" (string array, REQUIRED for radio/checkbox, OMIT for text): 1-3 predefined choices\n- \"id\" (string, optional): Unique identifier, auto-generated if omitted\n- \"required\" (boolean, optional): Defaults to true\n- \"placeholder\" (string, optional): Placeholder for text inputs\n</input_schema>\n\n<correct_example>\nReasoning: The user asked to \"build me a todo app\". I need to clarify the tech stack and key features. I'll use radio for single-choice and checkbox for multi-choice.\n\n{\n  \"questions\": [\n    {\n      \"type\": \"radio\",\n      \"question\": \"What visual style do you prefer?\",\n      \"options\": [\"Minimal & clean\", \"Colorful & playful\", \"Dark & modern\"]\n    },\n    {\n      \"type\": \"checkbox\",\n      \"question\": \"Which features do you want?\",\n      \"options\": [\"Due dates\", \"Categories/tags\", \"Priority levels\"]\n    }\n  ]\n}\n</correct_example>\n\n<incorrect_examples>\nWRONG — Empty questions array:\n{ \"questions\": [] }\n\nWRONG — options on text type:\n{ \"type\": \"text\", \"question\": \"...\", \"options\": [\"a\"] }\n\nWRONG — Empty options array:\n{ \"type\": \"radio\", \"question\": \"...\", \"options\": [] }\n\nWRONG — Missing options for radio:\n{ \"type\": \"radio\", \"question\": \"...\" }\n\nWRONG — More than 3 questions or more than 3 options\n\nWRONG — Array with empty object (missing required \"question\" and \"type\" fields):\n{ \"questions\": [{}] }\n</incorrect_examples>",
+        "input_schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "properties": {
+            "questions": {
+              "minItems": 1,
+              "maxItems": 3,
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "description": "Unique identifier for this question (auto-generated if omitted)",
+                    "type": "string"
+                  },
+                  "question": {
+                    "type": "string",
+                    "description": "The question text to display to the user"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "text",
+                      "radio",
+                      "checkbox"
+                    ],
+                    "description": "text for free-form input, radio for single choice, checkbox for multiple choice"
+                  },
+                  "options": {
+                    "description": "Options for radio/checkbox questions. Keep to max 3 — users can always provide a custom answer via the free-form text input. Omit for text questions.",
+                    "minItems": 1,
+                    "maxItems": 3,
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "required": {
+                    "description": "Whether this question requires an answer (defaults to true)",
+                    "type": "boolean"
+                  },
+                  "placeholder": {
+                    "description": "Placeholder text for text inputs",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "question",
+                  "type"
+                ],
+                "additionalProperties": false
+              },
+              "description": "A non empty array of 1-3 questions to present to the user"
+            }
+          },
+          "required": [
+            "questions"
+          ],
+          "additionalProperties": false
+        },
+        "eager_input_streaming": true
+      }
+    ],
+    "tool_choice": {
+      "type": "auto"
+    },
+    "stream": true
+  },
+  "headers": {
+    "authorization": "Bearer testdyadkey"
+  }
+}

--- a/src/components/chat/DyadMarkdownParser.tsx
+++ b/src/components/chat/DyadMarkdownParser.tsx
@@ -31,6 +31,7 @@ import { ipc } from "@/ipc/types";
 import { DyadMcpToolCall } from "./DyadMcpToolCall";
 import { DyadMcpToolResult } from "./DyadMcpToolResult";
 import { DyadMcpToolSearch } from "./DyadMcpToolSearch";
+import { DyadMcpToolSchema } from "./DyadMcpToolSchema";
 import { DyadWebSearchResult } from "./DyadWebSearchResult";
 import { DyadWebSearch } from "./DyadWebSearch";
 import { DyadWebCrawl } from "./DyadWebCrawl";
@@ -678,6 +679,20 @@ function renderCustomTag(
         >
           {content}
         </DyadMcpToolSearch>
+      );
+
+    case "dyad-mcp-tool-schema":
+      return (
+        <DyadMcpToolSchema
+          node={{
+            properties: {
+              tools: attributes.tools || "",
+              state: getState({ isStreaming, inProgress }),
+            },
+          }}
+        >
+          {content}
+        </DyadMcpToolSchema>
       );
     case "dyad-mcp-tool-call":
       return (

--- a/src/components/chat/DyadMcpToolSchema.tsx
+++ b/src/components/chat/DyadMcpToolSchema.tsx
@@ -1,0 +1,80 @@
+import type React from "react";
+import { useState, type ReactNode } from "react";
+import { ScrollText } from "lucide-react";
+import { CustomTagState } from "./stateTypes";
+import {
+  DyadCard,
+  DyadCardHeader,
+  DyadBadge,
+  DyadExpandIcon,
+  DyadStateIndicator,
+  DyadCardContent,
+} from "./DyadCardPrimitives";
+
+interface DyadMcpToolSchemaProps {
+  children?: ReactNode;
+  node?: {
+    // Comma-separated tool names whose signatures were requested.
+    properties?: { tools?: string; state?: CustomTagState };
+  };
+}
+
+export const DyadMcpToolSchema: React.FC<DyadMcpToolSchemaProps> = ({
+  children,
+  node,
+}) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const tools = node?.properties?.tools || "";
+  const state = node?.properties?.state as CustomTagState;
+  const inProgress = state === "pending";
+  const resultText = typeof children === "string" ? children.trimEnd() : "";
+
+  return (
+    <DyadCard
+      state={state}
+      accentColor="indigo"
+      onClick={() => setIsExpanded(!isExpanded)}
+      isExpanded={isExpanded}
+    >
+      <DyadCardHeader icon={<ScrollText size={15} />} accentColor="indigo">
+        <DyadBadge color="indigo">MCP Tool Schema</DyadBadge>
+        {!isExpanded && tools && (
+          <span className="text-sm text-muted-foreground italic truncate min-w-0">
+            {tools}
+          </span>
+        )}
+        {inProgress && (
+          <DyadStateIndicator
+            state="pending"
+            pendingLabel="Loading schema..."
+          />
+        )}
+        <div className="ml-auto">
+          <DyadExpandIcon isExpanded={isExpanded} />
+        </div>
+      </DyadCardHeader>
+      <DyadCardContent isExpanded={isExpanded}>
+        <div className="text-sm text-muted-foreground space-y-2">
+          {tools && (
+            <div>
+              <span className="text-xs font-medium text-muted-foreground">
+                Tools:
+              </span>
+              <div className="italic mt-0.5 text-foreground">{tools}</div>
+            </div>
+          )}
+          {children && (
+            <div>
+              <span className="text-xs font-medium text-muted-foreground">
+                Signatures:
+              </span>
+              <pre className="mt-0.5 whitespace-pre-wrap font-mono text-xs text-foreground overflow-x-auto">
+                {resultText || children}
+              </pre>
+            </div>
+          )}
+        </div>
+      </DyadCardContent>
+    </DyadCard>
+  );
+};

--- a/src/lib/streamingMessageParser.ts
+++ b/src/lib/streamingMessageParser.ts
@@ -52,6 +52,7 @@ const DYAD_CUSTOM_TAG_NAMES = [
   "dyad-mcp-tool-call",
   "dyad-mcp-tool-result",
   "dyad-mcp-tool-search",
+  "dyad-mcp-tool-schema",
   "dyad-list-files",
   "dyad-database-schema",
   "dyad-db-table-schema",

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -717,6 +717,10 @@ export async function handleLocalAgentStream(
       mcpInSandboxEnabled &&
       !!settings.enableMcpToolSearch &&
       agentTools.search_mcp_tools != undefined;
+    // get_mcp_tool_schema can be filtered out by tool permissions even while
+    // search mode is on, so the description must only advertise it when it's
+    // actually registered this turn.
+    const hasGetSchemaTool = agentTools.get_mcp_tool_schema != undefined;
     const mcpToolsForRegistration: ToolSet =
       !readOnly && !planModeOnly && !mcpInSandboxEnabled
         ? await getMcpTools(event, ctx)
@@ -729,6 +733,7 @@ export async function handleLocalAgentStream(
       agentTools.execute_sandbox_script.description =
         await buildExecuteSandboxScriptDescription([], {
           useSearch: useMcpToolSearch,
+          hasGetSchemaTool,
         });
       if (mcpInSandboxEnabled) {
         try {
@@ -741,6 +746,7 @@ export async function handleLocalAgentStream(
           agentTools.execute_sandbox_script.description =
             await buildExecuteSandboxScriptDescription(defs, {
               useSearch: useMcpToolSearch,
+              hasGetSchemaTool,
             });
         } catch (e) {
           logger.warn(

--- a/src/pro/main/ipc/handlers/local_agent/tool_definitions.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tool_definitions.ts
@@ -38,6 +38,7 @@ import { exitPlanTool } from "./tools/exit_plan";
 import { readGuideTool } from "./tools/read_guide";
 import { executeSandboxScriptTool } from "./tools/execute_sandbox_script";
 import { searchMcpToolsTool } from "./tools/search_mcp_tools";
+import { getMcpToolSchemaTool } from "./tools/get_mcp_tool_schema";
 import { writeAppBlueprintTool } from "./tools/write_app_blueprint";
 import type { LanguageModelV3ToolResultOutput } from "@ai-sdk/provider";
 import {
@@ -102,6 +103,7 @@ export const TOOL_DEFINITIONS: readonly ToolDefinition[] = [
   readGuideTool,
   executeSandboxScriptTool,
   searchMcpToolsTool,
+  getMcpToolSchemaTool,
   // Plan mode tools
   planningQuestionnaireTool,
   writePlanTool,

--- a/src/pro/main/ipc/handlers/local_agent/tools/execute_sandbox_script.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/execute_sandbox_script.spec.ts
@@ -219,4 +219,17 @@ describe("buildExecuteSandboxScriptDescription (search mode)", () => {
     // point is to keep schemas out of context until requested).
     expect(desc).not.toContain("declare function Sentry__get_issue");
   });
+
+  it("omits get_mcp_tool_schema wording when that tool is not registered", async () => {
+    const desc = await buildExecuteSandboxScriptDescription(
+      [def("Sentry", "get_issue"), def("Linear", "create_issue")],
+      { useSearch: true, hasGetSchemaTool: false },
+    );
+
+    // Names are still listed, and search is still offered.
+    expect(desc).toContain("Sentry__get_issue");
+    expect(desc).toContain("search_mcp_tools");
+    // But the model must not be told to call the filtered-out tool.
+    expect(desc).not.toContain("get_mcp_tool_schema");
+  });
 });

--- a/src/pro/main/ipc/handlers/local_agent/tools/execute_sandbox_script.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/execute_sandbox_script.spec.ts
@@ -198,7 +198,7 @@ describe("buildExecuteSandboxScriptDescription (search mode)", () => {
     };
   }
 
-  it("lists connected servers with tool counts instead of inlining signatures", async () => {
+  it("lists tool names grouped by server, without inlining signatures", async () => {
     const desc = await buildExecuteSandboxScriptDescription(
       [
         def("Sentry", "get_issue"),
@@ -208,12 +208,15 @@ describe("buildExecuteSandboxScriptDescription (search mode)", () => {
       { useSearch: true },
     );
 
-    expect(desc).toContain("Connected MCP servers:");
-    expect(desc).toContain("Sentry (2 tools)");
-    expect(desc).toContain("Linear (1 tool)");
+    // Names are listed up front so the model sees what exists.
+    expect(desc).toContain("Sentry__get_issue");
+    expect(desc).toContain("Sentry__list_issues");
+    expect(desc).toContain("Linear__create_issue");
+    // Both discovery tools are referenced.
+    expect(desc).toContain("get_mcp_tool_schema");
     expect(desc).toContain("search_mcp_tools");
     // Search mode must NOT inline the per-tool MCP signatures (the whole
-    // point of search is to keep them out of context).
-    expect(desc).not.toContain("Sentry__get_issue");
+    // point is to keep schemas out of context until requested).
+    expect(desc).not.toContain("declare function Sentry__get_issue");
   });
 });

--- a/src/pro/main/ipc/handlers/local_agent/tools/execute_sandbox_script.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/execute_sandbox_script.ts
@@ -207,18 +207,33 @@ ${typeDefsBlock}
 // sees what exists without paying for the full declarations. To call a tool it
 // pulls the full signature with `get_mcp_tool_schema` (when it recognizes the
 // tool) or finds one with `search_mcp_tools` (when it doesn't).
-function buildMcpSearchAddendum(defs: McpToolDef[]): string {
+//
+// `hasGetSchemaTool` reflects whether `get_mcp_tool_schema` is actually
+// registered this turn. A user can set it to `never` in tool permissions,
+// which filters it out while search mode stays on; in that case the wording
+// must not tell the model to call a tool that isn't available.
+function buildMcpSearchAddendum(
+  defs: McpToolDef[],
+  hasGetSchemaTool: boolean,
+): string {
   const inventory = buildMcpToolNameInventory(defs);
+  const howToUse = hasGetSchemaTool
+    ? `1. If you recognize the tool you need, call \`get_mcp_tool_schema\` with its name(s) to get its description and full TypeScript declaration.
+2. If you are not sure which tool you need, call \`search_mcp_tools\` with keywords (optionally a \`server\`) to find candidates and get their declarations.
+3. Call the declared host functions inside this script, exactly as declared.`
+    : `1. Call \`search_mcp_tools\` with keywords (optionally a \`server\`) to get the TypeScript declarations of the tools you need.
+2. Call the declared host functions inside this script, exactly as declared.`;
+  const inventoryHeading = hasGetSchemaTool
+    ? "Available MCP tools (call get_mcp_tool_schema for a tool's signature):"
+    : "Available MCP tools (search for one with search_mcp_tools to get its signature):";
   return `
 
 MCP tools can also be invoked from inside the script. The tools available on each connected server are listed below by name only. To use one:
-1. If you recognize the tool you need, call \`get_mcp_tool_schema\` with its name(s) to get its description and full TypeScript declaration.
-2. If you are not sure which tool you need, call \`search_mcp_tools\` with keywords (optionally a \`server\`) to find candidates and get their declarations.
-3. Call the declared host functions inside this script, exactly as declared.
+${howToUse}
 - Each MCP tool invocation may trigger a user consent prompt. A denied call throws.
 - MCP host functions are only available on the 'main' execution thread. They are NOT available on the 'worker' thread — if you need both heavy compute and MCP calls, split into two scripts (worker for the compute, then main for the MCP follow-up).
 
-Available MCP tools (call get_mcp_tool_schema for a tool's signature):
+${inventoryHeading}
 \`\`\`
 ${inventory}
 \`\`\``;
@@ -236,17 +251,21 @@ ${inventory}
  */
 export async function buildExecuteSandboxScriptDescription(
   precomputedDefs?: McpToolDef[],
-  options?: { useSearch?: boolean },
+  options?: { useSearch?: boolean; hasGetSchemaTool?: boolean },
 ): Promise<string> {
   const defs = precomputedDefs ?? (await collectMcpToolDefs());
   if (defs.length === 0) {
     return FILES_ONLY_PREAMBLE;
   }
-  // Search mode (experiment on): point the model at `search_mcp_tools`
-  // instead of inlining every tool's declarations. The full per-tool block is
-  // only embedded when search is off.
+  // Search mode: list tool names and point the model at the discovery tools
+  // instead of inlining every tool's declarations. `hasGetSchemaTool` defaults
+  // to true since get_mcp_tool_schema is normally registered alongside search;
+  // the handler passes false when tool permissions have filtered it out.
   if (options?.useSearch) {
-    return FILES_ONLY_PREAMBLE + buildMcpSearchAddendum(defs);
+    return (
+      FILES_ONLY_PREAMBLE +
+      buildMcpSearchAddendum(defs, options.hasGetSchemaTool ?? true)
+    );
   }
   return FILES_ONLY_PREAMBLE + buildMcpAddendum(buildMcpTypeDefsBlock(defs));
 }

--- a/src/pro/main/ipc/handlers/local_agent/tools/execute_sandbox_script.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/execute_sandbox_script.ts
@@ -20,6 +20,7 @@ import {
 import {
   collectMcpToolDefs,
   buildMcpTypeDefsBlock,
+  buildMcpToolNameInventory,
   buildMcpCapabilityMap,
   type McpToolDef,
 } from "./mcp_type_defs";
@@ -201,33 +202,26 @@ ${typeDefsBlock}
 \`\`\``;
 }
 
-// Search-mode addendum: used when the `enableMcpToolSearch` experiment is on.
-// The per-tool declarations are NOT listed here to keep context lean; the
-// model discovers them via `search_mcp_tools` and then calls the returned
-// host functions from inside the script.
-function buildServerInventory(defs: McpToolDef[]): string {
-  const counts = new Map<string, number>();
-  for (const def of defs) {
-    const name = def.serverName;
-    if (!name) continue;
-    counts.set(name, (counts.get(name) ?? 0) + 1);
-  }
-  if (counts.size === 0) return "";
-  const list = [...counts.entries()]
-    .map(([name, n]) => `${name} (${n} tool${n === 1 ? "" : "s"})`)
-    .join(", ");
-  return `\nConnected MCP servers: ${list}. Search within one with the \`server\` param, or across all by omitting it.`;
-}
-
+// Search-mode addendum: used when the `enableMcpToolSearch` setting is on.
+// Every tool is listed by NAME ONLY (no descriptions or schemas) so the model
+// sees what exists without paying for the full declarations. To call a tool it
+// pulls the full signature with `get_mcp_tool_schema` (when it recognizes the
+// tool) or finds one with `search_mcp_tools` (when it doesn't).
 function buildMcpSearchAddendum(defs: McpToolDef[]): string {
+  const inventory = buildMcpToolNameInventory(defs);
   return `
 
-MCP tools can also be invoked from inside the script. To use one:
-1. Call the \`search_mcp_tools\` tool with keywords (optionally a \`server\`) to get the TypeScript declarations of the tools you need.
-2. Call those declared host functions inside this script, exactly as declared.
-${buildServerInventory(defs)}
+MCP tools can also be invoked from inside the script. The tools available on each connected server are listed below by name only. To use one:
+1. If you recognize the tool you need, call \`get_mcp_tool_schema\` with its name(s) to get its description and full TypeScript declaration.
+2. If you are not sure which tool you need, call \`search_mcp_tools\` with keywords (optionally a \`server\`) to find candidates and get their declarations.
+3. Call the declared host functions inside this script, exactly as declared.
 - Each MCP tool invocation may trigger a user consent prompt. A denied call throws.
-- MCP host functions are only available on the 'main' execution thread. They are NOT available on the 'worker' thread — if you need both heavy compute and MCP calls, split into two scripts (worker for the compute, then main for the MCP follow-up).`;
+- MCP host functions are only available on the 'main' execution thread. They are NOT available on the 'worker' thread — if you need both heavy compute and MCP calls, split into two scripts (worker for the compute, then main for the MCP follow-up).
+
+Available MCP tools (call get_mcp_tool_schema for a tool's signature):
+\`\`\`
+${inventory}
+\`\`\``;
 }
 
 /**

--- a/src/pro/main/ipc/handlers/local_agent/tools/get_mcp_tool_schema.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/get_mcp_tool_schema.spec.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getMcpToolSchemaTool } from "./get_mcp_tool_schema";
+import type { McpToolDef } from "./mcp_type_defs";
+import type { AgentContext } from "./types";
+
+const readSettingsMock = vi.fn();
+
+vi.mock("@/main/settings", () => ({
+  readSettings: () => readSettingsMock(),
+}));
+
+function def(
+  overrides: Partial<McpToolDef> & { toolName: string },
+): McpToolDef {
+  return {
+    jsName: `srv__${overrides.toolName}`,
+    toolKey: `${overrides.serverName ?? "srv"}__${overrides.toolName}`,
+    serverId: 1,
+    serverName: "srv",
+    description: undefined,
+    inputSchema: { type: "object" },
+    ...overrides,
+  };
+}
+
+const TOOLS: McpToolDef[] = [
+  def({
+    jsName: "github__create_issue",
+    toolName: "create_issue",
+    serverName: "github",
+    description: "Create a new issue in a repository",
+    inputSchema: {
+      type: "object",
+      properties: { title: { type: "string" } },
+      required: ["title"],
+    },
+  }),
+  def({
+    jsName: "slack__send_message",
+    toolName: "send_message",
+    serverName: "slack",
+    description: "Post a message to a channel",
+  }),
+];
+
+function makeCtx(defs: McpToolDef[] | undefined): AgentContext {
+  return {
+    mcpToolsEnabled: true,
+    mcpToolDefs: defs,
+    onXmlComplete: vi.fn(),
+    onXmlStream: vi.fn(),
+  } as unknown as AgentContext;
+}
+
+beforeEach(() => {
+  readSettingsMock.mockReturnValue({
+    enableMcpToolSearch: true,
+    enableSandboxScriptExecution: true,
+  });
+});
+
+describe("getMcpToolSchemaTool.isEnabled", () => {
+  const baseCtx = { mcpToolsEnabled: true } as unknown as AgentContext;
+
+  it("is enabled when sandbox + search setting + mcpToolsEnabled are all on", () => {
+    expect(getMcpToolSchemaTool.isEnabled?.(baseCtx)).toBe(true);
+  });
+
+  it("is disabled when the search setting is off", () => {
+    readSettingsMock.mockReturnValue({
+      enableMcpToolSearch: false,
+      enableSandboxScriptExecution: true,
+    });
+    expect(getMcpToolSchemaTool.isEnabled?.(baseCtx)).toBe(false);
+  });
+
+  it("is disabled when MCP-in-sandbox is not active for the turn", () => {
+    expect(
+      getMcpToolSchemaTool.isEnabled?.({
+        mcpToolsEnabled: false,
+      } as unknown as AgentContext),
+    ).toBe(false);
+  });
+});
+
+describe("getMcpToolSchemaTool.execute", () => {
+  it("returns description + full declaration for tools requested by jsName", async () => {
+    const ctx = makeCtx(TOOLS);
+    const result = await getMcpToolSchemaTool.execute(
+      { tools: ["github__create_issue"] },
+      ctx,
+    );
+    expect(result).toContain("declare function github__create_issue");
+    expect(result).toContain("Create a new issue in a repository"); // description included
+    expect(result).toContain("title");
+    expect(result).not.toContain("declare function slack__send_message");
+    expect(ctx.onXmlComplete).toHaveBeenCalledOnce();
+  });
+
+  it("also resolves tools requested by raw toolName", async () => {
+    const ctx = makeCtx(TOOLS);
+    const result = await getMcpToolSchemaTool.execute(
+      { tools: ["send_message"] },
+      ctx,
+    );
+    expect(result).toContain("declare function slack__send_message");
+  });
+
+  it("returns multiple requested tools and notes the ones with no match", async () => {
+    const ctx = makeCtx(TOOLS);
+    const result = await getMcpToolSchemaTool.execute(
+      { tools: ["github__create_issue", "nope"] },
+      ctx,
+    );
+    expect(result).toContain("declare function github__create_issue");
+    expect(result).toContain("No match for: nope");
+  });
+
+  it("returns a helpful message when no requested tool matches", async () => {
+    const ctx = makeCtx(TOOLS);
+    const result = await getMcpToolSchemaTool.execute(
+      { tools: ["does_not_exist"] },
+      ctx,
+    );
+    expect(result).toContain("No MCP tool matched");
+    expect(result).not.toContain("declare function");
+  });
+
+  it("reports tools unavailable when the handler did not populate defs", async () => {
+    const ctx = makeCtx(undefined);
+    const result = await getMcpToolSchemaTool.execute(
+      { tools: ["github__create_issue"] },
+      ctx,
+    );
+    expect(result).toContain("temporarily unavailable");
+    expect(result).not.toContain("declare function");
+  });
+});

--- a/src/pro/main/ipc/handlers/local_agent/tools/get_mcp_tool_schema.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/get_mcp_tool_schema.ts
@@ -38,7 +38,8 @@ export const getMcpToolSchemaTool: ToolDefinition<GetMcpToolSchemaArgs> = {
     "Get the description and full TypeScript signature of MCP tools by name. " +
     "The MCP tools listed in execute_sandbox_script show only names; call " +
     "this to get a tool's description and input schema before calling it as " +
-    "a host function inside a script.",
+    "a host function inside a script. If a name is shared by tools on more " +
+    "than one server, the signatures for all of them are returned.",
   inputSchema: getMcpToolSchemaSchema,
   defaultConsent: "always",
 
@@ -51,9 +52,12 @@ export const getMcpToolSchemaTool: ToolDefinition<GetMcpToolSchemaArgs> = {
     `Get schema for MCP tool(s): ${args.tools.join(", ")}`,
 
   buildXml: (args, isComplete) => {
-    if (!args.tools || args.tools.length === 0) return undefined;
     if (isComplete) return undefined;
-    return `<dyad-mcp-tool-schema tools="${escapeXmlAttr(args.tools.join(", "))}">Loading...`;
+    // buildXml runs on partial, unvalidated args mid-stream; `tools` may not be
+    // an array yet, so guard before joining.
+    const tools = Array.isArray(args.tools) ? args.tools : [];
+    if (tools.length === 0) return undefined;
+    return `<dyad-mcp-tool-schema tools="${escapeXmlAttr(tools.join(", "))}">Loading...`;
   },
 
   execute: async (args: GetMcpToolSchemaArgs, ctx: AgentContext) => {

--- a/src/pro/main/ipc/handlers/local_agent/tools/get_mcp_tool_schema.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/get_mcp_tool_schema.ts
@@ -1,0 +1,91 @@
+import { z } from "zod";
+import {
+  ToolDefinition,
+  AgentContext,
+  escapeXmlAttr,
+  escapeXmlContent,
+} from "./types";
+import { buildMcpTypeDefsBlock, resolveMcpToolDefs } from "./mcp_type_defs";
+import { readSettings } from "@/main/settings";
+
+const getMcpToolSchemaSchema = z.object({
+  tools: z
+    .array(z.string())
+    .min(1)
+    .describe(
+      "Names of the MCP tools to fetch full TypeScript signatures for, as " +
+        "listed in execute_sandbox_script (e.g. ['github__issue_write']).",
+    ),
+});
+
+type GetMcpToolSchemaArgs = z.infer<typeof getMcpToolSchemaSchema>;
+
+/**
+ * Return the description and full TypeScript `declare function` signature
+ * (input schema included) for named MCP tools. The search-mode
+ * `execute_sandbox_script` description lists every tool by name only; the
+ * model calls this to get the details of the tool(s) it intends to use before
+ * calling them as host functions. `search_mcp_tools` remains available for
+ * when the name list isn't enough to know which tool fits.
+ *
+ * Only registered when MCP-in-sandbox is active AND the `enableMcpToolSearch`
+ * setting is on (the same setting that lists tool names and registers
+ * `search_mcp_tools`).
+ */
+export const getMcpToolSchemaTool: ToolDefinition<GetMcpToolSchemaArgs> = {
+  name: "get_mcp_tool_schema",
+  description:
+    "Get the description and full TypeScript signature of MCP tools by name. " +
+    "The MCP tools listed in execute_sandbox_script show only names; call " +
+    "this to get a tool's description and input schema before calling it as " +
+    "a host function inside a script.",
+  inputSchema: getMcpToolSchemaSchema,
+  defaultConsent: "always",
+
+  // ctx.mcpToolsEnabled already implies sandbox-script execution is on, so only
+  // the setting flag needs a separate check.
+  isEnabled: (ctx) =>
+    !!ctx.mcpToolsEnabled && !!readSettings().enableMcpToolSearch,
+
+  getConsentPreview: (args) =>
+    `Get schema for MCP tool(s): ${args.tools.join(", ")}`,
+
+  buildXml: (args, isComplete) => {
+    if (!args.tools || args.tools.length === 0) return undefined;
+    if (isComplete) return undefined;
+    return `<dyad-mcp-tool-schema tools="${escapeXmlAttr(args.tools.join(", "))}">Loading...`;
+  },
+
+  execute: async (args: GetMcpToolSchemaArgs, ctx: AgentContext) => {
+    const finish = (result: string) => {
+      ctx.onXmlComplete(
+        `<dyad-mcp-tool-schema tools="${escapeXmlAttr(args.tools.join(", "))}">${escapeXmlContent(result)}</dyad-mcp-tool-schema>`,
+      );
+      return result;
+    };
+
+    // No defs means the handler's collection failed and the sandbox has no MCP
+    // host functions this turn, so don't hand the model tools it can't call.
+    if (ctx.mcpToolDefs === undefined) {
+      return finish("MCP tools are temporarily unavailable. Try again.");
+    }
+
+    const { found, missing } = resolveMcpToolDefs(ctx.mcpToolDefs, args.tools);
+
+    if (found.length === 0) {
+      return finish(
+        `No MCP tool matched [${args.tools.join(", ")}]. Use the names exactly ` +
+          `as listed in execute_sandbox_script, or search_mcp_tools to find one.`,
+      );
+    }
+
+    const block = buildMcpTypeDefsBlock(found);
+    const missingNote =
+      missing.length > 0 ? `\n\n// No match for: ${missing.join(", ")}` : "";
+
+    return finish(
+      `Signature(s) for ${found.length} MCP tool(s). Call these as host ` +
+        `functions inside execute_sandbox_script:\n\n${block}${missingNote}`,
+    );
+  },
+};

--- a/src/pro/main/ipc/handlers/local_agent/tools/mcp_type_defs.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/mcp_type_defs.spec.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildMcpCapabilityMap,
   buildMcpTypeDefsBlock,
+  buildMcpToolNameInventory,
+  resolveMcpToolDefs,
   type McpToolDef,
 } from "./mcp_type_defs";
 import { mcpManager } from "@/ipc/utils/mcp_manager";
@@ -115,6 +117,68 @@ describe("buildMcpTypeDefsBlock", () => {
       declare function b__one(args: Record<string, unknown>): Promise<McpResult>;
       "
     `);
+  });
+});
+
+describe("buildMcpToolNameInventory", () => {
+  it("returns an empty string when defs are empty", () => {
+    expect(buildMcpToolNameInventory([])).toBe("");
+  });
+
+  it("lists jsNames grouped by server, no descriptions or schemas", () => {
+    const block = buildMcpToolNameInventory([
+      def({
+        jsName: "github__search_repositories",
+        serverName: "github",
+        description: "Find repositories by name/description/topic",
+        inputSchema: {
+          type: "object",
+          properties: { query: { type: "string" } },
+          required: ["query"],
+        },
+      }),
+      def({ jsName: "github__list_commits", serverName: "github" }),
+      def({ jsName: "linear__list_issues", serverName: "linear" }),
+    ]);
+    expect(block).toMatchInlineSnapshot(`
+      "// github
+      - github__search_repositories
+      - github__list_commits
+      // linear
+      - linear__list_issues"
+    `);
+    expect(block).not.toContain("declare function");
+    expect(block).not.toContain("Find repositories");
+    expect(block).not.toContain("query");
+  });
+});
+
+describe("resolveMcpToolDefs", () => {
+  const defs = [
+    def({ jsName: "github__create_issue", toolName: "create_issue" }),
+    def({ jsName: "slack__send_message", toolName: "send_message" }),
+  ];
+
+  it("resolves by jsName and by raw toolName", () => {
+    const { found, missing } = resolveMcpToolDefs(defs, [
+      "github__create_issue",
+      "send_message",
+    ]);
+    expect(found.map((d) => d.jsName)).toEqual([
+      "github__create_issue",
+      "slack__send_message",
+    ]);
+    expect(missing).toEqual([]);
+  });
+
+  it("collapses duplicates and collects unmatched names", () => {
+    const { found, missing } = resolveMcpToolDefs(defs, [
+      "github__create_issue",
+      "create_issue",
+      "nope",
+    ]);
+    expect(found.map((d) => d.jsName)).toEqual(["github__create_issue"]);
+    expect(missing).toEqual(["nope"]);
   });
 });
 

--- a/src/pro/main/ipc/handlers/local_agent/tools/mcp_type_defs.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/mcp_type_defs.spec.ts
@@ -180,6 +180,32 @@ describe("resolveMcpToolDefs", () => {
     expect(found.map((d) => d.jsName)).toEqual(["github__create_issue"]);
     expect(missing).toEqual(["nope"]);
   });
+
+  it("returns all matches when a raw toolName is shared across servers", () => {
+    const collidingDefs = [
+      def({ jsName: "github__create_issue", toolName: "create_issue" }),
+      def({ jsName: "linear__create_issue", toolName: "create_issue" }),
+    ];
+    const { found, missing } = resolveMcpToolDefs(collidingDefs, [
+      "create_issue",
+    ]);
+    expect(found.map((d) => d.jsName)).toEqual([
+      "github__create_issue",
+      "linear__create_issue",
+    ]);
+    expect(missing).toEqual([]);
+  });
+
+  it("resolves a jsName to exactly its def even when the toolName collides", () => {
+    const collidingDefs = [
+      def({ jsName: "github__create_issue", toolName: "create_issue" }),
+      def({ jsName: "linear__create_issue", toolName: "create_issue" }),
+    ];
+    const { found } = resolveMcpToolDefs(collidingDefs, [
+      "linear__create_issue",
+    ]);
+    expect(found.map((d) => d.jsName)).toEqual(["linear__create_issue"]);
+  });
 });
 
 function createCtx(): AgentContext {

--- a/src/pro/main/ipc/handlers/local_agent/tools/mcp_type_defs.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/mcp_type_defs.ts
@@ -235,3 +235,62 @@ export function buildMcpTypeDefsBlock(defs: McpToolDef[]): string {
 
   return sections.join("\n");
 }
+
+/**
+ * Build a names-only inventory of every MCP tool, grouped by server. Injected
+ * into the search-mode `execute_sandbox_script` description so the model sees
+ * which tools exist without paying for their descriptions or schemas. The
+ * model then pulls a tool's full signature with `get_mcp_tool_schema` (or
+ * finds one via `search_mcp_tools`). Names are the sandbox `jsName` (what the
+ * model actually calls). Returns "" when `defs` is empty.
+ */
+export function buildMcpToolNameInventory(defs: McpToolDef[]): string {
+  if (defs.length === 0) {
+    return "";
+  }
+
+  const byServer = new Map<string, McpToolDef[]>();
+  for (const d of defs) {
+    const list = byServer.get(d.serverName) ?? [];
+    list.push(d);
+    byServer.set(d.serverName, list);
+  }
+
+  const sections: string[] = [];
+  for (const [serverName, list] of byServer) {
+    sections.push(`// ${serverName}`);
+    for (const def of list) {
+      sections.push(`- ${def.jsName}`);
+    }
+  }
+
+  return sections.join("\n");
+}
+
+/**
+ * Resolve caller-supplied tool names to defs. Accepts either the sandbox
+ * `jsName` (what the inventory lists) or the raw MCP `toolName`, so the model
+ * can ask for whichever it has. Names matching nothing land in `missing`.
+ * Order follows the requested names; duplicates are collapsed.
+ */
+export function resolveMcpToolDefs(
+  defs: McpToolDef[],
+  names: string[],
+): { found: McpToolDef[]; missing: string[] } {
+  const byJsName = new Map(defs.map((d) => [d.jsName, d]));
+  const byToolName = new Map(defs.map((d) => [d.toolName, d]));
+  const found: McpToolDef[] = [];
+  const missing: string[] = [];
+  const seen = new Set<string>();
+  for (const name of names) {
+    const def = byJsName.get(name) ?? byToolName.get(name);
+    if (!def) {
+      missing.push(name);
+      continue;
+    }
+    if (seen.has(def.jsName)) continue;
+    seen.add(def.jsName);
+    found.push(def);
+  }
+  return { found, missing };
+}

--- a/src/pro/main/ipc/handlers/local_agent/tools/mcp_type_defs.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/mcp_type_defs.ts
@@ -269,28 +269,39 @@ export function buildMcpToolNameInventory(defs: McpToolDef[]): string {
 
 /**
  * Resolve caller-supplied tool names to defs. Accepts either the sandbox
- * `jsName` (what the inventory lists) or the raw MCP `toolName`, so the model
- * can ask for whichever it has. Names matching nothing land in `missing`.
- * Order follows the requested names; duplicates are collapsed.
+ * `jsName` (unique, what the inventory lists) or the raw MCP `toolName` (not
+ * unique: two servers can expose the same `toolName`). A jsName resolves to
+ * exactly one def; a raw toolName resolves to every def that shares it, so an
+ * ambiguous name returns all candidates rather than silently picking one.
+ * Names matching nothing land in `missing`. Order follows the requested names;
+ * duplicate defs are collapsed by jsName.
  */
 export function resolveMcpToolDefs(
   defs: McpToolDef[],
   names: string[],
 ): { found: McpToolDef[]; missing: string[] } {
   const byJsName = new Map(defs.map((d) => [d.jsName, d]));
-  const byToolName = new Map(defs.map((d) => [d.toolName, d]));
+  const byToolName = new Map<string, McpToolDef[]>();
+  for (const d of defs) {
+    const list = byToolName.get(d.toolName) ?? [];
+    list.push(d);
+    byToolName.set(d.toolName, list);
+  }
   const found: McpToolDef[] = [];
   const missing: string[] = [];
   const seen = new Set<string>();
   for (const name of names) {
-    const def = byJsName.get(name) ?? byToolName.get(name);
-    if (!def) {
+    const jsMatch = byJsName.get(name);
+    const matches = jsMatch ? [jsMatch] : (byToolName.get(name) ?? []);
+    if (matches.length === 0) {
       missing.push(name);
       continue;
     }
-    if (seen.has(def.jsName)) continue;
-    seen.add(def.jsName);
-    found.push(def);
+    for (const def of matches) {
+      if (seen.has(def.jsName)) continue;
+      seen.add(def.jsName);
+      found.push(def);
+    }
   }
   return { found, missing };
 }


### PR DESCRIPTION
When MCP tool search is enabled, execute_sandbox_script previously showed only a per-server tool count and required the model to call search_mcp_tools (BM25) to discover any tool. This PR lists every tool by name under its server and adds a get_mcp_tool_schema tool that returns a named tool's description and full TypeScript signature on demand. search_mcp_tools stays available as the fallback for when the names alone aren't enough to know which tool fits.

Why this helps: with the catalog visible, the model can go straight to a tool it recognizes instead of issuing a search that BM25 may rank poorly. The clearest case is search_repositories, which the obvious query "search repositories" pushes out of the top-5 behind the other search_* tools; with the names listed, the model fetches its schema directly in one step instead of re-querying.

Why names only, not name + description: it is tempting to assume the input schema is the only large part of a tool definition, but the description is also substantial. Estimating tokens based on character-count across real MCP servers, a tool definition breaks down roughly as 60% schema, 36% description, 4% name. Concretely, listing the GitHub catalog (53 tools) by name is ~360 tokens versus ~1987 tokens with full descriptions, and that block is re-sent on every turn. For that extra cost we measured no improvement in success rate and no meaningful reduction in the number of discovery/tool calls the agent made in most cases. get_mcp_tool_schema still surfaces the full description once a tool is chosen, so nothing is lost by leaving it out of the listing.

The new get_mcp_tool_schema emissions render as their own MCP Tool Schema card (distinct from the search card), wired through a new dyad-mcp-tool-schema tag.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

