### PR TITLE
Add OpenRouter free auto fallback

### DIFF
--- a/src/ipc/utils/get_model_client.test.ts
+++ b/src/ipc/utils/get_model_client.test.ts
@@ -134,7 +134,7 @@ describe("getModelClient", () => {
     ]);
   });
 
-  test("uses OpenRouter free alias as regular auto fallback only outside Dyad Pro", async () => {
+  test("adds OpenRouter free as a regular auto fallback only outside Dyad Pro", async () => {
     const { modelClient, isEngineEnabled } = await getModelClient(
       {
         provider: "auto",
@@ -152,9 +152,16 @@ describe("getModelClient", () => {
       } as unknown as UserSettings,
     );
 
-    expect((modelClient.model as { modelId: string }).modelId).toBe(
+    const fallbackModels = (
+      modelClient.model as unknown as {
+        settings: { models: Array<{ modelId: string }> };
+      }
+    ).settings.models;
+
+    expect(fallbackModels.map((model) => model.modelId)).toEqual([
       "nvidia/nemotron-3-super-120b-a12b:free",
-    );
+      "openrouter/free",
+    ]);
     expect(modelClient.builtinProviderId).toBe("openrouter");
     expect(isEngineEnabled).toBeFalsy();
   });

--- a/src/ipc/utils/get_model_client.ts
+++ b/src/ipc/utils/get_model_client.ts
@@ -59,6 +59,8 @@ const AUTO_MODEL_ALIASES = [
   "dyad/auto/openrouter",
 ] as const;
 
+const OPENROUTER_FREE_MODEL_NAME = "openrouter/free";
+
 export interface ModelClient {
   model: LanguageModel;
   builtinProviderId?: string;
@@ -82,6 +84,9 @@ export async function getModelClient(
         "Dyad",
       )
     : undefined;
+  const isDyadProEnabledForRequest = Boolean(
+    dyadApiKey && settings.enableDyadPro,
+  );
 
   // --- Handle specific provider ---
   const providerConfig = allProviders.find((p) => p.id === model.provider);
@@ -101,7 +106,7 @@ export async function getModelClient(
   }
 
   // Handle Dyad Pro override
-  if (dyadApiKey && settings.enableDyadPro) {
+  if (isDyadProEnabledForRequest) {
     const dyadEngineUrl = process.env.DYAD_ENGINE_URL;
     // Check if the selected provider supports Dyad Pro (has a gateway prefix) OR
     // we're using local engine.
@@ -204,6 +209,20 @@ export async function getModelClient(
         logger.log(
           `Using provider: ${resolvedModel.providerId} model: ${resolvedModel.apiName}`,
         );
+        if (
+          resolvedModel.providerId === "openrouter" &&
+          !isDyadProEnabledForRequest &&
+          providerInfo
+        ) {
+          return {
+            modelClient: getOpenRouterAutoFallbackModelClient({
+              primaryModelName: resolvedModel.apiName,
+              settings,
+              providerConfig: providerInfo,
+            }),
+            isEngineEnabled: false,
+          };
+        }
         // Recursively call with the specific model found
         return await getModelClient(
           {
@@ -220,6 +239,34 @@ export async function getModelClient(
     );
   }
   return getRegularModelClient(model, settings, providerConfig);
+}
+
+function getOpenRouterAutoFallbackModelClient({
+  primaryModelName,
+  settings,
+  providerConfig,
+}: {
+  primaryModelName: string;
+  settings: UserSettings;
+  providerConfig: LanguageModelProvider;
+}): ModelClient {
+  const modelNames = Array.from(
+    new Set([primaryModelName, OPENROUTER_FREE_MODEL_NAME]),
+  );
+
+  return {
+    model: createFallback({
+      models: modelNames.map(
+        (name) =>
+          getRegularModelClient(
+            { provider: "openrouter", name },
+            settings,
+            providerConfig,
+          ).modelClient.model,
+      ),
+    }),
+    builtinProviderId: "openrouter",
+  };
 }
 
 async function getProModelClient({


### PR DESCRIPTION
Summary:
- Adds openrouter/free as a fallback after Nemotron for non-Dyad Pro auto OpenRouter selection.
- Keeps Dyad Pro local-agent auto fallback limited to OpenAI, Anthropic, and Google.

Tests:
- npm test -- src/ipc/utils/get_model_client.test.ts
- npm test -- src/ipc/handlers/app_collection_handlers.test.ts
- PR push script ran npm run fmt, npm run lint:fix, and npm run ts. Full npm test is locally blocked by better-sqlite3 native binding ABI flapping during the parallel full suite after npm rebuild better-sqlite3.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which LLM is used for a common auto path and adds runtime fallback behavior, but scope is limited to non–Dyad Pro OpenRouter auto resolution in get_model_client.
> 
> **Overview**
> For **auto** mode when the user has an OpenRouter key but **not** Dyad Pro, selection no longer stops at a single resolved model (Nemotron). It now builds a **`createFallback`** chain: the catalog primary (`nvidia/nemotron-3-super-120b-a12b:free`) first, then **`openrouter/free`**, so failures can roll to OpenRouter’s free alias.
> 
> Dyad Pro routing is unchanged: local-agent auto still falls back only across OpenAI, Anthropic, and Google via **`AUTO_DYAD_PRO_MODEL_ALIASES`**. The Pro gate is refactored to a shared **`isDyadProEnabledForRequest`** flag used for both engine routing and the new OpenRouter branch.
> 
> Tests assert the two-step fallback list and that the engine stays off for this path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e18bae8f14bde52776a97a7dd6a83ed62a56242. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

