### PR TITLE
Fix app Git line ending staging failures

### DIFF
--- a/e2e-tests/helpers/page-objects/PageObject.ts
+++ b/e2e-tests/helpers/page-objects/PageObject.ts
@@ -39,6 +39,121 @@ import { ContextFilesPickerDialog } from "./dialogs/ContextFilesPickerDialog";
 import { ProModesDialog } from "./dialogs/ProModesDialog";
 import { Timeout } from "../constants";
 
+const IGNORED_SNAPSHOT_FILE_PATHS = new Set([".gitattributes"]);
+
+function isIgnoredSnapshotFile(filePath: string | undefined): boolean {
+  return (
+    typeof filePath === "string" &&
+    IGNORED_SNAPSHOT_FILE_PATHS.has(normalizePath(filePath))
+  );
+}
+
+function removeIgnoredDyadFileBlocks(text: string): string {
+  return text
+    .replace(
+      /\n?<dyad-file path="\.gitattributes">[\s\S]*?<\/dyad-file>\n*/g,
+      "",
+    )
+    .replace(
+      /This is my codebase\.\s+(<dyad-file)/g,
+      "This is my codebase. $1",
+    );
+}
+
+function sanitizeContentForSnapshot(content: unknown): unknown {
+  if (typeof content === "string") {
+    return removeIgnoredDyadFileBlocks(content);
+  }
+  if (Array.isArray(content)) {
+    return content.map((part) => {
+      if (
+        part &&
+        typeof part === "object" &&
+        "text" in part &&
+        typeof part.text === "string"
+      ) {
+        return {
+          ...part,
+          text: removeIgnoredDyadFileBlocks(part.text),
+        };
+      }
+      return part;
+    });
+  }
+  return content;
+}
+
+function removeIgnoredSnapshotFilesFromDump(dump: any): void {
+  const body = dump?.body;
+  if (!body) {
+    return;
+  }
+
+  for (const key of ["input", "messages"] as const) {
+    if (Array.isArray(body[key])) {
+      body[key] = body[key].map((message: any) => ({
+        ...message,
+        content: sanitizeContentForSnapshot(message.content),
+      }));
+    }
+  }
+
+  if (Array.isArray(body.dyad_options?.files)) {
+    body.dyad_options.files = body.dyad_options.files.filter(
+      (file: any) => !isIgnoredSnapshotFile(file.path),
+    );
+  }
+
+  if (Array.isArray(body.dyad_options?.mentioned_apps)) {
+    for (const mentionedApp of body.dyad_options.mentioned_apps) {
+      if (Array.isArray(mentionedApp.files)) {
+        mentionedApp.files = mentionedApp.files.filter(
+          (file: any) => !isIgnoredSnapshotFile(file.path),
+        );
+      }
+    }
+  }
+
+  const vf = body.dyad_options?.versioned_files;
+  if (!vf) {
+    return;
+  }
+
+  const ignoredFileIds = new Set<string>();
+  if (Array.isArray(vf.fileReferences)) {
+    vf.fileReferences = vf.fileReferences.filter((ref: any) => {
+      if (isIgnoredSnapshotFile(ref.path)) {
+        if (typeof ref.fileId === "string") {
+          ignoredFileIds.add(ref.fileId);
+        }
+        return false;
+      }
+      return true;
+    });
+  }
+
+  if (vf.fileIdToContent) {
+    for (const fileId of ignoredFileIds) {
+      delete vf.fileIdToContent[fileId];
+    }
+  }
+
+  if (vf.messageIndexToFilePathToFileId) {
+    for (const pathToId of Object.values(
+      vf.messageIndexToFilePathToFileId as Record<
+        string,
+        Record<string, string>
+      >,
+    )) {
+      for (const filePath of Object.keys(pathToId)) {
+        if (isIgnoredSnapshotFile(filePath)) {
+          delete pathToId[filePath];
+        }
+      }
+    }
+  }
+}
+
 export class PageObject {
   public userDataDir: string;
   public fakeLlmPort: number;
@@ -421,6 +536,9 @@ export class PageObject {
 
       // Sort by relative path to ensure deterministic output
       filesData.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+      filesData = filesData.filter(
+        (file) => !isIgnoredSnapshotFile(file.relativePath),
+      );
       if (files) {
         filesData = filesData.filter((file) =>
           files.some(
@@ -548,6 +666,7 @@ export class PageObject {
 
     // Perform snapshot comparison
     const parsedDump = JSON.parse(dumpContent);
+    removeIgnoredSnapshotFilesFromDump(parsedDump);
     if (parsedDump["body"]["input"]) {
       parsedDump["body"]["input"] = parsedDump["body"]["input"].map(
         (input: any) => {

--- a/src/ipc/services/git_service.test.ts
+++ b/src/ipc/services/git_service.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  ensureGitLineEndingPolicy: vi.fn(),
   gitInit: vi.fn(),
   gitAdd: vi.fn(),
   gitAddAll: vi.fn(),
@@ -32,8 +33,17 @@ describe("GitService", () => {
   it("initRepoWithInitialCommit inits, stages all, then commits", async () => {
     const hash = await service.initRepoWithInitialCommit({ path: "/repo" });
 
-    expect(callOrder).toEqual(["gitInit", "gitAddAll", "gitCommit"]);
+    expect(callOrder).toEqual([
+      "gitInit",
+      "ensureGitLineEndingPolicy",
+      "gitAddAll",
+      "gitCommit",
+    ]);
     expect(mocks.gitInit).toHaveBeenCalledWith({ path: "/repo", ref: "main" });
+    expect(mocks.ensureGitLineEndingPolicy).toHaveBeenCalledWith({
+      path: "/repo",
+      writeGitattributes: true,
+    });
     expect(mocks.gitCommit).toHaveBeenCalledWith({
       path: "/repo",
       message: "Init Dyad app",

--- a/src/ipc/services/git_service.ts
+++ b/src/ipc/services/git_service.ts
@@ -1,4 +1,5 @@
 import {
+  ensureGitLineEndingPolicy,
   gitAdd,
   gitAddAll,
   gitCommit,
@@ -31,6 +32,7 @@ export class GitService {
     ref?: string;
   }): Promise<string> {
     await gitInit({ path, ref });
+    await ensureGitLineEndingPolicy({ path, writeGitattributes: true });
     await gitAddAll({ path });
     return gitCommit({ path, message });
   }

--- a/src/ipc/utils/git_utils.test.ts
+++ b/src/ipc/utils/git_utils.test.ts
@@ -78,6 +78,7 @@ describe("ensureGitLineEndingPolicy", () => {
   it("does not overwrite an existing gitattributes file", async () => {
     vi.mocked(readSettings).mockReturnValue({ enableNativeGit: false } as any);
     repoDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "git-utils-"));
+    await runGit(repoDir, ["init"]);
     await fs.promises.writeFile(
       path.join(repoDir, ".gitattributes"),
       "*.png binary\n",
@@ -91,6 +92,35 @@ describe("ensureGitLineEndingPolicy", () => {
     await expect(
       fs.promises.readFile(path.join(repoDir, ".gitattributes"), "utf8"),
     ).resolves.toBe("*.png binary\n");
+  });
+
+  it("does not create gitattributes for non-repo paths", async () => {
+    vi.mocked(readSettings).mockReturnValue({ enableNativeGit: false } as any);
+    repoDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "git-utils-"));
+
+    await ensureGitLineEndingPolicy({
+      path: repoDir,
+      writeGitattributes: true,
+    });
+
+    await expect(
+      fs.promises.stat(path.join(repoDir, ".gitattributes")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("caches native git line ending config per repo path", async () => {
+    vi.mocked(readSettings).mockReturnValue({ enableNativeGit: true } as any);
+    repoDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "git-utils-"));
+
+    await runGit(repoDir, ["init"]);
+    await ensureGitLineEndingPolicy({ path: repoDir });
+    await runGit(repoDir, ["config", "--local", "core.eol", "crlf"]);
+
+    await ensureGitLineEndingPolicy({ path: repoDir });
+
+    await expect(
+      runGitOutput(repoDir, ["config", "--local", "core.eol"]),
+    ).resolves.toBe("crlf");
   });
 });
 

--- a/src/ipc/utils/git_utils.test.ts
+++ b/src/ipc/utils/git_utils.test.ts
@@ -23,6 +23,7 @@ vi.mock("@/main/settings", () => ({
 
 import { gitListFilesNative } from "@/ipc/utils/git_utils";
 import {
+  ensureGitLineEndingPolicy,
   getGitUncommittedFiles,
   getGitUncommittedFilesWithStatus,
 } from "@/ipc/utils/git_utils";
@@ -33,6 +34,65 @@ const execFileAsync = promisify(execFile);
 async function runGit(repoDir: string, args: string[]): Promise<void> {
   await execFileAsync("git", args, { cwd: repoDir });
 }
+
+async function runGitOutput(repoDir: string, args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync("git", args, { cwd: repoDir });
+  return stdout.trim();
+}
+
+describe("ensureGitLineEndingPolicy", () => {
+  let repoDir: string | undefined;
+
+  afterEach(async () => {
+    if (repoDir) {
+      await fs.promises.rm(repoDir, { recursive: true, force: true });
+      repoDir = undefined;
+    }
+  });
+
+  it("sets repo-local native git line ending config and creates gitattributes", async () => {
+    vi.mocked(readSettings).mockReturnValue({ enableNativeGit: true } as any);
+    repoDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "git-utils-"));
+
+    await runGit(repoDir, ["init"]);
+
+    await ensureGitLineEndingPolicy({
+      path: repoDir,
+      writeGitattributes: true,
+    });
+
+    await expect(
+      fs.promises.readFile(path.join(repoDir, ".gitattributes"), "utf8"),
+    ).resolves.toContain("* text=auto eol=lf");
+    await expect(
+      runGitOutput(repoDir, ["config", "--local", "core.autocrlf"]),
+    ).resolves.toBe("false");
+    await expect(
+      runGitOutput(repoDir, ["config", "--local", "core.eol"]),
+    ).resolves.toBe("lf");
+    await expect(
+      runGitOutput(repoDir, ["config", "--local", "core.safecrlf"]),
+    ).resolves.toBe("warn");
+  });
+
+  it("does not overwrite an existing gitattributes file", async () => {
+    vi.mocked(readSettings).mockReturnValue({ enableNativeGit: false } as any);
+    repoDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "git-utils-"));
+    await fs.promises.writeFile(
+      path.join(repoDir, ".gitattributes"),
+      "*.png binary\n",
+    );
+
+    await ensureGitLineEndingPolicy({
+      path: repoDir,
+      writeGitattributes: true,
+    });
+
+    await expect(
+      fs.promises.readFile(path.join(repoDir, ".gitattributes"), "utf8"),
+    ).resolves.toBe("*.png binary\n");
+  });
+});
 
 describe("gitListFilesNative", () => {
   let repoDir: string | undefined;

--- a/src/ipc/utils/git_utils.ts
+++ b/src/ipc/utils/git_utils.ts
@@ -194,6 +194,47 @@ async function execOrThrow(
   }
 }
 
+export async function ensureGitLineEndingPolicy({
+  path,
+  writeGitattributes = false,
+}: GitBaseParams & { writeGitattributes?: boolean }): Promise<void> {
+  if (writeGitattributes) {
+    const gitattributesPath = pathModule.join(path, ".gitattributes");
+    if (!fs.existsSync(gitattributesPath)) {
+      await fsPromises.writeFile(
+        gitattributesPath,
+        "# Normalize text files to LF so Dyad commits are stable across platforms.\n* text=auto eol=lf\n",
+      );
+    }
+  }
+
+  const settings = readSettings();
+  if (!settings.enableNativeGit) {
+    return;
+  }
+
+  const gitMetadataPath = pathModule.join(path, ".git");
+  if (!fs.existsSync(gitMetadataPath)) {
+    return;
+  }
+
+  await execOrThrow(
+    ["config", "--local", "core.autocrlf", "false"],
+    path,
+    "Failed to configure git line endings",
+  );
+  await execOrThrow(
+    ["config", "--local", "core.eol", "lf"],
+    path,
+    "Failed to configure git line endings",
+  );
+  await execOrThrow(
+    ["config", "--local", "core.safecrlf", "warn"],
+    path,
+    "Failed to configure git line endings",
+  );
+}
+
 /**
  * Prepends git config args for user.name and user.email to the provided args.
  * Automatically fetches the git author from settings.
@@ -492,6 +533,7 @@ export async function gitStageToRevert({
 export async function gitAddAll({ path }: GitBaseParams): Promise<void> {
   const settings = readSettings();
   if (settings.enableNativeGit) {
+    await ensureGitLineEndingPolicy({ path });
     await execOrThrow(["add", "."], path, "Failed to stage all files");
     return;
   } else {
@@ -526,6 +568,7 @@ export async function gitAdd({ path, filepath }: GitFileParams): Promise<void> {
   }
 
   if (settings.enableNativeGit) {
+    await ensureGitLineEndingPolicy({ path });
     await execOrThrow(
       ["add", "--", normalizedFilepath],
       path,

--- a/src/ipc/utils/git_utils.ts
+++ b/src/ipc/utils/git_utils.ts
@@ -194,17 +194,56 @@ async function execOrThrow(
   }
 }
 
+const gitLineEndingConfigPromises = new Map<string, Promise<void>>();
+
+function isAlreadyExistsError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as { code?: string }).code === "EEXIST"
+  );
+}
+
+async function configureGitLineEndings(path: string): Promise<void> {
+  await execOrThrow(
+    ["config", "--local", "core.autocrlf", "false"],
+    path,
+    "Failed to configure git line ending core.autocrlf",
+  );
+  await execOrThrow(
+    ["config", "--local", "core.eol", "lf"],
+    path,
+    "Failed to configure git line ending core.eol",
+  );
+  await execOrThrow(
+    ["config", "--local", "core.safecrlf", "warn"],
+    path,
+    "Failed to configure git line ending core.safecrlf",
+  );
+}
+
 export async function ensureGitLineEndingPolicy({
   path,
   writeGitattributes = false,
 }: GitBaseParams & { writeGitattributes?: boolean }): Promise<void> {
+  const gitMetadataPath = pathModule.join(path, ".git");
+  if (!fs.existsSync(gitMetadataPath)) {
+    return;
+  }
+
   if (writeGitattributes) {
     const gitattributesPath = pathModule.join(path, ".gitattributes");
-    if (!fs.existsSync(gitattributesPath)) {
+    try {
       await fsPromises.writeFile(
         gitattributesPath,
         "# Normalize text files to LF so Dyad commits are stable across platforms.\n* text=auto eol=lf\n",
+        { flag: "wx" },
       );
+      logger.debug(`Created default .gitattributes in ${path}`);
+    } catch (error) {
+      if (!isAlreadyExistsError(error)) {
+        throw error;
+      }
     }
   }
 
@@ -213,26 +252,20 @@ export async function ensureGitLineEndingPolicy({
     return;
   }
 
-  const gitMetadataPath = pathModule.join(path, ".git");
-  if (!fs.existsSync(gitMetadataPath)) {
-    return;
+  const resolvedPath = pathModule.resolve(path);
+  const existingPromise = gitLineEndingConfigPromises.get(resolvedPath);
+  if (existingPromise) {
+    return existingPromise;
   }
 
-  await execOrThrow(
-    ["config", "--local", "core.autocrlf", "false"],
-    path,
-    "Failed to configure git line endings",
-  );
-  await execOrThrow(
-    ["config", "--local", "core.eol", "lf"],
-    path,
-    "Failed to configure git line endings",
-  );
-  await execOrThrow(
-    ["config", "--local", "core.safecrlf", "warn"],
-    path,
-    "Failed to configure git line endings",
-  );
+  const promise = configureGitLineEndings(path);
+  gitLineEndingConfigPromises.set(resolvedPath, promise);
+  try {
+    await promise;
+  } catch (error) {
+    gitLineEndingConfigPromises.delete(resolvedPath);
+    throw error;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Set repo-local Git line-ending config before Dyad stages app changes so existing apps are insulated from global autocrlf/safecrlf settings.
- Add a default .gitattributes only for newly initialized Dyad app repos when one is absent, so the policy travels with new apps without overwriting user files.
- Cover the helper and GitService initialization order with focused tests.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches every native `git add` / initial commit path and writes repo config and optionally `.gitattributes`; behavior is gated on native Git and tested, but wrong line-ending logic could affect commits across platforms.
> 
> **Overview**
> Fixes **Git staging failures** on apps when the host’s global `autocrlf` / `safecrlf` settings disagree with Dyad’s LF-oriented files.
> 
> **Native Git path:** Before `git add`, Dyad now runs **`ensureGitLineEndingPolicy`**, which sets repo-local `core.autocrlf=false`, `core.eol=lf`, and `core.safecrlf=warn` (once per repo, with in-flight deduplication). **New app repos** get a default **`.gitattributes`** (`* text=auto eol=lf`) only when missing—`GitService.initRepoWithInitialCommit` applies this right after `git init` and before the first stage.
> 
> **E2E:** Snapshot helpers **ignore or strip `.gitattributes`** from app-file and server-dump comparisons so the new bootstrap file does not churn baselines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b6dcf78ac2a9ee1df389d17d44dc6c606f89624. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->