### PR TITLE
Fix local agent tool transcript sanitization

### DIFF
--- a/rules/local-agent-tools.md
+++ b/rules/local-agent-tools.md
@@ -33,6 +33,7 @@ Agent tool definitions live in `src/pro/main/ipc/handlers/local_agent/tools/`. E
 
 - When extending `handleLocalAgentStream` retry behavior, do not only match transport errors like `"terminated"`. Providers can emit structured stream errors such as `{ type: "error", error: { type: "server_error", ... } }`, and those transient 5xx / rate-limit failures need explicit retry classification too.
 - Anthropic rejects any assistant `tool_use` unless the immediately following message contains every matching `tool_result`. When changing local-agent history assembly, retry replay, message injection, or `aiMessagesJson` persistence, run the transcript through the shared tool-call sanitizer at the provider/persistence boundary rather than relying only on the injection site to preserve ordering.
+- In `prepareStep`-style paths, normalize the step message array even when `prepareStepMessages` returns `undefined`; split parallel tool results can still need merging on no-injection/no-compaction steps. Prefer the shared `sanitizeStepMessages` helper over ad hoc reference comparisons.
 
 ## Metadata-only stop tools
 

--- a/rules/local-agent-tools.md
+++ b/rules/local-agent-tools.md
@@ -32,6 +32,7 @@ Agent tool definitions live in `src/pro/main/ipc/handlers/local_agent/tools/`. E
 ## Stream retries
 
 - When extending `handleLocalAgentStream` retry behavior, do not only match transport errors like `"terminated"`. Providers can emit structured stream errors such as `{ type: "error", error: { type: "server_error", ... } }`, and those transient 5xx / rate-limit failures need explicit retry classification too.
+- Anthropic rejects any assistant `tool_use` unless the immediately following message contains every matching `tool_result`. When changing local-agent history assembly, retry replay, message injection, or `aiMessagesJson` persistence, run the transcript through the shared tool-call sanitizer at the provider/persistence boundary rather than relying only on the injection site to preserve ordering.
 
 ## Metadata-only stop tools
 

--- a/src/ipc/utils/ai_messages_utils.test.ts
+++ b/src/ipc/utils/ai_messages_utils.test.ts
@@ -45,31 +45,29 @@ describe("parseAiMessagesJson", () => {
           },
         ],
       };
+      const toolResultMessage: ModelMessage = {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-123",
+            toolName: "read_file",
+            output: { type: "text", value: "contents" },
+          },
+        ],
+      };
       const msg: DbMessageForParsing = {
         id: 2,
         role: "assistant",
         content: "fallback",
         aiMessagesJson: {
           sdkVersion: AI_MESSAGES_SDK_VERSION,
-          messages: [
-            toolMessage,
-            {
-              role: "tool",
-              content: [
-                {
-                  type: "tool-result",
-                  toolCallId: "call-123",
-                  toolName: "read_file",
-                  output: { type: "text", value: "contents" },
-                },
-              ],
-            },
-          ],
+          messages: [toolMessage, toolResultMessage],
         },
       };
 
       const result = parseAiMessagesJson(msg);
-      expect(result[0]).toEqual(toolMessage);
+      expect(result).toEqual([toolMessage, toolResultMessage]);
     });
   });
 
@@ -833,6 +831,41 @@ describe("getAiMessagesJsonIfWithinLimit", () => {
 });
 
 describe("sanitizeToolCallTranscript", () => {
+  it("preserves message references when the transcript is already canonical", () => {
+    const messages: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-1",
+            toolName: "read_file",
+            input: { path: "src/App.tsx" },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-1",
+            toolName: "read_file",
+            output: { type: "text", value: "file contents" },
+          },
+        ],
+      },
+      { role: "user", content: "Next request" },
+    ];
+
+    const result = sanitizeToolCallTranscript(messages);
+
+    expect(result).toEqual(messages);
+    expect(result[0]).toBe(messages[0]);
+    expect(result[1]).toBe(messages[1]);
+    expect(result[2]).toBe(messages[2]);
+  });
+
   it("moves user messages after the matching tool result", () => {
     const messages: ModelMessage[] = [
       {
@@ -965,6 +998,47 @@ describe("sanitizeToolCallTranscript", () => {
         ],
       },
     ]);
+  });
+
+  it("cleans collected tool-result metadata before merging", () => {
+    const messages: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-1",
+            toolName: "read_file",
+            input: { path: "src/App.tsx" },
+          },
+        ],
+      },
+      { role: "user", content: "Injected screenshot context" },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-1",
+            toolName: "read_file",
+            output: { type: "text", value: "file contents" },
+            providerOptions: {
+              openai: { itemId: "msg_expired" },
+            },
+          } as any,
+        ],
+      },
+    ];
+
+    const result = sanitizeToolCallTranscript(messages);
+    const toolResult = (result[1].content as any[])[0];
+
+    expect(result.map((message) => message.role)).toEqual([
+      "assistant",
+      "tool",
+      "user",
+    ]);
+    expect(toolResult.providerOptions).toBeUndefined();
   });
 
   it("drops dangling tool results without a preceding assistant tool call", () => {

--- a/src/ipc/utils/ai_messages_utils.test.ts
+++ b/src/ipc/utils/ai_messages_utils.test.ts
@@ -1000,6 +1000,77 @@ describe("sanitizeToolCallTranscript", () => {
     ]);
   });
 
+  it("preserves completed parallel tool pairs when another result is missing", () => {
+    const messages: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Checking the project." },
+          {
+            type: "tool-call",
+            toolCallId: "call-1",
+            toolName: "read_file",
+            input: { path: "src/App.tsx" },
+          },
+          {
+            type: "tool-call",
+            toolCallId: "call-2",
+            toolName: "read_file",
+            input: { path: "src/main.tsx" },
+          },
+          {
+            type: "tool-call",
+            toolCallId: "call-3",
+            toolName: "list_files",
+            input: { path: "src" },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-1",
+            toolName: "read_file",
+            output: { type: "text", value: "app" },
+          },
+        ],
+      },
+      { role: "user", content: "Injected context" },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-3",
+            toolName: "list_files",
+            output: { type: "text", value: "files" },
+          },
+        ],
+      },
+    ];
+
+    expect(sanitizeToolCallTranscript(messages)).toEqual([
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Checking the project." },
+          (messages[0].content as any[])[1],
+          (messages[0].content as any[])[3],
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          (messages[1].content as any[])[0],
+          (messages[3].content as any[])[0],
+        ],
+      },
+      messages[2],
+    ]);
+  });
+
   it("cleans collected tool-result metadata before merging", () => {
     const messages: ModelMessage[] = [
       {

--- a/src/ipc/utils/ai_messages_utils.test.ts
+++ b/src/ipc/utils/ai_messages_utils.test.ts
@@ -3,6 +3,7 @@ import {
   parseAiMessagesJson,
   getAiMessagesJsonIfWithinLimit,
   MAX_AI_MESSAGES_SIZE,
+  sanitizeToolCallTranscript,
   type DbMessageForParsing,
 } from "@/ipc/utils/ai_messages_utils";
 import { AI_MESSAGES_SDK_VERSION } from "@/db/schema";
@@ -50,12 +51,25 @@ describe("parseAiMessagesJson", () => {
         content: "fallback",
         aiMessagesJson: {
           sdkVersion: AI_MESSAGES_SDK_VERSION,
-          messages: [toolMessage],
+          messages: [
+            toolMessage,
+            {
+              role: "tool",
+              content: [
+                {
+                  type: "tool-result",
+                  toolCallId: "call-123",
+                  toolName: "read_file",
+                  output: { type: "text", value: "contents" },
+                },
+              ],
+            },
+          ],
         },
       };
 
       const result = parseAiMessagesJson(msg);
-      expect(result).toEqual([toolMessage]);
+      expect(result[0]).toEqual(toolMessage);
     });
   });
 
@@ -257,6 +271,17 @@ describe("parseAiMessagesJson", () => {
                 },
               ],
             },
+            {
+              role: "tool",
+              content: [
+                {
+                  type: "tool-result",
+                  toolCallId: "call-123",
+                  toolName: "read_file",
+                  output: { type: "text", value: "contents" },
+                },
+              ],
+            },
           ] as ModelMessage[],
         },
       };
@@ -283,6 +308,17 @@ describe("parseAiMessagesJson", () => {
                   toolCallId: "call-456",
                   toolName: "execute_sql",
                   input: "",
+                },
+              ],
+            },
+            {
+              role: "tool",
+              content: [
+                {
+                  type: "tool-result",
+                  toolCallId: "call-456",
+                  toolName: "execute_sql",
+                  output: { type: "text", value: "done" },
                 },
               ],
             },
@@ -315,6 +351,17 @@ describe("parseAiMessagesJson", () => {
                 },
               ],
             },
+            {
+              role: "tool",
+              content: [
+                {
+                  type: "tool-result",
+                  toolCallId: "call-789",
+                  toolName: "read_file",
+                  output: { type: "text", value: "contents" },
+                },
+              ],
+            },
           ] as ModelMessage[],
         },
       };
@@ -341,6 +388,17 @@ describe("parseAiMessagesJson", () => {
                   toolCallId: "call-valid",
                   toolName: "read_file",
                   input: { path: "/test" },
+                },
+              ],
+            },
+            {
+              role: "tool",
+              content: [
+                {
+                  type: "tool-result",
+                  toolCallId: "call-valid",
+                  toolName: "read_file",
+                  output: { type: "text", value: "contents" },
                 },
               ],
             },
@@ -378,6 +436,17 @@ describe("parseAiMessagesJson", () => {
                 {
                   type: "text",
                   text: "Here is my response",
+                },
+              ],
+            },
+            {
+              role: "tool",
+              content: [
+                {
+                  type: "tool-result",
+                  toolCallId: "call-123",
+                  toolName: "read_file",
+                  output: { type: "text", value: "contents" },
                 },
               ],
             },
@@ -447,6 +516,17 @@ describe("parseAiMessagesJson", () => {
                   toolCallId: "call-123",
                   toolName: "read_file",
                   input: { path: "/test" },
+                },
+              ],
+            },
+            {
+              role: "tool",
+              content: [
+                {
+                  type: "tool-result",
+                  toolCallId: "call-123",
+                  toolName: "read_file",
+                  output: { type: "text", value: "contents" },
                 },
               ],
             },
@@ -726,7 +806,7 @@ describe("getAiMessagesJsonIfWithinLimit", () => {
     expect(result?.messages).toEqual(messages);
   });
 
-  it("should handle messages with complex content types", () => {
+  it("should strip orphaned tool calls before saving", () => {
     const messages: ModelMessage[] = [
       {
         role: "assistant",
@@ -745,6 +825,164 @@ describe("getAiMessagesJsonIfWithinLimit", () => {
     const result = getAiMessagesJsonIfWithinLimit(messages);
     expect(result).toBeDefined();
     expect(result?.sdkVersion).toBe(AI_MESSAGES_SDK_VERSION);
-    expect(result?.messages[0]).toEqual(messages[0]);
+    expect(result?.messages[0]).toEqual({
+      role: "assistant",
+      content: [{ type: "text", text: "Here is the result" }],
+    });
+  });
+});
+
+describe("sanitizeToolCallTranscript", () => {
+  it("moves user messages after the matching tool result", () => {
+    const messages: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-1",
+            toolName: "read_file",
+            input: { path: "src/App.tsx" },
+          },
+        ],
+      },
+      { role: "user", content: "Injected screenshot context" },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-1",
+            toolName: "read_file",
+            output: { type: "text", value: "file contents" },
+          },
+        ],
+      },
+    ];
+
+    expect(sanitizeToolCallTranscript(messages)).toEqual([
+      messages[0],
+      messages[2],
+      messages[1],
+    ]);
+  });
+
+  it("strips assistant tool calls that have no matching result", () => {
+    const messages: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Let me check." },
+          {
+            type: "tool-call",
+            toolCallId: "call-1",
+            toolName: "read_file",
+            input: { path: "src/App.tsx" },
+          },
+        ],
+      },
+      { role: "user", content: "Next request" },
+    ];
+
+    expect(sanitizeToolCallTranscript(messages)).toEqual([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Let me check." }],
+      },
+      messages[1],
+    ]);
+  });
+
+  it("drops assistant messages that only contain orphaned tool calls", () => {
+    const messages: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-1",
+            toolName: "read_file",
+            input: { path: "src/App.tsx" },
+          },
+        ],
+      },
+      { role: "user", content: "Next request" },
+    ];
+
+    expect(sanitizeToolCallTranscript(messages)).toEqual([messages[1]]);
+  });
+
+  it("merges split parallel tool results into one immediate tool message", () => {
+    const messages: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-1",
+            toolName: "read_file",
+            input: { path: "src/App.tsx" },
+          },
+          {
+            type: "tool-call",
+            toolCallId: "call-2",
+            toolName: "read_file",
+            input: { path: "src/main.tsx" },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-1",
+            toolName: "read_file",
+            output: { type: "text", value: "app" },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-2",
+            toolName: "read_file",
+            output: { type: "text", value: "main" },
+          },
+        ],
+      },
+    ];
+
+    expect(sanitizeToolCallTranscript(messages)).toEqual([
+      messages[0],
+      {
+        role: "tool",
+        content: [
+          (messages[1].content as any[])[0],
+          (messages[2].content as any[])[0],
+        ],
+      },
+    ]);
+  });
+
+  it("drops dangling tool results without a preceding assistant tool call", () => {
+    const messages: ModelMessage[] = [
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-1",
+            toolName: "read_file",
+            output: { type: "text", value: "file contents" },
+          },
+        ],
+      },
+      { role: "assistant", content: "Done" },
+    ];
+
+    expect(sanitizeToolCallTranscript(messages)).toEqual([messages[1]]);
   });
 });

--- a/src/ipc/utils/ai_messages_utils.ts
+++ b/src/ipc/utils/ai_messages_utils.ts
@@ -145,13 +145,24 @@ export function sanitizeToolCallTranscript(
 
     const expectedToolCallIds = new Set(toolCallIds);
     const scanEnd = findNextAssistantIndex(cleaned, i + 1);
-    const collectedToolResults = collectToolResults(
-      cleaned.slice(i + 1, scanEnd),
-      expectedToolCallIds,
+    const collectedToolResults = orderToolResultsByCallOrder(
+      toolCallIds,
+      collectToolResults(cleaned.slice(i + 1, scanEnd), expectedToolCallIds),
+    );
+    const completedToolCallIds = new Set(
+      collectedToolResults.map((part) => part.toolCallId),
     );
 
-    if (hasAllToolResults(collectedToolResults, expectedToolCallIds)) {
-      sanitized.push(message);
+    if (completedToolCallIds.size > 0) {
+      const pairedAssistant = keepCompletedToolCalls(
+        message,
+        completedToolCallIds,
+      );
+      if (!pairedAssistant) {
+        continue;
+      }
+
+      sanitized.push(pairedAssistant);
       sanitized.push(
         getCanonicalToolMessage(cleaned[i + 1], collectedToolResults) ??
           ({
@@ -249,24 +260,47 @@ function collectToolResults(
   return results;
 }
 
-function hasAllToolResults(
-  toolResults: Array<{ toolCallId: string }>,
-  expectedToolCallIds: Set<string>,
-) {
-  const resultIds = new Set(toolResults.map((part) => part.toolCallId));
-  return [...expectedToolCallIds].every((toolCallId) =>
-    resultIds.has(toolCallId),
+function orderToolResultsByCallOrder(
+  toolCallIds: string[],
+  toolResults: ToolResultTranscriptPart[],
+): ToolResultTranscriptPart[] {
+  const resultByToolCallId = new Map(
+    toolResults.map((part) => [part.toolCallId, part]),
   );
+
+  return toolCallIds.flatMap((toolCallId) => {
+    const result = resultByToolCallId.get(toolCallId);
+    return result ? [result] : [];
+  });
 }
 
 function stripToolCalls(message: ModelMessage): ModelMessage | null {
+  return keepCompletedToolCalls(message, new Set());
+}
+
+function keepCompletedToolCalls(
+  message: ModelMessage,
+  completedToolCallIds: Set<string>,
+): ModelMessage | null {
   if (!Array.isArray(message.content)) {
     return message;
   }
 
-  const content = message.content.filter((part) => !isToolCallPart(part));
+  let didStripToolCall = false;
+  const content = message.content.filter((part) => {
+    if (!isToolCallPart(part)) {
+      return true;
+    }
+    const shouldKeep = completedToolCallIds.has(part.toolCallId);
+    didStripToolCall ||= !shouldKeep;
+    return shouldKeep;
+  });
   if (content.length === 0) {
     return null;
+  }
+
+  if (!didStripToolCall) {
+    return message;
   }
 
   const cleaned = cleanMessage({ ...message, content } as ModelMessage);
@@ -277,7 +311,7 @@ function stripToolCalls(message: ModelMessage): ModelMessage | null {
   return cleaned;
 }
 
-function isToolCallPart(part: unknown): part is ToolCallTranscriptPart {
+export function isToolCallPart(part: unknown): part is ToolCallTranscriptPart {
   return (
     typeof part === "object" &&
     part !== null &&
@@ -287,7 +321,9 @@ function isToolCallPart(part: unknown): part is ToolCallTranscriptPart {
   );
 }
 
-function isToolResultPart(part: unknown): part is ToolResultTranscriptPart {
+export function isToolResultPart(
+  part: unknown,
+): part is ToolResultTranscriptPart {
   return (
     typeof part === "object" &&
     part !== null &&
@@ -297,12 +333,12 @@ function isToolResultPart(part: unknown): part is ToolResultTranscriptPart {
   );
 }
 
-type ToolCallTranscriptPart = {
+export type ToolCallTranscriptPart = {
   type: "tool-call";
   toolCallId: string;
 };
 
-type ToolResultTranscriptPart = {
+export type ToolResultTranscriptPart = {
   type: "tool-result";
   toolCallId: string;
 };

--- a/src/ipc/utils/ai_messages_utils.ts
+++ b/src/ipc/utils/ai_messages_utils.ts
@@ -119,6 +119,175 @@ function cleanMessages(messages: ModelMessage[]): ModelMessage[] {
   return messages.map(cleanMessage);
 }
 
+/**
+ * Anthropic requires every assistant tool-call to be followed immediately by a
+ * tool message containing the matching results. Persisted or dynamically
+ * injected local-agent messages can occasionally violate that shape after
+ * retries, aborts, or mid-turn message insertion. Normalize the transcript
+ * before saving or sending it to a provider.
+ */
+export function sanitizeToolCallTranscript(
+  messages: ModelMessage[],
+): ModelMessage[] {
+  const sanitized: ModelMessage[] = [];
+
+  for (let i = 0; i < messages.length; i++) {
+    const message = cleanMessage(messages[i]);
+
+    // Tool messages are only valid when consumed by the immediately preceding
+    // assistant tool-call branch below. A standalone tool result is dangling.
+    if (message.role === "tool") {
+      continue;
+    }
+
+    const toolCallIds = getToolCallIds(message);
+    if (message.role !== "assistant" || toolCallIds.length === 0) {
+      sanitized.push(message);
+      continue;
+    }
+
+    const expectedToolCallIds = new Set(toolCallIds);
+    const scanEnd = findNextAssistantIndex(messages, i + 1);
+    const collectedToolResults = collectToolResults(
+      messages.slice(i + 1, scanEnd),
+      expectedToolCallIds,
+    );
+
+    if (hasAllToolResults(collectedToolResults, expectedToolCallIds)) {
+      sanitized.push(message);
+      sanitized.push({
+        role: "tool",
+        content: collectedToolResults,
+      } as ModelMessage);
+
+      for (let j = i + 1; j < scanEnd; j++) {
+        const interveningMessage = cleanMessage(messages[j]);
+        if (interveningMessage.role !== "tool") {
+          sanitized.push(interveningMessage);
+        }
+      }
+
+      i = scanEnd - 1;
+      continue;
+    }
+
+    const strippedAssistant = stripToolCalls(message);
+    if (strippedAssistant) {
+      sanitized.push(strippedAssistant);
+    }
+  }
+
+  return sanitized;
+}
+
+function findNextAssistantIndex(messages: ModelMessage[], startIndex: number) {
+  for (let i = startIndex; i < messages.length; i++) {
+    if (messages[i].role === "assistant") {
+      return i;
+    }
+  }
+  return messages.length;
+}
+
+function getToolCallIds(message: ModelMessage): string[] {
+  if (!Array.isArray(message.content)) {
+    return [];
+  }
+
+  const toolCallIds: string[] = [];
+  for (const part of message.content) {
+    if (isToolCallPart(part)) {
+      toolCallIds.push(part.toolCallId);
+    }
+  }
+  return toolCallIds;
+}
+
+function collectToolResults(
+  messages: ModelMessage[],
+  expectedToolCallIds: Set<string>,
+): ToolResultTranscriptPart[] {
+  const results: ToolResultTranscriptPart[] = [];
+  const seenToolCallIds = new Set<string>();
+
+  for (const message of messages) {
+    if (message.role !== "tool" || !Array.isArray(message.content)) {
+      continue;
+    }
+
+    for (const part of message.content) {
+      if (
+        isToolResultPart(part) &&
+        expectedToolCallIds.has(part.toolCallId) &&
+        !seenToolCallIds.has(part.toolCallId)
+      ) {
+        results.push(part);
+        seenToolCallIds.add(part.toolCallId);
+      }
+    }
+  }
+
+  return results;
+}
+
+function hasAllToolResults(
+  toolResults: Array<{ toolCallId: string }>,
+  expectedToolCallIds: Set<string>,
+) {
+  const resultIds = new Set(toolResults.map((part) => part.toolCallId));
+  return [...expectedToolCallIds].every((toolCallId) =>
+    resultIds.has(toolCallId),
+  );
+}
+
+function stripToolCalls(message: ModelMessage): ModelMessage | null {
+  if (!Array.isArray(message.content)) {
+    return message;
+  }
+
+  const content = message.content.filter((part) => !isToolCallPart(part));
+  if (content.length === 0) {
+    return null;
+  }
+
+  const cleaned = cleanMessage({ ...message, content } as ModelMessage);
+  if (Array.isArray(cleaned.content) && cleaned.content.length === 0) {
+    return null;
+  }
+
+  return cleaned;
+}
+
+function isToolCallPart(part: unknown): part is ToolCallTranscriptPart {
+  return (
+    typeof part === "object" &&
+    part !== null &&
+    "type" in part &&
+    (part as Record<string, unknown>).type === "tool-call" &&
+    typeof (part as Record<string, unknown>).toolCallId === "string"
+  );
+}
+
+function isToolResultPart(part: unknown): part is ToolResultTranscriptPart {
+  return (
+    typeof part === "object" &&
+    part !== null &&
+    "type" in part &&
+    (part as Record<string, unknown>).type === "tool-result" &&
+    typeof (part as Record<string, unknown>).toolCallId === "string"
+  );
+}
+
+type ToolCallTranscriptPart = {
+  type: "tool-call";
+  toolCallId: string;
+};
+
+type ToolResultTranscriptPart = {
+  type: "tool-result";
+  toolCallId: string;
+};
+
 /** Maximum size in bytes for ai_messages_json (10MB) */
 export const MAX_AI_MESSAGES_SIZE = 10_000_000;
 
@@ -133,8 +302,13 @@ export function getAiMessagesJsonIfWithinLimit(
     return undefined;
   }
 
+  const sanitizedMessages = sanitizeToolCallTranscript(aiMessages);
+  if (sanitizedMessages.length === 0) {
+    return undefined;
+  }
+
   const payload: AiMessagesJsonV6 = {
-    messages: aiMessages,
+    messages: sanitizedMessages,
     sdkVersion: AI_MESSAGES_SDK_VERSION,
   };
 
@@ -171,7 +345,7 @@ export function parseAiMessagesJson(msg: DbMessageForParsing): ModelMessage[] {
       Array.isArray(parsed) &&
       parsed.every((m) => m && typeof m.role === "string")
     ) {
-      return cleanMessages(parsed);
+      return sanitizeToolCallTranscript(cleanMessages(parsed));
     }
 
     if (
@@ -185,7 +359,9 @@ export function parseAiMessagesJson(msg: DbMessageForParsing): ModelMessage[] {
         (m: ModelMessage) => m && typeof m.role === "string",
       )
     ) {
-      return cleanMessages((parsed as AiMessagesJsonV6).messages);
+      return sanitizeToolCallTranscript(
+        cleanMessages((parsed as AiMessagesJsonV6).messages),
+      );
     }
   }
 

--- a/src/ipc/utils/ai_messages_utils.ts
+++ b/src/ipc/utils/ai_messages_utils.ts
@@ -115,10 +115,6 @@ export function cleanMessage<T extends ModelMessage>(message: T): T {
   return { ...message, content: cleanedContent } as T;
 }
 
-function cleanMessages(messages: ModelMessage[]): ModelMessage[] {
-  return messages.map(cleanMessage);
-}
-
 /**
  * Anthropic requires every assistant tool-call to be followed immediately by a
  * tool message containing the matching results. Persisted or dynamically
@@ -129,10 +125,11 @@ function cleanMessages(messages: ModelMessage[]): ModelMessage[] {
 export function sanitizeToolCallTranscript(
   messages: ModelMessage[],
 ): ModelMessage[] {
+  const cleaned = messages.map(cleanMessage);
   const sanitized: ModelMessage[] = [];
 
-  for (let i = 0; i < messages.length; i++) {
-    const message = cleanMessage(messages[i]);
+  for (let i = 0; i < cleaned.length; i++) {
+    const message = cleaned[i];
 
     // Tool messages are only valid when consumed by the immediately preceding
     // assistant tool-call branch below. A standalone tool result is dangling.
@@ -147,21 +144,24 @@ export function sanitizeToolCallTranscript(
     }
 
     const expectedToolCallIds = new Set(toolCallIds);
-    const scanEnd = findNextAssistantIndex(messages, i + 1);
+    const scanEnd = findNextAssistantIndex(cleaned, i + 1);
     const collectedToolResults = collectToolResults(
-      messages.slice(i + 1, scanEnd),
+      cleaned.slice(i + 1, scanEnd),
       expectedToolCallIds,
     );
 
     if (hasAllToolResults(collectedToolResults, expectedToolCallIds)) {
       sanitized.push(message);
-      sanitized.push({
-        role: "tool",
-        content: collectedToolResults,
-      } as ModelMessage);
+      sanitized.push(
+        getCanonicalToolMessage(cleaned[i + 1], collectedToolResults) ??
+          ({
+            role: "tool",
+            content: collectedToolResults,
+          } as ModelMessage),
+      );
 
       for (let j = i + 1; j < scanEnd; j++) {
-        const interveningMessage = cleanMessage(messages[j]);
+        const interveningMessage = cleaned[j];
         if (interveningMessage.role !== "tool") {
           sanitized.push(interveningMessage);
         }
@@ -178,6 +178,25 @@ export function sanitizeToolCallTranscript(
   }
 
   return sanitized;
+}
+
+function getCanonicalToolMessage(
+  message: ModelMessage | undefined,
+  collectedToolResults: ToolResultTranscriptPart[],
+): ModelMessage | null {
+  if (message?.role !== "tool" || !Array.isArray(message.content)) {
+    return null;
+  }
+
+  if (message.content.length !== collectedToolResults.length) {
+    return null;
+  }
+
+  return message.content.every(
+    (part, index) => part === collectedToolResults[index],
+  )
+    ? message
+    : null;
 }
 
 function findNextAssistantIndex(messages: ModelMessage[], startIndex: number) {
@@ -345,7 +364,7 @@ export function parseAiMessagesJson(msg: DbMessageForParsing): ModelMessage[] {
       Array.isArray(parsed) &&
       parsed.every((m) => m && typeof m.role === "string")
     ) {
-      return sanitizeToolCallTranscript(cleanMessages(parsed));
+      return sanitizeToolCallTranscript(parsed);
     }
 
     if (
@@ -359,9 +378,7 @@ export function parseAiMessagesJson(msg: DbMessageForParsing): ModelMessage[] {
         (m: ModelMessage) => m && typeof m.role === "string",
       )
     ) {
-      return sanitizeToolCallTranscript(
-        cleanMessages((parsed as AiMessagesJsonV6).messages),
-      );
+      return sanitizeToolCallTranscript((parsed as AiMessagesJsonV6).messages);
     }
   }
 

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.test.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.test.ts
@@ -351,10 +351,11 @@ describe("handleLocalAgentStream", () => {
     mockSettings = buildTestSettings();
     mockStreamResult = null;
     mockStreamTextImpl = null;
-    mockIsChatPendingCompaction.mockResolvedValue(false);
-    mockPerformCompaction.mockResolvedValue({ success: true });
-    mockCheckAndMarkForCompaction.mockResolvedValue(false);
+    mockIsChatPendingCompaction.mockReset().mockResolvedValue(false);
+    mockPerformCompaction.mockReset().mockResolvedValue({ success: true });
+    mockCheckAndMarkForCompaction.mockReset().mockResolvedValue(false);
     vi.mocked(streamText).mockClear();
+    vi.mocked(buildAgentToolSet).mockImplementation(() => ({}));
     mockRequireMcpToolConsent.mockResolvedValue({ approved: true });
   });
 
@@ -906,6 +907,194 @@ describe("handleLocalAgentStream", () => {
   });
 
   describe("Mid-turn compaction", () => {
+    it("preserves the full in-flight tail after sanitizing follow-up history", async () => {
+      const { event } = createFakeEvent();
+      mockSettings = buildTestSettings({ enableDyadPro: true });
+      mockChatData = buildTestChat();
+
+      vi.mocked(buildAgentToolSet).mockImplementation((ctx) => {
+        return {
+          update_todos: {
+            execute: async (args: any) => {
+              ctx.todos = args.todos;
+              ctx.onUpdateTodos(ctx.todos);
+              return "Updated todos";
+            },
+          },
+        } as any;
+      });
+
+      mockIsChatPendingCompaction
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true)
+        .mockResolvedValue(false);
+      mockCheckAndMarkForCompaction.mockResolvedValue(true);
+      mockPerformCompaction.mockImplementation(async () => {
+        if (!mockChatData) {
+          return { success: false, error: "missing chat" };
+        }
+        mockChatData = {
+          ...mockChatData,
+          messages: [
+            ...mockChatData.messages,
+            {
+              id: 20,
+              role: "assistant",
+              content: "Conversation compacted.",
+              isCompactionSummary: true,
+              createdAt: new Date("2025-01-01T00:03:30Z"),
+            },
+          ],
+        } as any;
+        return {
+          success: true,
+          summary: "Conversation compacted.",
+          backupPath: ".dyad/chats/1/compaction-test.md",
+        };
+      });
+
+      const splitParallelToolHistory = [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "call-1",
+              toolName: "read_file",
+              input: { path: "src/App.tsx" },
+            },
+            {
+              type: "tool-call",
+              toolCallId: "call-2",
+              toolName: "read_file",
+              input: { path: "src/main.tsx" },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "call-1",
+              toolName: "read_file",
+              output: "App result",
+            },
+          ],
+        },
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "call-2",
+              toolName: "read_file",
+              output: "main result",
+            },
+          ],
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "I started the work." }],
+        },
+      ];
+      const inFlightAssistant = {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-live",
+            toolName: "read_file",
+            input: { path: "src/live.ts" },
+          },
+        ],
+      };
+      const inFlightTool = {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-live",
+            toolName: "read_file",
+            output: "live result",
+          },
+        ],
+      };
+
+      let passCount = 0;
+      let preparedAfterCompaction: any[] = [];
+      mockStreamTextImpl = (options) => {
+        passCount += 1;
+        if (passCount === 1) {
+          return {
+            fullStream: (async function* () {
+              await options.tools.update_todos.execute({
+                merge: false,
+                todos: [
+                  {
+                    id: "todo-1",
+                    content: "Finish the requested work",
+                    status: "pending",
+                  },
+                ],
+              });
+              yield { type: "text-delta", text: "I started the work." };
+            })(),
+            response: Promise.resolve({
+              messages: splitParallelToolHistory,
+            }),
+            steps: Promise.resolve([
+              {
+                toolCalls: [{ toolName: "set_chat_summary" }],
+                response: { messages: splitParallelToolHistory },
+              },
+            ]),
+          };
+        }
+
+        return {
+          fullStream: (async function* () {
+            await options.onStepFinish?.({
+              usage: { totalTokens: 200_000 },
+              toolCalls: [{}],
+            });
+            const stepMessages = [
+              ...options.messages,
+              inFlightAssistant,
+              inFlightTool,
+            ];
+            const prepared = (await options.prepareStep?.({
+              messages: stepMessages,
+              stepNumber: 1,
+              steps: [],
+              model: {},
+              experimental_context: undefined,
+            })) ?? { messages: stepMessages };
+            preparedAfterCompaction = prepared.messages;
+            yield { type: "text-delta", text: "Finished the work." };
+          })(),
+          response: Promise.resolve({ messages: [] }),
+          steps: Promise.resolve([]),
+        };
+      };
+
+      await handleLocalAgentStream(
+        event,
+        { chatId: 1, prompt: "test" },
+        new AbortController(),
+        {
+          placeholderMessageId: 10,
+          systemPrompt: "You are helpful",
+          dyadRequestId,
+        },
+      );
+
+      expect(passCount).toBe(2);
+      expect(mockPerformCompaction).toHaveBeenCalledTimes(1);
+      expect(preparedAfterCompaction).toContain(inFlightAssistant);
+      expect(preparedAfterCompaction).toContain(inFlightTool);
+    });
+
     it("should compact between steps when token usage crosses threshold", async () => {
       // Arrange
       const { event, getMessagesByChannel } = createFakeEvent();

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -924,6 +924,15 @@ export async function handleLocalAgentStream(
         let streamErrorFromCallback: unknown;
         const retryReplayEvents: RetryReplayEvent[] = [];
         activeRetryReplayEvents = retryReplayEvents;
+        // Keep the stored history and its compaction boundary in the same
+        // canonical shape as the initial messages passed to the AI SDK. The
+        // sanitizer can merge split tool-result messages or remove orphaned
+        // messages, so a count taken before sanitization can skip generated
+        // in-flight messages during mid-turn compaction.
+        currentMessageHistory = sanitizeToolCallTranscript(
+          currentMessageHistory,
+        );
+        baseMessageHistoryCount = currentMessageHistory.length;
         const attemptMessages = needsContinuationInstruction
           ? [
               ...currentMessageHistory,

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -92,6 +92,7 @@ import { ensureDyadGitignored } from "@/ipc/handlers/gitignoreUtils";
 import { TOOL_DEFINITIONS } from "./tool_definitions";
 import {
   parseAiMessagesJson,
+  sanitizeToolCallTranscript,
   type DbMessageForParsing,
 } from "@/ipc/utils/ai_messages_utils";
 import {
@@ -929,6 +930,8 @@ export async function handleLocalAgentStream(
               buildTerminatedRetryContinuationInstruction(),
             ]
           : currentMessageHistory;
+        const sanitizedAttemptMessages =
+          sanitizeToolCallTranscript(attemptMessages);
         const attemptToolInputIds = new Set<string>();
         const cleanupAttemptToolStreamingEntries = () => {
           for (const toolCallId of attemptToolInputIds) {
@@ -960,7 +963,7 @@ export async function handleLocalAgentStream(
             temperature,
             maxRetries: 2,
             system: systemPrompt,
-            messages: attemptMessages,
+            messages: sanitizedAttemptMessages,
             tools: allTools,
             stopWhen: [
               stepCountIs(maxToolCallSteps),
@@ -1094,8 +1097,16 @@ export async function handleLocalAgentStream(
               // tool_use/tool_result pairing. Catches edge cases where
               // injection indices become stale after compaction.
               if (result?.messages) {
-                const fixed = ensureToolResultOrdering(result.messages);
-                if (fixed) {
+                const ordered = ensureToolResultOrdering(result.messages);
+                const beforeSanitize = ordered ?? result.messages;
+                const fixed = sanitizeToolCallTranscript(beforeSanitize);
+                const changed =
+                  ordered != null ||
+                  fixed.length !== beforeSanitize.length ||
+                  fixed.some(
+                    (message, index) => message !== beforeSanitize[index],
+                  );
+                if (changed) {
                   logger.warn(
                     `ensureToolResultOrdering fixed misplaced user messages in chat ${req.chatId}`,
                   );

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -84,7 +84,7 @@ import {
   buildTodoReminderMessage,
   hasIncompleteTodos,
   formatTodoSummary,
-  ensureToolResultOrdering,
+  sanitizeStepMessages,
   type InjectedMessage,
 } from "./prepare_step_utils";
 import { deleteTodos, loadTodos, saveTodos } from "./todo_persistence";
@@ -1093,25 +1093,20 @@ export async function handleLocalAgentStream(
                 preparedStep ??
                 (stepOptions === options ? undefined : stepOptions);
 
-              // Defensive: ensure injected user messages don't break
-              // tool_use/tool_result pairing. Catches edge cases where
-              // injection indices become stale after compaction.
-              if (result?.messages) {
-                const ordered = ensureToolResultOrdering(result.messages);
-                const beforeSanitize = ordered ?? result.messages;
-                const fixed = sanitizeToolCallTranscript(beforeSanitize);
-                const changed =
-                  ordered != null ||
-                  fixed.length !== beforeSanitize.length ||
-                  fixed.some(
-                    (message, index) => message !== beforeSanitize[index],
-                  );
-                if (changed) {
-                  logger.warn(
-                    `ensureToolResultOrdering fixed misplaced user messages in chat ${req.chatId}`,
-                  );
-                  result = { ...result, messages: fixed };
-                }
+              // Defensive: ensure injected user messages and split tool result
+              // messages don't break tool_use/tool_result pairing. This also
+              // runs when prepareStepMessages had no other changes to apply.
+              const normalizedStep = sanitizeStepMessages(
+                result?.messages ?? stepOptions.messages,
+              );
+              if (normalizedStep.changed) {
+                logger.warn(
+                  `Normalized local-agent tool-call transcript before step for chat ${req.chatId}`,
+                );
+                result = {
+                  ...(result ?? stepOptions),
+                  messages: normalizedStep.messages,
+                };
               }
 
               return result;

--- a/src/pro/main/ipc/handlers/local_agent/prepare_step_utils.test.ts
+++ b/src/pro/main/ipc/handlers/local_agent/prepare_step_utils.test.ts
@@ -7,6 +7,7 @@ import {
   hasIncompleteTodos,
   buildTodoReminderMessage,
   ensureToolResultOrdering,
+  sanitizeStepMessages,
   type InjectedMessage,
 } from "@/pro/main/ipc/handlers/local_agent/prepare_step_utils";
 import type {
@@ -1347,6 +1348,98 @@ describe("prepare_step_utils", () => {
       ];
 
       expect(ensureToolResultOrdering(messages)).toBeNull();
+    });
+  });
+
+  describe("sanitizeStepMessages", () => {
+    it("returns unchanged when an existing tool result is already canonical", () => {
+      const messages: ModelMessage[] = [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "call-1",
+              toolName: "read_file",
+              input: { path: "src/App.tsx" },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "call-1",
+              toolName: "read_file",
+              output: textToolResult("app"),
+            },
+          ],
+        },
+      ];
+
+      const result = sanitizeStepMessages(messages);
+
+      expect(result.changed).toBe(false);
+      expect(result.messages).toBe(messages);
+    });
+
+    it("merges split parallel tool results even without pending injections", () => {
+      const messages: ModelMessage[] = [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "call-1",
+              toolName: "read_file",
+              input: { path: "src/App.tsx" },
+            },
+            {
+              type: "tool-call",
+              toolCallId: "call-2",
+              toolName: "read_file",
+              input: { path: "src/main.tsx" },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "call-1",
+              toolName: "read_file",
+              output: textToolResult("app"),
+            },
+          ],
+        },
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "call-2",
+              toolName: "read_file",
+              output: textToolResult("main"),
+            },
+          ],
+        },
+      ];
+
+      const result = sanitizeStepMessages(messages);
+
+      expect(result.changed).toBe(true);
+      expect(result.messages).toEqual([
+        messages[0],
+        {
+          role: "tool",
+          content: [
+            (messages[1].content as any[])[0],
+            (messages[2].content as any[])[0],
+          ],
+        },
+      ]);
     });
   });
 

--- a/src/pro/main/ipc/handlers/local_agent/prepare_step_utils.test.ts
+++ b/src/pro/main/ipc/handlers/local_agent/prepare_step_utils.test.ts
@@ -1349,6 +1349,36 @@ describe("prepare_step_utils", () => {
 
       expect(ensureToolResultOrdering(messages)).toBeNull();
     });
+
+    it("ignores malformed non-string toolCallId parts", () => {
+      const messages: ModelMessage[] = [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: 123,
+              toolName: "read_file",
+              input: {},
+            } as any,
+          ],
+        },
+        { role: "user", content: [{ type: "text", text: "Injected" }] },
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: 123,
+              toolName: "read_file",
+              output: textToolResult("done"),
+            } as any,
+          ],
+        },
+      ];
+
+      expect(ensureToolResultOrdering(messages)).toBeNull();
+    });
   });
 
   describe("sanitizeStepMessages", () => {

--- a/src/pro/main/ipc/handlers/local_agent/prepare_step_utils.ts
+++ b/src/pro/main/ipc/handlers/local_agent/prepare_step_utils.ts
@@ -9,6 +9,8 @@ import { ImagePart, ModelMessage, TextPart, UserModelMessage } from "ai";
 import type { UserMessageContentPart, Todo } from "./tools/types";
 import {
   cleanMessage,
+  isToolCallPart,
+  isToolResultPart,
   sanitizeToolCallTranscript,
 } from "@/ipc/utils/ai_messages_utils";
 import { validateImageDimensions } from "./tools/image_utils";
@@ -308,29 +310,5 @@ function didMessageArrayChange(
   return (
     nextMessages.length !== previousMessages.length ||
     nextMessages.some((message, index) => message !== previousMessages[index])
-  );
-}
-
-function isToolCallPart(
-  part: unknown,
-): part is { type: "tool-call"; toolCallId: string } {
-  return (
-    typeof part === "object" &&
-    part !== null &&
-    "type" in part &&
-    (part as Record<string, unknown>).type === "tool-call" &&
-    "toolCallId" in part
-  );
-}
-
-function isToolResultPart(
-  part: unknown,
-): part is { type: "tool-result"; toolCallId: string } {
-  return (
-    typeof part === "object" &&
-    part !== null &&
-    "type" in part &&
-    (part as Record<string, unknown>).type === "tool-result" &&
-    "toolCallId" in part
   );
 }

--- a/src/pro/main/ipc/handlers/local_agent/prepare_step_utils.ts
+++ b/src/pro/main/ipc/handlers/local_agent/prepare_step_utils.ts
@@ -7,7 +7,10 @@
 
 import { ImagePart, ModelMessage, TextPart, UserModelMessage } from "ai";
 import type { UserMessageContentPart, Todo } from "./tools/types";
-import { cleanMessage } from "@/ipc/utils/ai_messages_utils";
+import {
+  cleanMessage,
+  sanitizeToolCallTranscript,
+} from "@/ipc/utils/ai_messages_utils";
 import { validateImageDimensions } from "./tools/image_utils";
 
 /**
@@ -281,6 +284,31 @@ export function ensureToolResultOrdering<T extends ModelMessage>(
   }
 
   return changed ? result : null;
+}
+
+export function sanitizeStepMessages<T extends ModelMessage>(
+  messages: T[],
+): { messages: T[]; changed: boolean } {
+  const ordered = ensureToolResultOrdering(messages);
+  const beforeSanitize = ordered ?? messages;
+  const sanitized = sanitizeToolCallTranscript(beforeSanitize);
+  const changed =
+    ordered != null || didMessageArrayChange(sanitized, beforeSanitize);
+
+  return {
+    messages: changed ? (sanitized as T[]) : messages,
+    changed,
+  };
+}
+
+function didMessageArrayChange(
+  nextMessages: ModelMessage[],
+  previousMessages: ModelMessage[],
+) {
+  return (
+    nextMessages.length !== previousMessages.length ||
+    nextMessages.some((message, index) => message !== previousMessages[index])
+  );
 }
 
 function isToolCallPart(


### PR DESCRIPTION
## Summary
- Normalize local-agent tool-call transcripts before provider calls and aiMessagesJson persistence so Anthropic never receives orphaned or separated tool results.
- Preserve recoverable context by moving injected user messages after matching tool results, while dropping unrecoverable orphaned tool calls/results.
- Add focused coverage for misplaced user messages, split parallel tool results, orphaned calls, and dangling results.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3758?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core local-agent message assembly for every provider call and persistence path; incorrect sanitization could drop context or break multi-step/compaction flows, though coverage targets those edge cases.
> 
> **Overview**
> Adds **`sanitizeToolCallTranscript`** in `ai_messages_utils` and runs it when loading/persisting `aiMessagesJson`, on each stream/retry attempt, and inside **`sanitizeStepMessages`** (replacing ad hoc `ensureToolResultOrdering` only at the `prepareStep` boundary).
> 
> The sanitizer enforces Anthropic’s tool-use shape: **immediate tool results after assistant tool calls**, **merged parallel results**, **injected user messages moved after matching results**, and **removal of orphaned tool calls / dangling tool messages** while keeping recoverable text.
> 
> **`handleLocalAgentStream`** sanitizes history before updating compaction boundaries so mid-turn compaction does not drop in-flight tool messages. Contributor docs in `rules/local-agent-tools.md` now require using this shared boundary sanitizer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40d2f5e69e8de3f576d8997378af4b137b190c00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->