### PR TITLE
Fix attachment area growth pushing chat messages off-screen and preventing scrolling

### DIFF
--- a/src/components/chat/AttachmentsList.tsx
+++ b/src/components/chat/AttachmentsList.tsx
@@ -1,6 +1,7 @@
 import { FileText, X, MessageSquare, Upload } from "lucide-react";
 import type { FileAttachment } from "@/ipc/types";
 import { useTranslation } from "react-i18next";
+import { Tooltip, TooltipTrigger, TooltipContent } from "../ui/tooltip";
 
 interface AttachmentsListProps {
   attachments: FileAttachment[];
@@ -30,19 +31,21 @@ export function AttachmentsList({
               <MessageSquare size={12} className="text-green-600" />
             )}
             {attachment.file.type.startsWith("image/") ? (
-              <div className="relative group">
-                <img
-                  src={URL.createObjectURL(attachment.file)}
-                  alt={attachment.file.name}
-                  className="w-12 h-12 object-cover rounded-md"
-                  onLoad={(e) =>
-                    URL.revokeObjectURL((e.target as HTMLImageElement).src)
-                  }
-                  onError={(e) =>
-                    URL.revokeObjectURL((e.target as HTMLImageElement).src)
-                  }
-                />
-                <div className="absolute hidden group-hover:block top-14 left-0 z-10">
+              <Tooltip>
+                <TooltipTrigger>
+                  <img
+                    src={URL.createObjectURL(attachment.file)}
+                    alt={attachment.file.name}
+                    className="w-12 h-12 object-cover rounded-md"
+                    onLoad={(e) =>
+                      URL.revokeObjectURL((e.target as HTMLImageElement).src)
+                    }
+                    onError={(e) =>
+                      URL.revokeObjectURL((e.target as HTMLImageElement).src)
+                    }
+                  />
+                </TooltipTrigger>
+                <TooltipContent className="bg-transparent p-0">
                   <img
                     src={URL.createObjectURL(attachment.file)}
                     alt={attachment.file.name}
@@ -54,8 +57,8 @@ export function AttachmentsList({
                       URL.revokeObjectURL((e.target as HTMLImageElement).src)
                     }
                   />
-                </div>
-              </div>
+                </TooltipContent>
+              </Tooltip>
             ) : (
               <FileText size={12} />
             )}

--- a/src/components/chat/AttachmentsList.tsx
+++ b/src/components/chat/AttachmentsList.tsx
@@ -1,5 +1,5 @@
 import { FileText, X, MessageSquare, Upload } from "lucide-react";
-import { useEffect, useMemo } from "react";
+import { useEffect, useState } from "react";
 import type { FileAttachment } from "@/ipc/types";
 import { useTranslation } from "react-i18next";
 import { Tooltip, TooltipTrigger, TooltipContent } from "../ui/tooltip";
@@ -10,14 +10,20 @@ interface AttachmentsListProps {
 }
 
 function ImageAttachmentThumbnail({ file }: { file: File }) {
-  // Create the object URL once per file and revoke it on unmount, so the
-  // shared URL stays valid for both the thumbnail and the hover preview
-  // regardless of how quickly the tooltip opens/closes.
-  const objectUrl = useMemo(() => URL.createObjectURL(file), [file]);
+  // Create the object URL inside the effect and revoke the same URL in its
+  // cleanup. This keeps a single shared URL valid for both the thumbnail and
+  // the hover preview (no leak on quick hover), while staying correct under
+  // React StrictMode's mount/unmount/remount cycle — each setup creates a
+  // fresh URL that its own cleanup revokes, so the rendered src is never stale.
+  const [objectUrl, setObjectUrl] = useState<string | null>(null);
 
   useEffect(() => {
-    return () => URL.revokeObjectURL(objectUrl);
-  }, [objectUrl]);
+    const url = URL.createObjectURL(file);
+    setObjectUrl(url);
+    return () => URL.revokeObjectURL(url);
+  }, [file]);
+
+  if (!objectUrl) return null;
 
   return (
     <Tooltip>

--- a/src/components/chat/AttachmentsList.tsx
+++ b/src/components/chat/AttachmentsList.tsx
@@ -38,7 +38,7 @@ function ImageAttachmentThumbnail({ file }: { file: File }) {
         <img
           src={objectUrl}
           alt={file.name}
-          className="max-w-[200px] max-h-[200px] object-contain bg-white p-1 rounded shadow-lg"
+          className="max-w-[200px] max-h-[200px] object-contain bg-background p-1 rounded shadow-lg"
         />
       </TooltipContent>
     </Tooltip>

--- a/src/components/chat/AttachmentsList.tsx
+++ b/src/components/chat/AttachmentsList.tsx
@@ -16,7 +16,7 @@ export function AttachmentsList({
   if (attachments.length === 0) return null;
 
   return (
-    <div className="px-2 pt-2 flex flex-wrap gap-1">
+    <div className="px-2 pt-2 flex flex-wrap gap-1 max-h-32 overflow-y-auto">
       {attachments.map((attachment, index) => (
         <div
           key={index}

--- a/src/components/chat/AttachmentsList.tsx
+++ b/src/components/chat/AttachmentsList.tsx
@@ -1,4 +1,5 @@
 import { FileText, X, MessageSquare, Upload } from "lucide-react";
+import { useEffect, useMemo } from "react";
 import type { FileAttachment } from "@/ipc/types";
 import { useTranslation } from "react-i18next";
 import { Tooltip, TooltipTrigger, TooltipContent } from "../ui/tooltip";
@@ -6,6 +7,36 @@ import { Tooltip, TooltipTrigger, TooltipContent } from "../ui/tooltip";
 interface AttachmentsListProps {
   attachments: FileAttachment[];
   onRemove: (index: number) => void;
+}
+
+function ImageAttachmentThumbnail({ file }: { file: File }) {
+  // Create the object URL once per file and revoke it on unmount, so the
+  // shared URL stays valid for both the thumbnail and the hover preview
+  // regardless of how quickly the tooltip opens/closes.
+  const objectUrl = useMemo(() => URL.createObjectURL(file), [file]);
+
+  useEffect(() => {
+    return () => URL.revokeObjectURL(objectUrl);
+  }, [objectUrl]);
+
+  return (
+    <Tooltip>
+      <TooltipTrigger render={<div className="flex" />}>
+        <img
+          src={objectUrl}
+          alt={file.name}
+          className="w-12 h-12 object-cover rounded-md"
+        />
+      </TooltipTrigger>
+      <TooltipContent className="bg-transparent p-0 [&_[data-slot=tooltip-arrow]]:hidden">
+        <img
+          src={objectUrl}
+          alt={file.name}
+          className="max-w-[200px] max-h-[200px] object-contain bg-white p-1 rounded shadow-lg"
+        />
+      </TooltipContent>
+    </Tooltip>
+  );
 }
 
 export function AttachmentsList({
@@ -31,34 +62,7 @@ export function AttachmentsList({
               <MessageSquare size={12} className="text-green-600" />
             )}
             {attachment.file.type.startsWith("image/") ? (
-              <Tooltip>
-                <TooltipTrigger>
-                  <img
-                    src={URL.createObjectURL(attachment.file)}
-                    alt={attachment.file.name}
-                    className="w-12 h-12 object-cover rounded-md"
-                    onLoad={(e) =>
-                      URL.revokeObjectURL((e.target as HTMLImageElement).src)
-                    }
-                    onError={(e) =>
-                      URL.revokeObjectURL((e.target as HTMLImageElement).src)
-                    }
-                  />
-                </TooltipTrigger>
-                <TooltipContent className="bg-transparent p-0">
-                  <img
-                    src={URL.createObjectURL(attachment.file)}
-                    alt={attachment.file.name}
-                    className="max-w-[200px] max-h-[200px] object-contain bg-white p-1 rounded shadow-lg"
-                    onLoad={(e) =>
-                      URL.revokeObjectURL((e.target as HTMLImageElement).src)
-                    }
-                    onError={(e) =>
-                      URL.revokeObjectURL((e.target as HTMLImageElement).src)
-                    }
-                  />
-                </TooltipContent>
-              </Tooltip>
+              <ImageAttachmentThumbnail file={attachment.file} />
             ) : (
               <FileText size={12} />
             )}

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -56,7 +56,10 @@ function TooltipContent({
           {...props}
         >
           {children}
-          <TooltipPrimitive.Arrow className="size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 bg-foreground fill-foreground z-50 data-[side=bottom]:top-1 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5" />
+          <TooltipPrimitive.Arrow
+            data-slot="tooltip-arrow"
+            className="size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 bg-foreground fill-foreground z-50 data-[side=bottom]:top-1 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5"
+          />
         </TooltipPrimitive.Popup>
       </TooltipPrimitive.Positioner>
     </TooltipPrimitive.Portal>


### PR DESCRIPTION
closes #3770
When many images are attached, the attachment area grew unbounded, pushing chat messages off-screen and preventing scrolling. Cap the area height and make it scroll vertically.

<img width="887" height="765" alt="image" src="https://github.com/user-attachments/assets/cf6b63fb-bb65-4a68-9b55-0f5450cadab2" />



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

