### PR TITLE
Improve home AI setup affordance

### DIFF
--- a/rules/ui-styling.md
+++ b/rules/ui-styling.md
@@ -39,6 +39,10 @@ The project uses **Tailwind v4** (see `tailwindcss: ^4.x` in `package.json`). A 
 - **Arbitrary widths/sizes:** `w-[17rem]`, `size-[3px]` — use these for fine-grained tweaks instead of inventing config values.
 - **`size-*` shorthand** sets both `width` and `height`.
 
+## Setup affordances that become manage affordances
+
+When reusing a setup component behind a persistent "Manage setup" entry point, make sure the component can render even after setup is complete. Components like setup banners often self-hide once `isAnyProviderSetup()` is true; add an explicit force/manage mode and a regression test that clicks the manage affordance and verifies dialog content appears.
+
 ## Visually verifying component designs without launching Electron
 
 To screenshot a redesigned component without driving the full Electron app (which may require onboarding/app state to reach the surface): build a standalone HTML harness using `@tailwindcss/browser@4` (CDN) with the app's CSS variables copied from `src/styles/globals.css` (including the `.dark` block for dark-mode frames), then screenshot it with the repo's Playwright. Note: import Playwright by absolute path — `import { chromium } from "file:///<repo>/node_modules/playwright/index.mjs"` — because plain `import "playwright"` fails with `ERR_MODULE_NOT_FOUND` when the script lives outside the repo (ESM resolves from the script's location, not cwd).

--- a/src/components/SetupBanner.tsx
+++ b/src/components/SetupBanner.tsx
@@ -74,12 +74,12 @@ export function SetupBanner({
     settingsScrollAndNavigateTo(SECTION_IDS.providers);
   };
 
+  const hasProviderSetup = isAnyProviderSetup();
+
   const itemsNeedAction: string[] = [];
-  if (!isAnyProviderSetup() && !loading) {
+  if (!hasProviderSetup && !loading) {
     itemsNeedAction.push("ai-setup");
   }
-
-  const hasProviderSetup = isAnyProviderSetup();
 
   if (itemsNeedAction.length === 0 && !forceShow) {
     if (variant === "dialog") {
@@ -103,7 +103,7 @@ export function SetupBanner({
       >
         <div className="mx-auto max-w-2xl text-center">
           <h2 className="text-2xl font-semibold tracking-tight text-foreground">
-            {variant === "dialog" && hasProviderSetup
+            {hasProviderSetup
               ? "Manage AI setup"
               : variant === "dialog"
                 ? "You're almost ready to build"

--- a/src/components/SetupBanner.tsx
+++ b/src/components/SetupBanner.tsx
@@ -30,8 +30,10 @@ import { SetupDyadProButton } from "./ProBanner";
 
 export function SetupBanner({
   variant = "inline",
+  forceShow = false,
 }: {
   variant?: "inline" | "dialog";
+  forceShow?: boolean;
 }) {
   const { t } = useTranslation("home");
   const posthog = usePostHog();
@@ -77,7 +79,9 @@ export function SetupBanner({
     itemsNeedAction.push("ai-setup");
   }
 
-  if (itemsNeedAction.length === 0) {
+  const hasProviderSetup = isAnyProviderSetup();
+
+  if (itemsNeedAction.length === 0 && !forceShow) {
     if (variant === "dialog") {
       return null;
     }
@@ -99,11 +103,13 @@ export function SetupBanner({
       >
         <div className="mx-auto max-w-2xl text-center">
           <h2 className="text-2xl font-semibold tracking-tight text-foreground">
-            {variant === "dialog"
-              ? "You're almost ready to build"
-              : "Connect AI to start building"}
+            {variant === "dialog" && hasProviderSetup
+              ? "Manage AI setup"
+              : variant === "dialog"
+                ? "You're almost ready to build"
+                : "Connect AI to start building"}
           </h2>
-          {variant === "dialog" && hasPendingPrompt ? (
+          {variant === "dialog" && hasPendingPrompt && !hasProviderSetup ? (
             <p className="mt-2 flex items-center justify-center gap-1.5 text-sm leading-6 text-muted-foreground">
               <CircleCheck
                 aria-hidden="true"
@@ -113,7 +119,9 @@ export function SetupBanner({
             </p>
           ) : (
             <p className="mt-2 text-sm leading-6 text-muted-foreground">
-              Dyad uses AI to build your app.
+              {hasProviderSetup
+                ? "Change how Dyad accesses AI."
+                : "Dyad uses AI to build your app."}
             </p>
           )}
         </div>

--- a/src/pages/home.test.tsx
+++ b/src/pages/home.test.tsx
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   attachments: [] as any[],
   isAnyProviderSetup: false,
   isLoadingLanguageModelProviders: true,
+  isSettingsLoading: false,
   effectiveDefaultChatMode: "build",
   hasManuallySelectedChatMode: false,
   inputValue: "Build a notes app",
@@ -94,6 +95,7 @@ vi.mock("@/hooks/useLoadApps", () => ({
 vi.mock("@/hooks/useSettings", () => ({
   useSettings: () => ({
     envVars: {},
+    loading: mocks.isSettingsLoading,
     settings: mocks.settings,
     updateSettings: mocks.updateSettings,
   }),
@@ -213,6 +215,7 @@ describe("HomePage", () => {
     mocks.hasManuallySelectedChatMode = false;
     mocks.inputValue = "Build a notes app";
     mocks.initialChatMode = "build";
+    mocks.isSettingsLoading = false;
     mocks.navigate.mockReset();
     mocks.posthogCapture.mockReset();
     mocks.openPreviewIfSetupRequired.mockReset();
@@ -289,7 +292,7 @@ describe("HomePage", () => {
 
   it("shows the setup pill for non-Pro users without a configured provider", () => {
     mocks.isAnyProviderSetup = false;
-    mocks.isLoadingLanguageModelProviders = true;
+    mocks.isLoadingLanguageModelProviders = false;
 
     renderHomePage();
 
@@ -297,6 +300,25 @@ describe("HomePage", () => {
       screen.getByRole("button", { name: /Connect AI to build/ }),
     ).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Dismiss" })).toBeNull();
+  });
+
+  it("hides the setup pill while settings or providers are loading", () => {
+    mocks.isAnyProviderSetup = false;
+    mocks.isLoadingLanguageModelProviders = true;
+
+    const { rerender } = renderHomePage();
+
+    expect(
+      screen.queryByRole("button", { name: /Connect AI to build/ }),
+    ).toBeNull();
+
+    mocks.isLoadingLanguageModelProviders = false;
+    mocks.isSettingsLoading = true;
+    rerenderHomePage(rerender);
+
+    expect(
+      screen.queryByRole("button", { name: /Connect AI to build/ }),
+    ).toBeNull();
   });
 
   it("de-emphasizes the setup pill when an AI provider is configured", () => {

--- a/src/pages/home.test.tsx
+++ b/src/pages/home.test.tsx
@@ -132,6 +132,8 @@ vi.mock("@/hooks/useLoadApp", () => ({
 
 vi.mock("@/lib/schemas", () => ({
   getEffectiveDefaultChatMode: () => mocks.effectiveDefaultChatMode,
+  hasDyadProKey: (settings: any) =>
+    Boolean(settings?.providerSettings?.auto?.apiKey?.value),
 }));
 
 vi.mock("@/lib/toast", () => ({
@@ -177,7 +179,8 @@ vi.mock("@/components/chat/HomeChatInput", () => ({
 }));
 
 vi.mock("@/components/SetupBanner", () => ({
-  SetupBanner: () => <div>AI setup dialog</div>,
+  SetupBanner: ({ forceShow }: { forceShow?: boolean }) =>
+    forceShow ? <div>AI setup dialog</div> : null,
 }));
 
 vi.mock("@/components/TelemetryBanner", () => ({
@@ -282,6 +285,67 @@ describe("HomePage", () => {
     await waitFor(() => {
       expect(mocks.setAtom).toHaveBeenCalledWith(false);
     });
+  });
+
+  it("shows the setup pill for non-Pro users without a configured provider", () => {
+    mocks.isAnyProviderSetup = false;
+    mocks.isLoadingLanguageModelProviders = true;
+
+    renderHomePage();
+
+    expect(
+      screen.getByRole("button", { name: /Connect AI to build/ }),
+    ).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Dismiss" })).toBeNull();
+  });
+
+  it("de-emphasizes the setup pill when an AI provider is configured", () => {
+    mocks.isAnyProviderSetup = true;
+    mocks.isLoadingLanguageModelProviders = false;
+
+    renderHomePage();
+
+    expect(
+      screen.getByRole("button", { name: "Manage AI setup" }),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: /Connect AI to build/ }),
+    ).toBeNull();
+  });
+
+  it("opens the setup dialog from the configured-provider manage link", () => {
+    mocks.isAnyProviderSetup = true;
+    mocks.isLoadingLanguageModelProviders = false;
+
+    renderHomePage();
+
+    fireEvent.click(screen.getByRole("button", { name: "Manage AI setup" }));
+
+    expect(screen.getByText("AI setup dialog")).toBeTruthy();
+  });
+
+  it("hides the setup pill when a Dyad Pro API key is saved", () => {
+    mocks.settings = {
+      enableDyadPro: false,
+      isTestMode: true,
+      providerSettings: {
+        auto: {
+          apiKey: {
+            value: "dyad-pro-key",
+          },
+        },
+      },
+      selectedChatMode: "build",
+    };
+
+    renderHomePage();
+
+    expect(
+      screen.queryByRole("button", { name: /Connect AI to build/ }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Manage AI setup" }),
+    ).toBeNull();
   });
 
   it("keeps the preview panel open when setup was opened for the new app", async () => {

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -72,7 +72,12 @@ export default function HomePage() {
   const navigate = useNavigate();
   const search = useSearch({ from: "/" });
   const { refreshApps } = useLoadApps();
-  const { settings, updateSettings, envVars } = useSettings();
+  const {
+    settings,
+    updateSettings,
+    envVars,
+    loading: isSettingsLoading,
+  } = useSettings();
   const { isAnyProviderSetup, isLoading: isLoadingLanguageModelProviders } =
     useLanguageModelProviders();
   const hasDyadProApiKey = settings ? hasDyadProKey(settings) : false;
@@ -459,27 +464,29 @@ export default function HomePage() {
           </div>
           <HomeChatInput onSubmit={handleSubmit} />
 
-          {!hasDyadProApiKey && (
-            <div className="-mt-2 flex justify-end px-4">
-              <button
-                type="button"
-                onClick={() => {
-                  posthog.capture("home:setup-pill:click");
-                  openAiSetupDialog();
-                }}
-                className={
-                  hasConfiguredAiProvider
-                    ? "flex cursor-pointer items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground hover:underline"
-                    : "flex cursor-pointer items-center gap-1 rounded-md px-2 py-1 text-xs font-semibold text-primary transition-colors hover:bg-primary/10 hover:underline"
-                }
-              >
-                <Zap aria-hidden="true" className="size-3.5" />
-                {hasConfiguredAiProvider
-                  ? "Manage AI setup"
-                  : "Connect AI to build — takes a minute"}
-              </button>
-            </div>
-          )}
+          {!isSettingsLoading &&
+            !isLoadingLanguageModelProviders &&
+            !hasDyadProApiKey && (
+              <div className="-mt-2 flex justify-end px-4">
+                <button
+                  type="button"
+                  onClick={() => {
+                    posthog.capture("home:setup-pill:click");
+                    openAiSetupDialog();
+                  }}
+                  className={
+                    hasConfiguredAiProvider
+                      ? "flex cursor-pointer items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground hover:underline"
+                      : "flex cursor-pointer items-center gap-1 rounded-md px-2 py-1 text-xs font-semibold text-primary transition-colors hover:bg-primary/10 hover:underline"
+                  }
+                >
+                  <Zap aria-hidden="true" className="size-3.5" />
+                  {hasConfiguredAiProvider
+                    ? "Manage AI setup"
+                    : "Connect AI to build — takes a minute"}
+                </button>
+              </div>
+            )}
 
           <div className="mt-4 flex flex-wrap justify-center gap-2">
             {randomPrompts.map((item) => (
@@ -514,9 +521,15 @@ export default function HomePage() {
       >
         <DialogContent className="p-0 sm:max-w-2xl">
           <DialogHeader className="sr-only">
-            <DialogTitle>You're almost ready to build</DialogTitle>
+            <DialogTitle>
+              {hasConfiguredAiProvider
+                ? "Manage AI setup"
+                : "You're almost ready to build"}
+            </DialogTitle>
             <DialogDescription>
-              Choose how Dyad should access AI before generating your app.
+              {hasConfiguredAiProvider
+                ? "Change how Dyad accesses AI."
+                : "Choose how Dyad should access AI before generating your app."}
             </DialogDescription>
           </DialogHeader>
           <SetupBanner variant="dialog" forceShow />

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -33,7 +33,11 @@ import type { FileAttachment } from "@/ipc/types";
 import type { ListedApp } from "@/ipc/types/app";
 import { NEON_TEMPLATE_IDS } from "@/shared/templates";
 import { neonTemplateHook } from "@/client_logic/template_hook";
-import { getEffectiveDefaultChatMode, type ChatMode } from "@/lib/schemas";
+import {
+  getEffectiveDefaultChatMode,
+  hasDyadProKey,
+  type ChatMode,
+} from "@/lib/schemas";
 import {
   FREE_PRO_MODEL_FALLBACK_CHAT_MODE,
   isFreeProBuildModeCombination,
@@ -49,7 +53,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { RefreshCw, X, Zap } from "lucide-react";
+import { RefreshCw, Zap } from "lucide-react";
 
 // Adding an export for attachments
 export interface HomeSubmitOptions {
@@ -71,6 +75,9 @@ export default function HomePage() {
   const { settings, updateSettings, envVars } = useSettings();
   const { isAnyProviderSetup, isLoading: isLoadingLanguageModelProviders } =
     useLanguageModelProviders();
+  const hasDyadProApiKey = settings ? hasDyadProKey(settings) : false;
+  const hasConfiguredAiProvider =
+    !isLoadingLanguageModelProviders && isAnyProviderSetup();
   const { isQuotaExceeded, isLoading: isQuotaLoading } = useFreeAgentQuota();
   const initialChatMode = useInitialChatMode();
   const homeInitialChatMode = useMemo<ChatMode | undefined>(() => {
@@ -99,7 +106,6 @@ export default function HomePage() {
   const { selectChat } = useSelectChat();
   const [isLoading, setIsLoading] = useState(false);
   const [isAiSetupDialogOpen, setIsAiSetupDialogOpen] = useState(false);
-  const [isSetupPillDismissed, setIsSetupPillDismissed] = useState(false);
   const [
     shouldOpenAiSetupDialogWhenProvidersLoad,
     setShouldOpenAiSetupDialogWhenProvidersLoad,
@@ -453,36 +459,27 @@ export default function HomePage() {
           </div>
           <HomeChatInput onSubmit={handleSubmit} />
 
-          {!isSetupPillDismissed &&
-            !isLoadingLanguageModelProviders &&
-            !isAnyProviderSetup() && (
-              <div className="mt-3 flex justify-center">
-                <div className="flex items-center gap-0.5 rounded-full border border-primary/25 bg-primary/5 py-0.5 pl-3 pr-0.5">
-                  <button
-                    type="button"
-                    onClick={() => {
-                      posthog.capture("home:setup-pill:click");
-                      openAiSetupDialog();
-                    }}
-                    className="flex cursor-pointer items-center gap-1.5 py-1 text-sm font-medium text-primary transition-colors hover:underline"
-                  >
-                    <Zap aria-hidden="true" className="size-3.5" />
-                    Connect AI to build — takes a minute
-                  </button>
-                  <button
-                    type="button"
-                    aria-label="Dismiss"
-                    onClick={() => {
-                      posthog.capture("home:setup-pill:dismiss");
-                      setIsSetupPillDismissed(true);
-                    }}
-                    className="flex size-6 cursor-pointer items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-primary/10 hover:text-foreground"
-                  >
-                    <X aria-hidden="true" className="size-3.5" />
-                  </button>
-                </div>
-              </div>
-            )}
+          {!hasDyadProApiKey && (
+            <div className="-mt-2 flex justify-end px-4">
+              <button
+                type="button"
+                onClick={() => {
+                  posthog.capture("home:setup-pill:click");
+                  openAiSetupDialog();
+                }}
+                className={
+                  hasConfiguredAiProvider
+                    ? "flex cursor-pointer items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground hover:underline"
+                    : "flex cursor-pointer items-center gap-1 rounded-md px-2 py-1 text-xs font-semibold text-primary transition-colors hover:bg-primary/10 hover:underline"
+                }
+              >
+                <Zap aria-hidden="true" className="size-3.5" />
+                {hasConfiguredAiProvider
+                  ? "Manage AI setup"
+                  : "Connect AI to build — takes a minute"}
+              </button>
+            </div>
+          )}
 
           <div className="mt-4 flex flex-wrap justify-center gap-2">
             {randomPrompts.map((item) => (
@@ -522,7 +519,7 @@ export default function HomePage() {
               Choose how Dyad should access AI before generating your app.
             </DialogDescription>
           </DialogHeader>
-          <SetupBanner variant="dialog" />
+          <SetupBanner variant="dialog" forceShow />
         </DialogContent>
       </Dialog>
     </div>


### PR DESCRIPTION
## Summary
- Improve home AI setup affordance
- Primary files: rules/ui-styling.md, src/components/SetupBanner.tsx, src/pages/home.test.tsx, src/pages/home.tsx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI copy and visibility on the home page only; no auth or submit-path logic changes beyond gating the affordance on settings/provider load and Dyad Pro key detection.
> 
> **Overview**
> Refines the home page **AI setup entry point** so it works both before and after a provider is configured, and documents the pattern for setup → manage reuse.
> 
> **Home (`home.tsx`)** replaces the centered dismissible “Connect AI” pill with a compact right-aligned link. It waits until settings and provider data finish loading, hides entirely when a **Dyad Pro API key** is present (`hasDyadProKey`), and switches copy/styling between urgent **Connect AI to build** and muted **Manage AI setup** when a provider is already set. The setup dialog passes **`forceShow`** into `SetupBanner` and updates accessible titles/descriptions for the manage case.
> 
> **`SetupBanner`** adds **`forceShow`** so the dialog body still renders after `isAnyProviderSetup()` is true; copy shifts to “Manage AI setup” / “Change how Dyad accesses AI” when appropriate, and the saved-prompt hint only shows when setup is still incomplete.
> 
> **Tests** in `home.test.tsx` cover pill visibility (loading, configured provider, Dyad Pro key), manage-link dialog open, and no dismiss control.
> 
> **`rules/ui-styling.md`** adds guidance to force/manage setup components and regression-test the manage entry point.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87d002e6552b56f93c23fa8dba5709e61b746434. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3822?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

