### PR TITLE
fix: commit enum value additions before dependent statements on Neon apply

### DIFF
--- a/src/neon_admin/neon_context.test.ts
+++ b/src/neon_admin/neon_context.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getNeonClient } from "./neon_management_client";
-import { getConnectionUri } from "./neon_context";
+import {
+  getConnectionUri,
+  isEnumValueAddition,
+  ensureAddValueIfNotExists,
+  partitionEnumValueAdditions,
+} from "./neon_context";
 
 vi.mock("./neon_management_client", () => ({
   getNeonClient: vi.fn(),
@@ -43,6 +48,83 @@ describe("getConnectionUri", () => {
       database_name: "neondb",
       role_name: "neondb_owner",
       pooled: false,
+    });
+  });
+});
+
+describe("isEnumValueAddition", () => {
+  it("matches ALTER TYPE ... ADD VALUE statements", () => {
+    expect(
+      isEnumValueAddition(`ALTER TYPE "public"."mood" ADD VALUE 'ok'`),
+    ).toBe(true);
+    expect(
+      isEnumValueAddition(
+        `ALTER TYPE "public"."mood" ADD VALUE 'ok' BEFORE 'sad'`,
+      ),
+    ).toBe(true);
+    expect(isEnumValueAddition("alter type mood add value 'ok'")).toBe(true);
+  });
+
+  it("does not match other statements", () => {
+    expect(
+      isEnumValueAddition(`CREATE TYPE "public"."mood" AS ENUM ('ok')`),
+    ).toBe(false);
+    expect(
+      isEnumValueAddition(
+        `ALTER TABLE "public"."messages" ALTER COLUMN "mood" SET DEFAULT 'ok'::"public"."mood"`,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("ensureAddValueIfNotExists", () => {
+  it("inserts IF NOT EXISTS while preserving the label and clauses", () => {
+    expect(
+      ensureAddValueIfNotExists(`ALTER TYPE "public"."mood" ADD VALUE 'ok'`),
+    ).toBe(`ALTER TYPE "public"."mood" ADD VALUE IF NOT EXISTS 'ok'`);
+    expect(
+      ensureAddValueIfNotExists(
+        `ALTER TYPE "public"."mood" ADD VALUE 'ok' BEFORE 'sad'`,
+      ),
+    ).toBe(
+      `ALTER TYPE "public"."mood" ADD VALUE IF NOT EXISTS 'ok' BEFORE 'sad'`,
+    );
+  });
+
+  it("is idempotent", () => {
+    const once = ensureAddValueIfNotExists(
+      `ALTER TYPE "public"."mood" ADD VALUE 'ok'`,
+    );
+    expect(ensureAddValueIfNotExists(once)).toBe(once);
+  });
+});
+
+describe("partitionEnumValueAdditions", () => {
+  it("separates enum additions from the rest, preserving order", () => {
+    const statements = [
+      `ALTER TYPE "public"."mood" ADD VALUE 'ok'`,
+      `ALTER TABLE "public"."messages" ALTER COLUMN "mood" SET DEFAULT 'ok'::"public"."mood"`,
+      `ALTER TYPE "public"."mood" ADD VALUE 'great'`,
+    ];
+    expect(partitionEnumValueAdditions(statements)).toEqual({
+      enumValueAdditions: [
+        `ALTER TYPE "public"."mood" ADD VALUE 'ok'`,
+        `ALTER TYPE "public"."mood" ADD VALUE 'great'`,
+      ],
+      transactionStatements: [
+        `ALTER TABLE "public"."messages" ALTER COLUMN "mood" SET DEFAULT 'ok'::"public"."mood"`,
+      ],
+    });
+  });
+
+  it("keeps every statement in the transaction when there are no enum additions", () => {
+    const statements = [
+      `CREATE TABLE "public"."a" ("id" integer)`,
+      `ALTER TABLE "public"."a" ADD COLUMN "name" text`,
+    ];
+    expect(partitionEnumValueAdditions(statements)).toEqual({
+      enumValueAdditions: [],
+      transactionStatements: statements,
     });
   });
 });

--- a/src/neon_admin/neon_context.ts
+++ b/src/neon_admin/neon_context.ts
@@ -163,11 +163,62 @@ export async function executeNeonSql({
   }
 }
 
+const ADD_VALUE_RE = /\bALTER\s+TYPE\b[\s\S]*?\bADD\s+VALUE\b/i;
+
+/** True for `ALTER TYPE ... ADD VALUE ...` statements. */
+export function isEnumValueAddition(statement: string): boolean {
+  return ADD_VALUE_RE.test(statement);
+}
+
+/**
+ * Make an `ALTER TYPE ... ADD VALUE` statement idempotent by inserting
+ * `IF NOT EXISTS`. Enum additions are applied outside the main transaction, so
+ * a retried apply (after the transaction half rolled back) must not fail on a
+ * label that already landed. Statements that already say `IF NOT EXISTS` and
+ * non-enum statements are returned unchanged.
+ */
+export function ensureAddValueIfNotExists(statement: string): string {
+  return statement.replace(
+    /\bADD\s+VALUE\s+(?!IF\s+NOT\s+EXISTS\b)/i,
+    "ADD VALUE IF NOT EXISTS ",
+  );
+}
+
+/**
+ * Split a migration plan into enum-value additions and everything else,
+ * preserving order within each group. PostgreSQL forbids using a newly added
+ * enum value until the transaction that added it commits, so an addition and a
+ * later statement referencing the new label (e.g. a column default cast to it)
+ * cannot share one transaction. See #3520.
+ */
+export function partitionEnumValueAdditions(statements: string[]): {
+  enumValueAdditions: string[];
+  transactionStatements: string[];
+} {
+  const enumValueAdditions: string[] = [];
+  const transactionStatements: string[] = [];
+  for (const statement of statements) {
+    if (isEnumValueAddition(statement)) {
+      enumValueAdditions.push(statement);
+    } else {
+      transactionStatements.push(statement);
+    }
+  }
+  return { enumValueAdditions, transactionStatements };
+}
+
 /**
  * Execute a list of SQL statements against a Neon database in a single
  * non-interactive Postgres transaction over HTTP. Either every statement
  * commits or the whole batch rolls back. PostgreSQL DDL is transactional, so
  * this is safe for migration apply.
+ *
+ * Exception: `ALTER TYPE ... ADD VALUE` can't share a transaction with
+ * statements that use the new label (PostgreSQL rejects the new value until its
+ * transaction commits). Those additions are committed first, on their own, and
+ * the rest still apply atomically. Additions are purely additive and rewritten
+ * with `IF NOT EXISTS`, so a leftover label from a rolled-back retry is
+ * harmless. See #3520.
  *
  * Caveat: a small set of statements (e.g. `CREATE INDEX CONCURRENTLY`) cannot
  * run inside a transaction. The Neon migration preview calls
@@ -203,13 +254,25 @@ export async function executeNeonStatementsInTransaction({
   }
 
   const sql = neon(connectionUri);
+  const { enumValueAdditions, transactionStatements } =
+    partitionEnumValueAdditions(statements);
   try {
+    // Commit enum-value additions first, each on its own, so a dependent
+    // statement later in the plan can reference the new label. When there are
+    // none this loop is skipped and the whole plan stays in one transaction.
+    for (const statement of enumValueAdditions) {
+      await sql.query(ensureAddValueIfNotExists(statement), []);
+    }
     // Returning an array of unawaited query promises is intentional: the
     // `@neondatabase/serverless` HTTP driver collects them into a single
     // batched POST wrapped in `BEGIN`/`COMMIT`. A socket-based driver (e.g.
     // `pg`) would expect the callback to `await` each query sequentially —
     // do not swap drivers without revisiting this call.
-    await sql.transaction((txn) => statements.map((s) => txn.query(s, [])));
+    if (transactionStatements.length > 0) {
+      await sql.transaction((txn) =>
+        transactionStatements.map((s) => txn.query(s, [])),
+      );
+    }
     return { executed: statements.length };
   } catch (error) {
     logger.error("Error applying migration transaction on Neon:", error);


### PR DESCRIPTION
Closes #3520.

`executeNeonStatementsInTransaction` runs the whole migration plan in one transaction, but PostgreSQL won't let a newly added enum value be used until the transaction that added it commits. So a plan like

```sql
ALTER TYPE "public"."mood" ADD VALUE 'ok';
ALTER TABLE "public"."messages" ALTER COLUMN "mood" SET DEFAULT 'ok'::"public"."mood";
```

fails on apply even though the `ADD VALUE` is ordered first — the dependent statement runs in the same transaction before the new label is visible.

I went with the "transaction groups" direction from the issue, but kept it minimal: pull the `ALTER TYPE ... ADD VALUE` statements out and commit them up front (each on its own), then run the rest atomically exactly as before. Plans with no enum additions take the same single-transaction path they do today, so nothing changes for the common case.

The one semantic shift is that enum additions now land outside the all-or-nothing batch. That's safe to commit early because they're purely additive — an unused enum label doesn't break anything — and I rewrite them with `IF NOT EXISTS`, so if a later statement rolls the main transaction back, retrying the same plan (the migrate handler keeps the plan around for retry) won't trip over a label that already exists.

Unit tests cover the partitioning and the `IF NOT EXISTS` rewrite (including the `BEFORE` clause and idempotency). The longer-term, fully explicit multi-transaction plan with partial-apply surfaced in the UI is still worth doing, but this stops the confusing failure against prod in the meantime.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

