### PR TITLE
perf(streaming): avoid O(n^2) partial-output work in streamText

### DIFF
--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -1248,7 +1248,7 @@ This conversation includes one or more image attachments. When the user uploads 
             // Avoids the SDK's O(n^2) per-chunk JSON.stringify of the full
             // accumulated text (see fastTextOutput). We read fullStream parts
             // directly and never consume partialOutput.
-            experimental_output: fastTextOutput(),
+            output: fastTextOutput(),
             providerOptions,
             system: systemPromptOverride,
             tools,

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -1,7 +1,10 @@
 import { v4 as uuidv4 } from "uuid";
 import { app, ipcMain, IpcMainInvokeEvent } from "electron";
 import { createTypedHandler } from "./base";
-import { computeStreamingPatch } from "../utils/stream_text_utils";
+import {
+  computeStreamingPatch,
+  fastTextOutput,
+} from "../utils/stream_text_utils";
 import { chatContracts } from "../types/chat";
 import {
   ModelMessage,
@@ -1242,6 +1245,10 @@ This conversation includes one or more image attachments. When the user uploads 
             maxRetries: 2,
             model: modelClient.model,
             stopWhen: [stepCountIs(20), hasToolCall("edit-code")],
+            // Avoids the SDK's O(n^2) per-chunk JSON.stringify of the full
+            // accumulated text (see fastTextOutput). We read fullStream parts
+            // directly and never consume partialOutput.
+            experimental_output: fastTextOutput(),
             providerOptions,
             system: systemPromptOverride,
             tools,

--- a/src/ipc/handlers/compaction/compaction_handler.ts
+++ b/src/ipc/handlers/compaction/compaction_handler.ts
@@ -18,7 +18,10 @@ import {
   shouldTriggerCompaction,
 } from "@/ipc/utils/token_utils";
 import { safeSend } from "@/ipc/utils/safe_sender";
-import { cancelOrphanedBaseStream } from "@/ipc/utils/stream_text_utils";
+import {
+  cancelOrphanedBaseStream,
+  fastTextOutput,
+} from "@/ipc/utils/stream_text_utils";
 import { COMPACTION_SYSTEM_PROMPT } from "@/prompts/compaction_system_prompt";
 import {
   storePreCompactionMessages,
@@ -184,6 +187,7 @@ export async function performCompaction(
     ];
 
     const summaryResult = streamText({
+      experimental_output: fastTextOutput(),
       model: modelClient.model,
       headers: {
         ...getAiHeaders({

--- a/src/ipc/handlers/compaction/compaction_handler.ts
+++ b/src/ipc/handlers/compaction/compaction_handler.ts
@@ -187,7 +187,7 @@ export async function performCompaction(
     ];
 
     const summaryResult = streamText({
-      experimental_output: fastTextOutput(),
+      output: fastTextOutput(),
       model: modelClient.model,
       headers: {
         ...getAiHeaders({

--- a/src/ipc/handlers/help_bot_handlers.ts
+++ b/src/ipc/handlers/help_bot_handlers.ts
@@ -4,7 +4,10 @@ import { readSettings } from "../../main/settings";
 
 import log from "electron-log";
 import { safeSend } from "../utils/safe_sender";
-import { cancelOrphanedBaseStream } from "../utils/stream_text_utils";
+import {
+  cancelOrphanedBaseStream,
+  fastTextOutput,
+} from "../utils/stream_text_utils";
 import {
   createOpenAI,
   openai,
@@ -81,6 +84,7 @@ export function registerHelpBotHandlers() {
       let assistantContent = "";
 
       const stream = streamText({
+        experimental_output: fastTextOutput(),
         model: provider.responses(helpBotModel.apiName),
         providerOptions: {
           openai: {

--- a/src/ipc/handlers/help_bot_handlers.ts
+++ b/src/ipc/handlers/help_bot_handlers.ts
@@ -84,7 +84,7 @@ export function registerHelpBotHandlers() {
       let assistantContent = "";
 
       const stream = streamText({
-        experimental_output: fastTextOutput(),
+        output: fastTextOutput(),
         model: provider.responses(helpBotModel.apiName),
         providerOptions: {
           openai: {

--- a/src/ipc/utils/stream_text_utils.test.ts
+++ b/src/ipc/utils/stream_text_utils.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from "vitest";
+import { streamText } from "ai";
+import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
+import type { LanguageModelV3StreamPart } from "@ai-sdk/provider";
 import { fastTextOutput } from "./stream_text_utils";
 
 describe("fastTextOutput", () => {
@@ -30,5 +33,54 @@ describe("fastTextOutput", () => {
     await expect(
       output.parseCompleteOutput({ text: "full response" }),
     ).resolves.toBe("full response");
+  });
+
+  // Guards the streaming mechanism the number partial depends on: the SDK's
+  // output transform publishes a text chunk only when the partial value changes.
+  // If an SDK change broke that for a number partial, text would batch to the
+  // end (or error) instead of flushing per chunk, and this test would fail.
+  it("streams text incrementally through streamText with the number partial", async () => {
+    const model = new MockLanguageModelV3({
+      doStream: async () => ({
+        stream: simulateReadableStream<LanguageModelV3StreamPart>({
+          chunks: [
+            { type: "stream-start", warnings: [] },
+            { type: "text-start", id: "1" },
+            { type: "text-delta", id: "1", delta: "Hello " },
+            { type: "text-delta", id: "1", delta: "world" },
+            { type: "text-delta", id: "1", delta: "!" },
+            { type: "text-end", id: "1" },
+            {
+              type: "finish",
+              finishReason: { unified: "stop", raw: "stop" },
+              usage: {
+                inputTokens: {
+                  total: 1,
+                  noCache: 1,
+                  cacheRead: 0,
+                  cacheWrite: 0,
+                },
+                outputTokens: { total: 3, text: 3, reasoning: 0 },
+              },
+            },
+          ],
+        }),
+      }),
+    });
+
+    const result = streamText({
+      model,
+      output: fastTextOutput(),
+      prompt: "hi",
+    });
+
+    const deltas: string[] = [];
+    for await (const part of result.fullStream) {
+      if (part.type === "text-delta") deltas.push(part.text);
+    }
+
+    // One delta per input chunk = incremental, not batched at the end.
+    expect(deltas).toEqual(["Hello ", "world", "!"]);
+    await expect(result.text).resolves.toBe("Hello world!");
   });
 });

--- a/src/ipc/utils/stream_text_utils.test.ts
+++ b/src/ipc/utils/stream_text_utils.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { fastTextOutput } from "./stream_text_utils";
+
+describe("fastTextOutput", () => {
+  it("returns the text length (a number) as the partial output", async () => {
+    const output = fastTextOutput();
+    const result = await output.parsePartialOutput({ text: "hello" });
+    expect(result).toEqual({ partial: 5 });
+    expect(typeof (result as { partial: unknown }).partial).toBe("number");
+  });
+
+  it("produces a value that grows as the accumulated text grows", async () => {
+    const output = fastTextOutput();
+    const shorter = await output.parsePartialOutput({ text: "ab" });
+    const longer = await output.parsePartialOutput({ text: "abcd" });
+    const shorterPartial = (shorter as unknown as { partial: number }).partial;
+    const longerPartial = (longer as unknown as { partial: number }).partial;
+    expect(longerPartial).toBeGreaterThan(shorterPartial);
+  });
+
+  it("preserves the base Output.text() behavior", async () => {
+    const output = fastTextOutput() as unknown as {
+      name: string;
+      responseFormat: Promise<unknown>;
+      parseCompleteOutput: (opts: { text: string }) => Promise<string>;
+    };
+    expect(output.name).toBe("text");
+    await expect(output.responseFormat).resolves.toEqual({ type: "text" });
+    // Completion still yields the full text, not the length.
+    await expect(
+      output.parseCompleteOutput({ text: "full response" }),
+    ).resolves.toBe("full response");
+  });
+});

--- a/src/ipc/utils/stream_text_utils.ts
+++ b/src/ipc/utils/stream_text_utils.ts
@@ -29,9 +29,15 @@ export function fastTextOutput(): ReturnType<typeof Output.text> {
   const base = Output.text();
   return {
     ...base,
+    // `text` is the SDK's append-only accumulated output, so its length strictly
+    // increases: the value changes every chunk (keeping text flushing) while
+    // staying O(1) to stringify and diff.
     parsePartialOutput: async ({ text }: { text: string }) => ({
       partial: text.length,
     }),
+    // `partial` is intentionally a number, not the base `Output.text()` string.
+    // Safe because nothing consumes `partialOutput`; we only use it as a cheap
+    // per-chunk change signal to drive flushing.
   } as unknown as ReturnType<typeof Output.text>;
 }
 

--- a/src/ipc/utils/stream_text_utils.ts
+++ b/src/ipc/utils/stream_text_utils.ts
@@ -37,7 +37,8 @@ export function fastTextOutput(): ReturnType<typeof Output.text> {
     }),
     // `partial` is intentionally a number, not the base `Output.text()` string.
     // Safe because nothing consumes `partialOutput`; we only use it as a cheap
-    // per-chunk change signal to drive flushing.
+    // per-chunk change signal to drive flushing. This holds as of ai@6.0.68;
+    // worth rechecking on AI SDK version bumps.
   } as unknown as ReturnType<typeof Output.text>;
 }
 

--- a/src/ipc/utils/stream_text_utils.ts
+++ b/src/ipc/utils/stream_text_utils.ts
@@ -1,8 +1,39 @@
 import log from "electron-log";
+import { Output } from "ai";
 import type { StreamingPatch } from "@/ipc/types";
 import { hashPrefix } from "@/lib/prefixHash";
 
 const logger = log.scope("stream_text_utils");
+
+/**
+ * Drop-in replacement for the AI SDK's default `Output.text()` that avoids an
+ * O(n^2) cost in `streamText`'s `fullStream`.
+ *
+ * `streamText` always pipes `fullStream` through `createOutputTransformStream`.
+ * With no `output` configured it defaults to `Output.text()`, whose
+ * `parsePartialOutput` returns the whole accumulated text as `partial`. On every
+ * text-delta the transform then runs `JSON.stringify(partial)` and diffs it
+ * against the previous value to decide whether to emit a `partialOutput`, so
+ * that stringify+diff is O(n) per chunk, O(n^2) over a long response. On large
+ * multi-file generations this saturates the main process's JS thread and
+ * freezes the app.
+ *
+ * We read `fullStream` parts directly and never consume `partialOutput`, so the
+ * work is pure waste. This returns an O(1) value that still changes every chunk
+ * (the text length), which keeps text flushing incrementally while making the
+ * per-chunk work O(1). (Returning `undefined` would instead make text flush only
+ * at block end, breaking streaming.) `responseFormat` is unchanged, so the model
+ * request is identical.
+ */
+export function fastTextOutput(): ReturnType<typeof Output.text> {
+  const base = Output.text();
+  return {
+    ...base,
+    parsePartialOutput: async ({ text }: { text: string }) => ({
+      partial: text.length,
+    }),
+  } as unknown as ReturnType<typeof Output.text>;
+}
 
 /**
  * Computes a tail-only streaming patch from `lastSentContent` to `fullResponse`

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.test.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.test.ts
@@ -229,13 +229,17 @@ let mockStreamTextImpl:
   | ((options: Record<string, any>) => FakeStreamResult)
   | null = null;
 
-vi.mock("ai", () => ({
-  streamText: vi.fn((options: Record<string, any>) =>
-    mockStreamTextImpl ? mockStreamTextImpl(options) : mockStreamResult,
-  ),
-  stepCountIs: vi.fn((n: number) => ({ steps: n })),
-  hasToolCall: vi.fn((toolName: string) => ({ toolName })),
-}));
+vi.mock("ai", async () => {
+  const actual = await vi.importActual<typeof import("ai")>("ai");
+  return {
+    ...actual,
+    streamText: vi.fn((options: Record<string, any>) =>
+      mockStreamTextImpl ? mockStreamTextImpl(options) : mockStreamResult,
+    ),
+    stepCountIs: vi.fn((n: number) => ({ steps: n })),
+    hasToolCall: vi.fn((toolName: string) => ({ toolName })),
+  };
+});
 
 vi.mock("@/ipc/utils/get_model_client", () => ({
   getModelClient: vi.fn(async () => ({

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -37,7 +37,10 @@ import { getDyadAppPath } from "@/paths/paths";
 import { detectFrameworkType } from "@/ipc/utils/framework_utils";
 import { getModelClient } from "@/ipc/utils/get_model_client";
 import { safeSend } from "@/ipc/utils/safe_sender";
-import { cancelOrphanedBaseStream } from "@/ipc/utils/stream_text_utils";
+import {
+  cancelOrphanedBaseStream,
+  fastTextOutput,
+} from "@/ipc/utils/stream_text_utils";
 import { getMaxTokens, getTemperature } from "@/ipc/utils/token_utils";
 import {
   getProviderOptions,
@@ -905,6 +908,7 @@ export async function handleLocalAgentStream(
 
         try {
           const streamResult = streamText({
+            experimental_output: fastTextOutput(),
             model: modelClient.model,
             headers: {
               ...getAiHeaders({

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -908,7 +908,7 @@ export async function handleLocalAgentStream(
 
         try {
           const streamResult = streamText({
-            experimental_output: fastTextOutput(),
+            output: fastTextOutput(),
             model: modelClient.model,
             headers: {
               ...getAiHeaders({

--- a/src/pro/main/ipc/handlers/local_agent/mcp_auto_consent.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/mcp_auto_consent.spec.ts
@@ -5,7 +5,10 @@ const mocks = vi.hoisted(() => ({
   getModelClient: vi.fn(),
 }));
 
-vi.mock("ai", () => ({ streamText: mocks.streamText }));
+vi.mock("ai", async () => {
+  const actual = await vi.importActual<typeof import("ai")>("ai");
+  return { ...actual, streamText: mocks.streamText };
+});
 vi.mock("@/ipc/utils/get_model_client", () => ({
   getModelClient: mocks.getModelClient,
 }));

--- a/src/pro/main/ipc/handlers/local_agent/mcp_auto_consent.ts
+++ b/src/pro/main/ipc/handlers/local_agent/mcp_auto_consent.ts
@@ -5,6 +5,7 @@ import { getModelClient } from "@/ipc/utils/get_model_client";
 import type { LargeLanguageModel, UserSettings } from "@/lib/schemas";
 import { buildMcpConsentSystemPrompt } from "@/prompts/mcp_consent_policy";
 import type { McpAutoApproveResult } from "@/ipc/utils/mcp_consent";
+import { fastTextOutput } from "@/ipc/utils/stream_text_utils";
 import {
   formatRecentTurns,
   getRecentTurnsForConsent,
@@ -99,6 +100,7 @@ export async function classifyMcpToolConsent(
     );
 
     const stream = streamText({
+      experimental_output: fastTextOutput(),
       model: modelClient.model,
       system: buildMcpConsentSystemPrompt(),
       maxRetries: 1,

--- a/src/pro/main/ipc/handlers/local_agent/mcp_auto_consent.ts
+++ b/src/pro/main/ipc/handlers/local_agent/mcp_auto_consent.ts
@@ -100,7 +100,7 @@ export async function classifyMcpToolConsent(
     );
 
     const stream = streamText({
-      experimental_output: fastTextOutput(),
+      output: fastTextOutput(),
       model: modelClient.model,
       system: buildMcpConsentSystemPrompt(),
       maxRetries: 1,

--- a/src/pro/main/ipc/handlers/local_agent/tools/explore_code_subagent.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/explore_code_subagent.spec.ts
@@ -37,7 +37,6 @@ const mocks = vi.hoisted(() => ({
   getAiHeaders: vi.fn(),
   getProviderOptions: vi.fn(),
   cancelOrphanedBaseStream: vi.fn(),
-  fastTextOutput: vi.fn(),
   runRawExploreCode: vi.fn(),
 }));
 
@@ -67,10 +66,15 @@ vi.mock("@/ipc/utils/provider_options", () => ({
   getProviderOptions: mocks.getProviderOptions,
 }));
 
-vi.mock("@/ipc/utils/stream_text_utils", () => ({
-  cancelOrphanedBaseStream: mocks.cancelOrphanedBaseStream,
-  fastTextOutput: mocks.fastTextOutput,
-}));
+vi.mock("@/ipc/utils/stream_text_utils", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/ipc/utils/stream_text_utils")
+  >("@/ipc/utils/stream_text_utils");
+  return {
+    ...actual,
+    cancelOrphanedBaseStream: mocks.cancelOrphanedBaseStream,
+  };
+});
 
 vi.mock("./explore_code_raw", async () => {
   const actual =

--- a/src/pro/main/ipc/handlers/local_agent/tools/explore_code_subagent.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/explore_code_subagent.spec.ts
@@ -37,6 +37,7 @@ const mocks = vi.hoisted(() => ({
   getAiHeaders: vi.fn(),
   getProviderOptions: vi.fn(),
   cancelOrphanedBaseStream: vi.fn(),
+  fastTextOutput: vi.fn(),
   runRawExploreCode: vi.fn(),
 }));
 
@@ -68,6 +69,7 @@ vi.mock("@/ipc/utils/provider_options", () => ({
 
 vi.mock("@/ipc/utils/stream_text_utils", () => ({
   cancelOrphanedBaseStream: mocks.cancelOrphanedBaseStream,
+  fastTextOutput: mocks.fastTextOutput,
 }));
 
 vi.mock("./explore_code_raw", async () => {

--- a/src/pro/main/ipc/handlers/local_agent/tools/explore_code_subagent.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/explore_code_subagent.ts
@@ -151,7 +151,7 @@ export async function runExploreCodeSubagent({
 
   try {
     const streamResult = streamText({
-      experimental_output: fastTextOutput(),
+      output: fastTextOutput(),
       model: modelInfo.modelClient.model,
       headers: getAiHeaders({
         builtinProviderId: modelInfo.modelClient.builtinProviderId,

--- a/src/pro/main/ipc/handlers/local_agent/tools/explore_code_subagent.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/explore_code_subagent.ts
@@ -5,7 +5,10 @@ import { readSettings } from "@/main/settings";
 import { cleanMessage } from "@/ipc/utils/ai_messages_utils";
 import { getModelClient } from "@/ipc/utils/get_model_client";
 import { getAiHeaders, getProviderOptions } from "@/ipc/utils/provider_options";
-import { cancelOrphanedBaseStream } from "@/ipc/utils/stream_text_utils";
+import {
+  cancelOrphanedBaseStream,
+  fastTextOutput,
+} from "@/ipc/utils/stream_text_utils";
 import { getMaxTokens, getTemperature } from "@/ipc/utils/token_utils";
 import type { UserSettings } from "@/lib/schemas";
 import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
@@ -148,6 +151,7 @@ export async function runExploreCodeSubagent({
 
   try {
     const streamResult = streamText({
+      experimental_output: fastTextOutput(),
       model: modelInfo.modelClient.model,
       headers: getAiHeaders({
         builtinProviderId: modelInfo.modelClient.builtinProviderId,

--- a/src/pro/main/ipc/handlers/themes_handlers.ts
+++ b/src/pro/main/ipc/handlers/themes_handlers.ts
@@ -720,7 +720,7 @@ images: ${imagesPart}`;
         }
 
         const stream = streamText({
-          experimental_output: fastTextOutput(),
+          output: fastTextOutput(),
           model: modelClient.model,
           system: systemPrompt,
           maxRetries: 1,
@@ -960,7 +960,7 @@ source: Live website (screenshot and content provided)`;
 
       try {
         const stream = streamText({
-          experimental_output: fastTextOutput(),
+          output: fastTextOutput(),
           model: modelClient.model,
           system: systemPrompt,
           maxRetries: 1,

--- a/src/pro/main/ipc/handlers/themes_handlers.ts
+++ b/src/pro/main/ipc/handlers/themes_handlers.ts
@@ -12,7 +12,10 @@ import { streamText, TextPart, ImagePart } from "ai";
 import { readSettings } from "../../../../main/settings";
 import { IS_TEST_BUILD } from "@/ipc/utils/test_utils";
 import { getModelClient } from "../../../../ipc/utils/get_model_client";
-import { cancelOrphanedBaseStream } from "../../../../ipc/utils/stream_text_utils";
+import {
+  cancelOrphanedBaseStream,
+  fastTextOutput,
+} from "../../../../ipc/utils/stream_text_utils";
 import { v4 as uuidv4 } from "uuid";
 import type {
   SetAppThemeParams,
@@ -717,6 +720,7 @@ images: ${imagesPart}`;
         }
 
         const stream = streamText({
+          experimental_output: fastTextOutput(),
           model: modelClient.model,
           system: systemPrompt,
           maxRetries: 1,
@@ -956,6 +960,7 @@ source: Live website (screenshot and content provided)`;
 
       try {
         const stream = streamText({
+          experimental_output: fastTextOutput(),
           model: modelClient.model,
           system: systemPrompt,
           maxRetries: 1,


### PR DESCRIPTION
streamText's fullStream runs every text chunk through the SDK's output transform. With the default text output, that transform JSON.stringifies the entire response-so-far on each chunk to build a "partial output" stream: O(n) per chunk, so O(n^2) over a long response. We read fullStream directly and never use partialOutput, so on big multi-file generations this just pegs the main thread until the app freezes and the user force-kills it.

This PR swaps in a text output whose partial is the text length instead of the text: O(1), still changes every chunk so text keeps streaming, and the request to the model is unchanged. The SDK's accumulated text is append-only, so the length always grows and never repeats, and the transform buffers and flushes each chunk regardless, so no text is dropped. It's applied to every streamText call (chat, agent mode, and the rest); the cost only actually bites on large responses, but the change is free on small ones and leaves no gaps.

Measured by streaming a large (~10 MB, 300-file) response from the fake-llm server into a production build. A CPU profile of the main process showed the SDK output transform at ~88% of main-thread time before the fix and ~0 after; an event-loop-lag sampler (setInterval overshoot) dropped from multi-second blocks to under a second, and the response finishes instead of freezing.

This could instead be fixed upstream in the SDK (skip the work for text output, or only do it when the partial stream is consumed) rather than here; still unclear which path we'll take.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

