### PR TITLE
Keep cancelled messages in LLM context

### DIFF
--- a/e2e-tests/cancelled_message.spec.ts
+++ b/e2e-tests/cancelled_message.spec.ts
@@ -2,7 +2,7 @@ import { test } from "./helpers/test_helper";
 import { expect } from "@playwright/test";
 import fs from "fs";
 
-test("cancelled message shows cancelled indicator and is excluded from context", async ({
+test("cancelled message shows cancelled indicator and is kept in context", async ({
   po,
 }) => {
   await po.setUp();
@@ -34,13 +34,14 @@ test("cancelled message shows cancelled indicator and is excluded from context",
   // Cancelled indicators should still be visible (messages stay in UI)
   await expect(cancelledIndicators).toHaveCount(2);
 
-  // Read the server dump to verify the cancelled message is NOT in the context
+  // Read the server dump to verify the cancelled message (and the user prompt
+  // that triggered it) ARE kept in the context sent to the LLM.
   const messagesListText = await messagesList.textContent();
   const dumpPathMatch = messagesListText?.match(
     /\[\[dyad-dump-path=([^\]]+)\]\]/,
   );
   expect(dumpPathMatch).toBeTruthy();
   const dumpContent = fs.readFileSync(dumpPathMatch![1], "utf-8");
-  expect(dumpContent).not.toContain("tc=cancelled-test");
-  expect(dumpContent).not.toContain("Response cancelled by user");
+  expect(dumpContent).toContain("tc=cancelled-test");
+  expect(dumpContent).toContain("Response cancelled by user");
 });

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -93,10 +93,7 @@ import {
 } from "../utils/dyad_tag_parser";
 import { fileExists } from "../utils/file_utils";
 import { isCodeExplorerReady } from "../processors/code_explorer";
-import {
-  appendCancelledResponseNotice,
-  filterCancelledMessagePairs,
-} from "@/shared/chatCancellation";
+import { appendCancelledResponseNotice } from "@/shared/chatCancellation";
 import {
   extractMentionedAppsCodebasesFromPrompt,
   extractMentionedAppsReferencesFromPrompt,
@@ -874,16 +871,12 @@ ${componentSnippet}
         );
 
         // Prepare message history for the AI
-        const messageHistoryRaw = updatedChat.messages.map((message) => ({
+        const messageHistory = updatedChat.messages.map((message) => ({
           role: message.role as "user" | "assistant" | "system",
           content: message.content,
           sourceCommitHash: message.sourceCommitHash,
           commitHash: message.commitHash,
         }));
-
-        // Filter out cancelled message pairs (user prompt + cancelled assistant response)
-        // so the AI doesn't try to reconcile cancelled/incorrect prompts with new ones.
-        const messageHistory = filterCancelledMessagePairs(messageHistoryRaw);
 
         // The DB stores display-friendly versions (short /implement-plan= form
         // or clean <dyad-attachment> tags). Replace the last user message with the

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -103,10 +103,7 @@ import { addIntegrationTool } from "./tools/add_integration";
 import { writePlanTool } from "./tools/write_plan";
 import { exitPlanTool } from "./tools/exit_plan";
 import { writeAppBlueprintTool } from "./tools/write_app_blueprint";
-import {
-  appendCancelledResponseNotice,
-  filterCancelledMessagePairs,
-} from "@/shared/chatCancellation";
+import { appendCancelledResponseNotice } from "@/shared/chatCancellation";
 import {
   isChatPendingCompaction,
   performCompaction,
@@ -245,11 +242,7 @@ function buildChatMessageHistory(
     .filter((msg) => !excludedIds?.has(msg.id))
     .filter((msg) => msg.content || msg.aiMessagesJson);
 
-  // Filter out cancelled message pairs (user prompt + cancelled assistant response)
-  // so the AI doesn't try to reconcile cancelled/incorrect prompts with new ones.
-  return filterCancelledMessagePairs(filtered).flatMap((msg) =>
-    parseAiMessagesJson(msg),
-  );
+  return filtered.flatMap((msg) => parseAiMessagesJson(msg));
 }
 
 /**

--- a/src/shared/chatCancellation.test.ts
+++ b/src/shared/chatCancellation.test.ts
@@ -4,7 +4,6 @@ import {
   appendCancelledResponseNotice,
   stripCancelledResponseNotice,
   applyCancellationNoticeToLastAssistantMessage,
-  filterCancelledMessagePairs,
 } from "@/shared/chatCancellation";
 
 describe("chatCancellation", () => {
@@ -153,72 +152,6 @@ describe("chatCancellation", () => {
     it("should handle empty messages array", () => {
       const result = applyCancellationNoticeToLastAssistantMessage([]);
       expect(result).toEqual([]);
-    });
-  });
-
-  describe("filterCancelledMessagePairs", () => {
-    it("should filter out cancelled assistant messages", () => {
-      const messages = [
-        { role: "user", content: "Hello" },
-        {
-          role: "assistant",
-          content: "Hi\n\n[Response cancelled by user]",
-        },
-        { role: "user", content: "Try again" },
-        { role: "assistant", content: "Hello!" },
-      ];
-      const result = filterCancelledMessagePairs(messages);
-      expect(result).toEqual([
-        { role: "user", content: "Try again" },
-        { role: "assistant", content: "Hello!" },
-      ]);
-    });
-
-    it("should filter the preceding user message of a cancelled response", () => {
-      const messages = [
-        { role: "user", content: "First question" },
-        {
-          role: "assistant",
-          content: "[Response cancelled by user]",
-        },
-      ];
-      const result = filterCancelledMessagePairs(messages);
-      expect(result).toEqual([]);
-    });
-
-    it("should not filter non-cancelled messages", () => {
-      const messages = [
-        { role: "user", content: "Hello" },
-        { role: "assistant", content: "Hi there" },
-      ];
-      const result = filterCancelledMessagePairs(messages);
-      expect(result).toEqual(messages);
-    });
-
-    it("should handle empty array", () => {
-      expect(filterCancelledMessagePairs([])).toEqual([]);
-    });
-
-    it("should handle multiple cancelled pairs", () => {
-      const messages = [
-        { role: "user", content: "Q1" },
-        {
-          role: "assistant",
-          content: "A1\n\n[Response cancelled by user]",
-        },
-        { role: "user", content: "Q2" },
-        {
-          role: "assistant",
-          content: "[Response cancelled by user]",
-        },
-        { role: "user", content: "Q3" },
-        { role: "assistant", content: "A3" },
-      ];
-      const result = filterCancelledMessagePairs(messages);
-      expect(result).toEqual([
-        { role: "user", content: "Q3" },
-        { role: "assistant", content: "A3" },
-      ]);
     });
   });
 });

--- a/src/shared/chatCancellation.ts
+++ b/src/shared/chatCancellation.ts
@@ -26,29 +26,6 @@ export function stripCancelledResponseNotice(content: string): string {
     .trimEnd();
 }
 
-/**
- * Filters out cancelled message pairs (user prompt + cancelled assistant response)
- * so the AI doesn't try to reconcile cancelled/incorrect prompts with new ones.
- */
-export function filterCancelledMessagePairs<
-  T extends { role: string; content: string },
->(messages: T[]): T[] {
-  return messages.filter((msg, index) => {
-    if (isCancelledResponseContent(msg.content)) {
-      return false;
-    }
-    // Also filter the preceding user message that triggered the cancelled response
-    if (
-      msg.role === "user" &&
-      index + 1 < messages.length &&
-      isCancelledResponseContent(messages[index + 1].content)
-    ) {
-      return false;
-    }
-    return true;
-  });
-}
-
 export function applyCancellationNoticeToLastAssistantMessage<
   T extends { role: string; content: string },
 >(messages: T[]): T[] {


### PR DESCRIPTION
closes #3756 
Previously the cancelled assistant message and its triggering user message were filtered out of the history via filterCancelledMessagePairs before building context for the next request. Stop filtering them so the model now sees the interrupted turn (the partial response still ends with the "[Response cancelled by user]" marker) and the prompt that triggered it.

Removes the now-dead filterCancelledMessagePairs helper and its unit tests, and flips the cancelled-message e2e assertions to expect the content to be present in the dumped LLM context.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

