### PR TITLE
Stop integration tests from calling real Dyad APIs

### DIFF
--- a/src/ipc/handlers/__tests__/default_chat_mode.integration.test.tsx
+++ b/src/ipc/handlers/__tests__/default_chat_mode.integration.test.tsx
@@ -29,6 +29,9 @@ describe("default chat mode selector (integration)", () => {
       electronMock: h,
       autoApprove: true,
       chatMode: "local-agent",
+      // Dyad Pro settings trigger free-quota fetches; route them to the fake
+      // engine instead of the real engine.dyad.sh.
+      engine: true,
       settings: { isTestMode: true, ...DYAD_PRO_SETTINGS },
     });
   }, 60_000);

--- a/src/ipc/handlers/__tests__/local_agent_search_replace.integration.test.ts
+++ b/src/ipc/handlers/__tests__/local_agent_search_replace.integration.test.ts
@@ -25,6 +25,7 @@ describe("local agent search_replace (hybrid)", () => {
   beforeAll(async () => {
     harness = await setupHybridChatHarness({
       electronMock: h,
+      engine: true,
       chatMode: "local-agent",
       settings: {
         isTestMode: true,

--- a/src/ipc/handlers/__tests__/local_agent_step_limit.integration.test.ts
+++ b/src/ipc/handlers/__tests__/local_agent_step_limit.integration.test.ts
@@ -39,6 +39,7 @@ describe("local agent step limit (integration)", () => {
   beforeAll(async () => {
     harness = await setupHybridChatHarness({
       electronMock: h,
+      engine: true,
       chatMode: "local-agent",
       settings: {
         isTestMode: true,

--- a/src/ipc/handlers/__tests__/local_agent_supabase_deploy_progress.integration.test.ts
+++ b/src/ipc/handlers/__tests__/local_agent_supabase_deploy_progress.integration.test.ts
@@ -38,6 +38,7 @@ describe("local agent supabase deploy progress (integration)", () => {
   beforeAll(async () => {
     harness = await setupHybridChatHarness({
       electronMock: h,
+      engine: true,
       chatMode: "local-agent",
       settings: {
         isTestMode: true,

--- a/src/ipc/handlers/__tests__/voice_to_text.integration.test.tsx
+++ b/src/ipc/handlers/__tests__/voice_to_text.integration.test.tsx
@@ -26,6 +26,9 @@ describe("voice-to-text chat input controls (integration)", () => {
     harness = await setupHybridChatHarness({
       electronMock: h,
       autoApprove: true,
+      // Tests below enable Dyad Pro, which triggers free-quota fetches; route
+      // them to the fake engine instead of the real engine.dyad.sh.
+      engine: true,
       settings: { isTestMode: true },
     });
   }, 60_000);

--- a/src/ipc/handlers/pro_handlers.ts
+++ b/src/ipc/handlers/pro_handlers.ts
@@ -24,6 +24,14 @@ const logger = log.scope("pro_handlers");
 const handle = createLoggedHandler(logger);
 const typedHandle = createLoggedTypedHandler(logger);
 
+function getUserInfoUrl() {
+  // Overridable so tests point at the fake LLM server instead of the real API.
+  if (process.env.DYAD_USER_INFO_URL) {
+    return process.env.DYAD_USER_INFO_URL;
+  }
+  return "https://api.dyad.sh/v1/user/info";
+}
+
 export function registerProHandlers() {
   // This method should try to avoid throwing errors because this is auxiliary
   // information and isn't critical to using the app
@@ -51,7 +59,7 @@ export function registerProHandlers() {
       return null;
     }
 
-    const url = "https://api.dyad.sh/v1/user/info";
+    const url = getUserInfoUrl();
     const headers = {
       "Content-Type": "application/json",
       Authorization: `Bearer ${apiKey}`,

--- a/src/testing/chat_flow_harness.ts
+++ b/src/testing/chat_flow_harness.ts
@@ -71,6 +71,7 @@ const HARNESS_ENV_KEYS = [
   "DYAD_LANGUAGE_MODEL_CATALOG_URL",
   "DYAD_ENGINE_URL",
   "DYAD_GATEWAY_URL",
+  "DYAD_USER_INFO_URL",
 ] as const;
 
 function snapshotHarnessEnv(): Map<string, string | undefined> {
@@ -250,6 +251,10 @@ export async function setupChatFlowHarness(
     if (options.useFakeCatalog !== false) {
       process.env.DYAD_LANGUAGE_MODEL_CATALOG_URL = `${fakeLlmUrl}/api/language-model-catalog`;
     }
+    // Always fake the Dyad Pro user-info endpoint: any test that configures an
+    // auto API key would otherwise send get-user-budget requests to the real
+    // api.dyad.sh.
+    process.env.DYAD_USER_INFO_URL = `${fakeLlmUrl}/api/user/info`;
     if (options.engine) {
       process.env.DYAD_ENGINE_URL = `${fakeLlmUrl}/engine/v1`;
       process.env.DYAD_GATEWAY_URL = `${fakeLlmUrl}/gateway/v1`;

--- a/testing/fake-llm-server/index.ts
+++ b/testing/fake-llm-server/index.ts
@@ -246,6 +246,22 @@ export function createFakeLlmApp(getPort: () => number) {
       );
   });
 
+  // Fake api.dyad.sh user info (Dyad Pro budget). Tests point
+  // DYAD_USER_INFO_URL here so get-user-budget never hits the real API.
+  app.get("/api/user/info", (req, res) => {
+    if (!req.headers.authorization?.startsWith("Bearer ")) {
+      res.status(401).json({ error: "Unauthorized" });
+      return;
+    }
+    res.json({
+      usedCredits: 100,
+      totalCredits: 1000,
+      budgetResetDate: "2099-01-01T00:00:00.000Z",
+      userId: "user_fake1234",
+      isTrial: false,
+    });
+  });
+
   app.get("/api/language-model-catalog", (req, res) => {
     res.json({
       version: "e2e-test-catalog-v1",
@@ -597,6 +613,20 @@ export function createFakeLlmApp(getPort: () => number) {
 
   // GitHub Git endpoints - intercept all paths with /github/git prefix
   app.all("/github/git/*", handleGitPush);
+
+  // Dyad Engine free-model quota endpoint (free_model_quota_handlers).
+  app.get("/engine/v1/free/quota", (req, res) => {
+    if (!req.headers.authorization?.startsWith("Bearer ")) {
+      res.status(401).json({ error: "Unauthorized" });
+      return;
+    }
+    res.json({
+      used: 5,
+      limit: 25,
+      remaining: 20,
+      resetAt: "2099-01-01T00:00:00.000Z",
+    });
+  });
 
   // Dyad Engine code-search endpoint for code_search tool
   app.post("/engine/v1/tools/code-search", (req, res) => {


### PR DESCRIPTION
## Summary
- Integration tests were silently making live network requests on every run: 94 calls to the hardcoded `https://api.dyad.sh/v1/user/info`, plus free-quota fetches that either 404ed on the fake engine (route missing) or hit the real `engine.dyad.sh` (Pro-enabled tests missing `engine: true`).
- `pro_handlers` gets a call-time `DYAD_USER_INFO_URL` override — deliberately the same per-endpoint pattern as `DYAD_LANGUAGE_MODEL_CATALOG_URL`/`DYAD_DESKTOP_CONFIG_URL` rather than a general API-base-URL refactor. The chat-flow harness points it at the fake server unconditionally, since any test with an auto API key can trigger budget fetches.
- The fake server serves `/api/user/info` and `/engine/v1/free/quota` with deterministic payloads (401 without a Bearer token, fixed reset dates so nothing is time-sensitive), and the five Pro-enabled tests that leaked engine traffic now pass `engine: true` like every other Pro test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and dev harness changes only; production default URLs are unchanged when env vars are unset.
> 
> **Overview**
> Integration tests were hitting **live** `api.dyad.sh` (user budget) and sometimes **real or incomplete** engine URLs (free-model quota). This PR wires those calls through the existing fake LLM server instead.
> 
> **`get-user-budget`** now resolves its URL via **`DYAD_USER_INFO_URL`** (same per-endpoint override pattern as the language-model catalog). The chat-flow harness **always** sets that env var to the fake server’s `/api/user/info`, so any test with an auto API key no longer phones home.
> 
> The fake server adds **`GET /api/user/info`** (Bearer-gated mock budget) and **`GET /engine/v1/free/quota`** (deterministic quota). Five Pro-enabled hybrid tests that were missing engine routing now pass **`engine: true`** so free-quota fetches use the fake engine base URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e449b2cff491a065a7fee875f7b4bcbd28852ac8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

