### PR TITLE
feat(mcp-consent): show the prompt immediately and race the classifier

### DIFF
--- a/e2e-tests/fixtures/engine/local-agent/mcp-print-envs.ts
+++ b/e2e-tests/fixtures/engine/local-agent/mcp-print-envs.ts
@@ -1,0 +1,31 @@
+import type { LocalAgentFixture } from "../../../../testing/fake-llm-server/localAgentTypes";
+
+// print_envs is the tool the fake classifier deliberately answers slowly for, so
+// the consent spinner is observable and the user can decide before the AI does.
+export const fixture: LocalAgentFixture = {
+  description: "Call an MCP tool (print_envs) that the classifier reviews slowly",
+  turns: [
+    {
+      text: "I'll read the server's environment variables.",
+      toolCalls: [
+        {
+          name: "execute_sandbox_script",
+          args: {
+            description: "Call print_envs through MCP",
+            script: [
+              "async function main() {",
+              "  const result = await testing_mcp_server__print_envs({});",
+              "  return JSON.stringify(result);",
+              "}",
+              "main();",
+            ].join("\n"),
+            execution_thread: "main",
+          },
+        },
+      ],
+    },
+    {
+      text: "Done reading the environment variables.",
+    },
+  ],
+};

--- a/e2e-tests/mcp_auto_consent.spec.ts
+++ b/e2e-tests/mcp_auto_consent.spec.ts
@@ -131,3 +131,31 @@ testSkipIfWindows(
     ).toHaveCount(0);
   },
 );
+
+// The prompt appears immediately with an "AI reviewing" spinner while the
+// classifier decides; the user can approve before it finishes. (The fake
+// classifier answers print_envs slowly so the spinner is observable.)
+testSkipIfWindows(
+  "mcp auto-consent - user can approve while the classifier is still reviewing",
+  async ({ po }) => {
+    await po.setUpDyadPro({ localAgent: true });
+    await addTestMcpServer(po);
+    await po.settings.waitForMcpTool("testing-mcp-server", "print_envs");
+    await enableAutoApproveSafeMcpTools(po);
+    await startAgentChat(po);
+
+    await po.sendPrompt("tc=local-agent/mcp-print-envs", {
+      skipWaitForCompletion: true,
+    });
+
+    // The prompt shows immediately with the reviewing spinner and live buttons.
+    await expect(po.page.getByText(/reviewing this request/i)).toBeVisible({
+      timeout: Timeout.MEDIUM,
+    });
+    // The user decides before the classifier returns.
+    await po.page.getByRole("button", { name: "Allow once" }).click();
+
+    await po.chatActions.waitForChatCompletion();
+    await expect(po.page.getByText(/reviewing this request/i)).toHaveCount(0);
+  },
+);

--- a/src/atoms/chatAtoms.ts
+++ b/src/atoms/chatAtoms.ts
@@ -481,6 +481,8 @@ export interface PendingToolConsent {
   serverId?: number;
   serverName?: string | null;
   classifierReason?: string | null;
+  // True while the auto-approve classifier is still deciding (shows a spinner).
+  classifierPending?: boolean;
 }
 
 export const pendingToolConsentsAtom = atom<PendingToolConsent[]>([]);

--- a/src/components/chat/AgentConsentBanner.test.tsx
+++ b/src/components/chat/AgentConsentBanner.test.tsx
@@ -8,6 +8,8 @@ vi.mock("react-i18next", () => ({
       ({
         changesDatabaseSchema: "Changes database schema",
         destructiveDataChange: "Destructive data change",
+        aiReviewingRequest:
+          "AI is reviewing this request to decide if it's safe to auto-approve…",
       })[key] ?? key,
   }),
 }));
@@ -71,5 +73,27 @@ describe("AgentConsentBanner", () => {
     expect(
       screen.getByText(/Sends an email to an external address/),
     ).toBeTruthy();
+  });
+
+  it("shows the reviewing spinner and live buttons while the classifier is pending", () => {
+    render(
+      <AgentConsentBanner
+        consent={{
+          kind: "mcp",
+          requestId: "request",
+          chatId: 1,
+          toolName: "calculator_add",
+          serverName: "calc-server",
+          classifierPending: true,
+        }}
+        onDecision={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/reviewing this request/i)).toBeTruthy();
+    // Buttons stay clickable during review.
+    expect(screen.getByRole("button", { name: "Allow once" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Decline" })).toBeTruthy();
   });
 });

--- a/src/components/chat/AgentConsentBanner.tsx
+++ b/src/components/chat/AgentConsentBanner.tsx
@@ -123,7 +123,7 @@ export function AgentConsentBanner({
             <X className="w-3.5 h-3.5" />
           </button>
         </div>
-        {classifierPending && (
+        {classifierPending ? (
           <div
             className="ml-6 mb-1.5 flex items-center gap-1.5 text-xs text-muted-foreground"
             role="status"
@@ -132,8 +132,7 @@ export function AgentConsentBanner({
             <Loader2 className="h-3.5 w-3.5 flex-shrink-0 animate-spin" />
             <span>{t("aiReviewingRequest")}</span>
           </div>
-        )}
-        {classifierReason && (
+        ) : classifierReason ? (
           <div className="ml-6 mb-1.5 flex gap-2 rounded-lg border-l-4 border-orange-400 bg-amber-50 px-3 py-2 dark:border-orange-500 dark:bg-amber-950/30">
             <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0 text-orange-500 dark:text-orange-400" />
             <div className="min-w-0">
@@ -145,7 +144,7 @@ export function AgentConsentBanner({
               </div>
             </div>
           </div>
-        )}
+        ) : null}
         {inputPreview && (
           <div className="ml-6 mb-1.5">
             {sqlMutatesSchema && (

--- a/src/components/chat/AgentConsentBanner.tsx
+++ b/src/components/chat/AgentConsentBanner.tsx
@@ -124,7 +124,11 @@ export function AgentConsentBanner({
           </button>
         </div>
         {classifierPending && (
-          <div className="ml-6 mb-1.5 flex items-center gap-1.5 text-xs text-muted-foreground">
+          <div
+            className="ml-6 mb-1.5 flex items-center gap-1.5 text-xs text-muted-foreground"
+            role="status"
+            aria-live="polite"
+          >
             <Loader2 className="h-3.5 w-3.5 flex-shrink-0 animate-spin" />
             <span>{t("aiReviewingRequest")}</span>
           </div>

--- a/src/components/chat/AgentConsentBanner.tsx
+++ b/src/components/chat/AgentConsentBanner.tsx
@@ -8,6 +8,7 @@ import {
   Check,
   Ban,
   AlertTriangle,
+  Loader2,
 } from "lucide-react";
 import type { PendingToolConsent } from "@/atoms/chatAtoms";
 import {
@@ -42,6 +43,7 @@ export function AgentConsentBanner({
     inputPreview,
     serverName,
     classifierReason,
+    classifierPending,
   } = consent;
   const sqlMutatesSchema = consent.metadata?.sqlMutatesSchema === true;
   const sqlDeletesData = consent.metadata?.sqlDeletesData === true;
@@ -121,6 +123,12 @@ export function AgentConsentBanner({
             <X className="w-3.5 h-3.5" />
           </button>
         </div>
+        {classifierPending && (
+          <div className="ml-6 mb-1.5 flex items-center gap-1.5 text-xs text-muted-foreground">
+            <Loader2 className="h-3.5 w-3.5 flex-shrink-0 animate-spin" />
+            <span>{t("aiReviewingRequest")}</span>
+          </div>
+        )}
         {classifierReason && (
           <div className="ml-6 mb-1.5 flex gap-2 rounded-lg border-l-4 border-orange-400 bg-amber-50 px-3 py-2 dark:border-orange-500 dark:bg-amber-950/30">
             <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0 text-orange-500 dark:text-orange-400" />

--- a/src/hooks/useNotificationHandler.ts
+++ b/src/hooks/useNotificationHandler.ts
@@ -347,9 +347,26 @@ export function useNotificationHandler() {
     return () => unsubscribe();
   }, [handleConsentRequest]);
 
-  // MCP Tool Consent Listener (IPC)
+  // MCP Tool Consent Listener (IPC). When the auto-approve classifier is still
+  // running we wait for its verdict: a notification fires only once we know the
+  // user is needed (see the classified listener), not for tools it auto-approves.
   useEffect(() => {
     const unsubscribe = ipc.events.mcp.onConsentRequest(async (payload) => {
+      if (payload.classifierPending) return;
+      handleConsentRequest({
+        chatId: payload.chatId,
+        toolName: payload.toolName,
+        sourceLabel: payload.serverName || "an MCP server",
+        tagPrefix: "dyad-mcp-consent",
+      }).catch(console.error);
+    });
+    return () => unsubscribe();
+  }, [handleConsentRequest]);
+
+  // Classifier asked for manual review: notify now, evaluating backgrounded
+  // state at this moment rather than when the request first arrived.
+  useEffect(() => {
+    const unsubscribe = ipc.events.mcp.onConsentClassified(async (payload) => {
       handleConsentRequest({
         chatId: payload.chatId,
         toolName: payload.toolName,

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -100,6 +100,7 @@
   "destructiveDataChange": "Destructive data change",
   "flaggedForReview": "Flagged for review",
   "autoApproved": "Auto-approved",
+  "aiReviewingRequest": "AI is reviewing this request to decide if it's safe to auto-approve…",
   "approved": "Approved",
   "rejected": "Rejected",
   "copy": "Copy",

--- a/src/ipc/types/mcp.ts
+++ b/src/ipc/types/mcp.ts
@@ -160,9 +160,21 @@ export const McpConsentRequestSchema = z.object({
   chatId: z.number(),
   // Classifier's reason for asking (agent mode, Pro). Shown in the prompt.
   reason: z.string().nullable().optional(),
+  // True while the auto-approve classifier is still deciding; the prompt shows
+  // a spinner and the user can decide manually or wait.
+  classifierPending: z.boolean().optional(),
 });
 
 export type McpConsentRequestPayload = z.infer<typeof McpConsentRequestSchema>;
+
+// The classifier auto-approved; dismiss the pending prompt.
+export const McpConsentResolvedSchema = z.object({ requestId: z.string() });
+
+// The classifier finished and wants review; drop the spinner and show why.
+export const McpConsentClassifiedSchema = z.object({
+  requestId: z.string(),
+  reason: z.string().nullable().optional(),
+});
 
 export const McpConsentDecisionEnum = z.enum([
   "accept-once",
@@ -286,6 +298,14 @@ export const mcpEvents = {
   consentRequest: defineEvent({
     channel: "mcp:tool-consent-request",
     payload: McpConsentRequestSchema,
+  }),
+  consentResolved: defineEvent({
+    channel: "mcp:tool-consent-resolved",
+    payload: McpConsentResolvedSchema,
+  }),
+  consentClassified: defineEvent({
+    channel: "mcp:tool-consent-classified",
+    payload: McpConsentClassifiedSchema,
   }),
 } as const;
 

--- a/src/ipc/types/mcp.ts
+++ b/src/ipc/types/mcp.ts
@@ -170,10 +170,15 @@ export type McpConsentRequestPayload = z.infer<typeof McpConsentRequestSchema>;
 // The classifier auto-approved; dismiss the pending prompt.
 export const McpConsentResolvedSchema = z.object({ requestId: z.string() });
 
-// The classifier finished and wants review; drop the spinner and show why.
+// The classifier finished and wants review; drop the spinner and show why. The
+// chat/tool identity lets the notification hook raise the OS notification only
+// now that we know the user is actually needed.
 export const McpConsentClassifiedSchema = z.object({
   requestId: z.string(),
   reason: z.string().nullable().optional(),
+  chatId: z.number(),
+  toolName: z.string(),
+  serverName: z.string().nullable().optional(),
 });
 
 export const McpConsentDecisionEnum = z.enum([

--- a/src/ipc/utils/mcp_consent.spec.ts
+++ b/src/ipc/utils/mcp_consent.spec.ts
@@ -1,12 +1,19 @@
 import { describe, it, expect, vi } from "vitest";
 
-vi.mock("../../db", () => ({ db: {} }));
+// getStoredConsent reads from the db; an empty result means "ask", which is the
+// path that runs the classifier race.
+vi.mock("../../db", () => ({
+  db: {
+    select: () => ({ from: () => ({ where: () => Promise.resolve([]) }) }),
+  },
+}));
 vi.mock("../../db/schema", () => ({ mcpToolConsents: {} }));
 
 import {
   waitForConsent,
   resolveConsent,
   clearPendingMcpConsentsForChat,
+  requireMcpToolConsent,
 } from "./mcp_consent";
 
 describe("clearPendingMcpConsentsForChat", () => {
@@ -22,5 +29,78 @@ describe("clearPendingMcpConsentsForChat", () => {
     // Not cleared; still resolvable normally.
     resolveConsent("r2", "accept-once");
     await expect(pending).resolves.toBe("accept-once");
+  });
+});
+
+describe("requireMcpToolConsent (classifier race)", () => {
+  const baseParams = {
+    serverId: 1,
+    serverName: "srv",
+    toolName: "tool",
+    toolDescription: "does a thing",
+    inputPreview: "{}",
+    chatId: 7,
+  };
+
+  function makeEvent() {
+    const send = vi.fn();
+    return { event: { sender: { send } } as any, send };
+  }
+
+  function lastRequestId(send: ReturnType<typeof vi.fn>): string {
+    return send.mock.calls[0][1].requestId as string;
+  }
+
+  it("sends a pending prompt, then dismisses it on auto-approve", async () => {
+    const { event, send } = makeEvent();
+    const result = await requireMcpToolConsent(event, {
+      ...baseParams,
+      autoApprove: async () => ({ approved: true, reason: "safe" }),
+    });
+
+    expect(result).toEqual({ approved: true, autoApprovedReason: "safe" });
+    expect(send).toHaveBeenCalledWith(
+      "mcp:tool-consent-request",
+      expect.objectContaining({ classifierPending: true }),
+    );
+    expect(send).toHaveBeenCalledWith(
+      "mcp:tool-consent-resolved",
+      expect.objectContaining({ requestId: expect.any(String) }),
+    );
+  });
+
+  it("surfaces the reason and waits for the user when the classifier asks", async () => {
+    const { event, send } = makeEvent();
+    const pending = requireMcpToolConsent(event, {
+      ...baseParams,
+      autoApprove: async () => ({ approved: false, reason: "risky" }),
+    });
+
+    // The classifier wins the race with "ask" and emits the classified event.
+    await vi.waitFor(() =>
+      expect(send).toHaveBeenCalledWith(
+        "mcp:tool-consent-classified",
+        expect.objectContaining({ reason: "risky" }),
+      ),
+    );
+    resolveConsent(lastRequestId(send), "accept-once");
+    await expect(pending).resolves.toEqual({ approved: true });
+  });
+
+  it("lets the user decide before the classifier finishes", async () => {
+    const { event, send } = makeEvent();
+    // Classifier never resolves; only the user can settle the prompt.
+    const pending = requireMcpToolConsent(event, {
+      ...baseParams,
+      autoApprove: () => new Promise(() => {}),
+    });
+
+    await vi.waitFor(() => expect(send).toHaveBeenCalled());
+    resolveConsent(lastRequestId(send), "decline");
+    await expect(pending).resolves.toEqual({ approved: false });
+    expect(send).not.toHaveBeenCalledWith(
+      "mcp:tool-consent-resolved",
+      expect.anything(),
+    );
   });
 });

--- a/src/ipc/utils/mcp_consent.spec.ts
+++ b/src/ipc/utils/mcp_consent.spec.ts
@@ -80,7 +80,13 @@ describe("requireMcpToolConsent (classifier race)", () => {
     await vi.waitFor(() =>
       expect(send).toHaveBeenCalledWith(
         "mcp:tool-consent-classified",
-        expect.objectContaining({ reason: "risky" }),
+        // Carries the chat/tool identity so the notification hook can notify now.
+        expect.objectContaining({
+          reason: "risky",
+          chatId: baseParams.chatId,
+          toolName: baseParams.toolName,
+          serverName: baseParams.serverName,
+        }),
       ),
     );
     resolveConsent(lastRequestId(send), "accept-once");

--- a/src/ipc/utils/mcp_consent.spec.ts
+++ b/src/ipc/utils/mcp_consent.spec.ts
@@ -44,7 +44,9 @@ describe("requireMcpToolConsent (classifier race)", () => {
 
   function makeEvent() {
     const send = vi.fn();
-    return { event: { sender: { send } } as any, send };
+    // safeSend guards on these before sending.
+    const sender = { send, isDestroyed: () => false, isCrashed: () => false };
+    return { event: { sender } as any, send };
   }
 
   function lastRequestId(send: ReturnType<typeof vi.fn>): string {

--- a/src/ipc/utils/mcp_consent.ts
+++ b/src/ipc/utils/mcp_consent.ts
@@ -184,6 +184,9 @@ export async function requireMcpToolConsent(
   send("mcp:tool-consent-classified", {
     requestId,
     reason: winner.result.reason,
+    chatId: params.chatId,
+    toolName: params.toolName,
+    serverName: params.serverName,
   });
   return finalize((await humanPromise).decision);
 }

--- a/src/ipc/utils/mcp_consent.ts
+++ b/src/ipc/utils/mcp_consent.ts
@@ -33,12 +33,6 @@ export function resolveConsent(requestId: string, decision: ConsentDecision) {
   }
 }
 
-// Drop a pending waiter without resolving it. Used when the classifier
-// auto-approves and the still-registered human waiter is no longer needed.
-export function cancelConsentWaiter(requestId: string): void {
-  pendingConsentResolvers.delete(requestId);
-}
-
 // Resolve any pending MCP consents for a chat as declined. Called when a stream
 // is cancelled or ends so the tool calls unblock instead of hanging once their
 // consent UI has been cleared.
@@ -183,8 +177,9 @@ export async function requireMcpToolConsent(
     return finalize(winner.decision);
   }
   if (winner.result.approved) {
-    // Auto-approved: dismiss the prompt and drop the still-registered waiter.
-    cancelConsentWaiter(requestId);
+    // Auto-approved: dismiss the prompt and settle the still-registered waiter.
+    // The decision is discarded since the race already resolved to the classifier.
+    resolveConsent(requestId, "decline");
     send("mcp:tool-consent-resolved", { requestId });
     return { approved: true, autoApprovedReason: winner.result.reason };
   }

--- a/src/ipc/utils/mcp_consent.ts
+++ b/src/ipc/utils/mcp_consent.ts
@@ -3,6 +3,7 @@ import { mcpToolConsents } from "../../db/schema";
 import { and, eq } from "drizzle-orm";
 import { IpcMainInvokeEvent } from "electron";
 import crypto from "node:crypto";
+import { safeSend } from "./safe_sender";
 
 export type Consent = "ask" | "always" | "denied";
 
@@ -131,8 +132,10 @@ export async function requireMcpToolConsent(
   // Strip the non-serializable callback before sending over IPC.
   const { autoApprove, ...serializableParams } = params;
   const requestId = `${params.serverId}:${params.toolName}:${crypto.randomUUID()}`;
+  // Some of these sends fire after an await, so guard against a renderer that
+  // was destroyed (window closed, e2e teardown) in the meantime.
   const send = (channel: string, payload: Record<string, unknown>) =>
-    (event.sender as any).send(channel, payload);
+    safeSend(event.sender, channel, payload);
 
   const finalize = async (
     response: ConsentDecision,
@@ -151,7 +154,10 @@ export async function requireMcpToolConsent(
   }
 
   // Classifier active: show the prompt immediately with a spinner and race the
-  // classifier against the user. The user can decide at any time.
+  // classifier against the user. The user can decide at any time, and a user
+  // decision always wins over the classifier. The only exception is a click
+  // issued in the sub-millisecond gap before its IPC reaches the main process,
+  // which is an acceptable window given the live buttons are shown throughout.
   send("mcp:tool-consent-request", {
     requestId,
     ...serializableParams,
@@ -171,6 +177,9 @@ export async function requireMcpToolConsent(
   const winner = await Promise.race([humanPromise, classifierPromise]);
 
   if (winner.source === "human") {
+    // The classifier promise is intentionally left to finish on its own; it is
+    // a stateless call whose result we no longer need. The .catch() above keeps
+    // a late rejection from going unhandled.
     return finalize(winner.decision);
   }
   if (winner.result.approved) {

--- a/src/ipc/utils/mcp_consent.ts
+++ b/src/ipc/utils/mcp_consent.ts
@@ -160,10 +160,14 @@ export async function requireMcpToolConsent(
   const humanPromise = waitForConsent(requestId, params.chatId).then(
     (decision) => ({ source: "human" as const, decision }),
   );
-  const classifierPromise = autoApprove().then((result) => ({
-    source: "classifier" as const,
-    result,
-  }));
+  // Fail closed if the classifier rejects: fall back to asking the user so the
+  // race always settles and the prompt never sticks on the spinner.
+  const classifierPromise = autoApprove()
+    .then((result) => ({ source: "classifier" as const, result }))
+    .catch(() => ({
+      source: "classifier" as const,
+      result: { approved: false } as McpAutoApproveResult,
+    }));
   const winner = await Promise.race([humanPromise, classifierPromise]);
 
   if (winner.source === "human") {

--- a/src/ipc/utils/mcp_consent.ts
+++ b/src/ipc/utils/mcp_consent.ts
@@ -32,6 +32,12 @@ export function resolveConsent(requestId: string, decision: ConsentDecision) {
   }
 }
 
+// Drop a pending waiter without resolving it. Used when the classifier
+// auto-approves and the still-registered human waiter is no longer needed.
+export function cancelConsentWaiter(requestId: string): void {
+  pendingConsentResolvers.delete(requestId);
+}
+
 // Resolve any pending MCP consents for a chat as declined. Called when a stream
 // is cancelled or ends so the tool calls unblock instead of hanging once their
 // consent UI has been cleared.
@@ -122,33 +128,58 @@ export async function requireMcpToolConsent(
   if (current === "always") return { approved: true };
   if (current === "denied") return { approved: false };
 
-  // The classifier's reason for asking, shown in the consent prompt.
-  let classifierReason: string | undefined;
-  if (params.autoApprove) {
-    const result = await params.autoApprove();
-    if (result.approved) {
-      return { approved: true, autoApprovedReason: result.reason };
+  // Strip the non-serializable callback before sending over IPC.
+  const { autoApprove, ...serializableParams } = params;
+  const requestId = `${params.serverId}:${params.toolName}:${crypto.randomUUID()}`;
+  const send = (channel: string, payload: Record<string, unknown>) =>
+    (event.sender as any).send(channel, payload);
+
+  const finalize = async (
+    response: ConsentDecision,
+  ): Promise<McpConsentResult> => {
+    if (response === "accept-always") {
+      await setStoredConsent(params.serverId, params.toolName, "always");
+      return { approved: true };
     }
-    classifierReason = result.reason;
+    return { approved: response === "accept-once" };
+  };
+
+  // No classifier: show the prompt and wait for the user.
+  if (!autoApprove) {
+    send("mcp:tool-consent-request", { requestId, ...serializableParams });
+    return finalize(await waitForConsent(requestId, params.chatId));
   }
 
-  // Ask renderer for a decision via event bridge. Strip non-serializable
-  // fields (the autoApprove callback) before sending over IPC.
-  const { autoApprove: _autoApprove, ...serializableParams } = params;
-  const requestId = `${params.serverId}:${params.toolName}:${crypto.randomUUID()}`;
-  (event.sender as any).send("mcp:tool-consent-request", {
+  // Classifier active: show the prompt immediately with a spinner and race the
+  // classifier against the user. The user can decide at any time.
+  send("mcp:tool-consent-request", {
     requestId,
     ...serializableParams,
-    reason: classifierReason,
+    classifierPending: true,
   });
-  const response = await waitForConsent(requestId, params.chatId);
+  const humanPromise = waitForConsent(requestId, params.chatId).then(
+    (decision) => ({ source: "human" as const, decision }),
+  );
+  const classifierPromise = autoApprove().then((result) => ({
+    source: "classifier" as const,
+    result,
+  }));
+  const winner = await Promise.race([humanPromise, classifierPromise]);
 
-  if (response === "accept-always") {
-    await setStoredConsent(params.serverId, params.toolName, "always");
-    return { approved: true };
+  if (winner.source === "human") {
+    return finalize(winner.decision);
   }
-  if (response === "decline") {
-    return { approved: false };
+  if (winner.result.approved) {
+    // Auto-approved: dismiss the prompt and drop the still-registered waiter.
+    cancelConsentWaiter(requestId);
+    send("mcp:tool-consent-resolved", { requestId });
+    return { approved: true, autoApprovedReason: winner.result.reason };
   }
-  return { approved: response === "accept-once" };
+  // Classifier wants review: drop the spinner, surface the reason, and keep
+  // waiting for the user via the existing waiter.
+  send("mcp:tool-consent-classified", {
+    requestId,
+    reason: winner.result.reason,
+  });
+  return finalize((await humanPromise).decision);
 }

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -242,8 +242,37 @@ function App() {
           toolDescription: payload.toolDescription,
           inputPreview: payload.inputPreview,
           classifierReason: payload.reason,
+          classifierPending: payload.classifierPending ?? false,
         },
       ]);
+    });
+    return () => unsubscribe();
+  }, [setPendingToolConsents]);
+
+  // Auto-approved by the classifier: remove the prompt.
+  useEffect(() => {
+    const unsubscribe = ipc.events.mcp.onConsentResolved((payload) => {
+      setPendingToolConsents((prev) =>
+        prev.filter((c) => c.requestId !== payload.requestId),
+      );
+    });
+    return () => unsubscribe();
+  }, [setPendingToolConsents]);
+
+  // Classifier wants review: drop the spinner and show the reason.
+  useEffect(() => {
+    const unsubscribe = ipc.events.mcp.onConsentClassified((payload) => {
+      setPendingToolConsents((prev) =>
+        prev.map((c) =>
+          c.requestId === payload.requestId
+            ? {
+                ...c,
+                classifierPending: false,
+                classifierReason: payload.reason,
+              }
+            : c,
+        ),
+      );
     });
     return () => unsubscribe();
   }, [setPendingToolConsents]);

--- a/testing/fake-llm-server/responsesHandler.ts
+++ b/testing/fake-llm-server/responsesHandler.ts
@@ -176,9 +176,21 @@ export const createResponsesHandler =
         decision: risky ? "ask" : "allow",
       });
       // Answer slowly for print_envs so e2e can observe the "AI reviewing"
-      // spinner and exercise the user-decides-before-the-AI path.
+      // spinner and exercise the user-decides-before-the-AI path. Race the delay
+      // against the client disconnecting so we don't write to a closed response.
       if (lastUserText.includes("Tool: print_envs")) {
-        await new Promise((resolve) => setTimeout(resolve, 4000));
+        await new Promise<void>((resolve) => {
+          const timer = setTimeout(() => {
+            req.off("close", onClose);
+            resolve();
+          }, 4000);
+          const onClose = () => {
+            clearTimeout(timer);
+            resolve();
+          };
+          req.on("close", onClose);
+        });
+        if (req.destroyed) return;
       }
     }
 

--- a/testing/fake-llm-server/responsesHandler.ts
+++ b/testing/fake-llm-server/responsesHandler.ts
@@ -175,6 +175,11 @@ export const createResponsesHandler =
         reason: risky ? "destructive tool" : "safe tool",
         decision: risky ? "ask" : "allow",
       });
+      // Answer slowly for print_envs so e2e can observe the "AI reviewing"
+      // spinner and exercise the user-decides-before-the-AI path.
+      if (lastUserText.includes("Tool: print_envs")) {
+        await new Promise((resolve) => setTimeout(resolve, 4000));
+      }
     }
 
     const responseId = `resp_${Date.now()}`;


### PR DESCRIPTION
The MCP consent prompt no longer blocks on the auto-approve classifier. It now appears immediately with an "AI is reviewing" spinner while the classifier decides, and the user can approve or decline at any time or wait for the AI.

requireMcpToolConsent races the classifier against the user: a classifier "allow" dismisses the prompt and auto-approves, a classifier "ask" drops the spinner and shows the reason, and a user decision wins immediately and discards the pending classifier. Adds the classifierPending flag plus the consent resolved/classified IPC events that drive the spinner and dismissal.

Covered by race unit tests, a banner render test for the spinner, and an e2e that approves while the classifier is still reviewing.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

