### PR TITLE
Add modified-files card after chat generation

### DIFF
--- a/e2e-tests/attach_image.spec.ts
+++ b/e2e-tests/attach_image.spec.ts
@@ -104,8 +104,12 @@ test("attach image - chat - upload to codebase", async ({ po }) => {
 
   await po.sendPrompt("[[UPLOAD_IMAGE_TO_CODEBASE]]");
 
-  // Wait for the uploaded file card to render before snapshotting
-  await expect(po.page.getByText("file.png", { exact: true })).toBeVisible();
+  // Wait for the uploaded file card to render before snapshotting. Use .first()
+  // because the modified-files card at the bottom of the chat now also lists
+  // "file.png"; the attachment card is rendered above it, so it comes first.
+  await expect(
+    po.page.getByText("file.png", { exact: true }).first(),
+  ).toBeVisible();
 
   await po.snapshotServerDump("last-message", { name: "upload-to-codebase" });
   await po.snapshotMessages({ replaceDumpPath: true });

--- a/e2e-tests/snapshots/approve.spec.ts_write-to-index-approve-check-preview-2.aria.yml
+++ b/e2e-tests/snapshots/approve.spec.ts_write-to-index-approve-check-preview-2.aria.yml
@@ -4,5 +4,6 @@
 - paragraph: And it's done!
 - button "Copy"
 - text: "[[Version 2: files changed]]"
+- button "M src/pages/Index.tsx +2 -12"
 - button "Undo"
 - button "Retry"

--- a/e2e-tests/snapshots/attach_image.spec.ts_attach-image---chat---upload-to-codebase-1.aria.yml
+++ b/e2e-tests/snapshots/attach_image.spec.ts_attach-image---chat---upload-to-codebase-1.aria.yml
@@ -11,5 +11,6 @@
 - paragraph: "[[dyad-dump-path=*]]"
 - button "Copy"
 - text: "[[Version 3: files changed]]"
+- button "A new/image/file.png"
 - button "Undo"
 - button "Retry"

--- a/e2e-tests/snapshots/auto_approve.spec.ts_auto-approve-1.aria.yml
+++ b/e2e-tests/snapshots/auto_approve.spec.ts_auto-approve-1.aria.yml
@@ -4,5 +4,6 @@
 - paragraph: And it's done!
 - button "Copy"
 - text: "[[Version 2: files changed]]"
+- button "M src/pages/Index.tsx +2 -12"
 - button "Undo"
 - button "Retry"

--- a/e2e-tests/snapshots/fix_error.spec.ts_fix-all-errors-button-1.aria.yml
+++ b/e2e-tests/snapshots/fix_error.spec.ts_fix-all-errors-button-1.aria.yml
@@ -18,5 +18,6 @@
 - paragraph: More EOM
 - button "Copy"
 - text: "[[Version 3: files changed]]"
+- button "A file1.txt +1"
 - button "Undo"
 - button "Retry"

--- a/e2e-tests/snapshots/fix_error.spec.ts_fix-error-with-AI-3.aria.yml
+++ b/e2e-tests/snapshots/fix_error.spec.ts_fix-error-with-AI-3.aria.yml
@@ -13,5 +13,6 @@
 - button "Index.tsx src/pages/Index.tsx Edit"
 - button "Copy"
 - text: "[[Version 3: files changed]]"
+- button "M src/pages/Index.tsx +8 -15"
 - button "Undo"
 - button "Retry"

--- a/e2e-tests/snapshots/local_agent_advanced.spec.ts_local-agent---enable-nitro-1.aria.yml
+++ b/e2e-tests/snapshots/local_agent_advanced.spec.ts_local-agent---enable-nitro-1.aria.yml
@@ -14,5 +14,12 @@
 - button "Copy"
 - text: "[[Version 3: files changed]]"
 - button "Copy Request ID"
+- text: Modified files (6)
+- button "A AI_RULES.md +51"
+- button "A nitro.config.ts +5"
+- button "M package.json +2"
+- button "M pnpm-lock.yaml +557 -5"
+- button "A server/routes/api/.gitkeep"
+- button "M vite.config.ts +3 -1"
 - button "Undo"
 - button "Retry"

--- a/e2e-tests/snapshots/local_agent_connection_retry.spec.ts_local-agent---recovers-from-connection-drop-1.aria.yml
+++ b/e2e-tests/snapshots/local_agent_connection_retry.spec.ts_local-agent---recovers-from-connection-drop-1.aria.yml
@@ -11,5 +11,7 @@
 - button "Copy"
 - text: "[[Version 3: files changed]]"
 - button "Copy Request ID"
+- text: Modified files (1)
+- button "A src/recovered.ts +1"
 - button "Undo"
 - button "Retry"

--- a/e2e-tests/snapshots/local_agent_file_upload.spec.ts_local-agent---upload-file-to-codebase-1.aria.yml
+++ b/e2e-tests/snapshots/local_agent_file_upload.spec.ts_local-agent---upload-file-to-codebase-1.aria.yml
@@ -13,5 +13,7 @@
 - button "Copy"
 - text: "[[Version 3: files changed]]"
 - button "Copy Request ID"
+- text: Modified files (1)
+- button "A assets/uploaded-file.png"
 - button "Undo"
 - button "Retry"

--- a/e2e-tests/snapshots/local_agent_persistent_todos.spec.ts_local-agent---persistent-todos-across-turns-1.aria.yml
+++ b/e2e-tests/snapshots/local_agent_persistent_todos.spec.ts_local-agent---persistent-todos-across-turns-1.aria.yml
@@ -20,5 +20,8 @@
 - button "Copy"
 - text: "[[Version 4: files changed]]"
 - button "Copy Request ID"
+- text: Modified files (2)
+- button "A src/lib/utils.test.ts +14"
+- button "M src/lib/utils.ts +8"
 - button "Undo"
 - button "Retry"

--- a/e2e-tests/snapshots/local_agent_todo_followup.spec.ts_local-agent---todo-follow-up-loop-1.aria.yml
+++ b/e2e-tests/snapshots/local_agent_todo_followup.spec.ts_local-agent---todo-follow-up-loop-1.aria.yml
@@ -15,5 +15,9 @@
 - button "Copy"
 - text: "[[Version 3: files changed]]"
 - button "Copy Request ID"
+- text: Modified files (3)
+- button "A src/utils/README.md +5"
+- button "A src/utils/helper.test.ts +5"
+- button "A src/utils/helper.ts +3"
 - button "Undo"
 - button "Retry"

--- a/e2e-tests/snapshots/partial_response.spec.ts_partial-message-is-resumed-1.aria.yml
+++ b/e2e-tests/snapshots/partial_response.spec.ts_partial-message-is-resumed-1.aria.yml
@@ -10,5 +10,6 @@
 - paragraph: "[[dyad-dump-path=*]]"
 - button "Copy"
 - text: "[[Version 3: files changed]]"
+- button "A src/new-file.ts +2"
 - button "Undo"
 - button "Retry"

--- a/src/atoms/appAtoms.ts
+++ b/src/atoms/appAtoms.ts
@@ -13,7 +13,16 @@ export type PreviewMode =
 
 export const previewModeAtom = atom<PreviewMode>("preview");
 export const selectedVersionIdAtom = atom<string | null>(null);
-// The file path the version diff view should open at. Set when navigating to a
-// specific changed file (e.g. from the modified-files card); null falls back to
-// the first changed file in the version.
-export const selectedVersionDiffFileAtom = atom<string | null>(null);
+// The changed file the version diff view should open at, scoped to the version
+// it belongs to. Set when navigating to a specific file (e.g. from the
+// modified-files card). The diff view only honors `path` when `versionId`
+// matches the version it is showing, so a selection made for one version never
+// leaks into another that happens to contain a file with the same path; null
+// (or a mismatched version) falls back to the first changed file.
+export interface SelectedVersionDiffFile {
+  versionId: string;
+  path: string;
+}
+export const selectedVersionDiffFileAtom = atom<SelectedVersionDiffFile | null>(
+  null,
+);

--- a/src/atoms/appAtoms.ts
+++ b/src/atoms/appAtoms.ts
@@ -13,3 +13,7 @@ export type PreviewMode =
 
 export const previewModeAtom = atom<PreviewMode>("preview");
 export const selectedVersionIdAtom = atom<string | null>(null);
+// The file path the version diff view should open at. Set when navigating to a
+// specific changed file (e.g. from the modified-files card); null falls back to
+// the first changed file in the version.
+export const selectedVersionDiffFileAtom = atom<string | null>(null);

--- a/src/components/chat/MessagesList.tsx
+++ b/src/components/chat/MessagesList.tsx
@@ -18,6 +18,7 @@ import { ipc } from "@/ipc/types";
 import { chatMessagesByIdAtom } from "@/atoms/chatAtoms";
 import { useLanguageModelProviders } from "@/hooks/useLanguageModelProviders";
 import { useSettings } from "@/hooks/useSettings";
+import { ModifiedFilesCard } from "./ModifiedFilesCard";
 import { isCancelledResponseContent } from "@/shared/chatCancellation";
 
 interface MessagesListProps {
@@ -72,155 +73,182 @@ function FooterComponent({ context }: { context?: FooterContext }) {
   const questionnaireState =
     selectedChatId != null ? submittedChatIds.get(selectedChatId) : undefined;
 
+  const lastMessage = messages.length
+    ? messages[messages.length - 1]
+    : undefined;
+  const isLastMessageAssistant = lastMessage?.role === "assistant";
+
+  // Reverts the whole last generation: targets the version just before the last
+  // assistant message's commit (falling back to its source commit) and drops the
+  // messages produced by that turn. Shared by the modified-files card and the
+  // standalone Undo button below.
+  const handleUndo = async () => {
+    if (!selectedChatId || !appId) {
+      console.error("No chat selected or app ID not available");
+      return;
+    }
+
+    setIsUndoLoading(true);
+    try {
+      const currentMessage = messages[messages.length - 1];
+      // The user message that triggered this assistant response
+      const userMessage = messages[messages.length - 2];
+      const currentCommitIndex = currentMessage?.commitHash
+        ? versions.findIndex(
+            (version) => version.oid === currentMessage.commitHash,
+          )
+        : -1;
+      const previousVersionId =
+        currentCommitIndex >= 0
+          ? versions[currentCommitIndex + 1]?.oid
+          : undefined;
+      const revertTargetVersionId =
+        previousVersionId ?? currentMessage?.sourceCommitHash;
+
+      if (revertTargetVersionId) {
+        console.debug("Reverting to previous version", revertTargetVersionId);
+        await revertVersion({
+          versionId: revertTargetVersionId,
+          currentChatMessageId: userMessage
+            ? {
+                chatId: selectedChatId,
+                messageId: userMessage.id,
+              }
+            : undefined,
+        });
+        const chat = await ipc.chat.getChat(selectedChatId);
+        setMessagesById((prev) => {
+          const next = new Map(prev);
+          next.set(selectedChatId, chat.messages);
+          return next;
+        });
+      } else {
+        showWarning(
+          "No source commit hash found for message. Need to manually undo code changes",
+        );
+      }
+    } catch (error) {
+      console.error("Error during undo operation:", error);
+      showError("Failed to undo changes");
+    } finally {
+      setIsUndoLoading(false);
+    }
+  };
+
+  // Re-runs the last user prompt. If the last assistant turn is still the tip of
+  // history it is first reverted (so the retry replaces it rather than stacking);
+  // otherwise the prompt is redone. Shared by the modified-files card and the
+  // standalone Retry button below.
+  const handleRetry = async () => {
+    if (!selectedChatId) {
+      console.error("No chat selected");
+      return;
+    }
+
+    setIsRetryLoading(true);
+    try {
+      // The last message is usually an assistant, but it might not be.
+      const lastVersion = versions[0];
+      const lastMessage = messages[messages.length - 1];
+      let shouldRedo = true;
+      if (
+        lastVersion.oid === lastMessage.commitHash &&
+        lastMessage.role === "assistant"
+      ) {
+        const previousAssistantMessage = messages[messages.length - 3];
+        if (
+          previousAssistantMessage?.role === "assistant" &&
+          previousAssistantMessage?.commitHash
+        ) {
+          console.debug("Reverting to previous assistant version");
+          await revertVersion({
+            versionId: previousAssistantMessage.commitHash,
+          });
+          shouldRedo = false;
+        } else {
+          const chat = await ipc.chat.getChat(selectedChatId);
+          if (chat.initialCommitHash) {
+            console.debug(
+              "Reverting to initial commit hash",
+              chat.initialCommitHash,
+            );
+            await revertVersion({
+              versionId: chat.initialCommitHash,
+            });
+          } else {
+            showWarning(
+              "No initial commit hash found for chat. Need to manually undo code changes",
+            );
+          }
+        }
+      }
+
+      // Find the last user message
+      const lastUserMessage = [...messages]
+        .reverse()
+        .find((message) => message.role === "user");
+      if (!lastUserMessage) {
+        console.error("No user message found");
+        return;
+      }
+      // Need to do a redo, if we didn't delete the message from a revert.
+      const redo = shouldRedo;
+      console.debug("Streaming message with redo", redo);
+
+      streamMessage({
+        prompt: lastUserMessage.content,
+        chatId: selectedChatId,
+        redo,
+      });
+    } catch (error) {
+      console.error("Error during retry operation:", error);
+      showError("Failed to retry message");
+    } finally {
+      setIsRetryLoading(false);
+    }
+  };
+
+  // When the last assistant turn produced a commit, show the modified-files card
+  // (which owns its own Undo/Retry buttons). Otherwise fall back to the standalone
+  // buttons so text-only replies keep those affordances.
+  const showModifiedFilesCard =
+    isLastMessageAssistant && !!lastMessage?.commitHash && appId != null;
+
   return (
     <>
-      {!isStreaming && (
+      {!isStreaming && showModifiedFilesCard && (
+        <ModifiedFilesCard
+          appId={appId!}
+          commitHash={lastMessage!.commitHash!}
+          onUndo={handleUndo}
+          isUndoLoading={isUndoLoading}
+          onRetry={handleRetry}
+          isRetryLoading={isRetryLoading}
+        />
+      )}
+      {!isStreaming && !showModifiedFilesCard && (
         <div className="flex max-w-3xl mx-auto gap-2">
-          {!!messages.length &&
-            messages[messages.length - 1].role === "assistant" && (
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={isUndoLoading}
-                onClick={async () => {
-                  if (!selectedChatId || !appId) {
-                    console.error("No chat selected or app ID not available");
-                    return;
-                  }
-
-                  setIsUndoLoading(true);
-                  try {
-                    const currentMessage = messages[messages.length - 1];
-                    // The user message that triggered this assistant response
-                    const userMessage = messages[messages.length - 2];
-                    const currentCommitIndex = currentMessage?.commitHash
-                      ? versions.findIndex(
-                          (version) =>
-                            version.oid === currentMessage.commitHash,
-                        )
-                      : -1;
-                    const previousVersionId =
-                      currentCommitIndex >= 0
-                        ? versions[currentCommitIndex + 1]?.oid
-                        : undefined;
-                    const revertTargetVersionId =
-                      previousVersionId ?? currentMessage?.sourceCommitHash;
-
-                    if (revertTargetVersionId) {
-                      console.debug(
-                        "Reverting to previous version",
-                        revertTargetVersionId,
-                      );
-                      await revertVersion({
-                        versionId: revertTargetVersionId,
-                        currentChatMessageId: userMessage
-                          ? {
-                              chatId: selectedChatId,
-                              messageId: userMessage.id,
-                            }
-                          : undefined,
-                      });
-                      const chat = await ipc.chat.getChat(selectedChatId);
-                      setMessagesById((prev) => {
-                        const next = new Map(prev);
-                        next.set(selectedChatId, chat.messages);
-                        return next;
-                      });
-                    } else {
-                      showWarning(
-                        "No source commit hash found for message. Need to manually undo code changes",
-                      );
-                    }
-                  } catch (error) {
-                    console.error("Error during undo operation:", error);
-                    showError("Failed to undo changes");
-                  } finally {
-                    setIsUndoLoading(false);
-                  }
-                }}
-              >
-                {isUndoLoading ? (
-                  <Loader2 size={16} className="mr-1 animate-spin" />
-                ) : (
-                  <Undo size={16} />
-                )}
-                Undo
-              </Button>
-            )}
+          {isLastMessageAssistant && (
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={isUndoLoading}
+              onClick={handleUndo}
+            >
+              {isUndoLoading ? (
+                <Loader2 size={16} className="mr-1 animate-spin" />
+              ) : (
+                <Undo size={16} />
+              )}
+              Undo
+            </Button>
+          )}
           {!!messages.length && (
             <Button
               variant="outline"
               size="sm"
               disabled={isRetryLoading}
-              onClick={async () => {
-                if (!selectedChatId) {
-                  console.error("No chat selected");
-                  return;
-                }
-
-                setIsRetryLoading(true);
-                try {
-                  // The last message is usually an assistant, but it might not be.
-                  const lastVersion = versions[0];
-                  const lastMessage = messages[messages.length - 1];
-                  let shouldRedo = true;
-                  if (
-                    lastVersion.oid === lastMessage.commitHash &&
-                    lastMessage.role === "assistant"
-                  ) {
-                    const previousAssistantMessage =
-                      messages[messages.length - 3];
-                    if (
-                      previousAssistantMessage?.role === "assistant" &&
-                      previousAssistantMessage?.commitHash
-                    ) {
-                      console.debug("Reverting to previous assistant version");
-                      await revertVersion({
-                        versionId: previousAssistantMessage.commitHash,
-                      });
-                      shouldRedo = false;
-                    } else {
-                      const chat = await ipc.chat.getChat(selectedChatId);
-                      if (chat.initialCommitHash) {
-                        console.debug(
-                          "Reverting to initial commit hash",
-                          chat.initialCommitHash,
-                        );
-                        await revertVersion({
-                          versionId: chat.initialCommitHash,
-                        });
-                      } else {
-                        showWarning(
-                          "No initial commit hash found for chat. Need to manually undo code changes",
-                        );
-                      }
-                    }
-                  }
-
-                  // Find the last user message
-                  const lastUserMessage = [...messages]
-                    .reverse()
-                    .find((message) => message.role === "user");
-                  if (!lastUserMessage) {
-                    console.error("No user message found");
-                    return;
-                  }
-                  // Need to do a redo, if we didn't delete the message from a revert.
-                  const redo = shouldRedo;
-                  console.debug("Streaming message with redo", redo);
-
-                  streamMessage({
-                    prompt: lastUserMessage.content,
-                    chatId: selectedChatId,
-                    redo,
-                  });
-                } catch (error) {
-                  console.error("Error during retry operation:", error);
-                  showError("Failed to retry message");
-                } finally {
-                  setIsRetryLoading(false);
-                }
-              }}
+              onClick={handleRetry}
             >
               {isRetryLoading ? (
                 <Loader2 size={16} className="mr-1 animate-spin" />

--- a/src/components/chat/MessagesList.tsx
+++ b/src/components/chat/MessagesList.tsx
@@ -148,12 +148,14 @@ function FooterComponent({ context }: { context?: FooterContext }) {
     setIsRetryLoading(true);
     try {
       // The last message is usually an assistant, but it might not be.
+      // versions[0] may be undefined if the versions query hasn't populated yet;
+      // in that case fall through to a plain redo rather than throwing.
       const lastVersion = versions[0];
       const lastMessage = messages[messages.length - 1];
       let shouldRedo = true;
       if (
-        lastVersion.oid === lastMessage.commitHash &&
-        lastMessage.role === "assistant"
+        lastMessage?.role === "assistant" &&
+        lastVersion?.oid === lastMessage.commitHash
       ) {
         const previousAssistantMessage = messages[messages.length - 3];
         if (

--- a/src/components/chat/ModifiedFilesCard.tsx
+++ b/src/components/chat/ModifiedFilesCard.tsx
@@ -1,0 +1,173 @@
+import { useMemo } from "react";
+import { useSetAtom } from "jotai";
+import { Loader2, RefreshCw, Undo } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { useVersionChanges } from "@/hooks/useVersionChanges";
+import { computeLineDiffStats } from "@/lib/lineDiffStats";
+import {
+  previewModeAtom,
+  selectedVersionIdAtom,
+  selectedVersionDiffFileAtom,
+} from "@/atoms/appAtoms";
+import { isPreviewOpenAtom } from "@/atoms/viewAtoms";
+import { STATUS_META } from "@/components/preview_panel/VersionDiffView";
+
+interface ModifiedFilesCardProps {
+  appId: number;
+  commitHash: string;
+  onUndo: () => void;
+  isUndoLoading: boolean;
+  onRetry: () => void;
+  isRetryLoading: boolean;
+}
+
+function splitPath(filePath: string): { dir: string; name: string } {
+  const index = filePath.lastIndexOf("/");
+  if (index === -1) {
+    return { dir: "", name: filePath };
+  }
+  return {
+    dir: filePath.slice(0, index + 1),
+    name: filePath.slice(index + 1),
+  };
+}
+
+/**
+ * Card shown at the bottom of the chat after a generation finishes, summarizing
+ * the files changed by that generation (one row per file with +/- line counts).
+ * Clicking a row opens the read-only diff view for that file in the preview
+ * panel; the Undo button reverts the whole generation.
+ */
+export function ModifiedFilesCard({
+  appId,
+  commitHash,
+  onUndo,
+  isUndoLoading,
+  onRetry,
+  isRetryLoading,
+}: ModifiedFilesCardProps) {
+  const { changes, loading, error } = useVersionChanges(appId, commitHash);
+  const setPreviewMode = useSetAtom(previewModeAtom);
+  const setSelectedVersionId = useSetAtom(selectedVersionIdAtom);
+  const setSelectedVersionDiffFile = useSetAtom(selectedVersionDiffFileAtom);
+  const setIsPreviewOpen = useSetAtom(isPreviewOpenAtom);
+
+  const statsByPath = useMemo(() => {
+    const map = new Map<string, ReturnType<typeof computeLineDiffStats>>();
+    for (const file of changes ?? []) {
+      map.set(
+        file.path,
+        computeLineDiffStats(file.oldContent, file.newContent),
+      );
+    }
+    return map;
+  }, [changes]);
+
+  // Nothing to show while loading, on error, or when the commit changed no
+  // user-visible files. Failing silently keeps the chat footer uncluttered; the
+  // underlying error is already logged by the diff view when it is opened.
+  if (loading || error || !changes || changes.length === 0) {
+    return null;
+  }
+
+  const openDiff = (filePath: string) => {
+    setSelectedVersionDiffFile(filePath);
+    setSelectedVersionId(commitHash);
+    setPreviewMode("code");
+    setIsPreviewOpen(true);
+  };
+
+  return (
+    <div className="max-w-3xl w-full mx-auto my-2 px-2">
+      <div
+        data-testid="modified-files-card"
+        className="rounded-xl border border-border/60 bg-(--background-lightest) overflow-hidden"
+      >
+        <div className="px-3 py-2 border-b border-border/60 text-sm font-medium">
+          Modified files{" "}
+          <span className="text-muted-foreground font-normal">
+            ({changes.length})
+          </span>
+        </div>
+        <div className="max-h-64 overflow-y-auto divide-y divide-border/60">
+          {changes.map((file) => {
+            const stats = statsByPath.get(file.path);
+            const meta = STATUS_META[file.type];
+            const { dir, name } = splitPath(file.path);
+            return (
+              <button
+                key={file.path}
+                type="button"
+                data-testid="modified-files-row"
+                onClick={() => openDiff(file.path)}
+                className="flex items-center gap-2 w-full px-3 py-1.5 text-left text-sm cursor-pointer hover:bg-(--background-lighter) transition-colors"
+                title={file.path}
+              >
+                <span
+                  className={cn(
+                    "flex-shrink-0 w-4 text-center font-mono text-xs font-semibold",
+                    meta.className,
+                  )}
+                  title={file.type}
+                >
+                  {meta.label}
+                </span>
+                <span className="min-w-0 flex-1 truncate">
+                  {dir && <span className="text-muted-foreground">{dir}</span>}
+                  <span className="font-medium">{name}</span>
+                </span>
+                {stats && (
+                  <span className="flex-shrink-0 flex items-center gap-2 font-mono text-xs">
+                    {stats.additions > 0 && (
+                      <span className="text-green-600 dark:text-green-400">
+                        +{stats.additions}
+                      </span>
+                    )}
+                    {stats.deletions > 0 && (
+                      <span className="text-red-600 dark:text-red-400">
+                        -{stats.deletions}
+                      </span>
+                    )}
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+        <div className="px-3 py-2 border-t border-border/60 flex justify-end gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            data-testid="modified-files-retry"
+            disabled={isRetryLoading}
+            onClick={onRetry}
+            className="gap-1.5 rounded-lg text-muted-foreground hover:text-foreground hover:border-border cursor-pointer transition-colors disabled:cursor-not-allowed"
+          >
+            {isRetryLoading ? (
+              <Loader2 size={16} className="animate-spin" />
+            ) : (
+              <RefreshCw size={16} />
+            )}
+            Retry
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            data-testid="modified-files-undo"
+            disabled={isUndoLoading}
+            onClick={onUndo}
+            className="gap-1.5 rounded-lg text-muted-foreground hover:text-foreground hover:border-border cursor-pointer transition-colors disabled:cursor-not-allowed"
+          >
+            {isUndoLoading ? (
+              <Loader2 size={16} className="animate-spin" />
+            ) : (
+              <Undo size={16} />
+            )}
+            Undo
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/chat/ModifiedFilesCard.tsx
+++ b/src/components/chat/ModifiedFilesCard.tsx
@@ -11,7 +11,7 @@ import {
   selectedVersionDiffFileAtom,
 } from "@/atoms/appAtoms";
 import { isPreviewOpenAtom } from "@/atoms/viewAtoms";
-import { STATUS_META } from "@/components/preview_panel/VersionDiffView";
+import { STATUS_META } from "@/components/preview_panel/versionChangeMeta";
 
 interface ModifiedFilesCardProps {
   appId: number;
@@ -77,28 +77,17 @@ export function ModifiedFilesCard({
   // available); only the header + list are hidden.
   const hasChanges = !loading && !error && !!changes && changes.length > 0;
 
+  // Undo and Retry both revert/replace the same last generation, so while either
+  // is in flight both are disabled to prevent overlapping operations.
+  const actionsDisabled = isUndoLoading || isRetryLoading;
+
   const footer = (
     <div className="px-3 py-2 border-t border-border/60 flex justify-end gap-2">
       <Button
         variant="outline"
         size="sm"
-        data-testid="modified-files-retry"
-        disabled={isRetryLoading}
-        onClick={onRetry}
-        className="gap-1.5 rounded-lg text-muted-foreground hover:text-foreground hover:border-border cursor-pointer transition-colors disabled:cursor-not-allowed"
-      >
-        {isRetryLoading ? (
-          <Loader2 size={16} className="animate-spin" />
-        ) : (
-          <RefreshCw size={16} />
-        )}
-        Retry
-      </Button>
-      <Button
-        variant="outline"
-        size="sm"
         data-testid="modified-files-undo"
-        disabled={isUndoLoading}
+        disabled={actionsDisabled}
         onClick={onUndo}
         className="gap-1.5 rounded-lg text-muted-foreground hover:text-foreground hover:border-border cursor-pointer transition-colors disabled:cursor-not-allowed"
       >
@@ -108,6 +97,21 @@ export function ModifiedFilesCard({
           <Undo size={16} />
         )}
         Undo
+      </Button>
+      <Button
+        variant="outline"
+        size="sm"
+        data-testid="modified-files-retry"
+        disabled={actionsDisabled}
+        onClick={onRetry}
+        className="gap-1.5 rounded-lg text-muted-foreground hover:text-foreground hover:border-border cursor-pointer transition-colors disabled:cursor-not-allowed"
+      >
+        {isRetryLoading ? (
+          <Loader2 size={16} className="animate-spin" />
+        ) : (
+          <RefreshCw size={16} />
+        )}
+        Retry
       </Button>
     </div>
   );

--- a/src/components/chat/ModifiedFilesCard.tsx
+++ b/src/components/chat/ModifiedFilesCard.tsx
@@ -82,7 +82,7 @@ export function ModifiedFilesCard({
   const actionsDisabled = isUndoLoading || isRetryLoading;
 
   const footer = (
-    <div className="px-3 py-2 border-t border-border/60 flex justify-end gap-2">
+    <div className="px-3 py-2 flex justify-end gap-2">
       <Button
         variant="outline"
         size="sm"
@@ -123,7 +123,7 @@ export function ModifiedFilesCard({
         className="rounded-xl border border-border/60 bg-[var(--background-lightest)] overflow-hidden"
       >
         {hasChanges && (
-          <div className="px-3 py-2 border-b border-border/60 text-sm font-medium">
+          <div className="px-3 py-2 text-sm font-medium">
             Modified files{" "}
             <span className="text-muted-foreground font-normal">
               ({changes.length})
@@ -131,7 +131,7 @@ export function ModifiedFilesCard({
           </div>
         )}
         {hasChanges && (
-          <div className="max-h-64 overflow-y-auto divide-y divide-border/60">
+          <div className="max-h-64 overflow-y-auto">
             {changes.map((file) => {
               const stats = statsByPath.get(file.path);
               const meta = STATUS_META[file.type];

--- a/src/components/chat/ModifiedFilesCard.tsx
+++ b/src/components/chat/ModifiedFilesCard.tsx
@@ -64,109 +64,118 @@ export function ModifiedFilesCard({
     return map;
   }, [changes]);
 
-  // Nothing to show while loading, on error, or when the commit changed no
-  // user-visible files. Failing silently keeps the chat footer uncluttered; the
-  // underlying error is already logged by the diff view when it is opened.
-  if (loading || error || !changes || changes.length === 0) {
-    return null;
-  }
-
   const openDiff = (filePath: string) => {
-    setSelectedVersionDiffFile(filePath);
+    setSelectedVersionDiffFile({ versionId: commitHash, path: filePath });
     setSelectedVersionId(commitHash);
     setPreviewMode("code");
     setIsPreviewOpen(true);
   };
 
+  // The file list is unavailable while loading, on error, or when the commit
+  // changed no user-visible files. In those cases we still render the Undo/Retry
+  // footer (the assistant turn produced a commit, so those affordances must stay
+  // available); only the header + list are hidden.
+  const hasChanges = !loading && !error && !!changes && changes.length > 0;
+
+  const footer = (
+    <div className="px-3 py-2 border-t border-border/60 flex justify-end gap-2">
+      <Button
+        variant="outline"
+        size="sm"
+        data-testid="modified-files-retry"
+        disabled={isRetryLoading}
+        onClick={onRetry}
+        className="gap-1.5 rounded-lg text-muted-foreground hover:text-foreground hover:border-border cursor-pointer transition-colors disabled:cursor-not-allowed"
+      >
+        {isRetryLoading ? (
+          <Loader2 size={16} className="animate-spin" />
+        ) : (
+          <RefreshCw size={16} />
+        )}
+        Retry
+      </Button>
+      <Button
+        variant="outline"
+        size="sm"
+        data-testid="modified-files-undo"
+        disabled={isUndoLoading}
+        onClick={onUndo}
+        className="gap-1.5 rounded-lg text-muted-foreground hover:text-foreground hover:border-border cursor-pointer transition-colors disabled:cursor-not-allowed"
+      >
+        {isUndoLoading ? (
+          <Loader2 size={16} className="animate-spin" />
+        ) : (
+          <Undo size={16} />
+        )}
+        Undo
+      </Button>
+    </div>
+  );
+
   return (
     <div className="max-w-3xl w-full mx-auto my-2 px-2">
       <div
         data-testid="modified-files-card"
-        className="rounded-xl border border-border/60 bg-(--background-lightest) overflow-hidden"
+        className="rounded-xl border border-border/60 bg-[var(--background-lightest)] overflow-hidden"
       >
-        <div className="px-3 py-2 border-b border-border/60 text-sm font-medium">
-          Modified files{" "}
-          <span className="text-muted-foreground font-normal">
-            ({changes.length})
-          </span>
-        </div>
-        <div className="max-h-64 overflow-y-auto divide-y divide-border/60">
-          {changes.map((file) => {
-            const stats = statsByPath.get(file.path);
-            const meta = STATUS_META[file.type];
-            const { dir, name } = splitPath(file.path);
-            return (
-              <button
-                key={file.path}
-                type="button"
-                data-testid="modified-files-row"
-                onClick={() => openDiff(file.path)}
-                className="flex items-center gap-2 w-full px-3 py-1.5 text-left text-sm cursor-pointer hover:bg-(--background-lighter) transition-colors"
-                title={file.path}
-              >
-                <span
-                  className={cn(
-                    "flex-shrink-0 w-4 text-center font-mono text-xs font-semibold",
-                    meta.className,
-                  )}
-                  title={file.type}
+        {hasChanges && (
+          <div className="px-3 py-2 border-b border-border/60 text-sm font-medium">
+            Modified files{" "}
+            <span className="text-muted-foreground font-normal">
+              ({changes.length})
+            </span>
+          </div>
+        )}
+        {hasChanges && (
+          <div className="max-h-64 overflow-y-auto divide-y divide-border/60">
+            {changes.map((file) => {
+              const stats = statsByPath.get(file.path);
+              const meta = STATUS_META[file.type];
+              const { dir, name } = splitPath(file.path);
+              return (
+                <button
+                  key={file.path}
+                  type="button"
+                  data-testid="modified-files-row"
+                  onClick={() => openDiff(file.path)}
+                  className="flex items-center gap-2 w-full px-3 py-1.5 text-left text-sm cursor-pointer hover:bg-[var(--background-lighter)] transition-colors"
+                  title={file.path}
                 >
-                  {meta.label}
-                </span>
-                <span className="min-w-0 flex-1 truncate">
-                  {dir && <span className="text-muted-foreground">{dir}</span>}
-                  <span className="font-medium">{name}</span>
-                </span>
-                {stats && (
-                  <span className="flex-shrink-0 flex items-center gap-2 font-mono text-xs">
-                    {stats.additions > 0 && (
-                      <span className="text-green-600 dark:text-green-400">
-                        +{stats.additions}
-                      </span>
+                  <span
+                    className={cn(
+                      "flex-shrink-0 w-4 text-center font-mono text-xs font-semibold",
+                      meta.className,
                     )}
-                    {stats.deletions > 0 && (
-                      <span className="text-red-600 dark:text-red-400">
-                        -{stats.deletions}
-                      </span>
-                    )}
+                    title={file.type}
+                  >
+                    {meta.label}
                   </span>
-                )}
-              </button>
-            );
-          })}
-        </div>
-        <div className="px-3 py-2 border-t border-border/60 flex justify-end gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            data-testid="modified-files-retry"
-            disabled={isRetryLoading}
-            onClick={onRetry}
-            className="gap-1.5 rounded-lg text-muted-foreground hover:text-foreground hover:border-border cursor-pointer transition-colors disabled:cursor-not-allowed"
-          >
-            {isRetryLoading ? (
-              <Loader2 size={16} className="animate-spin" />
-            ) : (
-              <RefreshCw size={16} />
-            )}
-            Retry
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            data-testid="modified-files-undo"
-            disabled={isUndoLoading}
-            onClick={onUndo}
-            className="gap-1.5 rounded-lg text-muted-foreground hover:text-foreground hover:border-border cursor-pointer transition-colors disabled:cursor-not-allowed"
-          >
-            {isUndoLoading ? (
-              <Loader2 size={16} className="animate-spin" />
-            ) : (
-              <Undo size={16} />
-            )}
-            Undo
-          </Button>
-        </div>
+                  <span className="min-w-0 flex-1 truncate">
+                    {dir && (
+                      <span className="text-muted-foreground">{dir}</span>
+                    )}
+                    <span className="font-medium">{name}</span>
+                  </span>
+                  {stats && (
+                    <span className="flex-shrink-0 flex items-center gap-2 font-mono text-xs">
+                      {stats.additions > 0 && (
+                        <span className="text-green-600 dark:text-green-400">
+                          +{stats.additions}
+                        </span>
+                      )}
+                      {stats.deletions > 0 && (
+                        <span className="text-red-600 dark:text-red-400">
+                          -{stats.deletions}
+                        </span>
+                      )}
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        )}
+        {footer}
       </div>
     </div>
   );

--- a/src/components/preview_panel/CodeView.tsx
+++ b/src/components/preview_panel/CodeView.tsx
@@ -2,7 +2,7 @@ import { FileEditor } from "./FileEditor";
 import { FileTree } from "./FileTree";
 import { useEffect, useState } from "react";
 import { useLoadApp } from "@/hooks/useLoadApp";
-import { RefreshCw, Maximize2, Minimize2, ArrowLeft } from "lucide-react";
+import { RefreshCw, Maximize2, Minimize2, ArrowLeft, X } from "lucide-react";
 import {
   Tooltip,
   TooltipTrigger,
@@ -10,7 +10,10 @@ import {
 } from "@/components/ui/tooltip";
 import { useAtomValue, useSetAtom } from "jotai";
 import { selectedFileAtom, stagedDiffFileAtom } from "@/atoms/viewAtoms";
-import { selectedVersionIdAtom } from "@/atoms/appAtoms";
+import {
+  selectedVersionIdAtom,
+  selectedVersionDiffFileAtom,
+} from "@/atoms/appAtoms";
 import { useTranslation } from "react-i18next";
 import { VersionDiffView } from "./VersionDiffView";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
@@ -35,8 +38,18 @@ export const CodeView = ({ loading, app }: CodeViewProps) => {
   const selectedVersionId = useAtomValue(selectedVersionIdAtom);
   const stagedDiffFile = useAtomValue(stagedDiffFileAtom);
   const setStagedDiffFile = useSetAtom(stagedDiffFileAtom);
+  const setSelectedVersionId = useSetAtom(selectedVersionIdAtom);
+  const setSelectedVersionDiffFile = useSetAtom(selectedVersionDiffFileAtom);
   const { refreshApp } = useLoadApp(app?.id ?? null);
   const { hasUncommittedFiles } = useUncommittedFiles(app?.id ?? null);
+
+  // Exits version-diff mode (entered via the version history pane or the chat's
+  // modified-files card) and returns to the live file tree. Without this the
+  // Code tab would stay pinned to a commit diff with no in-context way back.
+  const closeVersionDiff = () => {
+    setSelectedVersionId(null);
+    setSelectedVersionDiffFile(null);
+  };
   const [isFullscreen, setIsFullscreen] = useState(false);
 
   useEffect(() => {
@@ -131,6 +144,24 @@ export const CodeView = ({ loading, app }: CodeViewProps) => {
                 ? t("preview.viewingStagedChanges")
                 : `${app.files?.length ?? 0} ${t("preview.files")}`}
           </div>
+          {isVersionDiffMode && (
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <button
+                    data-testid="close-version-diff"
+                    onClick={closeVersionDiff}
+                    className="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700"
+                  />
+                }
+              >
+                <X size={16} />
+              </TooltipTrigger>
+              <TooltipContent>
+                {t("preview.closeVersionChanges")}
+              </TooltipContent>
+            </Tooltip>
+          )}
           <div className="flex-1" />
           {app.id != null && <CommitMenu appId={app.id} />}
           <Tooltip>

--- a/src/components/preview_panel/CodeView.tsx
+++ b/src/components/preview_panel/CodeView.tsx
@@ -2,7 +2,7 @@ import { FileEditor } from "./FileEditor";
 import { FileTree } from "./FileTree";
 import { useEffect, useState } from "react";
 import { useLoadApp } from "@/hooks/useLoadApp";
-import { RefreshCw, Maximize2, Minimize2, ArrowLeft, X } from "lucide-react";
+import { RefreshCw, Maximize2, Minimize2, ArrowLeft } from "lucide-react";
 import {
   Tooltip,
   TooltipTrigger,
@@ -137,13 +137,6 @@ export const CodeView = ({ loading, app }: CodeViewProps) => {
               <TooltipContent>{t("preview.backToEditor")}</TooltipContent>
             </Tooltip>
           )}
-          <div className="text-sm text-gray-500">
-            {isVersionDiffMode
-              ? t("preview.viewingVersionChanges")
-              : isStagedDiffMode
-                ? t("preview.viewingStagedChanges")
-                : `${app.files?.length ?? 0} ${t("preview.files")}`}
-          </div>
           {isVersionDiffMode && (
             <Tooltip>
               <TooltipTrigger
@@ -155,13 +148,20 @@ export const CodeView = ({ loading, app }: CodeViewProps) => {
                   />
                 }
               >
-                <X size={16} />
+                <ArrowLeft size={16} />
               </TooltipTrigger>
               <TooltipContent>
                 {t("preview.closeVersionChanges")}
               </TooltipContent>
             </Tooltip>
           )}
+          <div className="text-sm text-gray-500">
+            {isVersionDiffMode
+              ? t("preview.viewingVersionChanges")
+              : isStagedDiffMode
+                ? t("preview.viewingStagedChanges")
+                : `${app.files?.length ?? 0} ${t("preview.files")}`}
+          </div>
           <div className="flex-1" />
           {app.id != null && <CommitMenu appId={app.id} />}
           <Tooltip>

--- a/src/components/preview_panel/VersionDiffView.tsx
+++ b/src/components/preview_panel/VersionDiffView.tsx
@@ -5,20 +5,12 @@ import { useVersionChanges } from "@/hooks/useVersionChanges";
 import type { VersionChangedFile } from "@/ipc/types";
 import { selectedVersionDiffFileAtom } from "@/atoms/appAtoms";
 import { FileDiffEditor } from "./FileDiffEditor";
+import { STATUS_META } from "./versionChangeMeta";
 
 interface VersionDiffViewProps {
   appId: number;
   versionId: string;
 }
-
-export const STATUS_META: Record<
-  VersionChangedFile["type"],
-  { label: string; className: string }
-> = {
-  added: { label: "A", className: "text-green-600 dark:text-green-400" },
-  modified: { label: "M", className: "text-amber-600 dark:text-amber-400" },
-  deleted: { label: "D", className: "text-red-600 dark:text-red-400" },
-};
 
 function StatusBadge({ type }: { type: VersionChangedFile["type"] }) {
   const meta = STATUS_META[type];

--- a/src/components/preview_panel/VersionDiffView.tsx
+++ b/src/components/preview_panel/VersionDiffView.tsx
@@ -44,12 +44,14 @@ export function VersionDiffView({ appId, versionId }: VersionDiffViewProps) {
   const { changes, loading, error } = useVersionChanges(appId, versionId);
   // The selected file is held in a shared atom so external callers (e.g. the
   // modified-files card in the chat) can open the diff at a specific file. The
-  // displayed selection is derived during render (below) so switching versions
-  // never flashes the placeholder while waiting for an effect to reconcile a
-  // stale path.
-  const [selectedDiffPath, setSelectedDiffPath] = useAtom(
+  // selection is scoped to a version, so it is only applied when it belongs to
+  // the version being shown (see below); this avoids a stale path from another
+  // version leaking in without needing an effect to reconcile it.
+  const [selectedDiffFile, setSelectedDiffFile] = useAtom(
     selectedVersionDiffFileAtom,
   );
+  const selectedDiffPath =
+    selectedDiffFile?.versionId === versionId ? selectedDiffFile.path : null;
 
   if (loading) {
     return (
@@ -98,7 +100,7 @@ export function VersionDiffView({ appId, versionId }: VersionDiffViewProps) {
         {changes.map((file) => (
           <button
             key={file.path}
-            onClick={() => setSelectedDiffPath(file.path)}
+            onClick={() => setSelectedDiffFile({ versionId, path: file.path })}
             data-testid="version-diff-file"
             className={cn(
               "flex items-center gap-2 w-full px-3 py-1.5 text-left text-sm hover:bg-[var(--background-darkest)]",

--- a/src/components/preview_panel/VersionDiffView.tsx
+++ b/src/components/preview_panel/VersionDiffView.tsx
@@ -1,8 +1,9 @@
-import { useState } from "react";
+import { useAtom } from "jotai";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import { useVersionChanges } from "@/hooks/useVersionChanges";
 import type { VersionChangedFile } from "@/ipc/types";
+import { selectedVersionDiffFileAtom } from "@/atoms/appAtoms";
 import { FileDiffEditor } from "./FileDiffEditor";
 
 interface VersionDiffViewProps {
@@ -10,7 +11,7 @@ interface VersionDiffViewProps {
   versionId: string;
 }
 
-const STATUS_META: Record<
+export const STATUS_META: Record<
   VersionChangedFile["type"],
   { label: string; className: string }
 > = {
@@ -41,10 +42,14 @@ function StatusBadge({ type }: { type: VersionChangedFile["type"] }) {
 export function VersionDiffView({ appId, versionId }: VersionDiffViewProps) {
   const { t } = useTranslation("home");
   const { changes, loading, error } = useVersionChanges(appId, versionId);
-  // Tracks the file the user explicitly clicked. The displayed selection is
-  // derived during render (below) so switching versions never flashes the
-  // placeholder while waiting for an effect to reconcile a stale path.
-  const [userSelectedPath, setUserSelectedPath] = useState<string | null>(null);
+  // The selected file is held in a shared atom so external callers (e.g. the
+  // modified-files card in the chat) can open the diff at a specific file. The
+  // displayed selection is derived during render (below) so switching versions
+  // never flashes the placeholder while waiting for an effect to reconcile a
+  // stale path.
+  const [selectedDiffPath, setSelectedDiffPath] = useAtom(
+    selectedVersionDiffFileAtom,
+  );
 
   if (loading) {
     return (
@@ -74,13 +79,13 @@ export function VersionDiffView({ appId, versionId }: VersionDiffViewProps) {
     );
   }
 
-  // Derive the displayed file from the user's explicit selection, falling back
-  // to the first changed file. Computing this during render (rather than via an
-  // effect) means a version switch immediately shows a valid selection even
-  // when the previously selected path is absent in the new version.
+  // Derive the displayed file from the shared selection, falling back to the
+  // first changed file. Computing this during render (rather than via an effect)
+  // means a version switch immediately shows a valid selection even when the
+  // previously selected path is absent in the new version.
   const selected =
-    (userSelectedPath
-      ? changes.find((c) => c.path === userSelectedPath)
+    (selectedDiffPath
+      ? changes.find((c) => c.path === selectedDiffPath)
       : undefined) ?? changes[0];
   const selectedPath = selected?.path ?? null;
 
@@ -93,7 +98,7 @@ export function VersionDiffView({ appId, versionId }: VersionDiffViewProps) {
         {changes.map((file) => (
           <button
             key={file.path}
-            onClick={() => setUserSelectedPath(file.path)}
+            onClick={() => setSelectedDiffPath(file.path)}
             data-testid="version-diff-file"
             className={cn(
               "flex items-center gap-2 w-full px-3 py-1.5 text-left text-sm hover:bg-[var(--background-darkest)]",

--- a/src/components/preview_panel/versionChangeMeta.ts
+++ b/src/components/preview_panel/versionChangeMeta.ts
@@ -1,0 +1,14 @@
+import type { VersionChangedFile } from "@/ipc/types";
+
+// Display metadata (badge label + color) for each changed-file status. Kept in
+// its own module — separate from VersionDiffView — so lightweight consumers
+// (e.g. the chat's modified-files card) can import it without transitively
+// pulling in the Monaco-backed diff editor.
+export const STATUS_META: Record<
+  VersionChangedFile["type"],
+  { label: string; className: string }
+> = {
+  added: { label: "A", className: "text-green-600 dark:text-green-400" },
+  modified: { label: "M", className: "text-amber-600 dark:text-amber-400" },
+  deleted: { label: "D", className: "text-red-600 dark:text-red-400" },
+};

--- a/src/i18n/locales/en/home.json
+++ b/src/i18n/locales/en/home.json
@@ -254,6 +254,7 @@
     "commitMessage": "Commit message",
     "commitMessagePlaceholder": "Enter commit message...",
     "filesToCommit": "Files to commit ({{count}})",
+    "closeVersionChanges": "Close diff and return to files",
     "sendToChat": "Send to chat",
     "systemMessages": "System Messages",
     "consoleFilters": {

--- a/src/ipc/handlers/version_handlers.ts
+++ b/src/ipc/handlers/version_handlers.ts
@@ -41,6 +41,10 @@ import { storeDbTimestampAtCurrentVersion } from "../utils/neon_timestamp_utils"
 import { retryOnLocked } from "../utils/retryOnLocked";
 import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
 import { syncCloudSandboxSnapshot } from "../utils/cloud_sandbox_provider";
+import {
+  DIFF_BINARY_PLACEHOLDER,
+  DIFF_TOO_LARGE_PLACEHOLDER,
+} from "@/shared/diff_placeholders";
 
 const logger = log.scope("version_handlers");
 
@@ -58,11 +62,11 @@ function sanitizeDiffContent(content: string): string {
     content.length > MAX_DIFF_CONTENT_BYTES ||
     Buffer.byteLength(content, "utf-8") > MAX_DIFF_CONTENT_BYTES
   ) {
-    return "<file too large to display>";
+    return DIFF_TOO_LARGE_PLACEHOLDER;
   }
   // A NUL byte is a strong signal the file is binary.
   if (/\u0000/.test(content)) {
-    return "<binary file not shown>";
+    return DIFF_BINARY_PLACEHOLDER;
   }
   return content;
 }

--- a/src/lib/lineDiffStats.test.ts
+++ b/src/lib/lineDiffStats.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { computeLineDiffStats } from "./lineDiffStats";
+
+describe("computeLineDiffStats", () => {
+  it("returns zeros for identical content", () => {
+    expect(computeLineDiffStats("a\nb\nc", "a\nb\nc")).toEqual({
+      additions: 0,
+      deletions: 0,
+    });
+  });
+
+  it("counts every line as an addition for a new (empty old) file", () => {
+    expect(computeLineDiffStats("", "line1\nline2\nline3")).toEqual({
+      additions: 3,
+      deletions: 0,
+    });
+  });
+
+  it("counts every line as a deletion for a removed (empty new) file", () => {
+    expect(computeLineDiffStats("line1\nline2", "")).toEqual({
+      additions: 0,
+      deletions: 2,
+    });
+  });
+
+  it("ignores a single trailing newline", () => {
+    expect(computeLineDiffStats("", "line1\nline2\n")).toEqual({
+      additions: 2,
+      deletions: 0,
+    });
+  });
+
+  it("counts a changed line as one deletion and one addition", () => {
+    expect(computeLineDiffStats("a\nb\nc", "a\nB\nc")).toEqual({
+      additions: 1,
+      deletions: 1,
+    });
+  });
+
+  it("counts pure insertions without deletions", () => {
+    expect(computeLineDiffStats("a\nc", "a\nb\nc")).toEqual({
+      additions: 1,
+      deletions: 0,
+    });
+  });
+
+  it("counts pure removals without additions", () => {
+    expect(computeLineDiffStats("a\nb\nc", "a\nc")).toEqual({
+      additions: 0,
+      deletions: 1,
+    });
+  });
+
+  it("handles mixed additions and deletions", () => {
+    // old: a b c d  -> new: a x c e f
+    // LCS = a, c (length 2). old unique: b, d (2 del). new unique: x, e, f (3 add).
+    expect(computeLineDiffStats("a\nb\nc\nd", "a\nx\nc\ne\nf")).toEqual({
+      additions: 3,
+      deletions: 2,
+    });
+  });
+
+  it("returns zeros when both sides are empty", () => {
+    expect(computeLineDiffStats("", "")).toEqual({
+      additions: 0,
+      deletions: 0,
+    });
+  });
+});

--- a/src/lib/lineDiffStats.test.ts
+++ b/src/lib/lineDiffStats.test.ts
@@ -66,4 +66,32 @@ describe("computeLineDiffStats", () => {
       deletions: 0,
     });
   });
+
+  it("counts accurately for a small edit in a large file (prefix/suffix trim)", () => {
+    // A 10k-line file where a single line in the middle is changed. Trimming the
+    // shared prefix/suffix keeps the diff exact (and fast).
+    const lines = Array.from({ length: 10_000 }, (_, i) => `line ${i}`);
+    const oldContent = lines.join("\n");
+    const changed = [...lines];
+    changed[5000] = "CHANGED";
+    expect(computeLineDiffStats(oldContent, changed.join("\n"))).toEqual({
+      additions: 1,
+      deletions: 1,
+    });
+  });
+
+  it("falls back to worst-case counts for a huge fully-different middle", () => {
+    // Every line differs and there is no shared prefix/suffix to trim, so the DP
+    // exceeds the size guard and we report a worst-case (all lines changed).
+    const oldContent = Array.from({ length: 3000 }, (_, i) => `old ${i}`).join(
+      "\n",
+    );
+    const newContent = Array.from({ length: 3000 }, (_, i) => `new ${i}`).join(
+      "\n",
+    );
+    expect(computeLineDiffStats(oldContent, newContent)).toEqual({
+      additions: 3000,
+      deletions: 3000,
+    });
+  });
 });

--- a/src/lib/lineDiffStats.test.ts
+++ b/src/lib/lineDiffStats.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { computeLineDiffStats } from "./lineDiffStats";
+import {
+  DIFF_BINARY_PLACEHOLDER,
+  DIFF_TOO_LARGE_PLACEHOLDER,
+} from "@/shared/diff_placeholders";
 
 describe("computeLineDiffStats", () => {
   it("returns zeros for identical content", () => {
@@ -78,6 +82,20 @@ describe("computeLineDiffStats", () => {
       additions: 1,
       deletions: 1,
     });
+  });
+
+  it("returns zeros when either side is a sanitized placeholder", () => {
+    // Binary/oversized files are replaced by placeholder strings upstream;
+    // diffing those against real content would report meaningless line counts.
+    expect(
+      computeLineDiffStats(DIFF_BINARY_PLACEHOLDER, "line1\nline2"),
+    ).toEqual({ additions: 0, deletions: 0 });
+    expect(
+      computeLineDiffStats("line1\nline2", DIFF_TOO_LARGE_PLACEHOLDER),
+    ).toEqual({ additions: 0, deletions: 0 });
+    expect(
+      computeLineDiffStats(DIFF_TOO_LARGE_PLACEHOLDER, DIFF_BINARY_PLACEHOLDER),
+    ).toEqual({ additions: 0, deletions: 0 });
   });
 
   it("falls back to worst-case counts for a huge fully-different middle", () => {

--- a/src/lib/lineDiffStats.ts
+++ b/src/lib/lineDiffStats.ts
@@ -1,3 +1,5 @@
+import { isDiffPlaceholder } from "@/shared/diff_placeholders";
+
 export interface LineDiffStats {
   additions: number;
   deletions: number;
@@ -103,6 +105,13 @@ export function computeLineDiffStats(
   newContent: string,
 ): LineDiffStats {
   if (oldContent === newContent) {
+    return EMPTY_STATS;
+  }
+
+  // Either side may be a sanitized placeholder (binary/oversized file) rather
+  // than real content. Diffing the placeholder string would report meaningless
+  // line counts, so bail out with zeros instead.
+  if (isDiffPlaceholder(oldContent) || isDiffPlaceholder(newContent)) {
     return EMPTY_STATS;
   }
 

--- a/src/lib/lineDiffStats.ts
+++ b/src/lib/lineDiffStats.ts
@@ -1,0 +1,81 @@
+export interface LineDiffStats {
+  additions: number;
+  deletions: number;
+}
+
+const EMPTY_STATS: LineDiffStats = { additions: 0, deletions: 0 };
+
+/**
+ * Splits content into lines for diffing. A trailing newline should not count as
+ * an extra empty line, so it is stripped before splitting. Empty content yields
+ * zero lines (not a single empty line).
+ */
+function toLines(content: string): string[] {
+  if (content.length === 0) {
+    return [];
+  }
+  const normalized = content.replace(/\n$/, "");
+  return normalized.split("\n");
+}
+
+/**
+ * Length of the longest common subsequence between two line arrays. Used to
+ * derive how many lines were added/removed the same way `git diff` reports them:
+ * lines that don't participate in the LCS are counted as changes.
+ */
+function lcsLength(a: string[], b: string[]): number {
+  const n = a.length;
+  const m = b.length;
+  if (n === 0 || m === 0) {
+    return 0;
+  }
+  // Rolling two-row DP to keep memory at O(min dimension).
+  let previous = Array.from<number>({ length: m + 1 }).fill(0);
+  let current = Array.from<number>({ length: m + 1 }).fill(0);
+  for (let i = 1; i <= n; i++) {
+    for (let j = 1; j <= m; j++) {
+      if (a[i - 1] === b[j - 1]) {
+        current[j] = previous[j - 1] + 1;
+      } else {
+        current[j] = Math.max(previous[j], current[j - 1]);
+      }
+    }
+    [previous, current] = [current, previous];
+  }
+  return previous[m];
+}
+
+/**
+ * Computes added/deleted line counts between two file contents, matching how a
+ * line-based diff (e.g. `git diff`) tallies changes: additions are new lines not
+ * present in the longest common subsequence, deletions are old lines missing
+ * from it. A modified line therefore counts as one deletion plus one addition.
+ *
+ * Returns zeros when there is nothing to diff (identical content) or when either
+ * side is a sanitized placeholder (binary/oversized files), which would produce
+ * meaningless counts.
+ */
+export function computeLineDiffStats(
+  oldContent: string,
+  newContent: string,
+): LineDiffStats {
+  if (oldContent === newContent) {
+    return EMPTY_STATS;
+  }
+
+  const oldLines = toLines(oldContent);
+  const newLines = toLines(newContent);
+
+  if (oldLines.length === 0) {
+    return { additions: newLines.length, deletions: 0 };
+  }
+  if (newLines.length === 0) {
+    return { additions: 0, deletions: oldLines.length };
+  }
+
+  const common = lcsLength(oldLines, newLines);
+  return {
+    additions: newLines.length - common,
+    deletions: oldLines.length - common,
+  };
+}

--- a/src/lib/lineDiffStats.ts
+++ b/src/lib/lineDiffStats.ts
@@ -18,6 +18,12 @@ function toLines(content: string): string[] {
   return normalized.split("\n");
 }
 
+// Above this many DP cells (rows × columns of the untrimmable middle) we skip
+// the LCS and treat the middle as entirely changed. computeLineDiffStats runs
+// synchronously during render, so a pathological input (e.g. a large minified
+// bundle where every line differs) could otherwise block the main thread.
+const MAX_LCS_CELLS = 4_000_000;
+
 /**
  * Length of the longest common subsequence between two line arrays. Used to
  * derive how many lines were added/removed the same way `git diff` reports them:
@@ -29,12 +35,49 @@ function lcsLength(a: string[], b: string[]): number {
   if (n === 0 || m === 0) {
     return 0;
   }
-  // Rolling two-row DP to keep memory at O(min dimension).
-  let previous = Array.from<number>({ length: m + 1 }).fill(0);
-  let current = Array.from<number>({ length: m + 1 }).fill(0);
-  for (let i = 1; i <= n; i++) {
-    for (let j = 1; j <= m; j++) {
-      if (a[i - 1] === b[j - 1]) {
+
+  // Most edits change only a handful of lines, so trim the shared prefix and
+  // suffix first. This shrinks the DP table (often to nothing) and keeps the
+  // computation fast even for large files.
+  let start = 0;
+  while (start < n && start < m && a[start] === b[start]) {
+    start++;
+  }
+  let endA = n - 1;
+  let endB = m - 1;
+  while (endA >= start && endB >= start && a[endA] === b[endB]) {
+    endA--;
+    endB--;
+  }
+
+  // Shared prefix + suffix lines already accounted for as common.
+  const trimmedCommon = start + (n - 1 - endA);
+  const lenA = endA - start + 1;
+  const lenB = endB - start + 1;
+  if (lenA === 0 || lenB === 0) {
+    return trimmedCommon;
+  }
+
+  // Guard against pathological inputs: skip the DP and treat the untrimmable
+  // middle as entirely changed rather than block the main thread.
+  if (lenA * lenB > MAX_LCS_CELLS) {
+    return trimmedCommon;
+  }
+
+  // Use the smaller dimension for the rolling DP columns so memory/allocation
+  // stays at O(min(lenA, lenB)). The LCS length is symmetric in its arguments.
+  const [small, large] =
+    lenA <= lenB
+      ? [a.slice(start, endA + 1), b.slice(start, endB + 1)]
+      : [b.slice(start, endB + 1), a.slice(start, endA + 1)];
+  const sLen = small.length;
+  const lLen = large.length;
+
+  let previous = Array.from<number>({ length: sLen + 1 }).fill(0);
+  let current = Array.from<number>({ length: sLen + 1 }).fill(0);
+  for (let i = 1; i <= lLen; i++) {
+    for (let j = 1; j <= sLen; j++) {
+      if (large[i - 1] === small[j - 1]) {
         current[j] = previous[j - 1] + 1;
       } else {
         current[j] = Math.max(previous[j], current[j - 1]);
@@ -42,7 +85,7 @@ function lcsLength(a: string[], b: string[]): number {
     }
     [previous, current] = [current, previous];
   }
-  return previous[m];
+  return trimmedCommon + previous[sLen];
 }
 
 /**

--- a/src/shared/diff_placeholders.ts
+++ b/src/shared/diff_placeholders.ts
@@ -1,0 +1,15 @@
+// Placeholder strings substituted for file content that can't be shown in the
+// diff editor. Shared between the main-process sanitizer (which produces them)
+// and the renderer (which must recognize them so it doesn't diff a placeholder
+// as if it were real file content).
+export const DIFF_TOO_LARGE_PLACEHOLDER = "<file too large to display>";
+export const DIFF_BINARY_PLACEHOLDER = "<binary file not shown>";
+
+export const DIFF_PLACEHOLDERS: readonly string[] = [
+  DIFF_TOO_LARGE_PLACEHOLDER,
+  DIFF_BINARY_PLACEHOLDER,
+];
+
+export function isDiffPlaceholder(content: string): boolean {
+  return DIFF_PLACEHOLDERS.includes(content);
+}


### PR DESCRIPTION
Show a card at the bottom of the chat once streaming ends, listing the files changed by the last generation. Each row shows the file's status, path, and added/deleted line counts; clicking a row opens the read-only diff view for that file in the preview panel. The card's Undo button reverts the whole generation.

<img width="1746" height="676" alt="image" src="https://github.com/user-attachments/assets/f10f93ce-0309-44b7-b831-3e5968661abc" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

