### PR TITLE
Persist plan drafts so unaccepted plans survive a restart

### DIFF
--- a/src/components/preview_panel/PlanPanel.tsx
+++ b/src/components/preview_panel/PlanPanel.tsx
@@ -46,8 +46,10 @@ export const PlanPanel: React.FC = () => {
   const currentTitle = planData?.title ?? null;
   const currentSummary = planData?.summary ?? null;
   const isAccepted = chatId ? planState.acceptedChatIds.has(chatId) : false;
-  // Plan was already saved if we found it in the filesystem
-  const isSavedPlan = !!savedPlan;
+  // A persisted plan only counts as accepted once its status says so. Drafts
+  // are persisted too (so they survive a restart) but must still offer the
+  // accept buttons.
+  const isAcceptedPlan = savedPlan?.status === "accepted";
 
   // If there's no plan content, switch back to preview mode
   useEffect(() => {
@@ -249,7 +251,7 @@ export const PlanPanel: React.FC = () => {
       )}
 
       <div className="border-t p-4 space-y-4 bg-background">
-        {isAccepted || isSavedPlan ? (
+        {isAccepted || isAcceptedPlan ? (
           <div className="flex items-center gap-2 text-green-700 dark:text-green-300">
             <Check size={16} />
             <span className="text-sm font-medium">

--- a/src/components/preview_panel/PlanPanel.tsx
+++ b/src/components/preview_panel/PlanPanel.tsx
@@ -48,8 +48,16 @@ export const PlanPanel: React.FC = () => {
   const isAccepted = chatId ? planState.acceptedChatIds.has(chatId) : false;
   // A persisted plan only counts as accepted once its status says so. Drafts
   // are persisted too (so they survive a restart) but must still offer the
-  // accept buttons.
-  const isAcceptedPlan = savedPlan?.status === "accepted";
+  // accept buttons. We also require the saved-plan content to match what's
+  // currently displayed: after a chat receives a newer draft, the cached
+  // savedPlan may still report "accepted" for older content, and we must not
+  // keep hiding the accept buttons for the new draft.
+  const isAcceptedPlan =
+    savedPlan != null &&
+    savedPlan.status === "accepted" &&
+    savedPlan.content === currentPlan &&
+    savedPlan.title === currentTitle &&
+    (savedPlan.summary ?? null) === (currentSummary ?? null);
 
   // If there's no plan content, switch back to preview mode
   useEffect(() => {
@@ -255,9 +263,13 @@ export const PlanPanel: React.FC = () => {
           <div className="flex items-center gap-2 text-green-700 dark:text-green-300">
             <Check size={16} />
             <span className="text-sm font-medium">
-              {acceptedInNewChat === false
-                ? "Plan accepted — implementation started in this chat"
-                : "Plan accepted — implementation started in a new chat"}
+              {acceptedInNewChat === null
+                ? // After a restart the in-memory choice is lost, so we can't
+                  // say whether implementation started here or in a new chat.
+                  "Plan accepted"
+                : acceptedInNewChat === false
+                  ? "Plan accepted — implementation started in this chat"
+                  : "Plan accepted — implementation started in a new chat"}
             </span>
           </div>
         ) : (

--- a/src/ipc/handlers/planPersistence.ts
+++ b/src/ipc/handlers/planPersistence.ts
@@ -1,0 +1,79 @@
+import fs from "node:fs";
+import path from "node:path";
+import { buildFrontmatter, parsePlanFile, validatePlanId } from "./planUtils";
+import { ensureDyadGitignored } from "./gitignoreUtils";
+
+export type PlanStatus = "draft" | "accepted";
+
+/**
+ * A plan file is a `draft` while the user is still reviewing it and only
+ * becomes `accepted` once they choose to implement it. Legacy plan files
+ * (written before drafts were persisted) have no `status` field and are
+ * treated as `accepted`, since they were only ever written on acceptance.
+ */
+export function normalizePlanStatus(raw: string | undefined): PlanStatus {
+  return raw === "draft" ? "draft" : "accepted";
+}
+
+export function planDirForAppPath(appPath: string): string {
+  return path.join(appPath, ".dyad", "plans");
+}
+
+/**
+ * Stable per-chat slug so repeated saves (draft revisions, then acceptance)
+ * overwrite the same file instead of accumulating one file per keystroke/turn.
+ */
+export function planSlugForChat(chatId: number): string {
+  const slug = `chat-${chatId}-plan`;
+  validatePlanId(slug);
+  return slug;
+}
+
+/**
+ * Upserts the plan file for a chat under `.dyad/plans/`. Returns the plan slug.
+ *
+ * Used both when a plan is first drafted (`status: "draft"`, best-effort) and
+ * when it is accepted (`status: "accepted"`). Preserves the original
+ * `createdAt` when a file already exists so promotion to accepted doesn't reset
+ * it.
+ */
+export async function savePlanToDisk(params: {
+  appPath: string;
+  chatId: number;
+  title: string;
+  summary?: string;
+  content: string;
+  status: PlanStatus;
+}): Promise<string> {
+  const { appPath, chatId, title, summary, content, status } = params;
+  const planDir = planDirForAppPath(appPath);
+  await fs.promises.mkdir(planDir, { recursive: true });
+  await ensureDyadGitignored(appPath);
+
+  const slug = planSlugForChat(chatId);
+  const filePath = path.join(planDir, `${slug}.md`);
+  const now = new Date().toISOString();
+
+  // Preserve the original createdAt if we're overwriting an existing plan.
+  let createdAt = now;
+  try {
+    const existing = await fs.promises.readFile(filePath, "utf-8");
+    const { meta } = parsePlanFile(existing);
+    if (meta.createdAt) createdAt = meta.createdAt;
+  } catch {
+    // No existing plan file — this is the first save.
+  }
+
+  const meta: Record<string, string> = {
+    title,
+    summary: summary ?? "",
+    status,
+    chatId: String(chatId),
+    createdAt,
+    updatedAt: now,
+  };
+  const frontmatter = buildFrontmatter(meta);
+  await fs.promises.writeFile(filePath, frontmatter + content, "utf-8");
+
+  return slug;
+}

--- a/src/ipc/handlers/plan_handlers.ts
+++ b/src/ipc/handlers/plan_handlers.ts
@@ -8,22 +8,26 @@ import log from "electron-log";
 import { createTypedHandler } from "./base";
 import { planContracts } from "../types/plan";
 import { questionnaireResolver } from "../../pro/main/ipc/handlers/local_agent/userInputResolvers";
+import { buildFrontmatter, validatePlanId, parsePlanFile } from "./planUtils";
 import {
-  slugify,
-  buildFrontmatter,
-  validatePlanId,
-  parsePlanFile,
-} from "./planUtils";
+  normalizePlanStatus,
+  planDirForAppPath,
+  savePlanToDisk,
+} from "./planPersistence";
 import { ensureDyadGitignored } from "./gitignoreUtils";
 import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
 
 const logger = log.scope("plan_handlers");
 
-async function getPlanDir(appId: number): Promise<string> {
+async function getAppPath(appId: number): Promise<string> {
   const app = await db.query.apps.findFirst({ where: eq(apps.id, appId) });
   if (!app) throw new Error("App not found");
-  const appPath = getDyadAppPath(app.path);
-  const planDir = path.join(appPath, ".dyad", "plans");
+  return getDyadAppPath(app.path);
+}
+
+async function getPlanDir(appId: number): Promise<string> {
+  const appPath = await getAppPath(appId);
+  const planDir = planDirForAppPath(appPath);
   await fs.promises.mkdir(planDir, { recursive: true });
   await ensureDyadGitignored(appPath);
   return planDir;
@@ -32,24 +36,26 @@ async function getPlanDir(appId: number): Promise<string> {
 export function registerPlanHandlers() {
   createTypedHandler(planContracts.createPlan, async (_, params) => {
     const { appId, chatId, title, summary, content } = params;
-    const planDir = await getPlanDir(appId);
-    const now = new Date().toISOString();
-    const slug = `chat-${chatId}-${slugify(title)}-${Date.now()}`;
-    validatePlanId(slug);
-
-    const meta: Record<string, string> = {
+    const appPath = await getAppPath(appId);
+    // Accepting a plan promotes the (possibly already-persisted) draft to
+    // "accepted" and returns its stable per-chat slug.
+    const slug = await savePlanToDisk({
+      appPath,
+      chatId,
       title,
-      summary: summary ?? "",
-      chatId: String(chatId),
-      createdAt: now,
-      updatedAt: now,
-    };
-    const frontmatter = buildFrontmatter(meta);
+      summary,
+      content,
+      status: "accepted",
+    });
 
-    const filePath = path.join(planDir, `${slug}.md`);
-    await fs.promises.writeFile(filePath, frontmatter + content, "utf-8");
-
-    logger.info("Created plan:", slug, "for app:", appId, "with title:", title);
+    logger.info(
+      "Accepted plan:",
+      slug,
+      "for app:",
+      appId,
+      "with title:",
+      title,
+    );
 
     return slug;
   });
@@ -79,6 +85,7 @@ export function registerPlanHandlers() {
       title: meta.title ?? "",
       summary: meta.summary || null,
       content,
+      status: normalizePlanStatus(meta.status),
       createdAt: meta.createdAt ?? new Date().toISOString(),
       updatedAt: meta.updatedAt ?? new Date().toISOString(),
     };
@@ -100,14 +107,24 @@ export function registerPlanHandlers() {
       const prefix = `chat-${chatId}-`;
       const matches = mdFiles.filter((f) => f.startsWith(prefix));
       if (matches.length === 0) return null;
-      // Sort to get the latest plan (filenames contain timestamps)
-      matches.sort();
-      const match = matches[matches.length - 1];
 
-      const filePath = path.join(planDir, match);
-      const raw = await fs.promises.readFile(filePath, "utf-8");
-      const { meta, content } = parsePlanFile(raw);
-      const slug = match.replace(/\.md$/, "");
+      // A chat normally has a single stable-slug plan file, but legacy
+      // timestamped files may coexist. Pick the most recently updated one so
+      // filename ordering can't surface a stale plan over a newer draft.
+      const parsed = await Promise.all(
+        matches.map(async (file) => {
+          const raw = await fs.promises.readFile(
+            path.join(planDir, file),
+            "utf-8",
+          );
+          return { slug: file.replace(/\.md$/, ""), ...parsePlanFile(raw) };
+        }),
+      );
+      parsed.sort((a, b) =>
+        (a.meta.updatedAt ?? "").localeCompare(b.meta.updatedAt ?? ""),
+      );
+      const { slug, meta, content } = parsed[parsed.length - 1];
+
       return {
         id: slug,
         appId,
@@ -115,6 +132,7 @@ export function registerPlanHandlers() {
         title: meta.title ?? "",
         summary: meta.summary || null,
         content,
+        status: normalizePlanStatus(meta.status),
         createdAt: meta.createdAt ?? new Date().toISOString(),
         updatedAt: meta.updatedAt ?? new Date().toISOString(),
       };

--- a/src/ipc/handlers/plan_handlers.ts
+++ b/src/ipc/handlers/plan_handlers.ts
@@ -111,18 +111,34 @@ export function registerPlanHandlers() {
       // A chat normally has a single stable-slug plan file, but legacy
       // timestamped files may coexist. Pick the most recently updated one so
       // filename ordering can't surface a stale plan over a newer draft.
-      const parsed = await Promise.all(
+      // A single unreadable file (concurrent deletion, permission issue, etc.)
+      // must not prevent the chat from loading its other plans, so read each
+      // file defensively and drop the ones that fail.
+      const parsedResults = await Promise.all(
         matches.map(async (file) => {
-          const raw = await fs.promises.readFile(
-            path.join(planDir, file),
-            "utf-8",
-          );
-          return { slug: file.replace(/\.md$/, ""), ...parsePlanFile(raw) };
+          try {
+            const raw = await fs.promises.readFile(
+              path.join(planDir, file),
+              "utf-8",
+            );
+            return { slug: file.replace(/\.md$/, ""), ...parsePlanFile(raw) };
+          } catch (err) {
+            logger.warn(`Failed to read plan file ${file}:`, err);
+            return null;
+          }
         }),
       );
-      parsed.sort((a, b) =>
-        (a.meta.updatedAt ?? "").localeCompare(b.meta.updatedAt ?? ""),
+      const parsed = parsedResults.filter(
+        (p): p is NonNullable<typeof p> => p !== null,
       );
+      if (parsed.length === 0) return null;
+      // Fall back to createdAt (then empty) so a missing updatedAt can't sort a
+      // stale legacy plan ahead of a newer one.
+      parsed.sort((a, b) => {
+        const aTime = a.meta.updatedAt || a.meta.createdAt || "";
+        const bTime = b.meta.updatedAt || b.meta.createdAt || "";
+        return aTime.localeCompare(bTime);
+      });
       const { slug, meta, content } = parsed[parsed.length - 1];
 
       return {

--- a/src/ipc/types/plan.ts
+++ b/src/ipc/types/plan.ts
@@ -64,6 +64,10 @@ export const PlanSchema = z.object({
   title: z.string(),
   summary: z.string().nullable(),
   content: z.string(),
+  // "draft" while the user is still reviewing the plan, "accepted" once they
+  // choose to implement it. Legacy plans without a status are treated as
+  // "accepted".
+  status: z.enum(["draft", "accepted"]),
   createdAt: z.string(),
   updatedAt: z.string(),
 });

--- a/src/pro/main/ipc/handlers/local_agent/tools/write_plan.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/write_plan.ts
@@ -85,7 +85,7 @@ export const writePlanTool: ToolDefinition<z.infer<typeof writePlanSchema>> = {
         status: "draft",
       });
     } catch (error) {
-      logger.warn(`Failed to persist plan draft: ${error}`);
+      logger.warn("Failed to persist plan draft", error);
     }
 
     return `Implementation plan "${args.title}" has been presented to the user. They can review it in the preview panel and either accept it or request changes.`;

--- a/src/pro/main/ipc/handlers/local_agent/tools/write_plan.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/write_plan.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import log from "electron-log";
 import { ToolDefinition, AgentContext, escapeXmlAttr } from "./types";
 import { safeSend } from "@/ipc/utils/safe_sender";
+import { savePlanToDisk } from "@/ipc/handlers/planPersistence";
 
 const logger = log.scope("write_plan");
 
@@ -70,6 +71,22 @@ export const writePlanTool: ToolDefinition<z.infer<typeof writePlanSchema>> = {
       summary: args.summary,
       plan: args.plan,
     });
+
+    // Persist the plan as a draft so it survives an app restart before the user
+    // accepts it. Best-effort: the plan is still shown in-memory even if the
+    // write fails, so a persistence error must not fail the tool call.
+    try {
+      await savePlanToDisk({
+        appPath: ctx.appPath,
+        chatId: ctx.chatId,
+        title: args.title,
+        summary: args.summary,
+        content: args.plan,
+        status: "draft",
+      });
+    } catch (error) {
+      logger.warn(`Failed to persist plan draft: ${error}`);
+    }
 
     return `Implementation plan "${args.title}" has been presented to the user. They can review it in the preview panel and either accept it or request changes.`;
   },


### PR DESCRIPTION
Previously a plan was only written to disk when accepted, so an unaccepted plan lived only in memory and was lost on app restart.

Now the plan is persisted as a draft (status: "draft") the moment it is presented, and promoted to "accepted" on acceptance. The PlanPanel "already accepted" gate keys off status rather than mere file existence, so a rehydrated draft still offers the accept buttons.

- New planPersistence.ts: shared savePlanToDisk({ status }), a stable per-chat slug, and normalizePlanStatus (legacy files -> accepted).
- write_plan tool persists a draft (best-effort) when presenting a plan.
- createPlan promotes the draft to accepted; read handlers return status; getPlanForChat picks the most recently updated plan file.
- PlanSchema carries a status field.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

