### PR TITLE
Enable e2e parallelism on self-hosted mac shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,6 +371,9 @@ jobs:
         env:
           # Self-hosted macOS runners use fewer retries (1) vs GitHub-hosted CI (2)
           PLAYWRIGHT_RETRIES: ${{ contains(matrix.os.image, 'self-hosted') && '1' || '2' }}
+          # Pilot two workers only on self-hosted macOS shards. Keep GitHub-hosted
+          # macOS and Windows serial while preview-heavy specs shake out.
+          PLAYWRIGHT_PARALLELISM: ${{ contains(matrix.os.image, 'self-hosted') && '2' || '1' }}
         # You can add debug logging to make it easier to see what's failing
         # by adding "DEBUG=pw:browser" in front.
         # Use blob reporter for sharding and merge capabilities

--- a/e2e-tests/helpers/fixtures.ts
+++ b/e2e-tests/helpers/fixtures.ts
@@ -193,7 +193,10 @@ export const test = base.extend<{
         delete process.env.OPENAI_API_KEY;
       }
       const baseTmpDir = os.tmpdir();
-      const userDataDir = path.join(baseTmpDir, `dyad-e2e-tests-${Date.now()}`);
+      const userDataDir = path.join(
+        baseTmpDir,
+        `dyad-e2e-tests-worker-${testInfo.parallelIndex}-${Date.now()}`,
+      );
       if (electronConfig.preLaunchHook) {
         await electronConfig.preLaunchHook({ userDataDir, fakeLlmPort });
       }

--- a/e2e-tests/helpers/fixtures.ts
+++ b/e2e-tests/helpers/fixtures.ts
@@ -179,6 +179,7 @@ export const test = base.extend<{
       const fakeLlmPort = FAKE_LLM_BASE_PORT + testInfo.parallelIndex;
 
       process.env.FAKE_LLM_PORT = String(fakeLlmPort);
+      process.env.DYAD_E2E_PORT_BLOCK_INDEX = String(testInfo.parallelIndex);
       process.env.OLLAMA_HOST = `http://localhost:${fakeLlmPort}/ollama`;
       process.env.LM_STUDIO_BASE_URL_FOR_TESTING = `http://localhost:${fakeLlmPort}/lmstudio`;
       process.env.DYAD_ENGINE_URL = `http://localhost:${fakeLlmPort}/engine/v1`;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,20 +6,35 @@ export { FAKE_LLM_BASE_PORT };
 
 const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
 
-// Single worker + one fake LLM server: parallel workers were flaky (shared state / timing).
+const playwrightParallelism = parseInt(
+  process.env.PLAYWRIGHT_PARALLELISM ?? "1",
+  10,
+);
+const workerCount =
+  Number.isFinite(playwrightParallelism) && playwrightParallelism > 0
+    ? playwrightParallelism
+    : 1;
+
 function generateWebServerConfigs(): PlaywrightTestConfig["webServer"] {
-  return {
-    // Server runs build to avoid race conditions with concurrent webServer starts
-    command: `cd testing/fake-llm-server && npm run build && npm start -- --port=${FAKE_LLM_BASE_PORT}`,
-    url: `http://localhost:${FAKE_LLM_BASE_PORT}/health`,
-    // In CI, always start a fresh server; locally, reuse if one is already running
-    reuseExistingServer: !process.env.CI,
-  };
+  return Array.from({ length: workerCount }, (_, index) => {
+    const port = FAKE_LLM_BASE_PORT + index;
+    const command =
+      index === 0
+        ? `cd testing/fake-llm-server && npm run build && npm start -- --port=${port}`
+        : `while ! curl -fsS http://localhost:${FAKE_LLM_BASE_PORT}/health >/dev/null; do sleep 1; done; cd testing/fake-llm-server && npm start -- --port=${port}`;
+
+    return {
+      command,
+      url: `http://localhost:${port}/health`,
+      // In CI, always start a fresh server; locally, reuse if one is already running
+      reuseExistingServer: !process.env.CI,
+    };
+  });
 }
 
 const config: PlaywrightTestConfig = {
   testDir: "./e2e-tests",
-  workers: 1,
+  workers: workerCount,
   retries: parseInt(
     process.env.PLAYWRIGHT_RETRIES ?? (process.env.CI ? "2" : "0"),
     10,

--- a/shared/ports.ts
+++ b/shared/ports.ts
@@ -2,8 +2,37 @@
  * Calculate the port for a given app based on its ID.
  * Uses a base port of 32100 and offsets by appId % 10_000.
  */
+const APP_PORT_BASE = 32100;
+const APP_PORT_RANGE = 10_000;
+
+const E2E_PORT_BLOCK_SIZE = 2_050;
+const E2E_APP_PORT_RANGE = 1_000;
+const E2E_PROXY_PORT_RANGE = 1_000;
+
+function getE2ePortBlockBase(): number | null {
+  const raw =
+    typeof process === "undefined"
+      ? undefined
+      : process.env.DYAD_E2E_PORT_BLOCK_INDEX;
+  if (raw == null || raw.trim() === "") {
+    return null;
+  }
+
+  const index = Number.parseInt(raw, 10);
+  if (!Number.isFinite(index) || index < 0) {
+    return null;
+  }
+
+  return APP_PORT_BASE + index * E2E_PORT_BLOCK_SIZE;
+}
+
 export function getAppPort(appId: number): number {
-  return 32100 + (appId % 10_000);
+  const e2ePortBlockBase = getE2ePortBlockBase();
+  if (e2ePortBlockBase != null) {
+    return e2ePortBlockBase + (Math.abs(appId) % E2E_APP_PORT_RANGE);
+  }
+
+  return APP_PORT_BASE + (appId % APP_PORT_RANGE);
 }
 
 /**
@@ -24,6 +53,15 @@ export const PROXY_FALLBACK_PORT_START = PROXY_PORT_BASE + PROXY_PORT_RANGE;
 /** How many consecutive fallback ports to scan before giving up. */
 export const PROXY_FALLBACK_MAX_ATTEMPTS = 50;
 
+export function getProxyFallbackPortStart(): number {
+  const e2ePortBlockBase = getE2ePortBlockBase();
+  if (e2ePortBlockBase != null) {
+    return e2ePortBlockBase + E2E_APP_PORT_RANGE + E2E_PROXY_PORT_RANGE;
+  }
+
+  return PROXY_FALLBACK_PORT_START;
+}
+
 /**
  * Deterministic per-app port for the preview proxy worker.
  * The iframe loads this URL, so it must stay stable across restarts —
@@ -35,5 +73,14 @@ export const PROXY_FALLBACK_MAX_ATTEMPTS = 50;
  * killing whatever already holds the port.
  */
 export function getAppProxyPort(appId: number): number {
+  const e2ePortBlockBase = getE2ePortBlockBase();
+  if (e2ePortBlockBase != null) {
+    return (
+      e2ePortBlockBase +
+      E2E_APP_PORT_RANGE +
+      (Math.abs(appId) % E2E_PROXY_PORT_RANGE)
+    );
+  }
+
   return PROXY_PORT_BASE + (Math.abs(appId) % PROXY_PORT_RANGE);
 }

--- a/src/__tests__/ports.test.ts
+++ b/src/__tests__/ports.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   getAppPort,
   getAppProxyPort,
+  getProxyFallbackPortStart,
   PROXY_FALLBACK_PORT_START,
   PROXY_PORT_BASE,
   PROXY_PORT_RANGE,
@@ -27,5 +28,26 @@ describe("ports", () => {
   it("keeps app and proxy ports in separate deterministic ranges", () => {
     expect(getAppPort(123)).toBe(32223);
     expect(getAppProxyPort(123)).toBe(42223);
+  });
+
+  it("isolates app, proxy, and fallback ports by E2E worker block", () => {
+    const previous = process.env.DYAD_E2E_PORT_BLOCK_INDEX;
+    try {
+      process.env.DYAD_E2E_PORT_BLOCK_INDEX = "0";
+      expect(getAppPort(1)).toBe(32101);
+      expect(getAppProxyPort(1)).toBe(33101);
+      expect(getProxyFallbackPortStart()).toBe(34100);
+
+      process.env.DYAD_E2E_PORT_BLOCK_INDEX = "1";
+      expect(getAppPort(1)).toBe(34151);
+      expect(getAppProxyPort(1)).toBe(35151);
+      expect(getProxyFallbackPortStart()).toBe(36150);
+    } finally {
+      if (previous == null) {
+        delete process.env.DYAD_E2E_PORT_BLOCK_INDEX;
+      } else {
+        process.env.DYAD_E2E_PORT_BLOCK_INDEX = previous;
+      }
+    }
   });
 });

--- a/src/ipc/utils/start_proxy_server.ts
+++ b/src/ipc/utils/start_proxy_server.ts
@@ -5,8 +5,8 @@ import path from "path";
 import log from "electron-log";
 import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
 import {
-  PROXY_FALLBACK_PORT_START,
   PROXY_FALLBACK_MAX_ATTEMPTS,
+  getProxyFallbackPortStart,
 } from "../../../shared/ports";
 
 const logger = log.scope("start_proxy_server");
@@ -26,6 +26,7 @@ export async function startProxy(
       DyadErrorKind.Validation,
     );
   const { port, onStarted, onError, fixedHeaders } = opts;
+  const fallbackPortStart = getProxyFallbackPortStart();
   logger.info("Starting proxy on port", port);
 
   const worker = new Worker(
@@ -34,7 +35,7 @@ export async function startProxy(
       workerData: {
         targetOrigin,
         port,
-        fallbackPortStart: PROXY_FALLBACK_PORT_START,
+        fallbackPortStart,
         maxPortAttempts: PROXY_FALLBACK_MAX_ATTEMPTS,
         fixedHeaders,
       },
@@ -50,7 +51,7 @@ export async function startProxy(
       logger.error("[proxy] failed to bind:", m);
       onError?.(
         new DyadError(
-          `Could not start the preview proxy: every port from ${port} to ${PROXY_FALLBACK_PORT_START + PROXY_FALLBACK_MAX_ATTEMPTS - 1} is in use. Free up a port and restart the app.`,
+          `Could not start the preview proxy: every port from ${port} to ${fallbackPortStart + PROXY_FALLBACK_MAX_ATTEMPTS - 1} is in use. Free up a port and restart the app.`,
           DyadErrorKind.Conflict,
         ),
       );


### PR DESCRIPTION
## Summary
- Opts self-hosted macOS e2e shards into two Playwright workers while keeping GitHub-hosted macOS and Windows serial.
- Keeps local/default behavior serial unless PLAYWRIGHT_PARALLELISM is set, with one fake LLM server and userData directory per worker.
- Leaves preview-heavy broader rollout for a later canary once port contention has more coverage.

#skip-bugbot

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production port helpers and preview proxy fallback behavior when the E2E env var is set (normally unset outside tests); parallel e2e on self-hosted mac is a canary that could expose preview/port flakiness before broader rollout.
> 
> **Overview**
> Pilots **parallel Playwright e2e** on self-hosted macOS CI shards by setting `PLAYWRIGHT_PARALLELISM=2` there, while GitHub-hosted macOS and Windows stay at one worker.
> 
> **Playwright** reads `PLAYWRIGHT_PARALLELISM` for worker count and spins up **one fake LLM web server per worker** (worker 0 builds; others wait on worker 0’s health before starting on offset ports). **E2E fixtures** assign each worker its own fake LLM port, set `DYAD_E2E_PORT_BLOCK_INDEX` from `parallelIndex`, and use **worker-scoped `userDataDir`** paths so Electron instances don’t share state.
> 
> **Port allocation** in `shared/ports` adds optional E2E “blocks” keyed off `DYAD_E2E_PORT_BLOCK_INDEX`, shifting app dev ports, preview proxy ports, and proxy fallback scan start per worker. **Proxy startup** uses the new `getProxyFallbackPortStart()` for worker-aware fallback binding and error messages. **Unit tests** cover E2E block isolation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fb4ef26b22231a831baa9476c9a448faae54376. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

