### PR TITLE
Add disclosure for free API keys

### DIFF
--- a/src/components/settings/ProviderSettingsHeader.tsx
+++ b/src/components/settings/ProviderSettingsHeader.tsx
@@ -95,10 +95,16 @@ export function ProviderSettingsHeader({
           </span>
         </div>
         {!isLoading && hasFreeTier && (
-          <span className="text-blue-600 mt-2 dark:text-blue-400 text-sm font-medium bg-blue-100 dark:bg-blue-900/30 px-2 py-1 rounded-full inline-flex items-center">
-            <GiftIcon className="w-4 h-4 mr-1" />
-            Free tier available
-          </span>
+          <>
+            <span className="text-blue-600 mt-2 dark:text-blue-400 text-sm font-medium bg-blue-100 dark:bg-blue-900/30 px-2 py-1 rounded-full inline-flex items-center">
+              <GiftIcon className="w-4 h-4 mr-1" />
+              Free tier available
+            </span>
+            <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+              Free tiers typically allow the provider to use your data to train
+              AI models.
+            </p>
+          </>
         )}
       </div>
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only UI change on provider settings with no logic, API, or data-handling changes.
> 
> **Overview**
> When a provider shows the **Free tier available** badge on the configure screen, the header now also displays a short disclaimer that free tiers typically let the provider use your data to train AI models.
> 
> The badge is unchanged; it is wrapped in a fragment so the new gray helper text can sit directly below it, only while `hasFreeTier` is true and loading has finished.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6fc1cbcd2082c921d8d39d372c718f22dcaa2f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->