### PR TITLE
Bump to v1.5.0-beta.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dyad",
-  "version": "1.4.0",
+  "version": "1.5.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dyad",
-      "version": "1.4.0",
+      "version": "1.5.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/amazon-bedrock": "^4.0.46",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dyad",
-  "version": "1.4.0",
+  "version": "1.5.0-beta.1",
   "description": "Free, local, open-source AI app builder",
   "keywords": [],
   "license": "MIT",


### PR DESCRIPTION
#skip-bb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata only; no application or dependency changes beyond mirrored version fields in the lockfile.
> 
> **Overview**
> Bumps the **dyad** package from **1.4.0** to **1.5.0-beta.1** in `package.json` and the root entry in `package-lock.json`, aligning the lockfile with the new semver for the next beta release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fc8eb7cd74e8a683b85e04f224bcff8e30c8db7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->