### PR TITLE
Update Pro trial offer to seven days

### DIFF
--- a/plans/promo-message-improvements.md
+++ b/plans/promo-message-improvements.md
@@ -16,7 +16,7 @@
 - 12 messages rotate randomly by hash; **only 2 of 12 are Pro promos** (~17% of impressions). The rest are community/docs tips (Reddit, GitHub star, roadmap, report-a-bug).
 - **Zero analytics**: no PostHog impression/click events, no UTM params on the promo links (every other upgrade surface in the app has `utm_campaign`). We can't measure CTR or conversion per message.
 - No frequency capping, no dismiss, no targeting — the same random banner on every stream forever → banner blindness.
-- Messaging is feature-jargon-led ("Turbo Edits", "Smart Context") with no offer. Meanwhile the app _has_ a 3-day free trial (`trialCode=1PRO30`, used by DyadProTrialDialog/SetupBanner) that none of these messages mention.
+- Messaging is feature-jargon-led ("Turbo Edits", "Smart Context") with no offer. Meanwhile the app _has_ a 7-day free trial (`trialCode=7PRO30`, used by DyadProTrialDialog/SetupBanner) that none of these messages mention.
 
 ## Why it underperforms
 
@@ -44,7 +44,7 @@
 
 ### P1 — Offer-led, quantified copy
 
-- Lead with the trial: "Try Dyad Pro free for 3 days" beats "Get Dyad Pro".
+- Lead with the trial: "Try Dyad Pro free for 7 days" beats "Get Dyad Pro".
 - Use real numbers from the session where possible (tokens sent → Smart Context savings; elapsed stream time → speed; error/retry detected → Agent mode auto-debugging).
 - Benefit language, not feature names: "Stop juggling API keys — one plan with GPT-5.5 + Claude Opus", "Fix errors automatically with Agent mode".
 
@@ -65,5 +65,5 @@
 ## Link destination: dyad.sh/pro vs academy sign-in→checkout
 
 - **Education-style messages** (user may not know what Pro is) → `https://www.dyad.sh/pro?utm_...` — consideration page, low bounce.
-- **Direct-offer messages** ("Start your free 3-day trial") → `https://academy.dyad.sh/redirect-to-checkout?trialCode=1PRO30&utm_...` — same pattern the app already uses. Prefer this over hardcoding `/sign-in?redirect_url=...`: the redirect endpoint owns the auth flow (survives auth changes) and carries the trial code.
+- **Direct-offer messages** ("Start your free 7-day trial") → `https://academy.dyad.sh/redirect-to-checkout?trialCode=7PRO30&utm_...` — same pattern the app already uses. Prefer this over hardcoding `/sign-in?redirect_url=...`: the redirect endpoint owns the auth flow (survives auth changes) and carries the trial code.
 - **Best of both**: click → in-app `DyadProTrialDialog`, which offers "Start Free Trial" (checkout) and "Learn more" (/pro). Warm the user before the sign-in wall.

--- a/src/components/DyadProTrialDialog.tsx
+++ b/src/components/DyadProTrialDialog.tsx
@@ -19,7 +19,7 @@ export function DyadProTrialDialog({
 
   const handleStartTrial = () => {
     ipc.system.openExternalUrl(
-      `https://academy.dyad.sh/redirect-to-checkout?trialCode=1PRO30&${utmParams}`,
+      `https://academy.dyad.sh/redirect-to-checkout?trialCode=7PRO30&${utmParams}`,
     );
     onClose();
   };
@@ -60,7 +60,7 @@ export function DyadProTrialDialog({
               Unlock Dyad Pro
             </h2>
             <p className="mt-1 text-sm text-muted-foreground">
-              Start your free 3-day trial today
+              Start your free 7-day trial today
             </p>
           </div>
         </div>

--- a/src/components/SetupBanner.tsx
+++ b/src/components/SetupBanner.tsx
@@ -63,7 +63,7 @@ export function SetupBanner({
   const handleDyadProSetupClick = () => {
     posthog.capture("setup-flow:ai-provider-setup:dyad:click");
     ipc.system.openExternalUrl(
-      "https://academy.dyad.sh/redirect-to-checkout?trialCode=1PRO30&utm_source=dyad-app&utm_medium=app&utm_campaign=setup-dialog-v2",
+      "https://academy.dyad.sh/redirect-to-checkout?trialCode=7PRO30&utm_source=dyad-app&utm_medium=app&utm_campaign=setup-dialog-v2",
     );
   };
 

--- a/src/components/chat/PromoMessage.tsx
+++ b/src/components/chat/PromoMessage.tsx
@@ -26,7 +26,7 @@ export interface PromoMessageConfig {
 export const PROMO_MESSAGES: PromoMessageConfig[] = [
   {
     id: "pro-trial",
-    text: "Build more with Dyad Pro — free for 3 days.",
+    text: "Build more with Dyad Pro — free for 7 days.",
     cta: "Start Free Trial",
     target: { type: "trial-dialog" },
     weight: 3,


### PR DESCRIPTION
## Summary
- Update Pro trial offer to seven days
- Primary files: plans/promo-message-improvements.md, src/components/DyadProTrialDialog.tsx, src/components/SetupBanner.tsx, src/components/chat/PromoMessage.tsx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the trial code and marketing copy on conversion paths; a wrong or unsupported `7PRO30` code would break sign-ups until fixed on the academy/checkout side.
> 
> **Overview**
> Aligns in-app Pro trial messaging and checkout with a **7-day** offer by switching checkout links from `trialCode=1PRO30` to **`trialCode=7PRO30`** and updating user-facing copy from “3 days” to **“7 days.”**
> 
> **DyadProTrialDialog** and **SetupBanner** now send users to checkout with the new trial code. The streaming **PromoMessage** `pro-trial` line matches the same duration. The **promo-message-improvements** plan doc is updated so trial length, codes, and example URLs stay consistent with the app.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0f13333b090de75eee49fd9a3800d0124dd5f72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3824?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

