### PR TITLE
Open preview setup on chat submit

### DIFF
--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -112,6 +112,7 @@ import { useVoiceToText } from "@/hooks/useVoiceToText";
 import { isDyadProEnabled } from "@/lib/schemas";
 import { useChatMode } from "@/hooks/useChatMode";
 import { useInitialChatMode } from "@/hooks/useInitialChatMode";
+import { useOpenPreviewIfSetupRequired } from "@/hooks/useOpenPreviewIfSetupRequired";
 
 const showTokenBarAtom = atom(false);
 
@@ -144,6 +145,7 @@ export function ChatInput({ chatId }: { chatId?: number }) {
   const initialChatMode = useInitialChatMode();
   const appId = useAtomValue(selectedAppIdAtom);
   const { refreshVersions } = useVersions(appId);
+  const openPreviewIfSetupRequired = useOpenPreviewIfSetupRequired();
   const {
     streamMessage,
     isStreaming,
@@ -586,6 +588,7 @@ export function ChatInput({ chatId }: { chatId?: number }) {
       queryClient.invalidateQueries({ queryKey: queryKeys.chats.all });
       showInfo("We've switched you to a new chat for a clean context");
 
+      void openPreviewIfSetupRequired(appId);
       await streamMessage({
         prompt: promptWithImages,
         chatId: newChatId,
@@ -639,6 +642,7 @@ export function ChatInput({ chatId }: { chatId?: number }) {
     clearComposerAfterSubmit();
 
     // Send message with attachments and clear them after sending
+    void openPreviewIfSetupRequired(appId);
     await streamMessage({
       prompt: currentInput,
       chatId,

--- a/src/hooks/useOpenPreviewIfSetupRequired.test.tsx
+++ b/src/hooks/useOpenPreviewIfSetupRequired.test.tsx
@@ -1,0 +1,126 @@
+import { act, renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createStore, Provider } from "jotai";
+import type { PropsWithChildren } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { previewModeAtom } from "@/atoms/appAtoms";
+import { isPreviewOpenAtom } from "@/atoms/viewAtoms";
+import { useOpenPreviewIfSetupRequired } from "./useOpenPreviewIfSetupRequired";
+
+const mocks = vi.hoisted(() => ({
+  getNodejsStatus: vi.fn(),
+}));
+
+vi.mock("@/ipc/types", () => ({
+  ipc: {
+    system: {
+      getNodejsStatus: mocks.getNodejsStatus,
+    },
+  },
+}));
+
+describe("useOpenPreviewIfSetupRequired", () => {
+  beforeEach(() => {
+    mocks.getNodejsStatus.mockReset();
+  });
+
+  it("opens the preview panel when preview mode would show Node setup", async () => {
+    mocks.getNodejsStatus.mockResolvedValue({
+      nodeVersion: null,
+      pnpmVersion: null,
+      nodeDownloadUrl: "https://nodejs.org",
+    });
+    const { result, store } = renderUseOpenPreviewIfSetupRequired();
+
+    let opened = false;
+    await act(async () => {
+      opened = await result.current(1);
+    });
+
+    expect(opened).toBe(true);
+    expect(store.get(isPreviewOpenAtom)).toBe(true);
+  });
+
+  it("does not open the preview panel when Node is installed", async () => {
+    mocks.getNodejsStatus.mockResolvedValue({
+      nodeVersion: "v24.0.0",
+      pnpmVersion: "10.15.0",
+      nodeDownloadUrl: "https://nodejs.org",
+    });
+    const { result, store } = renderUseOpenPreviewIfSetupRequired();
+
+    let opened = true;
+    await act(async () => {
+      opened = await result.current(1);
+    });
+
+    expect(opened).toBe(false);
+    expect(store.get(isPreviewOpenAtom)).toBe(false);
+  });
+
+  it("does not open when the preview panel would show another mode", async () => {
+    const { result, store } = renderUseOpenPreviewIfSetupRequired({
+      previewMode: "code",
+    });
+
+    let opened = true;
+    await act(async () => {
+      opened = await result.current(1);
+    });
+
+    expect(opened).toBe(false);
+    expect(store.get(isPreviewOpenAtom)).toBe(false);
+    expect(mocks.getNodejsStatus).not.toHaveBeenCalled();
+  });
+
+  it("does not open on a refresh error when cached Node status is installed", async () => {
+    mocks.getNodejsStatus.mockRejectedValue(new Error("boom"));
+    const { result, store, queryClient } =
+      renderUseOpenPreviewIfSetupRequired();
+    queryClient.setQueryData(["system", "nodejsStatus"], {
+      nodeVersion: "v24.0.0",
+      pnpmVersion: "10.15.0",
+      nodeDownloadUrl: "https://nodejs.org",
+    });
+
+    let opened = true;
+    await act(async () => {
+      opened = await result.current(1);
+    });
+
+    expect(opened).toBe(false);
+    expect(store.get(isPreviewOpenAtom)).toBe(false);
+  });
+});
+
+function renderUseOpenPreviewIfSetupRequired({
+  previewMode = "preview",
+}: {
+  previewMode?: "preview" | "code";
+} = {}) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+  const store = createStore();
+  store.set(previewModeAtom, previewMode);
+  store.set(isPreviewOpenAtom, false);
+
+  function Wrapper({ children }: PropsWithChildren) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <Provider store={store}>{children}</Provider>
+      </QueryClientProvider>
+    );
+  }
+
+  return {
+    ...renderHook(() => useOpenPreviewIfSetupRequired(), { wrapper: Wrapper }),
+    queryClient,
+    store,
+  };
+}

--- a/src/hooks/useOpenPreviewIfSetupRequired.ts
+++ b/src/hooks/useOpenPreviewIfSetupRequired.ts
@@ -1,0 +1,50 @@
+import { useCallback } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useAtomValue, useSetAtom } from "jotai";
+
+import { previewModeAtom } from "@/atoms/appAtoms";
+import { isPreviewOpenAtom } from "@/atoms/viewAtoms";
+import { ipc } from "@/ipc/types";
+import type { NodeSystemInfo } from "@/ipc/types/system";
+import { queryKeys } from "@/lib/queryKeys";
+
+export function useOpenPreviewIfSetupRequired() {
+  const previewMode = useAtomValue(previewModeAtom);
+  const setIsPreviewOpen = useSetAtom(isPreviewOpenAtom);
+  const queryClient = useQueryClient();
+
+  return useCallback(
+    async (appId: number | null | undefined) => {
+      if (!appId || previewMode !== "preview") {
+        return false;
+      }
+
+      try {
+        const nodeSystemInfo = await queryClient.fetchQuery({
+          queryKey: queryKeys.system.nodejsStatus,
+          queryFn: () => ipc.system.getNodejsStatus(),
+        });
+
+        if (nodeSystemInfo.nodeVersion) {
+          return false;
+        }
+      } catch (error) {
+        const cachedNodeSystemInfo = queryClient.getQueryData<NodeSystemInfo>(
+          queryKeys.system.nodejsStatus,
+        );
+        if (cachedNodeSystemInfo?.nodeVersion) {
+          return false;
+        }
+
+        console.error(
+          "Failed to check Node.js status before opening preview setup:",
+          error,
+        );
+      }
+
+      setIsPreviewOpen(true);
+      return true;
+    },
+    [previewMode, queryClient, setIsPreviewOpen],
+  );
+}

--- a/src/pages/home.test.tsx
+++ b/src/pages/home.test.tsx
@@ -9,8 +9,10 @@ const mocks = vi.hoisted(() => ({
   createChat: vi.fn(),
   isAnyProviderSetup: false,
   isLoadingLanguageModelProviders: true,
+  openPreviewIfSetupRequired: vi.fn(),
   posthogCapture: vi.fn(),
   refreshApps: vi.fn(),
+  setAtom: vi.fn(),
   streamMessage: vi.fn(),
   updateSettings: vi.fn(),
 }));
@@ -18,7 +20,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock("jotai", async (importOriginal) => ({
   ...(await importOriginal<typeof import("jotai")>()),
   useAtom: () => ["Build a notes app", vi.fn()],
-  useSetAtom: () => vi.fn(),
+  useSetAtom: () => mocks.setAtom,
 }));
 
 vi.mock("posthog-js/react", () => ({
@@ -71,6 +73,10 @@ vi.mock("@/hooks/useFreeAgentQuota", () => ({
 
 vi.mock("@/hooks/useInitialChatMode", () => ({
   useInitialChatMode: () => "build",
+}));
+
+vi.mock("@/hooks/useOpenPreviewIfSetupRequired", () => ({
+  useOpenPreviewIfSetupRequired: () => mocks.openPreviewIfSetupRequired,
 }));
 
 vi.mock("@/hooks/useStreamChat", () => ({
@@ -153,7 +159,10 @@ describe("HomePage", () => {
     mocks.createApp.mockReset();
     mocks.createChat.mockReset();
     mocks.posthogCapture.mockReset();
+    mocks.openPreviewIfSetupRequired.mockReset();
+    mocks.openPreviewIfSetupRequired.mockResolvedValue(false);
     mocks.refreshApps.mockReset();
+    mocks.setAtom.mockReset();
     mocks.streamMessage.mockReset();
     mocks.updateSettings.mockReset();
     mocks.createApp.mockResolvedValue({
@@ -205,6 +214,27 @@ describe("HomePage", () => {
         prompt: "Build a notes app",
       }),
     );
+    expect(mocks.openPreviewIfSetupRequired).toHaveBeenCalledWith(1);
+    await waitFor(() => {
+      expect(mocks.setAtom).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it("keeps the preview panel open when setup was opened for the new app", async () => {
+    mocks.isAnyProviderSetup = true;
+    mocks.openPreviewIfSetupRequired.mockResolvedValue(true);
+
+    renderHomePage();
+
+    fireEvent.click(screen.getByRole("button", { name: "Submit home prompt" }));
+
+    await waitFor(() => {
+      expect(mocks.openPreviewIfSetupRequired).toHaveBeenCalledWith(1);
+    });
+    await waitFor(() => {
+      expect(mocks.streamMessage).toHaveBeenCalled();
+    });
+    expect(mocks.setAtom).not.toHaveBeenCalledWith(false);
   });
 });
 

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -31,6 +31,7 @@ import { getEffectiveDefaultChatMode } from "@/lib/schemas";
 import { useFreeAgentQuota } from "@/hooks/useFreeAgentQuota";
 import { useInitialChatMode } from "@/hooks/useInitialChatMode";
 import { useLanguageModelProviders } from "@/hooks/useLanguageModelProviders";
+import { useOpenPreviewIfSetupRequired } from "@/hooks/useOpenPreviewIfSetupRequired";
 import {
   Dialog,
   DialogContent,
@@ -65,6 +66,7 @@ export default function HomePage() {
   const initialChatMode = useInitialChatMode();
 
   const setIsPreviewOpen = useSetAtom(isPreviewOpenAtom);
+  const openPreviewIfSetupRequired = useOpenPreviewIfSetupRequired();
   const { selectChat } = useSelectChat();
   const [isLoading, setIsLoading] = useState(false);
   const [isAiSetupDialogOpen, setIsAiSetupDialogOpen] = useState(false);
@@ -204,6 +206,8 @@ export default function HomePage() {
         }
       }
 
+      const openedPreviewSetupPromise = openPreviewIfSetupRequired(appId);
+
       // Stream the message with attachments
       streamMessage({
         prompt: inputValue,
@@ -215,9 +219,12 @@ export default function HomePage() {
       await new Promise((resolve) =>
         setTimeout(resolve, settings?.isTestMode ? 0 : 2000),
       );
+      const openedPreviewSetup = await openedPreviewSetupPromise;
 
       setInputValue("");
-      setIsPreviewOpen(false);
+      if (!openedPreviewSetup) {
+        setIsPreviewOpen(false);
+      }
       await refreshApps();
       await invalidateAppQuery(queryClient, { appId });
       // Invalidate chats so ChatTabs picks up the new chat immediately.


### PR DESCRIPTION
## Summary
- Open the preview panel at submit time when the preview tab would show local setup, so users see the Node.js requirement immediately.
- Share the setup-detection logic between home/new-chat and existing chat submit flows while preserving the normal collapsed preview behavior otherwise.
- Cover the setup-open decision with focused hook and home submit tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only submit-time behavior using existing Node status IPC and preview atoms; no auth or data path changes.
> 
> **Overview**
> Adds **`useOpenPreviewIfSetupRequired`**, which opens the preview panel when the user is in preview mode and Node.js is missing (via `getNodejsStatus`, with a cache fallback on fetch errors). It is invoked on **home** and **chat** submit so the Node setup UI appears as soon as the user starts building, instead of staying hidden behind a collapsed panel.
> 
> **Home** now starts that check in parallel with streaming and only calls **`setIsPreviewOpen(false)`** after submit when setup was *not* opened—so the panel stays open when Node setup was shown. **ChatInput** fires the same check (fire-and-forget) on normal send and on the fresh-plan-chat path.
> 
> Tests cover the hook’s open/skip/error cases and home submit behavior when setup opens vs. when the panel should close.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e99378b3d24243e6bc9f74f44a3384a278cabc0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

