### PR TITLE
[codex] Fix Capacitor pnpm Corepack env

### DIFF
--- a/src/ipc/handlers/app_upgrade_handlers.ts
+++ b/src/ipc/handlers/app_upgrade_handlers.ts
@@ -14,6 +14,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { gitAddAll, gitCommit } from "../utils/git_utils";
 import { simpleSpawn } from "../utils/simpleSpawn";
+import { getPackageManagerCommandEnv } from "../utils/socket_firewall";
 
 export const logger = log.scope("app_upgrade_handlers");
 const handle = createLoggedHandler(logger);
@@ -90,6 +91,7 @@ async function applyCapacitor({
     command:
       "pnpm add --ignore-workspace-root-check @capacitor/core@7.4.4 @capacitor/cli@7.4.4 @capacitor/ios@7.4.4 @capacitor/android@7.4.4 || npm install @capacitor/core@7.4.4 @capacitor/cli@7.4.4 @capacitor/ios@7.4.4 @capacitor/android@7.4.4 --legacy-peer-deps",
     cwd: appPath,
+    env: getPackageManagerCommandEnv(),
     successMessage: "Capacitor dependencies installed successfully",
     errorPrefix: "Failed to install Capacitor dependencies",
   });
@@ -109,6 +111,7 @@ async function applyCapacitor({
     command:
       "pnpm install --prod=false || npm install --include=dev --legacy-peer-deps",
     cwd: appPath,
+    env: getPackageManagerCommandEnv(),
     successMessage: "Development dependencies installed successfully",
     errorPrefix: "Failed to install development dependencies",
   });


### PR DESCRIPTION
## Summary
- Pass Dyad's package-manager env into Capacitor upgrade dependency installs
- Prevent app-local package-manager pins from breaking pnpm add/install during the upgrade flow

## Validation
- npm run lint
- npm run ts
- pre-commit hook ran npm run ts

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to spawn env for an existing upgrade path; same pattern already used elsewhere in app upgrades.
> 
> **Overview**
> The Capacitor app upgrade now passes **`getPackageManagerCommandEnv()`** into the **`pnpm add`** and **`pnpm install`** **`simpleSpawn`** calls in **`applyCapacitor`**, aligning that flow with the component-tagger upgrade.
> 
> That env sets **`COREPACK_ENABLE_PROJECT_SPEC=0`** so app-local **`packageManager`** pins do not override Dyad’s pnpm/Corepack behavior during dependency installs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b108d1667a5afe93c1514d4e954089843fbb8e9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->