### PR TITLE
Bound preview screenshot memory usage

### DIFF
--- a/rules/ui-styling.md
+++ b/rules/ui-styling.md
@@ -27,6 +27,13 @@ Use `MoreHorizontal` for compact preview-mode overflow and `MoreVertical` for
 the right-most preview utility/actions menu. This keeps two ellipsis controls in
 the same preview header visually distinct.
 
+## Preview screenshot viewport offsets
+
+When using `html-to-image` to capture a scrolled viewport, do not translate or
+transform the cloned document root. A transformed ancestor becomes the
+containing block for fixed descendants and shifts headers, floating buttons,
+and modals; use non-transform layout offsets so fixed UI remains viewport-bound.
+
 ## Flex containers with non-shrinkable children
 
 Don't put an explicit `min-w-*` on a flex item whose children are `flex-shrink-0` (icon buttons, etc.) if that value is smaller than the children's combined width. An explicit `min-width` overrides flexbox's content-based minimum, so the item gets squeezed below its content and the overflow paints over sibling elements — visually broken and it intercepts their pointer events (this broke the preview Restart button at narrow widths). Use `min-w-fit` to let the item refuse to shrink below its content.

--- a/src/components/preview_panel/PreviewIframe.tsx
+++ b/src/components/preview_panel/PreviewIframe.tsx
@@ -338,6 +338,9 @@ export const PreviewIframe = ({ loading }: { loading: boolean }) => {
   // guard from a replaced iframe doesn't block future captures.
   useEffect(() => {
     pendingCommitScreenshotRequestRef.current = null;
+    pendingAnnotatorScreenshotRequestIdRef.current = null;
+    setAnnotatorMode(false);
+    setScreenshotDataUrl(null);
     if (captureTimeoutRef.current !== null) {
       clearTimeout(captureTimeoutRef.current);
       captureTimeoutRef.current = null;
@@ -347,6 +350,9 @@ export const PreviewIframe = ({ loading }: { loading: boolean }) => {
   // Clean up pending screenshot timeout on unmount
   useEffect(() => {
     return () => {
+      pendingAnnotatorScreenshotRequestIdRef.current = null;
+      setAnnotatorMode(false);
+      setScreenshotDataUrl(null);
       if (captureTimeoutRef.current !== null) {
         clearTimeout(captureTimeoutRef.current);
         captureTimeoutRef.current = null;
@@ -657,9 +663,6 @@ export const PreviewIframe = ({ loading }: { loading: boolean }) => {
       console.error("Failed to get element styles:", error);
     }
   };
-  useEffect(() => {
-    setAnnotatorMode(false);
-  }, []);
   // Reset visual editing state when app changes or component unmounts
   useEffect(() => {
     return () => {
@@ -1306,7 +1309,9 @@ export const PreviewIframe = ({ loading }: { loading: boolean }) => {
   // Function to handle annotator button click
   const handleAnnotatorClick = () => {
     if (annotatorMode) {
+      pendingAnnotatorScreenshotRequestIdRef.current = null;
       setAnnotatorMode(false);
+      setScreenshotDataUrl(null);
       return;
     }
     if (iframeRef.current?.contentWindow) {
@@ -2060,9 +2065,7 @@ export const PreviewIframe = ({ loading }: { loading: boolean }) => {
                     handleAnnotatorClick={handleAnnotatorClick}
                   />
                 ) : (
-                  <AnnotatorOnlyForPro
-                    onGoBack={() => setAnnotatorMode(false)}
-                  />
+                  <AnnotatorOnlyForPro onGoBack={handleAnnotatorClick} />
                 )}
               </div>
             ) : (

--- a/src/components/preview_panel/dyadScreenshotClient.test.ts
+++ b/src/components/preview_panel/dyadScreenshotClient.test.ts
@@ -1,0 +1,145 @@
+import fs from "node:fs";
+import path from "node:path";
+import vm from "node:vm";
+import { describe, expect, it, vi } from "vitest";
+
+const screenshotClientSource = fs.readFileSync(
+  path.resolve(process.cwd(), "worker/dyad-screenshot-client.js"),
+  "utf8",
+);
+
+type Dimensions = {
+  width: number;
+  height: number;
+};
+
+function loadScreenshotClient({
+  fullPage,
+  viewport,
+  devicePixelRatio = 1,
+}: {
+  fullPage: Dimensions;
+  viewport: Dimensions;
+  devicePixelRatio?: number;
+}) {
+  let messageHandler:
+    | ((event: { source: object; data: Record<string, unknown> }) => void)
+    | undefined;
+  const parent = { postMessage: vi.fn() };
+  const toPng = vi.fn().mockResolvedValue("data:image/png;base64,test");
+  const window = {
+    parent,
+    innerWidth: viewport.width,
+    innerHeight: viewport.height,
+    devicePixelRatio,
+    addEventListener: vi.fn(
+      (
+        eventName: string,
+        handler: (event: {
+          source: object;
+          data: Record<string, unknown>;
+        }) => void,
+      ) => {
+        if (eventName === "message") {
+          messageHandler = handler;
+        }
+      },
+    ),
+  };
+  const documentElement = {
+    scrollWidth: fullPage.width,
+    scrollHeight: fullPage.height,
+    offsetWidth: fullPage.width,
+    offsetHeight: fullPage.height,
+    clientWidth: viewport.width,
+    clientHeight: viewport.height,
+  };
+  const body = {
+    ...documentElement,
+    clientWidth: viewport.width,
+    clientHeight: viewport.height,
+  };
+
+  vm.runInNewContext(screenshotClientSource, {
+    console: {
+      debug: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+    },
+    document: { body, documentElement },
+    htmlToImage: { toPng },
+    window,
+  });
+
+  if (!messageHandler) {
+    throw new Error("Screenshot client did not register its message handler");
+  }
+
+  return {
+    parent,
+    toPng,
+    dispatchScreenshot(requestId: string) {
+      messageHandler?.({
+        source: parent,
+        data: { type: "dyad-take-screenshot", requestId },
+      });
+    },
+    async requestScreenshot() {
+      this.dispatchScreenshot("request-1");
+      await vi.waitFor(() => expect(parent.postMessage).toHaveBeenCalled());
+    },
+  };
+}
+
+describe("dyad screenshot client", () => {
+  it("preserves a normal full-page screenshot within the memory budget", async () => {
+    const client = loadScreenshotClient({
+      fullPage: { width: 1200, height: 3000 },
+      viewport: { width: 1200, height: 800 },
+      devicePixelRatio: 3,
+    });
+
+    await client.requestScreenshot();
+
+    expect(client.toPng).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        width: 1200,
+        height: 3000,
+        pixelRatio: 1,
+      }),
+    );
+  });
+
+  it("uses a bounded viewport for a page that is too tall", async () => {
+    const client = loadScreenshotClient({
+      fullPage: { width: 1920, height: 50_000 },
+      viewport: { width: 1280, height: 720 },
+    });
+
+    await client.requestScreenshot();
+
+    const options = client.toPng.mock.calls[0][1] as {
+      width: number;
+      height: number;
+      pixelRatio: number;
+    };
+    expect(options).toEqual({ width: 1280, height: 720, pixelRatio: 1 });
+    expect(options.width * options.height).toBeLessThanOrEqual(4 * 1024 * 1024);
+  });
+
+  it("reuses one canvas for concurrent screenshot requests", async () => {
+    const client = loadScreenshotClient({
+      fullPage: { width: 1200, height: 2000 },
+      viewport: { width: 1200, height: 800 },
+    });
+
+    client.dispatchScreenshot("request-1");
+    client.dispatchScreenshot("request-2");
+
+    expect(client.toPng).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() =>
+      expect(client.parent.postMessage).toHaveBeenCalledTimes(2),
+    );
+  });
+});

--- a/src/components/preview_panel/dyadScreenshotClient.test.ts
+++ b/src/components/preview_panel/dyadScreenshotClient.test.ts
@@ -138,13 +138,18 @@ describe("dyad screenshot client", () => {
         height: 720,
         pixelRatio: 1,
         style: {
-          transform: "matrix(1, 0, 0, 1, -120, -450)",
-          transformOrigin: "top left",
+          position: "relative",
+          left: "-120px",
+          top: "-450px",
+          zoom: "1",
           width: "1920px",
           height: "50000px",
         },
       }),
     );
+    // A transform on the body would establish a containing block and move
+    // fixed-position UI with the scrolled document content.
+    expect(options.style).not.toHaveProperty("transform");
     expect(options.width * options.height).toBeLessThanOrEqual(4 * 1024 * 1024);
   });
 

--- a/src/components/preview_panel/dyadScreenshotClient.test.ts
+++ b/src/components/preview_panel/dyadScreenshotClient.test.ts
@@ -17,10 +17,12 @@ function loadScreenshotClient({
   fullPage,
   viewport,
   devicePixelRatio = 1,
+  scroll = { x: 0, y: 0 },
 }: {
   fullPage: Dimensions;
   viewport: Dimensions;
   devicePixelRatio?: number;
+  scroll?: { x: number; y: number };
 }) {
   let messageHandler:
     | ((event: { source: object; data: Record<string, unknown> }) => void)
@@ -32,6 +34,10 @@ function loadScreenshotClient({
     innerWidth: viewport.width,
     innerHeight: viewport.height,
     devicePixelRatio,
+    scrollX: scroll.x,
+    scrollY: scroll.y,
+    pageXOffset: scroll.x,
+    pageYOffset: scroll.y,
     addEventListener: vi.fn(
       (
         eventName: string,
@@ -115,6 +121,7 @@ describe("dyad screenshot client", () => {
     const client = loadScreenshotClient({
       fullPage: { width: 1920, height: 50_000 },
       viewport: { width: 1280, height: 720 },
+      scroll: { x: 120, y: 450 },
     });
 
     await client.requestScreenshot();
@@ -123,8 +130,21 @@ describe("dyad screenshot client", () => {
       width: number;
       height: number;
       pixelRatio: number;
+      style: Record<string, string>;
     };
-    expect(options).toEqual({ width: 1280, height: 720, pixelRatio: 1 });
+    expect(options).toEqual(
+      expect.objectContaining({
+        width: 1280,
+        height: 720,
+        pixelRatio: 1,
+        style: {
+          transform: "matrix(1, 0, 0, 1, -120, -450)",
+          transformOrigin: "top left",
+          width: "1920px",
+          height: "50000px",
+        },
+      }),
+    );
     expect(options.width * options.height).toBeLessThanOrEqual(4 * 1024 * 1024);
   });
 
@@ -140,6 +160,62 @@ describe("dyad screenshot client", () => {
     expect(client.toPng).toHaveBeenCalledTimes(1);
     await vi.waitFor(() =>
       expect(client.parent.postMessage).toHaveBeenCalledTimes(2),
+    );
+  });
+
+  it("shares capture failures and retries with a fresh canvas", async () => {
+    const client = loadScreenshotClient({
+      fullPage: { width: 1200, height: 2000 },
+      viewport: { width: 1200, height: 800 },
+    });
+    let rejectCapture: ((reason?: unknown) => void) | undefined;
+    client.toPng.mockImplementationOnce(
+      () =>
+        new Promise<string>((_resolve, reject) => {
+          rejectCapture = reject;
+        }),
+    );
+
+    client.dispatchScreenshot("request-1");
+    client.dispatchScreenshot("request-2");
+
+    expect(client.toPng).toHaveBeenCalledTimes(1);
+    rejectCapture?.(new Error("capture failed"));
+    await vi.waitFor(() =>
+      expect(client.parent.postMessage).toHaveBeenCalledTimes(2),
+    );
+
+    expect(
+      client.parent.postMessage.mock.calls.map(([message]) => message),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          requestId: "request-1",
+          success: false,
+          error: "capture failed",
+        }),
+        expect.objectContaining({
+          requestId: "request-2",
+          success: false,
+          error: "capture failed",
+        }),
+      ]),
+    );
+
+    client.toPng.mockResolvedValueOnce("data:image/png;base64,retry");
+    client.dispatchScreenshot("request-3");
+
+    await vi.waitFor(() =>
+      expect(client.parent.postMessage).toHaveBeenCalledTimes(3),
+    );
+    expect(client.toPng).toHaveBeenCalledTimes(2);
+    expect(client.parent.postMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        requestId: "request-3",
+        success: true,
+        dataUrl: "data:image/png;base64,retry",
+      }),
+      "*",
     );
   });
 });

--- a/worker/dyad-screenshot-client.js
+++ b/worker/dyad-screenshot-client.js
@@ -114,13 +114,19 @@
             dimensions.height / dimensions.viewport.height,
           );
 
-          // html-to-image always clones from the document origin. Translate
-          // the clone to the current scroll position so the bounded fallback
-          // captures what the user is actually viewing. The scale also keeps
-          // unusually large viewports within the same pixel budget.
+          // html-to-image always clones from the document origin. Offset the
+          // clone to the current scroll position so the bounded fallback
+          // captures what the user is actually viewing. Avoid a transform:
+          // transforms establish a containing block for fixed descendants and
+          // would shift fixed headers, floating buttons, and modals along with
+          // the scrolled document content. CSS zoom keeps unusually large
+          // viewports within the same pixel budget without changing that
+          // fixed-position containing block.
           options.style = {
-            transform: `matrix(${scale}, 0, 0, ${scale}, ${-scrollX * scale}, ${-scrollY * scale})`,
-            transformOrigin: "top left",
+            position: "relative",
+            left: `${-scrollX}px`,
+            top: `${-scrollY}px`,
+            zoom: `${scale}`,
             width: `${dimensions.fullPage.width}px`,
             height: `${dimensions.fullPage.height}px`,
           };

--- a/worker/dyad-screenshot-client.js
+++ b/worker/dyad-screenshot-client.js
@@ -1,17 +1,121 @@
 (() => {
-  async function captureScreenshot() {
+  // Keep the raw RGBA canvas at or below ~16 MiB. html-to-image may allocate
+  // more than one intermediate surface, so relying on its 16,384px
+  // per-dimension fallback is not enough to avoid renderer OOMs.
+  const MAX_SCREENSHOT_DIMENSION = 4096;
+  const MAX_SCREENSHOT_PIXELS = 4 * 1024 * 1024;
+  let activeCapturePromise = null;
+
+  function getLargestDimension(...values) {
+    const validValues = values.filter(
+      (value) => Number.isFinite(value) && value > 0,
+    );
+    return validValues.length > 0 ? Math.ceil(Math.max(...validValues)) : 1;
+  }
+
+  function getFullPageDimensions() {
+    const root = document.documentElement;
+    const body = document.body;
+
+    return {
+      width: getLargestDimension(
+        root?.scrollWidth,
+        root?.offsetWidth,
+        root?.clientWidth,
+        body?.scrollWidth,
+        body?.offsetWidth,
+        body?.clientWidth,
+        window.innerWidth,
+      ),
+      height: getLargestDimension(
+        root?.scrollHeight,
+        root?.offsetHeight,
+        root?.clientHeight,
+        body?.scrollHeight,
+        body?.offsetHeight,
+        body?.clientHeight,
+        window.innerHeight,
+      ),
+    };
+  }
+
+  function getViewportDimensions() {
+    const root = document.documentElement;
+    return {
+      width: getLargestDimension(root?.clientWidth, window.innerWidth),
+      height: getLargestDimension(root?.clientHeight, window.innerHeight),
+    };
+  }
+
+  function fitsScreenshotBudget({ width, height }) {
+    return (
+      width <= MAX_SCREENSHOT_DIMENSION &&
+      height <= MAX_SCREENSHOT_DIMENSION &&
+      width * height <= MAX_SCREENSHOT_PIXELS
+    );
+  }
+
+  function fitScreenshotToBudget({ width, height }) {
+    const scale = Math.min(
+      1,
+      MAX_SCREENSHOT_DIMENSION / width,
+      MAX_SCREENSHOT_DIMENSION / height,
+      Math.sqrt(MAX_SCREENSHOT_PIXELS / (width * height)),
+    );
+
+    return {
+      width: Math.max(1, Math.floor(width * scale)),
+      height: Math.max(1, Math.floor(height * scale)),
+    };
+  }
+
+  function getScreenshotDimensions() {
+    const fullPage = getFullPageDimensions();
+    if (fitsScreenshotBudget(fullPage)) {
+      return fullPage;
+    }
+
+    const viewport = getViewportDimensions();
+    const boundedViewport = fitScreenshotToBudget(viewport);
+    console.warn(
+      `[dyad-screenshot] Full page ${fullPage.width}x${fullPage.height} exceeds the screenshot memory budget; capturing viewport ${boundedViewport.width}x${boundedViewport.height} instead.`,
+    );
+    return boundedViewport;
+  }
+
+  async function captureScreenshotOnce() {
     try {
       // Use html-to-image if available
       if (typeof htmlToImage !== "undefined") {
+        const { width, height } = getScreenshotDimensions();
         return await htmlToImage.toPng(document.body, {
-          width: document.documentElement.scrollWidth,
-          height: document.documentElement.scrollHeight,
+          width,
+          height,
+          // html-to-image otherwise multiplies the canvas by devicePixelRatio,
+          // which can turn a bounded screenshot into a 4-9x memory spike.
+          pixelRatio: 1,
         });
       }
       throw new Error("html-to-image library not found");
     } catch (error) {
       console.error("[dyad-screenshot] Failed to capture screenshot:", error);
       throw error;
+    }
+  }
+
+  async function captureScreenshot() {
+    // HMR, a commit, and the annotator can request a screenshot at nearly the
+    // same time. Reuse one bounded capture instead of allocating a canvas for
+    // every request.
+    if (activeCapturePromise) {
+      return activeCapturePromise;
+    }
+
+    activeCapturePromise = captureScreenshotOnce();
+    try {
+      return await activeCapturePromise;
+    } finally {
+      activeCapturePromise = null;
     }
   }
   async function handleScreenshotRequest(requestId) {

--- a/worker/dyad-screenshot-client.js
+++ b/worker/dyad-screenshot-client.js
@@ -72,7 +72,7 @@
   function getScreenshotDimensions() {
     const fullPage = getFullPageDimensions();
     if (fitsScreenshotBudget(fullPage)) {
-      return fullPage;
+      return { ...fullPage, fullPage, isViewport: false };
     }
 
     const viewport = getViewportDimensions();
@@ -80,21 +80,53 @@
     console.warn(
       `[dyad-screenshot] Full page ${fullPage.width}x${fullPage.height} exceeds the screenshot memory budget; capturing viewport ${boundedViewport.width}x${boundedViewport.height} instead.`,
     );
-    return boundedViewport;
+    return {
+      ...boundedViewport,
+      fullPage,
+      isViewport: true,
+      viewport,
+    };
+  }
+
+  function getScrollOffset(primaryValue, fallbackValue) {
+    const value = Number.isFinite(primaryValue) ? primaryValue : fallbackValue;
+    return Number.isFinite(value) ? Math.max(0, value) : 0;
   }
 
   async function captureScreenshotOnce() {
     try {
       // Use html-to-image if available
       if (typeof htmlToImage !== "undefined") {
-        const { width, height } = getScreenshotDimensions();
-        return await htmlToImage.toPng(document.body, {
-          width,
-          height,
+        const dimensions = getScreenshotDimensions();
+        const options = {
+          width: dimensions.width,
+          height: dimensions.height,
           // html-to-image otherwise multiplies the canvas by devicePixelRatio,
           // which can turn a bounded screenshot into a 4-9x memory spike.
           pixelRatio: 1,
-        });
+        };
+
+        if (dimensions.isViewport) {
+          const scrollX = getScrollOffset(window.scrollX, window.pageXOffset);
+          const scrollY = getScrollOffset(window.scrollY, window.pageYOffset);
+          const scale = Math.min(
+            dimensions.width / dimensions.viewport.width,
+            dimensions.height / dimensions.viewport.height,
+          );
+
+          // html-to-image always clones from the document origin. Translate
+          // the clone to the current scroll position so the bounded fallback
+          // captures what the user is actually viewing. The scale also keeps
+          // unusually large viewports within the same pixel budget.
+          options.style = {
+            transform: `matrix(${scale}, 0, 0, ${scale}, ${-scrollX * scale}, ${-scrollY * scale})`,
+            transformOrigin: "top left",
+            width: `${dimensions.fullPage.width}px`,
+            height: `${dimensions.fullPage.height}px`,
+          };
+        }
+
+        return await htmlToImage.toPng(document.body, options);
       }
       throw new Error("html-to-image library not found");
     } catch (error) {


### PR DESCRIPTION
## Summary
- cap preview screenshot canvases at 4096 pixels per dimension and about 4 million total pixels
- fall back to a bounded viewport capture for oversized full pages and coalesce concurrent capture requests
- release annotator screenshot data when leaving annotation mode, switching apps, or unmounting

## Root cause
The injected preview client passed the complete document scroll dimensions to html-to-image. Very tall pages, high-DPI displays, or concurrent requests could allocate multiple extremely large canvas surfaces before the later PNG-size check in the main process.

## Tests
- fnm exec --using=24.13.1 npm test -- src/components/preview_panel/dyadScreenshotClient.test.ts
- fnm exec --using=24.13.1 npm run ts
- PR push checks: formatting, lint, and TypeScript

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core preview capture behavior (full-page vs viewport fallback) and memory limits; incorrect dimensions could affect thumbnails/annotator fidelity, but scope is isolated to the iframe screenshot client and preview UI cleanup with regression tests.
> 
> **Overview**
> Caps preview iframe screenshots so **html-to-image** no longer allocates unbounded full-page canvases (4096px max dimension, ~4M pixels, **`pixelRatio: 1`**). Oversized pages fall back to a **bounded viewport** capture aligned to scroll via **`left`/`top`/`zoom`**—not **`transform`**—so fixed UI stays viewport-bound.
> 
> **Concurrent** screenshot requests (HMR, commit thumbnails, annotator) share **one in-flight capture**; failures propagate to all waiters and a later request can retry.
> 
> **PreviewIframe** clears annotator mode, pending annotator request IDs, and **`screenshotDataUrl`** on app switch, unmount, and when exiting annotator; non-Pro “go back” reuses the same toggle handler.
> 
> Adds **Vitest** coverage for the injected **`worker/dyad-screenshot-client.js`** and documents the viewport-offset rule in **`rules/ui-styling.md`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 561c1733616203a9a85ed659aeb823cdc0f2d3a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->