### PR TITLE
Make code view file tree horizontally resizable

### DIFF
--- a/src/components/preview_panel/CodeView.tsx
+++ b/src/components/preview_panel/CodeView.tsx
@@ -132,7 +132,7 @@ export const CodeView = ({ loading, app }: CodeViewProps) => {
             </Panel>
             <PanelResizeHandle
               aria-label="Resize file tree"
-              className="w-1 bg-gray-200 hover:bg-gray-300 dark:bg-gray-800 dark:hover:bg-gray-700 transition-colors cursor-col-resize"
+              className="w-1 bg-border hover:bg-gray-400 transition-colors cursor-col-resize"
             />
             <Panel defaultSize={67} minSize={30}>
               {selectedFile ? (

--- a/src/components/preview_panel/CodeView.tsx
+++ b/src/components/preview_panel/CodeView.tsx
@@ -125,12 +125,15 @@ export const CodeView = ({ loading, app }: CodeViewProps) => {
             autoSaveId="code-view-file-tree"
             className="flex-1 overflow-hidden"
           >
-            <Panel defaultSize={33} minSize={15} collapsible>
-              <div className="h-full border-r overflow-hidden flex flex-col min-h-0">
+            <Panel defaultSize={33} minSize={15}>
+              <div className="h-full overflow-hidden flex flex-col min-h-0">
                 <FileTree appId={app.id ?? null} files={app.files ?? []} />
               </div>
             </Panel>
-            <PanelResizeHandle className="w-1 bg-gray-200 hover:bg-gray-300 dark:bg-gray-800 dark:hover:bg-gray-700 transition-colors cursor-col-resize" />
+            <PanelResizeHandle
+              aria-label="Resize file tree"
+              className="w-1 bg-gray-200 hover:bg-gray-300 dark:bg-gray-800 dark:hover:bg-gray-700 transition-colors cursor-col-resize"
+            />
             <Panel defaultSize={67} minSize={30}>
               {selectedFile ? (
                 <FileEditor

--- a/src/components/preview_panel/CodeView.tsx
+++ b/src/components/preview_panel/CodeView.tsx
@@ -13,6 +13,7 @@ import { selectedFileAtom } from "@/atoms/viewAtoms";
 import { selectedVersionIdAtom } from "@/atoms/appAtoms";
 import { useTranslation } from "react-i18next";
 import { VersionDiffView } from "./VersionDiffView";
+import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 
 interface App {
   id?: number;
@@ -119,11 +120,18 @@ export const CodeView = ({ loading, app }: CodeViewProps) => {
         {isVersionDiffMode ? (
           <VersionDiffView appId={app.id!} versionId={selectedVersionId} />
         ) : (
-          <div className="flex flex-1 overflow-hidden">
-            <div className="w-1/3 border-r overflow-hidden flex flex-col min-h-0">
-              <FileTree appId={app.id ?? null} files={app.files ?? []} />
-            </div>
-            <div className="w-2/3">
+          <PanelGroup
+            direction="horizontal"
+            autoSaveId="code-view-file-tree"
+            className="flex-1 overflow-hidden"
+          >
+            <Panel defaultSize={33} minSize={15} collapsible>
+              <div className="h-full border-r overflow-hidden flex flex-col min-h-0">
+                <FileTree appId={app.id ?? null} files={app.files ?? []} />
+              </div>
+            </Panel>
+            <PanelResizeHandle className="w-1 bg-gray-200 hover:bg-gray-300 dark:bg-gray-800 dark:hover:bg-gray-700 transition-colors cursor-col-resize" />
+            <Panel defaultSize={67} minSize={30}>
               {selectedFile ? (
                 <FileEditor
                   key={`${app.id ?? "unknown"}:${selectedFile.path}`}
@@ -136,8 +144,8 @@ export const CodeView = ({ loading, app }: CodeViewProps) => {
                   {t("preview.selectFileToView")}
                 </div>
               )}
-            </div>
-          </div>
+            </Panel>
+          </PanelGroup>
         )}
       </div>
     );


### PR DESCRIPTION
Replace the fixed 1/3 / 2/3 split in CodeView with a react-resizable-panels PanelGroup so the file tree can be resized by dragging, with the width persisted across sessions and min-width bounds on both panes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

