### PR TITLE
Fix save error for gitignored files (e.g. .env.local)

### DIFF
--- a/src/ipc/services/git_service.test.ts
+++ b/src/ipc/services/git_service.test.ts
@@ -110,11 +110,28 @@ describe("GitService", () => {
       message: "msg",
     });
 
-    expect(callOrder).toEqual(["gitAdd", "gitCommit"]);
+    expect(callOrder).toEqual(["gitAdd", "hasStagedChanges", "gitCommit"]);
     expect(mocks.gitAdd).toHaveBeenCalledWith({
       path: "/repo",
       filepath: "src/a.ts",
     });
     expect(hash).toBe("commit-hash");
+  });
+
+  it("commitFile returns null when the file was ignored (nothing staged)", async () => {
+    mocks.hasStagedChanges.mockImplementation(async () => {
+      callOrder.push("hasStagedChanges");
+      return false;
+    });
+
+    const hash = await service.commitFile({
+      path: "/repo",
+      filepath: ".env.local",
+      message: "msg",
+    });
+
+    expect(callOrder).toEqual(["gitAdd", "hasStagedChanges"]);
+    expect(hash).toBeNull();
+    expect(mocks.gitCommit).not.toHaveBeenCalled();
   });
 });

--- a/src/ipc/services/git_service.ts
+++ b/src/ipc/services/git_service.ts
@@ -71,7 +71,12 @@ export class GitService {
   }
 
   /**
-   * Stages a single file and commits it. Returns the commit hash.
+   * Stages a single file and commits it. Returns the commit hash, or null
+   * when there was nothing to commit.
+   *
+   * `gitAdd` skips files ignored by .gitignore (e.g. `.env.local`), which
+   * leaves nothing staged. Guard the commit so those saves don't fail with
+   * "nothing to commit, working tree clean".
    */
   async commitFile({
     path,
@@ -81,8 +86,11 @@ export class GitService {
     path: string;
     filepath: string;
     message: string;
-  }): Promise<string> {
+  }): Promise<string | null> {
     await gitAdd({ path, filepath });
+    if (!(await hasStagedChanges({ path }))) {
+      return null;
+    }
     return gitCommit({ path, message });
   }
 }


### PR DESCRIPTION
closes #3726 
commitFile staged a file via gitAdd (which skips gitignored files) then always ran gitCommit, so saving a gitignored file like .env.local failed with "Failed to create commit ... nothing to commit, working tree clean" even though the file was written successfully.

Guard the commit with hasStagedChanges and return null when nothing is staged, mirroring stageAllAndCommitIfChanged.