### PR TITLE
Disable React DevTools autoload in dev

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,6 @@ import {
   Menu,
   protocol,
   net,
-  session,
   crashReporter,
 } from "electron";
 import * as path from "node:path";
@@ -288,72 +287,10 @@ export async function onReady() {
   // setAsDefaultProtocolClient above is unreliable on Linux.
   void registerDyadProtocolLinux();
 
-  // Load React DevTools extension in development
-  if (process.env.NODE_ENV === "development") {
-    let chromeUserData: string;
-    // Determine Chrome extensions path based on platform
-    if (process.platform === "win32") {
-      chromeUserData = path.join(
-        process.env.LOCALAPPDATA || "",
-        "Google",
-        "Chrome",
-        "User Data",
-        "Default",
-        "Extensions",
-      );
-    } else if (process.platform === "darwin") {
-      // macOS
-      chromeUserData = path.join(
-        process.env.HOME || "",
-        "Library",
-        "Application Support",
-        "Google",
-        "Chrome",
-        "Default",
-        "Extensions",
-      );
-    } else {
-      // Linux
-      chromeUserData = path.join(
-        process.env.HOME || "",
-        ".config",
-        "google-chrome",
-        "Default",
-        "Extensions",
-      );
-    }
-
-    // React DevTools extension ID
-    const reactDevToolsId = "fmkadmapgofadopljbjfkapdkoienihi";
-    const extensionsDir = path.join(chromeUserData, reactDevToolsId);
-
-    if (fs.existsSync(extensionsDir)) {
-      try {
-        const versions = fs.readdirSync(extensionsDir);
-        if (versions.length > 0) {
-          // Get the latest version using numeric sort to handle version boundaries (e.g., 9.0.0 vs 10.0.0)
-          const latestVersion = versions
-            .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
-            .reverse()[0];
-          const extensionPath = path.join(extensionsDir, latestVersion);
-          await session.defaultSession.loadExtension(extensionPath, {
-            allowFileAccess: true,
-          });
-          logger.info("React DevTools loaded successfully");
-        } else {
-          logger.warn(
-            "React DevTools extension directory is empty. Install it in Chrome first.",
-          );
-        }
-      } catch (err) {
-        logger.error("Failed to load React DevTools:", err);
-      }
-    } else {
-      logger.warn(
-        "React DevTools extension not found. Install it in Chrome first.",
-      );
-    }
-  }
+  // React DevTools extension loading is intentionally disabled. In Electron it
+  // can spam startup logs with:
+  // "Unchecked runtime.lastError: Could not establish connection. Receiving end does not exist."
+  // from chrome-extension://fmkadmapgofadopljbjfkapdkoienihi/main.html.
 
   try {
     const backupManager = new BackupManager({


### PR DESCRIPTION
## Summary
- Disable automatic React DevTools extension loading in Electron dev mode to stop Chromium extension messaging noise during npm start.
- Leave a source note with the specific runtime.lastError spam so the decision is easy to revisit if devtools loading is reintroduced.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only startup behavior change with no impact on production builds or core app logic.
> 
> **Overview**
> Removes **automatic loading of the Chrome React DevTools extension** during `onReady` in development. That path scanned the local Chrome install and called `session.defaultSession.loadExtension`, which was producing noisy **`runtime.lastError` / “Receiving end does not exist”** messages at startup.
> 
> The **`session` import** is dropped with that logic. A short comment in `onReady` documents why autoload is off so it can be revisited later. **Built-in Electron DevTools** (e.g. `openDevTools` in `createWindow`) are unchanged; only the bundled React DevTools extension autoload is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b632892d785deb5398c44faff568c1877ca76c5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

