### PR TITLE
Clarify unsupported image input errors

### DIFF
--- a/src/ipc/handlers/chat_stream_handlers.test.ts
+++ b/src/ipc/handlers/chat_stream_handlers.test.ts
@@ -9,6 +9,7 @@ import {
 
 import { processFullResponseActions } from "@/ipc/processors/response_processor";
 import {
+  formatAiStreamErrorMessage,
   removeDyadTags,
   hasUnclosedDyadWrite,
 } from "@/ipc/handlers/chat_stream_handlers";
@@ -86,6 +87,113 @@ vi.mock("@/db", () => ({
     })),
   },
 }));
+
+describe("formatAiStreamErrorMessage", () => {
+  it("replaces image input support errors with actionable copy", () => {
+    const message = formatAiStreamErrorMessage({
+      error: {
+        error: {
+          message: "This model does not support image input.",
+          responseBody: "GLM-5.2 accepts text only.",
+        },
+      },
+      isEngineEnabled: false,
+    });
+
+    expect(message).toBe(
+      "Sorry, there was an error from the AI: The selected model doesn't support image input. Remove image attachments or choose a vision-capable model.",
+    );
+  });
+
+  it("keeps request id and provider details for other errors", () => {
+    const message = formatAiStreamErrorMessage({
+      error: {
+        error: {
+          message: "Rate limit exceeded",
+          responseBody: "Retry after 30 seconds",
+        },
+      },
+      isEngineEnabled: true,
+      dyadRequestId: "req-123",
+    });
+
+    expect(message).toBe(
+      "Sorry, there was an error from the AI: [Request ID: req-123] Rate limit exceeded\n\nDetails: Retry after 30 seconds",
+    );
+  });
+
+  it("replaces image_url model support errors with actionable copy", () => {
+    const message = formatAiStreamErrorMessage({
+      error: {
+        error: {
+          message:
+            "Invalid content type. image_url is only supported by certain models.",
+        },
+      },
+      isEngineEnabled: false,
+    });
+
+    expect(message).toBe(
+      "Sorry, there was an error from the AI: The selected model doesn't support image input. Remove image attachments or choose a vision-capable model.",
+    );
+  });
+
+  it("replaces plural image model support errors with actionable copy", () => {
+    const message = formatAiStreamErrorMessage({
+      error: {
+        error: {
+          message: "This model cannot accept images.",
+        },
+      },
+      isEngineEnabled: false,
+    });
+
+    expect(message).toBe(
+      "Sorry, there was an error from the AI: The selected model doesn't support image input. Remove image attachments or choose a vision-capable model.",
+    );
+  });
+
+  it("keeps provider details for unsupported image formats", () => {
+    const message = formatAiStreamErrorMessage({
+      error: {
+        error: {
+          message: "Unsupported image media type: image/tiff",
+          responseBody: "Only PNG and JPEG are supported.",
+        },
+      },
+      isEngineEnabled: false,
+    });
+
+    expect(message).toBe(
+      "Sorry, there was an error from the AI: Unsupported image media type: image/tiff\n\nDetails: Only PNG and JPEG are supported.",
+    );
+  });
+
+  it("uses standard Error messages without an undefined request id", () => {
+    const message = formatAiStreamErrorMessage({
+      error: new Error("Network failed"),
+      isEngineEnabled: true,
+    });
+
+    expect(message).toBe(
+      "Sorry, there was an error from the AI: Network failed",
+    );
+  });
+
+  it("does not throw on circular error objects", () => {
+    const error: Record<string, unknown> = {};
+    error.self = error;
+
+    const message = formatAiStreamErrorMessage({
+      error,
+      isEngineEnabled: false,
+    });
+
+    expect(message).toBe(
+      "Sorry, there was an error from the AI: [object Object]",
+    );
+  });
+});
 
 describe("getDyadAddDependencyTags", () => {
   it("should return an empty array when no dyad-add-dependency tags are found", () => {

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -165,6 +165,80 @@ const activeStreams = new Map<number, AbortController>();
 // Track partial responses for cancelled streams
 const partialResponses = new Map<number, string>();
 
+const IMAGE_INPUT_UNSUPPORTED_ERROR_MESSAGE =
+  "The selected model doesn't support image input. Remove image attachments or choose a vision-capable model.";
+
+function isImageInputUnsupportedError(text: string): boolean {
+  const normalized = text.toLowerCase();
+  if (/image_url.*only supported by certain models/.test(normalized)) {
+    return true;
+  }
+  const isAttachmentFormatError =
+    /image\s+(media\s+type|mime|format|file\s+type|content\s+type)/.test(
+      normalized,
+    ) ||
+    /(media\s+type|mime|format|file\s+type|content\s+type).*image/.test(
+      normalized,
+    );
+  if (isAttachmentFormatError) {
+    return false;
+  }
+  return (
+    /\bmodel\b.*\b(does not|doesn't|cannot|can't|not)\b.*\b(support|accept|handle)\b.*\b(images?|vision|image input)\b/.test(
+      normalized,
+    ) ||
+    /\bimage input\b.*\b(is )?(not supported|unsupported)\b/.test(normalized)
+  );
+}
+
+function stringifyError(error: unknown): string {
+  if (typeof error === "string") {
+    return error;
+  }
+  if (error instanceof Error) {
+    return error.message || error.name;
+  }
+  try {
+    const json = JSON.stringify(error);
+    if (json && json !== "{}") {
+      return json;
+    }
+  } catch {
+    // Fall through to String(error) for circular objects.
+  }
+  return String(error ?? "Unknown error");
+}
+
+export function formatAiStreamErrorMessage({
+  error,
+  isEngineEnabled,
+  dyadRequestId,
+}: {
+  error: unknown;
+  isEngineEnabled?: boolean;
+  dyadRequestId?: string;
+}): string {
+  let message =
+    (error as any)?.error?.message ??
+    (error as any)?.message ??
+    stringifyError(error);
+  const responseBody = (error as any)?.error?.responseBody;
+  const responseBodyText =
+    responseBody === undefined ? undefined : stringifyError(responseBody);
+  if (message && responseBodyText) {
+    message += "\n\nDetails: " + responseBodyText;
+  }
+  const requestIdPrefix =
+    isEngineEnabled && dyadRequestId ? `[Request ID: ${dyadRequestId}] ` : "";
+  const displayMessage = isImageInputUnsupportedError(
+    `${message}\n${responseBodyText ?? ""}`,
+  )
+    ? IMAGE_INPUT_UNSUPPORTED_ERROR_MESSAGE
+    : message;
+
+  return `${AI_STREAMING_ERROR_MESSAGE_PREFIX}${requestIdPrefix}${displayMessage}`;
+}
+
 // Use escapeXmlAttr from shared/xmlEscape for XML escaping
 
 // Safely parse an MCP tool key that combines server and tool names.
@@ -1280,22 +1354,18 @@ This conversation includes one or more image attachments. When the user uploads 
               }
             },
             onError: (error: any) => {
-              let errorMessage = (error as any)?.error?.message;
-              const responseBody = error?.error?.responseBody;
-              if (errorMessage && responseBody) {
-                errorMessage += "\n\nDetails: " + responseBody;
-              }
-              const message = errorMessage || JSON.stringify(error);
-              const requestIdPrefix = isEngineEnabled
-                ? `[Request ID: ${dyadRequestId}] `
-                : "";
+              const message = formatAiStreamErrorMessage({
+                error,
+                isEngineEnabled,
+                dyadRequestId,
+              });
               logger.error(
-                `AI stream text error for request: ${requestIdPrefix} errorMessage=${errorMessage} error=`,
+                `AI stream text error for request: ${message} error=`,
                 error,
               );
               event.sender.send("chat:response:error", {
                 chatId: req.chatId,
-                error: `${AI_STREAMING_ERROR_MESSAGE_PREFIX}${requestIdPrefix}${message}`,
+                error: message,
               });
               // Clean up the abort controller
               activeStreams.delete(req.chatId);


### PR DESCRIPTION
## Summary
- show a clearer error when a provider rejects image input for a text-only model
- keep existing provider details/request IDs for unrelated stream errors
- add focused coverage for the formatter

Closes #3774

## Tests
- `npm run ts:main`
- `npm test -- src/ipc/handlers/chat_stream_handlers.test.ts -t "formatAiStreamErrorMessage"`
- `npx oxfmt --check src/ipc/handlers/chat_stream_handlers.ts src/ipc/handlers/chat_stream_handlers.test.ts`
- `npx oxlint src/ipc/handlers/chat_stream_handlers.ts src/ipc/handlers/chat_stream_handlers.test.ts`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

