### PR TITLE
Show Pro upgrade CTA only for valid Pro state & cleanup test harness

### DIFF
--- a/rules/hybrid-testing.md
+++ b/rules/hybrid-testing.md
@@ -38,3 +38,8 @@ When a hybrid test needs `IS_TEST_BUILD` behavior from modules that capture
 before app imports. `setupHybridChatHarness({ testBuild: true })` sets the flag
 before dynamic IPC registration, but it cannot fix static imports that already
 loaded modules such as the Neon management client.
+
+If a chat-flow or hybrid harness suite passes all tests but fails during
+`dispose()` with `ENOTEMPTY` for a `dyad-chat-flow-*` temp directory, look for a
+launched app process still writing under that root (often `pnpm install`). Stop
+running apps and await process closure before removing the harness temp dir.

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -784,7 +784,7 @@ export function ChatInput({ chatId }: { chatId?: number }) {
         <ChatErrorBox
           onDismiss={dismissError}
           error={error}
-          isDyadProEnabled={settings.enableDyadPro ?? false}
+          isDyadProEnabled={isProEnabled}
           onStartNewChat={handleNewChat}
         />
       )}

--- a/src/testing/chat_flow_harness.ts
+++ b/src/testing/chat_flow_harness.ts
@@ -22,6 +22,7 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 
 import { closeDatabase, db, initializeDatabase } from "@/db";
 import {
@@ -33,6 +34,11 @@ import {
 } from "@/db/schema";
 import { registerChatStreamHandlers } from "@/ipc/handlers/chat_stream_handlers";
 import type { ChatStreamParams } from "@/ipc/types";
+import {
+  runningApps,
+  stopAppByInfo,
+  stopAppGarbageCollection,
+} from "@/ipc/utils/process_manager";
 import { writeSettings } from "@/main/settings";
 import type { UserSettings } from "@/lib/schemas";
 import { asc, eq } from "drizzle-orm";
@@ -83,6 +89,29 @@ function restoreHarnessEnv(snapshot: Map<string, string | undefined>): void {
       delete process.env[key];
     } else {
       process.env[key] = value;
+    }
+  }
+}
+
+async function stopRunningAppsForHarness(): Promise<void> {
+  stopAppGarbageCollection();
+  const appsToStop = Array.from(runningApps.entries());
+  await Promise.allSettled(
+    appsToStop.map(([appId, appInfo]) => stopAppByInfo(appId, appInfo)),
+  );
+}
+
+async function removeHarnessTempRoot(tmpRootPath: string): Promise<void> {
+  const maxAttempts = 5;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      fs.rmSync(tmpRootPath, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      if (attempt === maxAttempts) {
+        throw error;
+      }
+      await delay(100 * attempt);
     }
   }
 }
@@ -388,6 +417,7 @@ export async function setupChatFlowHarness(
 
     const dispose = async (): Promise<void> => {
       try {
+        await stopRunningAppsForHarness();
         try {
           await fakeLlmHandle.close();
         } catch {
@@ -398,7 +428,7 @@ export async function setupChatFlowHarness(
         } catch {
           // ignore
         }
-        fs.rmSync(tmpRootPath, { recursive: true, force: true });
+        await removeHarnessTempRoot(tmpRootPath);
       } finally {
         // Simulate the Electron process exiting: drop every registered
         // handler/listener so a sequential harness can re-register (the mock,
@@ -444,7 +474,8 @@ export async function setupChatFlowHarness(
       // ignore
     }
     if (tmpRoot) {
-      fs.rmSync(tmpRoot, { recursive: true, force: true });
+      await stopRunningAppsForHarness();
+      await removeHarnessTempRoot(tmpRoot);
     }
     electronMock.ipcHandlers.clear();
     electronMock.ipcListeners?.clear();


### PR DESCRIPTION
## Summary
- Treat the chat error CTA as Pro-only only when Dyad Pro is both enabled and backed by a saved Pro key.
- Stabilize chat-flow harness teardown by stopping app processes before removing temp roots, since the full suite exposed a cleanup race while verifying this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI prop change and test-harness cleanup only; no auth or production runtime behavior beyond more accurate Pro error CTAs.
> 
> **Overview**
> **Chat error Pro gating:** `ChatInput` now passes **`isProEnabled`** (`isDyadProEnabled(settings)`) into `ChatErrorBox` instead of **`settings.enableDyadPro` alone**, so upgrade CTAs and Pro-only actions (e.g. “Start new chat”) align with **Pro enabled plus a saved Pro key**, not a toggle without credentials.
> 
> **Harness teardown:** `setupChatFlowHarness` **`dispose()`** (and failed-setup cleanup) **stops tracked running apps** via the process manager, then **retries recursive temp-root deletion** with backoff instead of a single synchronous `rmSync`, reducing **`ENOTEMPTY`** when child processes (e.g. `pnpm install`) still write under `dyad-chat-flow-*`.
> 
> **Docs:** `rules/hybrid-testing.md` adds guidance for **`dispose()` ENOTEMPTY** on chat-flow/hybrid harness temp dirs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ef341fe0ca2c3bbee98de14b455fd3ab8754c0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

