### PR TITLE
Require approval for destructive SQL

### DIFF
--- a/packages/pg-schema-classifier/src/index.ts
+++ b/packages/pg-schema-classifier/src/index.ts
@@ -23,6 +23,8 @@ export type SqlDataDeletionReason =
   | "delete"
   | "truncate"
   | "data_modifying_cte"
+  | "dynamic_execution"
+  | "unparseable_or_incomplete"
   | "drop_database"
   | "drop_schema"
   | "drop_table"
@@ -205,54 +207,67 @@ function classifyDataDeletionStatement(
 ): SqlDataDeletionStatement {
   const trimmed = statement.sql.trim();
   if (statement.incomplete) {
-    return nonDataDeleting(trimmed, null);
+    return dataDeleting(trimmed, "unparseable_or_incomplete", null);
   }
 
   const tokens = tokenizeStatement(trimmed);
+  return classifyDataDeletionTokens(tokens, trimmed);
+}
+
+function classifyDataDeletionTokens(
+  tokens: readonly Token[],
+  sql: string,
+): SqlDataDeletionStatement {
   const first = firstWord(tokens);
   if (first === null) {
-    return nonDataDeleting(trimmed, null);
+    return nonDataDeleting(sql, null);
   }
 
   if (first === "DELETE") {
-    return dataDeleting(trimmed, "delete", "DELETE");
+    return dataDeleting(sql, "delete", "DELETE");
   }
 
   if (first === "TRUNCATE") {
-    return dataDeleting(trimmed, "truncate", "TRUNCATE");
+    return dataDeleting(sql, "truncate", "TRUNCATE");
+  }
+
+  if (first === "DO" || first === "CALL") {
+    return dataDeleting(sql, "dynamic_execution", first);
   }
 
   if (first === "DROP") {
-    const droppedObject = wordAt(tokens, 1);
+    const droppedObject = droppedObjectType(tokens);
     if (droppedObject === "DATABASE") {
-      return dataDeleting(trimmed, "drop_database", "DROP DATABASE");
+      return dataDeleting(sql, "drop_database", "DROP DATABASE");
     }
     if (droppedObject === "SCHEMA") {
-      return dataDeleting(trimmed, "drop_schema", "DROP SCHEMA");
+      return dataDeleting(sql, "drop_schema", "DROP SCHEMA");
     }
     if (droppedObject === "TABLE") {
-      return dataDeleting(trimmed, "drop_table", "DROP TABLE");
+      return dataDeleting(sql, "drop_table", "DROP TABLE");
     }
   }
 
   if (first === "ALTER" && statementDropsColumn(tokens)) {
-    return dataDeleting(trimmed, "drop_column", "ALTER TABLE DROP COLUMN");
+    return dataDeleting(sql, "drop_column", "ALTER TABLE DROP COLUMN");
+  }
+
+  if (first === "MERGE" && mergeDeletesRows(tokens)) {
+    return dataDeleting(sql, "delete", "MERGE DELETE");
   }
 
   if (first === "WITH" && hasUnquotedWord(tokens, "DELETE")) {
-    return dataDeleting(trimmed, "data_modifying_cte", "WITH DELETE");
+    return dataDeleting(sql, "data_modifying_cte", "WITH DELETE");
   }
 
   if (first === "EXPLAIN" && explainExecutesStatement(tokens)) {
-    if (hasUnquotedWord(tokens, "TRUNCATE")) {
-      return dataDeleting(trimmed, "truncate", "EXPLAIN TRUNCATE");
-    }
-    if (hasUnquotedWord(tokens, "DELETE")) {
-      return dataDeleting(trimmed, "delete", "EXPLAIN DELETE");
+    const statementStart = explainStatementStartIndex(tokens);
+    if (statementStart !== null) {
+      return classifyDataDeletionTokens(tokens.slice(statementStart), sql);
     }
   }
 
-  return nonDataDeleting(trimmed, first);
+  return nonDataDeleting(sql, first);
 }
 
 function findSchemaFunctionCall(tokens: readonly Token[]): string | null {
@@ -317,6 +332,39 @@ function explainExecutesStatement(tokens: readonly Token[]): boolean {
   }
 
   return false;
+}
+
+function explainStatementStartIndex(tokens: readonly Token[]): number | null {
+  const explainIndex = tokens.findIndex((token) =>
+    isUnquotedWord(token, "EXPLAIN"),
+  );
+  if (explainIndex === -1) return null;
+
+  let index = explainIndex + 1;
+  const next = tokens[index];
+  if (next?.type === "symbol" && next.value === "(") {
+    let depth = 1;
+    for (index += 1; index < tokens.length; index += 1) {
+      const token = tokens[index];
+      if (token?.type !== "symbol") continue;
+      if (token.value === "(") {
+        depth += 1;
+        continue;
+      }
+      if (token.value !== ")") continue;
+      depth -= 1;
+      if (depth === 0) return index + 1;
+    }
+    return null;
+  }
+
+  if (isUnquotedWord(tokens[index], "ANALYZE")) {
+    index += 1;
+  }
+  if (isUnquotedWord(tokens[index], "VERBOSE")) {
+    index += 1;
+  }
+  return index < tokens.length ? index : null;
 }
 
 function explainOptionsEnableAnalyze(
@@ -438,8 +486,13 @@ function firstWord(tokens: readonly Token[]): string | null {
 }
 
 function wordAt(tokens: readonly Token[], index: number): string | null {
-  const words = tokens.filter((token) => isUnquotedWord(token));
-  return words[index]?.value ?? null;
+  return unquotedWords(tokens)[index] ?? null;
+}
+
+function unquotedWords(tokens: readonly Token[]): string[] {
+  return tokens
+    .filter((token) => isUnquotedWord(token))
+    .map((token) => token.value);
 }
 
 function isUnquotedWord(
@@ -457,14 +510,52 @@ function hasUnquotedWord(tokens: readonly Token[], value: string): boolean {
   return tokens.some((token) => isUnquotedWord(token, value));
 }
 
+function droppedObjectType(tokens: readonly Token[]): string | null {
+  const words = unquotedWords(tokens);
+  let index = 1;
+  if (words[index] === "IF" && words[index + 1] === "EXISTS") {
+    index += 2;
+  }
+  return words[index] ?? null;
+}
+
+const NON_COLUMN_ALTER_TABLE_DROP_TARGETS: ReadonlySet<string> = new Set([
+  "CONSTRAINT",
+  "DEFAULT",
+  "EXPRESSION",
+  "IDENTITY",
+  "INHERIT",
+  "NOT",
+  "OF",
+  "REPLICA",
+]);
+
 function statementDropsColumn(tokens: readonly Token[]): boolean {
   return (
     wordAt(tokens, 1) === "TABLE" &&
     tokens.some((token, index) => {
       if (!isUnquotedWord(token, "DROP")) return false;
-      return wordAt(tokens.slice(index + 1), 0) === "COLUMN";
+      const wordsAfterDrop = unquotedWords(tokens.slice(index + 1));
+      if (wordsAfterDrop[0] === "COLUMN") return true;
+
+      let targetIndex = 0;
+      if (
+        wordsAfterDrop[targetIndex] === "IF" &&
+        wordsAfterDrop[targetIndex + 1] === "EXISTS"
+      ) {
+        targetIndex += 2;
+      }
+
+      const target = wordsAfterDrop[targetIndex];
+      return (
+        target !== undefined && !NON_COLUMN_ALTER_TABLE_DROP_TARGETS.has(target)
+      );
     })
   );
+}
+
+function mergeDeletesRows(tokens: readonly Token[]): boolean {
+  return hasUnquotedWord(tokens, "MERGE") && hasUnquotedWord(tokens, "DELETE");
 }
 
 function hasTopLevelSelectInto(tokens: readonly Token[]): boolean {

--- a/packages/pg-schema-classifier/src/index.ts
+++ b/packages/pg-schema-classifier/src/index.ts
@@ -19,6 +19,27 @@ export type SqlSchemaMutationAnalysis = {
   readonly statements: readonly SqlSchemaMutationStatement[];
 };
 
+export type SqlDataDeletionReason =
+  | "delete"
+  | "truncate"
+  | "data_modifying_cte"
+  | "drop_database"
+  | "drop_schema"
+  | "drop_table"
+  | "drop_column";
+
+export type SqlDataDeletionStatement = {
+  readonly sql: string;
+  readonly deletesData: boolean;
+  readonly reason: SqlDataDeletionReason | null;
+  readonly command: string | null;
+};
+
+export type SqlDataDeletionAnalysis = {
+  readonly deletesData: boolean;
+  readonly statements: readonly SqlDataDeletionStatement[];
+};
+
 type SplitStatement = {
   readonly sql: string;
   readonly incomplete: boolean;
@@ -103,6 +124,14 @@ export function detectSqlSchemaMutation(
   };
 }
 
+export function detectSqlDataDeletion(sql: string): SqlDataDeletionAnalysis {
+  const statements = splitSqlStatements(sql).map(classifyDataDeletionStatement);
+  return {
+    deletesData: statements.some((statement) => statement.deletesData),
+    statements,
+  };
+}
+
 function classifyStatement(
   statement: SplitStatement,
 ): SqlSchemaMutationStatement {
@@ -169,6 +198,61 @@ function classifyStatement(
     reason: null,
     command: first,
   };
+}
+
+function classifyDataDeletionStatement(
+  statement: SplitStatement,
+): SqlDataDeletionStatement {
+  const trimmed = statement.sql.trim();
+  if (statement.incomplete) {
+    return nonDataDeleting(trimmed, null);
+  }
+
+  const tokens = tokenizeStatement(trimmed);
+  const first = firstWord(tokens);
+  if (first === null) {
+    return nonDataDeleting(trimmed, null);
+  }
+
+  if (first === "DELETE") {
+    return dataDeleting(trimmed, "delete", "DELETE");
+  }
+
+  if (first === "TRUNCATE") {
+    return dataDeleting(trimmed, "truncate", "TRUNCATE");
+  }
+
+  if (first === "DROP") {
+    const droppedObject = wordAt(tokens, 1);
+    if (droppedObject === "DATABASE") {
+      return dataDeleting(trimmed, "drop_database", "DROP DATABASE");
+    }
+    if (droppedObject === "SCHEMA") {
+      return dataDeleting(trimmed, "drop_schema", "DROP SCHEMA");
+    }
+    if (droppedObject === "TABLE") {
+      return dataDeleting(trimmed, "drop_table", "DROP TABLE");
+    }
+  }
+
+  if (first === "ALTER" && statementDropsColumn(tokens)) {
+    return dataDeleting(trimmed, "drop_column", "ALTER TABLE DROP COLUMN");
+  }
+
+  if (first === "WITH" && hasUnquotedWord(tokens, "DELETE")) {
+    return dataDeleting(trimmed, "data_modifying_cte", "WITH DELETE");
+  }
+
+  if (first === "EXPLAIN" && explainExecutesStatement(tokens)) {
+    if (hasUnquotedWord(tokens, "TRUNCATE")) {
+      return dataDeleting(trimmed, "truncate", "EXPLAIN TRUNCATE");
+    }
+    if (hasUnquotedWord(tokens, "DELETE")) {
+      return dataDeleting(trimmed, "delete", "EXPLAIN DELETE");
+    }
+  }
+
+  return nonDataDeleting(trimmed, first);
 }
 
 function findSchemaFunctionCall(tokens: readonly Token[]): string | null {
@@ -324,6 +408,31 @@ function mutating(
   };
 }
 
+function dataDeleting(
+  sql: string,
+  reason: SqlDataDeletionReason,
+  command: string | null,
+): SqlDataDeletionStatement {
+  return {
+    sql,
+    deletesData: true,
+    reason,
+    command,
+  };
+}
+
+function nonDataDeleting(
+  sql: string,
+  command: string | null,
+): SqlDataDeletionStatement {
+  return {
+    sql,
+    deletesData: false,
+    reason: null,
+    command,
+  };
+}
+
 function firstWord(tokens: readonly Token[]): string | null {
   return tokens.find((token) => isUnquotedWord(token))?.value ?? null;
 }
@@ -341,6 +450,20 @@ function isUnquotedWord(
     token?.type === "word" &&
     token.quoted !== true &&
     (value === undefined || token.value === value)
+  );
+}
+
+function hasUnquotedWord(tokens: readonly Token[], value: string): boolean {
+  return tokens.some((token) => isUnquotedWord(token, value));
+}
+
+function statementDropsColumn(tokens: readonly Token[]): boolean {
+  return (
+    wordAt(tokens, 1) === "TABLE" &&
+    tokens.some((token, index) => {
+      if (!isUnquotedWord(token, "DROP")) return false;
+      return wordAt(tokens.slice(index + 1), 0) === "COLUMN";
+    })
   );
 }
 

--- a/packages/pg-schema-classifier/src/index.ts
+++ b/packages/pg-schema-classifier/src/index.ts
@@ -21,6 +21,7 @@ export type SqlSchemaMutationAnalysis = {
 
 export type SqlDataDeletionReason =
   | "delete"
+  | "update"
   | "truncate"
   | "data_modifying_cte"
   | "dynamic_execution"
@@ -28,6 +29,7 @@ export type SqlDataDeletionReason =
   | "drop_database"
   | "drop_schema"
   | "drop_table"
+  | "drop_owned"
   | "drop_column";
 
 export type SqlDataDeletionStatement = {
@@ -227,11 +229,19 @@ function classifyDataDeletionTokens(
     return dataDeleting(sql, "delete", "DELETE");
   }
 
+  if (first === "UPDATE") {
+    return dataDeleting(sql, "update", "UPDATE");
+  }
+
   if (first === "TRUNCATE") {
     return dataDeleting(sql, "truncate", "TRUNCATE");
   }
 
-  if (first === "DO" || first === "CALL") {
+  if (first === "DO" || first === "CALL" || first === "EXECUTE") {
+    return dataDeleting(sql, "dynamic_execution", first);
+  }
+
+  if (first === "PREPARE") {
     return dataDeleting(sql, "dynamic_execution", first);
   }
 
@@ -246,6 +256,9 @@ function classifyDataDeletionTokens(
     if (droppedObject === "TABLE") {
       return dataDeleting(sql, "drop_table", "DROP TABLE");
     }
+    if (droppedObject === "OWNED") {
+      return dataDeleting(sql, "drop_owned", "DROP OWNED");
+    }
   }
 
   if (first === "ALTER" && statementDropsColumn(tokens)) {
@@ -256,8 +269,19 @@ function classifyDataDeletionTokens(
     return dataDeleting(sql, "delete", "MERGE DELETE");
   }
 
-  if (first === "WITH" && hasUnquotedWord(tokens, "DELETE")) {
-    return dataDeleting(sql, "data_modifying_cte", "WITH DELETE");
+  if (
+    first === "MERGE" &&
+    hasUnquotedWord(tokens, "UPDATE") &&
+    hasUnquotedWord(tokens, "SET")
+  ) {
+    return dataDeleting(sql, "update", "MERGE UPDATE");
+  }
+
+  if (
+    first === "WITH" &&
+    (hasUnquotedWord(tokens, "DELETE") || hasUnquotedWord(tokens, "UPDATE"))
+  ) {
+    return dataDeleting(sql, "data_modifying_cte", "WITH DATA CHANGE");
   }
 
   if (first === "EXPLAIN" && explainExecutesStatement(tokens)) {
@@ -769,5 +793,5 @@ function walkSql(sql: string, callbacks: SqlWalkerCallbacks): boolean {
     }
   }
 
-  return state !== "normal";
+  return state !== "normal" && state !== "line_comment";
 }

--- a/packages/pg-schema-classifier/src/index.ts
+++ b/packages/pg-schema-classifier/src/index.ts
@@ -596,20 +596,22 @@ function statementDropsColumn(tokens: readonly Token[]): boolean {
     wordAt(tokens, 1) === "TABLE" &&
     tokens.some((token, index) => {
       if (!isUnquotedWord(token, "DROP")) return false;
-      const wordsAfterDrop = unquotedWords(tokens.slice(index + 1));
-      if (wordsAfterDrop[0] === "COLUMN") return true;
+      const tokensAfterDrop = tokens.slice(index + 1);
+      if (isUnquotedWord(tokensAfterDrop[0], "COLUMN")) return true;
 
       let targetIndex = 0;
       if (
-        wordsAfterDrop[targetIndex] === "IF" &&
-        wordsAfterDrop[targetIndex + 1] === "EXISTS"
+        isUnquotedWord(tokensAfterDrop[targetIndex], "IF") &&
+        isUnquotedWord(tokensAfterDrop[targetIndex + 1], "EXISTS")
       ) {
         targetIndex += 2;
       }
 
-      const target = wordsAfterDrop[targetIndex];
-      return (
-        target !== undefined && !NON_COLUMN_ALTER_TABLE_DROP_TARGETS.has(target)
+      const target = tokensAfterDrop[targetIndex];
+      if (target?.type !== "word") return false;
+      return !(
+        isUnquotedWord(target) &&
+        NON_COLUMN_ALTER_TABLE_DROP_TARGETS.has(target.value)
       );
     })
   );

--- a/packages/pg-schema-classifier/src/index.ts
+++ b/packages/pg-schema-classifier/src/index.ts
@@ -118,6 +118,11 @@ const QUALIFIED_SCHEMA_FUNCTIONS: ReadonlyMap<string, string> = new Map([
   ["ALTER_JOB", "CRON"],
 ]);
 
+const DATA_DELETION_FUNCTIONS: ReadonlySet<string> = new Set([
+  // Arbitrary-SQL escape hatch: the payload is opaque, so flag the call.
+  "DBLINK_EXEC",
+]);
+
 export function detectSqlSchemaMutation(
   sql: string,
 ): SqlSchemaMutationAnalysis {
@@ -233,6 +238,10 @@ function classifyDataDeletionTokens(
     return dataDeleting(sql, "update", "UPDATE");
   }
 
+  if (first === "INSERT" && insertUpdatesOnConflict(tokens)) {
+    return dataDeleting(sql, "update", "INSERT ON CONFLICT DO UPDATE");
+  }
+
   if (first === "TRUNCATE") {
     return dataDeleting(sql, "truncate", "TRUNCATE");
   }
@@ -291,6 +300,13 @@ function classifyDataDeletionTokens(
     }
   }
 
+  if (shouldScanForDataDeletionFunctions(first, tokens)) {
+    const dataDeletionFunction = findDataDeletionFunctionCall(tokens);
+    if (dataDeletionFunction !== null) {
+      return dataDeleting(sql, "dynamic_execution", dataDeletionFunction);
+    }
+  }
+
   return nonDataDeleting(sql, first);
 }
 
@@ -340,6 +356,27 @@ function shouldScanForSchemaFunctions(
   }
 
   return false;
+}
+
+function shouldScanForDataDeletionFunctions(
+  first: string,
+  tokens: readonly Token[],
+): boolean {
+  if (first === "EXPLAIN") return explainExecutesStatement(tokens);
+  return shouldScanForSchemaFunctions(first, tokens);
+}
+
+function findDataDeletionFunctionCall(tokens: readonly Token[]): string | null {
+  for (let i = 0; i < tokens.length; i += 1) {
+    const open = tokens[i];
+    if (open?.type !== "symbol" || open.value !== "(") continue;
+
+    const nameValue = identifierTokenValue(tokens[i - 1]);
+    if (nameValue !== null && DATA_DELETION_FUNCTIONS.has(nameValue)) {
+      return nameValue;
+    }
+  }
+  return null;
 }
 
 function explainExecutesStatement(tokens: readonly Token[]): boolean {
@@ -580,6 +617,19 @@ function statementDropsColumn(tokens: readonly Token[]): boolean {
 
 function mergeDeletesRows(tokens: readonly Token[]): boolean {
   return hasUnquotedWord(tokens, "MERGE") && hasUnquotedWord(tokens, "DELETE");
+}
+
+function insertUpdatesOnConflict(tokens: readonly Token[]): boolean {
+  const words = unquotedWords(tokens);
+  const conflictIndex = words.findIndex(
+    (word, index) => word === "ON" && words[index + 1] === "CONFLICT",
+  );
+  if (conflictIndex === -1) return false;
+
+  for (let i = conflictIndex + 2; i < words.length - 1; i += 1) {
+    if (words[i] === "DO" && words[i + 1] === "UPDATE") return true;
+  }
+  return false;
 }
 
 function hasTopLevelSelectInto(tokens: readonly Token[]): boolean {

--- a/packages/pg-schema-classifier/test/unit.test.ts
+++ b/packages/pg-schema-classifier/test/unit.test.ts
@@ -201,11 +201,44 @@ describe("detectSqlDataDeletion", () => {
       "TRUNCATE events",
       "TRUNCATE TABLE events RESTART IDENTITY",
       "DROP TABLE users",
+      "DROP TABLE IF EXISTS users",
       "DROP SCHEMA private CASCADE",
+      "DROP SCHEMA IF EXISTS private CASCADE",
       "DROP DATABASE old_app",
+      "DROP DATABASE IF EXISTS old_app",
       "ALTER TABLE users DROP COLUMN legacy_id",
+      "ALTER TABLE users DROP legacy_id",
+      "ALTER TABLE users DROP IF EXISTS legacy_id",
+      "ALTER TABLE users DROP COLUMN IF EXISTS legacy_id",
+      "MERGE INTO users USING incoming ON users.id = incoming.id WHEN MATCHED THEN DELETE",
     ]) {
       expect(detectSqlDataDeletion(sql).deletesData, sql).toBe(true);
+    }
+  });
+
+  it("treats dynamic execution as destructive because the body is opaque", () => {
+    for (const sql of [
+      "DO $$ BEGIN DELETE FROM users WHERE inactive; END $$",
+      "DO $$ BEGIN EXECUTE 'DELETE FROM users'; END $$",
+      "CALL delete_inactive_users()",
+    ]) {
+      const result = detectSqlDataDeletion(sql);
+      expect(result.deletesData, sql).toBe(true);
+      expect(result.statements[0]?.reason, sql).toBe("dynamic_execution");
+    }
+  });
+
+  it("treats incomplete SQL as destructive because it gates auto-approval", () => {
+    for (const sql of [
+      "SELECT 'unterminated",
+      "DELETE FROM users -- cleanup",
+      "DROP TABLE users -- cleanup",
+    ]) {
+      const result = detectSqlDataDeletion(sql);
+      expect(result.deletesData, sql).toBe(true);
+      expect(result.statements[0]?.reason, sql).toBe(
+        "unparseable_or_incomplete",
+      );
     }
   });
 
@@ -228,6 +261,9 @@ describe("detectSqlDataDeletion", () => {
       "UPDATE users SET name = 'Ada'",
       "DROP VIEW old_users",
       "ALTER TABLE users DROP CONSTRAINT users_email_key",
+      "ALTER TABLE users DROP CONSTRAINT IF EXISTS users_email_key",
+      "ALTER TABLE users ALTER COLUMN legacy_id DROP DEFAULT",
+      "ALTER TABLE users ALTER COLUMN legacy_id DROP NOT NULL",
       "SELECT 'DELETE FROM users' AS example",
       "-- DELETE FROM users\nSELECT 1",
       "/* TRUNCATE events */ SELECT 1",
@@ -254,6 +290,19 @@ describe("detectSqlDataDeletion", () => {
     expect(
       detectSqlDataDeletion(
         "EXPLAIN (ANALYZE true) DELETE FROM users WHERE id = 1",
+      ).deletesData,
+    ).toBe(true);
+    expect(
+      detectSqlDataDeletion("EXPLAIN ANALYZE DROP TABLE users").deletesData,
+    ).toBe(true);
+    expect(
+      detectSqlDataDeletion(
+        "EXPLAIN (ANALYZE true) ALTER TABLE users DROP COLUMN legacy_id",
+      ).deletesData,
+    ).toBe(true);
+    expect(
+      detectSqlDataDeletion(
+        "EXPLAIN (ANALYZE true) MERGE INTO users USING incoming ON users.id = incoming.id WHEN MATCHED THEN DELETE",
       ).deletesData,
     ).toBe(true);
   });

--- a/packages/pg-schema-classifier/test/unit.test.ts
+++ b/packages/pg-schema-classifier/test/unit.test.ts
@@ -211,6 +211,8 @@ describe("detectSqlDataDeletion", () => {
       "ALTER TABLE users DROP legacy_id",
       "ALTER TABLE users DROP IF EXISTS legacy_id",
       "ALTER TABLE users DROP COLUMN IF EXISTS legacy_id",
+      'ALTER TABLE users DROP "email"',
+      'ALTER TABLE users DROP IF EXISTS "legacy_id"',
       "MERGE INTO users USING incoming ON users.id = incoming.id WHEN MATCHED THEN DELETE",
     ]) {
       expect(detectSqlDataDeletion(sql).deletesData, sql).toBe(true);
@@ -295,6 +297,7 @@ describe("detectSqlDataDeletion", () => {
       "DROP VIEW old_users",
       "ALTER TABLE users DROP CONSTRAINT users_email_key",
       "ALTER TABLE users DROP CONSTRAINT IF EXISTS users_email_key",
+      'ALTER TABLE users DROP CONSTRAINT "users_email_key"',
       "ALTER TABLE users ALTER COLUMN legacy_id DROP DEFAULT",
       "ALTER TABLE users ALTER COLUMN legacy_id DROP NOT NULL",
       "SELECT 'DELETE FROM users' AS example",

--- a/packages/pg-schema-classifier/test/unit.test.ts
+++ b/packages/pg-schema-classifier/test/unit.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { detectSqlSchemaMutation } from "../src/index.js";
+import {
+  detectSqlDataDeletion,
+  detectSqlSchemaMutation,
+} from "../src/index.js";
 
 describe("detectSqlSchemaMutation", () => {
   it("does not flag ordinary reads or DML", () => {
@@ -188,5 +191,82 @@ describe("detectSqlSchemaMutation", () => {
       mutatesSchema: true,
       reason: "unparseable_or_incomplete",
     });
+  });
+});
+
+describe("detectSqlDataDeletion", () => {
+  it("flags direct data deletion statements", () => {
+    for (const sql of [
+      "DELETE FROM users WHERE id = 1",
+      "TRUNCATE events",
+      "TRUNCATE TABLE events RESTART IDENTITY",
+      "DROP TABLE users",
+      "DROP SCHEMA private CASCADE",
+      "DROP DATABASE old_app",
+      "ALTER TABLE users DROP COLUMN legacy_id",
+    ]) {
+      expect(detectSqlDataDeletion(sql).deletesData, sql).toBe(true);
+    }
+  });
+
+  it("flags data-modifying CTE deletes", () => {
+    const result = detectSqlDataDeletion(`
+      WITH deleted AS (
+        DELETE FROM users WHERE inactive = true RETURNING id
+      )
+      SELECT * FROM deleted;
+    `);
+
+    expect(result.deletesData).toBe(true);
+    expect(result.statements[0]?.reason).toBe("data_modifying_cte");
+  });
+
+  it("does not flag reads, inserts, updates, comments, or quoted text", () => {
+    for (const sql of [
+      "SELECT * FROM users",
+      "INSERT INTO users (name) VALUES ('Ada')",
+      "UPDATE users SET name = 'Ada'",
+      "DROP VIEW old_users",
+      "ALTER TABLE users DROP CONSTRAINT users_email_key",
+      "SELECT 'DELETE FROM users' AS example",
+      "-- DELETE FROM users\nSELECT 1",
+      "/* TRUNCATE events */ SELECT 1",
+      `SELECT $$DELETE FROM users$$ AS example`,
+    ]) {
+      expect(detectSqlDataDeletion(sql).deletesData, sql).toBe(false);
+    }
+  });
+
+  it("only flags EXPLAIN-wrapped deletes when the statement executes", () => {
+    expect(
+      detectSqlDataDeletion("EXPLAIN DELETE FROM users WHERE id = 1")
+        .deletesData,
+    ).toBe(false);
+    expect(
+      detectSqlDataDeletion("EXPLAIN ANALYZE DELETE FROM users WHERE id = 1")
+        .deletesData,
+    ).toBe(true);
+    expect(
+      detectSqlDataDeletion(
+        "EXPLAIN (ANALYZE false) DELETE FROM users WHERE id = 1",
+      ).deletesData,
+    ).toBe(false);
+    expect(
+      detectSqlDataDeletion(
+        "EXPLAIN (ANALYZE true) DELETE FROM users WHERE id = 1",
+      ).deletesData,
+    ).toBe(true);
+  });
+
+  it("reports mixed multi-statement SQL when any statement deletes data", () => {
+    const result = detectSqlDataDeletion(`
+      SELECT * FROM users;
+      DELETE FROM users WHERE id = 1;
+    `);
+
+    expect(result.deletesData).toBe(true);
+    expect(result.statements.map((statement) => statement.deletesData)).toEqual(
+      [false, true],
+    );
   });
 });

--- a/packages/pg-schema-classifier/test/unit.test.ts
+++ b/packages/pg-schema-classifier/test/unit.test.ts
@@ -206,6 +206,7 @@ describe("detectSqlDataDeletion", () => {
       "DROP SCHEMA IF EXISTS private CASCADE",
       "DROP DATABASE old_app",
       "DROP DATABASE IF EXISTS old_app",
+      "DROP OWNED BY app_user CASCADE",
       "ALTER TABLE users DROP COLUMN legacy_id",
       "ALTER TABLE users DROP legacy_id",
       "ALTER TABLE users DROP IF EXISTS legacy_id",
@@ -216,11 +217,23 @@ describe("detectSqlDataDeletion", () => {
     }
   });
 
+  it("flags data update statements", () => {
+    for (const sql of [
+      "UPDATE users SET name = 'Ada'",
+      "UPDATE users SET email = NULL",
+      "MERGE INTO users USING incoming ON users.id = incoming.id WHEN MATCHED THEN UPDATE SET name = incoming.name",
+    ]) {
+      expect(detectSqlDataDeletion(sql).deletesData, sql).toBe(true);
+    }
+  });
+
   it("treats dynamic execution as destructive because the body is opaque", () => {
     for (const sql of [
       "DO $$ BEGIN DELETE FROM users WHERE inactive; END $$",
       "DO $$ BEGIN EXECUTE 'DELETE FROM users'; END $$",
       "CALL delete_inactive_users()",
+      "PREPARE wipe AS DELETE FROM users",
+      "EXECUTE wipe",
     ]) {
       const result = detectSqlDataDeletion(sql);
       expect(result.deletesData, sql).toBe(true);
@@ -229,17 +242,23 @@ describe("detectSqlDataDeletion", () => {
   });
 
   it("treats incomplete SQL as destructive because it gates auto-approval", () => {
-    for (const sql of [
-      "SELECT 'unterminated",
-      "DELETE FROM users -- cleanup",
-      "DROP TABLE users -- cleanup",
-    ]) {
+    for (const sql of ["SELECT 'unterminated", "SELECT 1 /* inspect"]) {
       const result = detectSqlDataDeletion(sql);
       expect(result.deletesData, sql).toBe(true);
       expect(result.statements[0]?.reason, sql).toBe(
         "unparseable_or_incomplete",
       );
     }
+  });
+
+  it("treats EOF line comments as complete SQL", () => {
+    expect(detectSqlDataDeletion("SELECT 1 -- inspect").deletesData).toBe(
+      false,
+    );
+
+    const deleteResult = detectSqlDataDeletion("DELETE FROM users -- cleanup");
+    expect(deleteResult.deletesData).toBe(true);
+    expect(deleteResult.statements[0]?.reason).toBe("delete");
   });
 
   it("flags data-modifying CTE deletes", () => {
@@ -254,11 +273,22 @@ describe("detectSqlDataDeletion", () => {
     expect(result.statements[0]?.reason).toBe("data_modifying_cte");
   });
 
-  it("does not flag reads, inserts, updates, comments, or quoted text", () => {
+  it("flags data-modifying CTE updates", () => {
+    const result = detectSqlDataDeletion(`
+      WITH updated AS (
+        UPDATE users SET email = NULL WHERE inactive = true RETURNING id
+      )
+      SELECT * FROM updated;
+    `);
+
+    expect(result.deletesData).toBe(true);
+    expect(result.statements[0]?.reason).toBe("data_modifying_cte");
+  });
+
+  it("does not flag reads, inserts, comments, or quoted text", () => {
     for (const sql of [
       "SELECT * FROM users",
       "INSERT INTO users (name) VALUES ('Ada')",
-      "UPDATE users SET name = 'Ada'",
       "DROP VIEW old_users",
       "ALTER TABLE users DROP CONSTRAINT users_email_key",
       "ALTER TABLE users DROP CONSTRAINT IF EXISTS users_email_key",
@@ -303,6 +333,11 @@ describe("detectSqlDataDeletion", () => {
     expect(
       detectSqlDataDeletion(
         "EXPLAIN (ANALYZE true) MERGE INTO users USING incoming ON users.id = incoming.id WHEN MATCHED THEN DELETE",
+      ).deletesData,
+    ).toBe(true);
+    expect(
+      detectSqlDataDeletion(
+        "EXPLAIN (ANALYZE true) UPDATE users SET email = NULL",
       ).deletesData,
     ).toBe(true);
   });

--- a/packages/pg-schema-classifier/test/unit.test.ts
+++ b/packages/pg-schema-classifier/test/unit.test.ts
@@ -221,6 +221,7 @@ describe("detectSqlDataDeletion", () => {
     for (const sql of [
       "UPDATE users SET name = 'Ada'",
       "UPDATE users SET email = NULL",
+      "INSERT INTO users (id, email) VALUES (1, 'x') ON CONFLICT (id) DO UPDATE SET email = EXCLUDED.email",
       "MERGE INTO users USING incoming ON users.id = incoming.id WHEN MATCHED THEN UPDATE SET name = incoming.name",
     ]) {
       expect(detectSqlDataDeletion(sql).deletesData, sql).toBe(true);
@@ -234,6 +235,7 @@ describe("detectSqlDataDeletion", () => {
       "CALL delete_inactive_users()",
       "PREPARE wipe AS DELETE FROM users",
       "EXECUTE wipe",
+      "SELECT dblink_exec('dbname=app', 'DELETE FROM users')",
     ]) {
       const result = detectSqlDataDeletion(sql);
       expect(result.deletesData, sql).toBe(true);
@@ -289,6 +291,7 @@ describe("detectSqlDataDeletion", () => {
     for (const sql of [
       "SELECT * FROM users",
       "INSERT INTO users (name) VALUES ('Ada')",
+      "INSERT INTO users (id, email) VALUES (1, 'x') ON CONFLICT (id) DO NOTHING",
       "DROP VIEW old_users",
       "ALTER TABLE users DROP CONSTRAINT users_email_key",
       "ALTER TABLE users DROP CONSTRAINT IF EXISTS users_email_key",
@@ -338,6 +341,16 @@ describe("detectSqlDataDeletion", () => {
     expect(
       detectSqlDataDeletion(
         "EXPLAIN (ANALYZE true) UPDATE users SET email = NULL",
+      ).deletesData,
+    ).toBe(true);
+    expect(
+      detectSqlDataDeletion(
+        "EXPLAIN SELECT dblink_exec('dbname=app', 'DELETE FROM users')",
+      ).deletesData,
+    ).toBe(false);
+    expect(
+      detectSqlDataDeletion(
+        "EXPLAIN ANALYZE SELECT dblink_exec('dbname=app', 'DELETE FROM users')",
       ).deletesData,
     ).toBe(true);
   });

--- a/rules/local-agent-tools.md
+++ b/rules/local-agent-tools.md
@@ -24,6 +24,7 @@ Agent tool definitions live in `src/pro/main/ipc/handlers/local_agent/tools/`. E
 
 - When changing `execute_sql` consent metadata or safety checks, audit both Agent mode (`shouldAutoApproveAgentTool` / `executeSqlTool.getConsentMetadata`) and Build mode auto-apply (`chat_stream_handlers.ts` with `autoApproveChanges`). A SQL safety rule only on the Agent tool path can still be bypassed by Build mode global auto-approve.
 - SQL destructive-action classifiers that gate auto-approval must be conservative: incomplete/unparseable SQL, opaque dynamic execution (`DO`/`CALL`), and executing wrappers such as `EXPLAIN ANALYZE` should require consent unless the wrapped statement can be proven safe.
+- Treat prepared-statement execution as opaque for SQL auto-approval too: top-level `PREPARE` can hide the statement body and top-level `EXECUTE` runs a previously prepared statement, so both should require consent unless the classifier can prove the executed statement is safe.
 
 ## Stream retries
 

--- a/rules/local-agent-tools.md
+++ b/rules/local-agent-tools.md
@@ -20,6 +20,10 @@ Agent tool definitions live in `src/pro/main/ipc/handlers/local_agent/tools/`. E
 
 - `requireMcpToolConsent` resolves to a structured result, not a bare boolean. If `npm run ts` reports `Argument of type 'boolean' is not assignable to parameter of type 'McpConsentResult'`, update mocks to return `{ approved: true/false }`.
 
+## SQL consent and auto-approval
+
+- When changing `execute_sql` consent metadata or safety checks, audit both Agent mode (`shouldAutoApproveAgentTool` / `executeSqlTool.getConsentMetadata`) and Build mode auto-apply (`chat_stream_handlers.ts` with `autoApproveChanges`). A SQL safety rule only on the Agent tool path can still be bypassed by Build mode global auto-approve.
+
 ## Stream retries
 
 - When extending `handleLocalAgentStream` retry behavior, do not only match transport errors like `"terminated"`. Providers can emit structured stream errors such as `{ type: "error", error: { type: "server_error", ... } }`, and those transient 5xx / rate-limit failures need explicit retry classification too.

--- a/rules/local-agent-tools.md
+++ b/rules/local-agent-tools.md
@@ -23,6 +23,7 @@ Agent tool definitions live in `src/pro/main/ipc/handlers/local_agent/tools/`. E
 ## SQL consent and auto-approval
 
 - When changing `execute_sql` consent metadata or safety checks, audit both Agent mode (`shouldAutoApproveAgentTool` / `executeSqlTool.getConsentMetadata`) and Build mode auto-apply (`chat_stream_handlers.ts` with `autoApproveChanges`). A SQL safety rule only on the Agent tool path can still be bypassed by Build mode global auto-approve.
+- SQL destructive-action classifiers that gate auto-approval must be conservative: incomplete/unparseable SQL, opaque dynamic execution (`DO`/`CALL`), and executing wrappers such as `EXPLAIN ANALYZE` should require consent unless the wrapped statement can be proven safe.
 
 ## Stream retries
 

--- a/src/atoms/chatAtoms.ts
+++ b/src/atoms/chatAtoms.ts
@@ -5,6 +5,7 @@ import type {
   ComponentSelection,
 } from "@/ipc/types";
 import type { ListedApp } from "@/ipc/types/app";
+import type { SqlConsentMetadata } from "@/shared/sqlConsentMetadata";
 import type { Getter, Setter } from "jotai";
 import { atom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
@@ -475,10 +476,7 @@ export interface PendingToolConsent {
   toolName: string;
   toolDescription?: string | null;
   inputPreview?: string | null;
-  metadata?: {
-    sqlMutatesSchema?: boolean;
-    sqlDeletesData?: boolean;
-  } | null;
+  metadata?: SqlConsentMetadata | null;
   // MCP-only fields.
   serverId?: number;
   serverName?: string | null;

--- a/src/atoms/chatAtoms.ts
+++ b/src/atoms/chatAtoms.ts
@@ -475,7 +475,10 @@ export interface PendingToolConsent {
   toolName: string;
   toolDescription?: string | null;
   inputPreview?: string | null;
-  metadata?: { sqlMutatesSchema?: boolean } | null;
+  metadata?: {
+    sqlMutatesSchema?: boolean;
+    sqlDeletesData?: boolean;
+  } | null;
   // MCP-only fields.
   serverId?: number;
   serverName?: string | null;

--- a/src/components/chat/AgentConsentBanner.test.tsx
+++ b/src/components/chat/AgentConsentBanner.test.tsx
@@ -7,6 +7,7 @@ vi.mock("react-i18next", () => ({
     t: (key: string) =>
       ({
         changesDatabaseSchema: "Changes database schema",
+        destructiveDataChange: "Destructive data change",
       })[key] ?? key,
   }),
 }));
@@ -29,6 +30,25 @@ describe("AgentConsentBanner", () => {
     );
 
     expect(screen.getByText("Changes database schema")).toBeTruthy();
+  });
+
+  it("shows destructive data metadata when present", () => {
+    render(
+      <AgentConsentBanner
+        consent={{
+          kind: "agent",
+          requestId: "request",
+          chatId: 1,
+          toolName: "execute_sql",
+          inputPreview: "DELETE FROM users WHERE id = 1;",
+          metadata: { sqlMutatesSchema: false, sqlDeletesData: true },
+        }}
+        onDecision={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Destructive data change")).toBeTruthy();
   });
 
   it("shows the server name and classifier reason for an MCP consent", () => {

--- a/src/components/chat/AgentConsentBanner.tsx
+++ b/src/components/chat/AgentConsentBanner.tsx
@@ -44,6 +44,7 @@ export function AgentConsentBanner({
     classifierReason,
   } = consent;
   const sqlMutatesSchema = consent.metadata?.sqlMutatesSchema === true;
+  const sqlDeletesData = consent.metadata?.sqlDeletesData === true;
 
   // Collapsible input preview state
   const [isInputExpanded, setIsInputExpanded] = React.useState(false);
@@ -139,6 +140,12 @@ export function AgentConsentBanner({
               <div className="mb-1.5 flex items-center gap-1.5 text-xs font-medium text-amber-700 dark:text-amber-400">
                 <AlertTriangle className="h-3.5 w-3.5 flex-shrink-0" />
                 <span>{t("changesDatabaseSchema")}</span>
+              </div>
+            )}
+            {sqlDeletesData && (
+              <div className="mb-1.5 flex items-center gap-1.5 text-xs font-medium text-red-700 dark:text-red-400">
+                <AlertTriangle className="h-3.5 w-3.5 flex-shrink-0" />
+                <span>{t("destructiveDataChange")}</span>
               </div>
             )}
             <div className="rounded bg-muted p-1.5">

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -79,7 +79,10 @@ import { SelectedComponentsDisplay } from "./SelectedComponentDisplay";
 import { useCheckProblems } from "@/hooks/useCheckProblems";
 import { LexicalChatInput } from "./LexicalChatInput";
 import { AuxiliaryActionsMenu } from "./AuxiliaryActionsMenu";
-import { doesSqlMutateSchema } from "@/lib/sqlSchemaMutation";
+import {
+  doesSqlDeleteData,
+  doesSqlMutateSchema,
+} from "@/lib/sqlSchemaMutation";
 import { ChatImageGenerationStrip } from "./ChatImageGenerationStrip";
 import {
   chatImageGenerationJobsAtom,
@@ -1631,6 +1634,10 @@ function SqlQueryItem({ query }: { query: SqlQuery }) {
     () => doesSqlMutateSchema(queryContent),
     [queryContent],
   );
+  const sqlDeletesData = useMemo(
+    () => doesSqlDeleteData(queryContent),
+    [queryContent],
+  );
 
   return (
     <li
@@ -1647,6 +1654,12 @@ function SqlQueryItem({ query }: { query: SqlQuery }) {
             <span className="inline-flex items-center gap-1 text-xs font-medium text-amber-700 dark:text-amber-400">
               <AlertTriangle className="h-3.5 w-3.5 flex-shrink-0" />
               {t("changesDatabaseSchema")}
+            </span>
+          )}
+          {sqlDeletesData && (
+            <span className="inline-flex items-center gap-1 text-xs font-medium text-red-700 dark:text-red-400">
+              <AlertTriangle className="h-3.5 w-3.5 flex-shrink-0" />
+              {t("destructiveDataChange")}
             </span>
           )}
         </div>

--- a/src/components/chat/DyadExecuteSql.test.tsx
+++ b/src/components/chat/DyadExecuteSql.test.tsx
@@ -7,6 +7,7 @@ vi.mock("react-i18next", () => ({
     t: (key: string) =>
       ({
         changesDatabaseSchema: "Changes database schema",
+        destructiveDataChange: "Destructive data change",
       })[key] ?? key,
   }),
 }));
@@ -34,5 +35,11 @@ describe("DyadExecuteSql", () => {
     render(<DyadExecuteSql>SELECT * FROM users;</DyadExecuteSql>);
 
     expect(screen.queryByText("Changes database schema")).toBeNull();
+  });
+
+  it("shows a destructive data indicator for deletes", () => {
+    render(<DyadExecuteSql>DELETE FROM users WHERE id = 1;</DyadExecuteSql>);
+
+    expect(screen.getByText("Destructive data change")).toBeTruthy();
   });
 });

--- a/src/components/chat/DyadExecuteSql.tsx
+++ b/src/components/chat/DyadExecuteSql.tsx
@@ -13,7 +13,10 @@ import {
   DyadStateIndicator,
   DyadCardContent,
 } from "./DyadCardPrimitives";
-import { doesSqlMutateSchema } from "@/lib/sqlSchemaMutation";
+import {
+  doesSqlDeleteData,
+  doesSqlMutateSchema,
+} from "@/lib/sqlSchemaMutation";
 
 interface DyadExecuteSqlProps {
   children?: ReactNode;
@@ -44,6 +47,10 @@ export const DyadExecuteSql: React.FC<DyadExecuteSqlProps> = ({
     () => (sqlText ? doesSqlMutateSchema(sqlText) : false),
     [sqlText],
   );
+  const sqlDeletesData = useMemo(
+    () => (sqlText ? doesSqlDeleteData(sqlText) : false),
+    [sqlText],
+  );
 
   return (
     <DyadCard
@@ -58,6 +65,12 @@ export const DyadExecuteSql: React.FC<DyadExecuteSqlProps> = ({
           <span className="inline-flex items-center gap-1 text-xs font-medium text-amber-700 dark:text-amber-400">
             <AlertTriangle className="h-3.5 w-3.5 flex-shrink-0" />
             {t("changesDatabaseSchema")}
+          </span>
+        )}
+        {sqlDeletesData && (
+          <span className="inline-flex items-center gap-1 text-xs font-medium text-red-700 dark:text-red-400">
+            <AlertTriangle className="h-3.5 w-3.5 flex-shrink-0" />
+            {t("destructiveDataChange")}
           </span>
         )}
         {queryDescription && (

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -97,6 +97,7 @@
   "noChanges": "No changes",
   "sqlQuery": "SQL Query",
   "changesDatabaseSchema": "Schema change",
+  "destructiveDataChange": "Destructive data change",
   "flaggedForReview": "Flagged for review",
   "autoApproved": "Auto-approved",
   "approved": "Approved",

--- a/src/i18n/locales/es/chat.json
+++ b/src/i18n/locales/es/chat.json
@@ -97,6 +97,7 @@
   "noChanges": "Sin cambios",
   "sqlQuery": "Consulta SQL",
   "changesDatabaseSchema": "Cambia el esquema de la base de datos",
+  "destructiveDataChange": "Cambio destructivo de datos",
   "approved": "Aprobado",
   "rejected": "Rechazado",
   "copy": "Copiar",

--- a/src/i18n/locales/pt-BR/chat.json
+++ b/src/i18n/locales/pt-BR/chat.json
@@ -97,6 +97,7 @@
   "noChanges": "Sem alterações",
   "sqlQuery": "Consulta SQL",
   "changesDatabaseSchema": "Altera o esquema do banco de dados",
+  "destructiveDataChange": "Alteração destrutiva de dados",
   "approved": "Aprovado",
   "rejected": "Rejeitado",
   "copy": "Copiar",

--- a/src/i18n/locales/zh-CN/chat.json
+++ b/src/i18n/locales/zh-CN/chat.json
@@ -97,6 +97,7 @@
   "noChanges": "无更改",
   "sqlQuery": "SQL 查询",
   "changesDatabaseSchema": "更改数据库架构",
+  "destructiveDataChange": "破坏性数据更改",
   "approved": "已批准",
   "rejected": "已拒绝",
   "copy": "复制",

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -1891,14 +1891,14 @@ ${problemReport.problems
           .set({ content: fullResponse })
           .where(eq(messages.id, placeholderAssistantMessage.id));
         const latestSettings = readSettings();
-        const hasDestructiveSql = getDyadExecuteSqlTags(fullResponse).some(
-          (query) => doesSqlDeleteData(query.content),
-        );
-        if (
-          latestSettings.autoApproveChanges &&
-          selectedChatMode !== "ask" &&
-          !hasDestructiveSql
-        ) {
+        const shouldAutoApply =
+          latestSettings.autoApproveChanges && selectedChatMode !== "ask";
+        const hasDestructiveSql =
+          shouldAutoApply &&
+          getDyadExecuteSqlTags(fullResponse).some((query) =>
+            doesSqlDeleteData(query.content),
+          );
+        if (shouldAutoApply && !hasDestructiveSql) {
           const status = await processFullResponseActions(
             fullResponse,
             req.chatId,

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -43,6 +43,8 @@ import {
   dryRunSearchReplace,
   processFullResponseActions,
 } from "../processors/response_processor";
+import { getDyadExecuteSqlTags } from "../utils/dyad_tag_parser";
+import { doesSqlDeleteData } from "@/lib/sqlSchemaMutation";
 import {
   streamTestResponse,
   getTestResponse,
@@ -1889,7 +1891,14 @@ ${problemReport.problems
           .set({ content: fullResponse })
           .where(eq(messages.id, placeholderAssistantMessage.id));
         const latestSettings = readSettings();
-        if (latestSettings.autoApproveChanges && selectedChatMode !== "ask") {
+        const hasDestructiveSql = getDyadExecuteSqlTags(fullResponse).some(
+          (query) => doesSqlDeleteData(query.content),
+        );
+        if (
+          latestSettings.autoApproveChanges &&
+          selectedChatMode !== "ask" &&
+          !hasDestructiveSql
+        ) {
           const status = await processFullResponseActions(
             fullResponse,
             req.chatId,

--- a/src/ipc/types/agent.ts
+++ b/src/ipc/types/agent.ts
@@ -6,6 +6,7 @@ import {
   createEventClient,
 } from "../contracts/core";
 import { AgentToolConsentSchema } from "../../lib/schemas";
+import { SqlConsentMetadataSchema } from "../../shared/sqlConsentMetadata";
 
 // =============================================================================
 // Agent Schemas
@@ -20,13 +21,7 @@ export const AgentToolConsentRequestSchema = z.object({
   toolName: z.string(),
   toolDescription: z.string().nullable().optional(),
   inputPreview: z.string().nullable().optional(),
-  metadata: z
-    .object({
-      sqlMutatesSchema: z.boolean().optional(),
-      sqlDeletesData: z.boolean().optional(),
-    })
-    .nullable()
-    .optional(),
+  metadata: SqlConsentMetadataSchema.nullable().optional(),
 });
 
 export type AgentToolConsentRequestPayload = z.infer<

--- a/src/ipc/types/agent.ts
+++ b/src/ipc/types/agent.ts
@@ -23,6 +23,7 @@ export const AgentToolConsentRequestSchema = z.object({
   metadata: z
     .object({
       sqlMutatesSchema: z.boolean().optional(),
+      sqlDeletesData: z.boolean().optional(),
     })
     .nullable()
     .optional(),

--- a/src/lib/sqlSchemaMutation.ts
+++ b/src/lib/sqlSchemaMutation.ts
@@ -1,5 +1,7 @@
 import {
+  detectSqlDataDeletion,
   detectSqlSchemaMutation,
+  type SqlDataDeletionAnalysis,
   type SqlSchemaMutationAnalysis,
 } from "pg-schema-classifier";
 
@@ -11,4 +13,14 @@ export function getSqlSchemaMutationAnalysis(
 
 export function doesSqlMutateSchema(sql: string): boolean {
   return getSqlSchemaMutationAnalysis(sql).mutatesSchema;
+}
+
+export function getSqlDataDeletionAnalysis(
+  sql: string,
+): SqlDataDeletionAnalysis {
+  return detectSqlDataDeletion(sql);
+}
+
+export function doesSqlDeleteData(sql: string): boolean {
+  return getSqlDataDeletionAnalysis(sql).deletesData;
 }

--- a/src/pro/main/ipc/handlers/local_agent/auto_approve_sql.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/auto_approve_sql.spec.ts
@@ -6,7 +6,7 @@ describe("shouldAutoApproveAgentTool", () => {
     expect(
       shouldAutoApproveAgentTool({
         toolName: "execute_sql",
-        metadata: { sqlMutatesSchema: false },
+        metadata: { sqlMutatesSchema: false, sqlDeletesData: false },
         autoApproveNonSchemaSql: true,
       }),
     ).toBe(true);
@@ -16,7 +16,17 @@ describe("shouldAutoApproveAgentTool", () => {
     expect(
       shouldAutoApproveAgentTool({
         toolName: "execute_sql",
-        metadata: { sqlMutatesSchema: true },
+        metadata: { sqlMutatesSchema: true, sqlDeletesData: false },
+        autoApproveNonSchemaSql: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("still asks for data-deleting execute_sql when enabled", () => {
+    expect(
+      shouldAutoApproveAgentTool({
+        toolName: "execute_sql",
+        metadata: { sqlMutatesSchema: false, sqlDeletesData: true },
         autoApproveNonSchemaSql: true,
       }),
     ).toBe(false);
@@ -26,14 +36,14 @@ describe("shouldAutoApproveAgentTool", () => {
     expect(
       shouldAutoApproveAgentTool({
         toolName: "execute_sql",
-        metadata: { sqlMutatesSchema: false },
+        metadata: { sqlMutatesSchema: false, sqlDeletesData: false },
         autoApproveNonSchemaSql: false,
       }),
     ).toBe(false);
     expect(
       shouldAutoApproveAgentTool({
         toolName: "execute_sql",
-        metadata: { sqlMutatesSchema: false },
+        metadata: { sqlMutatesSchema: false, sqlDeletesData: false },
         autoApproveNonSchemaSql: undefined,
       }),
     ).toBe(false);
@@ -53,7 +63,7 @@ describe("shouldAutoApproveAgentTool", () => {
     expect(
       shouldAutoApproveAgentTool({
         toolName: "write_file",
-        metadata: { sqlMutatesSchema: false },
+        metadata: { sqlMutatesSchema: false, sqlDeletesData: false },
         autoApproveNonSchemaSql: true,
       }),
     ).toBe(false);

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -681,7 +681,10 @@ export async function handleLocalAgentStream(
         toolName: string;
         toolDescription?: string | null;
         inputPreview?: string | null;
-        metadata?: { sqlMutatesSchema?: boolean } | null;
+        metadata?: {
+          sqlMutatesSchema?: boolean;
+          sqlDeletesData?: boolean;
+        } | null;
       }) => {
         return requireAgentToolConsent(event, {
           chatId: chat.id,

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -30,6 +30,7 @@ import {
   isBasicAgentMode,
   type UserSettings,
 } from "@/lib/schemas";
+import type { SqlConsentMetadata } from "@/shared/sqlConsentMetadata";
 import { isFreeProModel } from "@/lib/freeProModel";
 import { readSettings } from "@/main/settings";
 import { getDyadAppPath } from "@/paths/paths";
@@ -681,10 +682,7 @@ export async function handleLocalAgentStream(
         toolName: string;
         toolDescription?: string | null;
         inputPreview?: string | null;
-        metadata?: {
-          sqlMutatesSchema?: boolean;
-          sqlDeletesData?: boolean;
-        } | null;
+        metadata?: SqlConsentMetadata | null;
       }) => {
         return requireAgentToolConsent(event, {
           chatId: chat.id,

--- a/src/pro/main/ipc/handlers/local_agent/tool_definitions.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tool_definitions.ts
@@ -6,6 +6,7 @@
 import { IpcMainInvokeEvent } from "electron";
 import crypto from "node:crypto";
 import { readSettings, writeSettings } from "@/main/settings";
+import type { SqlConsentMetadata } from "@/shared/sqlConsentMetadata";
 import { writeFileTool } from "./tools/write_file";
 import { deleteFileTool } from "./tools/delete_file";
 import { renameFileTool } from "./tools/rename_file";
@@ -189,10 +190,7 @@ export function getDefaultConsent(toolName: AgentToolName): AgentToolConsent {
  */
 export function shouldAutoApproveAgentTool(params: {
   toolName: AgentToolName;
-  metadata?: {
-    sqlMutatesSchema?: boolean;
-    sqlDeletesData?: boolean;
-  } | null;
+  metadata?: SqlConsentMetadata | null;
   autoApproveNonSchemaSql: boolean | undefined;
 }): boolean {
   return (
@@ -247,10 +245,7 @@ export async function requireAgentToolConsent(
     toolName: AgentToolName;
     toolDescription?: string | null;
     inputPreview?: string | null;
-    metadata?: {
-      sqlMutatesSchema?: boolean;
-      sqlDeletesData?: boolean;
-    } | null;
+    metadata?: SqlConsentMetadata | null;
   },
 ): Promise<boolean> {
   const current = getAgentToolConsent(params.toolName);

--- a/src/pro/main/ipc/handlers/local_agent/tool_definitions.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tool_definitions.ts
@@ -183,17 +183,22 @@ export function getDefaultConsent(toolName: AgentToolName): AgentToolConsent {
 
 /**
  * When autoApproveNonSchemaSql is enabled, execute_sql calls that the schema
- * classifier determines do not mutate the schema run without a consent prompt.
- * Schema-mutating SQL still requires consent.
+ * classifier determines do not mutate the schema and do not delete data run
+ * without a consent prompt. Schema-mutating or data-deleting SQL still
+ * requires consent.
  */
 export function shouldAutoApproveAgentTool(params: {
   toolName: AgentToolName;
-  metadata?: { sqlMutatesSchema?: boolean } | null;
+  metadata?: {
+    sqlMutatesSchema?: boolean;
+    sqlDeletesData?: boolean;
+  } | null;
   autoApproveNonSchemaSql: boolean | undefined;
 }): boolean {
   return (
     params.toolName === "execute_sql" &&
     params.metadata?.sqlMutatesSchema === false &&
+    params.metadata?.sqlDeletesData === false &&
     params.autoApproveNonSchemaSql === true
   );
 }
@@ -242,7 +247,10 @@ export async function requireAgentToolConsent(
     toolName: AgentToolName;
     toolDescription?: string | null;
     inputPreview?: string | null;
-    metadata?: { sqlMutatesSchema?: boolean } | null;
+    metadata?: {
+      sqlMutatesSchema?: boolean;
+      sqlDeletesData?: boolean;
+    } | null;
   },
 ): Promise<boolean> {
   const current = getAgentToolConsent(params.toolName);

--- a/src/pro/main/ipc/handlers/local_agent/tools/execute_sql.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/execute_sql.spec.ts
@@ -41,13 +41,27 @@ describe("executeSqlTool", () => {
       executeSqlTool.getConsentMetadata?.({
         query: "CREATE TABLE users (id bigint);",
       }),
-    ).toEqual({ sqlMutatesSchema: true });
+    ).toEqual({ sqlMutatesSchema: true, sqlDeletesData: false });
 
     expect(
       executeSqlTool.getConsentMetadata?.({
         query: "SELECT * FROM users;",
       }),
-    ).toEqual({ sqlMutatesSchema: false });
+    ).toEqual({ sqlMutatesSchema: false, sqlDeletesData: false });
+  });
+
+  it("marks data-deleting SQL in consent metadata", () => {
+    expect(
+      executeSqlTool.getConsentMetadata?.({
+        query: "DELETE FROM users WHERE id = 1;",
+      }),
+    ).toEqual({ sqlMutatesSchema: false, sqlDeletesData: true });
+
+    expect(
+      executeSqlTool.getConsentMetadata?.({
+        query: "DROP TABLE users;",
+      }),
+    ).toEqual({ sqlMutatesSchema: true, sqlDeletesData: true });
   });
 
   it("returns the full query as the consent preview", () => {

--- a/src/pro/main/ipc/handlers/local_agent/tools/execute_sql.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/execute_sql.spec.ts
@@ -62,6 +62,19 @@ describe("executeSqlTool", () => {
         query: "DROP TABLE users;",
       }),
     ).toEqual({ sqlMutatesSchema: true, sqlDeletesData: true });
+
+    expect(
+      executeSqlTool.getConsentMetadata?.({
+        query:
+          "MERGE INTO users USING incoming ON users.id = incoming.id WHEN MATCHED THEN DELETE;",
+      }),
+    ).toEqual({ sqlMutatesSchema: false, sqlDeletesData: true });
+
+    expect(
+      executeSqlTool.getConsentMetadata?.({
+        query: "DO $$ BEGIN DELETE FROM users; END $$;",
+      }),
+    ).toEqual({ sqlMutatesSchema: true, sqlDeletesData: true });
   });
 
   it("returns the full query as the consent preview", () => {

--- a/src/pro/main/ipc/handlers/local_agent/tools/execute_sql.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/execute_sql.spec.ts
@@ -59,6 +59,12 @@ describe("executeSqlTool", () => {
 
     expect(
       executeSqlTool.getConsentMetadata?.({
+        query: "UPDATE users SET email = NULL;",
+      }),
+    ).toEqual({ sqlMutatesSchema: false, sqlDeletesData: true });
+
+    expect(
+      executeSqlTool.getConsentMetadata?.({
         query: "DROP TABLE users;",
       }),
     ).toEqual({ sqlMutatesSchema: true, sqlDeletesData: true });

--- a/src/pro/main/ipc/handlers/local_agent/tools/execute_sql.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/execute_sql.ts
@@ -10,7 +10,10 @@ import { executeNeonSql } from "../../../../../../neon_admin/neon_context";
 import { writeMigrationFile } from "../../../../../../ipc/utils/file_utils";
 import { readSettings } from "../../../../../../main/settings";
 import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
-import { doesSqlMutateSchema } from "@/lib/sqlSchemaMutation";
+import {
+  doesSqlDeleteData,
+  doesSqlMutateSchema,
+} from "@/lib/sqlSchemaMutation";
 
 const executeSqlSchema = z.object({
   query: z.string().describe("The SQL query to execute"),
@@ -33,6 +36,7 @@ export const executeSqlTool: ToolDefinition<z.infer<typeof executeSqlSchema>> =
 
     getConsentMetadata: (args) => ({
       sqlMutatesSchema: doesSqlMutateSchema(args.query),
+      sqlDeletesData: doesSqlDeleteData(args.query),
     }),
 
     buildXml: (args, isComplete) => {

--- a/src/pro/main/ipc/handlers/local_agent/tools/types.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/types.ts
@@ -8,6 +8,7 @@ import { jsonrepair } from "jsonrepair";
 import { AgentToolConsent } from "@/lib/schemas";
 import { AgentTodo } from "@/ipc/types";
 import type { AppFrameworkType } from "@/lib/framework_constants";
+import type { SqlConsentMetadata } from "@/shared/sqlConsentMetadata";
 import type { McpToolDef } from "./mcp_type_defs";
 
 // ============================================================================
@@ -93,10 +94,7 @@ export interface AgentContext {
     toolName: string;
     toolDescription?: string | null;
     inputPreview?: string | null;
-    metadata?: {
-      sqlMutatesSchema?: boolean;
-      sqlDeletesData?: boolean;
-    } | null;
+    metadata?: SqlConsentMetadata | null;
   }) => Promise<boolean>;
   /**
    * Append a user message to be sent after the tool result.
@@ -223,13 +221,7 @@ export interface ToolDefinition<T = any> {
    * Returns structured metadata for consent prompts. Keep this small and
    * renderer-safe; it is sent over IPC.
    */
-  getConsentMetadata?: (args: T) =>
-    | {
-        sqlMutatesSchema?: boolean;
-        sqlDeletesData?: boolean;
-      }
-    | null
-    | undefined;
+  getConsentMetadata?: (args: T) => SqlConsentMetadata | null | undefined;
 
   /**
    * Build XML from parsed partial args.

--- a/src/pro/main/ipc/handlers/local_agent/tools/types.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/types.ts
@@ -93,7 +93,10 @@ export interface AgentContext {
     toolName: string;
     toolDescription?: string | null;
     inputPreview?: string | null;
-    metadata?: { sqlMutatesSchema?: boolean } | null;
+    metadata?: {
+      sqlMutatesSchema?: boolean;
+      sqlDeletesData?: boolean;
+    } | null;
   }) => Promise<boolean>;
   /**
    * Append a user message to be sent after the tool result.
@@ -220,9 +223,13 @@ export interface ToolDefinition<T = any> {
    * Returns structured metadata for consent prompts. Keep this small and
    * renderer-safe; it is sent over IPC.
    */
-  getConsentMetadata?: (
-    args: T,
-  ) => { sqlMutatesSchema?: boolean } | null | undefined;
+  getConsentMetadata?: (args: T) =>
+    | {
+        sqlMutatesSchema?: boolean;
+        sqlDeletesData?: boolean;
+      }
+    | null
+    | undefined;
 
   /**
    * Build XML from parsed partial args.

--- a/src/shared/sqlConsentMetadata.ts
+++ b/src/shared/sqlConsentMetadata.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const SqlConsentMetadataSchema = z.object({
+  sqlMutatesSchema: z.boolean().optional(),
+  sqlDeletesData: z.boolean().optional(),
+});
+
+export type SqlConsentMetadata = z.infer<typeof SqlConsentMetadataSchema>;


### PR DESCRIPTION
## Summary
- Prevent SQL that deletes data from taking the non-schema SQL auto-approval path in both Agent mode and build-mode auto-approve.
- Reuse the PostgreSQL classifier scanner to identify obvious destructive data SQL while keeping quoted strings and comments out of the decision.
- Show a destructive data change warning wherever SQL is reviewed before execution.

cc: @RyanGroch i forgot we need to cover SQL queries which delete data (not just change schema) for the auto-approval to be safe.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes gate automatic execution of SQL that can delete or modify data across Agent and Build auto-apply paths; misclassification could either block safe queries or still allow risky ones, though the design errs conservative.
> 
> **Overview**
> Adds **destructive SQL detection** alongside existing schema-mutation checks so queries that delete or overwrite data cannot slip through non-schema auto-approval in **Agent mode** or **Build mode** global auto-apply.
> 
> The **`pg-schema-classifier`** package gains `detectSqlDataDeletion` / related types, reusing the same statement splitter and tokenizer to flag `DELETE`/`UPDATE`/`TRUNCATE`,500`, destructive `DROP`/`ALTER … DROP COLUMN`, data-modifying CTEs, `MERGE`, opaque dynamic SQL (`DO`/`CALL`/`PREPARE`/`EXECUTE`, `dblink_exec`), and executing `EXPLAIN ANALYZE` wrappers; incomplete SQL is treated as destructive. A small lexer tweak treats **EOF line comments** as complete statements.
> 
> **`execute_sql`** consent metadata now includes `sqlDeletesData` via shared **`SqlConsentMetadata`**, and **`shouldAutoApproveAgentTool`** only auto-approves when both schema mutation and data deletion are false. **Build streaming** skips `processFullResponseActions` when embedded `<dyad-execute-sql>` tags contain destructive SQL.
> 
> The UI shows a red **“Destructive data change”** label on consent banners, SQL tool cards, and proposal SQL query lists, with new i18n strings and unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1298f44063c694fb7e18e5961a0e597971d0bebd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

