### PR TITLE
fix: make git https work on RHEL-based Linux

### DIFF
--- a/makers/MakerAppImage.ts
+++ b/makers/MakerAppImage.ts
@@ -103,8 +103,11 @@ export class MakerAppImage extends MakerBase<{ icon?: string }> {
       await mkdir(binDir, { recursive: true, mode: 0o755 });
       await mkdir(libDir, { recursive: true, mode: 0o755 });
 
-      // Add the actual application code to the AppDir
-      await cp(dir, libDir, { recursive: true });
+      // Add the actual application code to the AppDir.
+      // verbatimSymlinks keeps relative symlinks (e.g. dugite's
+      // git-remote-https -> git-remote-http) intact; without it fs.cp rewrites
+      // them to absolute build-machine paths that dangle on the user's system.
+      await cp(dir, libDir, { recursive: true, verbatimSymlinks: true });
 
       // Generate .desktop file
       // See: https://docs.appimage.org/reference/desktop-integration.html#desktop-files

--- a/src/ipc/utils/git_utils.ts
+++ b/src/ipc/utils/git_utils.ts
@@ -13,6 +13,7 @@ import { platform } from "node:os";
 import { readSettings } from "../../main/settings";
 import log from "electron-log";
 import { normalizePath } from "../../../shared/normalizePath";
+import { ensureLibcurlShim } from "./linux_libcurl_shim";
 import type { UncommittedFile, UncommittedFileStatus } from "@/ipc/types";
 import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
 const logger = log.scope("git_utils");
@@ -108,7 +109,27 @@ async function execGit(
     return exec(args, path, execOptions);
   }
 
-  // On non-Windows, pass options through unchanged
+  // On Linux, the bundled git http helpers are linked against
+  // libcurl-gnutls.so.4, which RHEL-based distros don't ship. When needed,
+  // prepend a shim directory to LD_LIBRARY_PATH that exposes the system
+  // libcurl under that soname. No-op (returns undefined) on distros that
+  // already have libcurl-gnutls.so.4.
+  const shimDir = ensureLibcurlShim();
+  if (shimDir) {
+    const existingLdPath =
+      options?.env?.LD_LIBRARY_PATH ?? process.env.LD_LIBRARY_PATH;
+    const ldLibraryPath = [shimDir, existingLdPath].filter(Boolean).join(":");
+    return exec(args, path, {
+      ...options,
+      env: {
+        ...process.env,
+        ...options?.env,
+        LD_LIBRARY_PATH: ldLibraryPath,
+      },
+    });
+  }
+
+  // On non-Windows without a shim, pass options through unchanged
   return exec(args, path, options);
 }
 import type {

--- a/src/ipc/utils/git_utils.ts
+++ b/src/ipc/utils/git_utils.ts
@@ -13,7 +13,7 @@ import { platform } from "node:os";
 import { readSettings } from "../../main/settings";
 import log from "electron-log";
 import { normalizePath } from "../../../shared/normalizePath";
-import { ensureLibcurlShim } from "./linux_libcurl_shim";
+import { ensureLibcurlShimOnLinux } from "./linux_libcurl_shim";
 import type { UncommittedFile, UncommittedFileStatus } from "@/ipc/types";
 import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
 const logger = log.scope("git_utils");
@@ -114,7 +114,7 @@ async function execGit(
   // prepend a shim directory to LD_LIBRARY_PATH that exposes the system
   // libcurl under that soname. No-op (returns undefined) on distros that
   // already have libcurl-gnutls.so.4.
-  const shimDir = ensureLibcurlShim();
+  const shimDir = ensureLibcurlShimOnLinux();
   if (shimDir) {
     const existingLdPath =
       options?.env?.LD_LIBRARY_PATH ?? process.env.LD_LIBRARY_PATH;

--- a/src/ipc/utils/linux_libcurl_shim.test.ts
+++ b/src/ipc/utils/linux_libcurl_shim.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { parseLdconfig } from "./linux_libcurl_shim";
+
+const execFileSyncMock = vi.fn();
+const fsMock = {
+  mkdirSync: vi.fn(),
+  rmSync: vi.fn(),
+  symlinkSync: vi.fn(),
+  readlinkSync: vi.fn(),
+};
+
+vi.mock("node:child_process", () => ({
+  default: { execFileSync: (...args: unknown[]) => execFileSyncMock(...args) },
+  execFileSync: (...args: unknown[]) => execFileSyncMock(...args),
+}));
+
+vi.mock("node:fs", () => ({
+  default: {
+    mkdirSync: (...args: unknown[]) => fsMock.mkdirSync(...args),
+    rmSync: (...args: unknown[]) => fsMock.rmSync(...args),
+    symlinkSync: (...args: unknown[]) => fsMock.symlinkSync(...args),
+    readlinkSync: (...args: unknown[]) => fsMock.readlinkSync(...args),
+  },
+}));
+
+vi.mock("electron", () => ({
+  app: { getPath: () => "/userdata" },
+}));
+
+vi.mock("electron-log", () => ({
+  default: {
+    scope: () => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    }),
+  },
+}));
+
+const GNUTLS_LINE =
+  "\tlibcurl-gnutls.so.4 (libc6,x86-64) => /lib/x86_64-linux-gnu/libcurl-gnutls.so.4";
+const LIBCURL_LINE =
+  "\tlibcurl.so.4 (libc6,x86-64) => /lib/x86_64-linux-gnu/libcurl.so.4";
+const LIBCURL_PATH = "/lib/x86_64-linux-gnu/libcurl.so.4";
+
+function setPlatform(platform: NodeJS.Platform, arch: NodeJS.Architecture) {
+  Object.defineProperty(process, "platform", {
+    value: platform,
+    configurable: true,
+  });
+  Object.defineProperty(process, "arch", { value: arch, configurable: true });
+}
+
+// computeShimDir caches its result in module state, so import a fresh copy per
+// test to exercise it in isolation.
+async function loadEnsureLibcurlShim() {
+  vi.resetModules();
+  return (await import("./linux_libcurl_shim")).ensureLibcurlShim;
+}
+
+describe("ensureLibcurlShim", () => {
+  const origPlatform = process.platform;
+  const origArch = process.arch;
+
+  beforeEach(() => {
+    execFileSyncMock.mockReset();
+    fsMock.mkdirSync.mockReset();
+    fsMock.rmSync.mockReset();
+    fsMock.symlinkSync.mockReset();
+    fsMock.readlinkSync.mockReset();
+    // Default: a RHEL-like system (gnutls missing, plain libcurl present) with
+    // no existing shim symlink.
+    execFileSyncMock.mockReturnValue(LIBCURL_LINE);
+    fsMock.readlinkSync.mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+    setPlatform("linux", "x64");
+  });
+
+  afterEach(() => {
+    setPlatform(origPlatform, origArch);
+  });
+
+  it("returns undefined and touches nothing on non-Linux", async () => {
+    setPlatform("darwin", "x64");
+    const ensureLibcurlShim = await loadEnsureLibcurlShim();
+
+    expect(ensureLibcurlShim()).toBeUndefined();
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+    expect(fsMock.symlinkSync).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when libcurl-gnutls.so.4 is already present", async () => {
+    execFileSyncMock.mockReturnValue([GNUTLS_LINE, LIBCURL_LINE].join("\n"));
+    const ensureLibcurlShim = await loadEnsureLibcurlShim();
+
+    expect(ensureLibcurlShim()).toBeUndefined();
+    expect(fsMock.symlinkSync).not.toHaveBeenCalled();
+  });
+
+  it("creates a symlink to libcurl.so.4 when the gnutls soname is missing", async () => {
+    const ensureLibcurlShim = await loadEnsureLibcurlShim();
+
+    expect(ensureLibcurlShim()).toBe("/userdata/native-shims");
+    expect(fsMock.symlinkSync).toHaveBeenCalledWith(
+      LIBCURL_PATH,
+      "/userdata/native-shims/libcurl-gnutls.so.4",
+    );
+  });
+
+  it("returns undefined when no libcurl at all is found", async () => {
+    execFileSyncMock.mockReturnValue("");
+    const ensureLibcurlShim = await loadEnsureLibcurlShim();
+
+    expect(ensureLibcurlShim()).toBeUndefined();
+    expect(fsMock.symlinkSync).not.toHaveBeenCalled();
+  });
+
+  it("does not recreate the symlink when it already points at the right target", async () => {
+    fsMock.readlinkSync.mockReturnValue(LIBCURL_PATH);
+    const ensureLibcurlShim = await loadEnsureLibcurlShim();
+
+    expect(ensureLibcurlShim()).toBe("/userdata/native-shims");
+    expect(fsMock.rmSync).not.toHaveBeenCalled();
+    expect(fsMock.symlinkSync).not.toHaveBeenCalled();
+  });
+
+  it("computes once and caches the result across calls", async () => {
+    const ensureLibcurlShim = await loadEnsureLibcurlShim();
+
+    ensureLibcurlShim();
+    ensureLibcurlShim();
+
+    expect(execFileSyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the next ldconfig path when the first is unavailable", async () => {
+    execFileSyncMock.mockImplementation((bin: string) => {
+      if (bin === "/usr/sbin/ldconfig") throw new Error("ENOENT");
+      return LIBCURL_LINE;
+    });
+    const ensureLibcurlShim = await loadEnsureLibcurlShim();
+
+    expect(ensureLibcurlShim()).toBe("/userdata/native-shims");
+    expect(execFileSyncMock).toHaveBeenCalledWith("/sbin/ldconfig", ["-p"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  });
+});
+
+describe("parseLdconfig", () => {
+  it("parses soname -> path entries for the matching arch", () => {
+    const output = [
+      "1281 libs found in cache `/etc/ld.so.cache'",
+      "\tlibcurl.so.4 (libc6,x86-64) => /lib/x86_64-linux-gnu/libcurl.so.4",
+      "\tlibcurl-gnutls.so.4 (libc6,x86-64) => /lib/x86_64-linux-gnu/libcurl-gnutls.so.4",
+    ].join("\n");
+
+    const libs = parseLdconfig(output, "x86-64");
+
+    expect(libs.get("libcurl.so.4")).toBe("/lib/x86_64-linux-gnu/libcurl.so.4");
+    expect(libs.get("libcurl-gnutls.so.4")).toBe(
+      "/lib/x86_64-linux-gnu/libcurl-gnutls.so.4",
+    );
+  });
+
+  it("skips entries whose arch tag does not match (e.g. i386)", () => {
+    const output = [
+      "\tlibcurl.so.4 (libc6) => /lib/i386-linux-gnu/libcurl.so.4",
+      "\tlibcurl.so.4 (libc6,x86-64) => /lib/x86_64-linux-gnu/libcurl.so.4",
+    ].join("\n");
+
+    const libs = parseLdconfig(output, "x86-64");
+
+    // The i386 entry must be ignored so we never hand a 32-bit lib to a
+    // 64-bit binary.
+    expect(libs.get("libcurl.so.4")).toBe("/lib/x86_64-linux-gnu/libcurl.so.4");
+  });
+
+  it("keeps the first path listed for a given soname", () => {
+    const output = [
+      "\tlibcurl.so.4 (libc6,x86-64) => /usr/lib64/libcurl.so.4",
+      "\tlibcurl.so.4 (libc6,x86-64) => /usr/local/lib/libcurl.so.4",
+    ].join("\n");
+
+    const libs = parseLdconfig(output, "x86-64");
+
+    expect(libs.get("libcurl.so.4")).toBe("/usr/lib64/libcurl.so.4");
+  });
+
+  it("includes all matching archs when no arch tag is given", () => {
+    const output = [
+      "\tlibcurl.so.4 (libc6) => /lib/i386-linux-gnu/libcurl.so.4",
+    ].join("\n");
+
+    const libs = parseLdconfig(output, undefined);
+
+    expect(libs.get("libcurl.so.4")).toBe("/lib/i386-linux-gnu/libcurl.so.4");
+  });
+
+  it("ignores malformed lines and headers", () => {
+    const output = [
+      "1281 libs found in cache `/etc/ld.so.cache'",
+      "garbage without arrow",
+      "\tlibcurl.so.4 (libc6,x86-64) => /lib/x86_64-linux-gnu/libcurl.so.4",
+      "",
+    ].join("\n");
+
+    const libs = parseLdconfig(output, "x86-64");
+
+    expect(libs.size).toBe(1);
+    expect(libs.get("libcurl.so.4")).toBe("/lib/x86_64-linux-gnu/libcurl.so.4");
+  });
+
+  it("returns an empty map for empty output", () => {
+    expect(parseLdconfig("", "x86-64").size).toBe(0);
+  });
+});

--- a/src/ipc/utils/linux_libcurl_shim.test.ts
+++ b/src/ipc/utils/linux_libcurl_shim.test.ts
@@ -56,10 +56,10 @@ function setPlatform(platform: NodeJS.Platform, arch: NodeJS.Architecture) {
 // test to exercise it in isolation.
 async function loadEnsureLibcurlShim() {
   vi.resetModules();
-  return (await import("./linux_libcurl_shim")).ensureLibcurlShim;
+  return (await import("./linux_libcurl_shim")).ensureLibcurlShimOnLinux;
 }
 
-describe("ensureLibcurlShim", () => {
+describe("ensureLibcurlShimOnLinux", () => {
   const origPlatform = process.platform;
   const origArch = process.arch;
 
@@ -84,25 +84,25 @@ describe("ensureLibcurlShim", () => {
 
   it("returns undefined and touches nothing on non-Linux", async () => {
     setPlatform("darwin", "x64");
-    const ensureLibcurlShim = await loadEnsureLibcurlShim();
+    const ensureLibcurlShimOnLinux = await loadEnsureLibcurlShim();
 
-    expect(ensureLibcurlShim()).toBeUndefined();
+    expect(ensureLibcurlShimOnLinux()).toBeUndefined();
     expect(execFileSyncMock).not.toHaveBeenCalled();
     expect(fsMock.symlinkSync).not.toHaveBeenCalled();
   });
 
   it("no-ops when libcurl-gnutls.so.4 is already present", async () => {
     execFileSyncMock.mockReturnValue([GNUTLS_LINE, LIBCURL_LINE].join("\n"));
-    const ensureLibcurlShim = await loadEnsureLibcurlShim();
+    const ensureLibcurlShimOnLinux = await loadEnsureLibcurlShim();
 
-    expect(ensureLibcurlShim()).toBeUndefined();
+    expect(ensureLibcurlShimOnLinux()).toBeUndefined();
     expect(fsMock.symlinkSync).not.toHaveBeenCalled();
   });
 
   it("creates a symlink to libcurl.so.4 when the gnutls soname is missing", async () => {
-    const ensureLibcurlShim = await loadEnsureLibcurlShim();
+    const ensureLibcurlShimOnLinux = await loadEnsureLibcurlShim();
 
-    expect(ensureLibcurlShim()).toBe("/userdata/native-shims");
+    expect(ensureLibcurlShimOnLinux()).toBe("/userdata/native-shims");
     expect(fsMock.symlinkSync).toHaveBeenCalledWith(
       LIBCURL_PATH,
       "/userdata/native-shims/libcurl-gnutls.so.4",
@@ -111,26 +111,26 @@ describe("ensureLibcurlShim", () => {
 
   it("returns undefined when no libcurl at all is found", async () => {
     execFileSyncMock.mockReturnValue("");
-    const ensureLibcurlShim = await loadEnsureLibcurlShim();
+    const ensureLibcurlShimOnLinux = await loadEnsureLibcurlShim();
 
-    expect(ensureLibcurlShim()).toBeUndefined();
+    expect(ensureLibcurlShimOnLinux()).toBeUndefined();
     expect(fsMock.symlinkSync).not.toHaveBeenCalled();
   });
 
   it("does not recreate the symlink when it already points at the right target", async () => {
     fsMock.readlinkSync.mockReturnValue(LIBCURL_PATH);
-    const ensureLibcurlShim = await loadEnsureLibcurlShim();
+    const ensureLibcurlShimOnLinux = await loadEnsureLibcurlShim();
 
-    expect(ensureLibcurlShim()).toBe("/userdata/native-shims");
+    expect(ensureLibcurlShimOnLinux()).toBe("/userdata/native-shims");
     expect(fsMock.rmSync).not.toHaveBeenCalled();
     expect(fsMock.symlinkSync).not.toHaveBeenCalled();
   });
 
   it("computes once and caches the result across calls", async () => {
-    const ensureLibcurlShim = await loadEnsureLibcurlShim();
+    const ensureLibcurlShimOnLinux = await loadEnsureLibcurlShim();
 
-    ensureLibcurlShim();
-    ensureLibcurlShim();
+    ensureLibcurlShimOnLinux();
+    ensureLibcurlShimOnLinux();
 
     expect(execFileSyncMock).toHaveBeenCalledTimes(1);
   });
@@ -140,9 +140,9 @@ describe("ensureLibcurlShim", () => {
       if (bin === "/usr/sbin/ldconfig") throw new Error("ENOENT");
       return LIBCURL_LINE;
     });
-    const ensureLibcurlShim = await loadEnsureLibcurlShim();
+    const ensureLibcurlShimOnLinux = await loadEnsureLibcurlShim();
 
-    expect(ensureLibcurlShim()).toBe("/userdata/native-shims");
+    expect(ensureLibcurlShimOnLinux()).toBe("/userdata/native-shims");
     expect(execFileSyncMock).toHaveBeenCalledWith("/sbin/ldconfig", ["-p"], {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],

--- a/src/ipc/utils/linux_libcurl_shim.ts
+++ b/src/ipc/utils/linux_libcurl_shim.ts
@@ -24,8 +24,10 @@ const logger = log.scope("linux_libcurl_shim");
 
 const SONAME = "libcurl-gnutls.so.4";
 
-// Computed once per process. `undefined` means "no shim needed / possible".
-let cachedShimDir: string | undefined | "uncomputed" = "uncomputed";
+// Computed once per process. The outer `undefined` means "not computed yet";
+// once computed, `shimDir` is the directory (or `undefined` if no shim is
+// needed). Boxing lets us distinguish "uncached" from a cached no-shim result.
+let cachedShim: { shimDir: string | undefined } | undefined = undefined;
 
 /**
  * Returns the directory to prepend to LD_LIBRARY_PATH so the bundled git http
@@ -33,16 +35,15 @@ let cachedShimDir: string | undefined | "uncomputed" = "uncomputed";
  * `undefined` when no shim is needed (gnutls present, not Linux, or no usable
  * libcurl found).
  */
-export function ensureLibcurlShim(): string | undefined {
-  if (cachedShimDir !== "uncomputed") {
-    return cachedShimDir;
+export function ensureLibcurlShimOnLinux(): string | undefined {
+  if (cachedShim === undefined) {
+    cachedShim = { shimDir: computeShimDir() };
   }
-  cachedShimDir = computeShimDir();
-  return cachedShimDir;
+  return cachedShim.shimDir;
 }
 
 /**
- * Does the actual work behind ensureLibcurlShim (which caches the result).
+ * Does the actual work behind ensureLibcurlShimOnLinux (which caches the result).
  * Returns undefined when no shim is needed or possible: non-Linux, the gnutls
  * soname is already present, or no usable libcurl.so.4 was found. Otherwise
  * (re)creates the symlink and returns the directory containing it. Never

--- a/src/ipc/utils/linux_libcurl_shim.ts
+++ b/src/ipc/utils/linux_libcurl_shim.ts
@@ -1,0 +1,171 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { app } from "electron";
+import log from "electron-log";
+
+const logger = log.scope("linux_libcurl_shim");
+
+/**
+ * The bundled dugite git http helpers (git-remote-https/git-remote-http) are
+ * dynamically linked against `libcurl-gnutls.so.4`. Debian/Ubuntu ship that
+ * exact soname, but RHEL-based distros (Fedora, RHEL, CentOS, ...) ship only
+ * the OpenSSL flavor `libcurl.so.4`, so the helper fails to start with:
+ *   "error while loading shared libraries: libcurl-gnutls.so.4: cannot open
+ *    shared object file"
+ *
+ * The public curl API is identical across the two builds, so pointing the
+ * loader at the OpenSSL libcurl under the gnutls soname resolves the helper.
+ * We do this purely at runtime, only when the gnutls soname is genuinely
+ * missing, so systems that already have it are never touched.
+ *
+ * https://github.com/dyad-sh/dyad/issues/2975
+ */
+
+const SONAME = "libcurl-gnutls.so.4";
+
+// Computed once per process. `undefined` means "no shim needed / possible".
+let cachedShimDir: string | undefined | "uncomputed" = "uncomputed";
+
+/**
+ * Returns the directory to prepend to LD_LIBRARY_PATH so the bundled git http
+ * helpers can find a libcurl under the `libcurl-gnutls.so.4` soname, or
+ * `undefined` when no shim is needed (gnutls present, not Linux, or no usable
+ * libcurl found).
+ */
+export function ensureLibcurlShim(): string | undefined {
+  if (cachedShimDir !== "uncomputed") {
+    return cachedShimDir;
+  }
+  cachedShimDir = computeShimDir();
+  return cachedShimDir;
+}
+
+/**
+ * Does the actual work behind ensureLibcurlShim (which caches the result).
+ * Returns undefined when no shim is needed or possible: non-Linux, the gnutls
+ * soname is already present, or no usable libcurl.so.4 was found. Otherwise
+ * (re)creates the symlink and returns the directory containing it. Never
+ * throws; failures are logged and treated as "no shim".
+ */
+function computeShimDir(): string | undefined {
+  if (process.platform !== "linux") {
+    return undefined;
+  }
+
+  try {
+    const libs = listSystemLibs();
+
+    // gnutls soname already present: nothing to do, leave the system alone.
+    if (libs.has(SONAME)) {
+      return undefined;
+    }
+
+    const realLibcurl = libs.get("libcurl.so.4");
+    if (!realLibcurl) {
+      // No usable libcurl found. Can't fix it here; let the real loader error
+      // surface so the user sees an actionable message.
+      logger.warn(
+        `${SONAME} missing and no libcurl.so.4 found; git over https may fail`,
+      );
+      return undefined;
+    }
+
+    const shimDir = path.join(app.getPath("userData"), "native-shims");
+    fs.mkdirSync(shimDir, { recursive: true });
+
+    const link = path.join(shimDir, SONAME);
+    if (readlinkSafe(link) !== realLibcurl) {
+      fs.rmSync(link, { force: true });
+      fs.symlinkSync(realLibcurl, link);
+      logger.info(`Created libcurl shim: ${link} -> ${realLibcurl}`);
+    }
+
+    return shimDir;
+  } catch (error) {
+    logger.error("Failed to set up libcurl shim:", error);
+    return undefined;
+  }
+}
+
+/**
+ * Lists system libraries via `ldconfig -p`, as a map of soname -> absolute
+ * path restricted to the running process's architecture so we never hand a
+ * 32-bit (i386) library to a 64-bit binary. A GUI-launched app may have a
+ * minimal PATH that omits /sbin, so we try known absolute locations before a
+ * bare PATH lookup.
+ */
+function listSystemLibs(): Map<string, string> {
+  const archTag = ldconfigArchTag();
+  const ldconfigCandidates = [
+    "/usr/sbin/ldconfig",
+    "/sbin/ldconfig",
+    "ldconfig",
+  ];
+
+  for (const bin of ldconfigCandidates) {
+    try {
+      const out = execFileSync(bin, ["-p"], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+      const parsed = parseLdconfig(out, archTag);
+      if (parsed.size > 0) {
+        return parsed;
+      }
+    } catch {
+      // Not at this path / not executable; try the next candidate.
+    }
+  }
+
+  logger.warn("ldconfig not found or returned no libraries");
+  return new Map();
+}
+
+/**
+ * Parses the output of `ldconfig -p` into a map of soname -> absolute path,
+ * keeping only entries whose architecture annotation includes `archTag` (when
+ * provided). The first path listed for a soname wins, matching ldconfig's
+ * preferred-first ordering.
+ *
+ * Lines look like:
+ *   libcurl.so.4 (libc6,x86-64) => /lib/x86_64-linux-gnu/libcurl.so.4
+ */
+export function parseLdconfig(
+  output: string,
+  archTag: string | undefined,
+): Map<string, string> {
+  const result = new Map<string, string>();
+  const lineRe = /^\s*(\S+)\s+\(([^)]*)\)\s+=>\s+(\S+)\s*$/;
+  for (const line of output.split("\n")) {
+    const m = lineRe.exec(line);
+    if (!m) continue;
+    const [, soname, tags, libPath] = m;
+    if (archTag && !tags.includes(archTag)) continue;
+    if (!result.has(soname)) {
+      result.set(soname, libPath);
+    }
+  }
+  return result;
+}
+
+/**
+ * Reads a symlink's target, returning undefined if the path is missing or not
+ * a symlink.
+ */
+function readlinkSafe(p: string): string | undefined {
+  try {
+    return fs.readlinkSync(p);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * The architecture tag ldconfig uses in its parenthesized annotations. Dyad
+ * ships only an x64 Linux build, so we only map that; any other arch returns
+ * undefined and the arch filter is simply skipped.
+ */
+function ldconfigArchTag(): string | undefined {
+  return process.arch === "x64" ? "x86-64" : undefined;
+}


### PR DESCRIPTION
Two issues prevented git operations over https (GitHub sync, push, pull, template clone) from working on some Linux setups.

1. git http helpers can't find libcurl on RHEL-based distros

The bundled dugite git http helpers (git-remote-https/git-remote-http) are dynamically linked against libcurl-gnutls.so.4. Debian/Ubuntu ship that exact soname, but RHEL-based distros (Fedora, RHEL, CentOS) ship only the OpenSSL flavor libcurl.so.4, so the helper fails to start with:

  git-remote-https: error while loading shared libraries:
  libcurl-gnutls.so.4: cannot open shared object file

The public curl API is identical across the two builds, so at git-exec time on Linux, when libcurl-gnutls.so.4 is genuinely missing but libcurl.so.4 is present, we create a symlink in a private shim directory and prepend it to LD_LIBRARY_PATH for the spawned git process. Systems that already have libcurl-gnutls.so.4 are never touched, and the existing LD_LIBRARY_PATH is preserved. The whole path is Linux-only and no-ops everywhere else.

2. Dangling git helper symlinks in the AppImage

MakerAppImage copied the packaged app with fs.cp(..., { recursive: true }), which by default rewrites relative symlinks to absolute paths anchored at the build machine. dugite's git-remote-https -> git-remote-http (and the ftp variants) became absolute links into the build staging directory, dangling on every other machine. git then could not exec the helper:

  git: 'remote-https' is not a git command

Passing verbatimSymlinks: true keeps the relative symlinks intact. The rpm/deb makers were unaffected. This blocked the AppImage before the libcurl helper was even reached, so both fixes are needed for https git to work on RHEL-based AppImage installs.

Fixes #2975. Tested on Fedora 42.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

