### PR TITLE
Redesign preview panel Node.js install state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,8 @@ Target a Vitest file with `npm test -- path/to/file.test.ts`. Do not pass Jest-o
 
 Package-local Vitest suites may use their own config and not match the root `npm test -- path` include globs. For example, run `npm --prefix packages/ts-pg-schema-diff test` and `npm --prefix packages/ts-pg-schema-diff run typecheck` for `packages/ts-pg-schema-diff`.
 
+If `npm test` fails in files unrelated to your change, verify the failure is pre-existing before debugging: `git worktree add /tmp/main-check main`, symlink the repo's `node_modules` into it, and run the failing test file there. If it also fails on clean main, note it in the PR summary and move on. (Known example: `src/ipc/handlers/app_collection_handlers.test.ts` failed on main as of 2026-07-01.)
+
 ### E2E testing
 
 > **IMPORTANT: You MUST run `npm run build` before running E2E tests.** E2E tests run against the built application, not the dev server. If you have changed any application code (i.e. anything outside of test files), you MUST re-run `npm run build` before running the tests, otherwise the tests will run against stale code and results will be misleading. Only changes to test code itself (e.g. files in `e2e-tests/`) do not require a rebuild.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,39 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+Non-technical builders: people with an app idea but no coding background, often coming from Lovable/v0/Bolt-style tools. They run Dyad locally on Mac or Windows and are frequently in their first hour of the product. They have never used a terminal, don't know what Node.js is, and interpret unexplained technical states as "it's broken." Secondary audience: semi-technical tinkerers who bring their own API keys and local models.
+
+## Product Purpose
+
+Dyad is a local, open-source AI app builder. Users describe an app in plain language; Dyad's AI generates the code and runs a live preview on their machine. Success = a first-time user goes from typed idea to seeing their working app preview with as few decisions, detours, and moments of doubt as possible. Local-first (fast, private, no lock-in) is the core differentiator; Dyad Pro is the monetization path but must never make the free/BYOK path feel second-class.
+
+## Brand Personality
+
+Calm and capable. Quiet confidence in the vein of Linear or Things: the UI gets out of the way, explains exactly what's happening in plain language, and reassures without cheerleading. Progress is acknowledged with restraint, not confetti. Technical necessities (Node.js, API keys, local servers) are framed as brief, guided steps toward the user's app — never as system errors or developer chores.
+
+## Anti-references
+
+- **Enterprise SaaS clutter**: stacked banners, persistent upsell chrome, dashboard-cliché card grids.
+- **Toy-like / gimmicky**: mascots, confetti, over-animated "delight" that undermines trust in a tool holding your project.
+- **Dev-tool austere**: raw terminal aesthetics, walls of monospace, intimidating error dumps shown to non-developers.
+- **Generic AI-startup gloss**: gradient text, decorative glassmorphism, purple-glow hero clichés.
+
+## Design Principles
+
+1. **Never a dead end.** Every state — loading, empty, missing dependency, failure — names what's happening and offers exactly one obvious next action. Silent no-ops are bugs.
+2. **Protect the moment of intent.** The user's idea (their prompt, their app) is the center of gravity; setup and system chores orbit it and resume it, never discard it.
+3. **Translate, don't expose.** Technical machinery (Node, PATH, providers, ports) is translated into user-goal language ("so Dyad can run your app's preview"), with detail available but never leading.
+4. **Calm confidence over persuasion.** One primary action per surface; upsells earn their place contextually and quietly.
+5. **Motion explains, chrome doesn't.** Use small, purposeful motion to show progress and state change; avoid decorative chrome that competes with the user's app.
+
+## Accessibility & Inclusion
+
+- Target WCAG 2.1 AA: body text ≥4.5:1 contrast in both light and dark themes.
+- Full keyboard operability for all setup/onboarding flows (they're modal-heavy).
+- `prefers-reduced-motion` alternatives for every animation.
+- UI strings localized via i18n (en, pt-BR, zh-CN today); avoid idioms that translate poorly.

--- a/rules/ui-styling.md
+++ b/rules/ui-styling.md
@@ -38,3 +38,9 @@ The project uses **Tailwind v4** (see `tailwindcss: ^4.x` in `package.json`). A 
 - **Arbitrary opacity values:** `bg-primary/8`, `text-muted-foreground/85` — any integer 0–100 works, not just the v3-canonical steps.
 - **Arbitrary widths/sizes:** `w-[17rem]`, `size-[3px]` — use these for fine-grained tweaks instead of inventing config values.
 - **`size-*` shorthand** sets both `width` and `height`.
+
+## Visually verifying component designs without launching Electron
+
+To screenshot a redesigned component without driving the full Electron app (which may require onboarding/app state to reach the surface): build a standalone HTML harness using `@tailwindcss/browser@4` (CDN) with the app's CSS variables copied from `src/styles/globals.css` (including the `.dark` block for dark-mode frames), then screenshot it with the repo's Playwright. Note: import Playwright by absolute path — `import { chromium } from "file:///<repo>/node_modules/playwright/index.mjs"` — because plain `import "playwright"` fails with `ERR_MODULE_NOT_FOUND` when the script lives outside the repo (ESM resolves from the script's location, not cwd).
+
+Related: `npm run start:onboarding` launches the real app with fresh userData and `DYAD_DEV_NODEJS_STATUS=missing` to reproduce first-run / Node-missing states.

--- a/src/components/preview_panel/PreviewPanel.test.tsx
+++ b/src/components/preview_panel/PreviewPanel.test.tsx
@@ -164,6 +164,23 @@ describe("PreviewPanel", () => {
     render(<PreviewPanel />);
 
     expect(screen.getByText("Preview iframe")).toBeTruthy();
-    expect(screen.queryByText("Node.js is required for preview")).toBeNull();
+    expect(
+      screen.queryByText("Install Node.js to see your preview"),
+    ).toBeNull();
+  });
+
+  it("shows the preview-stage setup and skips running the app when Node.js is missing", () => {
+    mocks.nodeVersion = "";
+
+    render(<PreviewPanel />);
+
+    expect(
+      screen.getByText("Install Node.js to see your preview"),
+    ).toBeTruthy();
+    expect(screen.getByText("Your app · localhost")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: /Install Node\.js/ }),
+    ).toBeTruthy();
+    expect(mocks.runApp).not.toHaveBeenCalled();
   });
 });

--- a/src/components/preview_panel/PreviewPanel.tsx
+++ b/src/components/preview_panel/PreviewPanel.tsx
@@ -16,11 +16,12 @@ import {
   ChevronUp,
   Download,
   FolderOpen,
+  Globe,
   Loader2,
   Logs,
   RefreshCw,
 } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { PanelGroup, Panel, PanelResizeHandle } from "react-resizable-panels";
 import { Console } from "./Console";
 import { useRunApp } from "@/hooks/useRunApp";
@@ -177,6 +178,7 @@ export function PreviewPanel() {
               <div className="flex-1 overflow-y-auto">
                 {isNodeMissing ? (
                   <PreviewNodeRequirement
+                    appName={app?.name}
                     nodeDownloadUrl={nodeSystemInfo?.nodeDownloadUrl}
                     isCheckFailed={nodeCheckFailed}
                     onCheckAgain={async () => {
@@ -245,12 +247,16 @@ export function PreviewPanel() {
   );
 }
 
+const NODE_POLL_INTERVAL_MS = 4000;
+
 function PreviewNodeRequirement({
+  appName,
   nodeDownloadUrl,
   isCheckFailed,
   onCheckAgain,
   onSelectNodeFolder,
 }: {
+  appName?: string;
   nodeDownloadUrl?: string;
   isCheckFailed: boolean;
   onCheckAgain: () => Promise<void>;
@@ -259,6 +265,27 @@ function PreviewNodeRequirement({
   const [isCheckingAgain, setIsCheckingAgain] = useState(false);
   const [isSelectingNodeFolder, setIsSelectingNodeFolder] = useState(false);
   const [hasOpenedInstaller, setHasOpenedInstaller] = useState(false);
+
+  // Quietly re-check for Node.js while this state is visible so the preview
+  // starts on its own the moment the installer finishes — no click required.
+  const checkAgainRef = useRef(onCheckAgain);
+  checkAgainRef.current = onCheckAgain;
+  const isPollInFlightRef = useRef(false);
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      if (isPollInFlightRef.current) {
+        return;
+      }
+      isPollInFlightRef.current = true;
+      void checkAgainRef
+        .current()
+        .catch(() => {})
+        .finally(() => {
+          isPollInFlightRef.current = false;
+        });
+    }, NODE_POLL_INTERVAL_MS);
+    return () => window.clearInterval(id);
+  }, []);
 
   const handleInstallNode = () => {
     if (nodeDownloadUrl) {
@@ -288,103 +315,131 @@ function PreviewNodeRequirement({
   };
 
   return (
-    <div className="flex h-full items-center justify-center bg-(--background-lighter) p-6">
-      <div className="w-full max-w-md rounded-xl border border-border bg-background p-6 text-center shadow-sm">
-        <div className="mx-auto flex size-12 items-center justify-center rounded-full bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300">
-          <AlertCircle className="size-6" />
-        </div>
-
-        <h3 className="mt-4 text-xl font-semibold tracking-tight text-foreground">
-          Node.js is required for preview
-        </h3>
-        <p className="mt-2 text-sm leading-6 text-muted-foreground">
-          Dyad needs Node.js to run your app locally. Install it once, then
-          return here to start the preview.
-        </p>
-
-        {isCheckFailed && (
-          <p className="mt-4 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-left text-sm text-amber-800 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-200">
-            Dyad could not check your Node.js setup.
-          </p>
-        )}
-
-        <div className="mt-6 space-y-2">
-          <Button
-            variant={hasOpenedInstaller ? "outline" : "default"}
-            className="h-11 w-full cursor-pointer"
-            onClick={handleInstallNode}
-            disabled={!nodeDownloadUrl}
-          >
-            <Download className="size-4" />
-            Install Node.js
-          </Button>
-          <div className="grid gap-2 sm:grid-cols-2">
-            <Button
-              variant="outline"
-              className={`h-10 cursor-pointer bg-background ${hasOpenedInstaller ? "sm:col-span-2" : ""}`}
-              onClick={handleSelectNodeFolder}
-              disabled={isSelectingNodeFolder}
-            >
-              {isSelectingNodeFolder ? (
-                <Loader2 className="size-4 animate-spin" />
-              ) : (
-                <FolderOpen className="size-4" />
-              )}
-              I already have it
-            </Button>
-            {!hasOpenedInstaller && (
-              <Button
-                variant="outline"
-                className="h-10 cursor-pointer bg-background"
-                onClick={handleCheckAgain}
-                disabled={isCheckingAgain}
-              >
-                {isCheckingAgain ? (
-                  <Loader2 className="size-4 animate-spin" />
-                ) : (
-                  <RefreshCw className="size-4" />
-                )}
-                Check again
-              </Button>
-            )}
+    <div className="flex min-h-full bg-(--background-lighter) p-4 sm:p-6">
+      <div className="relative flex min-h-[26rem] w-full flex-col overflow-hidden rounded-xl border border-border bg-background shadow-sm">
+        {/* Browser chrome: this panel IS their site's window, one step early */}
+        <div className="flex items-center gap-3 border-b border-border bg-(--background-lighter) px-4 py-2.5">
+          <div className="flex gap-1.5" aria-hidden="true">
+            <span className="size-2.5 rounded-full bg-red-400/70 dark:bg-red-400/50" />
+            <span className="size-2.5 rounded-full bg-amber-400/70 dark:bg-amber-400/50" />
+            <span className="size-2.5 rounded-full bg-green-400/70 dark:bg-green-400/50" />
           </div>
+          <div className="mx-auto flex h-7 w-full min-w-0 max-w-xs items-center justify-center gap-1.5 rounded-full bg-(--background-darker)/70 px-3">
+            <Globe className="size-3 shrink-0 text-muted-foreground" />
+            <span className="truncate text-xs text-muted-foreground">
+              {appName ? `${appName} · localhost` : "Your app · localhost"}
+            </span>
+          </div>
+          <div className="w-13 shrink-0" aria-hidden="true" />
         </div>
 
-        {hasOpenedInstaller && (
-          <div className="mt-4 rounded-lg border border-primary/25 bg-primary/8 px-4 py-4 text-left">
-            <div className="flex flex-col gap-4">
-              <div>
-                <span className="rounded-full bg-background px-2.5 py-1 text-xs font-semibold text-primary">
-                  Next step
-                </span>
-                <p className="mt-3 text-sm font-semibold text-foreground">
-                  Node.js downloaded
+        <div className="relative flex-1 overflow-hidden">
+          {/* Setup card, centered in the waiting browser window */}
+          <div className="absolute inset-0 flex items-center justify-center overflow-y-auto p-4">
+            <div className="w-full max-w-sm rounded-xl border border-border bg-(--background-lightest) p-5 text-center shadow-lg">
+              {hasOpenedInstaller ? (
+                <>
+                  <h3 className="text-lg font-semibold tracking-tight text-foreground">
+                    Finish the Node.js install
+                  </h3>
+                  <ol className="mx-auto mt-3 max-w-xs space-y-1.5 text-left text-sm leading-6 text-foreground/80">
+                    <li>1. Open the installer you just downloaded.</li>
+                    <li>2. Click through with the default settings.</li>
+                  </ol>
+                  {/* Live watching status while polling for the install */}
+                  <div className="mt-4 flex items-center justify-center gap-2.5 rounded-lg bg-(--background-lighter) px-3 py-2.5">
+                    <span
+                      className="relative flex size-2 shrink-0"
+                      aria-hidden="true"
+                    >
+                      <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary/50 [animation-duration:2.5s] motion-reduce:animate-none" />
+                      <span className="relative inline-flex size-2 rounded-full bg-primary" />
+                    </span>
+                    <p className="text-left text-xs leading-5 text-foreground/80">
+                      Watching for Node.js…
+                    </p>
+                  </div>
+                </>
+              ) : (
+                <>
+                  <h3 className="text-lg font-semibold tracking-tight text-foreground">
+                    Install Node.js to see your preview
+                  </h3>
+                  <p className="mt-2 text-sm leading-6 text-foreground/80">
+                    The free engine that runs your app on this computer. About
+                    two minutes to install.
+                  </p>
+                  <Button
+                    className="mt-4 h-10 w-full cursor-pointer"
+                    onClick={handleInstallNode}
+                    disabled={!nodeDownloadUrl}
+                  >
+                    <Download className="size-4" />
+                    Install Node.js
+                  </Button>
+                </>
+              )}
+
+              {isCheckFailed && (
+                <p className="mt-4 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-left text-sm text-amber-800 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-200">
+                  <AlertCircle className="mr-1.5 inline size-3.5 align-[-2px]" />
+                  Dyad couldn't check for Node.js. It will keep trying.
                 </p>
-                <ol className="mt-2 space-y-1 text-sm leading-5 text-muted-foreground">
-                  <li>1. Open the Node.js installer and finish setup.</li>
-                  <li>2. Return to Dyad and click the button.</li>
-                </ol>
+              )}
+
+              <div className="mt-4 flex items-center gap-1 border-t border-border pt-3">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 flex-1 cursor-pointer text-[13px] font-medium text-muted-foreground hover:text-foreground"
+                  onClick={handleSelectNodeFolder}
+                  disabled={isSelectingNodeFolder}
+                >
+                  {isSelectingNodeFolder ? (
+                    <Loader2 className="size-3.5 animate-spin" />
+                  ) : (
+                    <FolderOpen className="size-3.5" />
+                  )}
+                  I already have Node.js
+                </Button>
+                <div
+                  className="h-4 w-px shrink-0 bg-border"
+                  aria-hidden="true"
+                />
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 flex-1 cursor-pointer text-[13px] font-medium text-muted-foreground hover:text-foreground"
+                  onClick={handleCheckAgain}
+                  disabled={isCheckingAgain}
+                >
+                  {isCheckingAgain ? (
+                    <Loader2 className="size-3.5 animate-spin" />
+                  ) : (
+                    <RefreshCw className="size-3.5" />
+                  )}
+                  Check now
+                </Button>
               </div>
-              <Button
-                size="lg"
-                className="h-11 w-full cursor-pointer"
-                onClick={handleCheckAgain}
-                disabled={isCheckingAgain}
-              >
-                {isCheckingAgain ? (
-                  <Loader2 className="size-4 animate-spin" />
-                ) : (
-                  <RefreshCw className="size-4" />
-                )}
-                I installed Node.js
-              </Button>
+
+              {hasOpenedInstaller && (
+                <div className="mt-2 flex items-center justify-center text-xs">
+                  <button
+                    type="button"
+                    onClick={handleInstallNode}
+                    className="cursor-pointer font-medium text-muted-foreground transition-colors hover:text-primary hover:underline"
+                  >
+                    Reopen download page
+                  </button>
+                </div>
+              )}
+
+              <p className="mt-3 text-xs leading-5 text-muted-foreground">
+                You can install Node.js while your app is building.
+              </p>
             </div>
           </div>
-        )}
-
-        <p className="mt-5 text-xs leading-5 text-muted-foreground">
-          You can keep editing your app while Node.js installs.
-        </p>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Reframes the missing-Node.js preview state as the app's own browser window one step from loading (chrome + address bar with the app name), replacing the amber warning card — deliberately without a fake skeleton site, which was tried and cut for reading as noise, especially in dark mode.
- Polls Node.js status every 4s while the state is visible (reloadEnvPath + refetch), so the preview starts itself when the installer finishes; "Check now" and "I already have Node.js" remain as a quiet divided row for manual control.
- Copy is deliberately terse and action-first ("Install Node.js to see your preview"); the post-download state swaps to finish-the-installer steps with a live "Watching for Node.js…" indicator.
- Also adds PRODUCT.md capturing design context (audience, tone, anti-references) used to guide this and future UI work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Preview-only UX and polling behavior; no changes to auth-timestamp, auth, or data handling.
> 
> **Overview**
> **Redesigns the preview panel when Node.js is missing** so it reads as the user’s app window waiting to load (browser chrome + `{appName} · localhost` address bar) instead of a centered amber warning card. Copy is shorter and goal-oriented (“Install Node.js to see your preview”); after opening the installer it switches to finish-install steps with a **“Watching for Node.js…”** indicator.
> 
> **Adds automatic re-checking** every 4s while that state is visible (`reloadEnvPath` + refetch), so preview can start without a manual “I installed” click. **“I already have Node.js”** and **“Check now”** remain as a low-key divided row; check-failure messaging is softer and notes polling continues.
> 
> **Tests** assert the new copy, localhost chrome, install CTA, and that **`runApp` is not called** when Node is missing. **Docs:** new **`PRODUCT.md`** (audience, tone, design principles for this work); **`AGENTS.md`** tip for verifying unrelated test failures on clean main; **`rules/ui-styling.md`** harness for screenshotting components without Electron.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8b7bdc67b12a24a6cdac0f4496c286d24c838f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

