### PR TITLE
feat(tabs): make group by app a sticky mode

### DIFF
--- a/e2e-tests/chat_tabs.spec.ts
+++ b/e2e-tests/chat_tabs.spec.ts
@@ -268,6 +268,72 @@ test("right-click context menu: Reopen closed tab", async ({ po }) => {
   }).toPass({ timeout: Timeout.MEDIUM });
 });
 
+test("group by app: new chat joins its app's group (grouping sticks)", async ({
+  po,
+}) => {
+  await po.setUp({ autoApprove: true });
+
+  // Imported apps are named after their fixture folder (see import_handlers).
+  const appA = "minimal";
+  const appB = "minimal-with-dyad";
+
+  // Reads the app-name line (top line of each tab) in left-to-right order.
+  const readTabAppNames = async () => {
+    const tabs = po.page.locator("div[draggable]");
+    const count = await tabs.count();
+    const names: string[] = [];
+    for (let i = 0; i < count; i++) {
+      const name = await tabs
+        .nth(i)
+        .locator("button")
+        .first()
+        .locator("span")
+        .first()
+        .innerText();
+      names.push(name.trim());
+    }
+    return names;
+  };
+
+  // App A + one chat.
+  await po.importApp(appA);
+  await po.sendPrompt("[dump] app A first chat");
+  await po.chatActions.waitForChatCompletion();
+
+  // App B + one chat. Tabs now span two apps.
+  await po.navigation.goToAppsTab();
+  await po.page.getByRole("button", { name: "New App" }).click();
+  await po.importApp(appB);
+  await po.sendPrompt("[dump] app B first chat");
+  await po.chatActions.waitForChatCompletion();
+
+  const closeButtons = po.page.getByLabel(/^Close tab:/);
+  await expect(async () => {
+    expect(await closeButtons.count()).toBe(2);
+  }).toPass({ timeout: Timeout.MEDIUM });
+
+  // Enable "Group tabs by app" from a tab's context menu.
+  const tabs = po.page.locator("div[draggable]");
+  await tabs.first().click({ button: "right" });
+  await po.page.getByText("Group tabs by app").click();
+  await po.page.keyboard.press("Escape");
+
+  // Switch back to App A and open a NEW chat there.
+  await po.appManagement.clickAppListItem({ appName: appA });
+  await po.appManagement.clickOpenInChatButton();
+  await po.chatActions.clickNewChat();
+  await po.sendPrompt("[dump] app A second chat");
+  await po.chatActions.waitForChatCompletion();
+
+  // Grouping sticks: the new App A chat slots into App A's existing group rather
+  // than landing alone at the front. App A's two tabs stay contiguous, ahead of
+  // App B's tab — i.e. [A, A, B], not the ungrouped [A, B, A].
+  await expect(async () => {
+    const names = await readTabAppNames();
+    expect(names).toEqual([appA, appA, appB]);
+  }).toPass({ timeout: Timeout.MEDIUM });
+});
+
 test("only shows tabs for chats opened in current session", async ({ po }) => {
   await po.setUp({ autoApprove: true });
   await po.importApp("minimal");

--- a/src/atoms/chatAtoms.ts
+++ b/src/atoms/chatAtoms.ts
@@ -134,6 +134,16 @@ export const chatTabSessionStorageAtom = atomWithStorage<ChatTabSession>(
   { getOnInit: true },
 );
 
+// When enabled, tabs are kept grouped by app on every render (a live layout),
+// so newly opened chats automatically slot into their app's group. Turned off
+// as soon as the user manually reorders tabs via drag.
+export const groupTabsByAppAtom = atomWithStorage<boolean>(
+  "group-tabs-by-app",
+  false,
+  undefined,
+  { getOnInit: true },
+);
+
 // Closed tab history for "Reopen closed tab"
 export interface ClosedTabRecord {
   chatId: number;

--- a/src/components/chat/ChatTabs.test.ts
+++ b/src/components/chat/ChatTabs.test.ts
@@ -430,4 +430,15 @@ describe("groupChatIdsByApp", () => {
     // app1 first (chat 1), then unknown (chat 2), then app2 (chat 3)
     expect(result).toEqual([1, 2, 3]);
   });
+
+  it("slots a newly opened chat into its app's existing group", () => {
+    // While grouped, the tabs read: app1 (1, 3), then app2 (2, 4).
+    // Opening a new chat (5) in app2 prepends it to the front, as
+    // pushRecentViewedChatId does. Re-grouping must place it in app2's group
+    // rather than leaving it stranded at the front.
+    const chats = [chat(1, 1), chat(3, 1), chat(2, 2), chat(4, 2), chat(5, 2)];
+    const result = groupChatIdsByApp([5, 1, 3, 2, 4], toMap(chats));
+    // app2 group comes first now (its chat 5 is seen first), new chat leads it.
+    expect(result).toEqual([5, 2, 4, 1, 3]);
+  });
 });

--- a/src/components/chat/ChatTabs.tsx
+++ b/src/components/chat/ChatTabs.tsx
@@ -20,6 +20,7 @@ import {
   closeMultipleTabsAtom,
   hydrateChatTabSessionAtom,
   persistChatTabSessionAtom,
+  groupTabsByAppAtom,
   type ClosedTabRecord,
 } from "@/atoms/chatAtoms";
 import { useReopenClosedTab } from "@/hooks/useReopenClosedTab";
@@ -33,6 +34,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import {
   ContextMenu,
+  ContextMenuCheckboxItem,
   ContextMenuContent,
   ContextMenuItem,
   ContextMenuSeparator,
@@ -227,6 +229,8 @@ export function ChatTabs({ selectedChatId }: ChatTabsProps) {
   const recentViewedChatIds = useAtomValue(recentViewedChatIdsAtom);
   const closedChatIds = useAtomValue(closedChatIdsAtom);
   const sessionOpenedChatIds = useAtomValue(sessionOpenedChatIdsAtom);
+  const groupTabsByApp = useAtomValue(groupTabsByAppAtom);
+  const setGroupTabsByApp = useSetAtom(groupTabsByAppAtom);
   const setRecentViewedChatIds = useSetAtom(setRecentViewedChatIdsAtom);
   const pushRecentViewedChatId = useSetAtom(pushRecentViewedChatIdAtom);
   const pruneClosedChatIds = useSetAtom(pruneClosedChatIdsAtom);
@@ -319,16 +323,24 @@ export function ChatTabs({ selectedChatId }: ChatTabsProps) {
     [apps],
   );
 
-  const orderedChatIds = useMemo(
-    () =>
-      getOrderedRecentChatIds(
-        recentViewedChatIds,
-        chats,
-        closedChatIds,
-        sessionOpenedChatIds,
-      ),
-    [recentViewedChatIds, chats, closedChatIds, sessionOpenedChatIds],
-  );
+  const orderedChatIds = useMemo(() => {
+    const base = getOrderedRecentChatIds(
+      recentViewedChatIds,
+      chats,
+      closedChatIds,
+      sessionOpenedChatIds,
+    );
+    // When grouping is enabled, re-bucket by app on every render so newly
+    // opened chats automatically join their app's existing group.
+    return groupTabsByApp ? groupChatIdsByApp(base, chatsById) : base;
+  }, [
+    recentViewedChatIds,
+    chats,
+    closedChatIds,
+    sessionOpenedChatIds,
+    groupTabsByApp,
+    chatsById,
+  ]);
 
   const orderedChats = useMemo(
     () =>
@@ -560,11 +572,8 @@ export function ChatTabs({ selectedChatId }: ChatTabsProps) {
     closeTabsAndClearNotifications(idsToClose, fallback);
   };
 
-  const handleGroupByApp = () => {
-    const grouped = groupChatIdsByApp(orderedChatIds, chatsById);
-    if (!isSameIdOrder(orderedChatIds, grouped)) {
-      setRecentViewedChatIds(grouped);
-    }
+  const handleToggleGroupByApp = () => {
+    setGroupTabsByApp((prev) => !prev);
   };
 
   // Check whether tabs span more than one app (used to enable/disable grouping)
@@ -648,7 +657,10 @@ export function ChatTabs({ selectedChatId }: ChatTabsProps) {
                               chat.id,
                             );
                             if (!isSameIdOrder(orderedChatIds, nextIds)) {
+                              // Persist the manual order and drop out of grouped
+                              // mode — a hand-arranged order wins over auto-grouping.
                               setRecentViewedChatIds(nextIds);
+                              setGroupTabsByApp(false);
                             }
                             setDraggingChatId(null);
                           }}
@@ -773,12 +785,13 @@ export function ChatTabs({ selectedChatId }: ChatTabsProps) {
                     {t("closeTabsToRight")}
                   </ContextMenuItem>
                   <ContextMenuSeparator />
-                  <ContextMenuItem
-                    onClick={handleGroupByApp}
-                    disabled={!hasMultipleApps}
+                  <ContextMenuCheckboxItem
+                    checked={groupTabsByApp}
+                    onCheckedChange={handleToggleGroupByApp}
+                    disabled={!hasMultipleApps && !groupTabsByApp}
                   >
                     {t("groupTabsByApp")}
-                  </ContextMenuItem>
+                  </ContextMenuCheckboxItem>
                   <ContextMenuSeparator />
                   <ContextMenuItem
                     onClick={reopenClosedTab}


### PR DESCRIPTION
closes #3702 
Turn "Group tabs by app" from a one-shot reorder into a persistent mode so newly opened chats automatically slot into their app's existing group.

- Add persisted groupTabsByAppAtom
- Apply groupChatIdsByApp as a render-time derivation when the mode is on
- Toggle the mode via a context-menu checkbox item
- Drop out of grouped mode on manual tab drag (hand-arranged order wins)
- Add unit + e2e coverage for a new chat joining its app's group

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

