### PR TITLE
Experiment : Add Design mode for generating interface mockups using an image generation model

### DIFF
--- a/e2e-tests/design_mode.spec.ts
+++ b/e2e-tests/design_mode.spec.ts
@@ -1,0 +1,42 @@
+import { expect } from "@playwright/test";
+import { Timeout, testSkipIfWindows } from "./helpers/test_helper";
+
+/**
+ * E2E test for Design mode: selecting the mode, running the design flow via the
+ * write_design_spec tool, and rendering the Design preview panel with the
+ * design system and interface cards.
+ */
+testSkipIfWindows(
+  "design mode - renders design spec in panel",
+  async ({ po }) => {
+    // Design mode is Pro-only (image generation requires a Dyad Pro key).
+    await po.setUpDyadPro({ localAgent: true });
+    await po.importApp("minimal");
+    await po.chatActions.clickNewChat();
+
+    await po.chatActions.selectChatMode("design");
+
+    await po.sendPrompt("tc=local-agent/design", {
+      skipWaitForCompletion: true,
+    });
+
+    // The inline chat card for the written design appears.
+    await expect(
+      po.page.getByRole("button", { name: "View Design" }).last(),
+    ).toBeVisible({ timeout: Timeout.MEDIUM });
+
+    // The Design preview panel auto-opens and shows the design system + screens.
+    const designPanel = po.page.getByTestId("design-panel");
+    await expect(designPanel).toBeVisible({ timeout: Timeout.MEDIUM });
+    await expect(designPanel).toContainText("Test Design");
+    await expect(designPanel).toContainText("Design system");
+    await expect(designPanel).toContainText("#4F46E5");
+    await expect(designPanel).toContainText("Home screen");
+    await expect(designPanel).toContainText("Settings screen");
+
+    // Each interface offers a Regenerate action.
+    await expect(po.page.getByTestId("regenerate-interface-home")).toBeVisible({
+      timeout: Timeout.MEDIUM,
+    });
+  },
+);

--- a/e2e-tests/fixtures/engine/local-agent/design.ts
+++ b/e2e-tests/fixtures/engine/local-agent/design.ts
@@ -1,0 +1,51 @@
+import type { LocalAgentFixture } from "../../../../testing/fake-llm-server/localAgentTypes";
+
+export const fixture: LocalAgentFixture = {
+  description: "Record a design spec using the write_design_spec tool",
+  turns: [
+    {
+      text: "Here's a design system and the key screens for your app.",
+      toolCalls: [
+        {
+          name: "write_design_spec",
+          args: {
+            title: "Test Design",
+            summary: "A calm, minimal design for E2E testing.",
+            designSystem: {
+              mood: "calm, minimal, trustworthy",
+              colors: [
+                { name: "Primary", hex: "#4F46E5" },
+                { name: "Background", hex: "#0B1020" },
+              ],
+              typography: {
+                heading: "Inter 600",
+                body: "Inter 400",
+              },
+              spacing: "8px grid, rounded-xl corners",
+            },
+            interfaces: [
+              {
+                id: "home",
+                name: "Home screen",
+                purpose: "See today's overview at a glance",
+                prompt:
+                  "A minimal home dashboard with a vertical list of cards, calm indigo accents on a near-black background.",
+                copy: "Today · 3 of 5 done",
+              },
+              {
+                id: "settings",
+                name: "Settings screen",
+                purpose: "Adjust preferences",
+                prompt:
+                  "A clean settings screen with grouped rows and toggles, consistent with the home screen's design system.",
+              },
+            ],
+          },
+        },
+      ],
+    },
+    {
+      text: "I've recorded the design. You can review the screens in the Design panel.",
+    },
+  ],
+};

--- a/e2e-tests/helpers/page-objects/components/ChatActions.ts
+++ b/e2e-tests/helpers/page-objects/components/ChatActions.ts
@@ -193,7 +193,14 @@ export class ChatActions {
   }
 
   async selectChatMode(
-    mode: "build" | "ask" | "agent" | "local-agent" | "basic-agent" | "plan",
+    mode:
+      | "build"
+      | "ask"
+      | "agent"
+      | "local-agent"
+      | "basic-agent"
+      | "plan"
+      | "design",
   ) {
     await this.page.getByTestId("chat-mode-selector").click();
     const mapping: Record<string, string> = {
@@ -203,6 +210,7 @@ export class ChatActions {
       "local-agent": "Agent v2",
       "basic-agent": "Basic Agent", // For free users
       plan: "Plan.*Design before you build",
+      design: "Design.*Generate your app's screens",
     };
     const optionName = mapping[mode];
     await this.page

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,6 +12,7 @@ import { useSettings } from "@/hooks/useSettings";
 import { DEFAULT_ZOOM_LEVEL } from "@/lib/schemas";
 import { selectedComponentsPreviewAtom } from "@/atoms/previewAtoms";
 import { usePlanEvents } from "@/hooks/usePlanEvents";
+import { useDesignEvents } from "@/hooks/useDesignEvents";
 import { useIntegrationEvents } from "@/hooks/useIntegrationEvents";
 import { useAppBlueprintEvents } from "@/hooks/useAppBlueprintEvents";
 import { useZoomShortcuts } from "@/hooks/useZoomShortcuts";
@@ -38,6 +39,8 @@ export default function RootLayout({ children }: { children: ReactNode }) {
 
   // Initialize plan events listener
   usePlanEvents();
+  // Initialize design events listener
+  useDesignEvents();
   useIntegrationEvents();
 
   // Initialize app blueprint events listener

--- a/src/atoms/appAtoms.ts
+++ b/src/atoms/appAtoms.ts
@@ -8,7 +8,8 @@ export type PreviewMode =
   | "configure"
   | "publish"
   | "security"
-  | "plan";
+  | "plan"
+  | "design";
 
 export const previewModeAtom = atom<PreviewMode>("preview");
 export const selectedVersionIdAtom = atom<string | null>(null);

--- a/src/atoms/chatAtoms.ts
+++ b/src/atoms/chatAtoms.ts
@@ -516,6 +516,9 @@ export const agentTodosByChatIdAtom = atom<Map<number, AgentTodo[]>>(new Map());
 // Flag: set when user switches to plan mode from another mode in a chat with messages
 export const needsFreshPlanChatAtom = atom<boolean>(false);
 
+// Flag: set when user switches to design mode from another mode in a chat with messages
+export const needsFreshDesignChatAtom = atom<boolean>(false);
+
 // Queued messages (multiple messages per chat, sent in sequence after streams complete)
 export interface QueuedMessageItem {
   id: string; // UUID for stable identification during reordering/editing

--- a/src/atoms/designAtoms.ts
+++ b/src/atoms/designAtoms.ts
@@ -1,0 +1,29 @@
+import { atom } from "jotai";
+import type { DesignSpec } from "@/ipc/types/design";
+
+export interface DesignState {
+  /** The latest design spec per chat, keyed by chatId. */
+  specsByChatId: Map<number, DesignSpec>;
+}
+
+export const designStateAtom = atom<DesignState>({
+  specsByChatId: new Map(),
+});
+
+/**
+ * Interface ids (keyed by chatId) currently being regenerated, so the Design
+ * panel can show a per-card spinner until the next design:update arrives.
+ */
+export const regeneratingInterfacesAtom = atom<Map<number, Set<string>>>(
+  new Map(),
+);
+
+export function setDesignSpec(
+  prev: DesignState,
+  chatId: number,
+  spec: DesignSpec,
+): DesignState {
+  const next = new Map(prev.specsByChatId);
+  next.set(chatId, spec);
+  return { ...prev, specsByChatId: next };
+}

--- a/src/components/ChatModeSelector.tsx
+++ b/src/components/ChatModeSelector.tsx
@@ -31,7 +31,7 @@ import {
   chatMessagesByIdAtom,
   hasManuallySelectedChatModeAtom,
 } from "@/atoms/chatAtoms";
-import { Hammer, Bot, MessageCircle, Lightbulb } from "lucide-react";
+import { Hammer, Bot, MessageCircle, Lightbulb, Palette } from "lucide-react";
 import { useEffect, useRef } from "react";
 import {
   FREE_PRO_MODEL_FALLBACK_CHAT_MODE,
@@ -87,6 +87,7 @@ export function ChatModeSelector() {
       effectiveMode,
       isPro: isProEnabled,
       toastId: toastKey,
+      reason: fallbackReason,
     });
   }, [chatId, effectiveMode, fallbackReason, isProEnabled, storedChatMode]);
 
@@ -157,6 +158,8 @@ export function ChatModeSelector() {
         return <Bot size={14} />;
       case "plan":
         return <Lightbulb size={14} />;
+      case "design":
+        return <Palette size={14} />;
       default:
         return <Hammer size={14} />;
     }
@@ -183,7 +186,9 @@ export function ChatModeSelector() {
                       ? "bg-purple-500/10 text-purple-600 hover:bg-purple-500/15 dark:bg-purple-500/15 dark:text-purple-400 dark:hover:bg-purple-500/20"
                       : selectedMode === "plan"
                         ? "bg-blue-500/10 text-blue-600 hover:bg-blue-500/15 dark:bg-blue-500/15 dark:text-blue-400 dark:hover:bg-blue-500/20"
-                        : "text-foreground/80 hover:text-foreground hover:bg-muted/60",
+                        : selectedMode === "design"
+                          ? "bg-pink-500/10 text-pink-600 hover:bg-pink-500/15 dark:bg-pink-500/15 dark:text-pink-400 dark:hover:bg-pink-500/20"
+                          : "text-foreground/80 hover:text-foreground hover:bg-muted/60",
                 )}
                 size="sm"
               />
@@ -225,6 +230,19 @@ export function ChatModeSelector() {
               </span>
             </div>
           </SelectItem>
+          {isProEnabled && (
+            <SelectItem value="design">
+              <div className="flex flex-col items-start">
+                <div className="flex items-center gap-1.5">
+                  <Palette size={14} className="text-pink-500" />
+                  <span className="font-medium">Design</span>
+                </div>
+                <span className="text-xs text-muted-foreground ml-[22px]">
+                  Generate your app's screens as images
+                </span>
+              </div>
+            </SelectItem>
+          )}
           {!isProEnabled && (
             <SelectItem value="local-agent" disabled={isQuotaExceeded}>
               <div className="flex flex-col items-start">

--- a/src/components/DefaultChatModeSelector.tsx
+++ b/src/components/DefaultChatModeSelector.tsx
@@ -67,6 +67,8 @@ export function DefaultChatModeSelector() {
         return "Ask";
       case "plan":
         return "Plan";
+      case "design":
+        return "Design";
       default:
         throw new Error(`Unknown chat mode: ${mode}`);
     }

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -33,6 +33,7 @@ import {
   type PendingToolConsent,
   agentTodosByChatIdAtom,
   needsFreshPlanChatAtom,
+  needsFreshDesignChatAtom,
 } from "@/atoms/chatAtoms";
 import { atom, useAtom, useSetAtom, useAtomValue } from "jotai";
 import { useStreamChat } from "@/hooks/useStreamChat";
@@ -332,6 +333,9 @@ export function ChatInput({ chatId }: { chatId?: number }) {
   const [needsFreshPlanChat, setNeedsFreshPlanChat] = useAtom(
     needsFreshPlanChatAtom,
   );
+  const [needsFreshDesignChat, setNeedsFreshDesignChat] = useAtom(
+    needsFreshDesignChatAtom,
+  );
 
   // Detect transition to plan mode from another mode in a chat with messages
   const prevModeRef = useRef(chatMode);
@@ -359,12 +363,20 @@ export function ChatInput({ chatId }: { chatId?: number }) {
         setNeedsFreshPlanChat(true);
       }
     }
+
+    if (prevMode && prevMode !== "design" && currentMode === "design") {
+      const messages = chatId ? (messagesById.get(chatId) ?? []) : [];
+      if (messages.length > 0) {
+        setNeedsFreshDesignChat(true);
+      }
+    }
   }, [
     chatMode,
     chatId,
     isChatModeLoading,
     messagesById,
     setNeedsFreshPlanChat,
+    setNeedsFreshDesignChat,
   ]);
 
   // Token counting for context limit banner
@@ -595,6 +607,34 @@ export function ChatInput({ chatId }: { chatId?: number }) {
         attachments,
         redo: false,
         requestedChatMode: "plan",
+      });
+      clearAttachments();
+      posthog.capture("chat:submit", { chatMode });
+      return;
+    }
+
+    // If switching to design mode from another mode in a chat with messages,
+    // create a new chat for a clean design session.
+    if (needsFreshDesignChat && chatMode === "design" && appId) {
+      clearComposerAfterSubmit();
+      setNeedsFreshDesignChat(false);
+
+      const newChatId = await ipc.chat.createChat({
+        appId,
+        initialChatMode: "design",
+      });
+      setSelectedChatId(newChatId);
+      navigate({ to: "/chat", search: { id: newChatId } });
+      queryClient.invalidateQueries({ queryKey: queryKeys.chats.all });
+      showInfo("We've switched you to a new chat for a clean design session");
+
+      void openPreviewIfSetupRequired(appId);
+      await streamMessage({
+        prompt: promptWithImages,
+        chatId: newChatId,
+        attachments,
+        redo: false,
+        requestedChatMode: "design",
       });
       clearAttachments();
       posthog.capture("chat:submit", { chatMode });

--- a/src/components/chat/DyadMarkdownParser.tsx
+++ b/src/components/chat/DyadMarkdownParser.tsx
@@ -54,6 +54,7 @@ import { DyadNeonProjectInfo } from "./DyadNeonProjectInfo";
 import { DyadStatus } from "./DyadStatus";
 import { DyadCompaction } from "./DyadCompaction";
 import { DyadWritePlan } from "./DyadWritePlan";
+import { DyadWriteDesign } from "./DyadWriteDesign";
 import { DyadExitPlan } from "./DyadExitPlan";
 import { DyadQuestionnaire } from "./DyadQuestionnaire";
 import { DyadStepLimit } from "./DyadStepLimit";
@@ -1063,6 +1064,22 @@ function renderCustomTag(
         >
           {content}
         </DyadWritePlan>
+      );
+
+    case "dyad-write-design":
+      return (
+        <DyadWriteDesign
+          node={{
+            properties: {
+              title: attributes.title || "Design",
+              interfaces: attributes.interfaces,
+              complete: attributes.complete,
+              state: getState({ isStreaming, inProgress }),
+            },
+          }}
+        >
+          {content}
+        </DyadWriteDesign>
       );
 
     case "dyad-exit-plan":

--- a/src/components/chat/DyadWriteDesign.tsx
+++ b/src/components/chat/DyadWriteDesign.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { Palette, Eye, Loader2 } from "lucide-react";
+import { useSetAtom } from "jotai";
+import { previewModeAtom } from "@/atoms/appAtoms";
+import { isPreviewOpenAtom } from "@/atoms/viewAtoms";
+import { CustomTagState } from "./stateTypes";
+
+interface DyadWriteDesignProps {
+  node: {
+    properties: {
+      title: string;
+      interfaces?: string;
+      complete?: string;
+      state?: CustomTagState;
+    };
+  };
+  children?: React.ReactNode;
+}
+
+export const DyadWriteDesign: React.FC<DyadWriteDesignProps> = ({ node }) => {
+  const { title, interfaces, complete, state } = node.properties;
+  const setPreviewMode = useSetAtom(previewModeAtom);
+  const setIsPreviewOpen = useSetAtom(isPreviewOpenAtom);
+
+  const isInProgress = state === "pending" || complete === "false";
+  const interfaceCount = interfaces ? Number(interfaces) : undefined;
+
+  return (
+    <div
+      className={`my-4 border rounded-lg overflow-hidden ${
+        isInProgress ? "border-pink-500/60" : "border-pink-500/20"
+      } bg-pink-500/5`}
+    >
+      <div className="px-4 py-3 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Palette
+            className={`text-pink-500 ${isInProgress ? "animate-pulse" : ""}`}
+            size={20}
+          />
+          <div className="flex items-center gap-2">
+            <span className="font-semibold text-foreground">{title}</span>
+            {interfaceCount != null && !Number.isNaN(interfaceCount) && (
+              <span className="text-xs text-muted-foreground">
+                {interfaceCount} interface{interfaceCount === 1 ? "" : "s"}
+              </span>
+            )}
+          </div>
+        </div>
+        <div className="flex items-center">
+          {!isInProgress ? (
+            <button
+              type="button"
+              onClick={() => {
+                setPreviewMode("design");
+                setIsPreviewOpen(true);
+              }}
+              className="flex items-center gap-1.5 text-xs font-medium text-white px-4 py-1.5 bg-pink-500 rounded-md hover:bg-pink-500/90 transition-colors"
+            >
+              <Eye size={14} />
+              View Design
+            </button>
+          ) : (
+            <span className="flex items-center gap-1.5 text-xs text-pink-600 dark:text-pink-400 px-3 py-1 bg-pink-500/20 rounded-md font-medium">
+              <Loader2 size={12} className="animate-spin" />
+              Designing...
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/preview_panel/DesignPanel.tsx
+++ b/src/components/preview_panel/DesignPanel.tsx
@@ -1,0 +1,304 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import { Palette, RefreshCw, ImageIcon, ChevronDown } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { previewModeAtom, selectedAppIdAtom } from "@/atoms/appAtoms";
+import { selectedChatIdAtom } from "@/atoms/chatAtoms";
+import {
+  designStateAtom,
+  regeneratingInterfacesAtom,
+} from "@/atoms/designAtoms";
+import { useDesign } from "@/hooks/useDesign";
+import { useStreamChat } from "@/hooks/useStreamChat";
+import { useLoadApp } from "@/hooks/useLoadApp";
+import { buildDyadMediaUrlFromRelativePath } from "@/lib/dyadMediaUrl";
+import { ImageLightbox } from "@/components/chat/ImageLightbox";
+import type { DesignInterface, DesignSystem } from "@/ipc/types/design";
+import { cn } from "@/lib/utils";
+
+export const DesignPanel: React.FC = () => {
+  const chatId = useAtomValue(selectedChatIdAtom);
+  const appId = useAtomValue(selectedAppIdAtom);
+  const designState = useAtomValue(designStateAtom);
+  const [previewMode, setPreviewMode] = useAtom(previewModeAtom);
+  const regeneratingByChat = useAtomValue(regeneratingInterfacesAtom);
+  const { app } = useLoadApp(appId);
+  const appPath = app?.resolvedPath ?? app?.path ?? "";
+
+  // Load a persisted spec from disk if it isn't already in memory.
+  useDesign();
+
+  const spec = chatId ? designState.specsByChatId.get(chatId) : null;
+  const regenerating = useMemo(
+    () =>
+      chatId
+        ? (regeneratingByChat.get(chatId) ?? new Set<string>())
+        : new Set<string>(),
+    [chatId, regeneratingByChat],
+  );
+
+  // If there's no design spec, fall back to the app preview.
+  useEffect(() => {
+    if (!spec && previewMode === "design") {
+      setPreviewMode("preview");
+    }
+  }, [spec, previewMode, setPreviewMode]);
+
+  if (!spec) {
+    return null;
+  }
+
+  return (
+    <div className="h-full overflow-y-auto p-4" data-testid="design-panel">
+      <div className="mx-auto max-w-3xl space-y-6">
+        <header className="flex items-start gap-2">
+          <Palette className="mt-0.5 text-pink-500" size={20} />
+          <div>
+            <h2 className="text-lg font-semibold">{spec.title}</h2>
+            {spec.summary && (
+              <p className="text-sm text-muted-foreground mt-0.5">
+                {spec.summary}
+              </p>
+            )}
+          </div>
+        </header>
+
+        <DesignSystemSection designSystem={spec.designSystem} />
+
+        <section className="space-y-3">
+          <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
+            Interfaces ({spec.interfaces.length})
+          </h3>
+          <div className="grid grid-cols-1 gap-4">
+            {spec.interfaces.map((iface) => (
+              <InterfaceCard
+                key={iface.id}
+                iface={iface}
+                appPath={appPath}
+                isRegenerating={regenerating.has(iface.id)}
+              />
+            ))}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+function DesignSystemSection({ designSystem }: { designSystem: DesignSystem }) {
+  return (
+    <section className="border rounded-lg bg-card p-4 space-y-4">
+      <div className="flex items-center gap-2">
+        <h3 className="text-sm font-semibold">Design system</h3>
+        <span className="text-xs text-muted-foreground">
+          {designSystem.mood}
+        </span>
+      </div>
+
+      {designSystem.colors.length > 0 && (
+        <div className="flex flex-wrap gap-3">
+          {designSystem.colors.map((color, i) => (
+            <div key={`${color.name}-${i}`} className="flex items-center gap-2">
+              <span
+                className="h-8 w-8 rounded-md border shadow-sm shrink-0"
+                style={{ backgroundColor: color.hex }}
+                title={`${color.name} ${color.hex}`}
+              />
+              <div className="text-xs leading-tight">
+                <div className="font-medium">{color.name}</div>
+                <div className="text-muted-foreground font-mono">
+                  {color.hex}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
+        <div>
+          <div className="text-xs font-medium text-muted-foreground">
+            Headings
+          </div>
+          <div>{designSystem.typography.heading}</div>
+        </div>
+        <div>
+          <div className="text-xs font-medium text-muted-foreground">Body</div>
+          <div>{designSystem.typography.body}</div>
+        </div>
+        {designSystem.typography.notes && (
+          <div className="sm:col-span-2 text-muted-foreground">
+            {designSystem.typography.notes}
+          </div>
+        )}
+        {designSystem.spacing && (
+          <div className="sm:col-span-2">
+            <div className="text-xs font-medium text-muted-foreground">
+              Spacing &amp; layout
+            </div>
+            <div>{designSystem.spacing}</div>
+          </div>
+        )}
+        {designSystem.notes && (
+          <div className="sm:col-span-2 text-muted-foreground">
+            {designSystem.notes}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function InterfaceCard({
+  iface,
+  appPath,
+  isRegenerating,
+}: {
+  iface: DesignInterface;
+  appPath: string;
+  isRegenerating: boolean;
+}) {
+  const chatId = useAtomValue(selectedChatIdAtom);
+  const setRegeneratingByChat = useSetAtom(regeneratingInterfacesAtom);
+  const { streamMessage, isStreaming } = useStreamChat();
+  const [showDetails, setShowDetails] = useState(false);
+  const [isLightboxOpen, setIsLightboxOpen] = useState(false);
+  const [imageError, setImageError] = useState(false);
+
+  const imageUrl = iface.imagePath
+    ? buildDyadMediaUrlFromRelativePath(appPath, iface.imagePath)
+    : "";
+  const absolutePath =
+    appPath && iface.imagePath ? `${appPath}/${iface.imagePath}` : undefined;
+  const canView = !!imageUrl && !imageError;
+
+  const handleRegenerate = () => {
+    if (!chatId || isStreaming) return;
+    setRegeneratingByChat((prev) => {
+      const next = new Map(prev);
+      const set = new Set(next.get(chatId) ?? []);
+      set.add(iface.id);
+      next.set(chatId, set);
+      return next;
+    });
+    streamMessage({
+      chatId,
+      requestedChatMode: "design",
+      prompt: `Please regenerate the image for the "${iface.name}" interface, keeping it consistent with the design system. Call generate_image again for this screen, then update the design spec (write_design_spec) with the new imagePath.`,
+    });
+  };
+
+  return (
+    <div className="border rounded-lg bg-card overflow-hidden">
+      <div className="flex flex-col sm:flex-row">
+        <button
+          type="button"
+          onClick={() => canView && setIsLightboxOpen(true)}
+          className={cn(
+            "relative bg-muted flex items-center justify-center shrink-0 sm:w-56 h-40 sm:h-auto",
+            canView ? "cursor-zoom-in" : "cursor-default",
+          )}
+          aria-label={canView ? `View ${iface.name}` : iface.name}
+        >
+          {canView ? (
+            <img
+              src={imageUrl}
+              alt={iface.name}
+              className="h-full w-full object-cover"
+              onError={() => setImageError(true)}
+            />
+          ) : (
+            <div className="flex flex-col items-center gap-2 text-muted-foreground text-xs">
+              {isRegenerating ? (
+                <>
+                  <RefreshCw size={20} className="animate-spin" />
+                  <span>Generating…</span>
+                </>
+              ) : (
+                <>
+                  <ImageIcon size={20} />
+                  <span>No image yet</span>
+                </>
+              )}
+            </div>
+          )}
+          {isRegenerating && canView && (
+            <div className="absolute inset-0 bg-background/60 flex items-center justify-center">
+              <RefreshCw size={20} className="animate-spin" />
+            </div>
+          )}
+        </button>
+
+        <div className="flex-1 min-w-0 p-3 space-y-2">
+          <div className="flex items-start justify-between gap-2">
+            <div className="min-w-0">
+              <h4 className="font-medium truncate">{iface.name}</h4>
+              <p className="text-xs text-muted-foreground">{iface.purpose}</p>
+            </div>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={handleRegenerate}
+              disabled={isStreaming || isRegenerating}
+              data-testid={`regenerate-interface-${iface.id}`}
+            >
+              <RefreshCw size={14} className="mr-1.5" />
+              Regenerate
+            </Button>
+          </div>
+
+          <button
+            type="button"
+            onClick={() => setShowDetails((v) => !v)}
+            className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+          >
+            <ChevronDown
+              size={14}
+              className={cn(
+                "transition-transform",
+                showDetails && "rotate-180",
+              )}
+            />
+            {showDetails ? "Hide" : "Show"} prompt &amp; copy
+          </button>
+
+          {showDetails && (
+            <div className="space-y-2 text-sm">
+              <div>
+                <div className="text-xs font-medium text-muted-foreground">
+                  Prompt
+                </div>
+                <p className="text-foreground whitespace-pre-wrap">
+                  {iface.prompt}
+                </p>
+              </div>
+              {iface.copy && (
+                <div>
+                  <div className="text-xs font-medium text-muted-foreground">
+                    Copy
+                  </div>
+                  <p className="text-foreground whitespace-pre-wrap">
+                    {iface.copy}
+                  </p>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {isLightboxOpen && imageUrl && (
+        <ImageLightbox
+          imageUrl={imageUrl}
+          alt={iface.name}
+          filePath={absolutePath}
+          onClose={() => setIsLightboxOpen(false)}
+          onError={() => {
+            setImageError(true);
+            setIsLightboxOpen(false);
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/preview_panel/PreviewPanel.tsx
+++ b/src/components/preview_panel/PreviewPanel.tsx
@@ -28,6 +28,7 @@ import { useRunApp } from "@/hooks/useRunApp";
 import { PublishPanel } from "./PublishPanel";
 import { SecurityPanel } from "./SecurityPanel";
 import { PlanPanel } from "./PlanPanel";
+import { DesignPanel } from "./DesignPanel";
 import { PackageManagerWarningBanner } from "./PackageManagerWarningBanner";
 import { useSupabase } from "@/hooks/useSupabase";
 import { useTranslation } from "react-i18next";
@@ -238,6 +239,8 @@ export function PreviewPanel() {
                   <SecurityPanel />
                 ) : previewMode === "plan" ? (
                   <PlanPanel />
+                ) : previewMode === "design" ? (
+                  <DesignPanel />
                 ) : (
                   <Problems />
                 )}

--- a/src/components/preview_panel/PreviewToolbar.tsx
+++ b/src/components/preview_panel/PreviewToolbar.tsx
@@ -36,12 +36,12 @@ const PRIMARY_MODES = [
   "preview",
   "code",
   "publish",
-] as const satisfies readonly Exclude<PreviewMode, "plan">[];
+] as const satisfies readonly Exclude<PreviewMode, "plan" | "design">[];
 const OVERFLOW_MODES = [
   "configure",
   "problems",
   "security",
-] as const satisfies readonly Exclude<PreviewMode, "plan">[];
+] as const satisfies readonly Exclude<PreviewMode, "plan" | "design">[];
 const COMPACT_TOOLBAR_THRESHOLD = 700;
 
 interface ModeButtonsProps {
@@ -89,7 +89,7 @@ const PreviewToolbarModeButtons = ({ isCompact }: ModeButtonsProps) => {
     }
   };
 
-  type ToolbarMode = Exclude<PreviewMode, "plan">;
+  type ToolbarMode = Exclude<PreviewMode, "plan" | "design">;
   const modeMeta: Record<
     ToolbarMode,
     { icon: React.ReactNode; label: string; testId: string }

--- a/src/hooks/useChatModeToggle.ts
+++ b/src/hooks/useChatModeToggle.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from "react";
 import { useShortcut } from "./useShortcut";
 import { usePostHog } from "posthog-js/react";
-import { ChatModeSchema } from "../lib/schemas";
+import { ChatModeSchema, type ChatMode } from "../lib/schemas";
 import { useChatMode } from "./useChatMode";
 import { useRouterState } from "@tanstack/react-router";
 import { useSetAtom } from "jotai";
@@ -36,9 +36,17 @@ export function useChatModeToggle() {
     if (!settings || !selectedMode) return;
 
     const currentMode = selectedMode;
-    // Migration on read ensures currentMode is never "agent"
-    const modes = ChatModeSchema.options;
-    const currentIndex = modes.indexOf(currentMode);
+    // Migration on read ensures currentMode is never "agent".
+    // "design" is a specialized Pro-only flow reached from the mode menu, not
+    // part of the keyboard toggle cycle.
+    const modes = ChatModeSchema.options.filter(
+      (m): m is Exclude<ChatMode, "design"> => m !== "design",
+    );
+    // currentMode may be "design" (not in the cycle) → indexOf returns -1, so
+    // the next mode falls back to the first cycle entry.
+    const currentIndex = modes.indexOf(
+      currentMode as Exclude<ChatMode, "design">,
+    );
     const newMode = modes[(currentIndex + 1) % modes.length];
 
     if (routeChatId == null) {

--- a/src/hooks/useDesign.ts
+++ b/src/hooks/useDesign.ts
@@ -1,0 +1,48 @@
+import { useEffect } from "react";
+import { useSetAtom, useAtomValue } from "jotai";
+import { useQuery } from "@tanstack/react-query";
+import { selectedAppIdAtom } from "@/atoms/appAtoms";
+import { designStateAtom, setDesignSpec } from "@/atoms/designAtoms";
+import { selectedChatIdAtom } from "@/atoms/chatAtoms";
+import { designClient } from "@/ipc/types/design";
+import { queryKeys } from "@/lib/queryKeys";
+
+/**
+ * Loads a saved design spec from disk and syncs it into memory state for the
+ * current chat (mirrors usePlan).
+ */
+export function useDesign({ enabled = true }: { enabled?: boolean } = {}) {
+  const chatId = useAtomValue(selectedChatIdAtom);
+  const appId = useAtomValue(selectedAppIdAtom);
+  const designState = useAtomValue(designStateAtom);
+  const setDesignState = useSetAtom(designStateAtom);
+
+  const hasSpecInMemory = chatId
+    ? designState.specsByChatId.has(chatId)
+    : false;
+
+  const { data: savedDesign, isLoading } = useQuery({
+    queryKey: queryKeys.designs.forChat({
+      appId: appId ?? null,
+      chatId: chatId ?? null,
+    }),
+    queryFn: async () => {
+      if (!appId || !chatId) return null;
+      return designClient.getDesignForChat({ appId, chatId });
+    },
+    enabled: !!appId && !!chatId && !hasSpecInMemory && enabled,
+    staleTime: 1000 * 60 * 5, // 5 minutes
+  });
+
+  useEffect(() => {
+    if (savedDesign && chatId && !hasSpecInMemory) {
+      setDesignState((prev) => setDesignSpec(prev, chatId, savedDesign));
+    }
+  }, [savedDesign, chatId, hasSpecInMemory, setDesignState]);
+
+  return {
+    savedDesign,
+    hasSpecInMemory,
+    isLoading,
+  };
+}

--- a/src/hooks/useDesignEvents.ts
+++ b/src/hooks/useDesignEvents.ts
@@ -1,0 +1,77 @@
+import { useEffect } from "react";
+import { useSetAtom } from "jotai";
+import { useQueryClient } from "@tanstack/react-query";
+import { queryKeys } from "@/lib/queryKeys";
+import {
+  designStateAtom,
+  regeneratingInterfacesAtom,
+  setDesignSpec,
+} from "@/atoms/designAtoms";
+import { previewModeAtom, selectedAppIdAtom } from "@/atoms/appAtoms";
+import {
+  designEventClient,
+  designClient,
+  type DesignUpdatePayload,
+} from "@/ipc/types/design";
+import { useAtomValue } from "jotai";
+
+/**
+ * Handles Design mode IPC events. Call at the app root, alongside usePlanEvents.
+ *
+ * On a design:update event it (1) stores the spec in memory, (2) persists it to
+ * `.dyad/design/<chatId>.json`, (3) clears any per-interface regenerating flags,
+ * and (4) surfaces the Design preview panel.
+ */
+export function useDesignEvents() {
+  const setDesignState = useSetAtom(designStateAtom);
+  const setPreviewMode = useSetAtom(previewModeAtom);
+  const setRegenerating = useSetAtom(regeneratingInterfacesAtom);
+  const appId = useAtomValue(selectedAppIdAtom);
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    const unsubscribe = designEventClient.onUpdate(
+      (payload: DesignUpdatePayload) => {
+        setDesignState((prev) =>
+          setDesignSpec(prev, payload.chatId, payload.spec),
+        );
+
+        // Persist to disk so the design survives reloads. Best-effort — the
+        // in-memory state already reflects the update for the UI.
+        if (appId != null) {
+          void designClient
+            .saveDesignSpec({
+              appId,
+              chatId: payload.chatId,
+              spec: payload.spec,
+            })
+            .then(() => {
+              queryClient.invalidateQueries({
+                queryKey: queryKeys.designs.forChat({
+                  appId,
+                  chatId: payload.chatId,
+                }),
+              });
+            })
+            .catch((error) => {
+              console.error("Failed to persist design spec:", error);
+            });
+        }
+
+        // Clear regenerating flags for this chat now that a new spec arrived.
+        setRegenerating((prev) => {
+          if (!prev.has(payload.chatId)) return prev;
+          const next = new Map(prev);
+          next.delete(payload.chatId);
+          return next;
+        });
+
+        setPreviewMode("design");
+      },
+    );
+
+    return () => {
+      unsubscribe();
+    };
+  }, [setDesignState, setPreviewMode, setRegenerating, appId, queryClient]);
+}

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -806,6 +806,7 @@ ${componentSnippet}
         const isLocalAgentMode = selectedChatMode === "local-agent";
         const isAskMode = selectedChatMode === "ask";
         const isPlanMode = selectedChatMode === "plan";
+        const isDesignMode = selectedChatMode === "design";
         const willUseLocalAgentStream =
           isLocalAgentBackedMode(selectedChatMode);
 
@@ -1426,6 +1427,41 @@ This conversation includes one or more image attachments. When the user uploads 
             systemPrompt: planModeSystemPrompt,
             dyadRequestId: dyadRequestId ?? "[no-request-id]",
             planModeOnly: true,
+            messageOverride: isSummarizeIntent ? chatMessages : undefined,
+            settingsOverride: settings,
+            freeModelMode,
+            referencedApps: referencedAppsForAgent,
+            currentTurnHasOnDiskAttachment: false,
+          });
+          return;
+        }
+
+        // Handle design mode: use local-agent with design tools only
+        // (planning_questionnaire, generate_image, write_design_spec). Design
+        // mode is Pro-only because image generation requires a Dyad Pro key.
+        if (isDesignMode) {
+          if (!isDyadProEnabled(settings)) {
+            safeSend(event.sender, "chat:response:error", {
+              chatId: req.chatId,
+              error:
+                "Design mode requires Dyad Pro. Please enable Dyad Pro in Settings → Pro.",
+            });
+            return;
+          }
+
+          const designModeSystemPrompt = constructSystemPrompt({
+            aiRules,
+            chatMode: "design",
+            enableTurboEditsV2: false,
+            themePrompt,
+            freeModelMode,
+          });
+
+          await handleLocalAgentStream(event, req, abortController, {
+            placeholderMessageId: placeholderAssistantMessage.id,
+            systemPrompt: designModeSystemPrompt,
+            dyadRequestId: dyadRequestId ?? "[no-request-id]",
+            designModeOnly: true,
             messageOverride: isSummarizeIntent ? chatMessages : undefined,
             settingsOverride: settings,
             freeModelMode,

--- a/src/ipc/handlers/design_handlers.ts
+++ b/src/ipc/handlers/design_handlers.ts
@@ -1,0 +1,114 @@
+import fs from "node:fs";
+import path from "node:path";
+import { db } from "../../db";
+import { apps } from "../../db/schema";
+import { eq } from "drizzle-orm";
+import { getDyadAppPath } from "../../paths/paths";
+import log from "electron-log";
+import { createTypedHandler } from "./base";
+import { designContracts, StoredDesignSpecSchema } from "../types/design";
+import type { StoredDesignSpec } from "../types/design";
+import { ensureDyadGitignored } from "./gitignoreUtils";
+import { withLock } from "../utils/lock_utils";
+import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
+
+const logger = log.scope("design_handlers");
+
+async function getDesignDir(appId: number): Promise<string> {
+  const app = await db.query.apps.findFirst({ where: eq(apps.id, appId) });
+  if (!app) throw new DyadError("App not found", DyadErrorKind.NotFound);
+  const appPath = getDyadAppPath(app.path);
+  const designDir = path.join(appPath, ".dyad", "design");
+  await fs.promises.mkdir(designDir, { recursive: true });
+  await ensureDyadGitignored(appPath);
+  return designDir;
+}
+
+// One design spec per chat, keyed by chatId. chatId is a validated number so
+// there is no path-traversal risk in the filename.
+function getDesignFilePath(designDir: string, chatId: number): string {
+  return path.join(designDir, `chat-${chatId}.json`);
+}
+
+async function readDesignSpec(
+  filePath: string,
+): Promise<StoredDesignSpec | null> {
+  let raw: string;
+  try {
+    raw = await fs.promises.readFile(filePath, "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw err;
+  }
+  const parsed = StoredDesignSpecSchema.safeParse(JSON.parse(raw));
+  if (!parsed.success) {
+    logger.warn("Ignoring invalid design spec file:", filePath, parsed.error);
+    return null;
+  }
+  return parsed.data;
+}
+
+export function registerDesignHandlers() {
+  createTypedHandler(
+    designContracts.saveDesignSpec,
+    async (_, { appId, chatId, spec }) => {
+      const designDir = await getDesignDir(appId);
+      const filePath = getDesignFilePath(designDir, chatId);
+
+      // Serialize writes per chat so concurrent tool calls (e.g. rapid
+      // write_design_spec updates while images generate) don't clobber.
+      return withLock(`design:${appId}:${chatId}`, async () => {
+        const existing = await readDesignSpec(filePath);
+        const now = new Date().toISOString();
+        const stored: StoredDesignSpec = {
+          ...spec,
+          appId,
+          chatId,
+          createdAt: existing?.createdAt ?? now,
+          updatedAt: now,
+        };
+        await fs.promises.writeFile(
+          filePath,
+          JSON.stringify(stored, null, 2),
+          "utf-8",
+        );
+        logger.info(
+          "Saved design spec for app:",
+          appId,
+          "chat:",
+          chatId,
+          "interfaces:",
+          spec.interfaces.length,
+        );
+        return stored;
+      });
+    },
+  );
+
+  createTypedHandler(
+    designContracts.getDesignForChat,
+    async (_, { appId, chatId }) => {
+      const designDir = await getDesignDir(appId);
+      const filePath = getDesignFilePath(designDir, chatId);
+      return readDesignSpec(filePath);
+    },
+  );
+
+  createTypedHandler(
+    designContracts.deleteDesignSpec,
+    async (_, { appId, chatId }) => {
+      const designDir = await getDesignDir(appId);
+      const filePath = getDesignFilePath(designDir, chatId);
+      try {
+        await fs.promises.unlink(filePath);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+          throw err;
+        }
+      }
+      logger.info("Deleted design spec for app:", appId, "chat:", chatId);
+    },
+  );
+}

--- a/src/ipc/ipc_host.ts
+++ b/src/ipc/ipc_host.ts
@@ -41,6 +41,7 @@ import { registerAgentToolHandlers } from "../pro/main/ipc/handlers/local_agent/
 import { registerFreeAgentQuotaHandlers } from "./handlers/free_agent_quota_handlers";
 import { registerFreeModelQuotaHandlers } from "./handlers/free_model_quota_handlers";
 import { registerPlanHandlers } from "./handlers/plan_handlers";
+import { registerDesignHandlers } from "./handlers/design_handlers";
 import { registerIntegrationHandlers } from "./handlers/integration_handlers";
 import { registerMediaHandlers } from "./handlers/media_handlers";
 import { registerImageGenerationHandlers } from "./handlers/image_generation_handlers";
@@ -94,6 +95,7 @@ export function registerIpcHandlers() {
   registerFreeAgentQuotaHandlers();
   registerFreeModelQuotaHandlers();
   registerPlanHandlers();
+  registerDesignHandlers();
   registerIntegrationHandlers();
   registerMediaHandlers();
   registerImageGenerationHandlers();

--- a/src/ipc/preload/channels.ts
+++ b/src/ipc/preload/channels.ts
@@ -41,6 +41,7 @@ import { miscContracts, miscEvents } from "../types/misc";
 import { freeAgentQuotaContracts } from "../types/free_agent_quota";
 import { freeModelQuotaContracts } from "../types/free_model_quota";
 import { planEvents, planContracts } from "../types/plan";
+import { designEvents, designContracts } from "../types/design";
 import { integrationEvents, integrationContracts } from "../types/integration";
 import { audioContracts } from "../types/audio";
 import { mediaContracts } from "../types/media";
@@ -108,6 +109,7 @@ export const VALID_INVOKE_CHANNELS = [
   ...getInvokeChannels(freeAgentQuotaContracts),
   ...getInvokeChannels(freeModelQuotaContracts),
   ...getInvokeChannels(planContracts),
+  ...getInvokeChannels(designContracts),
   ...getInvokeChannels(integrationContracts),
   ...getInvokeChannels(audioContracts),
   ...getInvokeChannels(mediaContracts),
@@ -140,6 +142,7 @@ export const VALID_RECEIVE_CHANNELS = [
   ...getReceiveChannels(systemEvents),
   ...getReceiveChannels(miscEvents),
   ...getReceiveChannels(planEvents),
+  ...getReceiveChannels(designEvents),
   ...getReceiveChannels(integrationEvents),
   ...getReceiveChannels(appBlueprintEvents),
 ] as const;

--- a/src/ipc/types/chat.ts
+++ b/src/ipc/types/chat.ts
@@ -168,7 +168,9 @@ export const ChatResponseChunkSchema = z.object({
   // only acks when chunkSeq is present.
   chunkSeq: z.number().int().nonnegative().finite().optional(),
   effectiveChatMode: ChatModeSchema.optional(),
-  chatModeFallbackReason: z.literal("quota-exhausted").optional(),
+  chatModeFallbackReason: z
+    .enum(["quota-exhausted", "pro-required"])
+    .optional(),
 });
 
 export type ChatResponseChunk = z.infer<typeof ChatResponseChunkSchema>;

--- a/src/ipc/types/design.test.ts
+++ b/src/ipc/types/design.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+  DesignSpecSchema,
+  StoredDesignSpecSchema,
+  type DesignSpec,
+} from "./design";
+
+const sampleSpec: DesignSpec = {
+  title: "Habit Tracker",
+  summary: "A calm, minimal habit tracker.",
+  designSystem: {
+    mood: "calm, minimal, trustworthy",
+    colors: [
+      { name: "Primary", hex: "#4F46E5" },
+      { name: "Background", hex: "#0B1020" },
+    ],
+    typography: { heading: "Inter 600", body: "Inter 400" },
+    spacing: "8px grid, rounded-xl corners",
+  },
+  interfaces: [
+    {
+      id: "home",
+      name: "Home",
+      purpose: "See today's habits at a glance",
+      prompt: "A dashboard with a vertical list of habit cards...",
+      copy: "Today · 3 of 5 done",
+      imagePath: ".dyad/media/generated-home.png",
+    },
+    {
+      id: "add",
+      name: "Add habit",
+      purpose: "Create a new habit",
+      prompt: "A focused form with a large title input...",
+    },
+  ],
+};
+
+describe("design spec schemas", () => {
+  it("accepts a well-formed design spec", () => {
+    expect(DesignSpecSchema.safeParse(sampleSpec).success).toBe(true);
+  });
+
+  it("allows interfaces without an image yet", () => {
+    const parsed = DesignSpecSchema.parse(sampleSpec);
+    expect(parsed.interfaces[1].imagePath).toBeUndefined();
+  });
+
+  it("round-trips a stored design spec through JSON", () => {
+    const stored = {
+      ...sampleSpec,
+      appId: 1,
+      chatId: 42,
+      createdAt: "2026-07-07T00:00:00.000Z",
+      updatedAt: "2026-07-07T00:00:00.000Z",
+    };
+    const json = JSON.stringify(stored);
+    const parsed = StoredDesignSpecSchema.safeParse(JSON.parse(json));
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.chatId).toBe(42);
+      expect(parsed.data.interfaces).toHaveLength(2);
+    }
+  });
+
+  it("rejects a spec missing the design system", () => {
+    const { designSystem: _omit, ...withoutSystem } = sampleSpec;
+    expect(DesignSpecSchema.safeParse(withoutSystem).success).toBe(false);
+  });
+});

--- a/src/ipc/types/design.ts
+++ b/src/ipc/types/design.ts
@@ -1,0 +1,126 @@
+import { z } from "zod";
+import {
+  defineEvent,
+  createEventClient,
+  defineContract,
+  createClient,
+} from "../contracts/core";
+
+// =============================================================================
+// Design Spec Schemas
+//
+// Design mode produces a structured, per-chat "design spec" describing the
+// app's visual system and the individual interfaces (screens) that will be
+// generated as images. Persisted to `.dyad/design/<chatId>.json` and rendered
+// in the Design preview panel.
+// =============================================================================
+
+export const DesignColorSchema = z.object({
+  name: z.string(),
+  hex: z.string(),
+});
+export type DesignColor = z.infer<typeof DesignColorSchema>;
+
+export const DesignTypographySchema = z.object({
+  heading: z.string(),
+  body: z.string(),
+  notes: z.string().optional(),
+});
+export type DesignTypography = z.infer<typeof DesignTypographySchema>;
+
+export const DesignSystemSchema = z.object({
+  mood: z.string(),
+  colors: z.array(DesignColorSchema),
+  typography: DesignTypographySchema,
+  spacing: z.string().optional(),
+  notes: z.string().optional(),
+});
+export type DesignSystem = z.infer<typeof DesignSystemSchema>;
+
+export const DesignInterfaceSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  purpose: z.string(),
+  /** Full descriptive image-generation prompt (layout, aesthetics, media, copy). */
+  prompt: z.string(),
+  /** Key copy strings for the screen. */
+  copy: z.string().optional(),
+  /**
+   * Relative path (within the app dir, under `.dyad/media`) of the generated
+   * image for this interface. Absent until the image has been generated.
+   */
+  imagePath: z.string().optional(),
+});
+export type DesignInterface = z.infer<typeof DesignInterfaceSchema>;
+
+export const DesignSpecSchema = z.object({
+  title: z.string(),
+  summary: z.string().optional(),
+  designSystem: DesignSystemSchema,
+  interfaces: z.array(DesignInterfaceSchema),
+});
+export type DesignSpec = z.infer<typeof DesignSpecSchema>;
+
+// The persisted record adds ownership + timestamps around the spec.
+export const StoredDesignSpecSchema = DesignSpecSchema.extend({
+  appId: z.number(),
+  chatId: z.number(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+export type StoredDesignSpec = z.infer<typeof StoredDesignSpecSchema>;
+
+// =============================================================================
+// Events (Main -> Renderer)
+// =============================================================================
+
+export const DesignUpdateSchema = z.object({
+  chatId: z.number(),
+  spec: DesignSpecSchema,
+});
+export type DesignUpdatePayload = z.infer<typeof DesignUpdateSchema>;
+
+export const designEvents = {
+  update: defineEvent({
+    channel: "design:update",
+    payload: DesignUpdateSchema,
+  }),
+} as const;
+
+// =============================================================================
+// CRUD Contracts (Invoke/Response)
+// =============================================================================
+
+export const SaveDesignSpecParamsSchema = z.object({
+  appId: z.number(),
+  chatId: z.number(),
+  spec: DesignSpecSchema,
+});
+export type SaveDesignSpecParams = z.infer<typeof SaveDesignSpecParamsSchema>;
+
+export const designContracts = {
+  saveDesignSpec: defineContract({
+    channel: "design:save",
+    input: SaveDesignSpecParamsSchema,
+    output: StoredDesignSpecSchema,
+  }),
+
+  getDesignForChat: defineContract({
+    channel: "design:get-for-chat",
+    input: z.object({ appId: z.number(), chatId: z.number() }),
+    output: StoredDesignSpecSchema.nullable(),
+  }),
+
+  deleteDesignSpec: defineContract({
+    channel: "design:delete",
+    input: z.object({ appId: z.number(), chatId: z.number() }),
+    output: z.void(),
+  }),
+} as const;
+
+// =============================================================================
+// Clients
+// =============================================================================
+
+export const designEventClient = createEventClient(designEvents);
+export const designClient = createClient(designContracts);

--- a/src/lib/chatMode.test.ts
+++ b/src/lib/chatMode.test.ts
@@ -279,4 +279,43 @@ describe("chat mode resolution", () => {
       }),
     ).toEqual({ mode: "local-agent" });
   });
+
+  it("normalizes stored design mode", () => {
+    expect(normalizeStoredChatMode("design")).toBe("design");
+  });
+
+  it("keeps stored design mode for Pro users", () => {
+    const settings = makeSettings({
+      enableDyadPro: true,
+      providerSettings: {
+        auto: { apiKey: { value: "dyad-key" } },
+      },
+    });
+
+    expect(
+      resolveChatMode({
+        storedChatMode: "design",
+        settings,
+        envVars: {},
+      }),
+    ).toEqual({ mode: "design" });
+  });
+
+  it("falls back from design mode to the default for non-Pro users", () => {
+    const settings = makeSettings({ defaultChatMode: "build" });
+
+    expect(
+      resolveChatMode({
+        storedChatMode: "design",
+        settings,
+        envVars: {},
+      }),
+    ).toEqual({ mode: "build", fallbackReason: "pro-required" });
+  });
+
+  it("does not surface design as the effective default for non-Pro users", () => {
+    const settings = makeSettings({ defaultChatMode: "design" });
+
+    expect(getEffectiveDefaultChatMode(settings, {}, false)).toBe("build");
+  });
 });

--- a/src/lib/chatMode.ts
+++ b/src/lib/chatMode.ts
@@ -7,7 +7,7 @@ import {
   type UserSettings,
 } from "./schemas";
 
-export type ChatModeFallbackReason = "quota-exhausted";
+export type ChatModeFallbackReason = "quota-exhausted" | "pro-required";
 
 export interface ChatModeResolution {
   mode: ChatMode;
@@ -38,6 +38,12 @@ export function getUnavailableChatModeReason({
   settings: UserSettings;
   freeAgentQuotaAvailable?: boolean;
 }): ChatModeFallbackReason | undefined {
+  // Design mode requires Dyad Pro (image generation is Pro-only). A non-Pro
+  // user with a stored "design" mode falls back to the effective default.
+  if (mode === "design") {
+    return isDyadProEnabled(settings) ? undefined : "pro-required";
+  }
+
   if (mode !== "local-agent") {
     return undefined;
   }

--- a/src/lib/chatModeToast.ts
+++ b/src/lib/chatModeToast.ts
@@ -12,6 +12,8 @@ export function getChatModeDisplayName(mode: ChatMode, isPro: boolean): string {
       return isPro ? "Agent" : "Basic Agent";
     case "plan":
       return "Plan";
+    case "design":
+      return "Design";
   }
 }
 
@@ -33,13 +35,18 @@ export function showChatModeFallbackToast({
   effectiveMode,
   isPro,
   toastId,
+  reason,
 }: {
   effectiveMode: ChatMode;
   isPro: boolean;
   toastId?: string;
+  reason?: ChatModeFallbackReason;
 }) {
   const modeName = getChatModeDisplayName(effectiveMode, isPro);
-  const message = `Quota exhausted. Using ${modeName} mode.`;
+  const message =
+    reason === "pro-required"
+      ? `Design mode requires Dyad Pro. Using ${modeName} mode.`
+      : `Quota exhausted. Using ${modeName} mode.`;
 
   toast.warning(message, {
     id: toastId,

--- a/src/lib/dyadMediaUrl.ts
+++ b/src/lib/dyadMediaUrl.ts
@@ -4,3 +4,23 @@
 export function buildDyadMediaUrl(appPath: string, fileName: string): string {
   return `dyad-media://media/${encodeURIComponent(appPath)}/.dyad/media/${encodeURIComponent(fileName)}`;
 }
+
+/**
+ * Builds a dyad-media:// URL from a project-relative path (e.g. an image path
+ * stored in a design spec like ".dyad/media/generated-123.png"). Returns "" if
+ * the path is empty or contains a directory traversal segment.
+ */
+export function buildDyadMediaUrlFromRelativePath(
+  appPath: string,
+  relativePath: string,
+): string {
+  const normalized = relativePath.split("\\").join("/");
+  const hasTraversal = normalized.split("/").some((seg) => seg === "..");
+  if (!appPath || !normalized || hasTraversal) {
+    return "";
+  }
+  return `dyad-media://media/${encodeURIComponent(appPath)}/${normalized
+    .split("/")
+    .map(encodeURIComponent)
+    .join("/")}`;
+}

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -85,6 +85,17 @@ export const queryKeys = {
     }) => ["plans", "forChat", appId, chatId] as const,
   },
 
+  designs: {
+    all: ["designs"] as const,
+    forChat: ({
+      appId,
+      chatId,
+    }: {
+      appId: number | null;
+      chatId: number | null;
+    }) => ["designs", "forChat", appId, chatId] as const,
+  },
+
   // ─────────────────────────────────────────────────────────────────────────────
   // Proposals
   // ─────────────────────────────────────────────────────────────────────────────
@@ -406,6 +417,7 @@ export type AppQueryKey =
     >
   | QueryKeyOf<(typeof queryKeys.chats)[keyof typeof queryKeys.chats]>
   | QueryKeyOf<(typeof queryKeys.plans)[keyof typeof queryKeys.plans]>
+  | QueryKeyOf<(typeof queryKeys.designs)[keyof typeof queryKeys.designs]>
   | QueryKeyOf<(typeof queryKeys.proposals)[keyof typeof queryKeys.proposals]>
   | QueryKeyOf<(typeof queryKeys.versions)[keyof typeof queryKeys.versions]>
   | QueryKeyOf<(typeof queryKeys.branches)[keyof typeof queryKeys.branches]>

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -15,7 +15,9 @@ export const ChatSummarySchema = z.object({
   appId: z.number(),
   title: z.string().nullable(),
   createdAt: z.date(),
-  chatMode: z.enum(["build", "ask", "local-agent", "plan"]).nullable(),
+  chatMode: z
+    .enum(["build", "ask", "local-agent", "plan", "design"])
+    .nullable(),
 });
 
 /**
@@ -154,13 +156,20 @@ export const StoredChatModeSchema = z.enum([
   "agent", // DEPRECATED: converted to "build" on read
   "local-agent",
   "plan",
+  "design",
 ]);
 export type StoredChatMode = z.infer<typeof StoredChatModeSchema>;
 
 /**
  * Active chat modes (excludes deprecated values)
  */
-export const ChatModeSchema = z.enum(["build", "ask", "local-agent", "plan"]);
+export const ChatModeSchema = z.enum([
+  "build",
+  "ask",
+  "local-agent",
+  "plan",
+  "design",
+]);
 export type ChatMode = z.infer<typeof ChatModeSchema>;
 
 /**
@@ -171,7 +180,12 @@ export type ChatMode = z.infer<typeof ChatModeSchema>;
  * what's actually sent to the model.
  */
 export function isLocalAgentBackedMode(mode: ChatMode | undefined): boolean {
-  return mode === "local-agent" || mode === "ask" || mode === "plan";
+  return (
+    mode === "local-agent" ||
+    mode === "ask" ||
+    mode === "plan" ||
+    mode === "design"
+  );
 }
 
 export const GitHubSecretsSchema = z.object({
@@ -512,6 +526,11 @@ export function getEffectiveDefaultChatMode(
       if (isPro) return "local-agent";
       if (freeAgentQuotaAvailable && hasNonGoogleProviderSetup)
         return "local-agent";
+      return "build";
+    }
+    // "design" is Pro-only (image generation requires a Dyad Pro key) and is
+    // never a real default; a non-Pro stored value falls back to "build".
+    if (settings.defaultChatMode === "design" && !isPro) {
       return "build";
     }
     return settings.defaultChatMode;

--- a/src/lib/streamingMessageParser.ts
+++ b/src/lib/streamingMessageParser.ts
@@ -66,6 +66,7 @@ const DYAD_CUSTOM_TAG_NAMES = [
   "dyad-copy",
   "dyad-image-generation",
   "dyad-write-plan",
+  "dyad-write-design",
   "dyad-exit-plan",
   "dyad-questionnaire",
   "dyad-step-limit",

--- a/src/pro/main/ipc/handlers/local_agent/design_mode_tools.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/design_mode_tools.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+
+// getAgentToolConsent (used by shouldIncludeTool) reads settings; stub it so
+// tools fall back to their defaultConsent rather than "never".
+vi.mock("@/main/settings", () => ({
+  readSettings: () => ({}),
+  writeSettings: () => {},
+}));
+
+import { TOOL_DEFINITIONS, shouldIncludeTool } from "./tool_definitions";
+import type { AgentContext } from "./tools/types";
+
+const proCtx = { isDyadPro: true } as unknown as AgentContext;
+
+function includedToolNames(
+  options: Parameters<typeof shouldIncludeTool>[2],
+): Set<string> {
+  return new Set(
+    TOOL_DEFINITIONS.filter((tool) =>
+      shouldIncludeTool(tool, proCtx, options),
+    ).map((tool) => tool.name),
+  );
+}
+
+describe("design mode tool gating", () => {
+  it("includes design-specific tools and excludes code-editing tools", () => {
+    const names = includedToolNames({ designModeOnly: true });
+
+    // Design-specific tools are available.
+    expect(names.has("write_design_spec")).toBe(true);
+    expect(names.has("generate_image")).toBe(true);
+    expect(names.has("planning_questionnaire")).toBe(true);
+
+    // Read-only exploration stays available.
+    expect(names.has("read_file")).toBe(true);
+    expect(names.has("list_files")).toBe(true);
+
+    // No code-editing / state-mutating tools.
+    expect(names.has("write_file")).toBe(false);
+    expect(names.has("search_replace")).toBe(false);
+    expect(names.has("delete_file")).toBe(false);
+
+    // Plan-only tools do not leak into design mode.
+    expect(names.has("write_plan")).toBe(false);
+    expect(names.has("exit_plan")).toBe(false);
+  });
+
+  it("excludes write_design_spec outside of design mode", () => {
+    expect(
+      includedToolNames({ planModeOnly: true }).has("write_design_spec"),
+    ).toBe(false);
+    expect(includedToolNames({}).has("write_design_spec")).toBe(false);
+  });
+});

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -365,6 +365,7 @@ export async function handleLocalAgentStream(
     dyadRequestId,
     readOnly = false,
     planModeOnly = false,
+    designModeOnly = false,
     messageOverride,
     settingsOverride,
     freeModelMode,
@@ -385,6 +386,13 @@ export async function handleLocalAgentStream(
      */
     planModeOnly?: boolean;
     /**
+     * If true, only include tools allowed in design mode (read-only exploration
+     * plus planning_questionnaire, generate_image, and write_design_spec). Like
+     * plan mode, this skips all workspace side effects (commits, deploys,
+     * gitignore writes, todos). No app code is edited.
+     */
+    designModeOnly?: boolean;
+    /**
      * If provided, use these messages instead of fetching from the database.
      * Used for summarization where messages need to be transformed.
      */
@@ -403,6 +411,12 @@ export async function handleLocalAgentStream(
   },
 ): Promise<boolean> {
   const settings = settingsOverride ?? readSettings();
+  // Plan and design modes share "no-write planning stream" semantics: they run
+  // through the local agent but must not touch the workspace (no commits,
+  // deploys, gitignore writes, todos, or MCP side effects). Guards that enforce
+  // that use this derived flag; the two modes only diverge in their tool
+  // allow-list and stop conditions.
+  const isPlanningStream = planModeOnly || designModeOnly;
   const maxToolCallSteps =
     settings.maxToolCallSteps ?? DEFAULT_MAX_TOOL_CALL_STEPS;
   let fullResponse = "";
@@ -621,8 +635,9 @@ export async function handleLocalAgentStream(
     // Load persisted todos from a previous turn (if any)
     persistedTodos = await loadTodos(appPath, chat.id);
     // Ensure .dyad/ is gitignored (idempotent; also done by compaction/plans)
-    // Skip in read-only/plan-only mode to avoid modifying the workspace
-    if (!readOnly && !planModeOnly) {
+    // Skip in read-only/planning modes to avoid modifying the workspace
+    // (design mode's own save handler gitignores .dyad when it writes).
+    if (!readOnly && !isPlanningStream) {
       await ensureDyadGitignored(appPath).catch((err: unknown) =>
         logger.warn("Failed to ensure .dyad gitignored:", err),
       );
@@ -719,7 +734,9 @@ export async function handleLocalAgentStream(
     const buildOptions = {
       readOnly,
       planModeOnly,
-      basicAgentMode: !readOnly && !planModeOnly && isBasicAgentMode(settings),
+      designModeOnly,
+      basicAgentMode:
+        !readOnly && !isPlanningStream && isBasicAgentMode(settings),
       freeModelMode: effectiveFreeModelMode,
       enableAppBlueprint:
         settings.enableAppBlueprint && chat.app.needsAppBlueprint,
@@ -737,7 +754,7 @@ export async function handleLocalAgentStream(
     // from the same predicate the builder uses. Off in read-only and plan mode.
     const mcpInSandboxEnabled =
       !readOnly &&
-      !planModeOnly &&
+      !isPlanningStream &&
       shouldIncludeTool(executeSandboxScriptTool, ctx, buildOptions);
     ctx.mcpToolsEnabled = mcpInSandboxEnabled;
 
@@ -754,7 +771,7 @@ export async function handleLocalAgentStream(
     // actually registered this turn.
     const hasGetSchemaTool = agentTools.get_mcp_tool_schema != undefined;
     const mcpToolsForRegistration: ToolSet =
-      !readOnly && !planModeOnly && !mcpInSandboxEnabled
+      !readOnly && !isPlanningStream && !mcpInSandboxEnabled
         ? await getMcpTools(event, ctx)
         : {};
     if (agentTools.execute_sandbox_script != undefined) {
@@ -852,7 +869,7 @@ export async function handleLocalAgentStream(
     if (
       !messageOverride &&
       !readOnly &&
-      !planModeOnly &&
+      !isPlanningStream &&
       persistedTodos.length > 0 &&
       hasIncompleteTodos(persistedTodos)
     ) {
@@ -1096,7 +1113,7 @@ export async function handleLocalAgentStream(
                       type: "text",
                       text: buildPlanningQuestionnaireReflectionMessage(
                         questionnaireError,
-                        planModeOnly,
+                        isPlanningStream,
                       ),
                     },
                   ]);
@@ -1483,7 +1500,7 @@ export async function handleLocalAgentStream(
       if (
         !shouldRunTodoFollowUpPass({
           readOnly,
-          planModeOnly,
+          planModeOnly: isPlanningStream,
           passEndedWithText,
           todos: ctx.todos,
           todoFollowUpLoops,
@@ -1540,8 +1557,8 @@ export async function handleLocalAgentStream(
       sendChunk(fullResponse);
     }
 
-    // In read-only and plan mode, skip the deploy step (commit follows below)
-    if (!readOnly && !planModeOnly) {
+    // In read-only and planning (plan/design) modes, skip the deploy step
+    if (!readOnly && !isPlanningStream) {
       // Deploy all Supabase functions if shared modules changed
       const deployResult = await deployAllFunctionsIfNeeded({
         ...ctx,
@@ -1601,8 +1618,8 @@ export async function handleLocalAgentStream(
       logger.warn("Failed to save AI messages JSON:", err);
     }
 
-    // In read-only and plan mode, skip commits
-    if (!readOnly && !planModeOnly) {
+    // In read-only and planning (plan/design) modes, skip commits
+    if (!readOnly && !isPlanningStream) {
       // Commit all changes
       const commitResult = await commitAllChanges(ctx, ctx.chatSummary);
 

--- a/src/pro/main/ipc/handlers/local_agent/tool_definitions.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tool_definitions.ts
@@ -36,6 +36,7 @@ import { exploreCodeTool } from "./tools/explore_code";
 import { planningQuestionnaireTool } from "./tools/planning_questionnaire";
 import { writePlanTool } from "./tools/write_plan";
 import { exitPlanTool } from "./tools/exit_plan";
+import { writeDesignSpecTool } from "./tools/write_design_spec";
 import { readGuideTool } from "./tools/read_guide";
 import { executeSandboxScriptTool } from "./tools/execute_sandbox_script";
 import { searchMcpToolsTool } from "./tools/search_mcp_tools";
@@ -111,6 +112,8 @@ export const TOOL_DEFINITIONS: readonly ToolDefinition[] = [
   planningQuestionnaireTool,
   writePlanTool,
   exitPlanTool,
+  // Design mode tools
+  writeDesignSpecTool,
   // App blueprint tools
   writeAppBlueprintTool,
 ];
@@ -383,6 +386,13 @@ export interface BuildAgentToolSetOptions {
    */
   planModeOnly?: boolean;
   /**
+   * If true, only include tools that are allowed in design mode.
+   * Design mode has access to read-only tools plus design-specific tools
+   * (planning_questionnaire, generate_image, write_design_spec). It must NOT
+   * include code-editing tools.
+   */
+  designModeOnly?: boolean;
+  /**
    * If true, exclude Pro-only tools.
    * Used for basic agent mode where some tools may not be available.
    */
@@ -412,6 +422,23 @@ const PLAN_MODE_ONLY_TOOLS = new Set(["write_plan", "exit_plan"]);
 const PLANNING_SPECIFIC_TOOLS = new Set([
   ...PLAN_MODE_ONLY_TOOLS,
   "planning_questionnaire",
+]);
+
+/**
+ * Tools that should ONLY be available in design mode (excluded from every
+ * other mode, like PLAN_MODE_ONLY_TOOLS).
+ */
+const DESIGN_MODE_ONLY_TOOLS = new Set(["write_design_spec"]);
+
+/**
+ * Design-specific tools allowed in design mode despite modifying state.
+ * Superset of DESIGN_MODE_ONLY_TOOLS plus state-modifying tools that design
+ * mode legitimately needs (asking questions, generating images).
+ */
+const DESIGN_SPECIFIC_TOOLS = new Set([
+  ...DESIGN_MODE_ONLY_TOOLS,
+  "planning_questionnaire",
+  "generate_image",
 ]);
 
 /**
@@ -473,6 +500,19 @@ export function shouldIncludeTool(
   }
   // Skip plan-mode-only tools when NOT in plan mode.
   if (!options.planModeOnly && PLAN_MODE_ONLY_TOOLS.has(tool.name)) {
+    return false;
+  }
+  // In design mode, skip state-modifying tools unless they're design-specific.
+  // This excludes all code-editing tools (write_file, search_replace, etc.).
+  if (
+    options.designModeOnly &&
+    toolModifiesState(tool, ctx) &&
+    !DESIGN_SPECIFIC_TOOLS.has(tool.name)
+  ) {
+    return false;
+  }
+  // Skip design-mode-only tools when NOT in design mode.
+  if (!options.designModeOnly && DESIGN_MODE_ONLY_TOOLS.has(tool.name)) {
     return false;
   }
   // Skip Pro-only tools in basic agent mode.

--- a/src/pro/main/ipc/handlers/local_agent/tools/write_design_spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/write_design_spec.ts
@@ -1,0 +1,134 @@
+import { z } from "zod";
+import log from "electron-log";
+import { ToolDefinition, AgentContext, escapeXmlAttr } from "./types";
+import { safeSend } from "@/ipc/utils/safe_sender";
+
+const logger = log.scope("write_design_spec");
+
+// Describing schema for the model. Structurally matches DesignSpecSchema in
+// src/ipc/types/design.ts — keep the two in sync.
+const designSpecSchema = z.object({
+  title: z
+    .string()
+    .describe("Short title for the app's design (e.g. the app name)"),
+  summary: z
+    .string()
+    .optional()
+    .describe("One or two sentences describing the overall look and feel"),
+  designSystem: z
+    .object({
+      mood: z
+        .string()
+        .describe(
+          "The overall mood / adjectives, e.g. 'calm, minimal, trustworthy'",
+        ),
+      colors: z
+        .array(
+          z.object({
+            name: z
+              .string()
+              .describe("Role of the color, e.g. 'Primary', 'Background'"),
+            hex: z.string().describe("Hex value, e.g. '#4F46E5'"),
+          }),
+        )
+        .describe("The color palette (4-8 colors with roles and hex values)"),
+      typography: z
+        .object({
+          heading: z
+            .string()
+            .describe("Heading typeface + notable weights/sizes"),
+          body: z.string().describe("Body typeface + notable weights/sizes"),
+          notes: z.string().optional().describe("Any extra typography notes"),
+        })
+        .describe("Typography choices"),
+      spacing: z
+        .string()
+        .optional()
+        .describe(
+          "Spacing / layout system notes (e.g. 8px grid, rounded corners)",
+        ),
+      notes: z.string().optional().describe("Any other design-system notes"),
+    })
+    .describe("The app-wide visual system"),
+  interfaces: z
+    .array(
+      z.object({
+        id: z
+          .string()
+          .describe("Stable slug for the interface, e.g. 'login', 'dashboard'"),
+        name: z.string().describe("Human name, e.g. 'Login screen'"),
+        purpose: z
+          .string()
+          .describe("One line describing what this screen is for"),
+        prompt: z
+          .string()
+          .describe(
+            "The full, detailed image-generation prompt for this interface: layout, aesthetic details, media assets, and real copy — consistent with the design system.",
+          ),
+        copy: z
+          .string()
+          .optional()
+          .describe("Key copy strings shown on the screen"),
+        imagePath: z
+          .string()
+          .optional()
+          .describe(
+            "Relative path (under .dyad/media) of the generated image for this interface. Fill this in AFTER calling generate_image, using the path it returns. Leave empty until the image exists.",
+          ),
+      }),
+    )
+    .describe("The list of interfaces (screens) that make up the app"),
+});
+
+const DESCRIPTION = `Record or update the app's structured **design spec** and present it in the Design preview panel.
+
+Use this in Design mode to capture:
+- The **design system**: mood, color palette (with hex), typography, spacing.
+- The **interfaces** (screens): for each, a stable id, name, purpose, a rich descriptive image-generation prompt (layout, aesthetics, media, copy), and — once generated — the imagePath.
+
+### Workflow
+1. First call: provide the design system + the initial list of interfaces (with prompts but no imagePath yet).
+2. For each interface, call the \`generate_image\` tool with that interface's \`prompt\`. It returns a path under \`.dyad/media\`.
+3. Call this tool again with the FULL spec, filling in each interface's \`imagePath\` from the generate_image result. Always send the complete spec (all interfaces) — this call replaces the stored spec.
+
+Do NOT write or edit any app code in Design mode. This tool only records the visual design.`;
+
+export const writeDesignSpecTool: ToolDefinition<
+  z.infer<typeof designSpecSchema>
+> = {
+  name: "write_design_spec",
+  description: DESCRIPTION,
+  inputSchema: designSpecSchema,
+  defaultConsent: "always",
+  modifiesState: true,
+
+  isEnabled: (ctx) => ctx.isDyadPro,
+
+  getConsentPreview: (args) =>
+    `Design: ${args.title} (${args.interfaces?.length ?? 0} interfaces)`,
+
+  buildXml: (args, isComplete) => {
+    if (!args.title) return undefined;
+    const title = escapeXmlAttr(args.title);
+    const count = args.interfaces?.length ?? 0;
+    return `<dyad-write-design title="${title}" interfaces="${count}" complete="${isComplete}"></dyad-write-design>`;
+  },
+
+  execute: async (args, ctx: AgentContext) => {
+    logger.log(
+      `Writing design spec: ${args.title} (${args.interfaces.length} interfaces)`,
+    );
+
+    safeSend(ctx.event.sender, "design:update", {
+      chatId: ctx.chatId,
+      spec: args,
+    });
+
+    const withImages = args.interfaces.filter((i) => i.imagePath).length;
+    return `Design spec "${args.title}" saved and shown in the Design preview panel (${args.interfaces.length} interfaces, ${withImages} with generated images). ${
+      withImages < args.interfaces.length
+        ? "Generate images for the remaining interfaces with generate_image, then call write_design_spec again with their imagePath filled in."
+        : "All interfaces have images. Let the user know they can review the design and switch to Build or Agent mode to implement it."
+    }`;
+  },
+};

--- a/src/prompts/design_mode_prompt.ts
+++ b/src/prompts/design_mode_prompt.ts
@@ -1,0 +1,87 @@
+export const DESIGN_MODE_SYSTEM_PROMPT = `
+<role>
+You are Dyad Design Mode, an AI product designer. Before any code is written, you help the user decide how their app should look and feel — its visual system and the individual interfaces (screens) — and you generate a preview image for each interface so the user can see the design.
+</role>
+
+# Core Mission
+
+Turn a plain-language app idea into a concrete, cohesive visual design: a design system (colors, typography, mood) plus a set of interface previews. You produce images, not code. Think of yourself as a senior product designer running a focused design kickoff.
+
+# Design Process Workflow
+
+## Phase 1: Understand the app
+1. Acknowledge the user's idea and restate what you understand.
+2. Use the \`planning_questionnaire\` tool to ask targeted questions until you understand:
+   - Who the app is for and its core purpose
+   - The main screens/flows the user needs
+   - Aesthetic preferences (mood, references, brand colors, light/dark)
+   - Any must-have content or copy
+   Ask 1-3 questions at a time — never overwhelm. Prefer radio/checkbox options with a free-text fallback. Stop asking once you have enough to design confidently.
+
+## Phase 2: Decide the design system
+Choose a cohesive design system:
+- **Mood**: a few adjectives (e.g. "calm, minimal, trustworthy").
+- **Colors**: a palette of 4-8 named colors WITH hex values (primary, background, surface, text, accent, etc.).
+- **Typography**: heading and body typefaces with notable weights/sizes.
+- **Spacing/layout**: grid, corner radius, density notes.
+
+## Phase 3: Decide the interfaces
+Decide how many interfaces the app needs and list them (e.g. Onboarding, Login, Home/Dashboard, Detail, Settings). Keep the set focused — the key screens that convey the product, typically 3-6.
+
+## Phase 4: Write the design spec
+Call the \`write_design_spec\` tool with:
+- The full \`designSystem\`.
+- The \`interfaces\` array. For EACH interface, write a rich, self-contained \`prompt\` describing the **layout**, **aesthetic details**, **media/imagery**, and **real copy** — all consistent with the design system. Leave \`imagePath\` empty at this stage.
+
+## Phase 5: Generate an image per interface
+For each interface, call the \`generate_image\` tool with that interface's \`prompt\`. The tool returns a path under \`.dyad/media\`. After generating (you can do them one at a time), call \`write_design_spec\` again with the SAME full spec but with each interface's \`imagePath\` filled in from the generate_image result. Always send the complete spec — the call replaces the stored one.
+
+## Phase 6: Wrap up
+When every interface has an image, briefly summarize the design and tell the user they can review it in the Design panel, request changes (you'll regenerate), or switch to Build or Agent mode to implement it.
+
+# Communication Guidelines
+- Be collaborative and concrete, like a designer walking the user through choices.
+- Explain the "why" behind color/type/layout decisions briefly.
+- When the user asks to change a screen, update its \`prompt\` and regenerate just that interface's image, then re-save the spec.
+
+# Available Tools
+- \`planning_questionnaire\` - Ask the user structured questions (accepts a \`questions\` array; returns their answers).
+- \`generate_image\` - Generate an interface preview image from a descriptive prompt (saved to .dyad/media).
+- \`write_design_spec\` - Record/update the structured design (design system + interfaces) shown in the Design preview panel.
+- Read-only exploration tools are available if you need to inspect an existing app for context.
+
+# Important Constraints
+- **NEVER write or edit app code in Design mode.** Do not use <dyad-write>, <dyad-edit>, <dyad-delete>, <dyad-add-dependency>, or any code-producing tags. There are no code-editing tools available to you.
+- Every interface prompt must be detailed and consistent with the design system.
+- Keep the interface set focused; don't invent screens the app doesn't need.
+- Always keep the design spec authoritative and complete — resend the full spec on each \`write_design_spec\` call.
+
+[[AI_RULES]]
+
+# Remember
+You are designing what the app will look like — not building it. Interview, decide a design system, enumerate interfaces, write a vivid prompt per interface, generate an image for each, and keep the design spec up to date so the user can see it in the Design panel.
+`;
+
+const DEFAULT_DESIGN_AI_RULES = `# Design Context
+Aim for a modern, accessible, cohesive look:
+- Ensure text/background color pairs meet WCAG AA contrast.
+- Prefer a restrained palette and consistent spacing.
+- Use real, plausible copy in previews — never lorem ipsum.
+- Keep interfaces visually consistent with one another (shared header, type, spacing).
+`;
+
+export function constructDesignModePrompt(
+  aiRules: string | undefined,
+  themePrompt?: string,
+): string {
+  let prompt = DESIGN_MODE_SYSTEM_PROMPT.replace(
+    "[[AI_RULES]]",
+    aiRules ?? DEFAULT_DESIGN_AI_RULES,
+  );
+
+  if (themePrompt) {
+    prompt += "\n\n" + themePrompt;
+  }
+
+  return prompt;
+}

--- a/src/prompts/system_prompt.ts
+++ b/src/prompts/system_prompt.ts
@@ -4,6 +4,7 @@ import log from "electron-log";
 import { TURBO_EDITS_V2_SYSTEM_PROMPT } from "../pro/main/prompts/turbo_edits_v2_prompt";
 import { constructLocalAgentPrompt } from "./local_agent_prompt";
 import { constructPlanModePrompt } from "./plan_mode_prompt";
+import { constructDesignModePrompt } from "./design_mode_prompt";
 import type { AppFrameworkType } from "@/lib/framework_constants";
 
 const logger = log.scope("system_prompt");
@@ -532,7 +533,7 @@ export const constructSystemPrompt = ({
   codeExplorerAvailable,
 }: {
   aiRules: string | undefined;
-  chatMode?: "build" | "ask" | "local-agent" | "plan";
+  chatMode?: "build" | "ask" | "local-agent" | "plan" | "design";
   enableTurboEditsV2: boolean;
   themePrompt?: string;
   /** If true, use read-only mode for local-agent (ask mode with tools) */
@@ -563,6 +564,10 @@ export const constructSystemPrompt = ({
 }) => {
   if (chatMode === "plan") {
     return constructPlanModePrompt(aiRules, themePrompt);
+  }
+
+  if (chatMode === "design") {
+    return constructDesignModePrompt(aiRules, themePrompt);
   }
 
   if (chatMode === "local-agent") {


### PR DESCRIPTION
Same as the #3839 PR , only this time we're using an image generation model instead of llm + konva

<img width="1745" height="1052" alt="Screenshot from 2026-07-09 00-27-21" src="https://github.com/user-attachments/assets/0fb016bd-76e6-437a-b6a1-824b76ede10d" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

