### PR TITLE
Track app usage metadata for credit attribution

### DIFF
--- a/drizzle/0034_flimsy_thing.sql
+++ b/drizzle/0034_flimsy_thing.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `apps` ADD `app_uuid` text;--> statement-breakpoint
+ALTER TABLE `messages` ADD `turn_uuid` text;

--- a/drizzle/meta/0034_snapshot.json
+++ b/drizzle/meta/0034_snapshot.json
@@ -1,0 +1,1075 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "7a4b5b0a-74f2-4517-aeb1-4fb281bebcf4",
+  "prevId": "b5003e32-965d-48d8-a807-e252fd088c09",
+  "tables": {
+    "app_collections": {
+      "name": "app_collections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "app_collections_name_unique": {
+          "name": "app_collections_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apps": {
+      "name": "apps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "app_uuid": {
+          "name": "app_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "github_org": {
+          "name": "github_org",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_repo": {
+          "name": "github_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_branch": {
+          "name": "github_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supabase_project_id": {
+          "name": "supabase_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supabase_parent_project_id": {
+          "name": "supabase_parent_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supabase_organization_slug": {
+          "name": "supabase_organization_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_project_id": {
+          "name": "neon_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_development_branch_id": {
+          "name": "neon_development_branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_preview_branch_id": {
+          "name": "neon_preview_branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_active_branch_id": {
+          "name": "neon_active_branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_production_auth_cookie_secret": {
+          "name": "neon_production_auth_cookie_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_development_auth_cookie_secret": {
+          "name": "neon_development_auth_cookie_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selected_database_branch_type": {
+          "name": "selected_database_branch_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vercel_project_id": {
+          "name": "vercel_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vercel_project_name": {
+          "name": "vercel_project_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vercel_team_id": {
+          "name": "vercel_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vercel_deployment_url": {
+          "name": "vercel_deployment_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "install_command": {
+          "name": "install_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_command": {
+          "name": "start_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chat_context": {
+          "name": "chat_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "theme_id": {
+          "name": "theme_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "needs_app_blueprint": {
+          "name": "needs_app_blueprint",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apps_collection_id_app_collections_id_fk": {
+          "name": "apps_collection_id_app_collections_id_fk",
+          "tableFrom": "apps",
+          "tableTo": "app_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chats": {
+      "name": "chats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "initial_commit_hash": {
+          "name": "initial_commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "compacted_at": {
+          "name": "compacted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "compaction_backup_path": {
+          "name": "compaction_backup_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pending_compaction": {
+          "name": "pending_compaction",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chat_mode": {
+          "name": "chat_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chats_app_id_apps_id_fk": {
+          "name": "chats_app_id_apps_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_themes": {
+      "name": "custom_themes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "language_model_providers": {
+      "name": "language_model_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_base_url": {
+          "name": "api_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "env_var_name": {
+          "name": "env_var_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "language_models": {
+      "name": "language_models",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_name": {
+          "name": "api_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "builtin_provider_id": {
+          "name": "builtin_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "custom_provider_id": {
+          "name": "custom_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_output_tokens": {
+          "name": "max_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "language_models_custom_provider_id_language_model_providers_id_fk": {
+          "name": "language_models_custom_provider_id_language_model_providers_id_fk",
+          "tableFrom": "language_models",
+          "tableTo": "language_model_providers",
+          "columnsFrom": [
+            "custom_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "env_json": {
+          "name": "env_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "headers_json": {
+          "name": "headers_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "oauth_enabled": {
+          "name": "oauth_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "oauth_state": {
+          "name": "oauth_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client_secret": {
+          "name": "oauth_client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_scope": {
+          "name": "oauth_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_callback_port": {
+          "name": "oauth_callback_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_tool_consents": {
+      "name": "mcp_tool_consents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consent": {
+          "name": "consent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ask'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "uniq_mcp_consent": {
+          "name": "uniq_mcp_consent",
+          "columns": [
+            "server_id",
+            "tool_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "mcp_tool_consents_server_id_mcp_servers_id_fk": {
+          "name": "mcp_tool_consents_server_id_mcp_servers_id_fk",
+          "tableFrom": "mcp_tool_consents",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "turn_uuid": {
+          "name": "turn_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "approval_state": {
+          "name": "approval_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_commit_hash": {
+          "name": "source_commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "commit_hash": {
+          "name": "commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_tokens_used": {
+          "name": "max_tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ai_messages_json": {
+          "name": "ai_messages_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "using_free_agent_mode_quota": {
+          "name": "using_free_agent_mode_quota",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_compaction_summary": {
+          "name": "is_compaction_summary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_chat_id_chats_id_fk": {
+          "name": "messages_chat_id_chats_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompts": {
+      "name": "prompts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "prompts_slug_unique": {
+          "name": "prompts_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "versions": {
+      "name": "versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "commit_hash": {
+          "name": "commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "neon_db_timestamp": {
+          "name": "neon_db_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "versions_app_commit_unique": {
+          "name": "versions_app_commit_unique",
+          "columns": [
+            "app_id",
+            "commit_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "versions_app_id_apps_id_fk": {
+          "name": "versions_app_id_apps_id_fk",
+          "tableFrom": "versions",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1780444627070,
       "tag": "0033_ambiguous_moon_knight",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "6",
+      "when": 1782515594860,
+      "tag": "0034_flimsy_thing",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -46,6 +46,7 @@ export const appCollections = sqliteTable(
 
 export const apps = sqliteTable("apps", {
   id: integer("id").primaryKey({ autoIncrement: true }),
+  appUuid: text("app_uuid"),
   name: text("name").notNull(),
   path: text("path").notNull(),
   createdAt: integer("created_at", { mode: "timestamp" })
@@ -120,6 +121,7 @@ export const chats = sqliteTable("chats", {
 
 export const messages = sqliteTable("messages", {
   id: integer("id").primaryKey({ autoIncrement: true }),
+  turnUuid: text("turn_uuid"),
   chatId: integer("chat_id")
     .notNull()
     .references(() => chats.id, { onDelete: "cascade" }),

--- a/src/ipc/handlers/app_handlers.ts
+++ b/src/ipc/handlers/app_handlers.ts
@@ -10,6 +10,7 @@ import { systemContracts } from "../types/system";
 import fs from "node:fs";
 import path from "node:path";
 import { spawn } from "node:child_process";
+import { v4 as uuidv4 } from "uuid";
 import {
   getDyadAppPath,
   getDefaultDyadAppsDirectory,
@@ -404,6 +405,7 @@ export function registerAppHandlers() {
     const [app] = await db
       .insert(apps)
       .values({
+        appUuid: uuidv4(),
         name: params.name,
         // Use the name as the path for now
         path: appPath,
@@ -516,6 +518,7 @@ export function registerAppHandlers() {
     const [newDbApp] = await db
       .insert(apps)
       .values({
+        appUuid: uuidv4(),
         name: newAppName,
         path: newAppName, // Use the new name for the path
         // Explicitly set these to null because we don't want to copy them over.
@@ -663,6 +666,12 @@ export function registerAppHandlers() {
       if (!app) {
         throw new DyadError("App not found", DyadErrorKind.NotFound);
       }
+      let appUuid = app.appUuid;
+      if (!appUuid) {
+        appUuid = uuidv4();
+        await db.update(apps).set({ appUuid }).where(eq(apps.id, app.id));
+        app.appUuid = appUuid;
+      }
 
       logger.debug(`Starting app ${appId} in path ${app.path}`);
 
@@ -673,6 +682,8 @@ export function registerAppHandlers() {
         await executeApp({
           appPath,
           appId,
+          appUuid,
+          appName: app.name,
           event,
           isNeon: !!app.neonProjectId,
           installCommand: app.installCommand,
@@ -938,10 +949,18 @@ export function registerAppHandlers() {
         logger.debug(
           `Executing app ${appId} in path ${app.path} after restart request`,
         ); // Adjusted log
+        let appUuid = app.appUuid;
+        if (!appUuid) {
+          appUuid = uuidv4();
+          await db.update(apps).set({ appUuid }).where(eq(apps.id, app.id));
+          app.appUuid = appUuid;
+        }
 
         await executeApp({
           appPath,
           appId,
+          appUuid,
+          appName: app.name,
           event,
           isNeon: !!app.neonProjectId,
           installCommand: app.installCommand,

--- a/src/ipc/handlers/app_handlers.ts
+++ b/src/ipc/handlers/app_handlers.ts
@@ -52,6 +52,7 @@ import {
   startCloudSandboxLogStream,
 } from "../services/app_runtime_service";
 import { getPtySessionManager } from "../utils/pty_session_manager";
+import { ensureAppUuid } from "../utils/app_uuid";
 
 /**
  * Read screenshot entries for a single app directory, filtered by filename
@@ -666,12 +667,7 @@ export function registerAppHandlers() {
       if (!app) {
         throw new DyadError("App not found", DyadErrorKind.NotFound);
       }
-      let appUuid = app.appUuid;
-      if (!appUuid) {
-        appUuid = uuidv4();
-        await db.update(apps).set({ appUuid }).where(eq(apps.id, app.id));
-        app.appUuid = appUuid;
-      }
+      const appUuid = await ensureAppUuid(app);
 
       logger.debug(`Starting app ${appId} in path ${app.path}`);
 
@@ -949,12 +945,7 @@ export function registerAppHandlers() {
         logger.debug(
           `Executing app ${appId} in path ${app.path} after restart request`,
         ); // Adjusted log
-        let appUuid = app.appUuid;
-        if (!appUuid) {
-          appUuid = uuidv4();
-          await db.update(apps).set({ appUuid }).where(eq(apps.id, app.id));
-          app.appUuid = appUuid;
-        }
+        const appUuid = await ensureAppUuid(app);
 
         await executeApp({
           appPath,

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -16,7 +16,7 @@ import {
 } from "ai";
 
 import { db } from "../../db";
-import { apps, chats, messages } from "../../db/schema";
+import { chats, messages } from "../../db/schema";
 import { and, eq, isNull } from "drizzle-orm";
 import type { SmartContextMode } from "../../lib/schemas";
 import {
@@ -67,6 +67,7 @@ import { getMaxTokens, getTemperature } from "../utils/token_utils";
 import { MAX_CHAT_TURNS_IN_CONTEXT } from "@/constants/settings_constants";
 import { validateChatContext } from "../utils/context_paths_utils";
 import { getProviderOptions, getAiHeaders } from "../utils/provider_options";
+import { ensureAppUuid } from "../utils/app_uuid";
 import { mcpServers } from "../../db/schema";
 import {
   requireMcpToolConsent,
@@ -726,15 +727,7 @@ ${componentSnippet}
           DyadErrorKind.NotFound,
         );
       }
-      let appUuid = updatedChat.app.appUuid;
-      if (!appUuid) {
-        appUuid = uuidv4();
-        await db
-          .update(apps)
-          .set({ appUuid })
-          .where(eq(apps.id, updatedChat.app.id));
-        updatedChat.app.appUuid = appUuid;
-      }
+      const appUuid = await ensureAppUuid(updatedChat.app);
 
       // Send the messages right away so that the loading state is shown for the message.
       safeSend(event.sender, "chat:response:chunk", {

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -16,7 +16,7 @@ import {
 } from "ai";
 
 import { db } from "../../db";
-import { chats, messages } from "../../db/schema";
+import { apps, chats, messages } from "../../db/schema";
 import { and, eq, isNull } from "drizzle-orm";
 import type { SmartContextMode } from "../../lib/schemas";
 import {
@@ -630,9 +630,11 @@ ${componentSnippet}
       const defaultAiUserPrompt =
         userPrompt + (attachmentInfo ? attachmentInfo : "");
 
+      const turnUuid = uuidv4();
       const [insertedUserMessage] = await db
         .insert(messages)
         .values({
+          turnUuid,
           chatId: req.chatId,
           role: "user",
           content:
@@ -723,6 +725,15 @@ ${componentSnippet}
           `Chat not found: ${req.chatId}`,
           DyadErrorKind.NotFound,
         );
+      }
+      let appUuid = updatedChat.app.appUuid;
+      if (!appUuid) {
+        appUuid = uuidv4();
+        await db
+          .update(apps)
+          .set({ appUuid })
+          .where(eq(apps.id, updatedChat.app.id));
+        updatedChat.app.appUuid = appUuid;
       }
 
       // Send the messages right away so that the loading state is shown for the message.
@@ -1223,6 +1234,10 @@ This conversation includes one or more image attachments. When the user uploads 
             : "balanced";
           const providerOptions = getProviderOptions({
             dyadAppId: updatedChat.app.id,
+            dyadAppUuid: appUuid,
+            dyadAppName: updatedChat.app.name,
+            dyadChatId: updatedChat.id,
+            dyadTurnUuid: turnUuid,
             dyadRequestId,
             dyadDisableFiles,
             smartContextMode,
@@ -1379,6 +1394,7 @@ This conversation includes one or more image attachments. When the user uploads 
               // and new chats will default to non-ask modes.
               systemPrompt: readOnlySystemPrompt,
               dyadRequestId: dyadRequestId ?? "[no-request-id]",
+              turnUuid,
               readOnly: true,
               messageOverride: isSummarizeIntent ? chatMessages : undefined,
               settingsOverride: settings,
@@ -1412,6 +1428,7 @@ This conversation includes one or more image attachments. When the user uploads 
             placeholderMessageId: placeholderAssistantMessage.id,
             systemPrompt: planModeSystemPrompt,
             dyadRequestId: dyadRequestId ?? "[no-request-id]",
+            turnUuid,
             planModeOnly: true,
             messageOverride: isSummarizeIntent ? chatMessages : undefined,
             settingsOverride: settings,
@@ -1462,6 +1479,7 @@ This conversation includes one or more image attachments. When the user uploads 
                 placeholderMessageId: placeholderAssistantMessage.id,
                 systemPrompt,
                 dyadRequestId: dyadRequestId ?? "[no-request-id]",
+                turnUuid,
                 messageOverride: isSummarizeIntent ? chatMessages : undefined,
                 settingsOverride: settings,
                 freeModelMode,

--- a/src/ipc/handlers/import_handlers.ts
+++ b/src/ipc/handlers/import_handlers.ts
@@ -8,6 +8,7 @@ import { apps } from "@/db/schema";
 import { db } from "@/db";
 import { chats } from "@/db/schema";
 import { eq } from "drizzle-orm";
+import { v4 as uuidv4 } from "uuid";
 
 import { ImportAppParams, ImportAppResult } from "@/ipc/types";
 import { copyDirectoryRecursive } from "../utils/file_utils";
@@ -137,6 +138,7 @@ export function registerImportHandlers() {
       const [app] = await db
         .insert(apps)
         .values({
+          appUuid: uuidv4(),
           name: appName,
           path: skipCopy ? sourcePath : appName,
           installCommand: installCommand ?? null,

--- a/src/ipc/services/app_runtime_service.ts
+++ b/src/ipc/services/app_runtime_service.ts
@@ -189,6 +189,8 @@ function emitPnpmMinimumReleaseAgeWarning({
 export async function executeApp({
   appPath,
   appId,
+  appUuid,
+  appName,
   event,
   isNeon,
   installCommand,
@@ -196,6 +198,8 @@ export async function executeApp({
 }: {
   appPath: string;
   appId: number;
+  appUuid?: string | null;
+  appName?: string;
   event: Electron.IpcMainInvokeEvent;
   isNeon: boolean;
   installCommand?: string | null;
@@ -217,6 +221,8 @@ export async function executeApp({
     await executeAppInCloud({
       appPath,
       appId,
+      appUuid,
+      appName,
       event,
       installCommand,
       startCommand,
@@ -850,12 +856,16 @@ ${errorOutput || "(empty)"}`,
 async function executeAppInCloud({
   appPath,
   appId,
+  appUuid,
+  appName,
   event,
   installCommand,
   startCommand,
 }: {
   appPath: string;
   appId: number;
+  appUuid?: string | null;
+  appName?: string;
   event: Electron.IpcMainInvokeEvent;
   installCommand?: string | null;
   startCommand?: string | null;
@@ -868,6 +878,8 @@ async function executeAppInCloud({
   try {
     const createResult = await createCloudSandbox({
       appId,
+      appUuid,
+      appName,
       appPath,
       installCommand,
       startCommand,

--- a/src/ipc/types/app.ts
+++ b/src/ipc/types/app.ts
@@ -13,6 +13,7 @@ import { ChatModeSchema } from "../../lib/schemas";
  */
 export const AppBaseSchema = z.object({
   id: z.number(),
+  appUuid: z.string().nullable(),
   name: z.string(),
   path: z.string(),
   createdAt: z.date(),

--- a/src/ipc/utils/app_uuid.ts
+++ b/src/ipc/utils/app_uuid.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { v4 as uuidv4 } from "uuid";
 import { db } from "../../db";
 import { apps } from "../../db/schema";
@@ -16,7 +16,25 @@ export async function ensureAppUuid<T extends AppWithUuid>(
   }
 
   const appUuid = uuidv4();
-  await db.update(apps).set({ appUuid }).where(eq(apps.id, app.id));
-  app.appUuid = appUuid;
-  return appUuid;
+  const [updated] = await db
+    .update(apps)
+    .set({ appUuid })
+    .where(and(eq(apps.id, app.id), isNull(apps.appUuid)))
+    .returning({ appUuid: apps.appUuid });
+
+  if (updated?.appUuid) {
+    app.appUuid = updated.appUuid;
+    return updated.appUuid;
+  }
+
+  const current = await db.query.apps.findFirst({
+    columns: { appUuid: true },
+    where: eq(apps.id, app.id),
+  });
+  if (current?.appUuid) {
+    app.appUuid = current.appUuid;
+    return current.appUuid;
+  }
+
+  throw new Error(`Could not ensure app UUID for app ${app.id}`);
 }

--- a/src/ipc/utils/app_uuid.ts
+++ b/src/ipc/utils/app_uuid.ts
@@ -1,0 +1,22 @@
+import { eq } from "drizzle-orm";
+import { v4 as uuidv4 } from "uuid";
+import { db } from "../../db";
+import { apps } from "../../db/schema";
+
+type AppWithUuid = {
+  id: number;
+  appUuid: string | null;
+};
+
+export async function ensureAppUuid<T extends AppWithUuid>(
+  app: T,
+): Promise<string> {
+  if (app.appUuid) {
+    return app.appUuid;
+  }
+
+  const appUuid = uuidv4();
+  await db.update(apps).set({ appUuid }).where(eq(apps.id, app.id));
+  app.appUuid = appUuid;
+  return appUuid;
+}

--- a/src/ipc/utils/cloud_sandbox_provider.ts
+++ b/src/ipc/utils/cloud_sandbox_provider.ts
@@ -174,6 +174,8 @@ export interface CloudSandboxProvider {
   name: string;
   createSandbox(input: {
     appId: number;
+    appUuid?: string | null;
+    appName?: string;
     appPath: string;
     installCommand?: string | null;
     startCommand?: string | null;
@@ -698,6 +700,8 @@ class DyadEngineCloudSandboxProvider implements CloudSandboxProvider {
 
   async createSandbox(input: {
     appId: number;
+    appUuid?: string | null;
+    appName?: string;
     appPath: string;
     installCommand?: string | null;
     startCommand?: string | null;
@@ -711,6 +715,8 @@ class DyadEngineCloudSandboxProvider implements CloudSandboxProvider {
       method: "POST",
       body: JSON.stringify({
         appId: input.appId,
+        appUuid: input.appUuid ?? undefined,
+        appName: input.appName,
         appPath: input.appPath,
         installCommand,
         startCommand,
@@ -823,6 +829,8 @@ export async function destroyCloudSandbox(sandboxId: string): Promise<void> {
 
 export async function createCloudSandbox(input: {
   appId: number;
+  appUuid?: string | null;
+  appName?: string;
   appPath: string;
   installCommand?: string | null;
   startCommand?: string | null;

--- a/src/ipc/utils/llm_engine_provider.test.ts
+++ b/src/ipc/utils/llm_engine_provider.test.ts
@@ -60,6 +60,10 @@ describe("createDyadEngine", () => {
       providerOptions: {
         "dyad-engine": {
           dyadAppId: 42,
+          dyadAppUuid: "00000000-0000-4000-8000-000000000042",
+          dyadAppName: "Test App",
+          dyadChatId: 7,
+          dyadTurnUuid: "00000000-0000-4000-8000-000000000007",
           dyadRequestId: "request-1",
           dyadFiles: [{ path: "src/App.tsx", content: "export {}" }],
         },
@@ -85,6 +89,10 @@ describe("createDyadEngine", () => {
       output_config: { effort: "medium" },
       dyad_options: {
         app_id: 42,
+        app_uuid: "00000000-0000-4000-8000-000000000042",
+        app_name: "Test App",
+        chat_id: 7,
+        turn_uuid: "00000000-0000-4000-8000-000000000007",
         enable_lazy_edits: true,
         enable_smart_files_context: true,
         enable_web_search: false,
@@ -92,6 +100,10 @@ describe("createDyadEngine", () => {
       },
     });
     expect(body).not.toHaveProperty("dyadAppId");
+    expect(body).not.toHaveProperty("dyadAppUuid");
+    expect(body).not.toHaveProperty("dyadAppName");
+    expect(body).not.toHaveProperty("dyadChatId");
+    expect(body).not.toHaveProperty("dyadTurnUuid");
     expect(body).not.toHaveProperty("dyadRequestId");
     expect(body).not.toHaveProperty("dyadFiles");
     expect(body).not.toHaveProperty("reasoning_effort");

--- a/src/ipc/utils/llm_engine_provider.test.ts
+++ b/src/ipc/utils/llm_engine_provider.test.ts
@@ -163,6 +163,83 @@ describe("createDyadEngine", () => {
     expect(url.searchParams.get("source")).toBe("test");
   });
 
+  test("keeps app metadata when file injection is disabled", async () => {
+    const requests: Array<{
+      input: RequestInfo | URL;
+      init?: RequestInit;
+    }> = [];
+
+    const provider = createDyadEngine({
+      apiKey: "dyad-pro-key",
+      baseURL: "https://engine.example.test/v1",
+      dyadOptions: {
+        enableLazyEdits: true,
+        enableSmartFilesContext: true,
+        enableWebSearch: true,
+      },
+      settings: {} as UserSettings,
+      fetch: async (input, init) => {
+        requests.push({ input, init });
+
+        return new Response(
+          JSON.stringify({
+            id: "chatcmpl_123",
+            object: "chat.completion",
+            created: 1,
+            model: "gpt-5",
+            choices: [
+              {
+                index: 0,
+                message: { role: "assistant", content: "ok" },
+                finish_reason: "stop",
+              },
+            ],
+            usage: {
+              prompt_tokens: 1,
+              completion_tokens: 1,
+              total_tokens: 2,
+            },
+          }),
+          {
+            headers: { "content-type": "application/json" },
+          },
+        );
+      },
+    });
+
+    const model = provider.chatModel("gpt-5", {
+      providerId: "openai",
+    }) as LanguageModelV3;
+
+    await model.doGenerate({
+      prompt: [{ role: "user", content: [{ type: "text", text: "Hello" }] }],
+      providerOptions: {
+        "dyad-engine": {
+          dyadAppId: 42,
+          dyadAppUuid: "00000000-0000-4000-8000-000000000042",
+          dyadAppName: "Test App",
+          dyadChatId: 7,
+          dyadTurnUuid: "00000000-0000-4000-8000-000000000007",
+          dyadRequestId: "request-1",
+          dyadFiles: [{ path: "src/App.tsx", content: "export {}" }],
+          dyadDisableFiles: true,
+        },
+      },
+    } satisfies LanguageModelV3CallOptions);
+
+    expect(requests).toHaveLength(1);
+    const body = JSON.parse(String(requests[0].init?.body));
+    expect(body.dyad_options).toEqual({
+      app_id: 42,
+      app_uuid: "00000000-0000-4000-8000-000000000042",
+      app_name: "Test App",
+      chat_id: 7,
+      turn_uuid: "00000000-0000-4000-8000-000000000007",
+    });
+    expect(body.dyad_options).not.toHaveProperty("files");
+    expect(body.dyad_options).not.toHaveProperty("enable_smart_files_context");
+  });
+
   test("sends stable free quota key separately from attempt request id", async () => {
     const requests: Array<{
       input: RequestInfo | URL;

--- a/src/ipc/utils/llm_engine_provider.test.ts
+++ b/src/ipc/utils/llm_engine_provider.test.ts
@@ -240,6 +240,72 @@ describe("createDyadEngine", () => {
     expect(body.dyad_options).not.toHaveProperty("enable_smart_files_context");
   });
 
+  test("omits nullable or invalid UUID metadata from dyad options", async () => {
+    const requests: Array<{
+      input: RequestInfo | URL;
+      init?: RequestInit;
+    }> = [];
+
+    const provider = createDyadEngine({
+      apiKey: "dyad-pro-key",
+      baseURL: "https://engine.example.test/v1",
+      dyadOptions: {},
+      settings: {} as UserSettings,
+      fetch: async (input, init) => {
+        requests.push({ input, init });
+
+        return new Response(
+          JSON.stringify({
+            id: "chatcmpl_123",
+            object: "chat.completion",
+            created: 1,
+            model: "gpt-5",
+            choices: [
+              {
+                index: 0,
+                message: { role: "assistant", content: "ok" },
+                finish_reason: "stop",
+              },
+            ],
+            usage: {
+              prompt_tokens: 1,
+              completion_tokens: 1,
+              total_tokens: 2,
+            },
+          }),
+          {
+            headers: { "content-type": "application/json" },
+          },
+        );
+      },
+    });
+
+    const model = provider.chatModel("gpt-5", {
+      providerId: "openai",
+    }) as LanguageModelV3;
+
+    await model.doGenerate({
+      prompt: [{ role: "user", content: [{ type: "text", text: "Hello" }] }],
+      providerOptions: {
+        "dyad-engine": {
+          dyadAppId: 42,
+          dyadAppUuid: null,
+          dyadAppName: "Test App",
+          dyadTurnUuid: "[no-request-id]",
+        },
+      },
+    } satisfies LanguageModelV3CallOptions);
+
+    expect(requests).toHaveLength(1);
+    const body = JSON.parse(String(requests[0].init?.body));
+    expect(body.dyad_options).toEqual({
+      app_id: 42,
+      app_name: "Test App",
+    });
+    expect(body).not.toHaveProperty("dyadAppUuid");
+    expect(body).not.toHaveProperty("dyadTurnUuid");
+  });
+
   test("sends stable free quota key separately from attempt request id", async () => {
     const requests: Array<{
       input: RequestInfo | URL;

--- a/src/ipc/utils/llm_engine_provider.ts
+++ b/src/ipc/utils/llm_engine_provider.ts
@@ -28,6 +28,23 @@ export interface ChatParams {
 
 type DyadEngineProviderOptions = Record<string, any>;
 
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function toOptionalUuid(value: unknown): string | undefined {
+  return typeof value === "string" && UUID_REGEX.test(value)
+    ? value
+    : undefined;
+}
+
+function toOptionalNumber(value: unknown): number | undefined {
+  return typeof value === "number" ? value : undefined;
+}
+
+function toOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
 export interface ExampleProviderSettings {
   /**
 Example API key.
@@ -166,61 +183,34 @@ export function createDyadEngine(
           ...getExtraProviderOptionsForEngine(providerId, options.settings),
         };
 
-        const getDyadOption = (key: string) =>
-          key in parsedBody ? parsedBody[key] : dyadProviderOptions?.[key];
+        const takeDyadOption = (key: string) => {
+          const value =
+            key in parsedBody ? parsedBody[key] : dyadProviderOptions?.[key];
+          if (key in parsedBody) {
+            delete parsedBody[key];
+          }
+          return value;
+        };
 
-        const dyadVersionedFiles = getDyadOption("dyadVersionedFiles");
-        if ("dyadVersionedFiles" in parsedBody) {
-          delete parsedBody.dyadVersionedFiles;
-        }
-        const dyadFiles = getDyadOption("dyadFiles");
-        if ("dyadFiles" in parsedBody) {
-          delete parsedBody.dyadFiles;
-        }
+        const dyadVersionedFiles = takeDyadOption("dyadVersionedFiles");
+        const dyadFiles = takeDyadOption("dyadFiles");
         // Read from body (OpenAICompatible models spread providerOptions into
         // the body) with a fallback to an internal header (OpenAIResponses
         // models don't forward providerOptions, so we pass it via header).
         const requestId =
-          getDyadOption("dyadRequestId") ??
+          takeDyadOption("dyadRequestId") ??
           (init.headers as Record<string, string> | undefined)?.[
             DYAD_INTERNAL_REQUEST_ID_HEADER
           ];
-        if ("dyadRequestId" in parsedBody) {
-          delete parsedBody.dyadRequestId;
-        }
-        const dyadAppId = getDyadOption("dyadAppId");
-        if ("dyadAppId" in parsedBody) {
-          delete parsedBody.dyadAppId;
-        }
-        const dyadAppUuid = getDyadOption("dyadAppUuid");
-        if ("dyadAppUuid" in parsedBody) {
-          delete parsedBody.dyadAppUuid;
-        }
-        const dyadAppName = getDyadOption("dyadAppName");
-        if ("dyadAppName" in parsedBody) {
-          delete parsedBody.dyadAppName;
-        }
-        const dyadChatId = getDyadOption("dyadChatId");
-        if ("dyadChatId" in parsedBody) {
-          delete parsedBody.dyadChatId;
-        }
-        const dyadTurnUuid = getDyadOption("dyadTurnUuid");
-        if ("dyadTurnUuid" in parsedBody) {
-          delete parsedBody.dyadTurnUuid;
-        }
+        const dyadAppId = takeDyadOption("dyadAppId");
+        const dyadAppUuid = takeDyadOption("dyadAppUuid");
+        const dyadAppName = takeDyadOption("dyadAppName");
+        const dyadChatId = takeDyadOption("dyadChatId");
+        const dyadTurnUuid = takeDyadOption("dyadTurnUuid");
         const dyadDisableFiles =
-          disableDyadOptions || getDyadOption("dyadDisableFiles");
-        if ("dyadDisableFiles" in parsedBody) {
-          delete parsedBody.dyadDisableFiles;
-        }
-        const dyadMentionedApps = getDyadOption("dyadMentionedApps");
-        if ("dyadMentionedApps" in parsedBody) {
-          delete parsedBody.dyadMentionedApps;
-        }
-        const dyadSmartContextMode = getDyadOption("dyadSmartContextMode");
-        if ("dyadSmartContextMode" in parsedBody) {
-          delete parsedBody.dyadSmartContextMode;
-        }
+          disableDyadOptions || takeDyadOption("dyadDisableFiles");
+        const dyadMentionedApps = takeDyadOption("dyadMentionedApps");
+        const dyadSmartContextMode = takeDyadOption("dyadSmartContextMode");
 
         // Track and modify requestId with attempt number
         let modifiedRequestId = requestId;
@@ -231,11 +221,11 @@ export function createDyadEngine(
         }
 
         parsedBody.dyad_options = {
-          app_id: dyadAppId,
-          app_uuid: dyadAppUuid,
-          app_name: dyadAppName,
-          chat_id: dyadChatId,
-          turn_uuid: dyadTurnUuid,
+          app_id: toOptionalNumber(dyadAppId),
+          app_uuid: toOptionalUuid(dyadAppUuid),
+          app_name: toOptionalString(dyadAppName),
+          chat_id: toOptionalNumber(dyadChatId),
+          turn_uuid: toOptionalUuid(dyadTurnUuid),
         };
 
         // Add files to the request if they exist.

--- a/src/ipc/utils/llm_engine_provider.ts
+++ b/src/ipc/utils/llm_engine_provider.ts
@@ -192,6 +192,22 @@ export function createDyadEngine(
         if ("dyadAppId" in parsedBody) {
           delete parsedBody.dyadAppId;
         }
+        const dyadAppUuid = getDyadOption("dyadAppUuid");
+        if ("dyadAppUuid" in parsedBody) {
+          delete parsedBody.dyadAppUuid;
+        }
+        const dyadAppName = getDyadOption("dyadAppName");
+        if ("dyadAppName" in parsedBody) {
+          delete parsedBody.dyadAppName;
+        }
+        const dyadChatId = getDyadOption("dyadChatId");
+        if ("dyadChatId" in parsedBody) {
+          delete parsedBody.dyadChatId;
+        }
+        const dyadTurnUuid = getDyadOption("dyadTurnUuid");
+        if ("dyadTurnUuid" in parsedBody) {
+          delete parsedBody.dyadTurnUuid;
+        }
         const dyadDisableFiles =
           disableDyadOptions || getDyadOption("dyadDisableFiles");
         if ("dyadDisableFiles" in parsedBody) {
@@ -225,6 +241,10 @@ export function createDyadEngine(
             smart_context_mode: dyadSmartContextMode,
             enable_web_search: options.dyadOptions.enableWebSearch,
             app_id: dyadAppId,
+            app_uuid: dyadAppUuid,
+            app_name: dyadAppName,
+            chat_id: dyadChatId,
+            turn_uuid: dyadTurnUuid,
           };
           if (dyadMentionedApps?.length) {
             parsedBody.dyad_options.mentioned_apps = dyadMentionedApps;

--- a/src/ipc/utils/llm_engine_provider.ts
+++ b/src/ipc/utils/llm_engine_provider.ts
@@ -230,9 +230,17 @@ export function createDyadEngine(
           modifiedRequestId = `${requestId}:attempt-${currentAttempt}`;
         }
 
-        // Add files to the request if they exist
+        parsedBody.dyad_options = {
+          app_id: dyadAppId,
+          app_uuid: dyadAppUuid,
+          app_name: dyadAppName,
+          chat_id: dyadChatId,
+          turn_uuid: dyadTurnUuid,
+        };
+
+        // Add files to the request if they exist.
         if (!dyadDisableFiles) {
-          parsedBody.dyad_options = {
+          Object.assign(parsedBody.dyad_options, {
             files: dyadFiles,
             versioned_files: dyadVersionedFiles,
             enable_lazy_edits: options.dyadOptions.enableLazyEdits,
@@ -240,12 +248,7 @@ export function createDyadEngine(
               options.dyadOptions.enableSmartFilesContext,
             smart_context_mode: dyadSmartContextMode,
             enable_web_search: options.dyadOptions.enableWebSearch,
-            app_id: dyadAppId,
-            app_uuid: dyadAppUuid,
-            app_name: dyadAppName,
-            chat_id: dyadChatId,
-            turn_uuid: dyadTurnUuid,
-          };
+          });
           if (dyadMentionedApps?.length) {
             parsedBody.dyad_options.mentioned_apps = dyadMentionedApps;
           }

--- a/src/ipc/utils/provider_options.ts
+++ b/src/ipc/utils/provider_options.ts
@@ -15,6 +15,10 @@ export interface MentionedAppCodebase {
 
 export interface GetProviderOptionsParams {
   dyadAppId: number;
+  dyadAppUuid?: string | null;
+  dyadAppName?: string;
+  dyadChatId?: number;
+  dyadTurnUuid?: string;
   dyadRequestId?: string;
   dyadDisableFiles?: boolean;
   smartContextMode?: SmartContextMode;
@@ -31,6 +35,10 @@ export interface GetProviderOptionsParams {
  */
 export function getProviderOptions({
   dyadAppId,
+  dyadAppUuid,
+  dyadAppName,
+  dyadChatId,
+  dyadTurnUuid,
   dyadRequestId,
   dyadDisableFiles,
   smartContextMode,
@@ -43,6 +51,10 @@ export function getProviderOptions({
   const providerOptions: Record<string, any> = {
     "dyad-engine": {
       dyadAppId,
+      dyadAppUuid,
+      dyadAppName,
+      dyadChatId,
+      dyadTurnUuid,
       dyadRequestId,
       dyadDisableFiles,
       dyadSmartContextMode: smartContextMode,

--- a/src/ipc/utils/provider_options.ts
+++ b/src/ipc/utils/provider_options.ts
@@ -51,10 +51,10 @@ export function getProviderOptions({
   const providerOptions: Record<string, any> = {
     "dyad-engine": {
       dyadAppId,
-      dyadAppUuid,
+      dyadAppUuid: dyadAppUuid ?? undefined,
       dyadAppName,
       dyadChatId,
-      dyadTurnUuid,
+      dyadTurnUuid: dyadTurnUuid ?? undefined,
       dyadRequestId,
       dyadDisableFiles,
       dyadSmartContextMode: smartContextMode,

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -13,6 +13,7 @@ import {
   type ToolExecutionOptions,
 } from "ai";
 import log from "electron-log";
+import { v4 as uuidv4 } from "uuid";
 
 import { db } from "@/db";
 import { chats, messages, mcpServers } from "@/db/schema";
@@ -359,7 +360,7 @@ export async function handleLocalAgentStream(
     placeholderMessageId,
     systemPrompt,
     dyadRequestId,
-    turnUuid = dyadRequestId,
+    turnUuid = uuidv4(),
     readOnly = false,
     planModeOnly = false,
     messageOverride,

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -359,6 +359,7 @@ export async function handleLocalAgentStream(
     placeholderMessageId,
     systemPrompt,
     dyadRequestId,
+    turnUuid = dyadRequestId,
     readOnly = false,
     planModeOnly = false,
     messageOverride,
@@ -370,6 +371,7 @@ export async function handleLocalAgentStream(
     placeholderMessageId: number;
     systemPrompt: string;
     dyadRequestId: string;
+    turnUuid?: string;
     /**
      * If true, the agent operates in read-only mode (e.g., ask mode).
      * State-modifying tools are disabled, and no commits/deploys are made.
@@ -641,6 +643,8 @@ export async function handleLocalAgentStream(
     const ctx: AgentContext = {
       event,
       appId: chat.app.id,
+      appUuid: chat.app.appUuid,
+      appName: chat.app.name,
       appPath,
       referencedApps: referencedAppsMap,
       chatId: chat.id,
@@ -656,6 +660,7 @@ export async function handleLocalAgentStream(
       pendingFunctionDeploys: [],
       todos: persistedTodos,
       dyadRequestId,
+      turnUuid,
       fileEditTracker,
       isDyadPro: isDyadProEnabled(settings),
       freeModelMode: effectiveFreeModelMode,
@@ -914,6 +919,10 @@ export async function handleLocalAgentStream(
             },
             providerOptions: getProviderOptions({
               dyadAppId: chat.app.id,
+              dyadAppUuid: chat.app.appUuid,
+              dyadAppName: chat.app.name,
+              dyadChatId: chat.id,
+              dyadTurnUuid: turnUuid,
               dyadRequestId,
               dyadDisableFiles: true, // Local agent uses tools, not file injection
               files: [],

--- a/src/pro/main/ipc/handlers/local_agent/tools/explore_code_subagent.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/explore_code_subagent.ts
@@ -154,6 +154,10 @@ export async function runExploreCodeSubagent({
       }),
       providerOptions: getProviderOptions({
         dyadAppId: ctx.appId,
+        dyadAppUuid: ctx.appUuid,
+        dyadAppName: ctx.appName,
+        dyadChatId: ctx.chatId,
+        dyadTurnUuid: ctx.turnUuid,
         dyadRequestId: ctx.dyadRequestId,
         dyadDisableFiles: true,
         files: [],

--- a/src/pro/main/ipc/handlers/local_agent/tools/types.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/types.ts
@@ -42,6 +42,8 @@ export interface FileEditTracker {
 export interface AgentContext {
   event: IpcMainInvokeEvent;
   appId: number;
+  appUuid?: string | null;
+  appName?: string;
   appPath: string;
   /**
    * Apps referenced via `@app:Name` in the current turn. Read-only tools
@@ -68,6 +70,8 @@ export interface AgentContext {
   todos: Todo[];
   /** Request ID for tracking requests to the Dyad engine */
   dyadRequestId: string;
+  /** Logical user-visible chat turn ID for grouping multiple model calls. */
+  turnUuid?: string;
   /** Tracks file edit tool usage per file for telemetry */
   fileEditTracker: FileEditTracker;
   /**


### PR DESCRIPTION
## Summary
- add nullable app_uuid on apps and turn_uuid on messages
- send app_uuid, app name, chat id, and turn_uuid through Dyad engine provider options
- pass app metadata to cloud sandbox creation for delayed sandbox billing attribution

## Tests
- npm test -- src/ipc/utils/llm_engine_provider.test.ts
- npm run ts

Companion PRs: dyad-llm-engine forwards this metadata into LiteLLM spend logs; dyad-cloud ingests and displays the durable aggregates.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Additive DB columns and broad plumbing on billing-related engine and cloud sandbox paths; behavior change is mostly extra metadata, with lazy UUID backfill on app run/chat.
> 
> **Overview**
> Adds **durable identifiers** so LLM and cloud sandbox usage can be attributed to a specific app and chat turn: nullable `app_uuid` on `apps`, `turn_uuid` on user `messages`, and a migration to match.
> 
> **App UUID lifecycle:** new create/copy/import rows get a UUID immediately; existing apps get one lazily via `ensureAppUuid` when starting or restarting the app or when a chat stream runs. `appUuid` is exposed on the app IPC schema.
> 
> **Turn UUID:** each user send generates a `turnUuid`, persisted on the user message and threaded through chat streaming, local agent (including subagents), and `getProviderOptions`.
> 
> **Dyad engine requests:** the provider now always attaches a `dyad_options` block with `app_id`, `app_uuid`, `app_name`, `chat_id`, and `turn_uuid` (invalid/null UUIDs omitted). File/context flags are still gated by `dyadDisableFiles`, but **app metadata is sent even when file injection is off**. Tests cover the new shape and edge cases.
> 
> **Cloud runtime:** `executeApp` / cloud sandbox creation POST includes `appUuid` and `appName` alongside `appId` for delayed sandbox billing attribution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a279f2f5c97a1e33a0a2fa6206ff3802d48863ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->