### PR TITLE
Render dyad-security-finding as an inline chat card

### DIFF
--- a/src/components/chat/DyadMarkdownParser.test.tsx
+++ b/src/components/chat/DyadMarkdownParser.test.tsx
@@ -50,6 +50,41 @@ describe("DyadMarkdownParser dyad-status", () => {
   });
 });
 
+describe("DyadMarkdownParser dyad-security-finding", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders a card with the title and severity level", () => {
+    render(
+      <DyadMarkdownParser
+        content={
+          '<dyad-security-finding title="SQL Injection in User Lookup" level="critical">\nUser input is concatenated into a query.\n</dyad-security-finding>'
+        }
+      />,
+    );
+
+    const card = screen.getByRole("button");
+    expect(screen.getByText("SQL Injection in User Lookup")).toBeTruthy();
+    // SeverityBadge renders the level text.
+    expect(screen.getByText("critical")).toBeTruthy();
+    // critical maps to the red left-accent.
+    expect(card.className).toContain("border-l-red-500");
+  });
+
+  it("falls back gracefully when the level is missing or invalid", () => {
+    render(
+      <DyadMarkdownParser
+        content={'<dyad-security-finding title="Partial finding">'}
+      />,
+    );
+
+    expect(screen.getByText("Partial finding")).toBeTruthy();
+    // No badge is rendered for an unknown level.
+    expect(screen.queryByText("critical")).toBeNull();
+  });
+});
+
 describe("DyadMarkdownParser closed-block render counts", () => {
   beforeEach(() => {
     markdownRenderCounts.clear();

--- a/src/components/chat/DyadMarkdownParser.tsx
+++ b/src/components/chat/DyadMarkdownParser.tsx
@@ -27,6 +27,7 @@ import {
 import { CustomTagState } from "./stateTypes";
 import { DyadOutput } from "./DyadOutput";
 import { DyadProblemSummary } from "./DyadProblemSummary";
+import { DyadSecurityFinding } from "./DyadSecurityFinding";
 import { ipc } from "@/ipc/types";
 import { DyadMcpToolCall } from "./DyadMcpToolCall";
 import { DyadMcpToolResult } from "./DyadMcpToolResult";
@@ -892,6 +893,13 @@ function renderCustomTag(
         <DyadProblemSummary summary={attributes.summary}>
           {content}
         </DyadProblemSummary>
+      );
+
+    case "dyad-security-finding":
+      return (
+        <DyadSecurityFinding title={attributes.title} level={attributes.level}>
+          {content}
+        </DyadSecurityFinding>
       );
 
     case "dyad-chat-summary":

--- a/src/components/chat/DyadSecurityFinding.tsx
+++ b/src/components/chat/DyadSecurityFinding.tsx
@@ -1,0 +1,87 @@
+import React, { useState } from "react";
+import { ShieldAlert } from "lucide-react";
+import {
+  DyadCard,
+  DyadCardHeader,
+  DyadExpandIcon,
+  DyadCardContent,
+  type DyadAccentColor,
+} from "./DyadCardPrimitives";
+import {
+  SeverityBadge,
+  type SecurityLevel,
+} from "@/components/security/severity";
+import { VanillaMarkdownParser } from "./DyadMarkdownParser";
+
+const VALID_LEVELS: readonly SecurityLevel[] = [
+  "critical",
+  "high",
+  "medium",
+  "low",
+];
+
+function isSecurityLevel(value: string | undefined): value is SecurityLevel {
+  return value != null && (VALID_LEVELS as readonly string[]).includes(value);
+}
+
+// Map a finding's severity onto the card's left-accent color. The exact level
+// is still conveyed precisely by the SeverityBadge; the accent is a coarser cue.
+const ACCENT_BY_LEVEL: Record<SecurityLevel, DyadAccentColor> = {
+  critical: "red",
+  high: "red",
+  medium: "amber",
+  low: "slate",
+};
+
+interface DyadSecurityFindingProps {
+  title?: string;
+  level?: string;
+  children?: React.ReactNode;
+}
+
+export function DyadSecurityFinding({
+  title,
+  level,
+  children,
+}: DyadSecurityFindingProps) {
+  const [isExpanded, setIsExpanded] = useState(true);
+
+  const validLevel = isSecurityLevel(level) ? level : undefined;
+  const accentColor: DyadAccentColor = validLevel
+    ? ACCENT_BY_LEVEL[validLevel]
+    : "slate";
+  const content = typeof children === "string" ? children : "";
+
+  return (
+    <DyadCard
+      accentColor={accentColor}
+      showAccent
+      isExpanded={isExpanded}
+      onClick={() => setIsExpanded(!isExpanded)}
+      data-testid="security-finding"
+    >
+      <DyadCardHeader
+        icon={<ShieldAlert size={15} />}
+        accentColor={accentColor}
+      >
+        {validLevel && <SeverityBadge level={validLevel} />}
+        <span className="font-medium text-sm text-foreground truncate">
+          {title || "Security finding"}
+        </span>
+        <div className="ml-auto">
+          <DyadExpandIcon isExpanded={isExpanded} />
+        </div>
+      </DyadCardHeader>
+      <DyadCardContent isExpanded={isExpanded}>
+        {content && (
+          <div
+            className="prose prose-sm dark:prose-invert max-w-none cursor-text"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <VanillaMarkdownParser content={content} />
+          </div>
+        )}
+      </DyadCardContent>
+    </DyadCard>
+  );
+}

--- a/src/components/preview_panel/SecurityPanel.tsx
+++ b/src/components/preview_panel/SecurityPanel.tsx
@@ -14,15 +14,8 @@ import {
   DialogTitle,
   DialogClose,
 } from "@/components/ui/dialog";
-import {
-  Shield,
-  AlertTriangle,
-  AlertCircle,
-  Info,
-  ChevronDown,
-  Pencil,
-  Wrench,
-} from "lucide-react";
+import { Shield, ChevronDown, Pencil, Wrench } from "lucide-react";
+import { getSeverityIcon, SeverityBadge } from "@/components/security/severity";
 import { useStreamChat } from "@/hooks/useStreamChat";
 import { showError } from "@/lib/toast";
 import { Badge } from "@/components/ui/badge";
@@ -37,32 +30,6 @@ import { showSuccess, showWarning } from "@/lib/toast";
 import { useLoadAppFile } from "@/hooks/useLoadAppFile";
 import { useQueryClient } from "@tanstack/react-query";
 import { useSelectChat } from "@/hooks/useSelectChat";
-
-const getSeverityColor = (level: SecurityFinding["level"]) => {
-  switch (level) {
-    case "critical":
-      return "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300 border-red-200 dark:border-red-800";
-    case "high":
-      return "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300 border-orange-200 dark:border-orange-800";
-    case "medium":
-      return "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300 border-yellow-200 dark:border-yellow-800";
-    case "low":
-      return "bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-300 border-gray-200 dark:border-gray-800";
-  }
-};
-
-const getSeverityIcon = (level: SecurityFinding["level"]) => {
-  switch (level) {
-    case "critical":
-      return <AlertTriangle className="h-4 w-4" />;
-    case "high":
-      return <AlertCircle className="h-4 w-4" />;
-    case "medium":
-      return <AlertCircle className="h-4 w-4" />;
-    case "low":
-      return <Info className="h-4 w-4" />;
-  }
-};
 
 const DESCRIPTION_PREVIEW_LENGTH = 150;
 
@@ -112,18 +79,6 @@ const getSeverityOrder = (level: SecurityFinding["level"]): number => {
       return 4;
   }
 };
-
-function SeverityBadge({ level }: { level: SecurityFinding["level"] }) {
-  return (
-    <Badge
-      variant="outline"
-      className={`${getSeverityColor(level)} uppercase text-xs font-semibold flex items-center gap-1 w-fit`}
-    >
-      <span className="flex-shrink-0">{getSeverityIcon(level)}</span>
-      <span>{level}</span>
-    </Badge>
-  );
-}
 
 function RunReviewButton({
   isRunning,

--- a/src/components/security/severity.tsx
+++ b/src/components/security/severity.tsx
@@ -1,0 +1,43 @@
+import { AlertTriangle, AlertCircle, Info } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import type { SecurityFinding } from "@/ipc/types/security";
+
+export type SecurityLevel = SecurityFinding["level"];
+
+export const getSeverityColor = (level: SecurityLevel) => {
+  switch (level) {
+    case "critical":
+      return "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300 border-red-200 dark:border-red-800";
+    case "high":
+      return "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300 border-orange-200 dark:border-orange-800";
+    case "medium":
+      return "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300 border-yellow-200 dark:border-yellow-800";
+    case "low":
+      return "bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-300 border-gray-200 dark:border-gray-800";
+  }
+};
+
+export const getSeverityIcon = (level: SecurityLevel) => {
+  switch (level) {
+    case "critical":
+      return <AlertTriangle className="h-4 w-4" />;
+    case "high":
+      return <AlertCircle className="h-4 w-4" />;
+    case "medium":
+      return <AlertCircle className="h-4 w-4" />;
+    case "low":
+      return <Info className="h-4 w-4" />;
+  }
+};
+
+export function SeverityBadge({ level }: { level: SecurityLevel }) {
+  return (
+    <Badge
+      variant="outline"
+      className={`${getSeverityColor(level)} uppercase text-xs font-semibold flex items-center gap-1 w-fit`}
+    >
+      <span className="flex-shrink-0">{getSeverityIcon(level)}</span>
+      <span>{level}</span>
+    </Badge>
+  );
+}

--- a/src/lib/streamingMessageParser.ts
+++ b/src/lib/streamingMessageParser.ts
@@ -71,6 +71,7 @@ const DYAD_CUSTOM_TAG_NAMES = [
   "dyad-step-limit",
   "dyad-script",
   "dyad-app-blueprint",
+  "dyad-security-finding",
 ];
 const DYAD_CUSTOM_TAG_SET = new Set(DYAD_CUSTOM_TAG_NAMES);
 


### PR DESCRIPTION
Register the dyad-security-finding tag in the streaming parser and add a DyadSecurityFinding card so findings render inline in chat instead of as raw text. Extract the shared severity helpers (color/icon/badge) into src/components/security/severity.tsx so the card and SecurityPanel reuse one source of truth.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

