### PR TITLE
Clarify Supabase publishable key error

### DIFF
--- a/src/supabase_admin/supabase_context.ts
+++ b/src/supabase_admin/supabase_context.ts
@@ -45,7 +45,7 @@ async function getPublishableKey({
 
   if (!publishableKey) {
     throw new DyadError(
-      "No publishable key found for project. Make sure you are connected to the correct Supabase account and project. See https://dyad.sh/docs/integrations/supabase#no-publishable-keys",
+      "Dyad couldn't find a publishable key for this Supabase project. It may be paused or connected through the wrong Supabase account. Resume the project in Supabase, or reconnect the correct project in Dyad. See https://dyad.sh/docs/integrations/supabase#no-publishable-keys",
       DyadErrorKind.NotFound,
     );
   }


### PR DESCRIPTION
## Summary
- Mention paused Supabase projects as a likely reason Dyad cannot find a publishable key.
- Keep the existing account/project reconnect guidance and docs link.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change to a user-facing error string with no logic or API behavior changes.
> 
> **Overview**
> Updates the **NotFound** error when `getPublishableKey` cannot locate an anon/publishable key in Supabase API results. The message now names Dyad explicitly, calls out a **paused project** as a common cause, and tells users to resume in Supabase or reconnect the right project—while keeping the existing docs link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c91d0fe8542f2d828db59bcc14b5483f08ee1d98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

