### PR TITLE
Polish AI setup flow on home page

### DIFF
--- a/src/components/ProBanner.tsx
+++ b/src/components/ProBanner.tsx
@@ -59,7 +59,7 @@ export function SetupDyadProButton() {
   return (
     <button
       type="button"
-      className="inline-flex cursor-pointer items-center gap-1.5 text-sm font-medium text-muted-foreground transition-colors hover:text-primary hover:underline"
+      className="inline-flex cursor-pointer items-center gap-1.5 text-xs font-medium text-muted-foreground transition-colors hover:text-primary hover:underline"
       onClick={() => {
         ipc.system.openExternalUrl("https://academy.dyad.sh/settings");
       }}

--- a/src/components/SetupBanner.tsx
+++ b/src/components/SetupBanner.tsx
@@ -1,6 +1,14 @@
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "@tanstack/react-router";
-import { ChevronRight, GiftIcon, Play, Settings } from "lucide-react";
+import { useAtomValue } from "jotai";
+import {
+  CircleCheck,
+  ChevronRight,
+  GiftIcon,
+  Play,
+  Settings,
+} from "lucide-react";
+import { pendingFirstPromptAtom } from "@/atoms/chatAtoms";
 import { providerSettingsRoute } from "@/routes/settings/providers/$provider";
 import { SECTION_IDS } from "@/lib/settingsSearchIndex";
 
@@ -28,6 +36,7 @@ export function SetupBanner({
   const { t } = useTranslation("home");
   const posthog = usePostHog();
   const navigate = useNavigate();
+  const hasPendingPrompt = useAtomValue(pendingFirstPromptAtom);
   const { isAnyProviderSetup, isLoading: loading } =
     useLanguageModelProviders();
 
@@ -98,6 +107,12 @@ export function SetupBanner({
             Dyad uses AI to build your app. Choose one option now; you can
             change it later.
           </p>
+          {variant === "dialog" && hasPendingPrompt && (
+            <p className="mt-2 flex items-center justify-center gap-1.5 text-sm text-muted-foreground">
+              <CircleCheck aria-hidden="true" className="size-4 text-primary" />
+              Your prompt is saved and will be sent as soon as you're connected.
+            </p>
+          )}
         </div>
 
         <button
@@ -130,16 +145,18 @@ export function SetupBanner({
 
         <div className="mt-4">
           <p className="mb-2 text-sm font-medium text-muted-foreground">
-            Prefer your own key?
+            Prefer your own key? Google and OpenRouter offer free API keys.
           </p>
           <div className="grid gap-2 sm:grid-cols-3">
             <ProviderOptionButton
-              label="Google Gemini"
+              label="Google"
+              chip="Free"
               onClick={handleGoogleSetupClick}
               icon={<img src={googleIcon} alt="Google" className="size-4" />}
             />
             <ProviderOptionButton
               label="OpenRouter"
+              chip="Free"
               onClick={handleOpenRouterSetupClick}
               icon={
                 <img src={openrouterLogo} alt="OpenRouter" className="size-4" />
@@ -181,10 +198,12 @@ export function SetupBanner({
 function ProviderOptionButton({
   label,
   icon,
+  chip,
   onClick,
 }: {
   label: string;
   icon: React.ReactNode;
+  chip?: string;
   onClick: () => void;
 }) {
   return (
@@ -199,7 +218,13 @@ function ProviderOptionButton({
         </span>
         <span className="truncate">{label}</span>
       </span>
-      <ChevronRight className="size-4 shrink-0 text-muted-foreground" />
+      {chip ? (
+        <span className="shrink-0 rounded-full border border-emerald-600/25 bg-emerald-500/10 px-1.5 py-px text-[11px] font-semibold text-emerald-700 dark:border-emerald-400/25 dark:text-emerald-300">
+          {chip}
+        </span>
+      ) : (
+        <ChevronRight className="size-4 shrink-0 text-muted-foreground" />
+      )}
     </button>
   );
 }

--- a/src/components/SetupBanner.tsx
+++ b/src/components/SetupBanner.tsx
@@ -103,14 +103,17 @@ export function SetupBanner({
               ? "You're almost ready to build"
               : "Connect AI to start building"}
           </h2>
-          <p className="mt-2 text-sm leading-6 text-muted-foreground">
-            Dyad uses AI to build your app. Choose one option now; you can
-            change it later.
-          </p>
-          {variant === "dialog" && hasPendingPrompt && (
-            <p className="mt-2 flex items-center justify-center gap-1.5 text-sm text-muted-foreground">
-              <CircleCheck aria-hidden="true" className="size-4 text-primary" />
-              Your prompt is saved and will be sent as soon as you're connected.
+          {variant === "dialog" && hasPendingPrompt ? (
+            <p className="mt-2 flex items-center justify-center gap-1.5 text-sm leading-6 text-muted-foreground">
+              <CircleCheck
+                aria-hidden="true"
+                className="size-4 shrink-0 text-primary"
+              />
+              Your prompt is saved — it'll send as soon as you're connected.
+            </p>
+          ) : (
+            <p className="mt-2 text-sm leading-6 text-muted-foreground">
+              Dyad uses AI to build your app.
             </p>
           )}
         </div>
@@ -125,14 +128,9 @@ export function SetupBanner({
               <img src={logo} alt="Dyad Logo" className="size-6" />
             </div>
             <div className="min-w-0">
-              <div className="flex flex-wrap items-center gap-2">
-                <h3 className="text-lg font-semibold text-primary">
-                  Start free Dyad Pro trial
-                </h3>
-                <span className="rounded-full border border-primary/20 bg-primary/10 px-2 py-0.5 text-xs font-semibold text-primary">
-                  Recommended
-                </span>
-              </div>
+              <h3 className="text-lg font-semibold text-primary">
+                Start free Dyad Pro trial
+              </h3>
               <p className="mt-0.5 text-sm text-muted-foreground">
                 No API keys. Access leading models instantly.
               </p>
@@ -145,7 +143,7 @@ export function SetupBanner({
 
         <div className="mt-4">
           <p className="mb-2 text-sm font-medium text-muted-foreground">
-            Prefer your own key? Google and OpenRouter offer free API keys.
+            Or use your own API key
           </p>
           <div className="grid gap-2 sm:grid-cols-3">
             <ProviderOptionButton
@@ -159,7 +157,11 @@ export function SetupBanner({
               chip="Free"
               onClick={handleOpenRouterSetupClick}
               icon={
-                <img src={openrouterLogo} alt="OpenRouter" className="size-4" />
+                <img
+                  src={openrouterLogo}
+                  alt="OpenRouter"
+                  className="size-4 dark:invert"
+                />
               }
             />
             <ProviderOptionButton
@@ -170,7 +172,7 @@ export function SetupBanner({
           </div>
         </div>
 
-        <div className="mt-4 flex w-full flex-col items-center justify-around gap-2 text-sm sm:flex-row">
+        <div className="mt-4 flex w-full flex-col items-center justify-around gap-2 text-xs sm:flex-row">
           <SetupDyadProButton />
           <button
             type="button"
@@ -181,10 +183,10 @@ export function SetupBanner({
             }}
             className="inline-flex cursor-pointer items-center gap-1.5 font-medium text-muted-foreground transition-colors hover:text-primary hover:underline"
           >
-            <span className="inline-flex h-4 w-5 items-center justify-center rounded-[4px] bg-red-600 text-white">
+            <span className="inline-flex h-3.5 w-4 items-center justify-center rounded-[3px] bg-red-600 text-white">
               <Play
                 aria-hidden="true"
-                className="ml-0.5 size-2.5 fill-current stroke-current"
+                className="ml-0.5 size-2 fill-current stroke-current"
               />
             </span>
             Watch the walkthrough
@@ -249,7 +251,11 @@ export const OpenRouterSetupBanner = ({
       }}
       tabIndex={0}
       leadingIcon={
-        <img src={openrouterLogo} alt="OpenRouter" className="w-4 h-4" />
+        <img
+          src={openrouterLogo}
+          alt="OpenRouter"
+          className="w-4 h-4 dark:invert"
+        />
       }
       title="Setup OpenRouter API Key"
       chip={

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -44,13 +44,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { RefreshCw } from "lucide-react";
-
-const ideaChipStyles = [
-  "border-violet-200/80 bg-violet-50/70 text-violet-950 hover:border-violet-300 hover:bg-violet-100/80 dark:border-violet-800/60 dark:bg-violet-950/30 dark:text-violet-100 dark:hover:bg-violet-900/40",
-  "border-sky-200/80 bg-sky-50/70 text-sky-950 hover:border-sky-300 hover:bg-sky-100/80 dark:border-sky-800/60 dark:bg-sky-950/30 dark:text-sky-100 dark:hover:bg-sky-900/40",
-  "border-emerald-200/80 bg-emerald-50/70 text-emerald-950 hover:border-emerald-300 hover:bg-emerald-100/80 dark:border-emerald-800/60 dark:bg-emerald-950/30 dark:text-emerald-100 dark:hover:bg-emerald-900/40",
-] as const;
+import { RefreshCw, X, Zap } from "lucide-react";
 
 // Adding an export for attachments
 export interface HomeSubmitOptions {
@@ -87,6 +81,7 @@ export default function HomePage() {
   const { selectChat } = useSelectChat();
   const [isLoading, setIsLoading] = useState(false);
   const [isAiSetupDialogOpen, setIsAiSetupDialogOpen] = useState(false);
+  const [isSetupPillDismissed, setIsSetupPillDismissed] = useState(false);
   const [
     shouldOpenAiSetupDialogWhenProvidersLoad,
     setShouldOpenAiSetupDialogWhenProvidersLoad,
@@ -401,34 +396,55 @@ export default function HomePage() {
           </div>
           <HomeChatInput onSubmit={handleSubmit} />
 
-          <div className="flex flex-col gap-4 mt-2">
-            <div className="flex flex-wrap gap-4 justify-center">
-              {randomPrompts.map((item, index) => (
-                <button
-                  type="button"
-                  key={item.label}
-                  onClick={() => setInputValue(item.prompt)}
-                  className={`group flex min-w-[13.5rem] max-w-[17rem] flex-1 items-center gap-3 rounded-2xl border px-4 py-3 text-left shadow-sm backdrop-blur-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md active:scale-[0.98] sm:flex-none ${ideaChipStyles[index % ideaChipStyles.length]}`}
-                >
-                  <span className="flex size-9 shrink-0 items-center justify-center rounded-xl bg-white/70 shadow-xs transition-transform duration-200 group-hover:scale-105 dark:bg-white/10">
-                    {item.icon}
-                  </span>
-                  <span className="min-w-0">
-                    <span className="block text-sm font-semibold leading-5">
-                      {item.label}
-                    </span>
-                    <span className="mt-0.5 block truncate text-xs opacity-70">
-                      Try this idea
-                    </span>
-                  </span>
-                </button>
-              ))}
-            </div>
+          {!isSetupPillDismissed &&
+            !isLoadingLanguageModelProviders &&
+            !isAnyProviderSetup() && (
+              <div className="mt-3 flex justify-center">
+                <div className="flex items-center gap-0.5 rounded-full border border-primary/25 bg-primary/5 py-0.5 pl-3 pr-0.5">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      posthog.capture("home:setup-pill:click");
+                      openAiSetupDialog();
+                    }}
+                    className="flex cursor-pointer items-center gap-1.5 py-1 text-sm font-medium text-primary transition-colors hover:underline"
+                  >
+                    <Zap aria-hidden="true" className="size-3.5" />
+                    Connect AI to build — takes a minute
+                  </button>
+                  <button
+                    type="button"
+                    aria-label="Dismiss"
+                    onClick={() => {
+                      posthog.capture("home:setup-pill:dismiss");
+                      setIsSetupPillDismissed(true);
+                    }}
+                    className="flex size-6 cursor-pointer items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-primary/10 hover:text-foreground"
+                  >
+                    <X aria-hidden="true" className="size-3.5" />
+                  </button>
+                </div>
+              </div>
+            )}
 
+          <div className="mt-4 flex flex-wrap justify-center gap-2">
+            {randomPrompts.map((item) => (
+              <button
+                type="button"
+                key={item.label}
+                onClick={() => setInputValue(item.prompt)}
+                className="flex cursor-pointer items-center gap-2 rounded-full border border-border bg-background px-3.5 py-1.5 text-sm text-muted-foreground transition-colors hover:border-primary/30 hover:bg-accent hover:text-foreground"
+              >
+                <span aria-hidden="true" className="[&_svg]:size-4">
+                  {item.icon}
+                </span>
+                {item.label}
+              </button>
+            ))}
             <button
               type="button"
               onClick={() => setRandomPrompts(getRandomPrompts())}
-              className="group self-center flex items-center gap-2 rounded-full border border-border bg-background/70 px-4 py-2 text-sm font-medium text-muted-foreground backdrop-blur-sm transition-all duration-200 hover:border-primary/30 hover:bg-background hover:text-primary hover:shadow-sm active:scale-[0.98]"
+              className="group flex cursor-pointer items-center gap-2 rounded-full border border-border bg-background px-3.5 py-1.5 text-sm text-muted-foreground transition-colors hover:border-primary/30 hover:bg-accent hover:text-foreground"
             >
               <RefreshCw className="size-4 transition-transform duration-200 group-hover:rotate-[-25deg]" />
               {t("moreIdeas")}


### PR DESCRIPTION
## Summary

- **SetupBanner**: Google and OpenRouter options now show a green **Free** chip, and the section copy tells users they can get a free API key ("Prefer your own key? Google and OpenRouter offer free API keys."). The chip replaces the chevron on those two buttons so labels don't truncate at dialog width; "Google Gemini" shortened to "Google" to match the copy.
- **SetupBanner (dialog)**: when a prompt is pending, the dialog reassures users their prompt isn't lost: "✓ Your prompt is saved and will be sent as soon as you're connected." Gated on `pendingFirstPromptAtom`, so it only appears when there's actually a saved prompt.
- **Home page**: a dismissible pill under the chat input ("⚡ Connect AI to build — takes a minute") lets proactive users start setup before writing a prompt, and gives users who dismissed the dialog a way back that isn't "submit again and get modal-ed". Shown only when no provider is configured; dismissal is session-local. Click/dismiss emit PostHog events.
- **Home page**: inspiration prompt cards simplified to subtle neutral pills — removed the colored card styles and "Try this idea" filler text; "More ideas" now sits inline as a matching pill.

## Screenshots

Verified against a packaged build with a fresh user-data dir (no providers configured), light and dark mode: home page pill + subtle idea chips, setup dialog with Free chips and prompt-saved reassurance, pill dismissal.

## Test plan

- `npm run ts` and `npm run lint` pass
- Manually drove the packaged app via Playwright: pill appears without providers, opens the setup dialog preserving the typed prompt, reassurance line shows only when a prompt is pending, pill dismisses cleanly
- No e2e snapshots or locale files reference the changed strings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI copy and styling only; setup navigation and existing `pendingFirstPromptAtom` resume flow are unchanged aside from new PostHog events.
> 
> **Overview**
> Polishes the **home AI setup** experience with clearer provider options, reassurance when a first prompt is queued, and a lighter inspiration row.
> 
> **Setup dialog (`SetupBanner`)** shows a **CircleCheck** line when `pendingFirstPromptAtom` is set in dialog mode (“Your prompt is saved…”). Google/OpenRouter rows get optional **Free** chips instead of chevrons; labels tighten (e.g. **Google**), copy shifts to “Or use your own API key”, and the Dyad Pro block drops the **Recommended** badge. OpenRouter icons use **`dark:invert`** in the banner and `OpenRouterSetupBanner`; footer links use slightly smaller type.
> 
> **Home** adds a **dismissible pill** under the chat input when no provider is configured—it opens the same setup dialog (PostHog `home:setup-pill:click` / `dismiss`) and respects session-local dismissal. **Inspiration prompts** move from colored cards to neutral rounded pills; **More ideas** matches that row.
> 
> **`SetupDyadProButton`** uses **`text-xs`** for consistency with the setup footer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f9352a8ddb802de4fb22d1c2c9d44740b65a413. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

