### PR TITLE
Add OpenRouter free Auto fallback

### DIFF
--- a/src/components/ModelPicker.test.tsx
+++ b/src/components/ModelPicker.test.tsx
@@ -8,6 +8,8 @@ const mocks = vi.hoisted(() => ({
   updateSettings: vi.fn(),
   selectedMode: "build",
   isTrial: false,
+  renderSubContent: false,
+  envVars: {} as Record<string, string | undefined>,
   freeModelQuota: {
     quotaStatus: {
       messagesUsed: 3,
@@ -38,6 +40,11 @@ const mocks = vi.hoisted(() => ({
           value: "dyad-pro-key",
         },
       },
+      openrouter: {
+        apiKey: {
+          value: "",
+        },
+      },
     },
     selectedModel: {
       name: "auto",
@@ -58,6 +65,7 @@ vi.mock("@/hooks/useSettings", () => ({
   useSettings: () => ({
     settings: mocks.settings,
     updateSettings: mocks.updateSettings,
+    envVars: mocks.envVars,
   }),
 }));
 
@@ -101,7 +109,7 @@ vi.mock("@/hooks/useLanguageModelsByProviders", () => ({
         },
         {
           apiName: "free",
-          displayName: "Free",
+          displayName: "Free (OpenRouter)",
           description: "Free model",
           type: "cloud",
         },
@@ -175,6 +183,15 @@ vi.mock("@/hooks/useLanguageModelsByProviders", () => ({
 vi.mock("@/hooks/useLanguageModelProviders", () => ({
   useLanguageModelProviders: () => ({
     isLoading: false,
+    isProviderSetup: (provider: string) => {
+      if (provider === "openrouter") {
+        return Boolean(
+          mocks.settings.providerSettings.openrouter.apiKey.value ||
+          mocks.envVars.OPENROUTER_API_KEY,
+        );
+      }
+      return false;
+    },
     data: [
       {
         id: "auto",
@@ -260,7 +277,8 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
   DropdownMenuSubTrigger: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   ),
-  DropdownMenuSubContent: () => null,
+  DropdownMenuSubContent: ({ children }: { children: React.ReactNode }) =>
+    mocks.renderSubContent ? <div>{children}</div> : null,
 }));
 
 describe("ModelPicker", () => {
@@ -270,8 +288,11 @@ describe("ModelPicker", () => {
     mocks.setChatMode.mockResolvedValue(undefined);
     mocks.updateSettings.mockReset();
     mocks.selectedMode = "build";
+    mocks.renderSubContent = false;
+    mocks.envVars = {};
     mocks.settings.enableDyadPro = true;
     mocks.settings.providerSettings.auto.apiKey.value = "dyad-pro-key";
+    mocks.settings.providerSettings.openrouter.apiKey.value = "";
     mocks.settings.selectedChatMode = "build";
     mocks.settings.defaultChatMode = "build";
     mocks.isTrial = false;
@@ -341,6 +362,64 @@ describe("ModelPicker", () => {
     expect(screen.queryByText("GPT 5")).toBeNull();
     expect(screen.queryByText("Grok Code Fast")).toBeNull();
     expect(screen.queryByText("Dyad Free")).toBeNull();
+  });
+
+  it("shows data sharing disclosure on Auto for non-Pro users with an OpenRouter key", () => {
+    mocks.settings.enableDyadPro = false;
+    mocks.settings.providerSettings.auto.apiKey.value = "";
+    mocks.settings.providerSettings.openrouter.apiKey.value = "openrouter-key";
+
+    render(<ModelPicker />);
+
+    expect(
+      screen.getAllByText("Auto")[1].closest("button")?.textContent,
+    ).toContain("Data sharing");
+  });
+
+  it("shows data sharing disclosure on Auto for non-Pro users with OPENROUTER_API_KEY", () => {
+    mocks.settings.enableDyadPro = false;
+    mocks.settings.providerSettings.auto.apiKey.value = "";
+    mocks.envVars.OPENROUTER_API_KEY = "openrouter-env-key";
+
+    render(<ModelPicker />);
+
+    expect(
+      screen.getAllByText("Auto")[1].closest("button")?.textContent,
+    ).toContain("Data sharing");
+  });
+
+  it("does not show data sharing disclosure on Auto without an OpenRouter key", () => {
+    mocks.settings.enableDyadPro = false;
+    mocks.settings.providerSettings.auto.apiKey.value = "";
+
+    render(<ModelPicker />);
+
+    expect(
+      screen.getAllByText("Auto")[1].closest("button")?.textContent,
+    ).not.toContain("Data sharing");
+  });
+
+  it("shows data sharing disclosure on the top-level Free OpenRouter model", () => {
+    mocks.settings.enableDyadPro = false;
+    mocks.settings.providerSettings.auto.apiKey.value = "";
+
+    render(<ModelPicker />);
+
+    expect(
+      screen.getAllByText("Free (OpenRouter)")[0].closest("button")
+        ?.textContent,
+    ).toContain("Data sharing");
+  });
+
+  it("shows data sharing disclosure on explicit free OpenRouter provider models", () => {
+    mocks.renderSubContent = true;
+    mocks.settings.enableDyadPro = false;
+    mocks.settings.providerSettings.auto.apiKey.value = "";
+
+    render(<ModelPicker />);
+
+    expect(screen.getAllByText("Free (OpenRouter)").length).toBe(2);
+    expect(screen.getAllByText("Data sharing").length).toBeGreaterThan(1);
   });
 
   it("selects flat Pro models with their source provider", () => {

--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -115,8 +115,11 @@ export function ModelPicker() {
   const { data: modelsByProviders, isLoading: modelsByProvidersLoading } =
     useLanguageModelsByProviders();
 
-  const { data: providers, isLoading: providersLoading } =
-    useLanguageModelProviders();
+  const {
+    data: providers,
+    isLoading: providersLoading,
+    isProviderSetup,
+  } = useLanguageModelProviders();
 
   const loading = modelsByProvidersLoading || providersLoading;
   const dyadProEnabled = settings ? isDyadProEnabled(settings) : false;
@@ -298,6 +301,18 @@ export function ModelPicker() {
       selectedModel.name === model.apiName;
     const isAutoProviderRow = providerId === "auto";
     const isFreeProRow = isFreeProLanguageModel(providerId, model.apiName);
+    const isFreeProviderRow =
+      model.apiName.endsWith(":free") || model.apiName.endsWith("/free");
+    const isAutoOpenRouterFreeRow =
+      isAutoProviderRow && model.apiName === "free";
+    const shouldShowDataSharingDisclosure =
+      isFreeProRow ||
+      isFreeProviderRow ||
+      isAutoOpenRouterFreeRow ||
+      (isAutoProviderRow &&
+        model.apiName === "auto" &&
+        !dyadProEnabled &&
+        isProviderSetup("openrouter"));
     const freeProResetTimeLabel = freeModelQuota.resetTime
       ? new Intl.DateTimeFormat(undefined, {
           hour: "numeric",
@@ -361,41 +376,41 @@ export function ModelPicker() {
               <CheckIcon className="size-3.5 text-primary shrink-0" />
             )}
             {isFreeProRow && (
-              <>
-                <span
-                  className={cn(
-                    PILL_CLASS,
-                    freeModelQuota.isQuotaExceeded
-                      ? "bg-destructive/10 text-destructive"
-                      : "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300",
-                  )}
-                  title={
-                    freeProResetTimeLabel
-                      ? `Resets at ${freeProResetTimeLabel}`
-                      : undefined
+              <span
+                className={cn(
+                  PILL_CLASS,
+                  freeModelQuota.isQuotaExceeded
+                    ? "bg-destructive/10 text-destructive"
+                    : "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300",
+                )}
+                title={
+                  freeProResetTimeLabel
+                    ? `Resets at ${freeProResetTimeLabel}`
+                    : undefined
+                }
+              >
+                {freeProQuotaLabel}
+              </span>
+            )}
+            {shouldShowDataSharingDisclosure && (
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <span
+                      className={cn(
+                        PILL_CLASS,
+                        "bg-amber-500/15 text-amber-700 dark:text-amber-300",
+                      )}
+                    >
+                      Data sharing
+                    </span>
                   }
-                >
-                  {freeProQuotaLabel}
-                </span>
-                <Tooltip>
-                  <TooltipTrigger
-                    render={
-                      <span
-                        className={cn(
-                          PILL_CLASS,
-                          "bg-amber-500/15 text-amber-700 dark:text-amber-300",
-                        )}
-                      >
-                        Data sharing
-                      </span>
-                    }
-                  />
-                  <TooltipContent side="right" align="start">
-                    Data may be shared with the AI provider and used for
-                    training models.
-                  </TooltipContent>
-                </Tooltip>
-              </>
+                />
+                <TooltipContent side="right" align="start">
+                  Data may be shared with the AI provider and used for training
+                  models.
+                </TooltipContent>
+              </Tooltip>
             )}
           </span>
         </div>

--- a/src/ipc/shared/language_model_constants.ts
+++ b/src/ipc/shared/language_model_constants.ts
@@ -23,6 +23,7 @@ export const OPUS_4_8 = "claude-opus-4-8";
 export const GEMINI_3_5_FLASH = "gemini-3.5-flash";
 export const GEMINI_3_FLASH = "gemini-3-flash-preview";
 export const GEMINI_3_1_PRO_PREVIEW = "gemini-3.1-pro-preview";
+export const NEMOTRON_3_SUPER_FREE = "nvidia/nemotron-3-super-120b-a12b:free";
 export const GPT_5_NANO = "gpt-5-nano";
 
 export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
@@ -250,6 +251,16 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
         "Uses one of the free OpenRouter models (data may be used for training)",
       maxOutputTokens: 32_000,
       contextWindow: 200_000,
+      temperature: 0,
+      dollarSigns: 0,
+    },
+    // https://openrouter.ai/nvidia/nemotron-3-super-120b-a12b:free
+    {
+      name: NEMOTRON_3_SUPER_FREE,
+      displayName: "Nemotron 3 Super (Free)",
+      description: "NVIDIA's open 120B MoE model with a 1M context window",
+      maxOutputTokens: 32_000,
+      contextWindow: 1_000_000,
       temperature: 0,
       dollarSigns: 0,
     },

--- a/src/ipc/shared/remote_language_model_catalog.ts
+++ b/src/ipc/shared/remote_language_model_catalog.ts
@@ -17,6 +17,7 @@ import {
   GPT_5_5_MODEL_NAME,
   GPT_5_NANO,
   MODEL_OPTIONS,
+  NEMOTRON_3_SUPER_FREE,
   OPUS_4_6,
   OPUS_4_8,
   PROVIDER_TO_ENV_VAR,
@@ -77,6 +78,7 @@ const KNOWN_BUILTIN_MODEL_ALIASES = [
   "dyad/auto/openai",
   "dyad/auto/anthropic",
   "dyad/auto/google",
+  "dyad/auto/openrouter",
   "dyad/help-bot/default",
 ] as const;
 
@@ -222,6 +224,15 @@ function buildFallbackCatalog(): BuiltinLanguageModelCatalog {
           apiName: GEMINI_3_5_FLASH,
         },
         displayName: "Auto Google",
+        purpose: "auto-mode",
+      },
+      {
+        id: "dyad/auto/openrouter",
+        resolvedModel: {
+          providerId: "openrouter",
+          apiName: NEMOTRON_3_SUPER_FREE,
+        },
+        displayName: "Auto OpenRouter",
         purpose: "auto-mode",
       },
       {

--- a/src/ipc/utils/get_model_client.test.ts
+++ b/src/ipc/utils/get_model_client.test.ts
@@ -40,6 +40,11 @@ vi.mock("../shared/language_model_helpers", () => ({
       gatewayPrefix: "gemini/",
       type: "cloud",
     },
+    {
+      id: "openrouter",
+      name: "OpenRouter",
+      type: "cloud",
+    },
   ]),
 }));
 
@@ -60,6 +65,11 @@ vi.mock("../shared/remote_language_model_catalog", () => ({
         return {
           providerId: "google",
           apiName: "gemini-3.5-flash",
+        };
+      case "dyad/auto/openrouter":
+        return {
+          providerId: "openrouter",
+          apiName: "nvidia/nemotron-3-super-120b-a12b:free",
         };
       default:
         return null;
@@ -121,6 +131,31 @@ describe("getModelClient", () => {
       "anthropic/claude-sonnet-4-20250514",
       "gemini/gemini-3.5-flash",
     ]);
+  });
+
+  test("uses OpenRouter free alias as regular auto fallback only outside Dyad Pro", async () => {
+    const { modelClient, isEngineEnabled } = await getModelClient(
+      {
+        provider: "auto",
+        name: "auto",
+      },
+      {
+        enableDyadPro: false,
+        providerSettings: {
+          openrouter: {
+            apiKey: {
+              value: "openrouter-key",
+            },
+          },
+        },
+      } as unknown as UserSettings,
+    );
+
+    expect((modelClient.model as { modelId: string }).modelId).toBe(
+      "nvidia/nemotron-3-super-120b-a12b:free",
+    );
+    expect(modelClient.builtinProviderId).toBe("openrouter");
+    expect(isEngineEnabled).toBeFalsy();
   });
 
   test("routes Dyad Free through its dedicated engine model", async () => {

--- a/src/ipc/utils/get_model_client.ts
+++ b/src/ipc/utils/get_model_client.ts
@@ -38,10 +38,15 @@ import { FREE_PRO_MODEL_NAME, isFreeProModel } from "@/lib/freeProModel";
 
 const dyadEngineUrl = process.env.DYAD_ENGINE_URL;
 
-const AUTO_MODEL_ALIASES = [
+const AUTO_DYAD_PRO_MODEL_ALIASES = [
   "dyad/auto/openai",
   "dyad/auto/anthropic",
   "dyad/auto/google",
+] as const;
+
+const AUTO_MODEL_ALIASES = [
+  ...AUTO_DYAD_PRO_MODEL_ALIASES,
+  "dyad/auto/openrouter",
 ] as const;
 
 export interface ModelClient {
@@ -232,9 +237,9 @@ async function getProModelClient({
   ) {
     const providers = await getLanguageModelProviders();
     const fallbackModels = await Promise.all(
-      AUTO_MODEL_ALIASES.map(async (aliasId) => {
+      AUTO_DYAD_PRO_MODEL_ALIASES.map(async (aliasId) => {
         const resolvedModel = await resolveBuiltinModelAlias(aliasId);
-        if (!resolvedModel) {
+        if (!resolvedModel || resolvedModel.apiName.endsWith(":free")) {
           return null;
         }
 


### PR DESCRIPTION
## Summary

- Add OpenRouter nvidia/nemotron-3-super-120b-a12b:free to the fallback model catalog.
- Add dyad/auto/openrouter as a non-Pro Auto fallback alias.
- Keep Dyad Pro Auto fallback limited to non-free OpenAI, Anthropic, and Google models.
- Add a unit test covering the regular Auto OpenRouter fallback path.

## Model source

- https://openrouter.ai/nvidia/nemotron-3-super-120b-a12b:free

## Tests

- npm test -- src/components/ModelPicker.test.tsx
- npm test -- src/ipc/utils/get_model_client.test.ts
- npm run ts

## Related

- dyad-cloud production catalog PR: https://github.com/dyad-sh/dyad-cloud/pull/355

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Auto model resolution and which free models users hit; wrong alias ordering or fallback rules could route traffic to unexpected providers, though scope is bounded by existing auto-alias iteration and new tests.
> 
> **Overview**
> **Non–Dyad Pro Auto** can resolve to OpenRouter’s free **Nemotron 3 Super** when an OpenRouter API key is configured, via a new **`dyad/auto/openrouter`** builtin alias and catalog entry. **Dyad Pro** Auto / local-agent fallback chains stay limited to paid OpenAI, Anthropic, and Google aliases—free `:free` models are excluded from that Pro fallback list.
> 
> The model catalog gains **`NEMOTRON_3_SUPER_FREE`** under OpenRouter (and the remote/fallback alias wiring). **ModelPicker** expands when the **“Data sharing”** pill appears: free OpenRouter rows, Auto **`free`**, and **Auto** for non-Pro users who have OpenRouter set up (settings or **`OPENROUTER_API_KEY`**), decoupled from Dyad Free quota UI. Tests cover the non-Pro Auto OpenRouter client path and the new disclosure cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f13d298c6a534e1369ac9f5304fcdd27f68929cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->