### PR TITLE
Validate provider API keys before saving

### DIFF
--- a/e2e-tests/dyad_pro_key_validation.spec.ts
+++ b/e2e-tests/dyad_pro_key_validation.spec.ts
@@ -1,0 +1,50 @@
+import { expect } from "@playwright/test";
+import { test, Timeout } from "./helpers/test_helper";
+
+// The Dyad engine (a LiteLLM proxy) reports invalid keys as an SSE error
+// event on an HTTP 200 response rather than an HTTP 401, so this covers the
+// in-stream error path of provider API key validation.
+test("Dyad Pro key is validated before saving", async ({ po }) => {
+  await po.navigation.goToSettingsTab();
+  await po.page
+    .locator("div")
+    .filter({ hasText: /^DyadNeeds Setup$/ })
+    .nth(1)
+    .click();
+
+  const keyInput = po.page.getByRole("textbox", { name: "Set Dyad API Key" });
+  await keyInput.fill("invalid-dyad-key");
+  await po.page.getByRole("button", { name: "Save Key" }).click();
+
+  const validationDialog = po.page.getByRole("alertdialog");
+  await expect(
+    validationDialog.getByRole("heading", { name: "API key check failed" }),
+  ).toBeVisible({ timeout: Timeout.MEDIUM });
+  await expect(
+    validationDialog.getByText(/Dyad rejected this API key/),
+  ).toBeVisible();
+  await validationDialog
+    .getByRole("button", { name: "Try another API key" })
+    .click();
+  await expect(validationDialog).toBeHidden({ timeout: Timeout.MEDIUM });
+
+  const settingsAfterRetry = po.settings.recordSettings() as {
+    providerSettings?: Record<string, unknown>;
+    enableDyadPro?: boolean;
+  };
+  expect(settingsAfterRetry.providerSettings?.auto).toBe(undefined);
+  expect(settingsAfterRetry.enableDyadPro).not.toBe(true);
+
+  await keyInput.fill("testdyadkey");
+  await po.page.getByRole("button", { name: "Save Key" }).click();
+
+  await expect(po.page.getByText("Current Key (Settings)")).toBeVisible({
+    timeout: Timeout.MEDIUM,
+  });
+  const settingsAfterSave = po.settings.recordSettings() as {
+    providerSettings?: Record<string, unknown>;
+    enableDyadPro?: boolean;
+  };
+  expect(settingsAfterSave.providerSettings?.auto).toBeDefined();
+  expect(settingsAfterSave.enableDyadPro).toBe(true);
+});

--- a/e2e-tests/setup_flow.spec.ts
+++ b/e2e-tests/setup_flow.spec.ts
@@ -16,14 +16,12 @@ testSetup.describe("Setup Flow", () => {
     const dialog = await openAiSetupDialog(po);
 
     await expect(
-      dialog.getByText("Dyad uses AI to build your app."),
+      dialog.getByText("Your prompt is saved — it'll send as soon as"),
     ).toBeVisible();
     await expect(
       dialog.getByRole("button", { name: /Start free Dyad Pro trial/ }),
     ).toBeVisible();
-    await expect(
-      dialog.getByRole("button", { name: "Google Gemini" }),
-    ).toBeVisible();
+    await expect(dialog.getByRole("button", { name: "Google" })).toBeVisible();
     await expect(
       dialog.getByRole("button", { name: "OpenRouter" }),
     ).toBeVisible();
@@ -40,7 +38,7 @@ testSetup.describe("Setup Flow", () => {
   testSetup("AI provider setup flow", async ({ po }) => {
     let dialog = await openAiSetupDialog(po);
 
-    await dialog.getByRole("button", { name: "Google Gemini" }).click();
+    await dialog.getByRole("button", { name: "Google" }).click();
     await expect(
       po.page.getByRole("heading", { name: "Configure Google" }),
     ).toBeVisible({ timeout: Timeout.MEDIUM });
@@ -73,7 +71,7 @@ testSetup.describe("Setup Flow", () => {
       const prompt = "Build a tiny habit tracker";
       const dialog = await openAiSetupDialog(po, prompt);
 
-      await dialog.getByRole("button", { name: "Google Gemini" }).click();
+      await dialog.getByRole("button", { name: "Google" }).click();
       await expect(
         po.page.getByRole("heading", { name: "Configure Google" }),
       ).toBeVisible({ timeout: Timeout.MEDIUM });
@@ -82,6 +80,43 @@ testSetup.describe("Setup Flow", () => {
         .getByPlaceholder(/Enter new Google API Key here/)
         .fill("test-google-key-12345");
       await po.page.getByRole("button", { name: "Save Key" }).click();
+      await expectGoogleApiKeySaved(po, "test-google-key-12345");
+
+      await expect(
+        po.page.getByTestId("messages-list").getByText(prompt),
+      ).toBeVisible({ timeout: Timeout.EXTRA_LONG });
+      await po.chatActions.waitForChatCompletion({
+        timeout: Timeout.EXTRA_LONG,
+      });
+      await expect(po.page.getByRole("dialog")).not.toBeVisible();
+      await expectSelectedApp(po);
+    },
+  );
+
+  testSetup(
+    "Google clipboard paste and save persists the key and resumes the pending first prompt",
+    async ({ po }) => {
+      await seedFakeModelSelection(po);
+      const prompt = "Build a tiny reading list";
+      const apiKey = "test-google-clipboard-key-12345";
+      const dialog = await openAiSetupDialog(po, prompt);
+
+      await dialog.getByRole("button", { name: "Google" }).click();
+      await expect(
+        po.page.getByRole("heading", { name: "Configure Google" }),
+      ).toBeVisible({ timeout: Timeout.MEDIUM });
+
+      await po.page
+        .context()
+        .grantPermissions(["clipboard-read", "clipboard-write"]);
+      await po.page.evaluate(
+        (key) => navigator.clipboard.writeText(key),
+        apiKey,
+      );
+      await po.page
+        .getByRole("button", { name: "Paste from clipboard and save" })
+        .click();
+      await expectGoogleApiKeySaved(po, apiKey);
 
       await expect(
         po.page.getByTestId("messages-list").getByText(prompt),
@@ -101,7 +136,7 @@ testSetup.describe("Setup Flow", () => {
       const prompt = "Build a tiny focus timer";
       const dialog = await openAiSetupDialog(po, prompt);
 
-      await dialog.getByRole("button", { name: "Google Gemini" }).click();
+      await dialog.getByRole("button", { name: "Google" }).click();
       await expect(
         po.page.getByRole("heading", { name: "Configure Google" }),
       ).toBeVisible({ timeout: Timeout.MEDIUM });
@@ -114,7 +149,7 @@ testSetup.describe("Setup Flow", () => {
       const validationDialog = po.page.getByRole("alertdialog");
       await expect(
         validationDialog.getByRole("heading", {
-          name: "API key check failed",
+          name: "API key rejected",
         }),
       ).toBeVisible({ timeout: Timeout.MEDIUM });
       await validationDialog
@@ -135,7 +170,7 @@ testSetup.describe("Setup Flow", () => {
       await po.page.getByRole("button", { name: "Test Key" }).click();
       await expect(
         validationDialog.getByRole("heading", {
-          name: "API key check failed",
+          name: "API key rejected",
         }),
       ).toBeVisible({ timeout: Timeout.MEDIUM });
       await expect(
@@ -151,7 +186,7 @@ testSetup.describe("Setup Flow", () => {
       await po.page.getByRole("button", { name: "Save Key" }).click();
       await expect(
         validationDialog.getByRole("heading", {
-          name: "API key check failed",
+          name: "API key rejected",
         }),
       ).toBeVisible({ timeout: Timeout.MEDIUM });
       await validationDialog
@@ -180,7 +215,7 @@ testSetup.describe("Setup Flow", () => {
         },
       });
 
-      await dialog.getByRole("button", { name: "Google Gemini" }).click();
+      await dialog.getByRole("button", { name: "Google" }).click();
       await expect(
         po.page.getByRole("heading", { name: "Configure Google" }),
       ).toBeVisible({ timeout: Timeout.MEDIUM });
@@ -237,6 +272,21 @@ async function expectSelectedApp(po: PageObject) {
       { timeout: Timeout.MEDIUM },
     )
     .not.toBe("");
+}
+
+async function expectGoogleApiKeySaved(po: PageObject, expectedApiKey: string) {
+  await expect
+    .poll(
+      async () => {
+        const settings = await po.page.evaluate(async () => {
+          const ipcRenderer = (window as any).electron.ipcRenderer;
+          return ipcRenderer.invoke("get-user-settings");
+        });
+        return settings.providerSettings?.google?.apiKey?.value;
+      },
+      { timeout: Timeout.MEDIUM },
+    )
+    .toBe(expectedApiKey);
 }
 
 async function seedFakeModelSelection(po: PageObject) {
@@ -307,9 +357,9 @@ async function openAiSetupDialog(
     .click();
 
   const dialog = po.page.getByRole("dialog");
-  await expect(dialog.getByText("Dyad uses AI to build your app.")).toBeVisible(
-    { timeout: Timeout.MEDIUM },
-  );
+  await expect(
+    dialog.getByText("Your prompt is saved — it'll send as soon as"),
+  ).toBeVisible({ timeout: Timeout.MEDIUM });
   return dialog;
 }
 

--- a/e2e-tests/setup_flow.spec.ts
+++ b/e2e-tests/setup_flow.spec.ts
@@ -95,6 +95,80 @@ testSetup.describe("Setup Flow", () => {
   );
 
   testSetup(
+    "invalid Google API key can be retried without saving or resuming",
+    async ({ po }) => {
+      await seedFakeModelSelection(po);
+      const prompt = "Build a tiny focus timer";
+      const dialog = await openAiSetupDialog(po, prompt);
+
+      await dialog.getByRole("button", { name: "Google Gemini" }).click();
+      await expect(
+        po.page.getByRole("heading", { name: "Configure Google" }),
+      ).toBeVisible({ timeout: Timeout.MEDIUM });
+
+      await po.page
+        .getByPlaceholder(/Enter new Google API Key here/)
+        .fill("invalid-google-key");
+      await po.page.getByRole("button", { name: "Save Key" }).click();
+
+      const validationDialog = po.page.getByRole("alertdialog");
+      await expect(
+        validationDialog.getByRole("heading", {
+          name: "API key check failed",
+        }),
+      ).toBeVisible({ timeout: Timeout.MEDIUM });
+      await validationDialog
+        .getByRole("button", { name: "Try another API key" })
+        .click();
+      await expect(validationDialog).toBeHidden({
+        timeout: Timeout.MEDIUM,
+      });
+
+      const settingsAfterRetry = po.settings.recordSettings() as {
+        providerSettings?: Record<string, unknown>;
+      };
+      expect(settingsAfterRetry.providerSettings?.google).toBe(undefined);
+      await expect(
+        po.page.getByRole("heading", { name: "Configure Google" }),
+      ).toBeVisible({ timeout: Timeout.MEDIUM });
+
+      await po.page.getByRole("button", { name: "Test Key" }).click();
+      await expect(
+        validationDialog.getByRole("heading", {
+          name: "API key check failed",
+        }),
+      ).toBeVisible({ timeout: Timeout.MEDIUM });
+      await expect(
+        validationDialog.getByRole("button", { name: "Keep invalid API key" }),
+      ).toBeHidden();
+      await validationDialog
+        .getByRole("button", { name: "Try another API key" })
+        .click();
+      await expect(validationDialog).toBeHidden({
+        timeout: Timeout.MEDIUM,
+      });
+
+      await po.page.getByRole("button", { name: "Save Key" }).click();
+      await expect(
+        validationDialog.getByRole("heading", {
+          name: "API key check failed",
+        }),
+      ).toBeVisible({ timeout: Timeout.MEDIUM });
+      await validationDialog
+        .getByRole("button", { name: "Keep invalid API key" })
+        .click();
+
+      await expect(
+        po.page.getByTestId("messages-list").getByText(prompt),
+      ).toBeVisible({ timeout: Timeout.EXTRA_LONG });
+      await po.chatActions.waitForChatCompletion({
+        timeout: Timeout.EXTRA_LONG,
+      });
+      await expectSelectedApp(po);
+    },
+  );
+
+  testSetup(
     "Google API key setup resumes an attachment-only first prompt",
     async ({ po }) => {
       await seedFakeModelSelection(po);

--- a/src/components/settings/ApiKeyConfiguration.test.tsx
+++ b/src/components/settings/ApiKeyConfiguration.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ApiKeyConfiguration } from "./ApiKeyConfiguration";
+
+function renderApiKeyConfiguration({
+  isSaving = false,
+  isTesting = false,
+}: {
+  isSaving?: boolean;
+  isTesting?: boolean;
+} = {}) {
+  return render(
+    <ApiKeyConfiguration
+      provider="google"
+      providerDisplayName="Google"
+      settings={
+        {
+          providerSettings: {
+            google: {
+              apiKey: { value: "test-google-key" },
+            },
+          },
+        } as any
+      }
+      envVars={{}}
+      envVarName="GOOGLE_API_KEY"
+      isSaving={isSaving}
+      isTesting={isTesting}
+      saveError={null}
+      testSuccessMessage={null}
+      apiKeyInput="new-google-key"
+      onApiKeyInputChange={vi.fn()}
+      onSaveKey={vi.fn()}
+      onTestKey={vi.fn()}
+      onDeleteKey={vi.fn()}
+      isDyad={false}
+      updateSettings={vi.fn()}
+    />,
+  );
+}
+
+describe("ApiKeyConfiguration", () => {
+  it("shows only the test button as testing during key tests", () => {
+    renderApiKeyConfiguration({ isTesting: true });
+
+    expect(
+      (screen.getByRole("button", { name: "Save Key" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+    expect(
+      (screen.getByRole("button", { name: "Testing..." }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+    expect(screen.queryByRole("button", { name: "Saving..." })).toBeNull();
+  });
+
+  it("shows only the save button as saving during key saves", () => {
+    renderApiKeyConfiguration({ isSaving: true });
+
+    expect(
+      (screen.getByRole("button", { name: "Saving..." }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+    expect(
+      (screen.getByRole("button", { name: "Test Key" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+    expect(screen.queryByRole("button", { name: "Testing..." })).toBeNull();
+  });
+});

--- a/src/components/settings/ApiKeyConfiguration.tsx
+++ b/src/components/settings/ApiKeyConfiguration.tsx
@@ -35,9 +35,11 @@ interface ApiKeyConfigurationProps {
   envVarName?: string;
   isSaving: boolean;
   saveError: string | null;
+  testSuccessMessage: string | null;
   apiKeyInput: string;
   onApiKeyInputChange: (value: string) => void;
   onSaveKey: (value: string) => Promise<void>;
+  onTestKey?: (value: string) => Promise<void>;
   onDeleteKey: () => Promise<void>;
   isDyad: boolean;
   updateSettings: (settings: Partial<UserSettings>) => Promise<UserSettings>;
@@ -51,9 +53,11 @@ export function ApiKeyConfiguration({
   envVarName,
   isSaving,
   saveError,
+  testSuccessMessage,
   apiKeyInput,
   onApiKeyInputChange,
   onSaveKey,
+  onTestKey,
   onDeleteKey,
   isDyad,
   updateSettings,
@@ -216,8 +220,23 @@ export function ApiKeyConfiguration({
               >
                 {isSaving ? "Saving..." : "Save Key"}
               </Button>
+              {onTestKey && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => onTestKey(apiKeyInput || userApiKey || "")}
+                  disabled={isSaving || (!apiKeyInput && !userApiKey)}
+                >
+                  {isSaving ? "Testing..." : "Test Key"}
+                </Button>
+              )}
             </div>
             {saveError && <p className="text-xs text-red-600">{saveError}</p>}
+            {testSuccessMessage && (
+              <p className="text-xs text-green-600 dark:text-green-400">
+                {testSuccessMessage}
+              </p>
+            )}
             <p className="text-xs text-gray-500 dark:text-gray-400">
               Setting a key here will override the environment variable (if
               set).

--- a/src/components/settings/ApiKeyConfiguration.tsx
+++ b/src/components/settings/ApiKeyConfiguration.tsx
@@ -34,6 +34,7 @@ interface ApiKeyConfigurationProps {
   envVars: Record<string, string | undefined>;
   envVarName?: string;
   isSaving: boolean;
+  isTesting: boolean;
   saveError: string | null;
   testSuccessMessage: string | null;
   apiKeyInput: string;
@@ -52,6 +53,7 @@ export function ApiKeyConfiguration({
   envVars,
   envVarName,
   isSaving,
+  isTesting,
   saveError,
   testSuccessMessage,
   apiKeyInput,
@@ -99,6 +101,7 @@ export function ApiKeyConfiguration({
     !userApiKey.startsWith("Invalid Key") &&
     userApiKey !== "Not Set";
   const hasEnvKey = !!envApiKey;
+  const isMutatingKey = isSaving || isTesting;
 
   const activeKeySource = isValidUserKey
     ? "settings"
@@ -137,7 +140,7 @@ export function ApiKeyConfiguration({
                   variant="destructive"
                   size="sm"
                   onClick={onDeleteKey}
-                  disabled={isSaving}
+                  disabled={isMutatingKey}
                   className="flex items-center gap-1 h-7 px-2"
                 >
                   <Trash2 className="h-4 w-4" />
@@ -205,7 +208,7 @@ export function ApiKeyConfiguration({
                     await handleSave(text);
                   }
                 }}
-                disabled={isSaving}
+                disabled={isMutatingKey}
                 variant="outline"
                 size="icon"
                 title="Paste from clipboard and save"
@@ -216,7 +219,7 @@ export function ApiKeyConfiguration({
 
               <Button
                 onClick={() => handleSave(apiKeyInput)}
-                disabled={isSaving || !apiKeyInput}
+                disabled={isMutatingKey || !apiKeyInput}
               >
                 {isSaving ? "Saving..." : "Save Key"}
               </Button>
@@ -225,9 +228,9 @@ export function ApiKeyConfiguration({
                   type="button"
                   variant="outline"
                   onClick={() => onTestKey(apiKeyInput || userApiKey || "")}
-                  disabled={isSaving || (!apiKeyInput && !userApiKey)}
+                  disabled={isMutatingKey || (!apiKeyInput && !userApiKey)}
                 >
-                  {isSaving ? "Testing..." : "Test Key"}
+                  {isTesting ? "Testing..." : "Test Key"}
                 </Button>
               )}
             </div>

--- a/src/components/settings/ProviderSettingsPage.test.tsx
+++ b/src/components/settings/ProviderSettingsPage.test.tsx
@@ -1,0 +1,149 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { PropsWithChildren } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DyadErrorKind } from "@/errors/dyad_error";
+import { ProviderSettingsPage } from "./ProviderSettingsPage";
+
+const mocks = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  routerBack: vi.fn(),
+  updateSettings: vi.fn(),
+  validateProviderApiKey: vi.fn(),
+  openExternalUrl: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => mocks.navigate,
+  useRouter: () => ({
+    history: {
+      length: 1,
+      back: mocks.routerBack,
+    },
+  }),
+}));
+
+vi.mock("@/hooks/useSettings", () => ({
+  useSettings: () => ({
+    settings: {
+      providerSettings: {},
+      enableDyadPro: false,
+    },
+    envVars: {},
+    loading: false,
+    error: null,
+    updateSettings: mocks.updateSettings,
+  }),
+}));
+
+vi.mock("@/hooks/useLanguageModelProviders", () => ({
+  useLanguageModelProviders: () => ({
+    data: [
+      {
+        id: "google",
+        name: "Google",
+        type: "local",
+        envVarName: "GOOGLE_API_KEY",
+      },
+    ],
+    isLoading: false,
+    error: null,
+    isAnyProviderSetup: () => false,
+  }),
+}));
+
+vi.mock("jotai", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("jotai")>()),
+  useAtomValue: () => false,
+}));
+
+vi.mock("@/ipc/types", () => ({
+  ipc: {
+    settings: {
+      validateProviderApiKey: mocks.validateProviderApiKey,
+    },
+    system: {
+      openExternalUrl: mocks.openExternalUrl,
+    },
+  },
+}));
+
+function validationError(message: string, kind: DyadErrorKind) {
+  return Object.assign(new Error(message), { kind });
+}
+
+function renderProviderSettingsPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+  const Wrapper = ({ children }: PropsWithChildren) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  return render(<ProviderSettingsPage provider="google" />, {
+    wrapper: Wrapper,
+  });
+}
+
+async function saveApiKey() {
+  fireEvent.change(screen.getByLabelText("Set Google API Key"), {
+    target: { value: "test-google-key" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: "Save Key" }));
+
+  await waitFor(() => {
+    expect(mocks.validateProviderApiKey).toHaveBeenCalledWith({
+      provider: "google",
+      apiKey: "test-google-key",
+    });
+  });
+}
+
+describe("ProviderSettingsPage", () => {
+  beforeEach(() => {
+    mocks.navigate.mockReset();
+    mocks.routerBack.mockReset();
+    mocks.updateSettings.mockReset();
+    mocks.validateProviderApiKey.mockReset();
+    mocks.openExternalUrl.mockReset();
+  });
+
+  it("titles auth validation errors as rejected API keys", async () => {
+    mocks.validateProviderApiKey.mockRejectedValue(
+      validationError("Google rejected this API key.", DyadErrorKind.Auth),
+    );
+
+    renderProviderSettingsPage();
+    await saveApiKey();
+
+    expect(await screen.findByText("API key rejected")).not.toBeNull();
+    expect(screen.queryByText("API key check failed")).toBeNull();
+  });
+
+  it.each([
+    [DyadErrorKind.RateLimited, "Google rate limited the API key check."],
+    [
+      DyadErrorKind.External,
+      "Google did not respond while checking this API key.",
+    ],
+  ])(
+    "titles %s validation errors as unverified API keys",
+    async (kind, message) => {
+      mocks.validateProviderApiKey.mockRejectedValue(
+        validationError(message, kind),
+      );
+
+      renderProviderSettingsPage();
+      await saveApiKey();
+
+      expect(
+        await screen.findByText("Could not verify API key"),
+      ).not.toBeNull();
+      expect(screen.queryByText("API key check failed")).toBeNull();
+    },
+  );
+});

--- a/src/components/settings/ProviderSettingsPage.tsx
+++ b/src/components/settings/ProviderSettingsPage.tsx
@@ -186,7 +186,7 @@ export function ProviderSettingsPage({ provider }: ProviderSettingsPageProps) {
     if (!normalizedValue) {
       return;
     }
-    setIsTesting(true);
+    setIsSaving(true);
     setSaveError(null);
     setTestSuccessMessage(null);
     try {
@@ -246,7 +246,7 @@ export function ProviderSettingsPage({ provider }: ProviderSettingsPageProps) {
       console.error("Error saving API key:", error);
       setSaveError(error.message || "Failed to save API key.");
     } finally {
-      setIsTesting(false);
+      setIsSaving(false);
     }
   };
 
@@ -260,7 +260,7 @@ export function ProviderSettingsPage({ provider }: ProviderSettingsPageProps) {
       return;
     }
 
-    setIsSaving(true);
+    setIsTesting(true);
     setSaveError(null);
     setTestSuccessMessage(null);
     try {
@@ -278,7 +278,7 @@ export function ProviderSettingsPage({ provider }: ProviderSettingsPageProps) {
         allowKeepInvalidKey: false,
       });
     } finally {
-      setIsSaving(false);
+      setIsTesting(false);
     }
   };
 

--- a/src/components/settings/ProviderSettingsPage.tsx
+++ b/src/components/settings/ProviderSettingsPage.tsx
@@ -88,6 +88,7 @@ export function ProviderSettingsPage({ provider }: ProviderSettingsPageProps) {
 
   const [apiKeyInput, setApiKeyInput] = useState("");
   const [isSaving, setIsSaving] = useState(false);
+  const [isTesting, setIsTesting] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [testSuccessMessage, setTestSuccessMessage] = useState<string | null>(
     null,
@@ -185,7 +186,7 @@ export function ProviderSettingsPage({ provider }: ProviderSettingsPageProps) {
     if (!normalizedValue) {
       return;
     }
-    setIsSaving(true);
+    setIsTesting(true);
     setSaveError(null);
     setTestSuccessMessage(null);
     try {
@@ -245,7 +246,7 @@ export function ProviderSettingsPage({ provider }: ProviderSettingsPageProps) {
       console.error("Error saving API key:", error);
       setSaveError(error.message || "Failed to save API key.");
     } finally {
-      setIsSaving(false);
+      setIsTesting(false);
     }
   };
 
@@ -484,6 +485,7 @@ export function ProviderSettingsPage({ provider }: ProviderSettingsPageProps) {
               envVars={envVars}
               envVarName={envVarName}
               isSaving={isSaving}
+              isTesting={isTesting}
               saveError={saveError}
               testSuccessMessage={testSuccessMessage}
               apiKeyInput={apiKeyInput}

--- a/src/components/settings/ProviderSettingsPage.tsx
+++ b/src/components/settings/ProviderSettingsPage.tsx
@@ -32,6 +32,7 @@ import {
   VertexProviderSetting,
   hasDyadProKey,
 } from "@/lib/schemas";
+import { DyadErrorKind } from "@/errors/dyad_error";
 import {
   findInvalidProviderApiKeyCharacter,
   formatInvalidProviderApiKeyMessage,
@@ -46,11 +47,37 @@ interface ProviderSettingsPageProps {
   provider: string;
 }
 
+type ApiKeyValidationDialogState = {
+  message: string;
+  apiKey: string;
+  allowKeepInvalidKey: boolean;
+  errorKind?: DyadErrorKind;
+};
+
 const VALIDATED_API_KEY_PROVIDERS = new Set<string>([
   "google",
   "openrouter",
   "auto",
 ]);
+
+function getErrorKind(error: unknown): DyadErrorKind | undefined {
+  const kind =
+    typeof error === "object" && error !== null
+      ? (error as { kind?: unknown }).kind
+      : undefined;
+  return typeof kind === "string" &&
+    Object.values(DyadErrorKind).includes(kind as DyadErrorKind)
+    ? (kind as DyadErrorKind)
+    : undefined;
+}
+
+function getApiKeyValidationDialogTitle(
+  dialog: ApiKeyValidationDialogState | null,
+) {
+  return dialog?.errorKind === DyadErrorKind.Auth
+    ? "API key rejected"
+    : "Could not verify API key";
+}
 
 export function ProviderSettingsPage({ provider }: ProviderSettingsPageProps) {
   const navigate = useNavigate();
@@ -93,11 +120,8 @@ export function ProviderSettingsPage({ provider }: ProviderSettingsPageProps) {
   const [testSuccessMessage, setTestSuccessMessage] = useState<string | null>(
     null,
   );
-  const [apiKeyValidationDialog, setApiKeyValidationDialog] = useState<{
-    message: string;
-    apiKey: string;
-    allowKeepInvalidKey: boolean;
-  } | null>(null);
+  const [apiKeyValidationDialog, setApiKeyValidationDialog] =
+    useState<ApiKeyValidationDialogState | null>(null);
   const [showStartBuildingBanner, setShowStartBuildingBanner] = useState(false);
   const queryClient = useQueryClient();
   const shouldResumeFirstPrompt = useAtomValue(pendingFirstPromptAtom);
@@ -203,6 +227,7 @@ export function ProviderSettingsPage({ provider }: ProviderSettingsPageProps) {
               `Dyad could not verify this ${providerDisplayName} API key.`,
             apiKey: normalizedValue,
             allowKeepInvalidKey: true,
+            errorKind: getErrorKind(error),
           });
           return;
         }
@@ -276,6 +301,7 @@ export function ProviderSettingsPage({ provider }: ProviderSettingsPageProps) {
           `Dyad could not verify this ${providerDisplayName} API key.`,
         apiKey: normalizedValue,
         allowKeepInvalidKey: false,
+        errorKind: getErrorKind(error),
       });
     } finally {
       setIsTesting(false);
@@ -401,7 +427,9 @@ export function ProviderSettingsPage({ provider }: ProviderSettingsPageProps) {
       >
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>API key check failed</AlertDialogTitle>
+            <AlertDialogTitle>
+              {getApiKeyValidationDialogTitle(apiKeyValidationDialog)}
+            </AlertDialogTitle>
             <AlertDialogDescription>
               {apiKeyValidationDialog?.message}
             </AlertDialogDescription>

--- a/src/components/settings/ProviderSettingsPage.tsx
+++ b/src/components/settings/ProviderSettingsPage.tsx
@@ -8,10 +8,21 @@ import { useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "@/lib/queryKeys";
 import { useAtomValue } from "jotai";
 import { pendingFirstPromptAtom } from "@/atoms/chatAtoms";
+import { ipc, type ProviderApiKeyValidationProvider } from "@/ipc/types";
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Skeleton } from "@/components/ui/skeleton";
 import {} from "@/components/ui/accordion";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 
 import { Switch } from "@/components/ui/switch";
 import { showError } from "@/lib/toast";
@@ -34,6 +45,12 @@ import { ModelsSection } from "./ModelsSection";
 interface ProviderSettingsPageProps {
   provider: string;
 }
+
+const VALIDATED_API_KEY_PROVIDERS = new Set<string>([
+  "google",
+  "openrouter",
+  "auto",
+]);
 
 export function ProviderSettingsPage({ provider }: ProviderSettingsPageProps) {
   const navigate = useNavigate();
@@ -72,6 +89,14 @@ export function ProviderSettingsPage({ provider }: ProviderSettingsPageProps) {
   const [apiKeyInput, setApiKeyInput] = useState("");
   const [isSaving, setIsSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
+  const [testSuccessMessage, setTestSuccessMessage] = useState<string | null>(
+    null,
+  );
+  const [apiKeyValidationDialog, setApiKeyValidationDialog] = useState<{
+    message: string;
+    apiKey: string;
+    allowKeepInvalidKey: boolean;
+  } | null>(null);
   const [showStartBuildingBanner, setShowStartBuildingBanner] = useState(false);
   const queryClient = useQueryClient();
   const shouldResumeFirstPrompt = useAtomValue(pendingFirstPromptAtom);
@@ -129,12 +154,13 @@ export function ProviderSettingsPage({ provider }: ProviderSettingsPageProps) {
         ? isVertexConfigured
         : isValidUserKey || hasEnvKey; // Configured if either is set
 
-  // --- Save Handler ---
-  const handleSaveKey = async (value: string) => {
+  const shouldValidateApiKey = VALIDATED_API_KEY_PROVIDERS.has(provider);
+
+  const normalizeAndValidateKeyInput = (value: string): string | null => {
     const normalizedValue = normalizeProviderApiKeyInput(value);
     if (!normalizedValue) {
       setSaveError("API Key cannot be empty.");
-      return;
+      return null;
     }
     const invalidCharacter =
       findInvalidProviderApiKeyCharacter(normalizedValue);
@@ -145,11 +171,42 @@ export function ProviderSettingsPage({ provider }: ProviderSettingsPageProps) {
           invalidCharacter,
         ),
       );
+      return null;
+    }
+    return normalizedValue;
+  };
+
+  // --- Save Handler ---
+  const handleSaveKey = async (
+    value: string,
+    options: { skipValidation?: boolean } = {},
+  ) => {
+    const normalizedValue = normalizeAndValidateKeyInput(value);
+    if (!normalizedValue) {
       return;
     }
     setIsSaving(true);
     setSaveError(null);
+    setTestSuccessMessage(null);
     try {
+      if (shouldValidateApiKey && !options.skipValidation) {
+        try {
+          await ipc.settings.validateProviderApiKey({
+            provider: provider as ProviderApiKeyValidationProvider,
+            apiKey: normalizedValue,
+          });
+        } catch (error: any) {
+          setApiKeyValidationDialog({
+            message:
+              error?.message ||
+              `Dyad could not verify this ${providerDisplayName} API key.`,
+            apiKey: normalizedValue,
+            allowKeepInvalidKey: true,
+          });
+          return;
+        }
+      }
+
       const isFirstProviderSetup = !isAnyProviderSetup();
       // Check if this is the first time user is setting up Dyad Pro
       const isNewDyadProSetup = isDyad && settings && !hasDyadProKey(settings);
@@ -187,6 +244,38 @@ export function ProviderSettingsPage({ provider }: ProviderSettingsPageProps) {
     } catch (error: any) {
       console.error("Error saving API key:", error);
       setSaveError(error.message || "Failed to save API key.");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleTestKey = async (value: string) => {
+    const normalizedValue = normalizeAndValidateKeyInput(value);
+    if (!normalizedValue) {
+      return;
+    }
+    if (!shouldValidateApiKey) {
+      setSaveError(`${providerDisplayName} API keys cannot be tested yet.`);
+      return;
+    }
+
+    setIsSaving(true);
+    setSaveError(null);
+    setTestSuccessMessage(null);
+    try {
+      await ipc.settings.validateProviderApiKey({
+        provider: provider as ProviderApiKeyValidationProvider,
+        apiKey: normalizedValue,
+      });
+      setTestSuccessMessage(`${providerDisplayName} API key looks good.`);
+    } catch (error: any) {
+      setApiKeyValidationDialog({
+        message:
+          error?.message ||
+          `Dyad could not verify this ${providerDisplayName} API key.`,
+        apiKey: normalizedValue,
+        allowKeepInvalidKey: false,
+      });
     } finally {
       setIsSaving(false);
     }
@@ -233,6 +322,9 @@ export function ProviderSettingsPage({ provider }: ProviderSettingsPageProps) {
   useEffect(() => {
     if (saveError) {
       setSaveError(null);
+    }
+    if (testSuccessMessage) {
+      setTestSuccessMessage(null);
     }
   }, [apiKeyInput]);
 
@@ -298,6 +390,43 @@ export function ProviderSettingsPage({ provider }: ProviderSettingsPageProps) {
 
   return (
     <div className="min-h-screen w-full">
+      <AlertDialog
+        open={!!apiKeyValidationDialog}
+        onOpenChange={(open) => {
+          if (!open) {
+            setApiKeyValidationDialog(null);
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>API key check failed</AlertDialogTitle>
+            <AlertDialogDescription>
+              {apiKeyValidationDialog?.message}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            {apiKeyValidationDialog?.allowKeepInvalidKey && (
+              <AlertDialogCancel
+                onClick={() => {
+                  const apiKey = apiKeyValidationDialog.apiKey;
+                  setApiKeyValidationDialog(null);
+                  void handleSaveKey(apiKey, { skipValidation: true });
+                }}
+              >
+                Keep invalid API key
+              </AlertDialogCancel>
+            )}
+            <AlertDialogAction
+              onClick={() => {
+                setApiKeyValidationDialog(null);
+              }}
+            >
+              Try another API key
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
       {shouldShowStartBuildingBanner && (
         <button
           type="button"
@@ -356,9 +485,11 @@ export function ProviderSettingsPage({ provider }: ProviderSettingsPageProps) {
               envVarName={envVarName}
               isSaving={isSaving}
               saveError={saveError}
+              testSuccessMessage={testSuccessMessage}
               apiKeyInput={apiKeyInput}
               onApiKeyInputChange={setApiKeyInput}
               onSaveKey={handleSaveKey}
+              onTestKey={shouldValidateApiKey ? handleTestKey : undefined}
               onDeleteKey={handleDeleteKey}
               isDyad={isDyad}
               updateSettings={updateSettings}

--- a/src/ipc/handlers/settings_handlers.ts
+++ b/src/ipc/handlers/settings_handlers.ts
@@ -1,6 +1,7 @@
 import { createTypedHandler } from "./base";
 import { settingsContracts } from "../types/settings";
 import { writeSettings, readEffectiveSettings } from "../../main/settings";
+import { validateProviderApiKey } from "../services/provider_api_key_validation_service";
 
 export function registerSettingsHandlers() {
   // Note: Settings handlers intentionally use createTypedHandler without logging
@@ -14,4 +15,11 @@ export function registerSettingsHandlers() {
     writeSettings(settings);
     return readEffectiveSettings();
   });
+
+  createTypedHandler(
+    settingsContracts.validateProviderApiKey,
+    async (_, params) => {
+      return validateProviderApiKey(params);
+    },
+  );
 }

--- a/src/ipc/services/provider_api_key_validation_service.ts
+++ b/src/ipc/services/provider_api_key_validation_service.ts
@@ -1,0 +1,228 @@
+import { createGoogleGenerativeAI as createGoogle } from "@ai-sdk/google";
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import { streamText, type LanguageModel } from "ai";
+import log from "electron-log";
+
+import { DyadError, DyadErrorKind, isDyadError } from "@/errors/dyad_error";
+import type { ProviderApiKeyValidationProvider } from "@/ipc/types";
+import { readEffectiveSettings } from "@/main/settings";
+import {
+  findInvalidProviderApiKeyCharacter,
+  formatInvalidProviderApiKeyMessage,
+  normalizeProviderApiKeyInput,
+} from "@/lib/providerApiKey";
+import type { UserSettings } from "@/lib/schemas";
+import { createDyadEngine } from "@/ipc/utils/llm_engine_provider";
+import { fastTextOutput } from "@/ipc/utils/stream_text_utils";
+import { IS_TEST_BUILD } from "@/ipc/utils/test_utils";
+
+const logger = log.scope("provider_api_key_validation");
+
+const VALIDATION_PROMPT =
+  "What number is after four? Reply with only the number.";
+const VALIDATION_TIMEOUT_MS = 20_000;
+
+const PROVIDER_DISPLAY_NAMES: Record<ProviderApiKeyValidationProvider, string> =
+  {
+    google: "Google",
+    openrouter: "OpenRouter",
+    auto: "Dyad",
+  };
+
+export async function validateProviderApiKey({
+  provider,
+  apiKey,
+}: {
+  provider: ProviderApiKeyValidationProvider;
+  apiKey: string;
+}): Promise<{ ok: true }> {
+  const normalizedApiKey = normalizeProviderApiKeyInput(apiKey);
+  const providerDisplayName = PROVIDER_DISPLAY_NAMES[provider];
+
+  if (!normalizedApiKey) {
+    throw new DyadError("API Key cannot be empty.", DyadErrorKind.Validation);
+  }
+
+  const invalidCharacter = findInvalidProviderApiKeyCharacter(normalizedApiKey);
+  if (invalidCharacter) {
+    throw new DyadError(
+      formatInvalidProviderApiKeyMessage(providerDisplayName, invalidCharacter),
+      DyadErrorKind.Validation,
+    );
+  }
+
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      controller.abort();
+      reject(
+        new DyadError(
+          `${providerDisplayName} did not respond while checking this API key. Please try again.`,
+          DyadErrorKind.External,
+        ),
+      );
+    }, VALIDATION_TIMEOUT_MS);
+  });
+
+  try {
+    const stream = streamText({
+      output: fastTextOutput(),
+      model: await createValidationModel(provider, normalizedApiKey),
+      maxOutputTokens: 8,
+      temperature: 0,
+      maxRetries: 0,
+      abortSignal: controller.signal,
+      messages: [{ role: "user", content: VALIDATION_PROMPT }],
+    });
+
+    const textPromise = Promise.resolve(stream.text);
+    textPromise.catch(() => {});
+    await Promise.race([textPromise, timeout]);
+    return { ok: true };
+  } catch (error) {
+    throw classifyValidationError(error, providerDisplayName);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
+async function createValidationModel(
+  provider: ProviderApiKeyValidationProvider,
+  apiKey: string,
+): Promise<LanguageModel> {
+  switch (provider) {
+    case "google": {
+      const google = createGoogle({
+        apiKey,
+        baseURL: getGoogleBaseUrl(),
+      });
+      return google("gemini-flash-latest");
+    }
+    case "openrouter": {
+      const openrouter = createOpenAICompatible({
+        name: "openrouter",
+        apiKey,
+        baseURL: getOpenRouterBaseUrl(),
+      });
+      return openrouter("openrouter/free");
+    }
+    case "auto": {
+      const settings = await readEffectiveSettings();
+      const dyad = createDyadEngine({
+        apiKey,
+        baseURL: getDyadEngineBaseUrl(),
+        dyadOptions: {
+          enableLazyEdits: false,
+          enableSmartFilesContext: false,
+          enableWebSearch: false,
+        },
+        settings: {
+          ...settings,
+          enableDyadPro: true,
+          providerSettings: {
+            ...settings.providerSettings,
+            auto: {
+              ...settings.providerSettings.auto,
+              apiKey: { value: apiKey },
+            },
+          },
+        } satisfies UserSettings,
+      });
+      return dyad("gemini/gemini-flash-latest", { providerId: "google" });
+    }
+  }
+}
+
+function getGoogleBaseUrl() {
+  if (IS_TEST_BUILD && process.env.FAKE_LLM_PORT) {
+    return `http://localhost:${process.env.FAKE_LLM_PORT}/google/v1beta`;
+  }
+  return undefined;
+}
+
+function getOpenRouterBaseUrl() {
+  if (IS_TEST_BUILD && process.env.FAKE_LLM_PORT) {
+    return `http://localhost:${process.env.FAKE_LLM_PORT}/openrouter/v1`;
+  }
+  return "https://openrouter.ai/api/v1";
+}
+
+function getDyadEngineBaseUrl() {
+  return process.env.DYAD_ENGINE_URL ?? "https://engine.dyad.sh/v1";
+}
+
+function classifyValidationError(
+  error: unknown,
+  providerDisplayName: string,
+): DyadError {
+  if (isDyadError(error)) {
+    return error;
+  }
+
+  const errorMessage = extractErrorMessage(error);
+  const statusCode = extractStatusCode(error);
+
+  logger.info(
+    `Validation failed for ${providerDisplayName}: status=${statusCode ?? "unknown"} message=${errorMessage}`,
+  );
+
+  if (statusCode === 401 || statusCode === 403 || isAuthError(errorMessage)) {
+    return new DyadError(
+      `${providerDisplayName} rejected this API key. Try another API key or keep this one anyway.`,
+      DyadErrorKind.Auth,
+    );
+  }
+
+  if (
+    statusCode === 429 ||
+    /rate.?limit|too many requests/i.test(errorMessage)
+  ) {
+    return new DyadError(
+      `${providerDisplayName} rate limited the API key check. You can try again later or keep this key anyway.`,
+      DyadErrorKind.RateLimited,
+    );
+  }
+
+  return new DyadError(
+    `Dyad could not verify this ${providerDisplayName} API key: ${errorMessage || "Unknown error"}`,
+    DyadErrorKind.External,
+  );
+}
+
+function extractErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  return String(error);
+}
+
+function extractStatusCode(error: unknown): number | undefined {
+  if (typeof error !== "object" || error === null) {
+    return undefined;
+  }
+
+  const candidate = error as {
+    statusCode?: unknown;
+    status?: unknown;
+    response?: { status?: unknown };
+    cause?: unknown;
+  };
+  const status =
+    candidate.statusCode ?? candidate.status ?? candidate.response?.status;
+  if (typeof status === "number") {
+    return status;
+  }
+  return extractStatusCode(candidate.cause);
+}
+
+function isAuthError(message: string) {
+  return /api key|unauthorized|unauthenticated|invalid.?key|permission denied|forbidden/i.test(
+    message,
+  );
+}

--- a/src/ipc/services/provider_api_key_validation_service.ts
+++ b/src/ipc/services/provider_api_key_validation_service.ts
@@ -125,7 +125,7 @@ async function createValidationModel(
           providerSettings: {
             ...settings.providerSettings,
             auto: {
-              ...settings.providerSettings.auto,
+              ...settings.providerSettings?.auto,
               apiKey: { value: apiKey },
             },
           },
@@ -166,7 +166,7 @@ function classifyValidationError(
   const statusCode = extractStatusCode(error);
 
   logger.info(
-    `Validation failed for ${providerDisplayName}: status=${statusCode ?? "unknown"} message=${errorMessage}`,
+    `Validation failed for ${providerDisplayName}: status=${statusCode ?? "unknown"} authError=${isAuthError(errorMessage)}`,
   );
 
   if (statusCode === 401 || statusCode === 403 || isAuthError(errorMessage)) {
@@ -202,8 +202,8 @@ function extractErrorMessage(error: unknown): string {
   return String(error);
 }
 
-function extractStatusCode(error: unknown): number | undefined {
-  if (typeof error !== "object" || error === null) {
+function extractStatusCode(error: unknown, depth = 0): number | undefined {
+  if (depth > 5 || typeof error !== "object" || error === null) {
     return undefined;
   }
 
@@ -218,7 +218,7 @@ function extractStatusCode(error: unknown): number | undefined {
   if (typeof status === "number") {
     return status;
   }
-  return extractStatusCode(candidate.cause);
+  return extractStatusCode(candidate.cause, depth + 1);
 }
 
 function isAuthError(message: string) {

--- a/src/ipc/services/provider_api_key_validation_service.ts
+++ b/src/ipc/services/provider_api_key_validation_service.ts
@@ -65,6 +65,14 @@ export async function validateProviderApiKey({
     }, VALIDATION_TIMEOUT_MS);
   });
 
+  // Some providers (e.g. the Dyad engine) report auth failures as an error
+  // event inside an HTTP 200 stream. streamText surfaces those through
+  // onError while its text promise resolves with empty text, so capture
+  // and re-throw them to fail validation. For HTTP-level failures the text
+  // promise rejects with a NoOutputGeneratedError wrapper while onError
+  // receives the underlying APICallError, so the captured error is also the
+  // better one to classify.
+  let streamError: unknown;
   try {
     const stream = streamText({
       output: fastTextOutput(),
@@ -73,15 +81,22 @@ export async function validateProviderApiKey({
       temperature: 0,
       maxRetries: 0,
       abortSignal: controller.signal,
+      onError: ({ error }) => {
+        streamError = error;
+      },
       messages: [{ role: "user", content: VALIDATION_PROMPT }],
     });
 
     const textPromise = Promise.resolve(stream.text);
     textPromise.catch(() => {});
     await Promise.race([textPromise, timeout]);
+    if (streamError !== undefined) {
+      throw streamError;
+    }
     return { ok: true };
   } catch (error) {
-    throw classifyValidationError(error, providerDisplayName);
+    const rootError = isDyadError(error) ? error : (streamError ?? error);
+    throw classifyValidationError(rootError, providerDisplayName);
   } finally {
     if (timer) {
       clearTimeout(timer);
@@ -131,7 +146,7 @@ async function createValidationModel(
           },
         } satisfies UserSettings,
       });
-      return dyad("gemini/gemini-flash-latest", { providerId: "google" });
+      return dyad("dyad/auto", { providerId: "openai" });
     }
   }
 }
@@ -163,7 +178,8 @@ function classifyValidationError(
   }
 
   const errorMessage = extractErrorMessage(error);
-  const statusCode = extractStatusCode(error);
+  const statusCode =
+    extractStatusCode(error) ?? extractStatusCodeFromMessage(errorMessage);
 
   logger.info(
     `Validation failed for ${providerDisplayName}: status=${statusCode ?? "unknown"} authError=${isAuthError(errorMessage)}`,
@@ -219,6 +235,14 @@ function extractStatusCode(error: unknown, depth = 0): number | undefined {
     return status;
   }
   return extractStatusCode(candidate.cause, depth + 1);
+}
+
+// Stream error events (e.g. from the Dyad engine's LiteLLM proxy) are plain
+// strings that lead with the upstream status code, like
+// "401 LiteLLM Virtual Key expected. ...".
+function extractStatusCodeFromMessage(message: string): number | undefined {
+  const match = /^\s*([45]\d{2})\b/.exec(message);
+  return match ? Number(match[1]) : undefined;
 }
 
 function isAuthError(message: string) {

--- a/src/ipc/shared/language_model_constants.ts
+++ b/src/ipc/shared/language_model_constants.ts
@@ -552,7 +552,7 @@ export const CLOUD_PROVIDERS: Record<
   google: {
     displayName: "Google",
     hasFreeTier: true,
-    websiteUrl: "https://aistudio.google.com/app/apikey",
+    websiteUrl: "https://aistudio.google.com/api-keys",
     gatewayPrefix: "gemini/",
   },
   vertex: {

--- a/src/ipc/types/index.ts
+++ b/src/ipc/types/index.ts
@@ -104,8 +104,11 @@ export { terminalClient } from "./terminal";
 export type {
   GetUserSettingsInput,
   GetUserSettingsOutput,
+  ProviderApiKeyValidationProvider,
   SetUserSettingsInput,
   SetUserSettingsOutput,
+  ValidateProviderApiKeyInput,
+  ValidateProviderApiKeyOutput,
 } from "./settings";
 
 // App types

--- a/src/ipc/types/settings.ts
+++ b/src/ipc/types/settings.ts
@@ -2,6 +2,12 @@ import { z } from "zod";
 import { defineContract, createClient } from "../contracts/core";
 import { UserSettingsSchema } from "../../lib/schemas";
 
+export const ProviderApiKeyValidationProviderSchema = z.enum([
+  "google",
+  "openrouter",
+  "auto",
+]);
+
 // =============================================================================
 // Settings Contracts
 // =============================================================================
@@ -29,6 +35,18 @@ export const settingsContracts = {
     channel: "set-user-settings",
     input: UserSettingsSchema.partial(),
     output: UserSettingsSchema,
+  }),
+
+  /**
+   * Validate a provider API key without saving it.
+   */
+  validateProviderApiKey: defineContract({
+    channel: "validate-provider-api-key",
+    input: z.object({
+      provider: ProviderApiKeyValidationProviderSchema,
+      apiKey: z.string(),
+    }),
+    output: z.object({ ok: z.literal(true) }),
   }),
 } as const;
 
@@ -68,4 +86,19 @@ export type SetUserSettingsInput = z.infer<
 /** Output type for setUserSettings */
 export type SetUserSettingsOutput = z.infer<
   (typeof settingsContracts)["setUserSettings"]["output"]
+>;
+
+/** Provider IDs supported by validateProviderApiKey */
+export type ProviderApiKeyValidationProvider = z.infer<
+  typeof ProviderApiKeyValidationProviderSchema
+>;
+
+/** Input type for validateProviderApiKey */
+export type ValidateProviderApiKeyInput = z.infer<
+  (typeof settingsContracts)["validateProviderApiKey"]["input"]
+>;
+
+/** Output type for validateProviderApiKey */
+export type ValidateProviderApiKeyOutput = z.infer<
+  (typeof settingsContracts)["validateProviderApiKey"]["output"]
 >;

--- a/src/main/pro.ts
+++ b/src/main/pro.ts
@@ -7,6 +7,10 @@ export function handleDyadProReturn({ apiKey }: { apiKey: string }) {
       ...settings.providerSettings,
       auto: {
         ...settings.providerSettings.auto,
+        // Do not validate keys returned by the Dyad Pro deeplink. The purchase
+        // return path is critical, returned keys are very unlikely to be
+        // invalid, and any future outage/regression in API key validation would
+        // otherwise block users immediately after checkout.
         apiKey: {
           value: apiKey,
         },

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -301,6 +301,12 @@ export default function HomePage() {
 
   const hasAttemptedAutoResumeRef = useRef(false);
   useEffect(() => {
+    if (!shouldResumeFirstPrompt) {
+      hasAttemptedAutoResumeRef.current = false;
+    }
+  }, [shouldResumeFirstPrompt]);
+
+  useEffect(() => {
     if (
       !shouldResumeFirstPrompt ||
       isLoadingLanguageModelProviders ||

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -330,6 +330,10 @@ export default function HomePage() {
         setPendingAttachments([]);
         setPendingSelectedApp(null);
       }
+      // Intentionally do not re-arm on failure: handleSubmit already surfaces
+      // an error toast, and re-arming would re-fire this effect immediately
+      // (inputValue and shouldResumeFirstPrompt are still set), causing an
+      // infinite retry loop. The user can retry manually from the input.
     })();
   }, [
     handleSubmit,

--- a/testing/fake-llm-server/chatCompletionHandler.ts
+++ b/testing/fake-llm-server/chatCompletionHandler.ts
@@ -14,6 +14,11 @@ import {
 
 let globalCounter = 0;
 
+function hasInvalidApiKey(req: Request): boolean {
+  const authorization = req.headers.authorization;
+  return typeof authorization === "string" && /invalid/i.test(authorization);
+}
+
 function hasExploreCodeToolResult(
   messages: any[],
   getTextContent: (msg: any) => string,
@@ -122,6 +127,17 @@ export const createChatCompletionHandler =
   (prefix: string) => async (req: Request, res: Response) => {
     const { stream = false, messages = [] } = req.body;
     console.log("* Received messages", messages);
+
+    if (hasInvalidApiKey(req)) {
+      return res.status(401).json({
+        error: {
+          message: "Invalid API key",
+          type: "authentication_error",
+          param: null,
+          code: "invalid_api_key",
+        },
+      });
+    }
 
     // Check if the last message contains "[429]" to simulate rate limiting
     const lastMessage = messages[messages.length - 1];

--- a/testing/fake-llm-server/chatCompletionHandler.ts
+++ b/testing/fake-llm-server/chatCompletionHandler.ts
@@ -129,6 +129,25 @@ export const createChatCompletionHandler =
     console.log("* Received messages", messages);
 
     if (hasInvalidApiKey(req)) {
+      // The Dyad engine (a LiteLLM proxy) reports auth failures as an SSE
+      // error event on an HTTP 200 response rather than an HTTP 401.
+      if (prefix === "engine") {
+        res.setHeader("Content-Type", "text/event-stream; charset=utf-8");
+        res.setHeader("Cache-Control", "no-cache");
+        res.write(
+          `event: error\ndata: ${JSON.stringify({
+            error: {
+              message:
+                "401 LiteLLM Virtual Key expected. Received=inva****-key, expected to start with 'sk-'.",
+              type: "server_error",
+              param: null,
+            },
+          })}\n\n`,
+        );
+        res.write("data: [DONE]\n\n");
+        res.end();
+        return;
+      }
       return res.status(401).json({
         error: {
           message: "Invalid API key",

--- a/testing/fake-llm-server/index.ts
+++ b/testing/fake-llm-server/index.ts
@@ -487,18 +487,70 @@ app.get("/lmstudio/api/v0/models", (req, res) => {
   res.json(lmStudioModels);
 });
 
-["lmstudio", "gateway", "engine", "ollama", "azure"].forEach((provider) => {
-  app.post(
-    `/${provider}/v1/chat/completions`,
-    createChatCompletionHandler(provider),
-  );
-  // Also add responses API endpoints for each provider
-  app.post(`/${provider}/v1/responses`, createResponsesHandler(provider));
-  app.post(
-    `/${provider}/v1/messages`,
-    createAnthropicMessagesHandler(provider),
-  );
-});
+app.post(
+  /^\/google\/v1beta\/models\/.+:(streamGenerateContent|generateContent)/,
+  (req, res) => {
+    const apiKeyHeader = req.headers["x-goog-api-key"];
+    const apiKey =
+      typeof apiKeyHeader === "string"
+        ? apiKeyHeader
+        : Array.isArray(apiKeyHeader)
+          ? apiKeyHeader.join(",")
+          : "";
+
+    if (/invalid/i.test(apiKey)) {
+      return res.status(401).json({
+        error: {
+          code: 401,
+          message: "Invalid API key",
+          status: "UNAUTHENTICATED",
+        },
+      });
+    }
+
+    const response = {
+      candidates: [
+        {
+          content: {
+            role: "model",
+            parts: [{ text: "5" }],
+          },
+          finishReason: "STOP",
+        },
+      ],
+      usageMetadata: {
+        promptTokenCount: 8,
+        candidatesTokenCount: 1,
+        totalTokenCount: 9,
+      },
+    };
+
+    if (req.path.includes("streamGenerateContent")) {
+      res.setHeader("Content-Type", "text/event-stream; charset=utf-8");
+      res.setHeader("Cache-Control", "no-cache");
+      res.write(`data: ${JSON.stringify(response)}\n\n`);
+      res.end();
+      return;
+    }
+
+    res.json(response);
+  },
+);
+
+["lmstudio", "gateway", "engine", "ollama", "azure", "openrouter"].forEach(
+  (provider) => {
+    app.post(
+      `/${provider}/v1/chat/completions`,
+      createChatCompletionHandler(provider),
+    );
+    // Also add responses API endpoints for each provider
+    app.post(`/${provider}/v1/responses`, createResponsesHandler(provider));
+    app.post(
+      `/${provider}/v1/messages`,
+      createAnthropicMessagesHandler(provider),
+    );
+  },
+);
 
 // Azure-specific endpoints (Azure client uses different URL patterns)
 app.post("/azure/chat/completions", createChatCompletionHandler("azure"));


### PR DESCRIPTION
## Summary
- Validates Google, OpenRouter, and Dyad keys with a tiny streamed model request before settings are written.
- Keeps failed keys out of settings unless the user explicitly chooses to keep them, preserving the first-prompt setup resume boundary.
- Covers the failure and override path in setup-flow E2E using fake provider responses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches provider credential save paths and outbound validation calls; misclassification or blocking validation could prevent setup, though deeplink bypass and optional keep-invalid mitigate Dyad Pro and transient failures.
> 
> **Overview**
> Saving or testing **Google**, **OpenRouter**, or **Dyad** keys now runs a small streamed model request via new IPC `validateProviderApiKey` before settings are written. Failed checks open an alert dialog (**API key rejected** vs **Could not verify API key**) with **Try another API key**; on **Save**, users can **Keep invalid API key** to persist anyway (not offered for **Test Key**).
> 
> Provider settings UI adds **Test Key**, shared save/test loading states, and success messaging. **Dyad Pro** checkout deeplink keys still save without validation so checkout is not blocked by validation outages.
> 
> First-prompt auto-resume on home resets its one-shot guard when the pending flag clears, avoiding stuck or looped retries. Setup E2E tests cover invalid keys, clipboard paste, and updated setup copy; the fake LLM server simulates Google and engine SSE auth errors for validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c75e147c73c5721b1582032368afb300460145ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

