### PR TITLE
Default Agent mode for non-Google providers

### DIFF
--- a/src/lib/chatMode.test.ts
+++ b/src/lib/chatMode.test.ts
@@ -73,7 +73,7 @@ describe("chat mode resolution", () => {
     ).toEqual({ mode: "build", fallbackReason: "quota-exhausted" });
   });
 
-  it("allows stored local-agent mode with a non-OpenAI/Anthropic provider", () => {
+  it("allows stored local-agent mode with Google/Gemini", () => {
     const settings = makeSettings({
       defaultChatMode: "build",
       providerSettings: {
@@ -91,7 +91,7 @@ describe("chat mode resolution", () => {
     ).toEqual({ mode: "local-agent" });
   });
 
-  it("allows stored local-agent mode with a non-OpenAI/Anthropic env var provider", () => {
+  it("allows stored local-agent mode with a non-Google env var provider", () => {
     const settings = makeSettings({ defaultChatMode: "build" });
 
     expect(
@@ -122,7 +122,7 @@ describe("chat mode resolution", () => {
     ).toEqual({ mode: "build", fallbackReason: "quota-exhausted" });
   });
 
-  it("does not auto-default to basic agent for non-OpenAI/Anthropic providers", () => {
+  it("does not auto-default to basic agent for Google/Gemini", () => {
     const settings = makeSettings({
       providerSettings: {
         google: { apiKey: { value: "test-key" } },
@@ -132,7 +132,54 @@ describe("chat mode resolution", () => {
     expect(getEffectiveDefaultChatMode(settings, {}, true)).toBe("build");
   });
 
-  it("does not honor a local-agent default for non-OpenAI/Anthropic providers", () => {
+  it("auto-defaults to basic agent for a non-Google provider", () => {
+    const settings = makeSettings({
+      providerSettings: {
+        openrouter: { apiKey: { value: "test-key" } },
+      },
+    });
+
+    expect(getEffectiveDefaultChatMode(settings, {}, true)).toBe("local-agent");
+  });
+
+  it("auto-defaults to basic agent for Vertex", () => {
+    const settings = makeSettings({
+      providerSettings: {
+        vertex: {
+          serviceAccountKey: { value: "test-key" },
+          projectId: "test-project",
+          location: "us-central1",
+        },
+      },
+    });
+
+    expect(getEffectiveDefaultChatMode(settings, {}, true)).toBe("local-agent");
+  });
+
+  it("auto-defaults to basic agent for a non-Google env var provider", () => {
+    const settings = makeSettings();
+
+    expect(
+      getEffectiveDefaultChatMode(
+        settings,
+        { OPENROUTER_API_KEY: "test-key" },
+        true,
+      ),
+    ).toBe("local-agent");
+  });
+
+  it("honors a local-agent default for a non-Google provider", () => {
+    const settings = makeSettings({
+      defaultChatMode: "local-agent",
+      providerSettings: {
+        openrouter: { apiKey: { value: "test-key" } },
+      },
+    });
+
+    expect(getEffectiveDefaultChatMode(settings, {}, true)).toBe("local-agent");
+  });
+
+  it("does not honor a local-agent default for Google/Gemini", () => {
     const settings = makeSettings({
       defaultChatMode: "local-agent",
       providerSettings: {

--- a/src/lib/providerUtils.ts
+++ b/src/lib/providerUtils.ts
@@ -80,17 +80,26 @@ export function isProviderSetup(
 }
 
 /**
- * Simple check for whether OpenAI or Anthropic provider is set up.
+ * Checks whether any non-Google provider is set up.
  * Used for determining if basic agent mode should be available.
  */
-export function isOpenAIOrAnthropicSetup(
+export function isNonGoogleProviderSetup(
   settings: UserSettings,
   envVars: Record<string, string | undefined>,
 ): boolean {
   if (!settings) return false;
 
   const options: ProviderCheckOptions = { settings, envVars };
-  return (
-    isProviderSetup("openai", options) || isProviderSetup("anthropic", options)
+  // Google/Gemini API keys are often free-tier keys with low rate limits, which
+  // makes users likely to hit errors in agent mode. Vertex is still eligible.
+  const excludedProviders = new Set(["auto", "google"]);
+  const configuredProviders = new Set([
+    ...Object.keys(settings.providerSettings ?? {}),
+    ...Object.keys(PROVIDER_TO_ENV_VAR),
+  ]);
+
+  return [...configuredProviders].some(
+    (provider) =>
+      !excludedProviders.has(provider) && isProviderSetup(provider, options),
   );
 }

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { isOpenAIOrAnthropicSetup } from "./providerUtils";
+import { isNonGoogleProviderSetup } from "./providerUtils";
 
 export const SecretSchema = z.object({
   value: z.string(),
@@ -486,11 +486,11 @@ export function shouldShowPnpmMinimumReleaseAgeWarning(
  * Gets the effective default chat mode based on settings, pro status, and free quota availability.
  * - If defaultChatMode is set and valid for the user's Pro status, use it
  * - If defaultChatMode is "local-agent" but user doesn't have Pro:
- *   - If free agent quota available AND OpenAI/Anthropic is set up, use "local-agent" (basic agent mode)
+ *   - If free agent quota available AND a non-Google provider is set up, use "local-agent" (basic agent mode)
  *   - Otherwise, fall back to "build"
  * - If defaultChatMode is NOT set:
  *   - Pro users: use "local-agent"
- *   - Non-Pro users with quota AND OpenAI/Anthropic set up: use "local-agent" (basic agent mode)
+ *   - Non-Pro users with quota AND a non-Google provider set up: use "local-agent" (basic agent mode)
  *   - Non-Pro users without quota or provider: use "build"
  */
 export function getEffectiveDefaultChatMode(
@@ -499,19 +499,17 @@ export function getEffectiveDefaultChatMode(
   freeAgentQuotaAvailable?: boolean,
 ): ChatMode {
   const isPro = isDyadProEnabled(settings);
-  // We are checking that OpenAI or Anthropic is setup, which are the first two
-  // choices for the Auto model selection.
-  //
-  // If user only has Gemini API key, we don't default to local-agent because
+  // If user only has a Google/Gemini API key, we don't default to local-agent because
   // most likely it's a free API key with stringent limits and they'll get
   // a bad experience with local-agent.
-  const hasPaidProviderSetup = isOpenAIOrAnthropicSetup(settings, envVars);
+  const hasNonGoogleProviderSetup = isNonGoogleProviderSetup(settings, envVars);
 
   if (settings.defaultChatMode) {
     // "local-agent" requires either Pro OR (available free quota AND provider setup)
     if (settings.defaultChatMode === "local-agent") {
       if (isPro) return "local-agent";
-      if (freeAgentQuotaAvailable && hasPaidProviderSetup) return "local-agent";
+      if (freeAgentQuotaAvailable && hasNonGoogleProviderSetup)
+        return "local-agent";
       return "build";
     }
     return settings.defaultChatMode;
@@ -519,7 +517,8 @@ export function getEffectiveDefaultChatMode(
 
   // No explicit default set
   if (isPro) return "local-agent";
-  if (freeAgentQuotaAvailable && hasPaidProviderSetup) return "local-agent";
+  if (freeAgentQuotaAvailable && hasNonGoogleProviderSetup)
+    return "local-agent";
   return "build";
 }
 


### PR DESCRIPTION
## Summary
- Allow Basic Agent to default on when any configured non-Google provider is available, while keeping Google/Gemini excluded because free API keys often hit low rate limits in Agent mode.
- Keep Vertex eligible and cover OpenRouter, env-var providers, Vertex, and Google fallback in chat mode tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default chat mode for many non-Pro users based on provider configuration; wrong exclusions could mis-route users to Build or Agent, but scope is limited to chat mode resolution with solid test coverage.
> 
> **Overview**
> **Basic Agent defaulting** now keys off *any* configured non-Google provider (OpenRouter, OpenAI, Anthropic, Vertex, env-var keys, etc.) instead of only OpenAI or Anthropic. **Google/Gemini API keys alone** no longer qualify, because free-tier Gemini limits often break Agent mode; **Vertex** still counts.
> 
> `isOpenAIOrAnthropicSetup` is replaced by `isNonGoogleProviderSetup`, which scans configured providers and env mappings and treats `auto` and `google` as excluded. `getEffectiveDefaultChatMode` uses that helper so non-Pro users with free agent quota default to `local-agent` when a qualifying provider exists, and fall back to `build` when only Google/Gemini is set up (including when `defaultChatMode` is `local-agent`).
> 
> Tests in `chatMode.test.ts` are renamed and expanded for Google vs non-Google, Vertex, OpenRouter, and env-var providers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d95a59f149c0a4b1f79a54178666550671c86dd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

