### PR TITLE
Update pr push test workflow

### DIFF
--- a/.claude/skills/pr-push/SKILL.md
+++ b/.claude/skills/pr-push/SKILL.md
@@ -10,14 +10,15 @@ Use this skill to publish the current work to GitHub. It must complete autonomou
 ## Workflow
 
 1. Run `/remember-learnings` first. This captures session learnings before any push or PR creation, so any resulting `AGENTS.md` or `rules/` changes are included in the same publish flow.
-2. Run the bundled script from the repository root. Set `PR_PUSH_COMMIT_MESSAGE` to a descriptive commit message for the work being published:
+2. Decide whether to run unit tests locally before publishing. For broad or cross-cutting changes, run `npm test`. For targeted changes, run the narrowest relevant test command, such as `npm test -- path/to/file.test.ts`. For docs, agent-config, or other low-risk changes, it is acceptable to skip local unit tests because GitHub CI will run the full suite.
+3. Run the bundled script from the repository root. Set `PR_PUSH_COMMIT_MESSAGE` to a descriptive commit message for the work being published:
 
    ```bash
-   PR_PUSH_COMMIT_MESSAGE="<descriptive commit message>" bash .claude/skills/pr-push/scripts/pr_push.sh
+   PR_PUSH_COMMIT_MESSAGE="<descriptive commit message>" bash .agents/skills/pr-push/scripts/pr_push.sh
    ```
 
-3. If the script reports a fixable failure, fix it and rerun the script. When fixing issues, do not run `git pull` from fork remotes; only pull from the upstream repo configured by `PR_PUSH_BASE_REPO` (default `dyad-sh/dyad`) if needed. Do not manually replay the full workflow unless the script itself is broken.
-4. Summarize the script's final output, including the branch, committed files, ignored files, checks, pushed remote, and PR URL or bot-account PR creation link.
+4. If the script reports a fixable failure, fix it and rerun the script. When fixing issues, do not run `git pull` from fork remotes; only pull from the upstream repo configured by `PR_PUSH_BASE_REPO` (default `dyad-sh/dyad`) if needed. Do not manually replay the full workflow unless the script itself is broken.
+5. Summarize the script's final output, including the branch, committed files, ignored files, checks, pushed remote, and PR URL or bot-account PR creation link. Also report the local unit-test decision and any test command that was run.
 
 ## Script Behavior
 
@@ -26,7 +27,8 @@ The script handles the mechanical workflow:
 - Refuses to push `main`/`master`; creates a feature branch if needed.
 - Stages relevant changes while ignoring obvious secrets/artifacts and spurious `package-lock.json` changes without `package.json`.
 - Commits changes with a generated message, unless `PR_PUSH_COMMIT_MESSAGE` is set.
-- Runs `npm run fmt`, `npm run lint:fix`, `npm run ts`, and `npm test`.
+- Runs `npm run fmt`, `npm run lint:fix`, and `npm run ts`.
+- Does not run unit tests. The agent decides whether to run `npm test` for broad changes or a targeted `npm test -- ...` command for narrow changes; GitHub CI runs the full suite.
 - Amends automated formatting/lint changes into the commit it created.
 - Pushes to the tracked upstream, an existing PR head remote, or `origin` with the documented fallback behavior.
 - Creates or updates the PR against `dyad-sh/dyad:main`, unless the active GitHub account is a bot.

--- a/.claude/skills/pr-push/scripts/pr_push.sh
+++ b/.claude/skills/pr-push/scripts/pr_push.sh
@@ -272,9 +272,6 @@ run_checks() {
 
   log "Running typecheck"
   npm run ts || die "Typecheck failed; fix the issues above and rerun"
-
-  log "Running tests"
-  npm test || die "Tests failed; fix the issues above and rerun"
 }
 
 amend_or_commit_check_changes() {
@@ -718,7 +715,7 @@ print_summary() {
     printf -- '- %s\n' "${IGNORED_FILES[@]+"${IGNORED_FILES[@]}"}"
   fi
   printf 'Automated check changes: %s\n' "$LINT_CHANGED"
-  printf 'Checks: passed\n'
+  printf 'Checks: fmt, lint:fix, ts passed; unit tests not run by script\n'
   printf 'Pushed remote: %s (%s)\n' "$PUSH_REMOTE" "$PUSH_OWNER_REPO"
   if [[ -n "$PR_URL" ]]; then
     printf 'PR: %s\n' "$PR_URL"

--- a/rules/git-workflow.md
+++ b/rules/git-workflow.md
@@ -76,6 +76,11 @@ When passing a PR body inline via `gh pr create --body "..."`, unescaped backtic
 formatting, check `git status` and revert unrelated skill-file churn before
 committing unless the task intentionally changes those skill docs.
 
+When editing skill files through `.agents/skills/...`, remember that
+`.agents/skills` is a symlink to `../.claude/skills`. If Git reports
+`fatal: pathspec '.agents/skills/...' is beyond a symbolic link`, inspect and
+commit the corresponding tracked `.claude/skills/...` path instead.
+
 ## Commit hooks and untracked artifacts
 
 After a commit with lint-staged hooks, re-check both `git status --short` and any untracked artifact files you intentionally left out of the commit. Hook cleanup can leave the tracked tree clean while untracked scratch files under directories like `.agents/` have been removed; restore or report them before finishing.


### PR DESCRIPTION
## Summary
- Stop pr-push from running unit tests automatically
- Document agent-selected local test strategy before publishing
- Record .agents skills symlink learning

## Testing
- bash -n .agents/skills/pr-push/scripts/pr_push.sh
- npm test not run (narrow agent skill/script change; CI runs full suite)

#skip-bugbot

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Agent workflow and documentation only; CI still runs the full test suite and the script continues fmt, lint, and typecheck.
> 
> **Overview**
> The **pr-push** publish script no longer runs **`npm test`** during its automated checks; it still runs **fmt**, **lint:fix**, and **ts**. The skill doc now tells agents to choose local tests (full **`npm test`**, a targeted path, or skip for low-risk changes) before running the script, to invoke **`pr_push.sh`** via **`.agents/skills/...`**, and to include the test decision in the final summary.
> 
> **`rules/git-workflow.md`** adds guidance that **`.agents/skills`** symlinks to **`.claude/skills`**, so commits should use the tracked **`.claude/skills`** path when Git rejects pathspecs beyond the symlink.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d8e0668a9906af961178f1c87eee54e09780ea3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

