### PR TITLE
Fix invisible code view toolbar icons on hover in dark mode

### DIFF
--- a/src/components/preview_panel/CodeView.tsx
+++ b/src/components/preview_panel/CodeView.tsx
@@ -81,7 +81,7 @@ export const CodeView = ({ loading, app }: CodeViewProps) => {
               render={
                 <button
                   onClick={() => refreshApp()}
-                  className="p-1 rounded hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
                   disabled={loading || !app.id}
                 />
               }
@@ -101,7 +101,7 @@ export const CodeView = ({ loading, app }: CodeViewProps) => {
               render={
                 <button
                   onClick={() => setIsFullscreen((value) => !value)}
-                  className="p-1 rounded hover:bg-gray-200"
+                  className="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700"
                 />
               }
             >


### PR DESCRIPTION
Add dark:hover:bg-gray-700 to the refresh and fullscreen buttons so the hover background is dark instead of light gray, keeping the icons visible.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

