### PR TITLE
fix(lmstudio): list vlm and other generative models, not just llm

### DIFF
--- a/src/ipc/handlers/local_model_lmstudio_handler.ts
+++ b/src/ipc/handlers/local_model_lmstudio_handler.ts
@@ -35,7 +35,7 @@ export async function fetchLMStudioModels(): Promise<{ models: LocalModel[] }> {
   const modelsJson = await modelsResponse.json();
   const downloadedModels = modelsJson.data as LMStudioModel[];
   const models: LocalModel[] = downloadedModels
-    .filter((model: any) => !NON_CHAT_LM_STUDIO_MODEL_TYPES.has(model.type))
+    .filter((model) => !NON_CHAT_LM_STUDIO_MODEL_TYPES.has(model.type))
     .map((model: any) => ({
       modelName: model.id,
       displayName: model.id,

--- a/src/ipc/handlers/local_model_lmstudio_handler.ts
+++ b/src/ipc/handlers/local_model_lmstudio_handler.ts
@@ -8,7 +8,7 @@ import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
 const logger = log.scope("lmstudio_handler");
 
 export interface LMStudioModel {
-  type: "llm" | "embedding" | string;
+  type: "llm" | "vlm" | "embedding" | "embeddings" | string;
   id: string;
   object: string;
   publisher: string;
@@ -19,6 +19,8 @@ export interface LMStudioModel {
   arch: string;
   [key: string]: any;
 }
+
+const NON_CHAT_LM_STUDIO_MODEL_TYPES = new Set(["embeddings", "embedding"]);
 
 export async function fetchLMStudioModels(): Promise<{ models: LocalModel[] }> {
   const modelsResponse: Response = await fetch(
@@ -33,7 +35,7 @@ export async function fetchLMStudioModels(): Promise<{ models: LocalModel[] }> {
   const modelsJson = await modelsResponse.json();
   const downloadedModels = modelsJson.data as LMStudioModel[];
   const models: LocalModel[] = downloadedModels
-    .filter((model: any) => model.type === "llm")
+    .filter((model: any) => !NON_CHAT_LM_STUDIO_MODEL_TYPES.has(model.type))
     .map((model: any) => ({
       modelName: model.id,
       displayName: model.id,


### PR DESCRIPTION
- Replace strict 'llm' filter with blacklist of non-chat model types
- Include both 'embeddings' and legacy 'embedding' in exclusion set  
- Update LMStudioModel type to reflect actual API values (llm, vlm, embeddings)
- Allows vision models (vlm) and future chat-capable types to work without code changes

Fixes #3668

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

