### PR TITLE
[codex] Use clang 18 for Linux release rebuilds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,11 +63,18 @@ jobs:
         env:
           # Required for @vscode/ripgrep to download binaries without hitting GitHub API rate limits
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Use clang for Linux native rebuilds
+      - name: Use clang 18 for Linux native rebuilds
         if: matrix.os.name == 'linux'
         run: |
-          echo "CC=clang" >> "$GITHUB_ENV"
-          echo "CXX=clang++" >> "$GITHUB_ENV"
+          sudo install -d -m 0755 /etc/apt/keyrings
+          wget -qO /tmp/llvm-snapshot.gpg.key https://apt.llvm.org/llvm-snapshot.gpg.key
+          gpg --dearmor /tmp/llvm-snapshot.gpg.key
+          sudo install -m 0644 /tmp/llvm-snapshot.gpg.key.gpg /etc/apt/keyrings/apt.llvm.org.gpg
+          echo "deb [signed-by=/etc/apt/keyrings/apt.llvm.org.gpg] https://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main" | sudo tee /etc/apt/sources.list.d/llvm-toolchain-jammy-18.list
+          sudo apt-get update
+          sudo apt-get install -y clang-18
+          echo "CC=clang-18" >> "$GITHUB_ENV"
+          echo "CXX=clang++-18" >> "$GITHUB_ENV"
       - name: add macos cert
         if: contains(matrix.os.name, 'macos')
         env:


### PR DESCRIPTION
## Summary
- Install clang 18 from apt.llvm.org for the Linux release build.
- Use clang-18 and clang++-18 for Linux native module rebuilds.
- Keep the release runner on Ubuntu 22.04 to preserve the Linux glibc baseline.

## Why
The previous clang attempt confirmed the compiler changed, but Ubuntu 22.04's preinstalled clang 15 still failed Electron 43's V8 headers because std::source_location was unavailable. A newer clang should handle that C++20 header path while avoiding a runner upgrade to Ubuntu 24.04.

## Testing
Not run per request.

#skip-bugbot

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only release workflow change with no application runtime or auth/data impact; main risk is build flakiness if apt.llvm.org or install steps fail.
> 
> **Overview**
> Updates the **Linux** release job so native module rebuilds use **clang 18** instead of the runner’s default **clang 15**.
> 
> The workflow step now adds the LLVM apt repo for Ubuntu 22.04 (jammy), installs `clang-18`, and sets `CC`/`CXX` to `clang-18` and `clang++-18`. The matrix still uses **ubuntu-22.04**, so the glibc baseline is unchanged; only the compiler toolchain for Electron/V8 C++20 builds is upgraded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8bedad93d44b29d322e79eaed913cf3c1cc6f0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->