### PR TITLE
Add version favorites notes

### DIFF
--- a/drizzle/0034_groovy_cassandra_nova.sql
+++ b/drizzle/0034_groovy_cassandra_nova.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `versions` ADD `is_favorite` integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE `versions` ADD `note` text;

--- a/drizzle/meta/0034_snapshot.json
+++ b/drizzle/meta/0034_snapshot.json
@@ -1,0 +1,1076 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "533d5162-c7e9-4feb-b6fc-b51bb5d37796",
+  "prevId": "b5003e32-965d-48d8-a807-e252fd088c09",
+  "tables": {
+    "app_collections": {
+      "name": "app_collections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "app_collections_name_unique": {
+          "name": "app_collections_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apps": {
+      "name": "apps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "github_org": {
+          "name": "github_org",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_repo": {
+          "name": "github_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_branch": {
+          "name": "github_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supabase_project_id": {
+          "name": "supabase_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supabase_parent_project_id": {
+          "name": "supabase_parent_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supabase_organization_slug": {
+          "name": "supabase_organization_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_project_id": {
+          "name": "neon_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_development_branch_id": {
+          "name": "neon_development_branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_preview_branch_id": {
+          "name": "neon_preview_branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_active_branch_id": {
+          "name": "neon_active_branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_production_auth_cookie_secret": {
+          "name": "neon_production_auth_cookie_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_development_auth_cookie_secret": {
+          "name": "neon_development_auth_cookie_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selected_database_branch_type": {
+          "name": "selected_database_branch_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vercel_project_id": {
+          "name": "vercel_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vercel_project_name": {
+          "name": "vercel_project_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vercel_team_id": {
+          "name": "vercel_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vercel_deployment_url": {
+          "name": "vercel_deployment_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "install_command": {
+          "name": "install_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_command": {
+          "name": "start_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chat_context": {
+          "name": "chat_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "theme_id": {
+          "name": "theme_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "needs_app_blueprint": {
+          "name": "needs_app_blueprint",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apps_collection_id_app_collections_id_fk": {
+          "name": "apps_collection_id_app_collections_id_fk",
+          "tableFrom": "apps",
+          "tableTo": "app_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chats": {
+      "name": "chats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "initial_commit_hash": {
+          "name": "initial_commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "compacted_at": {
+          "name": "compacted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "compaction_backup_path": {
+          "name": "compaction_backup_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pending_compaction": {
+          "name": "pending_compaction",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chat_mode": {
+          "name": "chat_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chats_app_id_apps_id_fk": {
+          "name": "chats_app_id_apps_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_themes": {
+      "name": "custom_themes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "language_model_providers": {
+      "name": "language_model_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_base_url": {
+          "name": "api_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "env_var_name": {
+          "name": "env_var_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "language_models": {
+      "name": "language_models",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_name": {
+          "name": "api_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "builtin_provider_id": {
+          "name": "builtin_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "custom_provider_id": {
+          "name": "custom_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_output_tokens": {
+          "name": "max_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "language_models_custom_provider_id_language_model_providers_id_fk": {
+          "name": "language_models_custom_provider_id_language_model_providers_id_fk",
+          "tableFrom": "language_models",
+          "tableTo": "language_model_providers",
+          "columnsFrom": [
+            "custom_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "env_json": {
+          "name": "env_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "headers_json": {
+          "name": "headers_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "oauth_enabled": {
+          "name": "oauth_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "oauth_state": {
+          "name": "oauth_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client_secret": {
+          "name": "oauth_client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_scope": {
+          "name": "oauth_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_callback_port": {
+          "name": "oauth_callback_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_tool_consents": {
+      "name": "mcp_tool_consents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consent": {
+          "name": "consent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ask'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "uniq_mcp_consent": {
+          "name": "uniq_mcp_consent",
+          "columns": [
+            "server_id",
+            "tool_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "mcp_tool_consents_server_id_mcp_servers_id_fk": {
+          "name": "mcp_tool_consents_server_id_mcp_servers_id_fk",
+          "tableFrom": "mcp_tool_consents",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "approval_state": {
+          "name": "approval_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_commit_hash": {
+          "name": "source_commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "commit_hash": {
+          "name": "commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_tokens_used": {
+          "name": "max_tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ai_messages_json": {
+          "name": "ai_messages_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "using_free_agent_mode_quota": {
+          "name": "using_free_agent_mode_quota",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_compaction_summary": {
+          "name": "is_compaction_summary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_chat_id_chats_id_fk": {
+          "name": "messages_chat_id_chats_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompts": {
+      "name": "prompts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "prompts_slug_unique": {
+          "name": "prompts_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "versions": {
+      "name": "versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "commit_hash": {
+          "name": "commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "neon_db_timestamp": {
+          "name": "neon_db_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "versions_app_commit_unique": {
+          "name": "versions_app_commit_unique",
+          "columns": [
+            "app_id",
+            "commit_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "versions_app_id_apps_id_fk": {
+          "name": "versions_app_id_apps_id_fk",
+          "tableFrom": "versions",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1780444627070,
       "tag": "0033_ambiguous_moon_knight",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "6",
+      "when": 1782176665376,
+      "tag": "0034_groovy_cassandra_nova",
+      "breakpoints": true
     }
   ]
 }

--- a/e2e-tests/switch_versions.spec.ts
+++ b/e2e-tests/switch_versions.spec.ts
@@ -39,7 +39,7 @@ const runSwitchVersionTest = async (
     await po.page.getByRole("button", { name: "Version" }).textContent(),
   ).toBe("Version 2");
   await po.page.getByRole("button", { name: "Version" }).click();
-  await po.page.getByText("Init Dyad app Restore").click();
+  await po.page.getByTestId("version-row-1").click();
   await po.previewPanel.snapshotPreview({ name: `v1` });
 
   await po.page

--- a/e2e-tests/version_integrity.spec.ts
+++ b/e2e-tests/version_integrity.spec.ts
@@ -47,7 +47,7 @@ const runVersionIntegrityTest = async (po: PageObject, nativeGit: boolean) => {
 
   // Open version pane
   await po.page.getByRole("button", { name: "Version 3" }).click();
-  await po.page.getByText("Init Dyad app Restore").click();
+  await po.page.getByTestId("version-row-1").click();
   await po.snapshotAppFiles({ name: "v1", files: VERSION_INTEGRITY_FILES });
 
   const restoreButton = po.page.getByRole("button", {

--- a/e2e-tests/version_search.spec.ts
+++ b/e2e-tests/version_search.spec.ts
@@ -34,6 +34,46 @@ testSkipIfWindows("version search", async ({ po }) => {
   await expect(po.page.getByText("Init Dyad app")).toBeVisible();
   await expect(po.page.getByText(/Version 2 \(/)).toBeVisible();
 
+  // Favorite a version and add a note without checking it out
+  const favoriteButton = po.page.getByTestId("version-favorite-button-2");
+  await favoriteButton.click();
+  await expect(favoriteButton.locator("svg")).toHaveClass(
+    /(?:^|\s)fill-\[#6c55dc\]/,
+  );
+
+  const versionNote = "Stable landing screen";
+  const noteInput = po.page.getByLabel("Note for version 2");
+  await noteInput.fill(versionNote);
+  await searchInput.click();
+  await po.page.waitForTimeout(800);
+  await expect(po.page.getByRole("button", { name: "Version" })).toHaveText(
+    "Version 2",
+  );
+
+  // Favorites-only filter should hide unfavorited versions
+  await po.page
+    .getByRole("button", { name: "Show favorite versions only" })
+    .click();
+  await expect(po.page.getByTestId("version-row-2")).toBeVisible();
+  await expect(po.page.getByTestId("version-row-1")).toBeHidden();
+
+  // Closing and reopening resets the filter to all versions while preserving metadata
+  await po.page.getByLabel("Close version pane").click();
+  await po.page.getByRole("button", { name: "Version" }).click();
+  await expect(po.page.getByTestId("version-row-1")).toBeVisible();
+  await expect(po.page.getByLabel("Note for version 2")).toHaveValue(
+    versionNote,
+  );
+  await expect(
+    po.page.getByTestId("version-favorite-button-2").locator("svg"),
+  ).toHaveClass(/(?:^|\s)fill-\[#6c55dc\]/);
+
+  // Notes are searchable
+  await po.page.getByLabel("Search versions").fill("Stable landing");
+  await expect(po.page.getByTestId("version-row-2")).toBeVisible();
+  await expect(po.page.getByTestId("version-row-1")).toBeHidden();
+  await po.page.getByLabel("Clear search").click();
+
   // Search by message text
   await searchInput.fill("Init Dyad");
   await expect(po.page.getByText("Init Dyad app")).toBeVisible();

--- a/e2e-tests/version_search.spec.ts
+++ b/e2e-tests/version_search.spec.ts
@@ -4,15 +4,17 @@ import { expect } from "@playwright/test";
 testSkipIfWindows("version search", async ({ po }) => {
   await po.setUp({ autoApprove: true });
   await po.sendPrompt("tc=write-index");
+  const versionButton = po.page.getByRole("button", {
+    name: /^Version \d+$/,
+  });
 
   // Wait for version 2 to appear
-  await expect(po.page.getByRole("button", { name: "Version" })).toHaveText(
-    "Version 2",
-    { timeout: Timeout.MEDIUM },
-  );
+  await expect(versionButton).toHaveText("Version 2", {
+    timeout: Timeout.MEDIUM,
+  });
 
   // Open version pane
-  await po.page.getByRole("button", { name: "Version" }).click();
+  await versionButton.click();
 
   // Both versions should be visible
   await expect(po.page.getByText("Init Dyad app")).toBeVisible();
@@ -42,13 +44,15 @@ testSkipIfWindows("version search", async ({ po }) => {
   );
 
   const versionNote = "Stable landing screen";
+  await po.page.getByLabel("Add note for version 2").click();
   const noteInput = po.page.getByLabel("Note for version 2");
   await noteInput.fill(versionNote);
-  await searchInput.click();
-  await po.page.waitForTimeout(800);
-  await expect(po.page.getByRole("button", { name: "Version" })).toHaveText(
-    "Version 2",
+  await po.page.getByLabel("Close version pane").click();
+  await versionButton.click();
+  await expect(po.page.getByLabel("Note for version 2")).toHaveValue(
+    versionNote,
   );
+  await expect(versionButton).toHaveText("Version 2");
 
   // Favorites-only filter should hide unfavorited versions
   await po.page
@@ -59,7 +63,7 @@ testSkipIfWindows("version search", async ({ po }) => {
 
   // Closing and reopening resets the filter to all versions while preserving metadata
   await po.page.getByLabel("Close version pane").click();
-  await po.page.getByRole("button", { name: "Version" }).click();
+  await versionButton.click();
   await expect(po.page.getByTestId("version-row-1")).toBeVisible();
   await expect(po.page.getByLabel("Note for version 2")).toHaveValue(
     versionNote,

--- a/e2e-tests/version_search.spec.ts
+++ b/e2e-tests/version_search.spec.ts
@@ -46,6 +46,7 @@ testSkipIfWindows("version search", async ({ po }) => {
   const versionNote = "Stable landing screen";
   await po.page.getByLabel("Add note for version 2").click();
   const noteInput = po.page.getByLabel("Note for version 2");
+  await expect(noteInput).toHaveAttribute("maxlength", "10000");
   await noteInput.fill(versionNote);
   await po.page.getByLabel("Close version pane").click();
   await versionButton.click();

--- a/rules/e2e-testing.md
+++ b/rules/e2e-testing.md
@@ -149,6 +149,8 @@ If `npm run build` fails while rebuilding native modules with `ImportError` from
 
 If `npm run build` / Electron Forge packaging fails with `Failed to locate module "<package>"` but `package.json` and `package-lock.json` already declare that package, run `npm install` to restore `node_modules` before debugging app code.
 
+If a targeted E2E fails before launch with `ENOENT: no such file or directory, scandir '<repo>/out'`, verify `ls out` immediately after `npm run build`. If Forge logs end around `Finalizing package` and `electron-forge:plugin:vite handling process exit` but no `out/` directory exists, treat it as a packaging-environment issue and do not debug the spec assertions yet.
+
 ## Common flaky test patterns and fixes
 
 - **After `po.importApp(...)`**: Some imports trigger an initial assistant turn (for example `minimal` generating `AI_RULES.md`) that can leave a visible `Retry` button in the chat. If the test is about a later prompt, first wait for that import-time turn to finish, then start a new chat before calling `sendPrompt()`, or helper methods that wait on `Retry` visibility may return too early.

--- a/rules/e2e-testing.md
+++ b/rules/e2e-testing.md
@@ -102,6 +102,7 @@ Snapshot normalizers must be idempotent — `normalize(normalize(x)) === normali
 If app-file snapshots unexpectedly include `dist/` assets after running `pnpm --dir scaffold build`, delete `scaffold/dist` and rerun `npm run build` before regenerating E2E baselines. The packaged Electron app snapshots the scaffold contents from the last package build, so a stale packaged `scaffold/dist` can keep contaminating snapshots even after the source directory is cleaned.
 When changing provider request model IDs, search all request-dump snapshots for the old model value. Local-agent snapshots can include the same engine model payloads as `engine.spec.ts`, so updating only the obvious engine snapshot may leave stale expected dumps.
 If CI shows E2E snapshot drift but a local `--update-snapshots` run produces no diff, rebuild the packaged app with `npm run build` and rerun the updater. A stale packaged Electron app can make local snapshot updates compare against old source behavior and hide required baseline changes.
+If a test-only E2E fix fails locally because a new source locator or UI element is missing, check whether the branch already had app-code changes that were never packaged. Rebuild with `npm run build` even if your current diff only touches tests.
 
 ## Accordion-wrapped settings in E2E tests
 

--- a/rules/git-workflow.md
+++ b/rules/git-workflow.md
@@ -20,7 +20,7 @@ When creating a new worktree branch from `upstream/main` with `git worktree add 
 
 If a PR's head branch is on another user's fork and `gh pr view --json maintainerCanModify` returns `false`, bot accounts cannot push fixes to that PR head even if review threads can be resolved. A fallback push to the base repo publishes the commit but does **not** update the original fork PR; call this out in the PR summary and ask the PR author or a maintainer to apply the published commit.
 
-If `gh pr checkout <number>` fetched a fork PR into a local branch without adding the fork as a remote, and `gh pr view --json headRepository --jq .headRepository.nameWithOwner` returns blank, use the REST pull payload instead: `gh api repos/dyad-sh/dyad/pulls/<number> --jq '{head_repo:.head.repo.full_name, head_ref:.head.ref, head_sha:.head.sha}'`. Push directly to `https://github.com/<head_repo>` with `HEAD:<head_ref>` and a `--force-with-lease` pinned to `head_sha`.
+If `gh pr checkout <number>` fetched a fork PR into a local branch without adding the fork as a remote, and `gh pr view --json headRepository --jq .headRepository.nameWithOwner` returns blank, use the REST pull payload instead: `gh api repos/dyad-sh/dyad/pulls/<number> --jq '{head_repo:.head.repo.full_name, head_ref:.head.ref, head_sha:.head.sha}'`. Push directly to `https://github.com/<head_repo>` with `HEAD:<head_ref>` and a `--force-with-lease` pinned to `head_sha`. Treat `head_ref` as untrusted shell input: assign it to a variable and quote the refspec, for example `git push <url> HEAD:\"$head_ref\"`, instead of interpolating it unquoted.
 
 ## `gh pr create` branch detection
 

--- a/rules/git-workflow.md
+++ b/rules/git-workflow.md
@@ -20,6 +20,8 @@ When creating a new worktree branch from `upstream/main` with `git worktree add 
 
 If a PR's head branch is on another user's fork and `gh pr view --json maintainerCanModify` returns `false`, bot accounts cannot push fixes to that PR head even if review threads can be resolved. A fallback push to the base repo publishes the commit but does **not** update the original fork PR; call this out in the PR summary and ask the PR author or a maintainer to apply the published commit.
 
+If `gh pr checkout <number>` fetched a fork PR into a local branch without adding the fork as a remote, and `gh pr view --json headRepository --jq .headRepository.nameWithOwner` returns blank, use the REST pull payload instead: `gh api repos/dyad-sh/dyad/pulls/<number> --jq '{head_repo:.head.repo.full_name, head_ref:.head.ref, head_sha:.head.sha}'`. Push directly to `https://github.com/<head_repo>` with `HEAD:<head_ref>` and a `--force-with-lease` pinned to `head_sha`.
+
 ## `gh pr create` branch detection
 
 If `gh pr create` says `you must first push the current branch to a remote` even though `git push -u` succeeded, create the PR with an explicit head ref:

--- a/src/components/chat/VersionPane.tsx
+++ b/src/components/chat/VersionPane.tsx
@@ -25,7 +25,6 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { showError } from "@/lib/toast";
 
 import { useRunApp } from "@/hooks/useRunApp";
 
@@ -59,6 +58,7 @@ type SaveVersionNote = (
   appId: number | null,
   versionId: string,
   note: string | null,
+  previousNote: string | null,
   saveSequence: number,
   syncCache: boolean,
 ) => void;
@@ -68,6 +68,7 @@ type PendingNoteSave = {
   appId: number | null;
   versionId: string;
   note: string | null;
+  previousNote: string | null;
   saveSequence: number;
   saveVersionNote: SaveVersionNote;
 };
@@ -133,6 +134,9 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
       setCachedVersions((prevVersions) => {
         const sourceVersions =
           prevVersions.length > 0 ? prevVersions : liveVersionsRef.current;
+        if (sourceVersions.length === 0) {
+          return prevVersions;
+        }
         return sourceVersions.map((version) =>
           version.oid === versionId ? { ...version, ...updates } : version,
         );
@@ -146,6 +150,7 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
       targetAppId: number | null,
       versionId: string,
       note: string | null,
+      previousNote: string | null,
       saveSequence: number,
       syncCache = true,
     ) => {
@@ -171,7 +176,11 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
           isLatestSave() &&
           targetAppId === currentAppIdRef.current
         ) {
-          showError("Failed to save version note. Please try again.");
+          updateCachedVersion(versionId, { note: previousNote });
+        }
+      } finally {
+        if (isLatestSave()) {
+          noteSaveSequencesRef.current.delete(pendingSaveKey);
         }
       }
     },
@@ -186,6 +195,7 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
         pendingSave.appId,
         pendingSave.versionId,
         pendingSave.note,
+        pendingSave.previousNote,
         pendingSave.saveSequence,
         syncCache && pendingSave.appId === currentAppIdRef.current,
       );
@@ -306,9 +316,14 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
       })
     : favoriteFilteredVersions;
 
-  const queueVersionNoteSave = (versionId: string, note: string | null) => {
+  const queueVersionNoteSave = (
+    versionId: string,
+    note: string | null,
+    previousNote: string | null,
+  ) => {
     const pendingSaveKey = getPendingNoteSaveKey(appId, versionId);
     const existingPendingSave = noteSaveTimeoutsRef.current.get(pendingSaveKey);
+    const noteToRevertTo = existingPendingSave?.previousNote ?? previousNote;
     if (existingPendingSave) {
       clearTimeout(existingPendingSave.timeout);
     }
@@ -325,6 +340,7 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
         pendingSave.appId,
         pendingSave.versionId,
         pendingSave.note,
+        pendingSave.previousNote,
         pendingSave.saveSequence,
         pendingSave.appId === currentAppIdRef.current,
       );
@@ -334,6 +350,7 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
       appId,
       versionId,
       note,
+      previousNote: noteToRevertTo,
       saveSequence,
       saveVersionNote,
     });
@@ -349,6 +366,7 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
         existingPendingSave.appId,
         existingPendingSave.versionId,
         note,
+        existingPendingSave.previousNote,
         existingPendingSave.saveSequence,
         existingPendingSave.appId === currentAppIdRef.current,
       );
@@ -660,7 +678,11 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
                                   return next;
                                 });
                                 updateCachedVersion(version.oid, { note });
-                                queueVersionNoteSave(version.oid, note);
+                                queueVersionNoteSave(
+                                  version.oid,
+                                  note,
+                                  version.note ?? null,
+                                );
                               }}
                               onBlur={(e) =>
                                 flushVersionNoteSave(

--- a/src/components/chat/VersionPane.tsx
+++ b/src/components/chat/VersionPane.tsx
@@ -12,7 +12,7 @@ import {
   Pencil,
 } from "lucide-react";
 import type { Version } from "@/ipc/types";
-import { ipc } from "@/ipc/types";
+import { ipc, MAX_VERSION_NOTE_LENGTH } from "@/ipc/types";
 import { cn } from "@/lib/utils";
 import { queryKeys } from "@/lib/queryKeys";
 import { useQuery } from "@tanstack/react-query";
@@ -55,6 +55,7 @@ interface VersionPaneProps {
 }
 
 type SaveVersionNote = (
+  appId: number | null,
   versionId: string,
   note: string | null,
   syncCache: boolean,
@@ -75,6 +76,7 @@ function getPendingNoteSaveKey(appId: number | null, versionId: string) {
 export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
   const appId = useAtomValue(selectedAppIdAtom);
   const currentAppIdRef = useRef(appId);
+  const previousAppIdRef = useRef(appId);
   currentAppIdRef.current = appId;
   const { refreshApp, app } = useLoadApp(appId);
   const { restartApp } = useRunApp();
@@ -98,8 +100,13 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
   const [expandedNoteVersionIds, setExpandedNoteVersionIds] = useState<
     Set<string>
   >(() => new Set());
+  const [autoFocusNoteVersionIds, setAutoFocusNoteVersionIds] = useState<
+    Set<string>
+  >(() => new Set());
   const searchInputRef = useRef<HTMLInputElement>(null);
   const noteSaveTimeoutsRef = useRef(new Map<string, PendingNoteSave>());
+  const liveVersionsRef = useRef(liveVersions);
+  liveVersionsRef.current = liveVersions;
 
   const { data: screenshotsData } = useQuery({
     queryKey: queryKeys.apps.screenshots({ appId }),
@@ -128,12 +135,17 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
   };
 
   const saveVersionNote = async (
+    targetAppId: number | null,
     versionId: string,
     note: string | null,
     syncCache = true,
   ) => {
     try {
-      const result = await setVersionNote({ versionId, note });
+      const result = await setVersionNote({
+        appId: targetAppId,
+        versionId,
+        note,
+      });
       if (syncCache) {
         updateCachedVersion(result.oid, {
           isFavorite: result.isFavorite,
@@ -146,7 +158,7 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
         return;
       }
       const result = await refreshVersions();
-      setCachedVersions(result.data ?? liveVersions);
+      setCachedVersions(result.data ?? liveVersionsRef.current);
     }
   };
   const flushPendingNoteSaves = useCallback((syncCache = true) => {
@@ -155,6 +167,7 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
     for (const [, pendingSave] of pendingSaves) {
       clearTimeout(pendingSave.timeout);
       void pendingSave.saveVersionNote(
+        pendingSave.appId,
         pendingSave.versionId,
         pendingSave.note,
         syncCache && pendingSave.appId === currentAppIdRef.current,
@@ -178,7 +191,7 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
       if (isVisible && !wasVisibleRef.current) {
         if (appId) {
           const result = await refreshVersions();
-          setCachedVersions(result.data ?? liveVersions);
+          setCachedVersions(result.data ?? liveVersionsRef.current);
         }
       }
 
@@ -188,6 +201,7 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
         setSearchQuery("");
         setShowFavoritesOnly(false);
         setExpandedNoteVersionIds(new Set());
+        setAutoFocusNoteVersionIds(new Set());
         if (selectedVersionId && appId) {
           setSelectedVersionId(null);
           await checkoutVersion({ appId, versionId: "main" });
@@ -212,6 +226,19 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
     liveVersions,
     restartApp,
   ]);
+
+  useEffect(() => {
+    if (previousAppIdRef.current === appId) {
+      return;
+    }
+    previousAppIdRef.current = appId;
+    flushPendingNoteSaves(false);
+    setCachedVersions([]);
+    setSearchQuery("");
+    setShowFavoritesOnly(false);
+    setExpandedNoteVersionIds(new Set());
+    setAutoFocusNoteVersionIds(new Set());
+  }, [appId, flushPendingNoteSaves]);
 
   useEffect(() => {
     return () => {
@@ -276,6 +303,7 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
       }
       noteSaveTimeoutsRef.current.delete(pendingSaveKey);
       void pendingSave.saveVersionNote(
+        pendingSave.appId,
         pendingSave.versionId,
         pendingSave.note,
         pendingSave.appId === currentAppIdRef.current,
@@ -297,6 +325,7 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
       clearTimeout(existingPendingSave.timeout);
       noteSaveTimeoutsRef.current.delete(pendingSaveKey);
       void existingPendingSave.saveVersionNote(
+        existingPendingSave.appId,
         existingPendingSave.versionId,
         note,
         existingPendingSave.appId === currentAppIdRef.current,
@@ -571,9 +600,20 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
                             value={version.note ?? ""}
                             placeholder="Add note..."
                             aria-label={`Note for version ${versionNumber}`}
-                            autoFocus={!version.note}
+                            autoFocus={autoFocusNoteVersionIds.has(version.oid)}
+                            maxLength={MAX_VERSION_NOTE_LENGTH}
                             onClick={(e) => e.stopPropagation()}
                             onKeyDown={(e) => e.stopPropagation()}
+                            onFocus={() => {
+                              setAutoFocusNoteVersionIds((previous) => {
+                                if (!previous.has(version.oid)) {
+                                  return previous;
+                                }
+                                const next = new Set(previous);
+                                next.delete(version.oid);
+                                return next;
+                              });
+                            }}
                             onChange={(e) => {
                               const note = e.target.value;
                               setExpandedNoteVersionIds((previous) => {
@@ -599,6 +639,11 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
                             onClick={(e) => {
                               e.stopPropagation();
                               setExpandedNoteVersionIds((previous) => {
+                                const next = new Set(previous);
+                                next.add(version.oid);
+                                return next;
+                              });
+                              setAutoFocusNoteVersionIds((previous) => {
                                 const next = new Set(previous);
                                 next.add(version.oid);
                                 return next;

--- a/src/components/chat/VersionPane.tsx
+++ b/src/components/chat/VersionPane.tsx
@@ -54,8 +54,28 @@ interface VersionPaneProps {
   onClose: () => void;
 }
 
+type SaveVersionNote = (
+  versionId: string,
+  note: string | null,
+  syncCache: boolean,
+) => void;
+
+type PendingNoteSave = {
+  timeout: ReturnType<typeof setTimeout>;
+  appId: number | null;
+  versionId: string;
+  note: string | null;
+  saveVersionNote: SaveVersionNote;
+};
+
+function getPendingNoteSaveKey(appId: number | null, versionId: string) {
+  return `${appId ?? "none"}:${versionId}`;
+}
+
 export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
   const appId = useAtomValue(selectedAppIdAtom);
+  const currentAppIdRef = useRef(appId);
+  currentAppIdRef.current = appId;
   const { refreshApp, app } = useLoadApp(appId);
   const { restartApp } = useRunApp();
   const {
@@ -79,15 +99,7 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
     Set<string>
   >(() => new Set());
   const searchInputRef = useRef<HTMLInputElement>(null);
-  const noteSaveTimeoutsRef = useRef(
-    new Map<
-      string,
-      { timeout: ReturnType<typeof setTimeout>; note: string | null }
-    >(),
-  );
-  const saveVersionNoteRef = useRef(
-    (_versionId: string, _note: string | null, _syncCache: boolean) => {},
-  );
+  const noteSaveTimeoutsRef = useRef(new Map<string, PendingNoteSave>());
 
   const { data: screenshotsData } = useQuery({
     queryKey: queryKeys.apps.screenshots({ appId }),
@@ -137,14 +149,16 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
       setCachedVersions(result.data ?? liveVersions);
     }
   };
-  saveVersionNoteRef.current = saveVersionNote;
-
   const flushPendingNoteSaves = useCallback((syncCache = true) => {
     const pendingSaves = [...noteSaveTimeoutsRef.current.entries()];
     noteSaveTimeoutsRef.current.clear();
-    for (const [versionId, pendingSave] of pendingSaves) {
+    for (const [, pendingSave] of pendingSaves) {
       clearTimeout(pendingSave.timeout);
-      void saveVersionNoteRef.current(versionId, pendingSave.note, syncCache);
+      void pendingSave.saveVersionNote(
+        pendingSave.versionId,
+        pendingSave.note,
+        syncCache && pendingSave.appId === currentAppIdRef.current,
+      );
     }
   }, []);
 
@@ -250,23 +264,43 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
     : favoriteFilteredVersions;
 
   const queueVersionNoteSave = (versionId: string, note: string | null) => {
-    const existingPendingSave = noteSaveTimeoutsRef.current.get(versionId);
+    const pendingSaveKey = getPendingNoteSaveKey(appId, versionId);
+    const existingPendingSave = noteSaveTimeoutsRef.current.get(pendingSaveKey);
     if (existingPendingSave) {
       clearTimeout(existingPendingSave.timeout);
     }
     const timeout = setTimeout(() => {
-      noteSaveTimeoutsRef.current.delete(versionId);
-      void saveVersionNoteRef.current(versionId, note, true);
+      const pendingSave = noteSaveTimeoutsRef.current.get(pendingSaveKey);
+      if (!pendingSave) {
+        return;
+      }
+      noteSaveTimeoutsRef.current.delete(pendingSaveKey);
+      void pendingSave.saveVersionNote(
+        pendingSave.versionId,
+        pendingSave.note,
+        pendingSave.appId === currentAppIdRef.current,
+      );
     }, 600);
-    noteSaveTimeoutsRef.current.set(versionId, { timeout, note });
+    noteSaveTimeoutsRef.current.set(pendingSaveKey, {
+      timeout,
+      appId,
+      versionId,
+      note,
+      saveVersionNote,
+    });
   };
 
   const flushVersionNoteSave = (versionId: string, note: string | null) => {
-    const existingPendingSave = noteSaveTimeoutsRef.current.get(versionId);
+    const pendingSaveKey = getPendingNoteSaveKey(appId, versionId);
+    const existingPendingSave = noteSaveTimeoutsRef.current.get(pendingSaveKey);
     if (existingPendingSave) {
       clearTimeout(existingPendingSave.timeout);
-      noteSaveTimeoutsRef.current.delete(versionId);
-      void saveVersionNoteRef.current(versionId, note, true);
+      noteSaveTimeoutsRef.current.delete(pendingSaveKey);
+      void existingPendingSave.saveVersionNote(
+        existingPendingSave.versionId,
+        note,
+        existingPendingSave.appId === currentAppIdRef.current,
+      );
     }
   };
 

--- a/src/components/chat/VersionPane.tsx
+++ b/src/components/chat/VersionPane.tsx
@@ -2,13 +2,21 @@ import { useAtom, useAtomValue } from "jotai";
 import { selectedAppIdAtom, selectedVersionIdAtom } from "@/atoms/appAtoms";
 import { useVersions } from "@/hooks/useVersions";
 import { formatDistanceToNow } from "date-fns";
-import { RotateCcw, X, Database, Loader2, Search, Star } from "lucide-react";
+import {
+  RotateCcw,
+  X,
+  Database,
+  Loader2,
+  Search,
+  Star,
+  Pencil,
+} from "lucide-react";
 import type { Version } from "@/ipc/types";
 import { ipc } from "@/ipc/types";
 import { cn } from "@/lib/utils";
 import { queryKeys } from "@/lib/queryKeys";
 import { useQuery } from "@tanstack/react-query";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useCheckoutVersion } from "@/hooks/useCheckoutVersion";
 import { useLoadApp } from "@/hooks/useLoadApp";
 import { Textarea } from "@/components/ui/textarea";
@@ -67,9 +75,18 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
   const [cachedVersions, setCachedVersions] = useState<Version[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
   const [showFavoritesOnly, setShowFavoritesOnly] = useState(false);
+  const [expandedNoteVersionIds, setExpandedNoteVersionIds] = useState<
+    Set<string>
+  >(() => new Set());
   const searchInputRef = useRef<HTMLInputElement>(null);
   const noteSaveTimeoutsRef = useRef(
-    new Map<string, ReturnType<typeof setTimeout>>(),
+    new Map<
+      string,
+      { timeout: ReturnType<typeof setTimeout>; note: string | null }
+    >(),
+  );
+  const saveVersionNoteRef = useRef(
+    (_versionId: string, _note: string | null, _syncCache: boolean) => {},
   );
 
   const { data: screenshotsData } = useQuery({
@@ -85,6 +102,62 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
     [screenshotsData],
   );
 
+  const updateCachedVersion = (
+    versionId: string,
+    updates: Partial<Pick<Version, "isFavorite" | "note">>,
+  ) => {
+    setCachedVersions((prevVersions) => {
+      const sourceVersions =
+        prevVersions.length > 0 ? prevVersions : liveVersions;
+      return sourceVersions.map((version) =>
+        version.oid === versionId ? { ...version, ...updates } : version,
+      );
+    });
+  };
+
+  const saveVersionNote = async (
+    versionId: string,
+    note: string | null,
+    syncCache = true,
+  ) => {
+    try {
+      const result = await setVersionNote({ versionId, note });
+      if (syncCache) {
+        updateCachedVersion(result.oid, {
+          isFavorite: result.isFavorite,
+          note: result.note,
+        });
+      }
+    } catch (error) {
+      if (!syncCache) {
+        console.error("Failed to save pending version note", error);
+        return;
+      }
+      const result = await refreshVersions();
+      setCachedVersions(result.data ?? liveVersions);
+    }
+  };
+  saveVersionNoteRef.current = saveVersionNote;
+
+  const flushPendingNoteSaves = useCallback((syncCache = true) => {
+    const pendingSaves = [...noteSaveTimeoutsRef.current.entries()];
+    noteSaveTimeoutsRef.current.clear();
+    for (const [versionId, pendingSave] of pendingSaves) {
+      clearTimeout(pendingSave.timeout);
+      void saveVersionNoteRef.current(versionId, pendingSave.note, syncCache);
+    }
+  }, []);
+
+  const versions = cachedVersions.length > 0 ? cachedVersions : liveVersions;
+
+  const versionNumberByOid = useMemo(() => {
+    const map = new Map<string, number>();
+    for (let index = 0; index < versions.length; index++) {
+      map.set(versions[index].oid, versions.length - index);
+    }
+    return map;
+  }, [versions]);
+
   useEffect(() => {
     async function updatePaneState() {
       // When pane becomes visible after being closed
@@ -97,8 +170,10 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
 
       // Reset when closing
       if (!isVisible && wasVisibleRef.current) {
+        flushPendingNoteSaves();
         setSearchQuery("");
         setShowFavoritesOnly(false);
+        setExpandedNoteVersionIds(new Set());
         if (selectedVersionId && appId) {
           setSelectedVersionId(null);
           await checkoutVersion({ appId, versionId: "main" });
@@ -118,6 +193,7 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
     appId,
     app?.neonProjectId,
     checkoutVersion,
+    flushPendingNoteSaves,
     refreshVersions,
     liveVersions,
     restartApp,
@@ -125,12 +201,9 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
 
   useEffect(() => {
     return () => {
-      for (const timeout of noteSaveTimeoutsRef.current.values()) {
-        clearTimeout(timeout);
-      }
-      noteSaveTimeoutsRef.current.clear();
+      flushPendingNoteSaves(false);
     };
-  }, []);
+  }, [flushPendingNoteSaves]);
 
   // Initial load of cached versions when live versions become available
   useEffect(() => {
@@ -159,8 +232,6 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
     }
   };
 
-  const versions = cachedVersions.length > 0 ? cachedVersions : liveVersions;
-
   const favoriteFilteredVersions = showFavoritesOnly
     ? versions.filter((version) => version.isFavorite)
     : versions;
@@ -168,7 +239,7 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
   const filteredVersions = searchQuery.trim()
     ? favoriteFilteredVersions.filter((v) => {
         const query = searchQuery.toLowerCase();
-        const versionNumber = String(versions.length - versions.indexOf(v));
+        const versionNumber = String(versionNumberByOid.get(v.oid) ?? 0);
         return (
           v.oid.toLowerCase().includes(query) ||
           (v.message && v.message.toLowerCase().includes(query)) ||
@@ -178,51 +249,24 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
       })
     : favoriteFilteredVersions;
 
-  const updateCachedVersion = (
-    versionId: string,
-    updates: Partial<Pick<Version, "isFavorite" | "note">>,
-  ) => {
-    setCachedVersions((prevVersions) => {
-      const sourceVersions =
-        prevVersions.length > 0 ? prevVersions : liveVersions;
-      return sourceVersions.map((version) =>
-        version.oid === versionId ? { ...version, ...updates } : version,
-      );
-    });
-  };
-
-  const saveVersionNote = (versionId: string, note: string | null) => {
-    void setVersionNote({ versionId, note })
-      .then((result) => {
-        updateCachedVersion(result.oid, {
-          isFavorite: result.isFavorite,
-          note: result.note,
-        });
-      })
-      .catch(async () => {
-        const result = await refreshVersions();
-        setCachedVersions(result.data ?? liveVersions);
-      });
-  };
-
   const queueVersionNoteSave = (versionId: string, note: string | null) => {
-    const existingTimeout = noteSaveTimeoutsRef.current.get(versionId);
-    if (existingTimeout) {
-      clearTimeout(existingTimeout);
+    const existingPendingSave = noteSaveTimeoutsRef.current.get(versionId);
+    if (existingPendingSave) {
+      clearTimeout(existingPendingSave.timeout);
     }
     const timeout = setTimeout(() => {
       noteSaveTimeoutsRef.current.delete(versionId);
-      saveVersionNote(versionId, note);
+      void saveVersionNoteRef.current(versionId, note, true);
     }, 600);
-    noteSaveTimeoutsRef.current.set(versionId, timeout);
+    noteSaveTimeoutsRef.current.set(versionId, { timeout, note });
   };
 
   const flushVersionNoteSave = (versionId: string, note: string | null) => {
-    const existingTimeout = noteSaveTimeoutsRef.current.get(versionId);
-    if (existingTimeout) {
-      clearTimeout(existingTimeout);
+    const existingPendingSave = noteSaveTimeoutsRef.current.get(versionId);
+    if (existingPendingSave) {
+      clearTimeout(existingPendingSave.timeout);
       noteSaveTimeoutsRef.current.delete(versionId);
-      saveVersionNote(versionId, note);
+      void saveVersionNoteRef.current(versionId, note, true);
     }
   };
 
@@ -306,7 +350,9 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
           <div className="divide-y divide-border">
             {filteredVersions.map((version: Version) => {
               const thumbnailUrl = screenshotByHash.get(version.oid);
-              const versionNumber = versions.length - versions.indexOf(version);
+              const versionNumber = versionNumberByOid.get(version.oid) ?? 0;
+              const showNoteEditor =
+                expandedNoteVersionIds.has(version.oid) || !!version.note;
               return (
                 <div
                   key={version.oid}
@@ -351,8 +397,8 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
                           data-testid={`version-favorite-button-${versionNumber}`}
                           aria-label={
                             version.isFavorite
-                              ? "Remove version from favorites"
-                              : "Favorite version"
+                              ? `Remove version ${versionNumber} from favorites`
+                              : `Favorite version ${versionNumber}`
                           }
                           title={
                             version.isFavorite
@@ -472,13 +518,10 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
                                   ? version.message.replace(
                                       /Reverted all changes back to version ([a-f0-9]+)/,
                                       (_, hash) => {
-                                        const targetIndex = versions.findIndex(
-                                          (v) => v.oid === hash,
-                                        );
-                                        return targetIndex !== -1
-                                          ? `Reverted all changes back to version ${
-                                              versions.length - targetIndex
-                                            }`
+                                        const targetVersionNumber =
+                                          versionNumberByOid.get(hash);
+                                        return targetVersionNumber !== undefined
+                                          ? `Reverted all changes back to version ${targetVersionNumber}`
                                           : version.message;
                                       },
                                     )
@@ -489,22 +532,50 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
                           </p>
                         )}
 
-                        <Textarea
-                          value={version.note ?? ""}
-                          placeholder="Add note..."
-                          aria-label={`Note for version ${versionNumber}`}
-                          onClick={(e) => e.stopPropagation()}
-                          onKeyDown={(e) => e.stopPropagation()}
-                          onChange={(e) => {
-                            const note = e.target.value;
-                            updateCachedVersion(version.oid, { note });
-                            queueVersionNoteSave(version.oid, note);
-                          }}
-                          onBlur={(e) =>
-                            flushVersionNoteSave(version.oid, e.target.value)
-                          }
-                          className="mt-2 min-h-8 resize-none px-2 py-1 text-xs focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-0"
-                        />
+                        {showNoteEditor ? (
+                          <Textarea
+                            value={version.note ?? ""}
+                            placeholder="Add note..."
+                            aria-label={`Note for version ${versionNumber}`}
+                            autoFocus={!version.note}
+                            onClick={(e) => e.stopPropagation()}
+                            onKeyDown={(e) => e.stopPropagation()}
+                            onChange={(e) => {
+                              const note = e.target.value;
+                              setExpandedNoteVersionIds((previous) => {
+                                if (previous.has(version.oid)) {
+                                  return previous;
+                                }
+                                const next = new Set(previous);
+                                next.add(version.oid);
+                                return next;
+                              });
+                              updateCachedVersion(version.oid, { note });
+                              queueVersionNoteSave(version.oid, note);
+                            }}
+                            onBlur={(e) =>
+                              flushVersionNoteSave(version.oid, e.target.value)
+                            }
+                            className="mt-2 min-h-8 resize-none px-2 py-1 text-xs focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-0"
+                          />
+                        ) : (
+                          <button
+                            type="button"
+                            aria-label={`Add note for version ${versionNumber}`}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setExpandedNoteVersionIds((previous) => {
+                                const next = new Set(previous);
+                                next.add(version.oid);
+                                return next;
+                              });
+                            }}
+                            className="mt-1 inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+                          >
+                            <Pencil className="h-3 w-3" />
+                            <span>Add note</span>
+                          </button>
+                        )}
                       </div>
 
                       <div className="flex items-center gap-1">

--- a/src/components/chat/VersionPane.tsx
+++ b/src/components/chat/VersionPane.tsx
@@ -25,6 +25,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { showError } from "@/lib/toast";
 
 import { useRunApp } from "@/hooks/useRunApp";
 
@@ -127,7 +128,7 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
   ) => {
     setCachedVersions((prevVersions) => {
       const sourceVersions =
-        prevVersions.length > 0 ? prevVersions : liveVersions;
+        prevVersions.length > 0 ? prevVersions : liveVersionsRef.current;
       return sourceVersions.map((version) =>
         version.oid === versionId ? { ...version, ...updates } : version,
       );
@@ -152,13 +153,8 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
           note: result.note,
         });
       }
-    } catch (error) {
-      if (!syncCache) {
-        console.error("Failed to save pending version note", error);
-        return;
-      }
-      const result = await refreshVersions();
-      setCachedVersions(result.data ?? liveVersionsRef.current);
+    } catch {
+      showError("Failed to save version note. Please try again.");
     }
   };
   const flushPendingNoteSaves = useCallback((syncCache = true) => {
@@ -223,7 +219,6 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
     checkoutVersion,
     flushPendingNoteSaves,
     refreshVersions,
-    liveVersions,
     restartApp,
   ]);
 
@@ -436,266 +431,284 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
                 >
                   <div
                     data-testid="version-list-item"
-                    className="flex-shrink-0 w-16 h-10 rounded border border-border bg-muted overflow-hidden flex items-center justify-center"
-                    aria-hidden="true"
+                    className="flex gap-3 w-full"
                   >
-                    {thumbnailUrl ? (
-                      <img
-                        src={thumbnailUrl}
-                        alt=""
-                        loading="lazy"
-                        className="w-full h-full object-cover object-top"
-                      />
-                    ) : (
-                      <span className="text-[10px] font-mono text-muted-foreground">
-                        {version.oid.slice(0, 4)}
-                      </span>
-                    )}
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center justify-between">
-                      <div className="flex items-center gap-2">
-                        <button
-                          type="button"
-                          data-testid={`version-favorite-button-${versionNumber}`}
-                          aria-label={
-                            version.isFavorite
-                              ? `Remove version ${versionNumber} from favorites`
-                              : `Favorite version ${versionNumber}`
-                          }
-                          title={
-                            version.isFavorite
-                              ? "Remove version from favorites"
-                              : "Favorite version"
-                          }
-                          onClick={async (e) => {
-                            e.stopPropagation();
-                            const nextIsFavorite = !version.isFavorite;
-                            updateCachedVersion(version.oid, {
-                              isFavorite: nextIsFavorite,
-                            });
-                            try {
-                              const result = await setVersionFavorite({
-                                versionId: version.oid,
-                                isFavorite: nextIsFavorite,
-                              });
-                              updateCachedVersion(result.oid, {
-                                isFavorite: result.isFavorite,
-                                note: result.note,
-                              });
-                            } catch {
-                              updateCachedVersion(version.oid, {
-                                isFavorite: version.isFavorite,
-                              });
-                            }
-                          }}
-                          className={cn(
-                            "rounded-sm p-0.5 transition-colors",
-                            version.isFavorite
-                              ? "text-[#6c55dc]"
-                              : "text-muted-foreground hover:text-foreground",
-                          )}
-                        >
-                          <Star
-                            className={cn(
-                              "h-3.5 w-3.5",
-                              version.isFavorite && "fill-[#6c55dc]",
-                            )}
-                          />
-                        </button>
-                        <span className="font-medium text-xs">
-                          Version{" "}
-                          <HighlightMatch
-                            text={String(versionNumber)}
-                            query={searchQuery.trim()}
-                          />{" "}
-                          (
-                          <HighlightMatch
-                            text={version.oid.slice(0, 7)}
-                            query={searchQuery.trim()}
-                          />
-                          )
+                    <div
+                      className="flex-shrink-0 w-16 h-10 rounded border border-border bg-muted overflow-hidden flex items-center justify-center"
+                      aria-hidden="true"
+                    >
+                      {thumbnailUrl ? (
+                        <img
+                          src={thumbnailUrl}
+                          alt=""
+                          loading="lazy"
+                          className="w-full h-full object-cover object-top"
+                        />
+                      ) : (
+                        <span className="text-[10px] font-mono text-muted-foreground">
+                          {version.oid.slice(0, 4)}
                         </span>
-                        {/* example format: '2025-07-25T21:52:01Z' */}
-                        {version.dbTimestamp &&
-                          (() => {
-                            const timestampMs = new Date(
-                              version.dbTimestamp,
-                            ).getTime();
-                            const isExpired =
-                              Date.now() - timestampMs > 24 * 60 * 60 * 1000;
-                            return (
-                              <Tooltip>
-                                <TooltipTrigger>
-                                  <div
-                                    className={cn(
-                                      "inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-medium rounded-md",
-                                      isExpired
-                                        ? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
-                                        : "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300",
-                                    )}
-                                  >
-                                    <Database size={10} />
-                                    <span>DB</span>
-                                  </div>
-                                </TooltipTrigger>
-                                <TooltipContent>
-                                  {isExpired
-                                    ? "DB snapshot may have expired (older than 24 hours)"
-                                    : `Database snapshot available at timestamp ${version.dbTimestamp}`}
-                                </TooltipContent>
-                              </Tooltip>
-                            );
-                          })()}
-                      </div>
-                      <div className="flex items-center gap-2">
-                        {isCheckingOutVersion &&
-                          selectedVersionId === version.oid && (
-                            <Loader2
-                              size={12}
-                              className="animate-spin text-primary"
-                            />
-                          )}
-                        <span className="text-xs opacity-90">
-                          {isCheckingOutVersion &&
-                          selectedVersionId === version.oid
-                            ? "Loading..."
-                            : formatDistanceToNow(
-                                new Date(version.timestamp * 1000),
-                                {
-                                  addSuffix: true,
-                                },
-                              )}
-                        </span>
-                      </div>
+                      )}
                     </div>
-                    <div className="mt-1 flex items-start justify-between gap-2">
-                      <div className="min-w-0 flex-1">
-                        {version.message && (
-                          <p className="text-sm">
-                            <HighlightMatch
-                              text={
-                                version.message.startsWith(
-                                  "Reverted all changes back to version ",
-                                )
-                                  ? version.message.replace(
-                                      /Reverted all changes back to version ([a-f0-9]+)/,
-                                      (_, hash) => {
-                                        const targetVersionNumber =
-                                          versionNumberByOid.get(hash);
-                                        return targetVersionNumber !== undefined
-                                          ? `Reverted all changes back to version ${targetVersionNumber}`
-                                          : version.message;
-                                      },
-                                    )
-                                  : version.message
-                              }
-                              query={searchQuery.trim()}
-                            />
-                          </p>
-                        )}
-
-                        {showNoteEditor ? (
-                          <Textarea
-                            value={version.note ?? ""}
-                            placeholder="Add note..."
-                            aria-label={`Note for version ${versionNumber}`}
-                            autoFocus={autoFocusNoteVersionIds.has(version.oid)}
-                            maxLength={MAX_VERSION_NOTE_LENGTH}
-                            onClick={(e) => e.stopPropagation()}
-                            onKeyDown={(e) => e.stopPropagation()}
-                            onFocus={() => {
-                              setAutoFocusNoteVersionIds((previous) => {
-                                if (!previous.has(version.oid)) {
-                                  return previous;
-                                }
-                                const next = new Set(previous);
-                                next.delete(version.oid);
-                                return next;
-                              });
-                            }}
-                            onChange={(e) => {
-                              const note = e.target.value;
-                              setExpandedNoteVersionIds((previous) => {
-                                if (previous.has(version.oid)) {
-                                  return previous;
-                                }
-                                const next = new Set(previous);
-                                next.add(version.oid);
-                                return next;
-                              });
-                              updateCachedVersion(version.oid, { note });
-                              queueVersionNoteSave(version.oid, note);
-                            }}
-                            onBlur={(e) =>
-                              flushVersionNoteSave(version.oid, e.target.value)
-                            }
-                            className="mt-2 min-h-8 resize-none px-2 py-1 text-xs focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-0"
-                          />
-                        ) : (
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-2">
                           <button
                             type="button"
-                            aria-label={`Add note for version ${versionNumber}`}
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              setExpandedNoteVersionIds((previous) => {
-                                const next = new Set(previous);
-                                next.add(version.oid);
-                                return next;
-                              });
-                              setAutoFocusNoteVersionIds((previous) => {
-                                const next = new Set(previous);
-                                next.add(version.oid);
-                                return next;
-                              });
-                            }}
-                            className="mt-1 inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
-                          >
-                            <Pencil className="h-3 w-3" />
-                            <span>Add note</span>
-                          </button>
-                        )}
-                      </div>
-
-                      <div className="flex items-center gap-1">
-                        {/* Restore button */}
-                        <button
-                          onClick={async (e) => {
-                            e.stopPropagation();
-
-                            await revertVersion({
-                              versionId: version.oid,
-                            });
-                            setSelectedVersionId(null);
-                            // Close the pane after revert to force a refresh on next open
-                            onClose();
-                            if (version.dbTimestamp) {
-                              await restartApp();
+                            data-testid={`version-favorite-button-${versionNumber}`}
+                            aria-label={
+                              version.isFavorite
+                                ? `Remove version ${versionNumber} from favorites`
+                                : `Favorite version ${versionNumber}`
                             }
-                          }}
-                          disabled={isRevertingVersion}
-                          className={cn(
-                            "invisible mt-1 flex items-center gap-1 px-2 py-0.5 text-sm font-medium bg-(--primary) text-(--primary-foreground) hover:bg-background-lightest rounded-md transition-colors",
-                            selectedVersionId === version.oid && "visible",
-                            isRevertingVersion &&
-                              "opacity-50 cursor-not-allowed",
-                          )}
-                          aria-label="Restore to this version"
-                          title={
-                            isRevertingVersion
-                              ? "Restoring to this version..."
-                              : "Restore to this version"
-                          }
-                        >
-                          {isRevertingVersion ? (
-                            <Loader2 size={12} className="animate-spin" />
-                          ) : (
-                            <RotateCcw size={12} />
-                          )}
-                          <span>
-                            {isRevertingVersion ? "Restoring..." : "Restore"}
+                            title={
+                              version.isFavorite
+                                ? "Remove version from favorites"
+                                : "Favorite version"
+                            }
+                            onClick={async (e) => {
+                              e.stopPropagation();
+                              const targetAppId = appId;
+                              const nextIsFavorite = !version.isFavorite;
+                              updateCachedVersion(version.oid, {
+                                isFavorite: nextIsFavorite,
+                              });
+                              try {
+                                const result = await setVersionFavorite({
+                                  appId: targetAppId,
+                                  versionId: version.oid,
+                                  isFavorite: nextIsFavorite,
+                                });
+                                if (targetAppId !== currentAppIdRef.current) {
+                                  return;
+                                }
+                                updateCachedVersion(result.oid, {
+                                  isFavorite: result.isFavorite,
+                                  note: result.note,
+                                });
+                              } catch {
+                                if (targetAppId !== currentAppIdRef.current) {
+                                  return;
+                                }
+                                updateCachedVersion(version.oid, {
+                                  isFavorite: version.isFavorite,
+                                });
+                              }
+                            }}
+                            className={cn(
+                              "rounded-sm p-0.5 transition-colors",
+                              version.isFavorite
+                                ? "text-[#6c55dc]"
+                                : "text-muted-foreground hover:text-foreground",
+                            )}
+                          >
+                            <Star
+                              className={cn(
+                                "h-3.5 w-3.5",
+                                version.isFavorite && "fill-[#6c55dc]",
+                              )}
+                            />
+                          </button>
+                          <span className="font-medium text-xs">
+                            Version{" "}
+                            <HighlightMatch
+                              text={String(versionNumber)}
+                              query={searchQuery.trim()}
+                            />{" "}
+                            (
+                            <HighlightMatch
+                              text={version.oid.slice(0, 7)}
+                              query={searchQuery.trim()}
+                            />
+                            )
                           </span>
-                        </button>
+                          {/* example format: '2025-07-25T21:52:01Z' */}
+                          {version.dbTimestamp &&
+                            (() => {
+                              const timestampMs = new Date(
+                                version.dbTimestamp,
+                              ).getTime();
+                              const isExpired =
+                                Date.now() - timestampMs > 24 * 60 * 60 * 1000;
+                              return (
+                                <Tooltip>
+                                  <TooltipTrigger>
+                                    <div
+                                      className={cn(
+                                        "inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-medium rounded-md",
+                                        isExpired
+                                          ? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+                                          : "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300",
+                                      )}
+                                    >
+                                      <Database size={10} />
+                                      <span>DB</span>
+                                    </div>
+                                  </TooltipTrigger>
+                                  <TooltipContent>
+                                    {isExpired
+                                      ? "DB snapshot may have expired (older than 24 hours)"
+                                      : `Database snapshot available at timestamp ${version.dbTimestamp}`}
+                                  </TooltipContent>
+                                </Tooltip>
+                              );
+                            })()}
+                        </div>
+                        <div className="flex items-center gap-2">
+                          {isCheckingOutVersion &&
+                            selectedVersionId === version.oid && (
+                              <Loader2
+                                size={12}
+                                className="animate-spin text-primary"
+                              />
+                            )}
+                          <span className="text-xs opacity-90">
+                            {isCheckingOutVersion &&
+                            selectedVersionId === version.oid
+                              ? "Loading..."
+                              : formatDistanceToNow(
+                                  new Date(version.timestamp * 1000),
+                                  {
+                                    addSuffix: true,
+                                  },
+                                )}
+                          </span>
+                        </div>
+                      </div>
+                      <div className="mt-1 flex items-start justify-between gap-2">
+                        <div className="min-w-0 flex-1">
+                          {version.message && (
+                            <p className="text-sm">
+                              <HighlightMatch
+                                text={
+                                  version.message.startsWith(
+                                    "Reverted all changes back to version ",
+                                  )
+                                    ? version.message.replace(
+                                        /Reverted all changes back to version ([a-f0-9]+)/,
+                                        (_, hash) => {
+                                          const targetVersionNumber =
+                                            versionNumberByOid.get(hash);
+                                          return targetVersionNumber !==
+                                            undefined
+                                            ? `Reverted all changes back to version ${targetVersionNumber}`
+                                            : version.message;
+                                        },
+                                      )
+                                    : version.message
+                                }
+                                query={searchQuery.trim()}
+                              />
+                            </p>
+                          )}
+
+                          {showNoteEditor ? (
+                            <Textarea
+                              value={version.note ?? ""}
+                              placeholder="Add note..."
+                              aria-label={`Note for version ${versionNumber}`}
+                              autoFocus={autoFocusNoteVersionIds.has(
+                                version.oid,
+                              )}
+                              maxLength={MAX_VERSION_NOTE_LENGTH}
+                              onClick={(e) => e.stopPropagation()}
+                              onKeyDown={(e) => e.stopPropagation()}
+                              onFocus={() => {
+                                setAutoFocusNoteVersionIds((previous) => {
+                                  if (!previous.has(version.oid)) {
+                                    return previous;
+                                  }
+                                  const next = new Set(previous);
+                                  next.delete(version.oid);
+                                  return next;
+                                });
+                              }}
+                              onChange={(e) => {
+                                const note = e.target.value;
+                                setExpandedNoteVersionIds((previous) => {
+                                  if (previous.has(version.oid)) {
+                                    return previous;
+                                  }
+                                  const next = new Set(previous);
+                                  next.add(version.oid);
+                                  return next;
+                                });
+                                updateCachedVersion(version.oid, { note });
+                                queueVersionNoteSave(version.oid, note);
+                              }}
+                              onBlur={(e) =>
+                                flushVersionNoteSave(
+                                  version.oid,
+                                  e.target.value,
+                                )
+                              }
+                              className="mt-2 min-h-8 resize-none px-2 py-1 text-xs focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-0"
+                            />
+                          ) : (
+                            <button
+                              type="button"
+                              aria-label={`Add note for version ${versionNumber}`}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                setExpandedNoteVersionIds((previous) => {
+                                  const next = new Set(previous);
+                                  next.add(version.oid);
+                                  return next;
+                                });
+                                setAutoFocusNoteVersionIds((previous) => {
+                                  const next = new Set(previous);
+                                  next.add(version.oid);
+                                  return next;
+                                });
+                              }}
+                              className="mt-1 inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+                            >
+                              <Pencil className="h-3 w-3" />
+                              <span>Add note</span>
+                            </button>
+                          )}
+                        </div>
+
+                        <div className="flex items-center gap-1">
+                          {/* Restore button */}
+                          <button
+                            onClick={async (e) => {
+                              e.stopPropagation();
+
+                              await revertVersion({
+                                versionId: version.oid,
+                              });
+                              setSelectedVersionId(null);
+                              // Close the pane after revert to force a refresh on next open
+                              onClose();
+                              if (version.dbTimestamp) {
+                                await restartApp();
+                              }
+                            }}
+                            disabled={isRevertingVersion}
+                            className={cn(
+                              "invisible mt-1 flex items-center gap-1 px-2 py-0.5 text-sm font-medium bg-(--primary) text-(--primary-foreground) hover:bg-background-lightest rounded-md transition-colors",
+                              selectedVersionId === version.oid && "visible",
+                              isRevertingVersion &&
+                                "opacity-50 cursor-not-allowed",
+                            )}
+                            aria-label="Restore to this version"
+                            title={
+                              isRevertingVersion
+                                ? "Restoring to this version..."
+                                : "Restore to this version"
+                            }
+                          >
+                            {isRevertingVersion ? (
+                              <Loader2 size={12} className="animate-spin" />
+                            ) : (
+                              <RotateCcw size={12} />
+                            )}
+                            <span>
+                              {isRevertingVersion ? "Restoring..." : "Restore"}
+                            </span>
+                          </button>
+                        </div>
                       </div>
                     </div>
                   </div>

--- a/src/components/chat/VersionPane.tsx
+++ b/src/components/chat/VersionPane.tsx
@@ -59,6 +59,7 @@ type SaveVersionNote = (
   appId: number | null,
   versionId: string,
   note: string | null,
+  saveSequence: number,
   syncCache: boolean,
 ) => void;
 
@@ -67,6 +68,7 @@ type PendingNoteSave = {
   appId: number | null;
   versionId: string;
   note: string | null;
+  saveSequence: number;
   saveVersionNote: SaveVersionNote;
 };
 
@@ -106,6 +108,7 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
   >(() => new Set());
   const searchInputRef = useRef<HTMLInputElement>(null);
   const noteSaveTimeoutsRef = useRef(new Map<string, PendingNoteSave>());
+  const noteSaveSequencesRef = useRef(new Map<string, number>());
   const liveVersionsRef = useRef(liveVersions);
   liveVersionsRef.current = liveVersions;
 
@@ -122,41 +125,58 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
     [screenshotsData],
   );
 
-  const updateCachedVersion = (
-    versionId: string,
-    updates: Partial<Pick<Version, "isFavorite" | "note">>,
-  ) => {
-    setCachedVersions((prevVersions) => {
-      const sourceVersions =
-        prevVersions.length > 0 ? prevVersions : liveVersionsRef.current;
-      return sourceVersions.map((version) =>
-        version.oid === versionId ? { ...version, ...updates } : version,
-      );
-    });
-  };
-
-  const saveVersionNote = async (
-    targetAppId: number | null,
-    versionId: string,
-    note: string | null,
-    syncCache = true,
-  ) => {
-    try {
-      const result = await setVersionNote({
-        appId: targetAppId,
-        versionId,
-        note,
+  const updateCachedVersion = useCallback(
+    (
+      versionId: string,
+      updates: Partial<Pick<Version, "isFavorite" | "note">>,
+    ) => {
+      setCachedVersions((prevVersions) => {
+        const sourceVersions =
+          prevVersions.length > 0 ? prevVersions : liveVersionsRef.current;
+        return sourceVersions.map((version) =>
+          version.oid === versionId ? { ...version, ...updates } : version,
+        );
       });
-      if (syncCache) {
-        updateCachedVersion(result.oid, {
-          isFavorite: result.isFavorite,
-          note: result.note,
+    },
+    [],
+  );
+
+  const saveVersionNote = useCallback(
+    async (
+      targetAppId: number | null,
+      versionId: string,
+      note: string | null,
+      saveSequence: number,
+      syncCache = true,
+    ) => {
+      const pendingSaveKey = getPendingNoteSaveKey(targetAppId, versionId);
+      const isLatestSave = () =>
+        noteSaveSequencesRef.current.get(pendingSaveKey) === saveSequence;
+      try {
+        const result = await setVersionNote({
+          appId: targetAppId,
+          versionId,
+          note,
         });
+        if (
+          syncCache &&
+          isLatestSave() &&
+          targetAppId === currentAppIdRef.current
+        ) {
+          updateCachedVersion(result.oid, { note: result.note });
+        }
+      } catch {
+        if (
+          syncCache &&
+          isLatestSave() &&
+          targetAppId === currentAppIdRef.current
+        ) {
+          showError("Failed to save version note. Please try again.");
+        }
       }
-    } catch {
-      showError("Failed to save version note. Please try again.");
-    }
-  };
+    },
+    [setVersionNote, updateCachedVersion],
+  );
   const flushPendingNoteSaves = useCallback((syncCache = true) => {
     const pendingSaves = [...noteSaveTimeoutsRef.current.entries()];
     noteSaveTimeoutsRef.current.clear();
@@ -166,6 +186,7 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
         pendingSave.appId,
         pendingSave.versionId,
         pendingSave.note,
+        pendingSave.saveSequence,
         syncCache && pendingSave.appId === currentAppIdRef.current,
       );
     }
@@ -291,6 +312,9 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
     if (existingPendingSave) {
       clearTimeout(existingPendingSave.timeout);
     }
+    const saveSequence =
+      (noteSaveSequencesRef.current.get(pendingSaveKey) ?? 0) + 1;
+    noteSaveSequencesRef.current.set(pendingSaveKey, saveSequence);
     const timeout = setTimeout(() => {
       const pendingSave = noteSaveTimeoutsRef.current.get(pendingSaveKey);
       if (!pendingSave) {
@@ -301,6 +325,7 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
         pendingSave.appId,
         pendingSave.versionId,
         pendingSave.note,
+        pendingSave.saveSequence,
         pendingSave.appId === currentAppIdRef.current,
       );
     }, 600);
@@ -309,6 +334,7 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
       appId,
       versionId,
       note,
+      saveSequence,
       saveVersionNote,
     });
   };
@@ -323,6 +349,7 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
         existingPendingSave.appId,
         existingPendingSave.versionId,
         note,
+        existingPendingSave.saveSequence,
         existingPendingSave.appId === currentAppIdRef.current,
       );
     }
@@ -484,7 +511,6 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
                                 }
                                 updateCachedVersion(result.oid, {
                                   isFavorite: result.isFavorite,
-                                  note: result.note,
                                 });
                               } catch {
                                 if (targetAppId !== currentAppIdRef.current) {

--- a/src/components/chat/VersionPane.tsx
+++ b/src/components/chat/VersionPane.tsx
@@ -2,7 +2,7 @@ import { useAtom, useAtomValue } from "jotai";
 import { selectedAppIdAtom, selectedVersionIdAtom } from "@/atoms/appAtoms";
 import { useVersions } from "@/hooks/useVersions";
 import { formatDistanceToNow } from "date-fns";
-import { RotateCcw, X, Database, Loader2, Search } from "lucide-react";
+import { RotateCcw, X, Database, Loader2, Search, Star } from "lucide-react";
 import type { Version } from "@/ipc/types";
 import { ipc } from "@/ipc/types";
 import { cn } from "@/lib/utils";
@@ -11,6 +11,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useCheckoutVersion } from "@/hooks/useCheckoutVersion";
 import { useLoadApp } from "@/hooks/useLoadApp";
+import { Textarea } from "@/components/ui/textarea";
 import {
   Tooltip,
   TooltipContent,
@@ -54,6 +55,8 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
     refreshVersions,
     revertVersion,
     isRevertingVersion,
+    setVersionFavorite,
+    setVersionNote,
   } = useVersions(appId);
 
   const [selectedVersionId, setSelectedVersionId] = useAtom(
@@ -63,7 +66,11 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
   const wasVisibleRef = useRef(false);
   const [cachedVersions, setCachedVersions] = useState<Version[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
+  const [showFavoritesOnly, setShowFavoritesOnly] = useState(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const noteSaveTimeoutsRef = useRef(
+    new Map<string, ReturnType<typeof setTimeout>>(),
+  );
 
   const { data: screenshotsData } = useQuery({
     queryKey: queryKeys.apps.screenshots({ appId }),
@@ -83,16 +90,17 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
       // When pane becomes visible after being closed
       if (isVisible && !wasVisibleRef.current) {
         if (appId) {
-          await refreshVersions();
-          setCachedVersions(liveVersions);
+          const result = await refreshVersions();
+          setCachedVersions(result.data ?? liveVersions);
         }
       }
 
       // Reset when closing
-      if (!isVisible && selectedVersionId) {
-        setSelectedVersionId(null);
+      if (!isVisible && wasVisibleRef.current) {
         setSearchQuery("");
-        if (appId) {
+        setShowFavoritesOnly(false);
+        if (selectedVersionId && appId) {
+          setSelectedVersionId(null);
           await checkoutVersion({ appId, versionId: "main" });
           if (app?.neonProjectId) {
             await restartApp();
@@ -108,10 +116,21 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
     selectedVersionId,
     setSelectedVersionId,
     appId,
+    app?.neonProjectId,
     checkoutVersion,
     refreshVersions,
     liveVersions,
+    restartApp,
   ]);
+
+  useEffect(() => {
+    return () => {
+      for (const timeout of noteSaveTimeoutsRef.current.values()) {
+        clearTimeout(timeout);
+      }
+      noteSaveTimeoutsRef.current.clear();
+    };
+  }, []);
 
   // Initial load of cached versions when live versions become available
   useEffect(() => {
@@ -142,17 +161,70 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
 
   const versions = cachedVersions.length > 0 ? cachedVersions : liveVersions;
 
+  const favoriteFilteredVersions = showFavoritesOnly
+    ? versions.filter((version) => version.isFavorite)
+    : versions;
+
   const filteredVersions = searchQuery.trim()
-    ? versions.filter((v, index) => {
+    ? favoriteFilteredVersions.filter((v) => {
         const query = searchQuery.toLowerCase();
-        const versionNumber = String(versions.length - index);
+        const versionNumber = String(versions.length - versions.indexOf(v));
         return (
           v.oid.toLowerCase().includes(query) ||
           (v.message && v.message.toLowerCase().includes(query)) ||
+          (v.note && v.note.toLowerCase().includes(query)) ||
           versionNumber.includes(query)
         );
       })
-    : versions;
+    : favoriteFilteredVersions;
+
+  const updateCachedVersion = (
+    versionId: string,
+    updates: Partial<Pick<Version, "isFavorite" | "note">>,
+  ) => {
+    setCachedVersions((prevVersions) => {
+      const sourceVersions =
+        prevVersions.length > 0 ? prevVersions : liveVersions;
+      return sourceVersions.map((version) =>
+        version.oid === versionId ? { ...version, ...updates } : version,
+      );
+    });
+  };
+
+  const saveVersionNote = (versionId: string, note: string | null) => {
+    void setVersionNote({ versionId, note })
+      .then((result) => {
+        updateCachedVersion(result.oid, {
+          isFavorite: result.isFavorite,
+          note: result.note,
+        });
+      })
+      .catch(async () => {
+        const result = await refreshVersions();
+        setCachedVersions(result.data ?? liveVersions);
+      });
+  };
+
+  const queueVersionNoteSave = (versionId: string, note: string | null) => {
+    const existingTimeout = noteSaveTimeoutsRef.current.get(versionId);
+    if (existingTimeout) {
+      clearTimeout(existingTimeout);
+    }
+    const timeout = setTimeout(() => {
+      noteSaveTimeoutsRef.current.delete(versionId);
+      saveVersionNote(versionId, note);
+    }, 600);
+    noteSaveTimeoutsRef.current.set(versionId, timeout);
+  };
+
+  const flushVersionNoteSave = (versionId: string, note: string | null) => {
+    const existingTimeout = noteSaveTimeoutsRef.current.get(versionId);
+    if (existingTimeout) {
+      clearTimeout(existingTimeout);
+      noteSaveTimeoutsRef.current.delete(versionId);
+      saveVersionNote(versionId, note);
+    }
+  };
 
   return (
     <div className="h-full border-t border-2 border-border w-full flex flex-col">
@@ -169,29 +241,56 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
         </div>
       </div>
       <div className="px-3 py-2 border-b border-border">
-        <div className="relative">
-          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
-          <input
-            ref={searchInputRef}
-            type="text"
-            placeholder="Search versions..."
-            aria-label="Search versions"
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-full rounded-md border border-input bg-transparent pl-8 pr-8 py-1.5 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-          />
-          {searchQuery && (
-            <button
-              onClick={() => {
-                setSearchQuery("");
-                searchInputRef.current?.focus();
-              }}
-              className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-              aria-label="Clear search"
-            >
-              <X className="h-3.5 w-3.5" />
-            </button>
-          )}
+        <div className="flex items-center gap-2">
+          <div className="relative flex-1 min-w-0">
+            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+            <input
+              ref={searchInputRef}
+              type="text"
+              placeholder="Search versions..."
+              aria-label="Search versions"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="w-full rounded-md border border-input bg-transparent pl-8 pr-8 py-1.5 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            />
+            {searchQuery && (
+              <button
+                onClick={() => {
+                  setSearchQuery("");
+                  searchInputRef.current?.focus();
+                }}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                aria-label="Clear search"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            )}
+          </div>
+          <button
+            type="button"
+            aria-label={
+              showFavoritesOnly
+                ? "Show all versions"
+                : "Show favorite versions only"
+            }
+            aria-pressed={showFavoritesOnly}
+            title={
+              showFavoritesOnly
+                ? "Show all versions"
+                : "Show favorite versions only"
+            }
+            onClick={() => setShowFavoritesOnly((value) => !value)}
+            className={cn(
+              "h-8 w-8 inline-flex items-center justify-center rounded-md border border-input transition-colors",
+              showFavoritesOnly
+                ? "bg-primary/10 text-primary"
+                : "text-muted-foreground hover:text-foreground hover:bg-accent",
+            )}
+          >
+            <Star
+              className={cn("h-3.5 w-3.5", showFavoritesOnly && "fill-current")}
+            />
+          </button>
         </div>
       </div>
       <div className="flex-1 overflow-y-auto min-h-0">
@@ -199,16 +298,19 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
           <div className="p-4">No versions available</div>
         ) : filteredVersions.length === 0 ? (
           <div className="p-4 text-sm text-muted-foreground">
-            No matching versions
+            {showFavoritesOnly && !searchQuery.trim()
+              ? "No favorite versions"
+              : "No matching versions"}
           </div>
         ) : (
           <div className="divide-y divide-border">
             {filteredVersions.map((version: Version) => {
               const thumbnailUrl = screenshotByHash.get(version.oid);
+              const versionNumber = versions.length - versions.indexOf(version);
               return (
                 <div
                   key={version.oid}
-                  data-testid="version-list-item"
+                  data-testid={`version-row-${versionNumber}`}
                   className={cn(
                     "px-4 py-2 hover:bg-(--background-lightest) cursor-pointer flex gap-3",
                     selectedVersionId === version.oid &&
@@ -224,6 +326,7 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
                   }}
                 >
                   <div
+                    data-testid="version-list-item"
                     className="flex-shrink-0 w-16 h-10 rounded border border-border bg-muted overflow-hidden flex items-center justify-center"
                     aria-hidden="true"
                   >
@@ -243,12 +346,58 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center justify-between">
                       <div className="flex items-center gap-2">
+                        <button
+                          type="button"
+                          data-testid={`version-favorite-button-${versionNumber}`}
+                          aria-label={
+                            version.isFavorite
+                              ? "Remove version from favorites"
+                              : "Favorite version"
+                          }
+                          title={
+                            version.isFavorite
+                              ? "Remove version from favorites"
+                              : "Favorite version"
+                          }
+                          onClick={async (e) => {
+                            e.stopPropagation();
+                            const nextIsFavorite = !version.isFavorite;
+                            updateCachedVersion(version.oid, {
+                              isFavorite: nextIsFavorite,
+                            });
+                            try {
+                              const result = await setVersionFavorite({
+                                versionId: version.oid,
+                                isFavorite: nextIsFavorite,
+                              });
+                              updateCachedVersion(result.oid, {
+                                isFavorite: result.isFavorite,
+                                note: result.note,
+                              });
+                            } catch {
+                              updateCachedVersion(version.oid, {
+                                isFavorite: version.isFavorite,
+                              });
+                            }
+                          }}
+                          className={cn(
+                            "rounded-sm p-0.5 transition-colors",
+                            version.isFavorite
+                              ? "text-[#6c55dc]"
+                              : "text-muted-foreground hover:text-foreground",
+                          )}
+                        >
+                          <Star
+                            className={cn(
+                              "h-3.5 w-3.5",
+                              version.isFavorite && "fill-[#6c55dc]",
+                            )}
+                          />
+                        </button>
                         <span className="font-medium text-xs">
                           Version{" "}
                           <HighlightMatch
-                            text={String(
-                              versions.length - versions.indexOf(version),
-                            )}
+                            text={String(versionNumber)}
                             query={searchQuery.trim()}
                           />{" "}
                           (
@@ -311,33 +460,52 @@ export function VersionPane({ isVisible, onClose }: VersionPaneProps) {
                         </span>
                       </div>
                     </div>
-                    <div className="flex items-center justify-between gap-2">
-                      {version.message && (
-                        <p className="mt-1 text-sm">
-                          <HighlightMatch
-                            text={
-                              version.message.startsWith(
-                                "Reverted all changes back to version ",
-                              )
-                                ? version.message.replace(
-                                    /Reverted all changes back to version ([a-f0-9]+)/,
-                                    (_, hash) => {
-                                      const targetIndex = versions.findIndex(
-                                        (v) => v.oid === hash,
-                                      );
-                                      return targetIndex !== -1
-                                        ? `Reverted all changes back to version ${
-                                            versions.length - targetIndex
-                                          }`
-                                        : version.message;
-                                    },
-                                  )
-                                : version.message
-                            }
-                            query={searchQuery.trim()}
-                          />
-                        </p>
-                      )}
+                    <div className="mt-1 flex items-start justify-between gap-2">
+                      <div className="min-w-0 flex-1">
+                        {version.message && (
+                          <p className="text-sm">
+                            <HighlightMatch
+                              text={
+                                version.message.startsWith(
+                                  "Reverted all changes back to version ",
+                                )
+                                  ? version.message.replace(
+                                      /Reverted all changes back to version ([a-f0-9]+)/,
+                                      (_, hash) => {
+                                        const targetIndex = versions.findIndex(
+                                          (v) => v.oid === hash,
+                                        );
+                                        return targetIndex !== -1
+                                          ? `Reverted all changes back to version ${
+                                              versions.length - targetIndex
+                                            }`
+                                          : version.message;
+                                      },
+                                    )
+                                  : version.message
+                              }
+                              query={searchQuery.trim()}
+                            />
+                          </p>
+                        )}
+
+                        <Textarea
+                          value={version.note ?? ""}
+                          placeholder="Add note..."
+                          aria-label={`Note for version ${versionNumber}`}
+                          onClick={(e) => e.stopPropagation()}
+                          onKeyDown={(e) => e.stopPropagation()}
+                          onChange={(e) => {
+                            const note = e.target.value;
+                            updateCachedVersion(version.oid, { note });
+                            queueVersionNoteSave(version.oid, note);
+                          }}
+                          onBlur={(e) =>
+                            flushVersionNoteSave(version.oid, e.target.value)
+                          }
+                          className="mt-2 min-h-8 resize-none px-2 py-1 text-xs focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-0"
+                        />
+                      </div>
 
                       <div className="flex items-center gap-1">
                         {/* Restore button */}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -161,6 +161,10 @@ export const versions = sqliteTable(
       .references(() => apps.id, { onDelete: "cascade" }),
     commitHash: text("commit_hash").notNull(),
     neonDbTimestamp: text("neon_db_timestamp"),
+    isFavorite: integer("is_favorite", { mode: "boolean" })
+      .notNull()
+      .default(sql`0`),
+    note: text("note"),
     createdAt: integer("created_at", { mode: "timestamp" })
       .notNull()
       .default(sql`(unixepoch())`),

--- a/src/hooks/useVersions.test.tsx
+++ b/src/hooks/useVersions.test.tsx
@@ -1,0 +1,127 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, act } from "@testing-library/react";
+import { Provider, createStore } from "jotai";
+import type { PropsWithChildren } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Version } from "@/ipc/types";
+import { queryKeys } from "@/lib/queryKeys";
+import { useVersions } from "./useVersions";
+
+const {
+  getChatMock,
+  listVersionsMock,
+  restartAppMock,
+  revertVersionMock,
+  setVersionFavoriteMock,
+  setVersionNoteMock,
+} = vi.hoisted(() => ({
+  getChatMock: vi.fn(),
+  listVersionsMock: vi.fn(),
+  restartAppMock: vi.fn(),
+  revertVersionMock: vi.fn(),
+  setVersionFavoriteMock: vi.fn(),
+  setVersionNoteMock: vi.fn(),
+}));
+
+vi.mock("@/ipc/types", () => ({
+  ipc: {
+    chat: {
+      getChat: getChatMock,
+    },
+    version: {
+      listVersions: listVersionsMock,
+      revertVersion: revertVersionMock,
+      setVersionFavorite: setVersionFavoriteMock,
+      setVersionNote: setVersionNoteMock,
+    },
+  },
+}));
+
+vi.mock("./useRunApp", () => ({
+  useRunApp: () => ({
+    restartApp: restartAppMock,
+  }),
+}));
+
+vi.mock("./useSettings", () => ({
+  useSettings: () => ({
+    settings: undefined,
+  }),
+}));
+
+function makeWrapper(queryClient: QueryClient) {
+  const store = createStore();
+
+  return function Wrapper({ children }: PropsWithChildren) {
+    return (
+      <Provider store={store}>
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      </Provider>
+    );
+  };
+}
+
+describe("useVersions", () => {
+  beforeEach(() => {
+    getChatMock.mockReset();
+    listVersionsMock.mockReset();
+    restartAppMock.mockReset();
+    revertVersionMock.mockReset();
+    setVersionFavoriteMock.mockReset();
+    setVersionNoteMock.mockReset();
+  });
+
+  it("updates the versions query cache after saving a note", async () => {
+    const appId = 42;
+    const oid = "a".repeat(40);
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, staleTime: Infinity },
+        mutations: { retry: false },
+      },
+    });
+    const version: Version = {
+      oid,
+      message: "Initial version",
+      timestamp: 1,
+      dbTimestamp: null,
+      isFavorite: false,
+      note: null,
+    };
+    queryClient.setQueryData(queryKeys.versions.list({ appId }), [version]);
+    setVersionNoteMock.mockResolvedValue({
+      oid,
+      isFavorite: false,
+      note: "Launch note",
+    });
+
+    const { result } = renderHook(() => useVersions(appId), {
+      wrapper: makeWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.setVersionNote({
+        appId,
+        versionId: oid,
+        note: "Launch note",
+      });
+    });
+
+    expect(setVersionNoteMock).toHaveBeenCalledWith({
+      appId,
+      versionId: oid,
+      note: "Launch note",
+    });
+    expect(
+      queryClient.getQueryData<Version[]>(
+        queryKeys.versions.list({ appId }),
+      )?.[0],
+    ).toMatchObject({
+      oid,
+      note: "Launch note",
+      isFavorite: false,
+    });
+  });
+});

--- a/src/hooks/useVersions.ts
+++ b/src/hooks/useVersions.ts
@@ -89,6 +89,115 @@ export function useVersions(appId: number | null) {
     meta: { showErrorToast: true },
   });
 
+  const setVersionFavoriteMutation = useMutation<
+    { oid: string; isFavorite: boolean; note: string | null },
+    Error,
+    { versionId: string; isFavorite: boolean },
+    { previousVersions?: Version[] }
+  >({
+    mutationFn: async ({ versionId, isFavorite }) => {
+      if (appId === null) {
+        throw new DyadError("App ID is null", DyadErrorKind.External);
+      }
+      return ipc.version.setVersionFavorite({
+        appId,
+        versionId,
+        isFavorite,
+      });
+    },
+    onMutate: async ({ versionId, isFavorite }) => {
+      const queryKey = queryKeys.versions.list({ appId });
+      await queryClient.cancelQueries({ queryKey });
+      const previousVersions = queryClient.getQueryData<Version[]>(queryKey);
+      queryClient.setQueryData<Version[]>(queryKey, (oldVersions) =>
+        oldVersions?.map((version) =>
+          version.oid === versionId ? { ...version, isFavorite } : version,
+        ),
+      );
+      return { previousVersions };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previousVersions) {
+        queryClient.setQueryData(
+          queryKeys.versions.list({ appId }),
+          context.previousVersions,
+        );
+      }
+    },
+    onSuccess: (result) => {
+      queryClient.setQueryData<Version[]>(
+        queryKeys.versions.list({ appId }),
+        (oldVersions) =>
+          oldVersions?.map((version) =>
+            version.oid === result.oid
+              ? {
+                  ...version,
+                  isFavorite: result.isFavorite,
+                  note: result.note,
+                }
+              : version,
+          ),
+      );
+    },
+    meta: { showErrorToast: true },
+  });
+
+  const setVersionNoteMutation = useMutation<
+    { oid: string; isFavorite: boolean; note: string | null },
+    Error,
+    { versionId: string; note: string | null },
+    { previousVersions?: Version[] }
+  >({
+    mutationFn: async ({ versionId, note }) => {
+      if (appId === null) {
+        throw new DyadError("App ID is null", DyadErrorKind.External);
+      }
+      return ipc.version.setVersionNote({
+        appId,
+        versionId,
+        note,
+      });
+    },
+    onMutate: async ({ versionId, note }) => {
+      const queryKey = queryKeys.versions.list({ appId });
+      await queryClient.cancelQueries({ queryKey });
+      const previousVersions = queryClient.getQueryData<Version[]>(queryKey);
+      const normalizedNote = note?.trim() || null;
+      queryClient.setQueryData<Version[]>(queryKey, (oldVersions) =>
+        oldVersions?.map((version) =>
+          version.oid === versionId
+            ? { ...version, note: normalizedNote }
+            : version,
+        ),
+      );
+      return { previousVersions };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previousVersions) {
+        queryClient.setQueryData(
+          queryKeys.versions.list({ appId }),
+          context.previousVersions,
+        );
+      }
+    },
+    onSuccess: (result) => {
+      queryClient.setQueryData<Version[]>(
+        queryKeys.versions.list({ appId }),
+        (oldVersions) =>
+          oldVersions?.map((version) =>
+            version.oid === result.oid
+              ? {
+                  ...version,
+                  isFavorite: result.isFavorite,
+                  note: result.note,
+                }
+              : version,
+          ),
+      );
+    },
+    meta: { showErrorToast: true },
+  });
+
   return {
     versions: versions || [],
     loading,
@@ -96,5 +205,9 @@ export function useVersions(appId: number | null) {
     refreshVersions,
     revertVersion: revertVersionMutation.mutateAsync,
     isRevertingVersion: revertVersionMutation.isPending,
+    setVersionFavorite: setVersionFavoriteMutation.mutateAsync,
+    isSettingVersionFavorite: setVersionFavoriteMutation.isPending,
+    setVersionNote: setVersionNoteMutation.mutateAsync,
+    isSettingVersionNote: setVersionNoteMutation.isPending,
   };
 }

--- a/src/hooks/useVersions.ts
+++ b/src/hooks/useVersions.ts
@@ -145,6 +145,14 @@ export function useVersions(appId: number | null) {
         note,
       });
     },
+    onSuccess: (result, variables) => {
+      updateVersionMetadataCache(
+        result.oid,
+        { note: result.note },
+        variables.appId === undefined ? appId : variables.appId,
+      );
+    },
+    meta: { showErrorToast: true },
   });
 
   return {

--- a/src/hooks/useVersions.ts
+++ b/src/hooks/useVersions.ts
@@ -115,20 +115,24 @@ export function useVersions(appId: number | null) {
   const setVersionFavoriteMutation = useMutation<
     { oid: string; isFavorite: boolean; note: string | null },
     Error,
-    { versionId: string; isFavorite: boolean }
+    { appId?: number | null; versionId: string; isFavorite: boolean }
   >({
-    mutationFn: async ({ versionId, isFavorite }) => {
-      if (appId === null) {
+    mutationFn: async ({ appId: mutationAppId, versionId, isFavorite }) => {
+      const targetAppId = mutationAppId === undefined ? appId : mutationAppId;
+      if (targetAppId === null) {
         throw new DyadError("App ID is null", DyadErrorKind.External);
       }
       return ipc.version.setVersionFavorite({
-        appId,
+        appId: targetAppId,
         versionId,
         isFavorite,
       });
     },
-    onSuccess: (result) => {
-      updateVersionMetadataCache(result);
+    onSuccess: (result, variables) => {
+      updateVersionMetadataCache(
+        result,
+        variables.appId === undefined ? appId : variables.appId,
+      );
     },
     meta: { showErrorToast: true },
   });

--- a/src/hooks/useVersions.ts
+++ b/src/hooks/useVersions.ts
@@ -16,6 +16,26 @@ export function useVersions(appId: number | null) {
   const { restartApp } = useRunApp();
   const { settings } = useSettings();
 
+  const updateVersionMetadataCache = (result: {
+    oid: string;
+    isFavorite: boolean;
+    note: string | null;
+  }) => {
+    queryClient.setQueryData<Version[]>(
+      queryKeys.versions.list({ appId }),
+      (oldVersions) =>
+        oldVersions?.map((version) =>
+          version.oid === result.oid
+            ? {
+                ...version,
+                isFavorite: result.isFavorite,
+                note: result.note,
+              }
+            : version,
+        ),
+    );
+  };
+
   const {
     data: versions,
     isLoading: loading,
@@ -92,8 +112,7 @@ export function useVersions(appId: number | null) {
   const setVersionFavoriteMutation = useMutation<
     { oid: string; isFavorite: boolean; note: string | null },
     Error,
-    { versionId: string; isFavorite: boolean },
-    { previousVersions?: Version[] }
+    { versionId: string; isFavorite: boolean }
   >({
     mutationFn: async ({ versionId, isFavorite }) => {
       if (appId === null) {
@@ -105,48 +124,14 @@ export function useVersions(appId: number | null) {
         isFavorite,
       });
     },
-    onMutate: async ({ versionId, isFavorite }) => {
-      const queryKey = queryKeys.versions.list({ appId });
-      await queryClient.cancelQueries({ queryKey });
-      const previousVersions = queryClient.getQueryData<Version[]>(queryKey);
-      queryClient.setQueryData<Version[]>(queryKey, (oldVersions) =>
-        oldVersions?.map((version) =>
-          version.oid === versionId ? { ...version, isFavorite } : version,
-        ),
-      );
-      return { previousVersions };
-    },
-    onError: (_error, _variables, context) => {
-      if (context?.previousVersions) {
-        queryClient.setQueryData(
-          queryKeys.versions.list({ appId }),
-          context.previousVersions,
-        );
-      }
-    },
-    onSuccess: (result) => {
-      queryClient.setQueryData<Version[]>(
-        queryKeys.versions.list({ appId }),
-        (oldVersions) =>
-          oldVersions?.map((version) =>
-            version.oid === result.oid
-              ? {
-                  ...version,
-                  isFavorite: result.isFavorite,
-                  note: result.note,
-                }
-              : version,
-          ),
-      );
-    },
+    onSuccess: updateVersionMetadataCache,
     meta: { showErrorToast: true },
   });
 
   const setVersionNoteMutation = useMutation<
     { oid: string; isFavorite: boolean; note: string | null },
     Error,
-    { versionId: string; note: string | null },
-    { previousVersions?: Version[] }
+    { versionId: string; note: string | null }
   >({
     mutationFn: async ({ versionId, note }) => {
       if (appId === null) {
@@ -158,43 +143,7 @@ export function useVersions(appId: number | null) {
         note,
       });
     },
-    onMutate: async ({ versionId, note }) => {
-      const queryKey = queryKeys.versions.list({ appId });
-      await queryClient.cancelQueries({ queryKey });
-      const previousVersions = queryClient.getQueryData<Version[]>(queryKey);
-      const normalizedNote = note?.trim() || null;
-      queryClient.setQueryData<Version[]>(queryKey, (oldVersions) =>
-        oldVersions?.map((version) =>
-          version.oid === versionId
-            ? { ...version, note: normalizedNote }
-            : version,
-        ),
-      );
-      return { previousVersions };
-    },
-    onError: (_error, _variables, context) => {
-      if (context?.previousVersions) {
-        queryClient.setQueryData(
-          queryKeys.versions.list({ appId }),
-          context.previousVersions,
-        );
-      }
-    },
-    onSuccess: (result) => {
-      queryClient.setQueryData<Version[]>(
-        queryKeys.versions.list({ appId }),
-        (oldVersions) =>
-          oldVersions?.map((version) =>
-            version.oid === result.oid
-              ? {
-                  ...version,
-                  isFavorite: result.isFavorite,
-                  note: result.note,
-                }
-              : version,
-          ),
-      );
-    },
+    onSuccess: updateVersionMetadataCache,
     meta: { showErrorToast: true },
   });
 

--- a/src/hooks/useVersions.ts
+++ b/src/hooks/useVersions.ts
@@ -17,24 +17,15 @@ export function useVersions(appId: number | null) {
   const { settings } = useSettings();
 
   const updateVersionMetadataCache = (
-    result: {
-      oid: string;
-      isFavorite: boolean;
-      note: string | null;
-    },
+    oid: string,
+    updates: Partial<Pick<Version, "isFavorite" | "note">>,
     targetAppId = appId,
   ) => {
     queryClient.setQueryData<Version[]>(
       queryKeys.versions.list({ appId: targetAppId }),
       (oldVersions) =>
         oldVersions?.map((version) =>
-          version.oid === result.oid
-            ? {
-                ...version,
-                isFavorite: result.isFavorite,
-                note: result.note,
-              }
-            : version,
+          version.oid === oid ? { ...version, ...updates } : version,
         ),
     );
   };
@@ -130,7 +121,8 @@ export function useVersions(appId: number | null) {
     },
     onSuccess: (result, variables) => {
       updateVersionMetadataCache(
-        result,
+        result.oid,
+        { isFavorite: result.isFavorite },
         variables.appId === undefined ? appId : variables.appId,
       );
     },
@@ -153,13 +145,6 @@ export function useVersions(appId: number | null) {
         note,
       });
     },
-    onSuccess: (result, variables) => {
-      updateVersionMetadataCache(
-        result,
-        variables.appId === undefined ? appId : variables.appId,
-      );
-    },
-    meta: { showErrorToast: true },
   });
 
   return {

--- a/src/hooks/useVersions.ts
+++ b/src/hooks/useVersions.ts
@@ -16,13 +16,16 @@ export function useVersions(appId: number | null) {
   const { restartApp } = useRunApp();
   const { settings } = useSettings();
 
-  const updateVersionMetadataCache = (result: {
-    oid: string;
-    isFavorite: boolean;
-    note: string | null;
-  }) => {
+  const updateVersionMetadataCache = (
+    result: {
+      oid: string;
+      isFavorite: boolean;
+      note: string | null;
+    },
+    targetAppId = appId,
+  ) => {
     queryClient.setQueryData<Version[]>(
-      queryKeys.versions.list({ appId }),
+      queryKeys.versions.list({ appId: targetAppId }),
       (oldVersions) =>
         oldVersions?.map((version) =>
           version.oid === result.oid
@@ -124,26 +127,34 @@ export function useVersions(appId: number | null) {
         isFavorite,
       });
     },
-    onSuccess: updateVersionMetadataCache,
+    onSuccess: (result) => {
+      updateVersionMetadataCache(result);
+    },
     meta: { showErrorToast: true },
   });
 
   const setVersionNoteMutation = useMutation<
     { oid: string; isFavorite: boolean; note: string | null },
     Error,
-    { versionId: string; note: string | null }
+    { appId?: number | null; versionId: string; note: string | null }
   >({
-    mutationFn: async ({ versionId, note }) => {
-      if (appId === null) {
+    mutationFn: async ({ appId: mutationAppId, versionId, note }) => {
+      const targetAppId = mutationAppId === undefined ? appId : mutationAppId;
+      if (targetAppId === null) {
         throw new DyadError("App ID is null", DyadErrorKind.External);
       }
       return ipc.version.setVersionNote({
-        appId,
+        appId: targetAppId,
         versionId,
         note,
       });
     },
-    onSuccess: updateVersionMetadataCache,
+    onSuccess: (result, variables) => {
+      updateVersionMetadataCache(
+        result,
+        variables.appId === undefined ? appId : variables.appId,
+      );
+    },
     meta: { showErrorToast: true },
   });
 

--- a/src/ipc/handlers/app_handlers.ts
+++ b/src/ipc/handlers/app_handlers.ts
@@ -538,6 +538,9 @@ export function registerAppHandlers() {
         .map((version) => ({
           appId: newDbApp.id,
           commitHash: version.commitHash,
+          // neonDbTimestamp intentionally omitted: duplicated apps get their
+          // own Neon branches, so snapshot timestamps from the original app
+          // do not apply.
           isFavorite: version.isFavorite,
           note: version.note,
         }));

--- a/src/ipc/handlers/app_handlers.ts
+++ b/src/ipc/handlers/app_handlers.ts
@@ -1,6 +1,6 @@
 import { ipcMain, app, dialog } from "electron";
 import { closeDatabase, db, getDatabaseFilePaths } from "../../db";
-import { apps, chats, messages } from "../../db/schema";
+import { apps, chats, messages, versions } from "../../db/schema";
 import { desc, eq, inArray, like } from "drizzle-orm";
 import { createTypedHandler } from "./base";
 import { appContracts } from "../types/app";
@@ -528,6 +528,24 @@ export function registerAppHandlers() {
         startCommand: originalApp.startCommand,
       })
       .returning();
+
+    if (withHistory) {
+      const originalVersionMetadata = await db.query.versions.findMany({
+        where: eq(versions.appId, appId),
+      });
+      const copiedVersionMetadata = originalVersionMetadata
+        .filter((version) => version.isFavorite || version.note)
+        .map((version) => ({
+          appId: newDbApp.id,
+          commitHash: version.commitHash,
+          isFavorite: version.isFavorite,
+          note: version.note,
+        }));
+
+      if (copiedVersionMetadata.length > 0) {
+        await db.insert(versions).values(copiedVersionMetadata);
+      }
+    }
 
     return { app: newDbApp };
   });

--- a/src/ipc/handlers/version_handlers.ts
+++ b/src/ipc/handlers/version_handlers.ts
@@ -17,6 +17,7 @@ import {
   gitCommit,
   gitStageToRevert,
   getCurrentCommitHash,
+  gitCommitExists,
   gitCurrentBranch,
   gitLog,
   isGitStatusClean,
@@ -129,11 +130,11 @@ async function assertVersionExists({
   appPath: string;
   versionId: string;
 }) {
-  const commits = await gitLog({
+  const exists = await gitCommitExists({
     path: appPath,
-    depth: 100_000,
+    commitHash: versionId,
   });
-  if (!commits.some((commit) => commit.oid === versionId)) {
+  if (!exists) {
     throw new DyadError("Version not found", DyadErrorKind.NotFound);
   }
 }

--- a/src/ipc/handlers/version_handlers.ts
+++ b/src/ipc/handlers/version_handlers.ts
@@ -100,6 +100,105 @@ async function syncCloudSandboxSnapshotBestEffort(appId: number) {
   }
 }
 
+function normalizeVersionNote(note: string | null): string | null {
+  const trimmed = note?.trim();
+  return trimmed ? trimmed : null;
+}
+
+async function getVersionAppPath(appId: number): Promise<string> {
+  const app = await db.query.apps.findFirst({
+    where: eq(apps.id, appId),
+  });
+
+  if (!app) {
+    throw new DyadError("App not found", DyadErrorKind.NotFound);
+  }
+
+  const appPath = getDyadAppPath(app.path);
+  if (!fs.existsSync(path.join(appPath, ".git"))) {
+    throw new DyadError("Not a git repository", DyadErrorKind.External);
+  }
+
+  return appPath;
+}
+
+async function assertVersionExists({
+  appPath,
+  versionId,
+}: {
+  appPath: string;
+  versionId: string;
+}) {
+  const commits = await gitLog({
+    path: appPath,
+    depth: 100_000,
+  });
+  if (!commits.some((commit) => commit.oid === versionId)) {
+    throw new DyadError("Version not found", DyadErrorKind.NotFound);
+  }
+}
+
+async function upsertVersionMetadata({
+  appId,
+  versionId,
+  isFavorite,
+  note,
+}: {
+  appId: number;
+  versionId: string;
+  isFavorite?: boolean;
+  note?: string | null;
+}) {
+  const appPath = await getVersionAppPath(appId);
+  await assertVersionExists({ appPath, versionId });
+
+  const normalizedNote =
+    note === undefined ? undefined : normalizeVersionNote(note);
+  const existingVersion = await db.query.versions.findFirst({
+    where: and(eq(versions.appId, appId), eq(versions.commitHash, versionId)),
+  });
+
+  if (existingVersion) {
+    const [updatedVersion] = await db
+      .update(versions)
+      .set({
+        ...(isFavorite === undefined ? {} : { isFavorite }),
+        ...(normalizedNote === undefined ? {} : { note: normalizedNote }),
+        updatedAt: new Date(),
+      })
+      .where(and(eq(versions.appId, appId), eq(versions.commitHash, versionId)))
+      .returning({
+        isFavorite: versions.isFavorite,
+        note: versions.note,
+      });
+
+    return {
+      oid: versionId,
+      isFavorite: updatedVersion.isFavorite,
+      note: updatedVersion.note,
+    };
+  }
+
+  const [createdVersion] = await db
+    .insert(versions)
+    .values({
+      appId,
+      commitHash: versionId,
+      isFavorite: isFavorite ?? false,
+      note: normalizedNote ?? null,
+    })
+    .returning({
+      isFavorite: versions.isFavorite,
+      note: versions.note,
+    });
+
+  return {
+    oid: versionId,
+    isFavorite: createdVersion.isFavorite,
+    note: createdVersion.note,
+  };
+}
+
 async function restoreBranchForPreview({
   appId,
   dbTimestamp,
@@ -148,32 +247,53 @@ export function registerVersionHandlers() {
       depth: 100_000, // KEEP UP TO DATE WITH ChatHeader.tsx
     });
 
-    // Get all snapshots for this app to match with commits
-    const appSnapshots = await db.query.versions.findMany({
+    // Get all stored version metadata for this app to match with commits.
+    const appVersionMetadata = await db.query.versions.findMany({
       where: eq(versions.appId, appId),
     });
 
-    // Create a map of commitHash -> snapshot info for quick lookup
-    const snapshotMap = new Map<
+    // Create a map of commitHash -> version metadata for quick lookup.
+    const metadataMap = new Map<
       string,
-      { neonDbTimestamp: string | null; createdAt: Date }
+      {
+        neonDbTimestamp: string | null;
+        isFavorite: boolean;
+        note: string | null;
+      }
     >();
-    for (const snapshot of appSnapshots) {
-      snapshotMap.set(snapshot.commitHash, {
-        neonDbTimestamp: snapshot.neonDbTimestamp,
-        createdAt: snapshot.createdAt,
+    for (const metadata of appVersionMetadata) {
+      metadataMap.set(metadata.commitHash, {
+        neonDbTimestamp: metadata.neonDbTimestamp,
+        isFavorite: metadata.isFavorite,
+        note: metadata.note,
       });
     }
 
     return commits.map((commit: GitCommit) => {
-      const snapshotInfo = snapshotMap.get(commit.oid);
+      const metadata = metadataMap.get(commit.oid);
       return {
         oid: commit.oid,
         message: commit.commit.message,
         timestamp: commit.commit.author.timestamp,
-        dbTimestamp: snapshotInfo?.neonDbTimestamp,
+        dbTimestamp: metadata?.neonDbTimestamp,
+        isFavorite: metadata?.isFavorite ?? false,
+        note: metadata?.note ?? null,
       };
     });
+  });
+
+  createTypedHandler(versionContracts.setVersionFavorite, async (_, params) => {
+    const { appId, versionId, isFavorite } = params;
+    return withLock(appId, async () =>
+      upsertVersionMetadata({ appId, versionId, isFavorite }),
+    );
+  });
+
+  createTypedHandler(versionContracts.setVersionNote, async (_, params) => {
+    const { appId, versionId, note } = params;
+    return withLock(appId, async () =>
+      upsertVersionMetadata({ appId, versionId, note }),
+    );
   });
 
   createTypedHandler(versionContracts.getCurrentBranch, async (_, params) => {

--- a/src/ipc/handlers/version_handlers.ts
+++ b/src/ipc/handlers/version_handlers.ts
@@ -155,38 +155,22 @@ async function upsertVersionMetadata({
 
   const normalizedNote =
     note === undefined ? undefined : normalizeVersionNote(note);
-  const existingVersion = await db.query.versions.findFirst({
-    where: and(eq(versions.appId, appId), eq(versions.commitHash, versionId)),
-  });
 
-  if (existingVersion) {
-    const [updatedVersion] = await db
-      .update(versions)
-      .set({
-        ...(isFavorite === undefined ? {} : { isFavorite }),
-        ...(normalizedNote === undefined ? {} : { note: normalizedNote }),
-        updatedAt: new Date(),
-      })
-      .where(and(eq(versions.appId, appId), eq(versions.commitHash, versionId)))
-      .returning({
-        isFavorite: versions.isFavorite,
-        note: versions.note,
-      });
-
-    return {
-      oid: versionId,
-      isFavorite: updatedVersion.isFavorite,
-      note: updatedVersion.note,
-    };
-  }
-
-  const [createdVersion] = await db
+  const [versionMetadata] = await db
     .insert(versions)
     .values({
       appId,
       commitHash: versionId,
       isFavorite: isFavorite ?? false,
       note: normalizedNote ?? null,
+    })
+    .onConflictDoUpdate({
+      target: [versions.appId, versions.commitHash],
+      set: {
+        ...(isFavorite === undefined ? {} : { isFavorite }),
+        ...(normalizedNote === undefined ? {} : { note: normalizedNote }),
+        updatedAt: new Date(),
+      },
     })
     .returning({
       isFavorite: versions.isFavorite,
@@ -195,8 +179,8 @@ async function upsertVersionMetadata({
 
   return {
     oid: versionId,
-    isFavorite: createdVersion.isFavorite,
-    note: createdVersion.note,
+    isFavorite: versionMetadata.isFavorite,
+    note: versionMetadata.note,
   };
 }
 

--- a/src/ipc/handlers/version_handlers.ts
+++ b/src/ipc/handlers/version_handlers.ts
@@ -285,16 +285,12 @@ export function registerVersionHandlers() {
 
   createTypedHandler(versionContracts.setVersionFavorite, async (_, params) => {
     const { appId, versionId, isFavorite } = params;
-    return withLock(appId, async () =>
-      upsertVersionMetadata({ appId, versionId, isFavorite }),
-    );
+    return upsertVersionMetadata({ appId, versionId, isFavorite });
   });
 
   createTypedHandler(versionContracts.setVersionNote, async (_, params) => {
     const { appId, versionId, note } = params;
-    return withLock(appId, async () =>
-      upsertVersionMetadata({ appId, versionId, note }),
-    );
+    return upsertVersionMetadata({ appId, versionId, note });
   });
 
   createTypedHandler(versionContracts.getCurrentBranch, async (_, params) => {

--- a/src/ipc/handlers/version_handlers.ts
+++ b/src/ipc/handlers/version_handlers.ts
@@ -161,6 +161,8 @@ async function upsertVersionMetadata({
     .values({
       appId,
       commitHash: versionId,
+      // Insert means this is the first metadata touch for the version. For an
+      // absent row, defaults for omitted fields preserve the intended baseline.
       isFavorite: isFavorite ?? false,
       note: normalizedNote ?? null,
     })

--- a/src/ipc/types/index.ts
+++ b/src/ipc/types/index.ts
@@ -37,7 +37,7 @@ export { supabaseContracts } from "./supabase";
 export { neonContracts } from "./neon";
 export { migrationContracts } from "./migration";
 export { systemContracts, systemEvents } from "./system";
-export { versionContracts } from "./version";
+export { versionContracts, MAX_VERSION_NOTE_LENGTH } from "./version";
 export { languageModelContracts } from "./language-model";
 export { promptContracts } from "./prompts";
 export { templateContracts } from "./templates";

--- a/src/ipc/types/version.test.ts
+++ b/src/ipc/types/version.test.ts
@@ -23,4 +23,21 @@ describe("version metadata schemas", () => {
       }).success,
     ).toBe(true);
   });
+
+  it("reject abbreviated commit hashes for version metadata", () => {
+    expect(
+      SetVersionFavoriteParamsSchema.safeParse({
+        appId: 1,
+        versionId: "abcd",
+        isFavorite: true,
+      }).success,
+    ).toBe(false);
+    expect(
+      SetVersionNoteParamsSchema.safeParse({
+        appId: 1,
+        versionId: "abcd",
+        note: "release candidate",
+      }).success,
+    ).toBe(false);
+  });
 });

--- a/src/ipc/types/version.test.ts
+++ b/src/ipc/types/version.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import {
+  SetVersionFavoriteParamsSchema,
+  SetVersionNoteParamsSchema,
+} from "./version";
+
+describe("version metadata schemas", () => {
+  it("accept 64-character SHA-256 commit hashes", () => {
+    const sha256 = "a".repeat(64);
+
+    expect(
+      SetVersionFavoriteParamsSchema.safeParse({
+        appId: 1,
+        versionId: sha256,
+        isFavorite: true,
+      }).success,
+    ).toBe(true);
+    expect(
+      SetVersionNoteParamsSchema.safeParse({
+        appId: 1,
+        versionId: sha256,
+        note: "release candidate",
+      }).success,
+    ).toBe(true);
+  });
+});

--- a/src/ipc/types/version.ts
+++ b/src/ipc/types/version.ts
@@ -82,7 +82,9 @@ export type CheckoutVersionResponse = z.infer<
   typeof CheckoutVersionResponseSchema
 >;
 
-const CommitHashSchema = z.string().regex(/^[a-f0-9]{40}$/i);
+const CommitHashSchema = z
+  .string()
+  .regex(/^[a-f0-9]{4,64}$/i, "versionId must be a hex commit SHA");
 export const MAX_VERSION_NOTE_LENGTH = 10_000;
 
 export const SetVersionFavoriteParamsSchema = z.object({

--- a/src/ipc/types/version.ts
+++ b/src/ipc/types/version.ts
@@ -82,15 +82,17 @@ export type CheckoutVersionResponse = z.infer<
   typeof CheckoutVersionResponseSchema
 >;
 
+const CommitHashSchema = z.string().regex(/^[a-f0-9]{40}$/i);
+
 export const SetVersionFavoriteParamsSchema = z.object({
   appId: z.number(),
-  versionId: z.string(),
+  versionId: CommitHashSchema,
   isFavorite: z.boolean(),
 });
 
 export const SetVersionNoteParamsSchema = z.object({
   appId: z.number(),
-  versionId: z.string(),
+  versionId: CommitHashSchema,
   note: z.string().nullable(),
 });
 

--- a/src/ipc/types/version.ts
+++ b/src/ipc/types/version.ts
@@ -83,6 +83,7 @@ export type CheckoutVersionResponse = z.infer<
 >;
 
 const CommitHashSchema = z.string().regex(/^[a-f0-9]{40}$/i);
+export const MAX_VERSION_NOTE_LENGTH = 10_000;
 
 export const SetVersionFavoriteParamsSchema = z.object({
   appId: z.number(),
@@ -93,7 +94,7 @@ export const SetVersionFavoriteParamsSchema = z.object({
 export const SetVersionNoteParamsSchema = z.object({
   appId: z.number(),
   versionId: CommitHashSchema,
-  note: z.string().nullable(),
+  note: z.string().max(MAX_VERSION_NOTE_LENGTH).nullable(),
 });
 
 export const VersionMetadataResultSchema = z.object({

--- a/src/ipc/types/version.ts
+++ b/src/ipc/types/version.ts
@@ -84,7 +84,7 @@ export type CheckoutVersionResponse = z.infer<
 
 const CommitHashSchema = z
   .string()
-  .regex(/^[a-f0-9]{4,64}$/i, "versionId must be a hex commit SHA");
+  .regex(/^[a-f0-9]{40,64}$/i, "versionId must be a full hex commit SHA");
 export const MAX_VERSION_NOTE_LENGTH = 10_000;
 
 export const SetVersionFavoriteParamsSchema = z.object({

--- a/src/ipc/types/version.ts
+++ b/src/ipc/types/version.ts
@@ -10,6 +10,8 @@ export const VersionSchema = z.object({
   message: z.string(),
   timestamp: z.number(),
   dbTimestamp: z.string().nullable().optional(),
+  isFavorite: z.boolean(),
+  note: z.string().nullable(),
 });
 
 export type Version = z.infer<typeof VersionSchema>;
@@ -80,6 +82,24 @@ export type CheckoutVersionResponse = z.infer<
   typeof CheckoutVersionResponseSchema
 >;
 
+export const SetVersionFavoriteParamsSchema = z.object({
+  appId: z.number(),
+  versionId: z.string(),
+  isFavorite: z.boolean(),
+});
+
+export const SetVersionNoteParamsSchema = z.object({
+  appId: z.number(),
+  versionId: z.string(),
+  note: z.string().nullable(),
+});
+
+export const VersionMetadataResultSchema = z.object({
+  oid: z.string(),
+  isFavorite: z.boolean(),
+  note: z.string().nullable(),
+});
+
 // =============================================================================
 // Version Contracts
 // =============================================================================
@@ -107,6 +127,18 @@ export const versionContracts = {
     channel: "get-version-changes",
     input: GetVersionChangesParamsSchema,
     output: z.array(VersionChangedFileSchema),
+  }),
+
+  setVersionFavorite: defineContract({
+    channel: "set-version-favorite",
+    input: SetVersionFavoriteParamsSchema,
+    output: VersionMetadataResultSchema,
+  }),
+
+  setVersionNote: defineContract({
+    channel: "set-version-note",
+    input: SetVersionNoteParamsSchema,
+    output: VersionMetadataResultSchema,
   }),
 
   getCurrentBranch: defineContract({

--- a/src/ipc/utils/git_utils.ts
+++ b/src/ipc/utils/git_utils.ts
@@ -383,6 +383,31 @@ export async function getCurrentCommitHash({
   }
 }
 
+export async function gitCommitExists({
+  path,
+  commitHash,
+}: GitBaseParams & { commitHash: string }): Promise<boolean> {
+  const settings = readSettings();
+  if (settings.enableNativeGit) {
+    const result = await execGit(
+      ["cat-file", "-e", `${commitHash}^{commit}`],
+      path,
+    );
+    return result.exitCode === 0;
+  }
+
+  try {
+    await git.readCommit({
+      fs,
+      dir: path,
+      oid: commitHash,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function isGitStatusClean({
   path,
 }: {

--- a/src/utils/codebase.ts
+++ b/src/utils/codebase.ts
@@ -627,7 +627,6 @@ export async function extractCodebase({
   const sortedFiles = await sortFilesByModificationTime([...new Set(files)]);
 
   // Format files and collect individual file contents
-  const filesArray: CodebaseFile[] = [];
   const formatPromises = sortedFiles.map(async (file) => {
     // Get raw content for the files array
     const normalizedRelativePath = path
@@ -659,16 +658,21 @@ export async function extractCodebase({
       fileContent = readContent ?? "// Error reading file";
     }
 
-    filesArray.push({
-      path: normalizedRelativePath,
-      content: fileContent,
-      force: isForced,
-    });
-
-    return formattedContent;
+    return {
+      formattedContent,
+      file: {
+        path: normalizedRelativePath,
+        content: fileContent,
+        force: isForced,
+      } satisfies CodebaseFile,
+    };
   });
 
-  const formattedFiles = await Promise.all(formatPromises);
+  const formattedResults = await Promise.all(formatPromises);
+  const formattedFiles = formattedResults.map(
+    (result) => result.formattedContent,
+  );
+  const filesArray = formattedResults.map((result) => result.file);
   const formattedOutput = formattedFiles.join("");
 
   const endTime = Date.now();


### PR DESCRIPTION
 ## Summary
  - Store per-version favorite/note metadata in SQLite without modifying git commits.
  - Add version-pane stars, favorites-only filtering, inline autosaved notes, and note search.
  - Copy favorites/notes when duplicating an app with git history, while leaving external DB timestamps behind.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a DB migration and new version/checkout-adjacent IPC paths tied to git commit validation; UI note saving has async race handling but does not alter restore/checkout core logic.
> 
> **Overview**
> Adds **SQLite-backed version metadata** (`is_favorite`, `note`) on the existing `versions` table via migration **0034**, without changing git commits. **Version History** gains star toggles, a favorites-only filter, inline notes with debounced autosave (flush on blur/close/app switch), and search that includes note text; rows use stable `version-row-N` test IDs.
> 
> New IPC contracts **`setVersionFavorite`** and **`setVersionNote`** upsert metadata after validating the commit exists (`gitCommitExists`), merge favorites/notes into **`listVersions`**, and **`useVersions`** keeps the React Query cache in sync. Duplicating an app **with history** copies favorite/note rows by commit hash but **not** Neon DB timestamps.
> 
> E2E specs were updated for the new locators and extended **`version_search`** coverage for favorites, notes, and filtering. Minor unrelated tweaks: **`extractCodebase`** refactors parallel file formatting, plus small docs in **`rules/e2e-testing.md`** and **`rules/git-workflow.md`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fca79669fe970daa0611aed76dd9a7f5b12a2404. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

