### PR TITLE
[codex] Use clang for Linux release rebuilds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,11 @@ jobs:
         env:
           # Required for @vscode/ripgrep to download binaries without hitting GitHub API rate limits
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Use clang for Linux native rebuilds
+        if: matrix.os.name == 'linux'
+        run: |
+          echo "CC=clang" >> "$GITHUB_ENV"
+          echo "CXX=clang++" >> "$GITHUB_ENV"
       - name: add macos cert
         if: contains(matrix.os.name, 'macos')
         env:


### PR DESCRIPTION
## Summary
- Configure the Linux release build to use clang and clang++ for native module rebuilds.
- Leaves macOS and Windows release jobs unchanged.

## Why
The release workflow is failing on Ubuntu while rebuilding better-sqlite3 against Electron 43 headers with GCC. Using clang may avoid the V8 header parsing failure in the native rebuild step.

## Testing
Not run per request.

#skip-bugbot

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow tweak with no runtime or application code changes; assumes clang is available on the Ubuntu runner image.
> 
> **Overview**
> Adds a **Linux-only** step in the release build job that exports `CC=clang` and `CXX=clang++` via `GITHUB_ENV` after `npm ci` and before the Electron Forge dry-run publish.
> 
> That steers native rebuilds (e.g. **better-sqlite3** against Electron headers) away from GCC on Ubuntu, which the PR targets as the cause of release failures. macOS and Windows matrix jobs are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81f4bbbf2f42048871f8222e638e83f5e74db6ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->