### PR TITLE
Fix safeStorage Keychain account lookup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ Detailed rules and learnings are in the `rules/` directory. Read the relevant fi
 | [rules/claude-github-workflows.md](rules/claude-github-workflows.md) | Editing `.github/workflows/*.yml` that invoke `anthropics/claude-code-action` — workflow shape, untrusted-input handling, and **permission/`.claude/settings.json` hardening** |
 | [rules/ui-styling.md](rules/ui-styling.md)                           | Adding provider/brand icons, styling scrollable popovers, or using Tailwind v4 arbitrary values                                                                                |
 | [rules/auto-update.md](rules/auto-update.md)                         | Debugging Squirrel/update-electron-app failures, update feed URLs, or updater log capture in bug reports and session debug bundles                                             |
+| [rules/safe-storage.md](rules/safe-storage.md)                       | Working with Electron `safeStorage`, macOS Keychain identities, or legacy os_crypt secret recovery                                                                             |
 
 ## Project setup and lints
 

--- a/rules/safe-storage.md
+++ b/rules/safe-storage.md
@@ -1,0 +1,3 @@
+# Safe Storage
+
+- On macOS, Electron/Chromium `safeStorage` stores the os_crypt password as a generic Keychain item whose service is `"<product> Safe Storage"` and whose account is `"<product> Key"`. Do not query the account as only the product name; `security find-generic-password -s "dyad Safe Storage" -a "dyad"` misses the real item, which is under `dyad Key`.

--- a/src/main/safe_storage_legacy.test.ts
+++ b/src/main/safe_storage_legacy.test.ts
@@ -79,8 +79,8 @@ function makeFakeReader(map: Record<string, string>): FakeReader {
   };
 }
 
-const DYAD_KEY = "dyad Safe Storage::dyad";
-const CHROMIUM_KEY = "Chromium Safe Storage::Chromium";
+const DYAD_KEY = "dyad Safe Storage::dyad Key";
+const CHROMIUM_KEY = "Chromium Safe Storage::Chromium Key";
 
 describe("deriveLegacyOsCryptKey", () => {
   it("uses Chromium's fixed PBKDF2 parameters", () => {
@@ -167,8 +167,8 @@ describe("recoverLegacySafeStorageSecret", () => {
     // Both identities are consulted before returning so a later plausible
     // decrypt cannot be skipped.
     expect(reader.calls).toEqual([
-      { service: "dyad Safe Storage", account: "dyad" },
-      { service: "Chromium Safe Storage", account: "Chromium" },
+      { service: "dyad Safe Storage", account: "dyad Key" },
+      { service: "Chromium Safe Storage", account: "Chromium Key" },
     ]);
     expect(getRecoveryStatsForTesting()).toEqual({
       attempted: 1,
@@ -188,8 +188,8 @@ describe("recoverLegacySafeStorageSecret", () => {
       );
     });
     expect(reader.calls).toEqual([
-      { service: "dyad Safe Storage", account: "dyad" },
-      { service: "Chromium Safe Storage", account: "Chromium" },
+      { service: "dyad Safe Storage", account: "dyad Key" },
+      { service: "Chromium Safe Storage", account: "Chromium Key" },
     ]);
   });
 
@@ -247,8 +247,8 @@ describe("recoverLegacySafeStorageSecret", () => {
       expect(recoverLegacySafeStorageSecret(ciphertext, reader)).toBeNull();
     });
     expect(reader.calls).toEqual([
-      { service: "dyad Safe Storage", account: "dyad" },
-      { service: "Chromium Safe Storage", account: "Chromium" },
+      { service: "dyad Safe Storage", account: "dyad Key" },
+      { service: "Chromium Safe Storage", account: "Chromium Key" },
     ]);
     expect(getRecoveryStatsForTesting()).toEqual({
       attempted: 1,
@@ -395,7 +395,7 @@ describe.skipIf(process.platform !== "darwin")(
         "-s",
         "dyad Safe Storage",
         "-a",
-        "dyad",
+        "dyad Key",
         "-w",
         storedPassword,
         keychainPath,
@@ -416,7 +416,7 @@ describe.skipIf(process.platform !== "darwin")(
 
     it("reads a stored password from the temp keychain", () => {
       const reader = new SecurityCliKeychainPasswordReader(keychainPath);
-      expect(reader.readPassword("dyad Safe Storage", "dyad")).toBe(
+      expect(reader.readPassword("dyad Safe Storage", "dyad Key")).toBe(
         storedPassword,
       );
     });
@@ -443,7 +443,7 @@ describe.skipIf(process.platform !== "darwin")(
       // under the reader: cached answers must keep being served without any
       // further CLI calls (a re-read of the now-missing item would return
       // null, and a prompt-per-secret would stall startup on real machines).
-      expect(reader.readPassword("dyad Safe Storage", "dyad")).toBe(
+      expect(reader.readPassword("dyad Safe Storage", "dyad Key")).toBe(
         storedPassword,
       );
       expect(reader.readPassword("Missing Safe Storage", "nobody")).toBeNull();
@@ -454,7 +454,7 @@ describe.skipIf(process.platform !== "darwin")(
         keychainPath,
       ]);
       try {
-        expect(reader.readPassword("dyad Safe Storage", "dyad")).toBe(
+        expect(reader.readPassword("dyad Safe Storage", "dyad Key")).toBe(
           storedPassword,
         );
         expect(
@@ -465,7 +465,7 @@ describe.skipIf(process.platform !== "darwin")(
         expect(
           new SecurityCliKeychainPasswordReader(keychainPath).readPassword(
             "dyad Safe Storage",
-            "dyad",
+            "dyad Key",
           ),
         ).toBeNull();
       } finally {
@@ -476,7 +476,7 @@ describe.skipIf(process.platform !== "darwin")(
           "-s",
           "dyad Safe Storage",
           "-a",
-          "dyad",
+          "dyad Key",
           "-w",
           storedPassword,
           keychainPath,

--- a/src/main/safe_storage_legacy.ts
+++ b/src/main/safe_storage_legacy.ts
@@ -17,7 +17,7 @@ const logger = log.scope("safe_storage_recovery");
  * Chromium macOS os_crypt scheme (verified byte-for-byte against Electron
  * 40/43 output):
  *   - Keychain generic password: service "<product> Safe Storage",
- *     account "<product>" -> the password string.
+ *     account "<product> Key" -> the password string.
  *   - key = PBKDF2-HMAC-SHA1(password, salt "saltysalt", 1003 iters, 16 bytes)
  *   - ciphertext = "v10" + AES-128-CBC(key, IV = 16 * 0x20, PKCS#7) of UTF-8
  *     plaintext.
@@ -42,8 +42,8 @@ interface LegacyIdentity {
 // Ordered by likelihood on a current install: the post-`ready` "dyad" identity
 // first, then the legacy "Chromium" identity from the pre-`ready` race.
 const LEGACY_IDENTITIES: LegacyIdentity[] = [
-  { service: "dyad Safe Storage", account: "dyad" },
-  { service: "Chromium Safe Storage", account: "Chromium" },
+  { service: "dyad Safe Storage", account: "dyad Key" },
+  { service: "Chromium Safe Storage", account: "Chromium Key" },
 ];
 
 /**


### PR DESCRIPTION
## Summary
- Fix safeStorage Keychain account lookup
- Primary files: AGENTS.md, rules/safe-storage.md, src/main/safe_storage_legacy.test.ts, src/main/safe_storage_legacy.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches secret decryption and Keychain lookup on macOS; wrong accounts would block recovery, but the change aligns with Chromium’s documented scheme and is covered by existing recovery tests.
> 
> **Overview**
> Fixes **legacy `safeStorage` secret recovery on macOS** by looking up the correct Keychain generic-password **account** names. Recovery now uses `"dyad Key"` and `"Chromium Key"` (with the existing `"… Safe Storage"` services) instead of bare `"dyad"` / `"Chromium"`, matching Electron/Chromium’s os_crypt layout so `security find-generic-password` can find the real items.
> 
> **`safe_storage_legacy.ts`** updates `LEGACY_IDENTITIES` and module docs; **tests and darwin integration setup** use the same account strings. Adds **`rules/safe-storage.md`** and an **AGENTS.md** index entry so future work doesn’t query the wrong account.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aadb63fe294cfa99abfe70b010083e26c9c533db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

