### PR TITLE
Speed up PR push skill

### DIFF
--- a/.claude/skills/pr-push/SKILL.md
+++ b/.claude/skills/pr-push/SKILL.md
@@ -10,13 +10,13 @@ Use this skill to publish the current work to GitHub. It must complete autonomou
 ## Workflow
 
 1. Run `/remember-learnings` first. This captures session learnings before any push or PR creation, so any resulting `AGENTS.md` or `rules/` changes are included in the same publish flow.
-2. Run the bundled script from the repository root:
+2. Run the bundled script from the repository root. Set `PR_PUSH_COMMIT_MESSAGE` to a descriptive commit message for the work being published:
 
    ```bash
-   bash .claude/skills/pr-push/scripts/pr_push.sh
+   PR_PUSH_COMMIT_MESSAGE="<descriptive commit message>" bash .claude/skills/pr-push/scripts/pr_push.sh
    ```
 
-3. If the script reports a fixable failure, fix it and rerun the script. Do not manually replay the full workflow unless the script itself is broken.
+3. If the script reports a fixable failure, fix it and rerun the script. When fixing issues, do not run `git pull` from fork remotes; only pull from the upstream repo (`dyad-sh/dyad`) if needed. Do not manually replay the full workflow unless the script itself is broken.
 4. Summarize the script's final output, including the branch, committed files, ignored files, checks, pushed remote, and PR URL or bot-account PR creation link.
 
 ## Script Behavior

--- a/.claude/skills/pr-push/SKILL.md
+++ b/.claude/skills/pr-push/SKILL.md
@@ -1,217 +1,42 @@
 ---
 name: dyad:pr-push
-description: Commit any uncommitted changes, run lint checks, fix any issues, and push the current branch.
+description: Fast script-driven workflow to commit uncommitted changes, run checks, push the branch, and create or update a GitHub PR.
 ---
 
 # PR Push
 
-Commit any uncommitted changes, run lint checks, fix any issues, and push the current branch.
+Use this skill to publish the current work to GitHub. It must complete autonomously and push by the end unless GitHub auth or permissions block the operation.
 
-**IMPORTANT:** This skill MUST complete all steps autonomously. Do NOT ask for user confirmation at any step. Do NOT stop partway through. You MUST push to GitHub by the end of this skill.
+## Workflow
 
-## Task Tracking
+1. Run `/remember-learnings` first. This captures session learnings before any push or PR creation, so any resulting `AGENTS.md` or `rules/` changes are included in the same publish flow.
+2. Run the bundled script from the repository root:
 
-**You MUST use the TaskCreate and TaskUpdate tools to track your progress.** At the start, create tasks for each step below. Mark each task as `in_progress` when you start it and `completed` when you finish. This ensures you complete ALL steps.
-
-## Instructions
-
-1. **Ensure you are NOT on main branch:**
-
-   Run `git branch --show-current` to check the current branch.
-
-   **CRITICAL:** You MUST NEVER push directly to the main branch. If you are on `main` or `master`:
-   - Generate a descriptive branch name based on the uncommitted changes (e.g., `fix-login-validation`, `add-user-settings-page`)
-   - Create and switch to the new branch: `git checkout -b <branch-name>`
-   - Report that you created a new branch
-
-   If you are already on a feature branch, proceed to the next step.
-
-2. **Check for uncommitted changes:**
-
-   Run `git status` to check for any uncommitted changes (staged, unstaged, or untracked files).
-
-   If there are uncommitted changes:
-   - **When in doubt, `git add` the files.** Assume changed/untracked files are related to the current work unless they are egregiously unrelated (e.g., completely different feature area with no connection to the current changes).
-   - Only exclude files that are clearly secrets or artifacts that should never be committed (e.g., `.env`, `.env.*`, `credentials.*`, `*.secret`, `*.key`, `*.pem`, `.DS_Store`, `node_modules/`, `*.log`).
-   - **Do NOT stage `package-lock.json` unless `package.json` has also been modified.** Changes to `package-lock.json` without a corresponding `package.json` change are spurious diffs (e.g., from running `npm install` locally) and should be excluded. If `package-lock.json` is dirty but `package.json` is not, run `git checkout -- package-lock.json` to discard the changes.
-   - Stage and commit all relevant files with a descriptive commit message summarizing the changes.
-   - Keep track of any files you ignored so you can report them at the end.
-
-   If there are no uncommitted changes, proceed to the next step.
-
-3. **Run lint checks:**
-
-   Run these commands to ensure the code passes all pre-commit checks:
-
-   ```
-   npm run fmt && npm run lint:fix && npm run ts
+   ```bash
+   .claude/skills/pr-push/scripts/pr_push.sh
    ```
 
-   If there are errors that could not be auto-fixed, read the affected files and fix them manually, then re-run the checks until they pass.
+3. If the script reports a fixable failure, fix it and rerun the script. Do not manually replay the full workflow unless the script itself is broken.
+4. Summarize the script's final output, including the branch, committed files, ignored files, checks, pushed remote, and PR URL or bot-account PR creation link.
 
-   **IMPORTANT:** Do NOT stop after lint passes. You MUST continue to step 4.
+## Script Behavior
 
-4. **Run tests:**
+The script handles the mechanical workflow:
 
-   Run the test suite to ensure nothing is broken:
+- Refuses to push `main`/`master`; creates a feature branch if needed.
+- Stages relevant changes while ignoring obvious secrets/artifacts and spurious `package-lock.json` changes without `package.json`.
+- Commits changes with a generated message, unless `PR_PUSH_COMMIT_MESSAGE` is set.
+- Runs `npm run fmt`, `npm run lint:fix`, `npm run ts`, and `npm test`.
+- Amends automated formatting/lint changes into the commit it created.
+- Pushes to the tracked upstream, an existing PR head remote, or `origin` with the documented fallback behavior.
+- Creates or updates the PR against `dyad-sh/dyad:main`, unless the active GitHub account is a bot.
+- Removes `needs-human:review-issue` when a PR exists.
 
-   ```
-   npm test
-   ```
+Optional environment overrides:
 
-   If any tests fail, fix them before proceeding. Do NOT skip failing tests.
-
-   **IMPORTANT:** Do NOT stop after tests pass. You MUST continue to step 5.
-
-5. **If lint made changes, amend the last commit:**
-
-   If the lint checks made any changes, stage and amend them into the last commit:
-
-   ```
-   git add -A
-   git commit --amend --no-edit
-   ```
-
-   **IMPORTANT:** Do NOT stop here. You MUST continue to step 6.
-
-6. **Push the branch (REQUIRED):**
-
-   You MUST push the branch to GitHub. Do NOT skip this step or ask for confirmation.
-
-   **CRITICAL:** You MUST NEVER run `git pull --rebase` (or any `git pull`) from the fork repo. If you need to pull/rebase, ONLY pull from the upstream repo (`dyad-sh/dyad`). Pulling from a fork can overwrite local changes or introduce unexpected commits from the fork's history.
-
-   First, determine the correct remote to push to:
-
-   a. Check if the branch already tracks a remote:
-
-   ```
-   git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null
-   ```
-
-   If this succeeds (e.g., returns `origin/my-branch` or `someuser/my-branch`), the branch already has an upstream. Push to it:
-
-   ```
-   git push --force-with-lease
-   ```
-
-   **Permission fallback:** If the push fails with a permission error (e.g., the branch tracks `upstream` but the current account lacks write access to `dyad-sh/dyad`), fall back to pushing to `origin` instead:
-
-   ```
-   git push --force-with-lease -u origin HEAD
-   ```
-
-   b. If there is NO upstream, check if a PR already exists and determine which remote it was opened from:
-
-   First, get the PR's head repository as `owner/repo`:
-
-   ```
-   gh pr view --json headRepository --jq .headRepository.nameWithOwner
-   ```
-
-   **Error handling:** If `gh pr view` exits with a non-zero status, check whether the error indicates "no PR found" (expected — proceed to step c) or another failure (auth, network, ambiguous branch — report the error and stop rather than silently falling back).
-
-   If a PR exists, find which local remote corresponds to that `owner/repo`. List all remotes and extract the `owner/repo` portion from each URL:
-
-   ```
-   git remote -v
-   ```
-
-   For each remote URL, extract the `owner/repo` by stripping the protocol/hostname prefix and `.git` suffix. This handles all URL formats:
-   - SSH: `git@github.com:owner/repo.git` → `owner/repo`
-   - HTTPS: `https://github.com/owner/repo.git` → `owner/repo`
-   - Token-authenticated: `https://x-access-token:...@github.com/owner/repo.git` → `owner/repo`
-
-   Match the PR's `owner/repo` against each remote's extracted `owner/repo`. If multiple remotes match (e.g., both SSH and HTTPS URLs for the same repo), prefer the first match. If no remote matches (e.g., the fork is not configured locally), proceed to step c.
-
-   Push to the matched remote:
-
-   ```
-   git push --force-with-lease -u <matched-remote> HEAD
-   ```
-
-   c. If no PR exists (or no matching remote was found) and there is no upstream, fall back to `origin`. If pushing to `origin` fails due to permission errors, try pushing to `upstream` instead (per the project's git workflow in CLAUDE.md). Report which remote was used.
-
-   ```
-   git push --force-with-lease -u origin HEAD
-   ```
-
-   Note: `--force-with-lease` is used because the commit may have been amended. It's safer than `--force` as it will fail if someone else has pushed to the branch.
-
-7. **Create or update the PR (REQUIRED):**
-
-   First, check if a PR already exists for this branch:
-
-   ```
-   gh pr view --json number,url
-   ```
-
-   If a PR already exists, skip PR creation (the push already updated it — this works regardless of which account is active).
-
-   If NO PR exists, check whether the active GitHub account is a bot:
-
-   ```
-   gh auth status
-   ```
-
-   Look at the active account name in the output (e.g., `Logged in to github.com account keppo-bot[bot]`). The account is a bot if the name ends with `[bot]`.
-
-   **If the account is a bot, do NOT create the PR.** PRs _authored_ by bot accounts do not trigger third-party code reviewers (Cursor Bugbot, Gemini Code Assist, cubic, Copilot), so the PR must be created by a human. Instead:
-   - Construct the PR-creation link for the pushed branch: `https://github.com/<owner>/<repo>/pull/new/<branch-name>` (use the repo the branch was pushed to)
-   - Write the suggested PR title and body (same format as the `gh pr create` body below) so the user can paste them in
-   - In the final summary, tell the user to create the PR themselves using that link, title, and body
-   - Skip step 9 (there is no PR to edit yet); later pushes to the branch will update the PR normally once the user has created it
-
-   **If the account is NOT a bot:** do NOT tell the user to visit a URL to create a PR. You MUST create it automatically using `gh pr create`:
-
-   ```
-   gh pr create --title "<descriptive title>" --body "$(cat <<'EOF'
-   ## Summary
-   <1-3 bullet points summarizing the changes>
-   EOF
-   )"
-   ```
-
-   Use the commit messages and changed files to write a good title and summary.
-
-   **PR description style:** do NOT state the obvious (what the diff already shows). Concisely capture the design decisions and trade-offs, staying close to the original prompt / user intent — why this approach, what was deliberately not done, and any behavior boundaries a reviewer should know.
-
-8. **Do NOT automatically add `cc:request`:**
-
-   Do not add the `cc:request` label automatically as part of this skill. Leave review-request labeling unchanged unless the user explicitly asks for it separately.
-
-9. **Remove review-issue label:**
-
-   After pushing, remove the `needs-human:review-issue` label if it exists (this label indicates the issue needed human review before work started, which is now complete):
-
-   ```
-   gh pr edit --remove-label "needs-human:review-issue" 2>/dev/null || true
-   ```
-
-10. **Remember learnings (after initial push):**
-
-Run the `/remember-learnings` skill to capture any errors, snags, or insights from this session into `AGENTS.md` or `rules/` files.
-
-If any files were modified by the skill (check with `git status`):
-
-- Stage the modified files: `git add AGENTS.md rules/`
-- Create a new commit for the learnings:
-  ```
-  git commit -m "docs: record session learnings"
-  ```
-- Push the learnings commit:
-  ```
-  git push
-  ```
-
-**IMPORTANT:** Do NOT amend the previous commit. Create a separate commit for learnings so the main work is already pushed before this step.
-
-11. **Summarize the results:**
-
-- Report if a new feature branch was created (and its name)
-- Report any uncommitted changes that were committed in step 2
-- Report any files that were IGNORED and not committed (if any), explaining why they were skipped
-- Report any lint fixes that were applied
-- Confirm tests passed
-- Confirm the branch has been pushed
-- Report any learnings added to `AGENTS.md` or `rules/` (and whether a follow-up push was made)
-- **Include the PR URL** (either newly created or existing) — or, if PR creation was skipped because the active account is a bot, include the PR-creation link plus the suggested title and body for the user to paste
+- `PR_PUSH_COMMIT_MESSAGE`: commit message for newly staged work.
+- `PR_PUSH_PR_TITLE`: PR title.
+- `PR_PUSH_PR_BODY`: PR body.
+- `PR_PUSH_BASE_REPO`: default `dyad-sh/dyad`.
+- `PR_PUSH_BASE_BRANCH`: default `main`.
+- `PR_PUSH_REMOTE`: default fallback remote `origin`.

--- a/.claude/skills/pr-push/SKILL.md
+++ b/.claude/skills/pr-push/SKILL.md
@@ -16,7 +16,7 @@ Use this skill to publish the current work to GitHub. It must complete autonomou
    PR_PUSH_COMMIT_MESSAGE="<descriptive commit message>" bash .claude/skills/pr-push/scripts/pr_push.sh
    ```
 
-3. If the script reports a fixable failure, fix it and rerun the script. When fixing issues, do not run `git pull` from fork remotes; only pull from the upstream repo (`dyad-sh/dyad`) if needed. Do not manually replay the full workflow unless the script itself is broken.
+3. If the script reports a fixable failure, fix it and rerun the script. When fixing issues, do not run `git pull` from fork remotes; only pull from the upstream repo configured by `PR_PUSH_BASE_REPO` (default `dyad-sh/dyad`) if needed. Do not manually replay the full workflow unless the script itself is broken.
 4. Summarize the script's final output, including the branch, committed files, ignored files, checks, pushed remote, and PR URL or bot-account PR creation link.
 
 ## Script Behavior

--- a/.claude/skills/pr-push/SKILL.md
+++ b/.claude/skills/pr-push/SKILL.md
@@ -13,7 +13,7 @@ Use this skill to publish the current work to GitHub. It must complete autonomou
 2. Run the bundled script from the repository root:
 
    ```bash
-   .claude/skills/pr-push/scripts/pr_push.sh
+   bash .claude/skills/pr-push/scripts/pr_push.sh
    ```
 
 3. If the script reports a fixable failure, fix it and rerun the script. Do not manually replay the full workflow unless the script itself is broken.

--- a/.claude/skills/pr-push/scripts/pr_push.sh
+++ b/.claude/skills/pr-push/scripts/pr_push.sh
@@ -269,8 +269,29 @@ remote_for_owner_repo() {
   return 1
 }
 
-no_pr_found_error() {
-  grep -qiE 'no (open )?pull requests? found|no pull request found' <<<"$1"
+find_existing_pr_for_branch() {
+  local branch="$1" number_output url_output
+
+  if ! number_output="$(gh pr list --repo "$BASE_REPO" --head "$branch" --json number --jq '.[0].number // empty' 2>&1)"; then
+    printf '%s\n' "$number_output" >&2
+    die "Unable to list existing PRs"
+  fi
+
+  [[ -n "$number_output" ]] || return 1
+
+  if ! url_output="$(gh pr list --repo "$BASE_REPO" --head "$branch" --json url --jq '.[0].url // empty' 2>&1)"; then
+    printf '%s\n' "$url_output" >&2
+    die "Unable to read existing PR URL"
+  fi
+
+  PR_NUMBER="$number_output"
+  PR_URL="$url_output"
+  return 0
+}
+
+pr_head_repo() {
+  local pr_number="$1"
+  gh api "repos/$BASE_REPO/pulls/$pr_number" --jq .head.repo.full_name
 }
 
 push_with_fallback() {
@@ -305,18 +326,19 @@ push_with_fallback() {
     git branch --unset-upstream >/dev/null 2>&1 || true
   fi
 
-  local pr_head_repo pr_view_output matched_remote
-  if pr_view_output="$(gh pr view "$branch" --repo "$BASE_REPO" --json headRepository --jq .headRepository.nameWithOwner 2>&1)"; then
-    pr_head_repo="$pr_view_output"
+  local pr_head_repo_name pr_view_output matched_remote
+  if find_existing_pr_for_branch "$branch"; then
+    pr_view_output="$(pr_head_repo "$PR_NUMBER" 2>&1)" || {
+      printf '%s\n' "$pr_view_output" >&2
+      die "Unable to check existing PR head repository before push"
+    }
+    pr_head_repo_name="$pr_view_output"
     while IFS= read -r remote; do
-      if [[ "$(remote_owner_repo "$remote")" == "$pr_head_repo" ]]; then
+      if [[ "$(remote_owner_repo "$remote")" == "$pr_head_repo_name" ]]; then
         matched_remote="$remote"
         break
       fi
     done < <(git remote)
-  elif ! no_pr_found_error "$pr_view_output"; then
-    printf '%s\n' "$pr_view_output" >&2
-    die "Unable to check existing PR before push"
   fi
 
   PUSH_REMOTE="${matched_remote:-$DEFAULT_REMOTE}"
@@ -407,20 +429,12 @@ branch_has_commits_ahead() {
 }
 
 create_or_update_pr() {
-  local view_output branch head_owner title body create_error create_error_file
+  local branch head_owner title body create_error create_error_file
 
   branch="$(current_branch)"
-  if PR_NUMBER="$(gh pr view "$branch" --repo "$BASE_REPO" --json number --jq .number 2>&1)"; then
-    PR_URL="$(gh pr view "$branch" --repo "$BASE_REPO" --json url --jq .url)"
+  if find_existing_pr_for_branch "$branch"; then
     log "PR already exists: $PR_URL"
   else
-    view_output="$PR_NUMBER"
-    PR_NUMBER=""
-    if ! no_pr_found_error "$view_output"; then
-      printf '%s\n' "$view_output" >&2
-      die "Unable to check PR state"
-    fi
-
     if ! branch_has_commits_ahead; then
       log "Skipping PR creation because $PR_SKIPPED_REASON"
       return

--- a/.claude/skills/pr-push/scripts/pr_push.sh
+++ b/.claude/skills/pr-push/scripts/pr_push.sh
@@ -17,6 +17,7 @@ PR_CREATION_LINK=""
 SUGGESTED_TITLE=""
 SUGGESTED_BODY=""
 CREATED_COMMIT="no"
+PR_SKIPPED_REASON=""
 
 log() {
   printf '==> %s\n' "$*"
@@ -37,6 +38,20 @@ current_branch() {
 
 has_changes() {
   [[ -n "$(git status --porcelain -uall)" ]]
+}
+
+remember_staged_files() {
+  local file existing committed_file
+  while IFS= read -r file; do
+    existing="no"
+    for committed_file in "${COMMITTED_FILES[@]}"; do
+      if [[ "$committed_file" == "$file" ]]; then
+        existing="yes"
+        break
+      fi
+    done
+    [[ "$existing" == "yes" ]] || COMMITTED_FILES+=("$file")
+  done < <(staged_file_list)
 }
 
 is_ignored_file() {
@@ -69,12 +84,28 @@ restore_spurious_package_lock() {
   fi
 }
 
+git_status_paths() {
+  local record xy path
+  while IFS= read -r -d '' record; do
+    xy="${record:0:2}"
+    path="${record:3}"
+    [[ -z "$path" ]] && continue
+
+    printf '%s\0' "$path"
+
+    case "$xy" in
+      R* | C* | *R | *C)
+        IFS= read -r -d '' _ || true
+        ;;
+    esac
+  done < <(git status --porcelain=v1 -z -uall)
+}
+
 stage_relevant_changes() {
   restore_spurious_package_lock
 
-  local status path
-  while IFS= read -r status; do
-    path="${status:3}"
+  local path
+  while IFS= read -r -d '' path; do
     [[ -z "$path" ]] && continue
 
     if is_ignored_file "$path"; then
@@ -82,8 +113,8 @@ stage_relevant_changes() {
       continue
     fi
 
-    git add -- "$path"
-  done < <(git status --porcelain -uall)
+    git add -A -- "$path"
+  done < <(git_status_paths)
 }
 
 staged_file_list() {
@@ -92,7 +123,7 @@ staged_file_list() {
 
 default_branch_name() {
   local files joined
-  files="$(git status --porcelain -uall | awk '{print $2}' | head -5 | tr '\n' ' ')"
+  files="$(git_status_paths | tr '\0' '\n' | head -5 | tr '\n' ' ')"
 
   case "$files" in
     *".claude/skills/pr-push"*) joined="fast-pr-push-skill" ;;
@@ -150,9 +181,7 @@ commit_if_needed() {
     return
   fi
 
-  while IFS= read -r file; do
-    COMMITTED_FILES+=("$file")
-  done < <(staged_file_list)
+  remember_staged_files
   local message
   message="$(commit_message_from_staged_files)"
   log "Committing staged changes: $message"
@@ -188,6 +217,7 @@ amend_or_commit_check_changes() {
     return
   fi
 
+  remember_staged_files
   if [[ "$CREATED_COMMIT" == "yes" ]]; then
     log "Amending automated check changes into previous commit"
     git commit --amend --no-edit
@@ -200,10 +230,16 @@ amend_or_commit_check_changes() {
 
 remote_owner_repo() {
   local remote="$1"
-  local url
+  local url parsed
   url="$(git remote get-url --push "$remote" 2>/dev/null || git remote get-url "$remote")"
 
   url="${url%.git}"
+  parsed="$(printf '%s' "$url" | sed -E 's#^[[:alpha:]][[:alnum:].+-]*://##; s#^[^@/]+@##; s#^github.com[:/]##; s#^git@github.com[:/]##')"
+  if [[ "$parsed" != "$url" && "$parsed" == */* ]]; then
+    printf '%s\n' "$parsed"
+    return
+  fi
+
   case "$url" in
     git@github.com:*) printf '%s\n' "${url#git@github.com:}" ;;
     https://github.com/*) printf '%s\n' "${url#https://github.com/}" ;;
@@ -212,28 +248,48 @@ remote_owner_repo() {
   esac
 }
 
+is_permission_push_error() {
+  grep -qiE 'permission|denied|403|not allowlisted|could not read Username' <<<"$1"
+}
+
+has_remote() {
+  git remote get-url "$1" >/dev/null 2>&1
+}
+
+no_pr_found_error() {
+  grep -qiE 'no (open )?pull requests? found|no pull request found' <<<"$1"
+}
+
 push_with_fallback() {
-  local upstream push_output
+  local branch upstream upstream_branch push_output
+  branch="$(current_branch)"
 
   if upstream="$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null)"; then
     PUSH_REMOTE="${upstream%%/*}"
-    log "Pushing to tracked upstream $upstream"
-    if push_output="$(git push --force-with-lease 2>&1)"; then
-      printf '%s\n' "$push_output"
-      PUSH_OWNER_REPO="$(remote_owner_repo "$PUSH_REMOTE")"
-      return
+    upstream_branch="${upstream#*/}"
+
+    if [[ "$upstream_branch" != "main" && "$upstream_branch" != "master" ]]; then
+      log "Pushing to tracked upstream $upstream"
+      if push_output="$(git push --force-with-lease 2>&1)"; then
+        printf '%s\n' "$push_output"
+        PUSH_OWNER_REPO="$(remote_owner_repo "$PUSH_REMOTE")"
+        return
+      fi
+
+      printf '%s\n' "$push_output" >&2
+      if is_permission_push_error "$push_output"; then
+        log "Tracked push failed with permission-like error; falling back to $DEFAULT_REMOTE"
+        PUSH_REMOTE="$DEFAULT_REMOTE"
+        git push --force-with-lease -u "$DEFAULT_REMOTE" HEAD
+        PUSH_OWNER_REPO="$(remote_owner_repo "$PUSH_REMOTE")"
+        return
+      fi
+
+      die "Push to tracked upstream failed"
     fi
 
-    printf '%s\n' "$push_output" >&2
-    if grep -qiE 'permission|denied|403|not allowlisted' <<<"$push_output"; then
-      log "Tracked push failed with permission-like error; falling back to $DEFAULT_REMOTE"
-      PUSH_REMOTE="$DEFAULT_REMOTE"
-      git push --force-with-lease -u "$DEFAULT_REMOTE" HEAD
-      PUSH_OWNER_REPO="$(remote_owner_repo "$PUSH_REMOTE")"
-      return
-    fi
-
-    die "Push to tracked upstream failed"
+    log "Ignoring tracked upstream $upstream because it points at the base branch"
+    git branch --unset-upstream >/dev/null 2>&1 || true
   fi
 
   local pr_head_repo pr_view_output matched_remote
@@ -245,33 +301,37 @@ push_with_fallback() {
         break
       fi
     done < <(git remote)
-  elif ! grep -qiE 'no pull requests found|no pull request found' <<<"$pr_view_output"; then
+  elif ! no_pr_found_error "$pr_view_output"; then
     printf '%s\n' "$pr_view_output" >&2
     die "Unable to check existing PR before push"
   fi
 
   PUSH_REMOTE="${matched_remote:-$DEFAULT_REMOTE}"
   log "Pushing to $PUSH_REMOTE"
-  if git push --force-with-lease -u "$PUSH_REMOTE" HEAD; then
+  if push_output="$(git push --force-with-lease -u "$PUSH_REMOTE" HEAD 2>&1)"; then
+    printf '%s\n' "$push_output"
     PUSH_OWNER_REPO="$(remote_owner_repo "$PUSH_REMOTE")"
     return
   fi
 
-  if [[ "$PUSH_REMOTE" != "upstream" ]]; then
-    log "Push to $PUSH_REMOTE failed; trying upstream as fallback"
+  printf '%s\n' "$push_output" >&2
+  if [[ "$PUSH_REMOTE" != "upstream" ]] && has_remote "upstream" && is_permission_push_error "$push_output"; then
+    log "Push to $PUSH_REMOTE failed with permission-like error; trying upstream as fallback"
     PUSH_REMOTE="upstream"
-    git push --force-with-lease -u upstream HEAD
-    PUSH_OWNER_REPO="$(remote_owner_repo "$PUSH_REMOTE")"
-    return
+    if push_output="$(git push --force-with-lease -u upstream "HEAD:$branch" 2>&1)"; then
+      printf '%s\n' "$push_output"
+      PUSH_OWNER_REPO="$(remote_owner_repo "$PUSH_REMOTE")"
+      return
+    fi
+    printf '%s\n' "$push_output" >&2
   fi
 
   die "Push failed"
 }
 
 active_account_is_bot() {
-  local status account
-  status="$(gh auth status 2>&1)"
-  account="$(sed -nE 's/.*Logged in to github.com account ([^ ]+).*/\1/p' <<<"$status" | head -1)"
+  local account
+  account="$(gh api user --jq .login 2>/dev/null || true)"
   [[ "$account" == *"[bot]" ]]
 }
 
@@ -283,17 +343,7 @@ pr_title() {
 
   local subject
   subject="$(git log -1 --pretty=%s)"
-  local lower_subject
-  lower_subject="$(printf '%s' "$subject" | tr '[:upper:]' '[:lower:]')"
-  case "$lower_subject" in
-    chore:\ *) subject="${subject#*: }" ;;
-    fix:\ *) subject="${subject#*: }" ;;
-    feat:\ *) subject="${subject#*: }" ;;
-    docs:\ *) subject="${subject#*: }" ;;
-    ci:\ *) subject="${subject#*: }" ;;
-    test:\ *) subject="${subject#*: }" ;;
-    refactor:\ *) subject="${subject#*: }" ;;
-  esac
+  subject="$(printf '%s' "$subject" | sed -E 's/^[[:alpha:]]+(\([^)]*\))?!?:[[:space:]]+//')"
 
   if [[ -z "$subject" ]]; then
     printf 'Update project files\n'
@@ -309,7 +359,7 @@ pr_body() {
   fi
 
   local files_line
-  files_line="$(git diff --name-only "$BASE_BRANCH"...HEAD 2>/dev/null | head -6 | awk 'BEGIN { sep="" } { printf "%s%s", sep, $0; sep=", " }')"
+  files_line="$( (git diff --name-only "$BASE_BRANCH"...HEAD 2>/dev/null || true) | head -6 | awk 'BEGIN { sep="" } { printf "%s%s", sep, $0; sep=", " }')"
 
   printf '## Summary\n'
   printf -- '- %s\n' "$(git log -1 --pretty=%s)"
@@ -318,17 +368,30 @@ pr_body() {
   fi
 }
 
-create_or_update_pr() {
-  local view_output body_file branch head_owner title body
+branch_has_commits_ahead() {
+  local count
+  count="$(git rev-list --count "$BASE_BRANCH"..HEAD 2>/dev/null || true)"
+  [[ -z "$count" || "$count" != "0" ]]
+}
 
-  if view_output="$(gh pr view --json number,url 2>&1)"; then
-    PR_NUMBER="$(jq -r .number <<<"$view_output")"
-    PR_URL="$(jq -r .url <<<"$view_output")"
+create_or_update_pr() {
+  local view_output branch head_owner title body
+
+  if PR_NUMBER="$(gh pr view --json number --jq .number 2>&1)"; then
+    PR_URL="$(gh pr view --json url --jq .url)"
     log "PR already exists: $PR_URL"
   else
-    if ! grep -qiE 'no pull requests found|no pull request found' <<<"$view_output"; then
+    view_output="$PR_NUMBER"
+    PR_NUMBER=""
+    if ! no_pr_found_error "$view_output"; then
       printf '%s\n' "$view_output" >&2
       die "Unable to check PR state"
+    fi
+
+    if ! branch_has_commits_ahead; then
+      PR_SKIPPED_REASON="branch has no commits ahead of $BASE_BRANCH"
+      log "Skipping PR creation because $PR_SKIPPED_REASON"
+      return
     fi
 
     branch="$(current_branch)"
@@ -344,18 +407,27 @@ create_or_update_pr() {
       return
     fi
 
-    mkdir -p .claude/tmp
-    body_file="$(mktemp .claude/tmp/pr-push-body.XXXXXX)"
-    printf '%s\n' "$body" >"$body_file"
-
     log "Creating PR against $BASE_REPO"
-    PR_URL="$(gh pr create \
+    if ! PR_URL="$(gh pr create \
       --repo "$BASE_REPO" \
       --head "${head_owner}:${branch}" \
       --base "$BASE_BRANCH" \
       --title "$title" \
-      --body-file "$body_file")"
-    rm -f "$body_file"
+      --body "$body" 2>&1)"; then
+      if grep -qi 'fork collab' <<<"$PR_URL"; then
+        log "Retrying PR creation without maintainer edits"
+        PR_URL="$(gh pr create \
+          --repo "$BASE_REPO" \
+          --head "${head_owner}:${branch}" \
+          --base "$BASE_BRANCH" \
+          --title "$title" \
+          --body "$body" \
+          --no-maintainer-edit)"
+      else
+        printf '%s\n' "$PR_URL" >&2
+        die "Unable to create PR"
+      fi
+    fi
     PR_NUMBER="${PR_URL##*/}"
   fi
 
@@ -386,6 +458,8 @@ print_summary() {
   printf 'Pushed remote: %s (%s)\n' "$PUSH_REMOTE" "$PUSH_OWNER_REPO"
   if [[ -n "$PR_URL" ]]; then
     printf 'PR: %s\n' "$PR_URL"
+  elif [[ -n "$PR_SKIPPED_REASON" ]]; then
+    printf 'PR creation skipped: %s\n' "$PR_SKIPPED_REASON"
   elif [[ -n "$PR_CREATION_LINK" ]]; then
     printf 'PR creation skipped for bot account.\n'
     printf 'Create PR: %s\n' "$PR_CREATION_LINK"

--- a/.claude/skills/pr-push/scripts/pr_push.sh
+++ b/.claude/skills/pr-push/scripts/pr_push.sh
@@ -44,7 +44,7 @@ remember_staged_files() {
   local file existing committed_file
   while IFS= read -r file; do
     existing="no"
-    for committed_file in "${COMMITTED_FILES[@]}"; do
+    for committed_file in "${COMMITTED_FILES[@]+"${COMMITTED_FILES[@]}"}"; do
       if [[ "$committed_file" == "$file" ]]; then
         existing="yes"
         break
@@ -110,6 +110,7 @@ stage_relevant_changes() {
 
     if is_ignored_file "$path"; then
       IGNORED_FILES+=("$path")
+      git restore --staged -- "$path" 2>/dev/null || true
       continue
     fi
 
@@ -191,16 +192,16 @@ commit_if_needed() {
 
 run_checks() {
   log "Running formatter"
-  npm run fmt
+  npm run fmt || die "Formatter failed; fix the issues above and rerun"
 
   log "Running lint fix"
-  npm run lint:fix
+  npm run lint:fix || die "Lint failed; fix the issues above and rerun"
 
   log "Running typecheck"
-  npm run ts
+  npm run ts || die "Typecheck failed; fix the issues above and rerun"
 
   log "Running tests"
-  npm test
+  npm test || die "Tests failed; fix the issues above and rerun"
 }
 
 amend_or_commit_check_changes() {
@@ -256,6 +257,18 @@ has_remote() {
   git remote get-url "$1" >/dev/null 2>&1
 }
 
+remote_for_owner_repo() {
+  local owner_repo="$1" remote
+  while IFS= read -r remote; do
+    if [[ "$(remote_owner_repo "$remote")" == "$owner_repo" ]]; then
+      printf '%s\n' "$remote"
+      return 0
+    fi
+  done < <(git remote)
+
+  return 1
+}
+
 no_pr_found_error() {
   grep -qiE 'no (open )?pull requests? found|no pull request found' <<<"$1"
 }
@@ -293,7 +306,7 @@ push_with_fallback() {
   fi
 
   local pr_head_repo pr_view_output matched_remote
-  if pr_view_output="$(gh pr view --json headRepository --jq .headRepository.nameWithOwner 2>&1)"; then
+  if pr_view_output="$(gh pr view "$branch" --repo "$BASE_REPO" --json headRepository --jq .headRepository.nameWithOwner 2>&1)"; then
     pr_head_repo="$pr_view_output"
     while IFS= read -r remote; do
       if [[ "$(remote_owner_repo "$remote")" == "$pr_head_repo" ]]; then
@@ -368,17 +381,37 @@ pr_body() {
   fi
 }
 
+base_comparison_ref() {
+  local base_remote
+  if base_remote="$(remote_for_owner_repo "$BASE_REPO")"; then
+    printf '%s/%s\n' "$base_remote" "$BASE_BRANCH"
+  else
+    printf '%s\n' "$BASE_BRANCH"
+  fi
+}
+
 branch_has_commits_ahead() {
-  local count
-  count="$(git rev-list --count "$BASE_BRANCH"..HEAD 2>/dev/null || true)"
-  [[ -z "$count" || "$count" != "0" ]]
+  local base_ref count
+  base_ref="$(base_comparison_ref)"
+  if ! count="$(git rev-list --count "$base_ref"..HEAD 2>/dev/null)"; then
+    PR_SKIPPED_REASON="could not determine commit count against $base_ref"
+    return 1
+  fi
+
+  if [[ "$count" == "0" ]]; then
+    PR_SKIPPED_REASON="branch has no commits ahead of $base_ref"
+    return 1
+  fi
+
+  return 0
 }
 
 create_or_update_pr() {
-  local view_output branch head_owner title body
+  local view_output branch head_owner title body create_error create_error_file
 
-  if PR_NUMBER="$(gh pr view --json number --jq .number 2>&1)"; then
-    PR_URL="$(gh pr view --json url --jq .url)"
+  branch="$(current_branch)"
+  if PR_NUMBER="$(gh pr view "$branch" --repo "$BASE_REPO" --json number --jq .number 2>&1)"; then
+    PR_URL="$(gh pr view "$branch" --repo "$BASE_REPO" --json url --jq .url)"
     log "PR already exists: $PR_URL"
   else
     view_output="$PR_NUMBER"
@@ -389,12 +422,10 @@ create_or_update_pr() {
     fi
 
     if ! branch_has_commits_ahead; then
-      PR_SKIPPED_REASON="branch has no commits ahead of $BASE_BRANCH"
       log "Skipping PR creation because $PR_SKIPPED_REASON"
       return
     fi
 
-    branch="$(current_branch)"
     head_owner="${PUSH_OWNER_REPO%%/*}"
     title="$(pr_title)"
     body="$(pr_body)"
@@ -408,13 +439,17 @@ create_or_update_pr() {
     fi
 
     log "Creating PR against $BASE_REPO"
+    mkdir -p .claude/tmp
+    create_error_file=".claude/tmp/pr-push-create-error.$$"
     if ! PR_URL="$(gh pr create \
       --repo "$BASE_REPO" \
       --head "${head_owner}:${branch}" \
       --base "$BASE_BRANCH" \
       --title "$title" \
-      --body "$body" 2>&1)"; then
-      if grep -qi 'fork collab' <<<"$PR_URL"; then
+      --body "$body" 2>"$create_error_file")"; then
+      create_error="$(cat "$create_error_file")"
+      rm -f "$create_error_file"
+      if grep -qi 'fork collab' <<<"$create_error"; then
         log "Retrying PR creation without maintainer edits"
         PR_URL="$(gh pr create \
           --repo "$BASE_REPO" \
@@ -424,10 +459,11 @@ create_or_update_pr() {
           --body "$body" \
           --no-maintainer-edit)"
       else
-        printf '%s\n' "$PR_URL" >&2
+        printf '%s\n' "$create_error" >&2
         die "Unable to create PR"
       fi
     fi
+    rm -f "$create_error_file"
     PR_NUMBER="${PR_URL##*/}"
   fi
 
@@ -445,13 +481,13 @@ print_summary() {
   if ((${#COMMITTED_FILES[@]} == 0)); then
     printf -- '- none\n'
   else
-    printf -- '- %s\n' "${COMMITTED_FILES[@]}"
+    printf -- '- %s\n' "${COMMITTED_FILES[@]+"${COMMITTED_FILES[@]}"}"
   fi
   printf 'Ignored files:\n'
   if ((${#IGNORED_FILES[@]} == 0)); then
     printf -- '- none\n'
   else
-    printf -- '- %s\n' "${IGNORED_FILES[@]}"
+    printf -- '- %s\n' "${IGNORED_FILES[@]+"${IGNORED_FILES[@]}"}"
   fi
   printf 'Automated check changes: %s\n' "$LINT_CHANGED"
   printf 'Checks: passed\n'

--- a/.claude/skills/pr-push/scripts/pr_push.sh
+++ b/.claude/skills/pr-push/scripts/pr_push.sh
@@ -1,0 +1,408 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REPO="${PR_PUSH_BASE_REPO:-dyad-sh/dyad}"
+BASE_BRANCH="${PR_PUSH_BASE_BRANCH:-main}"
+DEFAULT_REMOTE="${PR_PUSH_REMOTE:-origin}"
+REVIEW_LABEL="needs-human:review-issue"
+CREATED_BRANCH=""
+IGNORED_FILES=()
+COMMITTED_FILES=()
+LINT_CHANGED="no"
+PUSH_REMOTE=""
+PUSH_OWNER_REPO=""
+PR_URL=""
+PR_NUMBER=""
+PR_CREATION_LINK=""
+SUGGESTED_TITLE=""
+SUGGESTED_BODY=""
+CREATED_COMMIT="no"
+
+log() {
+  printf '==> %s\n' "$*"
+}
+
+die() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+repo_root() {
+  git rev-parse --show-toplevel
+}
+
+current_branch() {
+  git branch --show-current
+}
+
+has_changes() {
+  [[ -n "$(git status --porcelain -uall)" ]]
+}
+
+is_ignored_file() {
+  local file="$1"
+
+  case "$file" in
+    .env | .env.* | */.env | */.env.* | credentials.* | */credentials.* | *.secret | *.key | *.pem | .DS_Store | */.DS_Store | *.log | node_modules/* | */node_modules/*)
+      return 0
+      ;;
+  esac
+
+  return 1
+}
+
+path_is_dirty() {
+  local file="$1"
+  [[ -n "$(git status --porcelain -uall -- "$file")" ]]
+}
+
+package_json_dirty() {
+  path_is_dirty "package.json"
+}
+
+restore_spurious_package_lock() {
+  if path_is_dirty "package-lock.json" && ! package_json_dirty; then
+    log "Discarding package-lock.json because package.json is unchanged"
+    git restore --staged package-lock.json 2>/dev/null || true
+    git restore package-lock.json
+    IGNORED_FILES+=("package-lock.json (spurious without package.json)")
+  fi
+}
+
+stage_relevant_changes() {
+  restore_spurious_package_lock
+
+  local status path
+  while IFS= read -r status; do
+    path="${status:3}"
+    [[ -z "$path" ]] && continue
+
+    if is_ignored_file "$path"; then
+      IGNORED_FILES+=("$path")
+      continue
+    fi
+
+    git add -- "$path"
+  done < <(git status --porcelain -uall)
+}
+
+staged_file_list() {
+  git diff --cached --name-only
+}
+
+default_branch_name() {
+  local files joined
+  files="$(git status --porcelain -uall | awk '{print $2}' | head -5 | tr '\n' ' ')"
+
+  case "$files" in
+    *".claude/skills/pr-push"*) joined="fast-pr-push-skill" ;;
+    *".github/workflows"*) joined="update-workflows" ;;
+    *"rules/"* | *"AGENTS.md"*) joined="update-agent-docs" ;;
+    *"src/"*) joined="update-app-code" ;;
+    *) joined="codex-pr-push" ;;
+  esac
+
+  printf '%s-%s' "$joined" "$(date +%Y%m%d%H%M%S)"
+}
+
+ensure_feature_branch() {
+  local branch
+  branch="$(current_branch)"
+
+  [[ -n "$branch" ]] || die "Detached HEAD is not supported"
+
+  if [[ "$branch" == "main" || "$branch" == "master" ]]; then
+    CREATED_BRANCH="$(default_branch_name)"
+    log "On $branch; creating feature branch $CREATED_BRANCH"
+    git checkout -b "$CREATED_BRANCH"
+  else
+    log "Using existing feature branch $branch"
+  fi
+}
+
+commit_message_from_staged_files() {
+  if [[ -n "${PR_PUSH_COMMIT_MESSAGE:-}" ]]; then
+    printf '%s\n' "$PR_PUSH_COMMIT_MESSAGE"
+    return
+  fi
+
+  local files
+  files="$(staged_file_list | tr '\n' ' ')"
+
+  case "$files" in
+    *".claude/skills/pr-push"*) printf 'chore: speed up pr push skill\n' ;;
+    *"rules/"* | *"AGENTS.md"*) printf 'docs: record session learnings\n' ;;
+    *".github/workflows"*) printf 'ci: update workflows\n' ;;
+    *) printf 'chore: update project files\n' ;;
+  esac
+}
+
+commit_if_needed() {
+  if ! has_changes; then
+    log "No uncommitted changes to commit"
+    return
+  fi
+
+  stage_relevant_changes
+
+  if [[ -z "$(staged_file_list)" ]]; then
+    log "No relevant changes staged"
+    return
+  fi
+
+  while IFS= read -r file; do
+    COMMITTED_FILES+=("$file")
+  done < <(staged_file_list)
+  local message
+  message="$(commit_message_from_staged_files)"
+  log "Committing staged changes: $message"
+  git commit -m "$message"
+  CREATED_COMMIT="yes"
+}
+
+run_checks() {
+  log "Running formatter"
+  npm run fmt
+
+  log "Running lint fix"
+  npm run lint:fix
+
+  log "Running typecheck"
+  npm run ts
+
+  log "Running tests"
+  npm test
+}
+
+amend_or_commit_check_changes() {
+  if ! has_changes; then
+    log "Checks did not modify tracked files"
+    return
+  fi
+
+  LINT_CHANGED="yes"
+  stage_relevant_changes
+
+  if [[ -z "$(staged_file_list)" ]]; then
+    log "Checks only touched ignored files"
+    return
+  fi
+
+  if [[ "$CREATED_COMMIT" == "yes" ]]; then
+    log "Amending automated check changes into previous commit"
+    git commit --amend --no-edit
+  else
+    log "Committing automated check changes"
+    git commit -m "chore: apply automated fixes"
+    CREATED_COMMIT="yes"
+  fi
+}
+
+remote_owner_repo() {
+  local remote="$1"
+  local url
+  url="$(git remote get-url --push "$remote" 2>/dev/null || git remote get-url "$remote")"
+
+  url="${url%.git}"
+  case "$url" in
+    git@github.com:*) printf '%s\n' "${url#git@github.com:}" ;;
+    https://github.com/*) printf '%s\n' "${url#https://github.com/}" ;;
+    https://*@github.com/*) printf '%s\n' "${url#*@github.com/}" ;;
+    *) printf '%s\n' "$url" ;;
+  esac
+}
+
+push_with_fallback() {
+  local upstream push_output
+
+  if upstream="$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null)"; then
+    PUSH_REMOTE="${upstream%%/*}"
+    log "Pushing to tracked upstream $upstream"
+    if push_output="$(git push --force-with-lease 2>&1)"; then
+      printf '%s\n' "$push_output"
+      PUSH_OWNER_REPO="$(remote_owner_repo "$PUSH_REMOTE")"
+      return
+    fi
+
+    printf '%s\n' "$push_output" >&2
+    if grep -qiE 'permission|denied|403|not allowlisted' <<<"$push_output"; then
+      log "Tracked push failed with permission-like error; falling back to $DEFAULT_REMOTE"
+      PUSH_REMOTE="$DEFAULT_REMOTE"
+      git push --force-with-lease -u "$DEFAULT_REMOTE" HEAD
+      PUSH_OWNER_REPO="$(remote_owner_repo "$PUSH_REMOTE")"
+      return
+    fi
+
+    die "Push to tracked upstream failed"
+  fi
+
+  local pr_head_repo pr_view_output matched_remote
+  if pr_view_output="$(gh pr view --json headRepository --jq .headRepository.nameWithOwner 2>&1)"; then
+    pr_head_repo="$pr_view_output"
+    while IFS= read -r remote; do
+      if [[ "$(remote_owner_repo "$remote")" == "$pr_head_repo" ]]; then
+        matched_remote="$remote"
+        break
+      fi
+    done < <(git remote)
+  elif ! grep -qiE 'no pull requests found|no pull request found' <<<"$pr_view_output"; then
+    printf '%s\n' "$pr_view_output" >&2
+    die "Unable to check existing PR before push"
+  fi
+
+  PUSH_REMOTE="${matched_remote:-$DEFAULT_REMOTE}"
+  log "Pushing to $PUSH_REMOTE"
+  if git push --force-with-lease -u "$PUSH_REMOTE" HEAD; then
+    PUSH_OWNER_REPO="$(remote_owner_repo "$PUSH_REMOTE")"
+    return
+  fi
+
+  if [[ "$PUSH_REMOTE" != "upstream" ]]; then
+    log "Push to $PUSH_REMOTE failed; trying upstream as fallback"
+    PUSH_REMOTE="upstream"
+    git push --force-with-lease -u upstream HEAD
+    PUSH_OWNER_REPO="$(remote_owner_repo "$PUSH_REMOTE")"
+    return
+  fi
+
+  die "Push failed"
+}
+
+active_account_is_bot() {
+  local status account
+  status="$(gh auth status 2>&1)"
+  account="$(sed -nE 's/.*Logged in to github.com account ([^ ]+).*/\1/p' <<<"$status" | head -1)"
+  [[ "$account" == *"[bot]" ]]
+}
+
+pr_title() {
+  if [[ -n "${PR_PUSH_PR_TITLE:-}" ]]; then
+    printf '%s\n' "$PR_PUSH_PR_TITLE"
+    return
+  fi
+
+  local subject
+  subject="$(git log -1 --pretty=%s)"
+  local lower_subject
+  lower_subject="$(printf '%s' "$subject" | tr '[:upper:]' '[:lower:]')"
+  case "$lower_subject" in
+    chore:\ *) subject="${subject#*: }" ;;
+    fix:\ *) subject="${subject#*: }" ;;
+    feat:\ *) subject="${subject#*: }" ;;
+    docs:\ *) subject="${subject#*: }" ;;
+    ci:\ *) subject="${subject#*: }" ;;
+    test:\ *) subject="${subject#*: }" ;;
+    refactor:\ *) subject="${subject#*: }" ;;
+  esac
+
+  if [[ -z "$subject" ]]; then
+    printf 'Update project files\n'
+  else
+    printf '%s%s\n' "$(tr '[:lower:]' '[:upper:]' <<<"${subject:0:1}")" "${subject:1}"
+  fi
+}
+
+pr_body() {
+  if [[ -n "${PR_PUSH_PR_BODY:-}" ]]; then
+    printf '%s\n' "$PR_PUSH_PR_BODY"
+    return
+  fi
+
+  local files_line
+  files_line="$(git diff --name-only "$BASE_BRANCH"...HEAD 2>/dev/null | head -6 | awk 'BEGIN { sep="" } { printf "%s%s", sep, $0; sep=", " }')"
+
+  printf '## Summary\n'
+  printf -- '- %s\n' "$(git log -1 --pretty=%s)"
+  if [[ -n "$files_line" ]]; then
+    printf -- '- Primary files: %s\n' "$files_line"
+  fi
+}
+
+create_or_update_pr() {
+  local view_output body_file branch head_owner title body
+
+  if view_output="$(gh pr view --json number,url 2>&1)"; then
+    PR_NUMBER="$(jq -r .number <<<"$view_output")"
+    PR_URL="$(jq -r .url <<<"$view_output")"
+    log "PR already exists: $PR_URL"
+  else
+    if ! grep -qiE 'no pull requests found|no pull request found' <<<"$view_output"; then
+      printf '%s\n' "$view_output" >&2
+      die "Unable to check PR state"
+    fi
+
+    branch="$(current_branch)"
+    head_owner="${PUSH_OWNER_REPO%%/*}"
+    title="$(pr_title)"
+    body="$(pr_body)"
+    SUGGESTED_TITLE="$title"
+    SUGGESTED_BODY="$body"
+
+    if active_account_is_bot; then
+      PR_CREATION_LINK="https://github.com/${PUSH_OWNER_REPO}/pull/new/${branch}"
+      log "Active GitHub account is a bot; skipping PR creation"
+      return
+    fi
+
+    mkdir -p .claude/tmp
+    body_file="$(mktemp .claude/tmp/pr-push-body.XXXXXX)"
+    printf '%s\n' "$body" >"$body_file"
+
+    log "Creating PR against $BASE_REPO"
+    PR_URL="$(gh pr create \
+      --repo "$BASE_REPO" \
+      --head "${head_owner}:${branch}" \
+      --base "$BASE_BRANCH" \
+      --title "$title" \
+      --body-file "$body_file")"
+    rm -f "$body_file"
+    PR_NUMBER="${PR_URL##*/}"
+  fi
+
+  if [[ -n "$PR_NUMBER" ]]; then
+    gh pr edit "$PR_NUMBER" --repo "$BASE_REPO" --remove-label "$REVIEW_LABEL" >/dev/null 2>&1 || true
+  fi
+}
+
+print_summary() {
+  printf '\nPR push summary\n'
+  printf '---------------\n'
+  printf 'Branch: %s\n' "$(current_branch)"
+  [[ -n "$CREATED_BRANCH" ]] && printf 'Created branch: %s\n' "$CREATED_BRANCH"
+  printf 'Committed files:\n'
+  if ((${#COMMITTED_FILES[@]} == 0)); then
+    printf -- '- none\n'
+  else
+    printf -- '- %s\n' "${COMMITTED_FILES[@]}"
+  fi
+  printf 'Ignored files:\n'
+  if ((${#IGNORED_FILES[@]} == 0)); then
+    printf -- '- none\n'
+  else
+    printf -- '- %s\n' "${IGNORED_FILES[@]}"
+  fi
+  printf 'Automated check changes: %s\n' "$LINT_CHANGED"
+  printf 'Checks: passed\n'
+  printf 'Pushed remote: %s (%s)\n' "$PUSH_REMOTE" "$PUSH_OWNER_REPO"
+  if [[ -n "$PR_URL" ]]; then
+    printf 'PR: %s\n' "$PR_URL"
+  elif [[ -n "$PR_CREATION_LINK" ]]; then
+    printf 'PR creation skipped for bot account.\n'
+    printf 'Create PR: %s\n' "$PR_CREATION_LINK"
+    printf 'Suggested title: %s\n' "$SUGGESTED_TITLE"
+    printf 'Suggested body:\n%s\n' "$SUGGESTED_BODY"
+  fi
+}
+
+main() {
+  cd "$(repo_root)"
+  ensure_feature_branch
+  commit_if_needed
+  run_checks
+  amend_or_commit_check_changes
+  push_with_fallback
+  create_or_update_pr
+  print_summary
+}
+
+main "$@"

--- a/.claude/skills/pr-push/scripts/pr_push.sh
+++ b/.claude/skills/pr-push/scripts/pr_push.sh
@@ -58,7 +58,7 @@ is_ignored_file() {
   local file="$1"
 
   case "$file" in
-    .env | .env.* | */.env | */.env.* | credentials.* | */credentials.* | *.secret | *.key | *.pem | .DS_Store | */.DS_Store | *.log | node_modules/* | */node_modules/*)
+    .env | .env.* | */.env | */.env.* | credentials.* | */credentials.* | *.secret | *.key | *.pem | .DS_Store | */.DS_Store | *.log | node_modules/* | */node_modules/* | .claude/tmp/*)
       return 0
       ;;
   esac
@@ -104,18 +104,30 @@ git_status_paths() {
 stage_relevant_changes() {
   restore_spurious_package_lock
 
-  local path
-  while IFS= read -r -d '' path; do
+  local record xy path paired_path
+  while IFS= read -r -d '' record; do
+    xy="${record:0:2}"
+    path="${record:3}"
+    paired_path=""
     [[ -z "$path" ]] && continue
 
-    if is_ignored_file "$path"; then
+    case "$xy" in
+      R* | C* | *R | *C)
+        IFS= read -r -d '' paired_path || true
+        ;;
+    esac
+
+    if is_ignored_file "$path" || { [[ -n "$paired_path" ]] && is_ignored_file "$paired_path"; }; then
       IGNORED_FILES+=("$path")
+      [[ -z "$paired_path" ]] || IGNORED_FILES+=("$paired_path")
       git restore --staged -- "$path" 2>/dev/null || true
+      [[ -z "$paired_path" ]] || git restore --staged -- "$paired_path" 2>/dev/null || true
       continue
     fi
 
     git add -A -- "$path"
-  done < <(git_status_paths)
+    [[ -z "$paired_path" ]] || git add -A -- "$paired_path"
+  done < <(git status --porcelain=v1 -z -uall)
 }
 
 staged_file_list() {
@@ -127,7 +139,7 @@ default_branch_name() {
   files="$(git_status_paths | awk -v RS='\0' 'NR <= 5 { printf "%s ", $0 }')"
 
   case "$files" in
-    *".claude/skills/pr-push"*) joined="fast-pr-push-skill" ;;
+    *".claude/skills/pr-push"*) joined="update-pr-push-skill" ;;
     *".github/workflows"*) joined="update-workflows" ;;
     *"rules/"* | *"AGENTS.md"*) joined="update-agent-docs" ;;
     *"src/"*) joined="update-app-code" ;;
@@ -162,7 +174,7 @@ commit_message_from_staged_files() {
   files="$(staged_file_list | tr '\n' ' ')"
 
   case "$files" in
-    *".claude/skills/pr-push"*) printf 'chore: speed up pr push skill\n' ;;
+    *".claude/skills/pr-push"*) printf 'chore: update pr push skill\n' ;;
     *"rules/"* | *"AGENTS.md"*) printf 'docs: record session learnings\n' ;;
     *".github/workflows"*) printf 'ci: update workflows\n' ;;
     *) printf 'chore: update project files\n' ;;
@@ -229,10 +241,15 @@ amend_or_commit_check_changes() {
   fi
 }
 
-remote_owner_repo() {
-  local remote="$1"
-  local url parsed
-  url="$(git remote get-url --push "$remote" 2>/dev/null || git remote get-url "$remote")"
+repo_temp_file() {
+  local name="$1"
+  mkdir -p .claude/tmp
+  mktemp ".claude/tmp/${name}.XXXXXX"
+}
+
+owner_repo_from_url() {
+  local url="$1"
+  local parsed
 
   url="${url%.git}"
   case "$url" in
@@ -256,8 +273,45 @@ remote_owner_repo() {
   esac
 }
 
+remote_owner_repo() {
+  local remote="$1"
+  local url
+  url="$(git remote get-url --push "$remote" 2>/dev/null || git remote get-url "$remote")"
+  owner_repo_from_url "$url"
+}
+
+remote_fetch_owner_repo() {
+  local remote="$1"
+  local url
+  url="$(git remote get-url "$remote")"
+  owner_repo_from_url "$url"
+}
+
 is_permission_push_error() {
   grep -qiE 'permission|denied|403|not allowlisted|could not read Username' <<<"$1"
+}
+
+git_push_with_token_retry() {
+  local output_var="$1"
+  shift
+  local output retry_output
+
+  if output="$("$@" 2>&1)"; then
+    printf -v "$output_var" '%s' "$output"
+    return 0
+  fi
+
+  if [[ -n "${GH_TOKEN:-}" ]] && is_permission_push_error "$output"; then
+    log "Push failed with permission-like error; retrying same remote without GH_TOKEN"
+    if retry_output="$(env -u GH_TOKEN "$@" 2>&1)"; then
+      printf -v "$output_var" '%s' "$retry_output"
+      return 0
+    fi
+    output="${output}"$'\n'"Retry without GH_TOKEN also failed:"$'\n'"${retry_output}"
+  fi
+
+  printf -v "$output_var" '%s' "$output"
+  return 1
 }
 
 has_remote() {
@@ -276,14 +330,30 @@ remote_for_owner_repo() {
   return 1
 }
 
-list_existing_prs_for_branch() {
-  local branch="$1" list_output
+remote_for_fetch_owner_repo() {
+  local owner_repo="$1" remote
+  while IFS= read -r remote; do
+    if [[ "$(remote_fetch_owner_repo "$remote")" == "$owner_repo" ]]; then
+      printf '%s\n' "$remote"
+      return 0
+    fi
+  done < <(git remote)
 
-  if ! list_output="$(gh pr list --repo "$BASE_REPO" --head "$branch" --json number,url,headRepository,headRepositoryOwner --jq '.[] | [.number, .url, (((.headRepositoryOwner.login // "") + "/" + (.headRepository.name // "")) | select(. != "/"))] | @tsv' 2>&1)"; then
+  return 1
+}
+
+list_existing_prs_for_branch() {
+  local branch="$1" list_output error_file
+  error_file="$(repo_temp_file pr-push-list-error)"
+
+  if ! list_output="$(gh pr list --repo "$BASE_REPO" --head "$branch" --json number,url,headRepository,headRepositoryOwner --jq '.[] | [.number, .url, (((.headRepositoryOwner.login // "") + "/" + (.headRepository.name // "")) | select(. != "/"))] | @tsv' 2>"$error_file")"; then
+    cat "$error_file" >&2
+    rm -f "$error_file"
     printf '%s\n' "$list_output" >&2
     die "Unable to list existing PRs"
   fi
 
+  rm -f "$error_file"
   printf '%s\n' "$list_output"
 }
 
@@ -338,7 +408,7 @@ push_with_fallback() {
 
     if [[ "$upstream_branch" != "main" && "$upstream_branch" != "master" ]]; then
       log "Pushing to tracked upstream $upstream"
-      if push_output="$(git push --force-with-lease 2>&1)"; then
+      if git_push_with_token_retry push_output git push --force-with-lease; then
         printf '%s\n' "$push_output"
         PUSH_OWNER_REPO="$(remote_owner_repo "$PUSH_REMOTE")"
         return
@@ -348,9 +418,13 @@ push_with_fallback() {
       if is_permission_push_error "$push_output"; then
         log "Tracked push failed with permission-like error; falling back to $DEFAULT_REMOTE"
         PUSH_REMOTE="$DEFAULT_REMOTE"
-        git push --force-with-lease -u "$DEFAULT_REMOTE" HEAD
-        PUSH_OWNER_REPO="$(remote_owner_repo "$PUSH_REMOTE")"
-        return
+        if git_push_with_token_retry push_output git push --force-with-lease -u "$DEFAULT_REMOTE" HEAD; then
+          printf '%s\n' "$push_output"
+          PUSH_OWNER_REPO="$(remote_owner_repo "$PUSH_REMOTE")"
+          return
+        fi
+        printf '%s\n' "$push_output" >&2
+        die "Fallback push to $DEFAULT_REMOTE failed after tracked push to $upstream failed"
       fi
 
       die "Push to tracked upstream failed"
@@ -372,7 +446,7 @@ push_with_fallback() {
 
   PUSH_REMOTE="${matched_remote:-$DEFAULT_REMOTE}"
   log "Pushing to $PUSH_REMOTE"
-  if push_output="$(git push --force-with-lease -u "$PUSH_REMOTE" HEAD 2>&1)"; then
+  if git_push_with_token_retry push_output git push --force-with-lease -u "$PUSH_REMOTE" HEAD; then
     printf '%s\n' "$push_output"
     PUSH_OWNER_REPO="$(remote_owner_repo "$PUSH_REMOTE")"
     return
@@ -381,13 +455,15 @@ push_with_fallback() {
   printf '%s\n' "$push_output" >&2
   if [[ "$PUSH_REMOTE" != "upstream" ]] && has_remote "upstream" && is_permission_push_error "$push_output"; then
     log "Push to $PUSH_REMOTE failed with permission-like error; trying upstream as fallback"
+    local failed_remote="$PUSH_REMOTE"
     PUSH_REMOTE="upstream"
-    if push_output="$(git push --force-with-lease -u upstream "HEAD:$branch" 2>&1)"; then
+    if git_push_with_token_retry push_output git push --force-with-lease -u upstream "HEAD:$branch"; then
       printf '%s\n' "$push_output"
       PUSH_OWNER_REPO="$(remote_owner_repo "$PUSH_REMOTE")"
       return
     fi
     printf '%s\n' "$push_output" >&2
+    die "Fallback push to upstream failed after push to $failed_remote failed"
   fi
 
   die "Push failed"
@@ -435,7 +511,7 @@ pr_body() {
 
 base_comparison_ref() {
   local base_remote
-  if base_remote="$(remote_for_owner_repo "$BASE_REPO")"; then
+  if base_remote="$(remote_for_fetch_owner_repo "$BASE_REPO")"; then
     if ! git show-ref --verify --quiet "refs/remotes/$base_remote/$BASE_BRANCH"; then
       git fetch "$base_remote" "$BASE_BRANCH" >/dev/null 2>&1 || true
     fi
@@ -469,6 +545,7 @@ create_or_update_pr() {
   local branch head_owner title body create_error create_error_file
 
   branch="$(current_branch)"
+  [[ -n "$PUSH_OWNER_REPO" && "$PUSH_OWNER_REPO" != *://* && "$PUSH_OWNER_REPO" == */* ]] || die "Cannot determine owner/repo for push remote $PUSH_REMOTE"
   head_owner="${PUSH_OWNER_REPO%%/*}"
   if find_existing_pr_for_branch "$branch" "$head_owner"; then
     log "PR already exists: $PR_URL"
@@ -490,7 +567,7 @@ create_or_update_pr() {
     fi
 
     log "Creating PR against $BASE_REPO"
-    create_error_file="$(mktemp "${TMPDIR:-/tmp}/pr-push-create-error.XXXXXX")"
+    create_error_file="$(repo_temp_file pr-push-create-error)"
     if ! PR_URL="$(gh pr create \
       --repo "$BASE_REPO" \
       --head "${head_owner}:${branch}" \

--- a/.claude/skills/pr-push/scripts/pr_push.sh
+++ b/.claude/skills/pr-push/scripts/pr_push.sh
@@ -367,7 +367,7 @@ push_with_fallback() {
 active_account_is_bot() {
   local account
   account="$(gh api user --jq .login 2>/dev/null || true)"
-  [[ "$account" == *"[bot]" ]]
+  [[ "$account" == *\[bot\] ]]
 }
 
 pr_title() {
@@ -406,10 +406,17 @@ pr_body() {
 base_comparison_ref() {
   local base_remote
   if base_remote="$(remote_for_owner_repo "$BASE_REPO")"; then
-    printf '%s/%s\n' "$base_remote" "$BASE_BRANCH"
-  else
-    printf '%s\n' "$BASE_BRANCH"
+    if ! git show-ref --verify --quiet "refs/remotes/$base_remote/$BASE_BRANCH"; then
+      git fetch "$base_remote" "$BASE_BRANCH" >/dev/null 2>&1 || true
+    fi
+
+    if git show-ref --verify --quiet "refs/remotes/$base_remote/$BASE_BRANCH"; then
+      printf '%s/%s\n' "$base_remote" "$BASE_BRANCH"
+      return
+    fi
   fi
+
+  printf '%s\n' "$BASE_BRANCH"
 }
 
 branch_has_commits_ahead() {

--- a/.claude/skills/pr-push/scripts/pr_push.sh
+++ b/.claude/skills/pr-push/scripts/pr_push.sh
@@ -79,7 +79,7 @@ restore_spurious_package_lock() {
   if path_is_dirty "package-lock.json" && ! package_json_dirty; then
     log "Discarding package-lock.json because package.json is unchanged"
     git restore --staged package-lock.json 2>/dev/null || true
-    git restore package-lock.json
+    git restore package-lock.json 2>/dev/null || true
     IGNORED_FILES+=("package-lock.json (spurious without package.json)")
   fi
 }
@@ -124,7 +124,7 @@ staged_file_list() {
 
 default_branch_name() {
   local files joined
-  files="$(git_status_paths | tr '\0' '\n' | head -5 | tr '\n' ' ')"
+  files="$(git_status_paths | awk -v RS='\0' 'NR <= 5 { printf "%s ", $0 }')"
 
   case "$files" in
     *".claude/skills/pr-push"*) joined="fast-pr-push-skill" ;;
@@ -235,16 +235,23 @@ remote_owner_repo() {
   url="$(git remote get-url --push "$remote" 2>/dev/null || git remote get-url "$remote")"
 
   url="${url%.git}"
-  parsed="$(printf '%s' "$url" | sed -E 's#^[[:alpha:]][[:alnum:].+-]*://##; s#^[^@/]+@##; s#^github.com[:/]##; s#^git@github.com[:/]##')"
-  if [[ "$parsed" != "$url" && "$parsed" == */* ]]; then
-    printf '%s\n' "$parsed"
-    return
-  fi
-
   case "$url" in
+    *://*)
+      parsed="${url#*://}"
+      parsed="${parsed#*@}"
+      case "$parsed" in
+        github.com/* | github.com:*/* | ssh.github.com/* | ssh.github.com:*/*)
+          parsed="${parsed#*/}"
+          if [[ "$parsed" == */* ]]; then
+            printf '%s\n' "$parsed"
+            return
+          fi
+          ;;
+      esac
+      ;;
     git@github.com:*) printf '%s\n' "${url#git@github.com:}" ;;
-    https://github.com/*) printf '%s\n' "${url#https://github.com/}" ;;
-    https://*@github.com/*) printf '%s\n' "${url#*@github.com/}" ;;
+    github.com:*) printf '%s\n' "${url#github.com:}" ;;
+    github.com/*) printf '%s\n' "${url#github.com/}" ;;
     *) printf '%s\n' "$url" ;;
   esac
 }
@@ -269,29 +276,56 @@ remote_for_owner_repo() {
   return 1
 }
 
-find_existing_pr_for_branch() {
-  local branch="$1" number_output url_output
+list_existing_prs_for_branch() {
+  local branch="$1" list_output
 
-  if ! number_output="$(gh pr list --repo "$BASE_REPO" --head "$branch" --json number --jq '.[0].number // empty' 2>&1)"; then
-    printf '%s\n' "$number_output" >&2
+  if ! list_output="$(gh pr list --repo "$BASE_REPO" --head "$branch" --json number,url,headRepository,headRepositoryOwner --jq '.[] | [.number, .url, (((.headRepositoryOwner.login // "") + "/" + (.headRepository.name // "")) | select(. != "/"))] | @tsv' 2>&1)"; then
+    printf '%s\n' "$list_output" >&2
     die "Unable to list existing PRs"
   fi
 
-  [[ -n "$number_output" ]] || return 1
-
-  if ! url_output="$(gh pr list --repo "$BASE_REPO" --head "$branch" --json url --jq '.[0].url // empty' 2>&1)"; then
-    printf '%s\n' "$url_output" >&2
-    die "Unable to read existing PR URL"
-  fi
-
-  PR_NUMBER="$number_output"
-  PR_URL="$url_output"
-  return 0
+  printf '%s\n' "$list_output"
 }
 
-pr_head_repo() {
-  local pr_number="$1"
-  gh api "repos/$BASE_REPO/pulls/$pr_number" --jq .head.repo.full_name
+find_existing_pr_for_branch() {
+  local branch="$1" head_owner="${2:-}"
+  local list_output number url head_repo
+
+  list_output="$(list_existing_prs_for_branch "$branch")"
+  [[ -n "$list_output" ]] || return 1
+
+  while IFS=$'\t' read -r number url head_repo; do
+    [[ -n "$number" ]] || continue
+    if [[ -n "$head_owner" && "$head_repo" != "$head_owner/"* ]]; then
+      continue
+    fi
+
+    PR_NUMBER="$number"
+    PR_URL="$url"
+    return 0
+  done <<<"$list_output"
+
+  return 1
+}
+
+find_existing_pr_head_repo_for_local_remote() {
+  local branch="$1"
+  local list_output number url head_repo
+
+  list_output="$(list_existing_prs_for_branch "$branch")"
+  [[ -n "$list_output" ]] || return 1
+
+  while IFS=$'\t' read -r number url head_repo; do
+    [[ -n "$number" && -n "$head_repo" ]] || continue
+    if remote_for_owner_repo "$head_repo" >/dev/null; then
+      PR_NUMBER="$number"
+      PR_URL="$url"
+      printf '%s\n' "$head_repo"
+      return 0
+    fi
+  done <<<"$list_output"
+
+  return 1
 }
 
 push_with_fallback() {
@@ -326,13 +360,8 @@ push_with_fallback() {
     git branch --unset-upstream >/dev/null 2>&1 || true
   fi
 
-  local pr_head_repo_name pr_view_output matched_remote
-  if find_existing_pr_for_branch "$branch"; then
-    pr_view_output="$(pr_head_repo "$PR_NUMBER" 2>&1)" || {
-      printf '%s\n' "$pr_view_output" >&2
-      die "Unable to check existing PR head repository before push"
-    }
-    pr_head_repo_name="$pr_view_output"
+  local pr_head_repo_name matched_remote
+  if pr_head_repo_name="$(find_existing_pr_head_repo_for_local_remote "$branch")"; then
     while IFS= read -r remote; do
       if [[ "$(remote_owner_repo "$remote")" == "$pr_head_repo_name" ]]; then
         matched_remote="$remote"
@@ -393,8 +422,9 @@ pr_body() {
     return
   fi
 
-  local files_line
-  files_line="$( (git diff --name-only "$BASE_BRANCH"...HEAD 2>/dev/null || true) | head -6 | awk 'BEGIN { sep="" } { printf "%s%s", sep, $0; sep=", " }')"
+  local base_ref files_line
+  base_ref="$(base_comparison_ref)"
+  files_line="$(git diff --name-only "$base_ref"...HEAD 2>/dev/null | awk 'NR <= 6 { printf "%s%s", sep, $0; sep=", " }' || true)"
 
   printf '## Summary\n'
   printf -- '- %s\n' "$(git log -1 --pretty=%s)"
@@ -439,7 +469,8 @@ create_or_update_pr() {
   local branch head_owner title body create_error create_error_file
 
   branch="$(current_branch)"
-  if find_existing_pr_for_branch "$branch"; then
+  head_owner="${PUSH_OWNER_REPO%%/*}"
+  if find_existing_pr_for_branch "$branch" "$head_owner"; then
     log "PR already exists: $PR_URL"
   else
     if ! branch_has_commits_ahead; then
@@ -447,7 +478,6 @@ create_or_update_pr() {
       return
     fi
 
-    head_owner="${PUSH_OWNER_REPO%%/*}"
     title="$(pr_title)"
     body="$(pr_body)"
     SUGGESTED_TITLE="$title"
@@ -460,8 +490,7 @@ create_or_update_pr() {
     fi
 
     log "Creating PR against $BASE_REPO"
-    mkdir -p .claude/tmp
-    create_error_file=".claude/tmp/pr-push-create-error.$$"
+    create_error_file="$(mktemp "${TMPDIR:-/tmp}/pr-push-create-error.XXXXXX")"
     if ! PR_URL="$(gh pr create \
       --repo "$BASE_REPO" \
       --head "${head_owner}:${branch}" \
@@ -536,4 +565,6 @@ main() {
   print_summary
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/.claude/skills/pr-push/scripts/pr_push.sh
+++ b/.claude/skills/pr-push/scripts/pr_push.sh
@@ -366,7 +366,7 @@ create_or_update_pr() {
 
 print_summary() {
   printf '\nPR push summary\n'
-  printf '---------------\n'
+  printf -- '---------------\n'
   printf 'Branch: %s\n' "$(current_branch)"
   [[ -n "$CREATED_BRANCH" ]] && printf 'Created branch: %s\n' "$CREATED_BRANCH"
   printf 'Committed files:\n'

--- a/.claude/skills/pr-push/scripts/pr_push.sh
+++ b/.claude/skills/pr-push/scripts/pr_push.sh
@@ -79,7 +79,11 @@ restore_spurious_package_lock() {
   if path_is_dirty "package-lock.json" && ! package_json_dirty; then
     log "Discarding package-lock.json because package.json is unchanged"
     git restore --staged package-lock.json 2>/dev/null || true
-    git restore package-lock.json 2>/dev/null || true
+    if git ls-files --error-unmatch package-lock.json >/dev/null 2>&1; then
+      git restore package-lock.json 2>/dev/null || true
+    else
+      rm -f package-lock.json
+    fi
     IGNORED_FILES+=("package-lock.json (spurious without package.json)")
   fi
 }
@@ -101,9 +105,7 @@ git_status_paths() {
   done < <(git status --porcelain=v1 -z -uall)
 }
 
-stage_relevant_changes() {
-  restore_spurious_package_lock
-
+ignored_status_paths() {
   local record xy path paired_path
   while IFS= read -r -d '' record; do
     xy="${record:0:2}"
@@ -116,6 +118,65 @@ stage_relevant_changes() {
         IFS= read -r -d '' paired_path || true
         ;;
     esac
+
+    if is_ignored_file "$path" && [[ -f "$path" ]]; then
+      printf '%s\0' "$path"
+    fi
+    if [[ -n "$paired_path" ]] && is_ignored_file "$paired_path" && [[ -f "$paired_path" ]]; then
+      printf '%s\0' "$paired_path"
+    fi
+  done < <(git status --porcelain=v1 -z -uall)
+}
+
+status_is_delete() {
+  local xy="$1"
+  [[ "$xy" == D* || "$xy" == " D" ]]
+}
+
+deleted_path_matches_ignored_file() {
+  local deleted_path="$1" ignored_path
+  shift
+
+  git cat-file -e "HEAD:$deleted_path" 2>/dev/null || return 1
+  for ignored_path in "$@"; do
+    [[ -f "$ignored_path" ]] || continue
+    if cmp -s <(git show "HEAD:$deleted_path") "$ignored_path"; then
+      printf '%s\n' "$ignored_path"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+stage_relevant_changes() {
+  restore_spurious_package_lock
+
+  local ignored_paths=() ignored_path record xy path paired_path moved_target
+  while IFS= read -r -d '' ignored_path; do
+    ignored_paths+=("$ignored_path")
+  done < <(ignored_status_paths)
+
+  while IFS= read -r -d '' record; do
+    xy="${record:0:2}"
+    path="${record:3}"
+    paired_path=""
+    [[ -z "$path" ]] && continue
+
+    case "$xy" in
+      R* | C* | *R | *C)
+        IFS= read -r -d '' paired_path || true
+        ;;
+    esac
+
+    if status_is_delete "$xy" && ((${#ignored_paths[@]} > 0)); then
+      if moved_target="$(deleted_path_matches_ignored_file "$path" "${ignored_paths[@]}")"; then
+        IGNORED_FILES+=("$path (moved to ignored path $moved_target)")
+        git restore --staged -- "$path" 2>/dev/null || true
+        git restore -- "$path" 2>/dev/null || true
+        continue
+      fi
+    fi
 
     if is_ignored_file "$path" || { [[ -n "$paired_path" ]] && is_ignored_file "$paired_path"; }; then
       IGNORED_FILES+=("$path")
@@ -291,6 +352,10 @@ is_permission_push_error() {
   grep -qiE 'permission|denied|403|not allowlisted|could not read Username' <<<"$1"
 }
 
+has_github_token_env() {
+  [[ -n "${GH_TOKEN:-}${GITHUB_TOKEN:-}${GH_ENTERPRISE_TOKEN:-}${GITHUB_ENTERPRISE_TOKEN:-}" ]]
+}
+
 git_push_with_token_retry() {
   local output_var="$1"
   shift
@@ -301,13 +366,13 @@ git_push_with_token_retry() {
     return 0
   fi
 
-  if [[ -n "${GH_TOKEN:-}" ]] && is_permission_push_error "$output"; then
-    log "Push failed with permission-like error; retrying same remote without GH_TOKEN"
-    if retry_output="$(env -u GH_TOKEN "$@" 2>&1)"; then
+  if has_github_token_env && is_permission_push_error "$output"; then
+    log "Push failed with permission-like error; retrying same remote without GitHub token environment variables"
+    if retry_output="$(env -u GH_TOKEN -u GITHUB_TOKEN -u GH_ENTERPRISE_TOKEN -u GITHUB_ENTERPRISE_TOKEN "$@" 2>&1)"; then
       printf -v "$output_var" '%s' "$retry_output"
       return 0
     fi
-    output="${output}"$'\n'"Retry without GH_TOKEN also failed:"$'\n'"${retry_output}"
+    output="${output}"$'\n'"Retry without GitHub token environment variables also failed:"$'\n'"${retry_output}"
   fi
 
   printf -v "$output_var" '%s' "$output"
@@ -340,6 +405,38 @@ remote_for_fetch_owner_repo() {
   done < <(git remote)
 
   return 1
+}
+
+remote_has_split_push_repo() {
+  local remote="$1" fetch_owner_repo push_owner_repo
+  fetch_owner_repo="$(remote_fetch_owner_repo "$remote")"
+  push_owner_repo="$(remote_owner_repo "$remote")"
+  [[ -n "$fetch_owner_repo" && -n "$push_owner_repo" && "$fetch_owner_repo" != "$push_owner_repo" ]]
+}
+
+push_branch_to_remote() {
+  local output_var="$1" remote="$2" set_upstream="$3" refspec="${4:-}"
+  local args
+
+  if remote_has_split_push_repo "$remote"; then
+    log "Remote $remote has separate fetch and push repositories; using --force because --force-with-lease checks the fetch-side tracking ref"
+    args=(git push --force)
+  else
+    args=(git push --force-with-lease)
+  fi
+
+  if [[ "$set_upstream" == "yes" ]]; then
+    args+=(-u)
+  fi
+
+  args+=("$remote")
+  if [[ -n "$refspec" ]]; then
+    args+=("$refspec")
+  else
+    args+=(HEAD)
+  fi
+
+  git_push_with_token_retry "$output_var" "${args[@]}"
 }
 
 list_existing_prs_for_branch() {
@@ -408,7 +505,7 @@ push_with_fallback() {
 
     if [[ "$upstream_branch" != "main" && "$upstream_branch" != "master" ]]; then
       log "Pushing to tracked upstream $upstream"
-      if git_push_with_token_retry push_output git push --force-with-lease; then
+      if push_branch_to_remote push_output "$PUSH_REMOTE" "no" "HEAD:$upstream_branch"; then
         printf '%s\n' "$push_output"
         PUSH_OWNER_REPO="$(remote_owner_repo "$PUSH_REMOTE")"
         return
@@ -418,7 +515,7 @@ push_with_fallback() {
       if is_permission_push_error "$push_output"; then
         log "Tracked push failed with permission-like error; falling back to $DEFAULT_REMOTE"
         PUSH_REMOTE="$DEFAULT_REMOTE"
-        if git_push_with_token_retry push_output git push --force-with-lease -u "$DEFAULT_REMOTE" HEAD; then
+        if push_branch_to_remote push_output "$DEFAULT_REMOTE" "yes"; then
           printf '%s\n' "$push_output"
           PUSH_OWNER_REPO="$(remote_owner_repo "$PUSH_REMOTE")"
           return
@@ -446,7 +543,7 @@ push_with_fallback() {
 
   PUSH_REMOTE="${matched_remote:-$DEFAULT_REMOTE}"
   log "Pushing to $PUSH_REMOTE"
-  if git_push_with_token_retry push_output git push --force-with-lease -u "$PUSH_REMOTE" HEAD; then
+  if push_branch_to_remote push_output "$PUSH_REMOTE" "yes"; then
     printf '%s\n' "$push_output"
     PUSH_OWNER_REPO="$(remote_owner_repo "$PUSH_REMOTE")"
     return
@@ -457,7 +554,7 @@ push_with_fallback() {
     log "Push to $PUSH_REMOTE failed with permission-like error; trying upstream as fallback"
     local failed_remote="$PUSH_REMOTE"
     PUSH_REMOTE="upstream"
-    if git_push_with_token_retry push_output git push --force-with-lease -u upstream "HEAD:$branch"; then
+    if push_branch_to_remote push_output upstream "yes" "HEAD:$branch"; then
       printf '%s\n' "$push_output"
       PUSH_OWNER_REPO="$(remote_owner_repo "$PUSH_REMOTE")"
       return
@@ -549,6 +646,8 @@ create_or_update_pr() {
   head_owner="${PUSH_OWNER_REPO%%/*}"
   if find_existing_pr_for_branch "$branch" "$head_owner"; then
     log "PR already exists: $PR_URL"
+  elif find_existing_pr_for_branch "$branch"; then
+    log "PR already exists for branch $branch with a different head owner: $PR_URL"
   else
     if ! branch_has_commits_ahead; then
       log "Skipping PR creation because $PR_SKIPPED_REASON"
@@ -578,13 +677,15 @@ create_or_update_pr() {
       rm -f "$create_error_file"
       if grep -qi 'fork collab' <<<"$create_error"; then
         log "Retrying PR creation without maintainer edits"
-        PR_URL="$(gh pr create \
+        if ! PR_URL="$(gh pr create \
           --repo "$BASE_REPO" \
           --head "${head_owner}:${branch}" \
           --base "$BASE_BRANCH" \
           --title "$title" \
           --body "$body" \
-          --no-maintainer-edit)"
+          --no-maintainer-edit 2>&1)"; then
+          die "Unable to create PR (--no-maintainer-edit retry): $PR_URL"
+        fi
       else
         printf '%s\n' "$create_error" >&2
         die "Unable to create PR"

--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,7 @@ userData/
 
 # Claude Code
 .claude/settings.local.json
+.claude/tmp/
 
 # Python
 __pycache__/

--- a/rules/git-workflow.md
+++ b/rules/git-workflow.md
@@ -40,6 +40,8 @@ When a workflow has already identified a target PR number, pass that number expl
 
 If `gh pr view --repo <owner>/<repo> --json ...` fails with `argument required when using the --repo flag`, rerun it with an explicit PR number, URL, or branch argument. If a prior `gh pr edit` printed a PR URL, extract that number and use `gh pr view <number> --repo <owner>/<repo>`.
 
+When using `gh pr list --json headRepository` to match PRs by head repo, do not rely on `headRepository.nameWithOwner`; some installed `gh` versions return it as an empty string. Request `headRepositoryOwner` too and compose `<owner>/<repo>` from `headRepositoryOwner.login` plus `headRepository.name`.
+
 ## GH auth allowlist and git push
 
 If `gh auth status` succeeds but `git push` fails with `Repo <owner>/<repo> is not allowlisted` followed by `fatal: could not read Username for 'https://github.com/...': Device not configured`, run `gh auth setup-git` first and then push to an allowlisted remote. In some bot workspaces, fork remotes are not allowlisted even when `upstream` is, so retry the push against `upstream` if project policy permits it.


### PR DESCRIPTION
## Summary
- Replace the long manual pr-push checklist with a script-backed workflow so routine publish steps run without agent-by-agent command replay.
- Move remember-learnings ahead of push and PR creation so any captured rules changes publish with the same flow.
- Keep the skill body short and expose environment overrides for commit and PR text when needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to agent skill docs, a helper bash script, gitignore, and workflow notes—no application runtime or user-facing product code.
> 
> **Overview**
> Replaces the long agent-driven **pr-push** checklist with a single bundled **`pr_push.sh`** run from the repo root, so commit → fmt/lint/ts/test → push → PR creation happens in one deterministic pass instead of replaying many shell/`gh` steps per session.
> 
> The **SKILL.md** is trimmed to: run **`/remember-learnings` first** (so new `AGENTS.md` / `rules/` edits land in the same publish commit), invoke the script with optional **`PR_PUSH_*`** env overrides, fix and rerun on failure, then report the script summary.
> 
> The script encodes prior skill behavior: feature-branch guard on `main`/`master`, selective staging (secrets, spurious **`package-lock.json`**, **`.claude/tmp/`**), check amend, push fallbacks (tracked upstream, existing PR head remote, **`origin`/`upstream`**, token retry, split fetch/push remotes), **`gh pr create`** against **`dyad-sh/dyad`**, bot-account skip with manual link, and removing **`needs-human:review-issue`**.
> 
> **`rules/git-workflow.md`** adds guidance to compose PR head repo from **`headRepositoryOwner`** + **`headRepository.name`** when **`nameWithOwner`** is empty. **`.gitignore`** ignores **`.claude/tmp/`** for script temp files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2fc106b9116e285f6c013fadb7e3189ed5cdc80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

