### PR TITLE
[codex] Fix managed Node E2E on Windows

### DIFF
--- a/e2e-tests/managed_node.spec.ts
+++ b/e2e-tests/managed_node.spec.ts
@@ -5,60 +5,99 @@ import os from "os";
 import path from "path";
 import { pathToFileURL } from "url";
 import { execFileSync } from "child_process";
-import { testWithConfigSkipIfWindows, Timeout } from "./helpers/test_helper";
+import { testWithConfig, Timeout } from "./helpers/test_helper";
 
 const MANAGED_NODE_VERSION = "v24.18.0";
 
 function createManagedNodeFixtureArchive(userDataDir: string) {
   const fixtureDir = path.join(userDataDir, "managed-node-fixture");
+  const isWindows = process.platform === "win32";
   const rootDir = path.join(
     fixtureDir,
-    `node-${MANAGED_NODE_VERSION}-${process.platform}-${os.arch()}`,
+    isWindows
+      ? `node-${MANAGED_NODE_VERSION}-win-${os.arch()}`
+      : `node-${MANAGED_NODE_VERSION}-${process.platform}-${os.arch()}`,
   );
-  const binDir = path.join(rootDir, "bin");
+  const binDir = isWindows ? rootDir : path.join(rootDir, "bin");
   fs.mkdirSync(binDir, { recursive: true });
 
-  const nodePath = path.join(binDir, "node");
-  fs.writeFileSync(
-    nodePath,
-    [
-      "#!/bin/sh",
-      `if [ "$1" = "--version" ]; then echo "${MANAGED_NODE_VERSION}"; exit 0; fi`,
-      `exec "${process.execPath.replace(/"/g, '\\"')}" "$@"`,
-      "",
-    ].join("\n"),
-  );
-  fs.chmodSync(nodePath, 0o755);
+  if (isWindows) {
+    fs.copyFileSync(process.execPath, path.join(binDir, "node.exe"));
+    fs.writeFileSync(
+      path.join(binDir, "pnpm.cmd"),
+      [
+        "@echo off",
+        "setlocal EnableDelayedExpansion",
+        'set "previous="',
+        "for %%A in (%*) do (",
+        '  if "%%~A"=="--version" echo 10.15.0 & exit /b 0',
+        '  if "%%~A"=="install" echo Already up to date & exit /b 0',
+        '  if "!previous!"=="run" if "%%~A"=="dev" "%~dp0node.exe" -e "const http=require(\'http\');const server=http.createServer((_req,res)=>res.end(\'managed node ok\'));server.listen(0,()=>console.log(\'http://localhost:\'+server.address().port));" & exit /b 0',
+        '  set "previous=%%~A"',
+        ")",
+        "echo Unsupported fake pnpm command: %* 1>&2",
+        "exit /b 1",
+        "",
+      ].join("\r\n"),
+    );
+  } else {
+    const nodePath = path.join(binDir, "node");
+    fs.writeFileSync(
+      nodePath,
+      [
+        "#!/bin/sh",
+        `if [ "$1" = "--version" ]; then echo "${MANAGED_NODE_VERSION}"; exit 0; fi`,
+        `exec "${process.execPath.replace(/"/g, '\\"')}" "$@"`,
+        "",
+      ].join("\n"),
+    );
+    fs.chmodSync(nodePath, 0o755);
 
-  const pnpmPath = path.join(binDir, "pnpm");
-  fs.writeFileSync(
-    pnpmPath,
-    [
-      "#!/bin/sh",
-      'previous=""',
-      'for arg in "$@"; do',
-      '  if [ "$arg" = "--version" ]; then echo "10.15.0"; exit 0; fi',
-      '  if [ "$arg" = "install" ]; then echo "Already up to date"; exit 0; fi',
-      '  if [ "$previous" = "run" ] && [ "$arg" = "dev" ]; then',
-      `  exec "${process.execPath.replace(/"/g, '\\"')}" -e "const http=require('http');const server=http.createServer((_req,res)=>res.end('managed node ok'));server.listen(0,()=>console.log('http://localhost:'+server.address().port));"`,
-      "  fi",
-      '  previous="$arg"',
-      "done",
-      'echo "Unsupported fake pnpm command: $@" >&2',
-      "exit 1",
-      "",
-    ].join("\n"),
-  );
-  fs.chmodSync(pnpmPath, 0o755);
+    const pnpmPath = path.join(binDir, "pnpm");
+    fs.writeFileSync(
+      pnpmPath,
+      [
+        "#!/bin/sh",
+        'previous=""',
+        'for arg in "$@"; do',
+        '  if [ "$arg" = "--version" ]; then echo "10.15.0"; exit 0; fi',
+        '  if [ "$arg" = "install" ]; then echo "Already up to date"; exit 0; fi',
+        '  if [ "$previous" = "run" ] && [ "$arg" = "dev" ]; then',
+        `  exec "${process.execPath.replace(/"/g, '\\"')}" -e "const http=require('http');const server=http.createServer((_req,res)=>res.end('managed node ok'));server.listen(0,()=>console.log('http://localhost:'+server.address().port));"`,
+        "  fi",
+        '  previous="$arg"',
+        "done",
+        'echo "Unsupported fake pnpm command: $@" >&2',
+        "exit 1",
+        "",
+      ].join("\n"),
+    );
+    fs.chmodSync(pnpmPath, 0o755);
+  }
 
-  const archivePath = path.join(fixtureDir, "managed-node.tar.gz");
-  execFileSync("tar", [
-    "-czf",
-    archivePath,
-    "-C",
+  const archivePath = path.join(
     fixtureDir,
-    path.basename(rootDir),
-  ]);
+    isWindows ? "managed-node.zip" : "managed-node.tar.gz",
+  );
+  if (isWindows) {
+    const quotePowerShellString = (value: string) =>
+      `'${value.replace(/'/g, "''")}'`;
+    execFileSync("powershell.exe", [
+      "-NoProfile",
+      "-ExecutionPolicy",
+      "Bypass",
+      "-Command",
+      `Compress-Archive -LiteralPath ${quotePowerShellString(rootDir)} -DestinationPath ${quotePowerShellString(archivePath)} -Force`,
+    ]);
+  } else {
+    execFileSync("tar", [
+      "-czf",
+      archivePath,
+      "-C",
+      fixtureDir,
+      path.basename(rootDir),
+    ]);
+  }
   const sha256 = crypto
     .createHash("sha256")
     .update(fs.readFileSync(archivePath))
@@ -67,15 +106,19 @@ function createManagedNodeFixtureArchive(userDataDir: string) {
   process.env.DYAD_TEST_MANAGED_NODE_ARCHIVE_URL =
     pathToFileURL(archivePath).toString();
   process.env.DYAD_TEST_MANAGED_NODE_SHA256 = sha256;
+  process.env.DYAD_TEST_MANAGED_NODE_EXPECTED_VERSION = isWindows
+    ? process.version
+    : MANAGED_NODE_VERSION;
 }
 
-const test = testWithConfigSkipIfWindows({
+const test = testWithConfig({
   preLaunchHook: async ({ userDataDir }) => {
     createManagedNodeFixtureArchive(userDataDir);
   },
   postLaunchHook: async () => {
     delete process.env.DYAD_TEST_MANAGED_NODE_ARCHIVE_URL;
     delete process.env.DYAD_TEST_MANAGED_NODE_SHA256;
+    delete process.env.DYAD_TEST_MANAGED_NODE_EXPECTED_VERSION;
   },
 });
 

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -122,9 +122,9 @@ if (isWindowsSigningEnabled && !process.env.AZURE_CODE_SIGNING_DLIB) {
 
 const config: ForgeConfig = {
   packagerConfig: {
-    // Local file: dependencies are installed as links on Windows. Dereference
-    // them so packaging does not require symlink privileges in the temp app.
-    derefSymlinks: true,
+    // E2E test builds install local file: dependencies as links on Windows.
+    // Dereference them so packaging does not require symlink privileges in the temp app.
+    derefSymlinks: isEndToEndTestBuild ? true : undefined,
     windowsSign: isWindowsSigningEnabled ? windowsSign : undefined,
     afterCopy: [
       (buildPath, _electronVersion, platform, arch, callback) => {

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -122,6 +122,9 @@ if (isWindowsSigningEnabled && !process.env.AZURE_CODE_SIGNING_DLIB) {
 
 const config: ForgeConfig = {
   packagerConfig: {
+    // Local file: dependencies are installed as links on Windows. Dereference
+    // them so packaging does not require symlink privileges in the temp app.
+    derefSymlinks: true,
     windowsSign: isWindowsSigningEnabled ? windowsSign : undefined,
     afterCopy: [
       (buildPath, _electronVersion, platform, arch, callback) => {

--- a/src/ipc/utils/managed_node.ts
+++ b/src/ipc/utils/managed_node.ts
@@ -21,6 +21,10 @@ import { isVersionAtLeast } from "@/shared/version_utils";
 const logger = log.scope("managed_node");
 
 export const MANAGED_NODE_VERSION = "v24.18.0";
+const EXPECTED_MANAGED_NODE_VERSION =
+  IS_TEST_BUILD && process.env.DYAD_TEST_MANAGED_NODE_EXPECTED_VERSION
+    ? process.env.DYAD_TEST_MANAGED_NODE_EXPECTED_VERSION
+    : MANAGED_NODE_VERSION;
 export const MINIMUM_SYSTEM_NODE_VERSION = "20.0.0";
 export const MANAGED_NODE_INSTALL_CANCELLED_MESSAGE =
   "Managed Node.js install was cancelled.";
@@ -616,9 +620,9 @@ async function installFromArchive({
 
     const verifiedVersion = await getManagedNodeVersionFromDir(tempInstallDir);
     throwIfManagedNodeInstallCancelled(signal);
-    if (verifiedVersion !== MANAGED_NODE_VERSION) {
+    if (verifiedVersion !== EXPECTED_MANAGED_NODE_VERSION) {
       throw new ManagedNodeInstallError(
-        `Installed Node.js reported ${verifiedVersion ?? "no version"} instead of ${MANAGED_NODE_VERSION}. Your antivirus may have blocked the executable.`,
+        `Installed Node.js reported ${verifiedVersion ?? "no version"} instead of ${EXPECTED_MANAGED_NODE_VERSION}. Your antivirus may have blocked the executable.`,
         "av-blocked",
       );
     }


### PR DESCRIPTION
Summary: Fix managed Node E2E coverage on Windows by using a Windows-shaped fixture archive, allowing test builds to verify the copied fixture Node version, and dereferencing local file dependencies during Electron packaging. Root cause: the test fixture used Unix shell launchers and the packaged build preserved Windows links for local file dependencies. Validation: npm run build; PLAYWRIGHT_HTML_OPEN=never npm run e2e -- e2e-tests/managed_node.spec.ts; npm run fmt.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test fixtures, a test-build-only version check override, and E2E packaging; production managed Node install behavior is unchanged except using the same constant name for the pinned version check.
> 
> **Overview**
> **Managed Node E2E now runs on Windows** instead of being skipped. The spec builds a **platform-shaped fake Node archive**: Unix still uses `tar.gz` with shell `node`/`pnpm` stubs; Windows uses a **zip** with `node.exe` (copied from the test runner), a **`pnpm.cmd`** stub, and PowerShell **`Compress-Archive`**, matching real Windows Node layout (`win-*` folder, binaries at root).
> 
> Test-only install verification accepts an **override expected version** via `DYAD_TEST_MANAGED_NODE_EXPECTED_VERSION` (Windows expects the runner’s `process.version` because the fixture copies `node.exe`; non-Windows still expect `v24.18.0`). Production installs still require the pinned managed version.
> 
> **E2E Electron packaging** sets **`derefSymlinks: true`** when `E2E_TEST_BUILD` is set so Windows packs **`file:` dependencies** without needing symlink privileges in the temp app.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf58fc0bfb322e19fa2b6432966375a4112f55d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->