### PR TITLE
Honor manually selected chat mode on Home submit

### DIFF
--- a/src/pages/home.test.tsx
+++ b/src/pages/home.test.tsx
@@ -451,6 +451,39 @@ describe("HomePage", () => {
     expect(mocks.updateSettings).not.toHaveBeenCalled();
   });
 
+  it("submits with the manually selected chat mode instead of the effective default", async () => {
+    mocks.isAnyProviderSetup = true;
+    mocks.isLoadingLanguageModelProviders = false;
+    // Effective default differs from what the user actually picked.
+    mocks.initialChatMode = "build";
+    mocks.effectiveDefaultChatMode = "local-agent";
+    // User latched a manual "plan" selection via the selector.
+    mocks.hasManuallySelectedChatMode = true;
+    mocks.settings = {
+      isTestMode: true,
+      selectedChatMode: "plan",
+    };
+
+    renderHomePage();
+
+    fireEvent.click(screen.getByRole("button", { name: "Submit home prompt" }));
+
+    await waitFor(() => {
+      expect(mocks.createApp).toHaveBeenCalledWith(
+        expect.objectContaining({
+          initialChatMode: "plan",
+        }),
+      );
+    });
+    expect(mocks.streamMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestedChatMode: "plan",
+      }),
+    );
+    // The latched manual selection must not be overwritten by the sync effect.
+    expect(mocks.updateSettings).not.toHaveBeenCalled();
+  });
+
   it("auto-submits an attachment-only pending first prompt once provider setup is ready", async () => {
     const attachment = {
       file: new File(["hello"], "notes.txt", { type: "text/plain" }),

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -206,6 +206,23 @@ export default function HomePage() {
     shouldOpenAiSetupDialogWhenProvidersLoad,
   ]);
 
+  // Honor a manually picked mode (e.g. "plan") on submit; otherwise fall back
+  // to the effective default so it still tracks provider/quota state. Apply the
+  // Free Pro fallback for an invalid build-mode + free-pro-model combination.
+  const homeSubmitChatMode = useMemo<ChatMode | undefined>(() => {
+    const selected =
+      hasManuallySelectedChatMode && settings?.selectedChatMode
+        ? settings.selectedChatMode
+        : homeInitialChatMode;
+    if (
+      settings &&
+      isFreeProBuildModeCombination(settings.selectedModel, selected)
+    ) {
+      return FREE_PRO_MODEL_FALLBACK_CHAT_MODE;
+    }
+    return selected;
+  }, [settings, homeInitialChatMode, hasManuallySelectedChatMode]);
+
   const handleSubmit = useCallback(
     async (options?: HomeSubmitOptions) => {
       const attachments = options?.attachments || [];
@@ -236,14 +253,14 @@ export default function HomePage() {
           // Existing app flow: create a new chat in the selected app
           chatId = await ipc.chat.createChat({
             appId: selectedApp.id,
-            initialChatMode: homeInitialChatMode,
+            initialChatMode: homeSubmitChatMode,
           });
           appId = selectedApp.id;
         } else {
           // New app flow (default behavior)
           const result = await ipc.app.createApp({
             name: generateCuteAppName(),
-            initialChatMode: homeInitialChatMode,
+            initialChatMode: homeSubmitChatMode,
           });
           chatId = result.chatId;
           appId = result.app.id;
@@ -275,7 +292,7 @@ export default function HomePage() {
           chatId,
           appId,
           attachments,
-          requestedChatMode: homeInitialChatMode,
+          requestedChatMode: homeSubmitChatMode,
         });
         await new Promise((resolve) =>
           setTimeout(resolve, settings?.isTestMode ? 0 : 2000),
@@ -307,7 +324,7 @@ export default function HomePage() {
     },
     [
       inputValue,
-      homeInitialChatMode,
+      homeSubmitChatMode,
       isAnyProviderSetup,
       isLoadingLanguageModelProviders,
       navigate,


### PR DESCRIPTION
Home submit created the chat with homeInitialChatMode (the computed effective default), which discarded a manually selected mode like "plan" and switched the new chat back to the default. Use the latched manual selection on submit when present, falling back to the effective default otherwise.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

