### PR TITLE
Bump mustardscript to 0.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "lexical-beautiful-mentions": "^0.1.47",
         "lucide-react": "^0.487.0",
         "monaco-editor": "^0.52.2",
-        "mustardscript": "^0.2.0",
+        "mustardscript": "^0.2.1",
         "node-pty": "^1.1.0",
         "perfect-freehand": "^1.2.2",
         "pg-schema-classifier": "file:packages/pg-schema-classifier",
@@ -4648,9 +4648,9 @@
       }
     },
     "node_modules/@mustardscript/binding-darwin-arm64": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@mustardscript/binding-darwin-arm64/-/binding-darwin-arm64-0.2.0.tgz",
-      "integrity": "sha512-RTUFA/uqmQhkH2dcCIG5P9BXE/R/UF5TmRcx/6vn6DEqskBXXeTcP61uM5xsDr1TWOHON6ODyVDlQLWnn96+4w==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@mustardscript/binding-darwin-arm64/-/binding-darwin-arm64-0.2.1.tgz",
+      "integrity": "sha512-Jbb6k4r8jH3Urq+vz7LClJ9chIJ1iF8S58KzEDGQCjR9sksvxqjDdjSm6dyfckiCaKtaFok4AhMeYyRhD56kxQ==",
       "cpu": [
         "arm64"
       ],
@@ -4661,9 +4661,9 @@
       ]
     },
     "node_modules/@mustardscript/binding-darwin-x64": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@mustardscript/binding-darwin-x64/-/binding-darwin-x64-0.2.0.tgz",
-      "integrity": "sha512-VlT4VkQLmTX0TlKsCsb2ewwZbbvo/Ep7GEEtiQ4denk9yYA7YE+hgt1IrLSq+Ti18IfmFGt1VFt3/MUBZk1aGQ==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@mustardscript/binding-darwin-x64/-/binding-darwin-x64-0.2.1.tgz",
+      "integrity": "sha512-T9J0EYhhFOCkXy++kxCBBLxZFVla0AJBwfPty3NXUd/GQh/eFZwAGbf+ktJyaoDM3QwqwiRDfV/5uP8fElS7lA==",
       "cpu": [
         "x64"
       ],
@@ -4674,11 +4674,14 @@
       ]
     },
     "node_modules/@mustardscript/binding-linux-x64-gnu": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@mustardscript/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.2.0.tgz",
-      "integrity": "sha512-VS24XkdJlbXfoIHkZj7afIl2aWVfUwuwi7QtEAiIWbmO6ogPmqgK3B6N6L+wbDax6GCihU1gZZjAWjTW3U90ig==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@mustardscript/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.2.1.tgz",
+      "integrity": "sha512-Y9SlDqj9v0opJRiA4TU8w2fGoW3GbXkYkbisRhnsIkgfLCvUESAwZErU6OmMSWU4PS1MuHPM9e5GsQEM7Ko9mw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -4687,9 +4690,9 @@
       ]
     },
     "node_modules/@mustardscript/binding-win32-x64-msvc": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@mustardscript/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.2.0.tgz",
-      "integrity": "sha512-LAoZNkaW3OiW/8i5I0bfiCOuMVhCSeUUyL8GmBwsEjFcwpYUWE3kaRbqhFTzsozXbPFDO2Nsdzd7so5ozJtaDA==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@mustardscript/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.2.1.tgz",
+      "integrity": "sha512-5zER8HQIBO9Cb04KHGta18/2oZ4yuISNAYZpIXggK4vAuYU65DjrpfSiGsaL+yQH5LMnXE0E9No6kNClyqAXIQ==",
       "cpu": [
         "x64"
       ],
@@ -18258,15 +18261,15 @@
       "license": "MIT"
     },
     "node_modules/mustardscript": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/mustardscript/-/mustardscript-0.2.0.tgz",
-      "integrity": "sha512-HobTbDYEEn75tnhjZcnOI/Q17ptPItrcL2AvFoHmudxLAWYeUhbmxuuoY8V5lM8GA8G6aN1FlGF6S+itnHva3A==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/mustardscript/-/mustardscript-0.2.1.tgz",
+      "integrity": "sha512-kwFnZXaKzMhyYkrSC05/WEnQO7Wr67b3iK0Wadng3I7pj+KLH7Q3hDf0k4tQLS4ikdiEX2xGBidV0t4tnzE8hg==",
       "license": "Apache-2.0",
       "optionalDependencies": {
-        "@mustardscript/binding-darwin-arm64": "0.2.0",
-        "@mustardscript/binding-darwin-x64": "0.2.0",
-        "@mustardscript/binding-linux-x64-gnu": "0.2.0",
-        "@mustardscript/binding-win32-x64-msvc": "0.2.0"
+        "@mustardscript/binding-darwin-arm64": "0.2.1",
+        "@mustardscript/binding-darwin-x64": "0.2.1",
+        "@mustardscript/binding-linux-x64-gnu": "0.2.1",
+        "@mustardscript/binding-win32-x64-msvc": "0.2.1"
       }
     },
     "node_modules/mute-stream": {

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "lexical-beautiful-mentions": "^0.1.47",
     "lucide-react": "^0.487.0",
     "monaco-editor": "^0.52.2",
-    "mustardscript": "^0.2.0",
+    "mustardscript": "^0.2.1",
     "node-pty": "^1.1.0",
     "perfect-freehand": "^1.2.2",
     "pg-schema-classifier": "file:packages/pg-schema-classifier",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Patch-level dependency bump with lockfile-only changes; native bindings may affect local-agent behavior on upgrade but no app logic was modified.
> 
> **Overview**
> Updates the **mustardscript** dependency from `^0.2.0` to **`^0.2.1`** in `package.json` and refreshes `package-lock.json` so the main package and all **`@mustardscript/binding-*`** optional native binaries resolve to **0.2.1** (with updated integrity hashes). The lockfile also records **`libc: glibc`** on the Linux x64 GNU binding entry.
> 
> There are no application or build-script source changes—only dependency version pins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aad554884e6bd2504e01c82a37489ab454c7ffc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

