### PR TITLE
Fix Home chat mode default sync

### DIFF
--- a/src/atoms/chatAtoms.ts
+++ b/src/atoms/chatAtoms.ts
@@ -72,6 +72,12 @@ pendingFirstPromptAtom.debugLabel = "pendingFirstPromptAtom";
 export const homeSelectedAppAtom = atom<ListedApp | null>(null);
 homeSelectedAppAtom.debugLabel = "homeSelectedAppAtom";
 
+// Latched when the user explicitly picks a chat mode outside a chat. While
+// false, the home page keeps settings.selectedChatMode synced to the
+// effective default chat mode as quota/provider state loads or changes.
+export const hasManuallySelectedChatModeAtom = atom<boolean>(false);
+hasManuallySelectedChatModeAtom.debugLabel = "hasManuallySelectedChatModeAtom";
+
 // Used for scrolling to the bottom of the chat messages (per chat)
 export const chatStreamCountByIdAtom = atom<Map<number, number>>(new Map());
 export const recentStreamChatIdsAtom = atom<Set<number>>(new Set<number>());

--- a/src/components/ChatModeSelector.tsx
+++ b/src/components/ChatModeSelector.tsx
@@ -26,8 +26,11 @@ import { detectIsMac } from "@/hooks/useChatModeToggle";
 import { useRouterState } from "@tanstack/react-router";
 import { toast } from "sonner";
 import { LocalAgentNewChatToast } from "./LocalAgentNewChatToast";
-import { useAtomValue } from "jotai";
-import { chatMessagesByIdAtom } from "@/atoms/chatAtoms";
+import { useAtomValue, useSetAtom } from "jotai";
+import {
+  chatMessagesByIdAtom,
+  hasManuallySelectedChatModeAtom,
+} from "@/atoms/chatAtoms";
 import { Hammer, Bot, MessageCircle, Lightbulb } from "lucide-react";
 import { useEffect, useRef } from "react";
 import {
@@ -51,6 +54,9 @@ export function ChatModeSelector() {
     setChatMode,
     settings,
   } = useChatMode(isChatRoute ? chatId : null);
+  const setHasManuallySelectedChatMode = useSetAtom(
+    hasManuallySelectedChatModeAtom,
+  );
   const fallbackToastKeyRef = useRef<string | null>(null);
 
   const isProEnabled = settings ? isDyadProEnabled(settings) : false;
@@ -101,6 +107,11 @@ export function ChatModeSelector() {
     ) {
       toast.error("Dyad Free is not available in Build mode.");
       return;
+    }
+    // An explicit pick outside a chat updates settings.selectedChatMode;
+    // latch so the home page stops syncing it to the effective default.
+    if (!isChatRoute || chatId == null) {
+      setHasManuallySelectedChatMode(true);
     }
     void setChatMode(newMode).catch(() => {});
 

--- a/src/hooks/useChatModeToggle.test.tsx
+++ b/src/hooks/useChatModeToggle.test.tsx
@@ -1,0 +1,117 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PropsWithChildren } from "react";
+import { createStore, Provider, useAtomValue } from "jotai";
+
+import { hasManuallySelectedChatModeAtom } from "@/atoms/chatAtoms";
+import { useChatModeToggle } from "./useChatModeToggle";
+
+const mocks = vi.hoisted(() => ({
+  lastChatId: null as number | null | undefined,
+  pathname: "/",
+  posthogCapture: vi.fn(),
+  search: {} as { id?: number },
+  selectedMode: "build",
+  setChatMode: vi.fn(),
+  settings: {
+    selectedChatMode: "build",
+  },
+}));
+
+vi.mock("./useChatMode", () => ({
+  useChatMode: (chatId: number | null | undefined) => {
+    mocks.lastChatId = chatId;
+    return {
+      selectedMode: mocks.selectedMode,
+      setChatMode: mocks.setChatMode,
+      settings: mocks.settings,
+    };
+  },
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useRouterState: () => ({
+    location: {
+      pathname: mocks.pathname,
+      search: mocks.search,
+    },
+  }),
+}));
+
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => ({
+    capture: mocks.posthogCapture,
+  }),
+}));
+
+function makeWrapper() {
+  const store = createStore();
+  return function Wrapper({ children }: PropsWithChildren) {
+    return <Provider store={store}>{children}</Provider>;
+  };
+}
+
+describe("useChatModeToggle", () => {
+  beforeEach(() => {
+    mocks.lastChatId = null;
+    mocks.pathname = "/";
+    mocks.posthogCapture.mockReset();
+    mocks.search = {};
+    mocks.selectedMode = "build";
+    mocks.setChatMode.mockReset();
+    mocks.setChatMode.mockResolvedValue(undefined);
+    mocks.settings = {
+      selectedChatMode: "build",
+    };
+  });
+
+  it("latches home shortcut mode changes as manual selections", () => {
+    const { result } = renderHook(
+      () => ({
+        ...useChatModeToggle(),
+        hasManuallySelectedChatMode: useAtomValue(
+          hasManuallySelectedChatModeAtom,
+        ),
+      }),
+      { wrapper: makeWrapper() },
+    );
+
+    expect(result.current.hasManuallySelectedChatMode).toBe(false);
+
+    act(() => {
+      result.current.toggleChatMode();
+    });
+
+    expect(mocks.lastChatId).toBeNull();
+    expect(mocks.setChatMode).toHaveBeenCalledWith("ask");
+    expect(result.current.hasManuallySelectedChatMode).toBe(true);
+    expect(mocks.posthogCapture).toHaveBeenCalledWith("chat:mode_toggle", {
+      from: "build",
+      to: "ask",
+      trigger: "keyboard_shortcut",
+    });
+  });
+
+  it("does not latch chat-route shortcut mode changes", () => {
+    mocks.pathname = "/chat";
+    mocks.search = { id: 42 };
+
+    const { result } = renderHook(
+      () => ({
+        ...useChatModeToggle(),
+        hasManuallySelectedChatMode: useAtomValue(
+          hasManuallySelectedChatModeAtom,
+        ),
+      }),
+      { wrapper: makeWrapper() },
+    );
+
+    act(() => {
+      result.current.toggleChatMode();
+    });
+
+    expect(mocks.lastChatId).toBe(42);
+    expect(mocks.setChatMode).toHaveBeenCalledWith("ask");
+    expect(result.current.hasManuallySelectedChatMode).toBe(false);
+  });
+});

--- a/src/hooks/useChatModeToggle.ts
+++ b/src/hooks/useChatModeToggle.ts
@@ -4,6 +4,8 @@ import { usePostHog } from "posthog-js/react";
 import { ChatModeSchema } from "../lib/schemas";
 import { useChatMode } from "./useChatMode";
 import { useRouterState } from "@tanstack/react-router";
+import { useSetAtom } from "jotai";
+import { hasManuallySelectedChatModeAtom } from "@/atoms/chatAtoms";
 
 export function useChatModeToggle() {
   const routerState = useRouterState();
@@ -12,6 +14,9 @@ export function useChatModeToggle() {
       ? (routerState.location.search.id as number | undefined)
       : null;
   const { selectedMode, setChatMode, settings } = useChatMode(routeChatId);
+  const setHasManuallySelectedChatMode = useSetAtom(
+    hasManuallySelectedChatModeAtom,
+  );
   const posthog = usePostHog();
 
   // Detect if user is on mac
@@ -36,13 +41,23 @@ export function useChatModeToggle() {
     const currentIndex = modes.indexOf(currentMode);
     const newMode = modes[(currentIndex + 1) % modes.length];
 
+    if (routeChatId == null) {
+      setHasManuallySelectedChatMode(true);
+    }
     void setChatMode(newMode).catch(() => {});
     posthog.capture("chat:mode_toggle", {
       from: currentMode,
       to: newMode,
       trigger: "keyboard_shortcut",
     });
-  }, [selectedMode, setChatMode, settings, posthog]);
+  }, [
+    selectedMode,
+    setChatMode,
+    settings,
+    routeChatId,
+    setHasManuallySelectedChatMode,
+    posthog,
+  ]);
 
   // Add keyboard shortcut with memoized modifiers
   useShortcut(

--- a/src/pages/home.test.tsx
+++ b/src/pages/home.test.tsx
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   isAnyProviderSetup: false,
   isLoadingLanguageModelProviders: true,
   effectiveDefaultChatMode: "build",
+  hasManuallySelectedChatMode: false,
   inputValue: "Build a notes app",
   initialChatMode: "build",
   navigate: vi.fn(),
@@ -46,6 +47,9 @@ vi.mock("jotai", async (importOriginal) => ({
   useAtomValue: (atom: { debugLabel?: string }) => {
     if (atom.debugLabel === "pendingFirstPromptAtom") {
       return mocks.shouldResumeFirstPrompt;
+    }
+    if (atom.debugLabel === "hasManuallySelectedChatModeAtom") {
+      return mocks.hasManuallySelectedChatMode;
     }
     return undefined;
   },
@@ -203,6 +207,7 @@ describe("HomePage", () => {
     mocks.createApp.mockReset();
     mocks.createChat.mockReset();
     mocks.effectiveDefaultChatMode = "build";
+    mocks.hasManuallySelectedChatMode = false;
     mocks.inputValue = "Build a notes app";
     mocks.initialChatMode = "build";
     mocks.navigate.mockReset();
@@ -392,46 +397,14 @@ describe("HomePage", () => {
     const { rerender } = renderHomePage();
 
     mocks.updateSettings.mockClear();
-    mocks.effectiveDefaultChatMode = "local-agent";
+
+    // User explicitly picks a mode from the selector, which latches the flag.
+    mocks.hasManuallySelectedChatMode = true;
     mocks.settings = {
       isTestMode: true,
       selectedChatMode: "ask",
     };
-    rerenderHomePage(rerender);
-
-    expect(mocks.updateSettings).not.toHaveBeenCalled();
-  });
-
-  it("keeps a manual mode selection when the effective default temporarily matches it", () => {
-    mocks.isAnyProviderSetup = true;
-    mocks.isLoadingLanguageModelProviders = false;
-    mocks.initialChatMode = "local-agent";
     mocks.effectiveDefaultChatMode = "local-agent";
-    mocks.settings = {
-      isTestMode: true,
-      selectedChatMode: "local-agent",
-    };
-
-    const { rerender } = renderHomePage();
-
-    mocks.updateSettings.mockClear();
-
-    // User manually switches from the effective default to Build.
-    mocks.settings = {
-      isTestMode: true,
-      selectedChatMode: "build",
-    };
-    rerenderHomePage(rerender);
-
-    // The effective default later temporarily matches the manual Build choice.
-    mocks.effectiveDefaultChatMode = "build";
-    mocks.settings = { ...mocks.settings };
-    rerenderHomePage(rerender);
-
-    // When the effective default returns to Agent, the manual Build selection
-    // should not be reclassified as auto-applied and overwritten.
-    mocks.effectiveDefaultChatMode = "local-agent";
-    mocks.settings = { ...mocks.settings };
     rerenderHomePage(rerender);
 
     expect(mocks.updateSettings).not.toHaveBeenCalled();

--- a/src/pages/home.test.tsx
+++ b/src/pages/home.test.tsx
@@ -384,6 +384,47 @@ describe("HomePage", () => {
     });
   });
 
+  it("uses the Free Pro fallback when the effective home default resolves to build", async () => {
+    mocks.isAnyProviderSetup = true;
+    mocks.isLoadingLanguageModelProviders = false;
+    mocks.initialChatMode = "build";
+    mocks.effectiveDefaultChatMode = "build";
+    mocks.settings = {
+      isTestMode: true,
+      selectedChatMode: "build",
+      selectedModel: {
+        provider: "auto",
+        name: "free-pro",
+      },
+    };
+
+    renderHomePage();
+
+    await waitFor(() => {
+      expect(mocks.updateSettings).toHaveBeenCalledWith({
+        selectedChatMode: "local-agent",
+      });
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Submit home prompt" }));
+
+    await waitFor(() => {
+      expect(mocks.createApp).toHaveBeenCalledWith(
+        expect.objectContaining({
+          initialChatMode: "local-agent",
+        }),
+      );
+    });
+    expect(mocks.streamMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestedChatMode: "local-agent",
+      }),
+    );
+    expect(mocks.updateSettings).not.toHaveBeenCalledWith({
+      selectedChatMode: "build",
+    });
+  });
+
   it("does not override a manually selected chat mode when the effective home default changes", () => {
     mocks.isAnyProviderSetup = true;
     mocks.isLoadingLanguageModelProviders = false;

--- a/src/pages/home.test.tsx
+++ b/src/pages/home.test.tsx
@@ -354,6 +354,89 @@ describe("HomePage", () => {
     );
   });
 
+  it("syncs selected chat mode when provider setup changes the effective home default", async () => {
+    mocks.isAnyProviderSetup = true;
+    mocks.isLoadingLanguageModelProviders = false;
+    mocks.initialChatMode = "build";
+    mocks.effectiveDefaultChatMode = "build";
+    mocks.settings = {
+      isTestMode: true,
+      selectedChatMode: "build",
+    };
+
+    const { rerender } = renderHomePage();
+
+    expect(mocks.updateSettings).not.toHaveBeenCalled();
+
+    mocks.effectiveDefaultChatMode = "local-agent";
+    mocks.settings = { ...mocks.settings };
+    rerenderHomePage(rerender);
+
+    await waitFor(() => {
+      expect(mocks.updateSettings).toHaveBeenCalledWith({
+        selectedChatMode: "local-agent",
+      });
+    });
+  });
+
+  it("does not override a manually selected chat mode when the effective home default changes", () => {
+    mocks.isAnyProviderSetup = true;
+    mocks.isLoadingLanguageModelProviders = false;
+    mocks.initialChatMode = "build";
+    mocks.effectiveDefaultChatMode = "build";
+    mocks.settings = {
+      isTestMode: true,
+      selectedChatMode: "build",
+    };
+
+    const { rerender } = renderHomePage();
+
+    mocks.updateSettings.mockClear();
+    mocks.effectiveDefaultChatMode = "local-agent";
+    mocks.settings = {
+      isTestMode: true,
+      selectedChatMode: "ask",
+    };
+    rerenderHomePage(rerender);
+
+    expect(mocks.updateSettings).not.toHaveBeenCalled();
+  });
+
+  it("keeps a manual mode selection when the effective default temporarily matches it", () => {
+    mocks.isAnyProviderSetup = true;
+    mocks.isLoadingLanguageModelProviders = false;
+    mocks.initialChatMode = "local-agent";
+    mocks.effectiveDefaultChatMode = "local-agent";
+    mocks.settings = {
+      isTestMode: true,
+      selectedChatMode: "local-agent",
+    };
+
+    const { rerender } = renderHomePage();
+
+    mocks.updateSettings.mockClear();
+
+    // User manually switches from the effective default to Build.
+    mocks.settings = {
+      isTestMode: true,
+      selectedChatMode: "build",
+    };
+    rerenderHomePage(rerender);
+
+    // The effective default later temporarily matches the manual Build choice.
+    mocks.effectiveDefaultChatMode = "build";
+    mocks.settings = { ...mocks.settings };
+    rerenderHomePage(rerender);
+
+    // When the effective default returns to Agent, the manual Build selection
+    // should not be reclassified as auto-applied and overwritten.
+    mocks.effectiveDefaultChatMode = "local-agent";
+    mocks.settings = { ...mocks.settings };
+    rerenderHomePage(rerender);
+
+    expect(mocks.updateSettings).not.toHaveBeenCalled();
+  });
+
   it("auto-submits an attachment-only pending first prompt once provider setup is ready", async () => {
     const attachment = {
       file: new File(["hello"], "notes.txt", { type: "text/plain" }),

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import {
   attachmentsAtom,
+  hasManuallySelectedChatModeAtom,
   homeChatInputValueAtom,
   homeSelectedAppAtom,
   pendingFirstPromptAtom,
@@ -119,62 +120,32 @@ export default function HomePage() {
     }
   }, [appId, navigate]);
 
-  // Apply default chat mode when navigating to home page
-  // Wait for quota status to load to avoid race condition where we default to Basic Agent
-  // before knowing if quota is actually exceeded
-  const defaultChatModeSyncState = useRef<{
-    isTrackingDefault: boolean;
-    lastEffectiveDefault?: ChatMode;
-    pendingAutoAppliedDefault?: ChatMode;
-  }>({
-    isTrackingDefault: true,
-  });
+  // Keep the selected chat mode synced to the effective default (which can
+  // change as quota/provider state loads) until the user explicitly picks a
+  // mode. Wait for quota status to load to avoid race condition where we
+  // default to Basic Agent before knowing if quota is actually exceeded.
+  const hasManuallySelectedChatMode = useAtomValue(
+    hasManuallySelectedChatModeAtom,
+  );
   useEffect(() => {
-    if (!settings || !homeInitialChatMode || isQuotaLoading) {
-      return;
-    }
-
-    const syncState = defaultChatModeSyncState.current;
-    const selectedModeChangedManually = syncState.pendingAutoAppliedDefault
-      ? settings.selectedChatMode !== syncState.pendingAutoAppliedDefault &&
-        settings.selectedChatMode !== syncState.lastEffectiveDefault
-      : syncState.lastEffectiveDefault &&
-        settings.selectedChatMode !== syncState.lastEffectiveDefault;
-
-    if (selectedModeChangedManually) {
-      syncState.isTrackingDefault = false;
-      syncState.pendingAutoAppliedDefault = undefined;
-    }
-
     if (
-      !syncState.isTrackingDefault ||
-      settings.selectedChatMode === homeInitialChatMode
+      !settings ||
+      !homeInitialChatMode ||
+      isQuotaLoading ||
+      hasManuallySelectedChatMode
     ) {
-      syncState.lastEffectiveDefault = homeInitialChatMode;
-      syncState.pendingAutoAppliedDefault = undefined;
       return;
     }
-
-    if (syncState.pendingAutoAppliedDefault === homeInitialChatMode) {
-      return;
+    if (settings.selectedChatMode !== homeInitialChatMode) {
+      updateSettings({ selectedChatMode: homeInitialChatMode });
     }
-
-    syncState.pendingAutoAppliedDefault = homeInitialChatMode;
-    void Promise.resolve(
-      updateSettings({ selectedChatMode: homeInitialChatMode }),
-    )
-      .then(() => {
-        if (syncState.pendingAutoAppliedDefault === homeInitialChatMode) {
-          syncState.lastEffectiveDefault = homeInitialChatMode;
-          syncState.pendingAutoAppliedDefault = undefined;
-        }
-      })
-      .catch(() => {
-        if (syncState.pendingAutoAppliedDefault === homeInitialChatMode) {
-          syncState.pendingAutoAppliedDefault = undefined;
-        }
-      });
-  }, [homeInitialChatMode, settings, updateSettings, isQuotaLoading]);
+  }, [
+    homeInitialChatMode,
+    settings,
+    updateSettings,
+    isQuotaLoading,
+    hasManuallySelectedChatMode,
+  ]);
 
   const openAiSetupDialog = useCallback(() => {
     posthog.capture("home:ai-setup-dialog-open");

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -34,6 +34,10 @@ import type { ListedApp } from "@/ipc/types/app";
 import { NEON_TEMPLATE_IDS } from "@/shared/templates";
 import { neonTemplateHook } from "@/client_logic/template_hook";
 import { getEffectiveDefaultChatMode, type ChatMode } from "@/lib/schemas";
+import {
+  FREE_PRO_MODEL_FALLBACK_CHAT_MODE,
+  isFreeProBuildModeCombination,
+} from "@/lib/freeProModel";
 import { useFreeAgentQuota } from "@/hooks/useFreeAgentQuota";
 import { useInitialChatMode } from "@/hooks/useInitialChatMode";
 import { useLanguageModelProviders } from "@/hooks/useLanguageModelProviders";
@@ -74,7 +78,20 @@ export default function HomePage() {
       return initialChatMode;
     }
 
-    return getEffectiveDefaultChatMode(settings, envVars, !isQuotaExceeded);
+    const effectiveDefaultChatMode = getEffectiveDefaultChatMode(
+      settings,
+      envVars,
+      !isQuotaExceeded,
+    );
+    if (
+      isFreeProBuildModeCombination(
+        settings.selectedModel,
+        effectiveDefaultChatMode,
+      )
+    ) {
+      return FREE_PRO_MODEL_FALLBACK_CHAT_MODE;
+    }
+    return effectiveDefaultChatMode;
   }, [envVars, initialChatMode, isQuotaExceeded, isQuotaLoading, settings]);
 
   const setIsPreviewOpen = useSetAtom(isPreviewOpenAtom);

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -122,19 +122,58 @@ export default function HomePage() {
   // Apply default chat mode when navigating to home page
   // Wait for quota status to load to avoid race condition where we default to Basic Agent
   // before knowing if quota is actually exceeded
-  const hasAppliedDefaultChatMode = useRef(false);
+  const defaultChatModeSyncState = useRef<{
+    isTrackingDefault: boolean;
+    lastEffectiveDefault?: ChatMode;
+    pendingAutoAppliedDefault?: ChatMode;
+  }>({
+    isTrackingDefault: true,
+  });
   useEffect(() => {
-    if (
-      settings &&
-      homeInitialChatMode &&
-      !hasAppliedDefaultChatMode.current &&
-      !isQuotaLoading
-    ) {
-      hasAppliedDefaultChatMode.current = true;
-      if (settings.selectedChatMode !== homeInitialChatMode) {
-        updateSettings({ selectedChatMode: homeInitialChatMode });
-      }
+    if (!settings || !homeInitialChatMode || isQuotaLoading) {
+      return;
     }
+
+    const syncState = defaultChatModeSyncState.current;
+    const selectedModeChangedManually = syncState.pendingAutoAppliedDefault
+      ? settings.selectedChatMode !== syncState.pendingAutoAppliedDefault &&
+        settings.selectedChatMode !== syncState.lastEffectiveDefault
+      : syncState.lastEffectiveDefault &&
+        settings.selectedChatMode !== syncState.lastEffectiveDefault;
+
+    if (selectedModeChangedManually) {
+      syncState.isTrackingDefault = false;
+      syncState.pendingAutoAppliedDefault = undefined;
+    }
+
+    if (
+      !syncState.isTrackingDefault ||
+      settings.selectedChatMode === homeInitialChatMode
+    ) {
+      syncState.lastEffectiveDefault = homeInitialChatMode;
+      syncState.pendingAutoAppliedDefault = undefined;
+      return;
+    }
+
+    if (syncState.pendingAutoAppliedDefault === homeInitialChatMode) {
+      return;
+    }
+
+    syncState.pendingAutoAppliedDefault = homeInitialChatMode;
+    void Promise.resolve(
+      updateSettings({ selectedChatMode: homeInitialChatMode }),
+    )
+      .then(() => {
+        if (syncState.pendingAutoAppliedDefault === homeInitialChatMode) {
+          syncState.lastEffectiveDefault = homeInitialChatMode;
+          syncState.pendingAutoAppliedDefault = undefined;
+        }
+      })
+      .catch(() => {
+        if (syncState.pendingAutoAppliedDefault === homeInitialChatMode) {
+          syncState.pendingAutoAppliedDefault = undefined;
+        }
+      });
   }, [homeInitialChatMode, settings, updateSettings, isQuotaLoading]);
 
   const openAiSetupDialog = useCallback(() => {


### PR DESCRIPTION
## Summary
- Keep Home's selected chat mode aligned when provider setup changes the effective default mode.
- Preserve a user's manual mode selection after Home has started tracking the default.
- Add Home tests for provider-driven default changes and manual override behavior.

## Tests
- npm test -- src/pages/home.test.tsx
- npm run fmt
- npm run lint:fix
- npm run ts
- npm test

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI/settings behavior on Home only; no auth or backend changes. Main risk is edge cases around when the manual latch resets (atom is in-memory, not persisted).
> 
> **Overview**
> Fixes Home chat mode drifting or sticking on the wrong default when provider setup or quota changes the **effective default** after the page loads.
> 
> **Home** no longer applies the default once with a ref; it **continuously syncs** `settings.selectedChatMode` to `homeInitialChatMode` until quota finishes loading and the user has **not** manually chosen a mode. **`homeInitialChatMode`** also maps Dyad Free + Build to the existing **Free Pro fallback** mode so submit uses a valid mode.
> 
> A new **`hasManuallySelectedChatModeAtom`** latches on explicit picks **outside an active chat** (Home mode selector and **⌘/Ctrl+.** toggle). While latched, Home skips auto-sync so a user’s Ask/Plan/etc. choice is not overwritten when the default shifts to Agent.
> 
> Adds **`useChatModeToggle`** and **`home.test`** coverage for latch behavior, provider-driven sync, Free Pro fallback, and manual override.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 642d8e210f77ceff3d65d74baa09b7d06d22b63e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->