### PR TITLE
Add OpenRouter app attribution

### DIFF
--- a/src/ipc/services/provider_api_key_validation_service.ts
+++ b/src/ipc/services/provider_api_key_validation_service.ts
@@ -17,6 +17,7 @@ import { fastTextOutput } from "@/ipc/utils/stream_text_utils";
 import { IS_TEST_BUILD } from "@/ipc/utils/test_utils";
 import { getDyadEngineBaseUrl } from "@/ipc/utils/dyad_engine_url";
 import { getTestFetchOption } from "@/ipc/utils/test_fetch_override";
+import { getOpenRouterAppAttributionHeaders } from "@/ipc/utils/openrouter_attribution";
 
 const logger = log.scope("provider_api_key_validation");
 
@@ -124,6 +125,7 @@ async function createValidationModel(
         name: "openrouter",
         apiKey,
         baseURL: getOpenRouterBaseUrl(),
+        headers: getOpenRouterAppAttributionHeaders(),
         ...getTestFetchOption(),
       });
       return openrouter("openrouter/free");

--- a/src/ipc/utils/get_model_client.test.ts
+++ b/src/ipc/utils/get_model_client.test.ts
@@ -1,7 +1,16 @@
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { generateText } from "ai";
 
 import type { UserSettings } from "../../lib/schemas";
-import { getModelClient } from "./get_model_client";
+import {
+  getModelClient,
+  setModelClientFetchForTesting,
+} from "./get_model_client";
+import {
+  OPENROUTER_APP_CATEGORIES,
+  OPENROUTER_APP_REFERER,
+  OPENROUTER_APP_TITLE,
+} from "./openrouter_attribution";
 
 vi.mock("electron-log", () => ({
   default: {
@@ -79,6 +88,10 @@ vi.mock("../shared/remote_language_model_catalog", () => ({
 }));
 
 describe("getModelClient", () => {
+  afterEach(() => {
+    setModelClientFetchForTesting(undefined);
+  });
+
   test("keeps the Anthropic gateway prefix for Dyad Engine models", async () => {
     const { modelClient } = await getModelClient(
       {
@@ -186,5 +199,62 @@ describe("getModelClient", () => {
 
     expect((modelClient.model as { modelId: string }).modelId).toBe("free-pro");
     expect(modelClient.builtinProviderId).toBe("auto");
+  });
+
+  test("sends OpenRouter app attribution headers", async () => {
+    let capturedHeaders: Headers | undefined;
+    setModelClientFetchForTesting(
+      vi.fn(async (_url, init) => {
+        capturedHeaders = new Headers(init?.headers);
+        return new Response(
+          JSON.stringify({
+            id: "chatcmpl-test",
+            choices: [
+              {
+                message: {
+                  role: "assistant",
+                  content: "ok",
+                },
+                finish_reason: "stop",
+              },
+            ],
+          }),
+          {
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }),
+    );
+
+    const { modelClient } = await getModelClient(
+      {
+        provider: "openrouter",
+        name: "openrouter/free",
+      },
+      {
+        providerSettings: {
+          openrouter: {
+            apiKey: {
+              value: "openrouter-key",
+            },
+          },
+        },
+      } as unknown as UserSettings,
+    );
+
+    await generateText({
+      model: modelClient.model,
+      prompt: "hi",
+      maxRetries: 0,
+    });
+
+    expect(capturedHeaders?.get("Authorization")).toBe("Bearer openrouter-key");
+    expect(capturedHeaders?.get("HTTP-Referer")).toBe(OPENROUTER_APP_REFERER);
+    expect(capturedHeaders?.get("X-OpenRouter-Title")).toBe(
+      OPENROUTER_APP_TITLE,
+    );
+    expect(capturedHeaders?.get("X-OpenRouter-Categories")).toBe(
+      OPENROUTER_APP_CATEGORIES,
+    );
   });
 });

--- a/src/ipc/utils/get_model_client.ts
+++ b/src/ipc/utils/get_model_client.ts
@@ -38,6 +38,7 @@ import {
   normalizeProviderApiKeyInput,
 } from "@/lib/providerApiKey";
 import { FREE_PRO_MODEL_NAME, isFreeProModel } from "@/lib/freeProModel";
+import { getOpenRouterAppAttributionHeaders } from "./openrouter_attribution";
 
 // The test-only fetch seam lives in ./test_fetch_override (dependency-free,
 // so secondary factories can use it without import cycles). Re-exported here
@@ -490,6 +491,7 @@ function getRegularModelClient(
         name: "openrouter",
         baseURL: "https://openrouter.ai/api/v1",
         apiKey,
+        headers: getOpenRouterAppAttributionHeaders(),
         ...getModelClientFetchOption(),
       });
       return {

--- a/src/ipc/utils/openrouter_attribution.ts
+++ b/src/ipc/utils/openrouter_attribution.ts
@@ -1,0 +1,11 @@
+export const OPENROUTER_APP_REFERER = "https://www.dyad.sh";
+export const OPENROUTER_APP_TITLE = "Dyad";
+export const OPENROUTER_APP_CATEGORIES = "native-app-builder,programming-app";
+
+export function getOpenRouterAppAttributionHeaders(): Record<string, string> {
+  return {
+    "HTTP-Referer": OPENROUTER_APP_REFERER,
+    "X-OpenRouter-Title": OPENROUTER_APP_TITLE,
+    "X-OpenRouter-Categories": OPENROUTER_APP_CATEGORIES,
+  };
+}


### PR DESCRIPTION
## Summary
- Add OpenRouter app attribution
- Primary files: src/ipc/services/provider_api_key_validation_service.ts, src/ipc/utils/get_model_client.test.ts, src/ipc/utils/get_model_client.ts, src/ipc/utils/openrouter_attribution.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds static HTTP headers only; no changes to auth, routing, or model selection logic.
> 
> **Overview**
> OpenRouter requests from Dyad now include **app attribution headers** so traffic can be identified on OpenRouter’s side.
> 
> A shared helper in `openrouter_attribution.ts` sets `HTTP-Referer`, `X-OpenRouter-Title`, and `X-OpenRouter-Categories` (Dyad site, title, and categories). Those headers are attached when building the OpenRouter client in **`get_model_client`** and during **OpenRouter API key validation** in `provider_api_key_validation_service`.
> 
> A **`get_model_client` test** stubs fetch and asserts the attribution headers (plus auth) on a real `generateText` call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e5465bb44a0b637c3fd97b87b0e7de896f4ba23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

