### PR TITLE
Fix safeStorage E2E keychain account names

### DIFF
--- a/e2e-tests/safe_storage_keychain_identity.spec.ts
+++ b/e2e-tests/safe_storage_keychain_identity.spec.ts
@@ -136,8 +136,8 @@ function freshTempKeychain(): void {
   // items via the `security` CLI (the -A ACL lets it read them without a
   // prompt), which is what makes the fallback exercisable in this environment.
   for (const [service, account, password] of [
-    [CHROMIUM_SERVICE, "Chromium", "e2e-chromium-identity-key"],
-    [DYAD_SERVICE, "dyad", "e2e-dyad-identity-key"],
+    [CHROMIUM_SERVICE, "Chromium Key", "e2e-chromium-identity-key"],
+    [DYAD_SERVICE, "dyad Key", "e2e-dyad-identity-key"],
   ]) {
     security([
       "add-generic-password",

--- a/rules/safe-storage.md
+++ b/rules/safe-storage.md
@@ -1,3 +1,4 @@
 # Safe Storage
 
 - On macOS, Electron/Chromium `safeStorage` stores the os_crypt password as a generic Keychain item whose service is `"<product> Safe Storage"` and whose account is `"<product> Key"`. Do not query the account as only the product name; `security find-generic-password -s "dyad Safe Storage" -a "dyad"` misses the real item, which is under `dyad Key`.
+- The opt-in `safe_storage_keychain_identity.spec.ts` fixture must pre-seed its temporary Keychain with the same account names (`dyad Key` / `Chromium Key`). If it seeds bare `dyad` / `Chromium`, the Layer 1 recovery test fails with `settings.githubAccessToken` undefined even though production lookup is correct.


### PR DESCRIPTION
## Summary
- update the opt-in safeStorage E2E fixture to preseed dyad Key and Chromium Key accounts
- document that the fixture must match Electron/Chromium safeStorage Keychain account names

## Context
- Fixes the safe-storage-e2e failure in https://github.com/dyad-sh/dyad/actions/runs/29004553432/job/86073931029
- The failure returned undefined githubAccessToken because the fixture seeded bare dyad and Chromium accounts while recovery looks up dyad Key and Chromium Key.

## Testing
- Started DYAD_E2E_SAFE_STORAGE=1 PLAYWRIGHT_HTML_OPEN=never npx playwright test e2e-tests/safe_storage_keychain_identity.spec.ts --workers=1, then stopped at user request before completion.
- pr-push runs fmt, lint:fix, and ts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test fixture and documentation only; no production safeStorage or recovery logic changes.
> 
> **Overview**
> Fixes the opt-in macOS **safeStorage** E2E suite by pre-seeding the temporary Keychain with **`Chromium Key`** and **`dyad Key`** accounts instead of bare **`Chromium`** / **`dyad`**, matching how Electron/Chromium stores the os_crypt password under `"<product> Safe Storage"`.
> 
> **`rules/safe-storage.md`** now states that the fixture must use those account names; mismatched seeding breaks the Layer 1 recovery scenario (`githubAccessToken` undefined in IPC) even when production lookup is correct.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 877da374a47de9eb857a9ee75255b1cae2ea2530. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

