### PR TITLE
Update Auto Google model alias

### DIFF
--- a/src/ipc/shared/language_model_constants.ts
+++ b/src/ipc/shared/language_model_constants.ts
@@ -20,6 +20,7 @@ export const GPT_5_5_MODEL_NAME = "gpt-5.5";
 export const SONNET_4_6 = "claude-sonnet-4-6";
 export const OPUS_4_6 = "claude-opus-4-6";
 export const OPUS_4_8 = "claude-opus-4-8";
+export const GEMINI_3_5_FLASH = "gemini-3.5-flash";
 export const GEMINI_3_FLASH = "gemini-3-flash-preview";
 export const GEMINI_3_1_PRO_PREVIEW = "gemini-3.1-pro-preview";
 export const GPT_5_NANO = "gpt-5-nano";
@@ -169,6 +170,19 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
       // Recommended by Google: https://ai.google.dev/gemini-api/docs/gemini-3?thinking=high#temperature
       temperature: 1.0,
       dollarSigns: 4,
+    },
+    // Mirrors the production catalog entry for Gemini 3.5 Flash.
+    {
+      name: GEMINI_3_5_FLASH,
+      displayName: "Gemini 3.5 Flash",
+      description: "Google's high-quality Flash model",
+      // See Flash 2.5 comment below (go 1 below just to be safe, even though it seems OK now).
+      maxOutputTokens: 65_536 - 1,
+      // Gemini context window = input token + output token
+      contextWindow: 1_048_576,
+      // Recommended by Google: https://ai.google.dev/gemini-api/docs/gemini-3?thinking=high#temperature
+      temperature: 1.0,
+      dollarSigns: 3,
     },
     // https://ai.google.dev/gemini-api/docs/models#gemini-3-pro
     {

--- a/src/ipc/shared/remote_language_model_catalog.ts
+++ b/src/ipc/shared/remote_language_model_catalog.ts
@@ -11,6 +11,7 @@ import {
 } from "@/ipc/types/templates";
 import {
   CLOUD_PROVIDERS,
+  GEMINI_3_5_FLASH,
   GEMINI_3_1_PRO_PREVIEW,
   GPT_5_2_MODEL_NAME,
   GPT_5_5_MODEL_NAME,
@@ -19,7 +20,6 @@ import {
   OPUS_4_6,
   OPUS_4_8,
   PROVIDER_TO_ENV_VAR,
-  GEMINI_3_FLASH,
 } from "./language_model_constants";
 
 const logger = log.scope("remote_language_model_catalog");
@@ -219,7 +219,7 @@ function buildFallbackCatalog(): BuiltinLanguageModelCatalog {
         id: "dyad/auto/google",
         resolvedModel: {
           providerId: "google",
-          apiName: GEMINI_3_FLASH,
+          apiName: GEMINI_3_5_FLASH,
         },
         displayName: "Auto Google",
         purpose: "auto-mode",

--- a/src/ipc/utils/get_model_client.test.ts
+++ b/src/ipc/utils/get_model_client.test.ts
@@ -59,7 +59,7 @@ vi.mock("../shared/remote_language_model_catalog", () => ({
       case "dyad/auto/google":
         return {
           providerId: "google",
-          apiName: "gemini-3-flash-preview",
+          apiName: "gemini-3.5-flash",
         };
       default:
         return null;
@@ -119,7 +119,7 @@ describe("getModelClient", () => {
     expect(fallbackModels.map((model) => model.modelId)).toEqual([
       "gpt-5.5",
       "anthropic/claude-sonnet-4-20250514",
-      "gemini/gemini-3-flash-preview",
+      "gemini/gemini-3.5-flash",
     ]);
   });
 


### PR DESCRIPTION
## Summary

- Add Gemini 3.5 Flash to the fallback Google model catalog.
- Point the fallback Auto Google alias at gemini-3.5-flash.
- Update the Auto fallback unit test expectation.

## Tests

- npm test -- src/ipc/utils/get_model_client.test.ts
- npm run ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small catalog and alias change only; behavior shift is which Google model Auto mode uses when the remote catalog is unavailable or merged from fallback.
> 
> **Overview**
> **Auto Google** now resolves to **`gemini-3.5-flash`** instead of **`gemini-3-flash-preview`** in the fallback language model catalog (`dyad/auto/google`).
> 
> The change adds **`GEMINI_3_5_FLASH`** and a Google **`MODEL_OPTIONS`** entry for Gemini 3.5 Flash (aligned with the production catalog). **`get_model_client.test.ts`** expectations for auto-mode Google fallback are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67587ca4bbf159b6303f8cea88f5dcf2742393fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

