### PR TITLE
Show only preview/diff panels when version selected

### DIFF
--- a/src/components/preview_panel/PreviewToolbar.tsx
+++ b/src/components/preview_panel/PreviewToolbar.tsx
@@ -58,7 +58,7 @@ const PreviewToolbarModeButtons = ({ isCompact }: ModeButtonsProps) => {
   const { problemReport } = useCheckProblems(selectedAppId);
 
   // When a version is selected, only the preview/diff panels are available.
-  // Coerce a stale previewMode (e.g. "configure", "problems") to the diff
+  // Coerce a stale previewMode (e.g. "configure", "problems") to the preview
   // view so the toolbar and rendered panel don't diverge.
   useEffect(() => {
     if (
@@ -66,7 +66,7 @@ const PreviewToolbarModeButtons = ({ isCompact }: ModeButtonsProps) => {
       previewMode !== "preview" &&
       previewMode !== "code"
     ) {
-      setPreviewMode("code");
+      setPreviewMode("preview");
     }
   }, [isVersionSelected, previewMode, setPreviewMode]);
 

--- a/src/components/preview_panel/PreviewToolbar.tsx
+++ b/src/components/preview_panel/PreviewToolbar.tsx
@@ -3,12 +3,14 @@ import {
   type PreviewMode,
   previewModeAtom,
   selectedAppIdAtom,
+  selectedVersionIdAtom,
 } from "@/atoms/appAtoms";
 import { isPreviewOpenAtom } from "@/atoms/viewAtoms";
 import { useCheckProblems } from "@/hooks/useCheckProblems";
 import {
   AlertTriangle,
   Code,
+  Diff,
   Eye,
   Globe,
   MoreHorizontal,
@@ -51,6 +53,8 @@ const PreviewToolbarModeButtons = ({ isCompact }: ModeButtonsProps) => {
   const [previewMode, setPreviewMode] = useAtom(previewModeAtom);
   const [isPreviewOpen, setIsPreviewOpen] = useAtom(isPreviewOpenAtom);
   const selectedAppId = useAtomValue(selectedAppIdAtom);
+  const selectedVersionId = useAtomValue(selectedVersionIdAtom);
+  const isVersionSelected = selectedVersionId != null;
   const { problemReport } = useCheckProblems(selectedAppId);
 
   const problemCount = problemReport ? problemReport.problems.length : 0;
@@ -88,8 +92,8 @@ const PreviewToolbarModeButtons = ({ isCompact }: ModeButtonsProps) => {
       testId: "problems-mode-button",
     },
     code: {
-      icon: <Code size={16} />,
-      label: t("preview.code"),
+      icon: isVersionSelected ? <Diff size={16} /> : <Code size={16} />,
+      label: isVersionSelected ? t("preview.diff") : t("preview.code"),
       testId: "code-mode-button",
     },
     configure: {
@@ -147,9 +151,11 @@ const PreviewToolbarModeButtons = ({ isCompact }: ModeButtonsProps) => {
     );
   };
 
-  const visibleModes: readonly ToolbarMode[] = isCompact
-    ? PRIMARY_MODES
-    : [...PRIMARY_MODES, ...OVERFLOW_MODES];
+  const visibleModes: readonly ToolbarMode[] = isVersionSelected
+    ? (["preview", "code"] as const)
+    : isCompact
+      ? PRIMARY_MODES
+      : [...PRIMARY_MODES, ...OVERFLOW_MODES];
   const isOverflowActive =
     (OVERFLOW_MODES as readonly PreviewMode[]).includes(previewMode) &&
     isPreviewOpen;
@@ -158,7 +164,7 @@ const PreviewToolbarModeButtons = ({ isCompact }: ModeButtonsProps) => {
   return (
     <div className="flex items-center gap-0.5">
       {visibleModes.map((mode) => renderButton(mode))}
-      {isCompact && (
+      {isCompact && !isVersionSelected && (
         <DropdownMenu>
           <Tooltip>
             <TooltipTrigger

--- a/src/components/preview_panel/PreviewToolbar.tsx
+++ b/src/components/preview_panel/PreviewToolbar.tsx
@@ -57,6 +57,19 @@ const PreviewToolbarModeButtons = ({ isCompact }: ModeButtonsProps) => {
   const isVersionSelected = selectedVersionId != null;
   const { problemReport } = useCheckProblems(selectedAppId);
 
+  // When a version is selected, only the preview/diff panels are available.
+  // Coerce a stale previewMode (e.g. "configure", "problems") to the diff
+  // view so the toolbar and rendered panel don't diverge.
+  useEffect(() => {
+    if (
+      isVersionSelected &&
+      previewMode !== "preview" &&
+      previewMode !== "code"
+    ) {
+      setPreviewMode("code");
+    }
+  }, [isVersionSelected, previewMode, setPreviewMode]);
+
   const problemCount = problemReport ? problemReport.problems.length : 0;
   const displayCount =
     problemCount === 0

--- a/src/i18n/locales/en/home.json
+++ b/src/i18n/locales/en/home.json
@@ -199,6 +199,7 @@
     "title": "Preview",
     "problems": "Problems",
     "code": "Code",
+    "diff": "Diff",
     "configure": "Configure",
     "security": "Security",
     "publish": "Publish",

--- a/src/i18n/locales/es/home.json
+++ b/src/i18n/locales/es/home.json
@@ -199,6 +199,7 @@
     "title": "Vista Previa",
     "problems": "Problemas",
     "code": "Código",
+    "diff": "Diff",
     "configure": "Configurar",
     "security": "Seguridad",
     "publish": "Publicar",

--- a/src/i18n/locales/pt-BR/home.json
+++ b/src/i18n/locales/pt-BR/home.json
@@ -196,6 +196,7 @@
     "title": "Pré-visualização",
     "problems": "Problemas",
     "code": "Código",
+    "diff": "Diff",
     "configure": "Configurar",
     "security": "Segurança",
     "publish": "Publicar",

--- a/src/i18n/locales/zh-CN/home.json
+++ b/src/i18n/locales/zh-CN/home.json
@@ -196,6 +196,7 @@
     "title": "预览",
     "problems": "问题",
     "code": "代码",
+    "diff": "差异",
     "configure": "配置",
     "security": "安全",
     "publish": "发布",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

