### PR TITLE
Bound codebase extraction memory usage

### DIFF
--- a/rules/jotai-testing.md
+++ b/rules/jotai-testing.md
@@ -48,3 +48,7 @@ The vitest setup does not register `@testing-library/jest-dom`, so matchers like
 ## Hooks That Indirectly Use React Query
 
 If a `renderHook` test starts failing with `No QueryClient set, use QueryClientProvider to set one`, check whether the hook now calls another hook such as `useSettings()` or `useAppVersion()` that uses TanStack Query internally. Either wrap the test in a `QueryClientProvider` or mock the indirect hook when the test is only exercising Jotai/event behavior.
+
+## Partially Mock the Jotai Module
+
+When a component test overrides `useAtomValue`, preserve the rest of Jotai with an async partial mock (`const actual = await importOriginal<typeof import("jotai")>(); return { ...actual, useAtomValue: ... }`). A complete `vi.mock("jotai", () => ({ useAtomValue }))` can start failing when a transitive import creates a real atom, with `No "atom" export is defined on the "jotai" mock`.

--- a/src/__tests__/codebase.test.ts
+++ b/src/__tests__/codebase.test.ts
@@ -364,13 +364,35 @@ describe("extractCodebase", () => {
     expect(startedIndexes).toEqual([0, 1]);
   });
 
+  it("uses stable path ordering when virtual-file stats are unavailable", async () => {
+    appDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "codebase-"));
+    const virtualFileSystem = new AsyncVirtualFileSystem(appDir);
+    virtualFileSystem.applyResponseChanges({
+      deletePaths: [],
+      renameTags: [],
+      writeTags: [
+        { path: "b.ts", content: "b" },
+        { path: "a.ts", content: "a" },
+      ],
+    });
+
+    const result = await extractCodebase({
+      appPath: appDir,
+      chatContext: { contextPaths: [], smartContextAutoIncludes: [] },
+      virtualFileSystem,
+      limits: { maxFiles: 1, maxTotalBytes: 100 },
+    });
+
+    expect(result.files.map((file) => file.path)).toEqual(["a.ts"]);
+  });
+
   it("lists metadata without reading file contents", async () => {
     appDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "codebase-"));
     await fs.promises.writeFile(path.join(appDir, "a.ts"), "secret content");
     await fs.promises.writeFile(path.join(appDir, "b.ts"), "more content");
     const readFileSpy = vi.spyOn(fs.promises, "readFile");
 
-    const files = await listCodebaseFileMetadata({
+    const result = await listCodebaseFileMetadata({
       appPath: appDir,
       chatContext: {
         contextPaths: [],
@@ -378,7 +400,26 @@ describe("extractCodebase", () => {
       },
     });
 
-    expect(files.map((file) => file.path)).toEqual(["a.ts", "b.ts"]);
+    expect(result.files.map((file) => file.path)).toEqual(["a.ts", "b.ts"]);
+    expect(result.totalFileCount).toBe(2);
     expect(readFileSpy).not.toHaveBeenCalled();
+  });
+
+  it("bounds metadata results while retaining the total file count", async () => {
+    appDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "codebase-"));
+    await Promise.all(
+      ["a.ts", "b.ts", "c.ts"].map((file) =>
+        fs.promises.writeFile(path.join(appDir!, file), file),
+      ),
+    );
+
+    const result = await listCodebaseFileMetadata({
+      appPath: appDir,
+      chatContext: { contextPaths: [], smartContextAutoIncludes: [] },
+      maxFiles: 2,
+    });
+
+    expect(result.files).toHaveLength(2);
+    expect(result.totalFileCount).toBe(3);
   });
 });

--- a/src/__tests__/codebase.test.ts
+++ b/src/__tests__/codebase.test.ts
@@ -1,8 +1,10 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { extractCodebase } from "@/utils/codebase";
+import { extractCodebase, listCodebaseFileMetadata } from "@/utils/codebase";
+import { readSettings } from "@/main/settings";
+import { AsyncVirtualFileSystem } from "../../shared/VirtualFilesystem";
 
 vi.mock("electron-log", () => ({
   default: {
@@ -32,11 +34,20 @@ vi.mock("@/ipc/utils/git_utils", () => ({
 describe("extractCodebase", () => {
   let appDir: string | undefined;
 
+  beforeEach(() => {
+    vi.mocked(readSettings).mockReturnValue({
+      enableNativeGit: false,
+      enableDyadPro: false,
+      enableProSmartFilesContextMode: false,
+    } as ReturnType<typeof readSettings>);
+  });
+
   afterEach(async () => {
     if (appDir) {
       await fs.promises.rm(appDir, { recursive: true, force: true });
       appDir = undefined;
     }
+    vi.restoreAllMocks();
   });
 
   it("includes shader source file contents", async () => {
@@ -106,5 +117,193 @@ describe("extractCodebase", () => {
       "src.ts",
     ]);
     expect(result.formattedOutput).not.toContain(".gitattributes");
+  });
+
+  it("deterministically truncates at the aggregate byte budget", async () => {
+    appDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "codebase-"));
+    await fs.promises.writeFile(path.join(appDir, "a.ts"), "aaaa");
+    await fs.promises.writeFile(path.join(appDir, "b.ts"), "bbbb");
+    await fs.promises.writeFile(path.join(appDir, "c.ts"), "c");
+    const fixedTime = new Date("2020-01-01T00:00:00.000Z");
+    await Promise.all(
+      ["a.ts", "b.ts", "c.ts"].map((fileName) =>
+        fs.promises.utimes(path.join(appDir!, fileName), fixedTime, fixedTime),
+      ),
+    );
+
+    const extract = () =>
+      extractCodebase({
+        appPath: appDir!,
+        chatContext: {
+          contextPaths: [],
+          smartContextAutoIncludes: [],
+        },
+        limits: {
+          maxFiles: 10,
+          maxTotalBytes: 5,
+          ioConcurrency: 2,
+        },
+      });
+
+    const firstResult = await extract();
+    const secondResult = await extract();
+
+    expect(firstResult.files.map((file) => file.path)).toEqual([
+      "a.ts",
+      "c.ts",
+    ]);
+    expect(secondResult).toEqual(firstResult);
+    expect(firstResult.truncation).toEqual({
+      totalFileCount: 3,
+      includedFileCount: 2,
+      omittedFileCount: 1,
+      includedContentBytes: 5,
+      maxFiles: 10,
+      maxTotalBytes: 5,
+      reasons: ["total-bytes"],
+    });
+    expect(firstResult.formattedOutput).toContain(
+      '<dyad-codebase-truncated included_files="2" omitted_files="1" included_content_bytes="5" max_files="10" max_total_bytes="5" reasons="total-bytes" />',
+    );
+  });
+
+  it("applies the file-count limit at its exact boundary", async () => {
+    appDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "codebase-"));
+    await Promise.all(
+      Array.from({ length: 5 }, (_, index) =>
+        fs.promises.writeFile(
+          path.join(appDir!, `file-${index}.ts`),
+          String(index),
+        ),
+      ),
+    );
+    const fixedTime = new Date("2020-01-01T00:00:00.000Z");
+    await Promise.all(
+      Array.from({ length: 5 }, (_, index) =>
+        fs.promises.utimes(
+          path.join(appDir!, `file-${index}.ts`),
+          fixedTime,
+          fixedTime,
+        ),
+      ),
+    );
+
+    const result = await extractCodebase({
+      appPath: appDir,
+      chatContext: {
+        contextPaths: [],
+        smartContextAutoIncludes: [],
+      },
+      limits: {
+        maxFiles: 3,
+        maxTotalBytes: 100,
+      },
+    });
+
+    expect(result.files.map((file) => file.path)).toEqual([
+      "file-0.ts",
+      "file-1.ts",
+      "file-2.ts",
+    ]);
+    expect(result.truncation).toMatchObject({
+      totalFileCount: 5,
+      includedFileCount: 3,
+      omittedFileCount: 2,
+      reasons: ["file-count"],
+    });
+  });
+
+  it("prioritizes forced smart-context files when a budget truncates", async () => {
+    appDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "codebase-"));
+    await fs.promises.writeFile(path.join(appDir, "a.ts"), "a");
+    await fs.promises.writeFile(path.join(appDir, "b.ts"), "b");
+    await fs.promises.writeFile(path.join(appDir, "forced.ts"), "forced");
+    vi.mocked(readSettings).mockReturnValue({
+      enableNativeGit: false,
+      enableDyadPro: true,
+      enableProSmartFilesContextMode: true,
+    } as ReturnType<typeof readSettings>);
+
+    const result = await extractCodebase({
+      appPath: appDir,
+      chatContext: {
+        contextPaths: [],
+        smartContextAutoIncludes: [{ globPath: "forced.ts" }],
+      },
+      limits: {
+        maxFiles: 1,
+        maxTotalBytes: 100,
+      },
+    });
+
+    expect(result.files).toEqual([
+      { path: "forced.ts", content: "forced", force: true },
+    ]);
+  });
+
+  it("bounds concurrent reads and reads each selected file once", async () => {
+    appDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "codebase-"));
+    const fileCount = 12;
+    await Promise.all(
+      Array.from({ length: fileCount }, (_, index) =>
+        fs.promises.writeFile(
+          path.join(appDir!, `file-${String(index).padStart(2, "0")}.ts`),
+          `export const value${index} = ${index};`,
+        ),
+      ),
+    );
+
+    let activeReads = 0;
+    let maxActiveReads = 0;
+    let totalReads = 0;
+    const virtualFileSystem = new AsyncVirtualFileSystem(appDir, {
+      readFile: async (fileName) => {
+        activeReads++;
+        totalReads++;
+        maxActiveReads = Math.max(maxActiveReads, activeReads);
+        try {
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          return await fs.promises.readFile(fileName, "utf8");
+        } finally {
+          activeReads--;
+        }
+      },
+    });
+
+    const result = await extractCodebase({
+      appPath: appDir,
+      chatContext: {
+        contextPaths: [],
+        smartContextAutoIncludes: [],
+      },
+      virtualFileSystem,
+      limits: {
+        maxFiles: fileCount,
+        maxTotalBytes: 10_000,
+        ioConcurrency: 3,
+      },
+    });
+
+    expect(result.files).toHaveLength(fileCount);
+    expect(totalReads).toBe(fileCount);
+    expect(maxActiveReads).toBeLessThanOrEqual(3);
+  });
+
+  it("lists metadata without reading file contents", async () => {
+    appDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "codebase-"));
+    await fs.promises.writeFile(path.join(appDir, "a.ts"), "secret content");
+    await fs.promises.writeFile(path.join(appDir, "b.ts"), "more content");
+    const readFileSpy = vi.spyOn(fs.promises, "readFile");
+
+    const files = await listCodebaseFileMetadata({
+      appPath: appDir,
+      chatContext: {
+        contextPaths: [],
+        smartContextAutoIncludes: [],
+      },
+    });
+
+    expect(files.map((file) => file.path)).toEqual(["a.ts", "b.ts"]);
+    expect(readFileSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/codebase.test.ts
+++ b/src/__tests__/codebase.test.ts
@@ -2,7 +2,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { extractCodebase, listCodebaseFileMetadata } from "@/utils/codebase";
+import {
+  extractCodebase,
+  formatCodebaseTruncationWarning,
+  listCodebaseFileMetadata,
+  mapWithConcurrency,
+} from "@/utils/codebase";
 import { readSettings } from "@/main/settings";
 import { AsyncVirtualFileSystem } from "../../shared/VirtualFilesystem";
 
@@ -213,6 +218,59 @@ describe("extractCodebase", () => {
     });
   });
 
+  it("does not spend the byte budget on normally omitted file contents", async () => {
+    appDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "codebase-"));
+    await fs.promises.mkdir(path.join(appDir, "src", "components", "ui"), {
+      recursive: true,
+    });
+    await fs.promises.writeFile(path.join(appDir, "app.ts"), "a");
+    await fs.promises.writeFile(
+      path.join(appDir, "src", "components", "ui", "Button.tsx"),
+      "export const Button = () => null;",
+    );
+
+    const result = await extractCodebase({
+      appPath: appDir,
+      chatContext: {
+        contextPaths: [],
+        smartContextAutoIncludes: [],
+      },
+      limits: {
+        maxFiles: 10,
+        maxTotalBytes: 1,
+      },
+    });
+
+    expect(result.files).toHaveLength(2);
+    expect(result.files).toContainEqual({
+      path: "app.ts",
+      content: "a",
+      force: false,
+    });
+    expect(result.files).toContainEqual({
+      path: "src/components/ui/Button.tsx",
+      content: "// File contents excluded from context",
+      force: false,
+    });
+    expect(result.truncation).toBeUndefined();
+  });
+
+  it("formats truncation warnings for files-only consumers", () => {
+    expect(
+      formatCodebaseTruncationWarning({
+        totalFileCount: 10,
+        includedFileCount: 4,
+        omittedFileCount: 6,
+        includedContentBytes: 123,
+        maxFiles: 4,
+        maxTotalBytes: 1_000,
+        reasons: ["file-count"],
+      }),
+    ).toBe(
+      "Codebase context is incomplete: 4 of 10 files were included (6 omitted; limits reached: file-count). Results based only on the included files may be incomplete.",
+    );
+  });
+
   it("prioritizes forced smart-context files when a budget truncates", async () => {
     appDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "codebase-"));
     await fs.promises.writeFile(path.join(appDir, "a.ts"), "a");
@@ -287,6 +345,23 @@ describe("extractCodebase", () => {
     expect(result.files).toHaveLength(fileCount);
     expect(totalReads).toBe(fileCount);
     expect(maxActiveReads).toBeLessThanOrEqual(3);
+  });
+
+  it("stops concurrency workers after the first mapper failure", async () => {
+    const startedIndexes: number[] = [];
+
+    await expect(
+      mapWithConcurrency([0, 1, 2, 3], 2, async (_item, index) => {
+        startedIndexes.push(index);
+        if (index === 0) {
+          throw new Error("mapper failed");
+        }
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        return index;
+      }),
+    ).rejects.toThrow("mapper failed");
+
+    expect(startedIndexes).toEqual([0, 1]);
   });
 
   it("lists metadata without reading file contents", async () => {

--- a/src/__tests__/codebase.test.ts
+++ b/src/__tests__/codebase.test.ts
@@ -314,6 +314,23 @@ describe("extractCodebase", () => {
     );
   });
 
+  it("formats a clear warning when a shared budget prevents scanning", () => {
+    expect(
+      formatCodebaseTruncationWarning({
+        totalFileCount: 0,
+        includedFileCount: 0,
+        omittedFileCount: 0,
+        includedContentBytes: 0,
+        maxFiles: 0,
+        maxTotalBytes: 100,
+        reasons: ["file-count"],
+        budgetExhaustedBeforeScan: true,
+      }),
+    ).toBe(
+      "Codebase context was not scanned because the shared extraction budget was already exhausted (limits reached: file-count). Results do not include files from this app.",
+    );
+  });
+
   it("prioritizes forced smart-context files when a budget truncates", async () => {
     appDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "codebase-"));
     await fs.promises.writeFile(path.join(appDir, "a.ts"), "a");

--- a/src/__tests__/codebase.test.ts
+++ b/src/__tests__/codebase.test.ts
@@ -10,6 +10,7 @@ import {
 } from "@/utils/codebase";
 import { readSettings } from "@/main/settings";
 import { AsyncVirtualFileSystem } from "../../shared/VirtualFilesystem";
+import { gitListFilesNative } from "@/ipc/utils/git_utils";
 
 vi.mock("electron-log", () => ({
   default: {
@@ -40,6 +41,7 @@ describe("extractCodebase", () => {
   let appDir: string | undefined;
 
   beforeEach(() => {
+    vi.mocked(gitListFilesNative).mockReset().mockResolvedValue([]);
     vi.mocked(readSettings).mockReturnValue({
       enableNativeGit: false,
       enableDyadPro: false,
@@ -216,6 +218,47 @@ describe("extractCodebase", () => {
       omittedFileCount: 2,
       reasons: ["file-count"],
     });
+  });
+
+  it("reports both limits when omitted files exceed the remaining byte budget", async () => {
+    appDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "codebase-"));
+    await Promise.all(
+      ["a.ts", "b.ts", "c.ts"].map((file) =>
+        fs.promises.writeFile(path.join(appDir!, file), "data"),
+      ),
+    );
+
+    const result = await extractCodebase({
+      appPath: appDir,
+      chatContext: { contextPaths: [], smartContextAutoIncludes: [] },
+      limits: { maxFiles: 2, maxTotalBytes: 8 },
+    });
+
+    expect(result.truncation?.reasons).toEqual(["file-count", "total-bytes"]);
+  });
+
+  it("conservatively budgets real files whose final stat fails", async () => {
+    appDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "codebase-"));
+    await fs.promises.writeFile(path.join(appDir, "unstable.ts"), "content");
+    vi.mocked(readSettings).mockReturnValue({
+      enableNativeGit: true,
+      enableDyadPro: false,
+      enableProSmartFilesContextMode: false,
+    } as ReturnType<typeof readSettings>);
+    vi.mocked(gitListFilesNative).mockResolvedValue(["unstable.ts"]);
+    vi.spyOn(fs.promises, "stat").mockRejectedValueOnce(
+      new Error("transient stat failure"),
+    );
+
+    const result = await extractCodebase({
+      appPath: appDir,
+      chatContext: { contextPaths: [], smartContextAutoIncludes: [] },
+      limits: { maxFiles: 10, maxTotalBytes: 100 },
+    });
+
+    expect(result.files).toEqual([]);
+    expect(result.includedContentBytes).toBe(0);
+    expect(result.truncation?.reasons).toEqual(["total-bytes"]);
   });
 
   it("does not spend the byte budget on normally omitted file contents", async () => {

--- a/src/components/preview_panel/PreviewPanel.test.tsx
+++ b/src/components/preview_panel/PreviewPanel.test.tsx
@@ -27,23 +27,27 @@ const mocks = vi.hoisted(() => ({
   updateSettings: vi.fn(),
 }));
 
-vi.mock("jotai", () => ({
-  useAtomValue: (atom: symbol) => {
-    if (atom === mocks.previewModeAtom) {
-      return "preview";
-    }
-    if (atom === mocks.selectedAppIdAtom) {
-      return 1;
-    }
-    if (atom === mocks.currentPreviewReloadTokenAtom) {
-      return 0;
-    }
-    if (atom === mocks.currentConsoleEntriesAtom) {
-      return [];
-    }
-    return undefined;
-  },
-}));
+vi.mock("jotai", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("jotai")>();
+  return {
+    ...actual,
+    useAtomValue: (atom: symbol) => {
+      if (atom === mocks.previewModeAtom) {
+        return "preview";
+      }
+      if (atom === mocks.selectedAppIdAtom) {
+        return 1;
+      }
+      if (atom === mocks.currentPreviewReloadTokenAtom) {
+        return 0;
+      }
+      if (atom === mocks.currentConsoleEntriesAtom) {
+        return [];
+      }
+      return undefined;
+    },
+  };
+});
 
 vi.mock("../../atoms/appAtoms", () => ({
   previewModeAtom: mocks.previewModeAtom,

--- a/src/ipc/handlers/chat_stream_handlers.test.ts
+++ b/src/ipc/handlers/chat_stream_handlers.test.ts
@@ -9,6 +9,7 @@ import {
 
 import { processFullResponseActions } from "@/ipc/processors/response_processor";
 import {
+  includeSelectedComponentsInSmartContext,
   removeDyadTags,
   hasUnclosedDyadWrite,
 } from "@/ipc/handlers/chat_stream_handlers";
@@ -91,6 +92,41 @@ vi.mock("@/db", () => ({
     })),
   },
 }));
+
+describe("includeSelectedComponentsInSmartContext", () => {
+  it("adds selected component paths as forced smart-context inputs", () => {
+    const chatContext = {
+      contextPaths: [],
+      smartContextAutoIncludes: [{ globPath: "src/existing.ts" }],
+      excludePaths: [],
+    };
+
+    const result = includeSelectedComponentsInSmartContext(chatContext, [
+      {
+        id: "component-1",
+        name: "Selected",
+        relativePath: "src/Selected.tsx",
+        lineNumber: 1,
+        columnNumber: 1,
+      },
+      {
+        id: "component-2",
+        name: "Existing",
+        relativePath: "src/existing.ts",
+        lineNumber: 1,
+        columnNumber: 1,
+      },
+    ]);
+
+    expect(result.smartContextAutoIncludes).toEqual([
+      { globPath: "src/existing.ts" },
+      { globPath: "src/Selected.tsx" },
+    ]);
+    expect(chatContext.smartContextAutoIncludes).toEqual([
+      { globPath: "src/existing.ts" },
+    ]);
+  });
+});
 
 describe("getDyadAddDependencyTags", () => {
   it("should return an empty array when no dyad-add-dependency tags are found", () => {

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -40,6 +40,7 @@ import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
 import {
   CodebaseFile,
   extractCodebase,
+  formatCodebaseTruncationWarning,
   readFileWithCache,
 } from "../../utils/codebase";
 import {
@@ -780,10 +781,11 @@ ${componentSnippet}
             : validateChatContext(updatedChat.app.chatContext);
 
         // Extract codebase for current app
-        const { formattedOutput: codebaseInfo, files } = await extractCodebase({
-          appPath,
-          chatContext,
-        });
+        const {
+          formattedOutput: codebaseInfo,
+          files,
+          truncation: codebaseTruncation,
+        } = await extractCodebase({ appPath, chatContext });
 
         // For smart context and selected components, we will mark the selected components' files as focused.
         // This means that we don't do the regular smart context handling, but we'll allow fetching
@@ -1079,6 +1081,29 @@ This conversation includes one or more image attachments. When the user uploads 
 4. For diagrams or wireframes, try to understand the content and structure shown.
 5. For screenshots of code or errors, try to identify the issue or explain the code.
 `;
+        }
+
+        if (isEngineEnabled) {
+          const truncationWarnings: string[] = [];
+          if (codebaseTruncation) {
+            truncationWarnings.push(
+              `- Current app: ${formatCodebaseTruncationWarning(codebaseTruncation)}`,
+            );
+          }
+          for (const mentionedApp of mentionedAppsCodebases) {
+            if (mentionedApp.truncation) {
+              truncationWarnings.push(
+                `- Referenced app "${mentionedApp.appName}": ${formatCodebaseTruncationWarning(mentionedApp.truncation)}`,
+              );
+            }
+          }
+          if (truncationWarnings.length > 0) {
+            systemPrompt += `
+
+# Partial Codebase Context
+${truncationWarnings.join("\n")}
+Do not assume an absent file or symbol does not exist. Inspect files on demand when possible, and qualify conclusions that depend on complete codebase coverage.`;
+          }
         }
 
         const codebasePrefix = isEngineEnabled

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -21,7 +21,7 @@ import {
 import { db } from "../../db";
 import { chats, messages } from "../../db/schema";
 import { and, eq, isNull } from "drizzle-orm";
-import type { SmartContextMode } from "../../lib/schemas";
+import type { AppChatContext, SmartContextMode } from "../../lib/schemas";
 import {
   constructSystemPrompt,
   readAiRules,
@@ -264,6 +264,28 @@ async function processStreamChunks({
   }
 
   return { fullResponse, incrementalResponse };
+}
+
+export function includeSelectedComponentsInSmartContext(
+  chatContext: AppChatContext,
+  selectedComponents: ChatStreamParams["selectedComponents"],
+): AppChatContext {
+  if (!selectedComponents?.length) {
+    return chatContext;
+  }
+
+  const smartContextAutoIncludes = [...chatContext.smartContextAutoIncludes];
+  const includedPaths = new Set(
+    smartContextAutoIncludes.map((entry) => entry.globPath),
+  );
+  for (const component of selectedComponents) {
+    if (!includedPaths.has(component.relativePath)) {
+      includedPaths.add(component.relativePath);
+      smartContextAutoIncludes.push({ globPath: component.relativePath });
+    }
+  }
+
+  return { ...chatContext, smartContextAutoIncludes };
 }
 
 export function registerChatStreamHandlers() {
@@ -768,7 +790,7 @@ ${componentSnippet}
         //
         // If we have selected components and smart context is enabled,
         // we handle this specially below.
-        const chatContext =
+        const baseChatContext =
           req.selectedComponents &&
           req.selectedComponents.length > 0 &&
           !isSmartContextEnabled
@@ -779,6 +801,12 @@ ${componentSnippet}
                 smartContextAutoIncludes: [],
               }
             : validateChatContext(updatedChat.app.chatContext);
+        const chatContext = isSmartContextEnabled
+          ? includeSelectedComponentsInSmartContext(
+              baseChatContext,
+              req.selectedComponents,
+            )
+          : baseChatContext;
 
         // Extract codebase for current app
         const {
@@ -1083,7 +1111,7 @@ This conversation includes one or more image attachments. When the user uploads 
 `;
         }
 
-        if (isEngineEnabled) {
+        if (isEngineEnabled && !isSummarizeIntent) {
           const truncationWarnings: string[] = [];
           if (codebaseTruncation) {
             truncationWarnings.push(

--- a/src/ipc/utils/mention_apps.test.ts
+++ b/src/ipc/utils/mention_apps.test.ts
@@ -132,4 +132,50 @@ describe("mention app utilities", () => {
       }),
     );
   });
+
+  it("skips later app traversal after the shared file budget is exhausted", async () => {
+    dbMocks.findMany.mockResolvedValue([
+      {
+        id: 1,
+        name: "First",
+        path: "first",
+        chatContext: { contextPaths: [], smartContextAutoIncludes: [] },
+      },
+      {
+        id: 2,
+        name: "Second",
+        path: "second",
+        chatContext: { contextPaths: [], smartContextAutoIncludes: [] },
+      },
+    ]);
+    vi.mocked(extractCodebase).mockResolvedValueOnce({
+      formattedOutput: "first",
+      files: Array.from({ length: 2_000 }, (_, index) => ({
+        path: `file-${index}.ts`,
+        content: "",
+        force: false,
+      })),
+      includedContentBytes: 0,
+    });
+
+    const result = await extractMentionedAppsCodebasesFromPrompt(
+      "Compare @app:First and @app:Second",
+    );
+
+    expect(extractCodebase).toHaveBeenCalledTimes(1);
+    expect(result).toHaveLength(2);
+    expect(result[1]).toMatchObject({
+      appName: "Second",
+      appPath: "/dyad-apps/second",
+      codebaseInfo: "",
+      files: [],
+      truncation: {
+        includedFileCount: 0,
+        includedContentBytes: 0,
+        maxFiles: 0,
+        reasons: ["file-count"],
+        budgetExhaustedBeforeScan: true,
+      },
+    });
+  });
 });

--- a/src/ipc/utils/mention_apps.test.ts
+++ b/src/ipc/utils/mention_apps.test.ts
@@ -19,6 +19,11 @@ vi.mock("@/paths/paths", () => ({
 }));
 
 vi.mock("@/utils/codebase", () => ({
+  DEFAULT_CODEBASE_EXTRACTION_LIMITS: {
+    maxFiles: 2_000,
+    maxTotalBytes: 20 * 1024 * 1024,
+    ioConcurrency: 16,
+  },
   extractCodebase: vi.fn(),
 }));
 
@@ -36,11 +41,16 @@ vi.mock("electron-log", () => ({
   },
 }));
 
-import { extractMentionedAppsReferencesFromPrompt } from "@/ipc/utils/mention_apps";
+import {
+  extractMentionedAppsCodebasesFromPrompt,
+  extractMentionedAppsReferencesFromPrompt,
+} from "@/ipc/utils/mention_apps";
+import { extractCodebase } from "@/utils/codebase";
 
 describe("mention app utilities", () => {
   beforeEach(() => {
     dbMocks.findMany.mockReset();
+    vi.mocked(extractCodebase).mockReset();
   });
 
   it("does not query apps when the prompt has no app mentions", async () => {
@@ -72,5 +82,54 @@ describe("mention app utilities", () => {
         appPath: "/dyad-apps/foo-app",
       },
     ]);
+  });
+
+  it("shares one extraction budget across all mentioned apps", async () => {
+    dbMocks.findMany.mockResolvedValue([
+      {
+        id: 1,
+        name: "First",
+        path: "first",
+        chatContext: { contextPaths: [], smartContextAutoIncludes: [] },
+      },
+      {
+        id: 2,
+        name: "Second",
+        path: "second",
+        chatContext: { contextPaths: [], smartContextAutoIncludes: [] },
+      },
+    ]);
+    vi.mocked(extractCodebase)
+      .mockResolvedValueOnce({
+        formattedOutput: "first",
+        files: [{ path: "first.ts", content: "1234567890", force: false }],
+        includedContentBytes: 10,
+      })
+      .mockResolvedValueOnce({
+        formattedOutput: "second",
+        files: [{ path: "second.ts", content: "12345", force: false }],
+        includedContentBytes: 5,
+      });
+
+    const result = await extractMentionedAppsCodebasesFromPrompt(
+      "Compare @app:First and @app:Second",
+    );
+
+    expect(result).toHaveLength(2);
+    expect(extractCodebase).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        limits: { maxFiles: 2_000, maxTotalBytes: 20 * 1024 * 1024 },
+      }),
+    );
+    expect(extractCodebase).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        limits: {
+          maxFiles: 1_999,
+          maxTotalBytes: 20 * 1024 * 1024 - 10,
+        },
+      }),
+    );
   });
 });

--- a/src/ipc/utils/mention_apps.ts
+++ b/src/ipc/utils/mention_apps.ts
@@ -2,6 +2,7 @@ import { db } from "../../db";
 import { apps } from "../../db/schema";
 import { getDyadAppPath } from "../../paths/paths";
 import {
+  DEFAULT_CODEBASE_EXTRACTION_LIMITS,
   type CodebaseFile,
   type CodebaseTruncation,
   extractCodebase,
@@ -81,16 +82,29 @@ async function extractCodebasesForApps(
   dedupedApps: (typeof apps.$inferSelect)[],
 ): Promise<MentionedAppCodebaseEntry[]> {
   const results: MentionedAppCodebaseEntry[] = [];
+  let remainingFiles = DEFAULT_CODEBASE_EXTRACTION_LIMITS.maxFiles;
+  let remainingContentBytes = DEFAULT_CODEBASE_EXTRACTION_LIMITS.maxTotalBytes;
 
   for (const app of dedupedApps) {
     try {
       const appPath = getDyadAppPath(app.path);
       const chatContext = validateChatContext(app.chatContext);
 
-      const { formattedOutput, files, truncation } = await extractCodebase({
-        appPath,
-        chatContext,
-      });
+      const { formattedOutput, files, includedContentBytes, truncation } =
+        await extractCodebase({
+          appPath,
+          chatContext,
+          limits: {
+            maxFiles: remainingFiles,
+            maxTotalBytes: remainingContentBytes,
+          },
+        });
+
+      remainingFiles = Math.max(0, remainingFiles - files.length);
+      remainingContentBytes = Math.max(
+        0,
+        remainingContentBytes - includedContentBytes,
+      );
 
       results.push({
         appName: app.name,

--- a/src/ipc/utils/mention_apps.ts
+++ b/src/ipc/utils/mention_apps.ts
@@ -88,6 +88,37 @@ async function extractCodebasesForApps(
   for (const app of dedupedApps) {
     try {
       const appPath = getDyadAppPath(app.path);
+
+      // With no file slots left, extraction cannot include anything. Preserve
+      // an entry for the referenced app so downstream prompts can disclose
+      // that it was skipped, without traversing and statting its whole tree.
+      if (remainingFiles <= 0) {
+        const reasons: CodebaseTruncation["reasons"] = ["file-count"];
+        if (remainingContentBytes <= 0) {
+          reasons.push("total-bytes");
+        }
+        results.push({
+          appName: app.name,
+          appPath,
+          codebaseInfo: "",
+          files: [],
+          truncation: {
+            totalFileCount: 0,
+            includedFileCount: 0,
+            omittedFileCount: 0,
+            includedContentBytes: 0,
+            maxFiles: remainingFiles,
+            maxTotalBytes: remainingContentBytes,
+            reasons,
+            budgetExhaustedBeforeScan: true,
+          },
+        });
+        logger.warn(
+          `Skipped codebase extraction for mentioned app ${app.name}: shared file budget exhausted`,
+        );
+        continue;
+      }
+
       const chatContext = validateChatContext(app.chatContext);
 
       const { formattedOutput, files, includedContentBytes, truncation } =

--- a/src/ipc/utils/mention_apps.ts
+++ b/src/ipc/utils/mention_apps.ts
@@ -1,7 +1,11 @@
 import { db } from "../../db";
 import { apps } from "../../db/schema";
 import { getDyadAppPath } from "../../paths/paths";
-import { CodebaseFile, extractCodebase } from "../../utils/codebase";
+import {
+  type CodebaseFile,
+  type CodebaseTruncation,
+  extractCodebase,
+} from "../../utils/codebase";
 import { validateChatContext } from "../utils/context_paths_utils";
 import log from "electron-log";
 import { parseKnownAppMentions } from "@/shared/parse_mention_apps";
@@ -16,6 +20,7 @@ export interface MentionedAppReference {
 export interface MentionedAppCodebaseEntry extends MentionedAppReference {
   codebaseInfo: string;
   files: CodebaseFile[];
+  truncation?: CodebaseTruncation;
 }
 
 async function resolveMentionedApps(
@@ -82,7 +87,7 @@ async function extractCodebasesForApps(
       const appPath = getDyadAppPath(app.path);
       const chatContext = validateChatContext(app.chatContext);
 
-      const { formattedOutput, files } = await extractCodebase({
+      const { formattedOutput, files, truncation } = await extractCodebase({
         appPath,
         chatContext,
       });
@@ -92,6 +97,7 @@ async function extractCodebasesForApps(
         appPath,
         codebaseInfo: formattedOutput,
         files,
+        truncation,
       });
 
       logger.log(`Extracted codebase for mentioned app: ${app.name}`);

--- a/src/pro/main/ipc/handlers/local_agent/tools/code_search.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/code_search.spec.ts
@@ -221,6 +221,25 @@ describe("codeSearchTool", () => {
       expect(searchedPaths).not.toContain("current.ts");
     });
 
+    it("excludes referenced-app internals before extraction limits apply", async () => {
+      mockContext.referencedApps.set("other-app", otherAppDir);
+      mockEngineResponse(["other.ts"]);
+
+      await codeSearchTool.execute(
+        { query: "bar", app_name: "other-app" },
+        mockContext,
+      );
+
+      expect(mocks.extractCodebase).toHaveBeenCalledWith(
+        expect.objectContaining({
+          appPath: otherAppDir,
+          chatContext: expect.objectContaining({
+            excludePaths: [{ globPath: ".dyad/**" }],
+          }),
+        }),
+      );
+    });
+
     it("throws a clear error when app_name is not in the allow-list", async () => {
       mockContext.referencedApps.set("other-app", otherAppDir);
       await expect(

--- a/src/pro/main/ipc/handlers/local_agent/tools/code_search.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/code_search.spec.ts
@@ -18,9 +18,20 @@ vi.mock("electron-log", () => ({
 
 const mocks = vi.hoisted(() => ({
   engineFetch: vi.fn(),
+  extractCodebase: vi.fn(),
   readSettings: vi.fn(() => ({ enableCodeExplorer: false })),
   isCodeExplorerReady: vi.fn(() => false),
 }));
+
+vi.mock("../../../../../../utils/codebase", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../../../../utils/codebase")>();
+  mocks.extractCodebase.mockImplementation(actual.extractCodebase);
+  return {
+    ...actual,
+    extractCodebase: mocks.extractCodebase,
+  };
+});
 
 const engineFetchMock = mocks.engineFetch;
 vi.mock("./engine_fetch", () => ({
@@ -242,6 +253,38 @@ describe("codeSearchTool", () => {
 
       const xmlCall = (mockContext.onXmlComplete as any).mock.calls[0]?.[0];
       expect(xmlCall).not.toContain("app_name=");
+    });
+
+    it("qualifies empty results when the extracted codebase was truncated", async () => {
+      mocks.extractCodebase.mockResolvedValueOnce({
+        formattedOutput: "",
+        files: [{ path: "current.ts", content: "export {};", force: false }],
+        truncation: {
+          totalFileCount: 3,
+          includedFileCount: 1,
+          omittedFileCount: 2,
+          includedContentBytes: 10,
+          maxFiles: 1,
+          maxTotalBytes: 100,
+          reasons: ["file-count"],
+        },
+      });
+      mockEngineResponse([]);
+
+      const result = await codeSearchTool.execute(
+        { query: "missing" },
+        mockContext,
+      );
+
+      expect(result).toContain("1 of 3 files were included");
+      expect(result).toContain(
+        "No relevant files were found in the included subset.",
+      );
+      const xmlCall = (mockContext.onXmlComplete as any).mock.calls[0]?.[0];
+      expect(xmlCall).toContain("Results based only on the included files");
+      expect(xmlCall).not.toContain(
+        "No relevant files found.</dyad-code-search>",
+      );
     });
   });
 });

--- a/src/pro/main/ipc/handlers/local_agent/tools/code_search.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/code_search.ts
@@ -138,7 +138,10 @@ export const codeSearchTool: ToolDefinition<CodeSearchArgs> = {
       chatContext: {
         contextPaths: [],
         smartContextAutoIncludes: [],
-        excludePaths: [],
+        // Referenced-app internals are outside the @app contract. Exclude
+        // them before extraction limits are applied so they cannot consume
+        // the bounded search context and hide visible source files.
+        excludePaths: args.app_name ? [{ globPath: ".dyad/**" }] : [],
       },
     });
 

--- a/src/pro/main/ipc/handlers/local_agent/tools/code_search.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/code_search.ts
@@ -6,7 +6,10 @@ import {
   escapeXmlAttr,
   escapeXmlContent,
 } from "./types";
-import { extractCodebase } from "../../../../../../utils/codebase";
+import {
+  extractCodebase,
+  formatCodebaseTruncationWarning,
+} from "../../../../../../utils/codebase";
 import { engineFetch } from "./engine_fetch";
 import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
 import { readSettings } from "@/main/settings";
@@ -130,7 +133,7 @@ export const codeSearchTool: ToolDefinition<CodeSearchArgs> = {
     const targetAppPath = resolveTargetAppPath(ctx, args.app_name);
 
     // Gather all files from the project
-    const { files } = await extractCodebase({
+    const { files, truncation } = await extractCodebase({
       appPath: targetAppPath,
       chatContext: {
         contextPaths: [],
@@ -162,22 +165,35 @@ export const codeSearchTool: ToolDefinition<CodeSearchArgs> = {
     );
 
     // Format results
+    const truncationWarning = truncation
+      ? formatCodebaseTruncationWarning(truncation)
+      : undefined;
     const resultText =
       relevantFiles.length === 0
-        ? "No relevant files found."
+        ? truncation
+          ? "No relevant files were found in the included subset."
+          : "No relevant files found."
         : relevantFiles.map((f) => ` - ${f}`).join("\n");
+    const surfacedResult = truncationWarning
+      ? `${truncationWarning}\n${resultText}`
+      : resultText;
 
     // Write final result to UI and DB with dyad-code-search wrapper
     ctx.onXmlComplete(
-      `<dyad-code-search${buildCodeSearchAttributes(args)}>${escapeXmlContent(resultText)}</dyad-code-search>`,
+      `<dyad-code-search${buildCodeSearchAttributes(args)}>${escapeXmlContent(surfacedResult)}</dyad-code-search>`,
     );
 
     logger.log(`Code search completed for query: ${args.query}`);
 
     if (relevantFiles.length === 0) {
-      return "No relevant files found for the given query.";
+      return truncationWarning
+        ? surfacedResult
+        : "No relevant files found for the given query.";
     }
 
-    return `Found ${relevantFiles.length} relevant file(s):\n${resultText}`;
+    const foundResult = `Found ${relevantFiles.length} relevant file(s):\n${resultText}`;
+    return truncationWarning
+      ? `${truncationWarning}\n${foundResult}`
+      : foundResult;
   },
 };

--- a/src/pro/main/ipc/handlers/local_agent/tools/list_files.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/list_files.spec.ts
@@ -326,6 +326,35 @@ describe("listFilesTool", () => {
       expect(result).toContain("other-a.ts");
     });
 
+    it("filters referenced-app internals before applying the result cap", async () => {
+      const generatedDir = path.join(otherAppDir, "generated");
+      await fs.promises.mkdir(generatedDir);
+      await Promise.all(
+        Array.from({ length: 1_001 }, (_, index) =>
+          fs.promises.writeFile(
+            path.join(
+              generatedDir,
+              `file-${String(index).padStart(4, "0")}.ts`,
+            ),
+            "generated",
+          ),
+        ),
+      );
+      mockContext.referencedApps.set("other-app", otherAppDir);
+
+      const result = await listFilesTool.execute(
+        { app_name: "other-app", recursive: true },
+        mockContext,
+      );
+      const listedPathCount = result
+        .split("\n")
+        .filter((line) => line.startsWith(" - ")).length;
+
+      expect(listedPathCount).toBe(1_000);
+      expect(result).toContain("[TRUNCATED: Showing 1000 of 1003 paths.");
+      expect(result).not.toContain(".dyad/rules.md");
+    });
+
     it("emits app_name attribute in the final XML output", async () => {
       mockContext.referencedApps.set("other-app", otherAppDir);
       await listFilesTool.execute({ app_name: "other-app" }, mockContext);

--- a/src/pro/main/ipc/handlers/local_agent/tools/list_files.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/list_files.ts
@@ -166,14 +166,13 @@ export const listFilesTool: ToolDefinition<ListFilesArgs> = {
           smartContextAutoIncludes: [],
           excludePaths: [],
         },
-        maxFiles: MAX_PATHS_TO_RETURN,
       });
 
       const filteredFiles = filterDyadInternalFiles(
         metadata.files,
         args.app_name,
       );
-      totalPathCount = metadata.totalFileCount;
+      totalPathCount = filteredFiles.length;
 
       // Build the list of file paths
       allPaths = sortListedPaths(

--- a/src/pro/main/ipc/handlers/local_agent/tools/list_files.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/list_files.ts
@@ -135,6 +135,7 @@ export const listFilesTool: ToolDefinition<ListFilesArgs> = {
       : globSuffix.slice(1); // Remove leading "/" for root directory
 
     let allPaths: ListedPath[];
+    let totalPathCount: number | undefined;
 
     if (args.include_ignored) {
       const normalizedAppPath = targetAppPath.replace(/\\/g, "/");
@@ -158,16 +159,21 @@ export const listFilesTool: ToolDefinition<ListFilesArgs> = {
         })),
       );
     } else {
-      const files = await listCodebaseFileMetadata({
+      const metadata = await listCodebaseFileMetadata({
         appPath: targetAppPath,
         chatContext: {
           contextPaths: [{ globPath }],
           smartContextAutoIncludes: [],
           excludePaths: [],
         },
+        maxFiles: MAX_PATHS_TO_RETURN,
       });
 
-      const filteredFiles = filterDyadInternalFiles(files, args.app_name);
+      const filteredFiles = filterDyadInternalFiles(
+        metadata.files,
+        args.app_name,
+      );
+      totalPathCount = metadata.totalFileCount;
 
       // Build the list of file paths
       allPaths = sortListedPaths(
@@ -178,7 +184,7 @@ export const listFilesTool: ToolDefinition<ListFilesArgs> = {
       );
     }
 
-    const totalCount = allPaths.length;
+    const totalCount = totalPathCount ?? allPaths.length;
     const cappedPaths = allPaths.slice(0, MAX_PATHS_TO_RETURN);
     const wasTruncated = totalCount > cappedPaths.length;
 

--- a/src/pro/main/ipc/handlers/local_agent/tools/list_files.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/list_files.ts
@@ -7,7 +7,7 @@ import {
   escapeXmlAttr,
   escapeXmlContent,
 } from "./types";
-import { extractCodebase } from "../../../../../../utils/codebase";
+import { listCodebaseFileMetadata } from "../../../../../../utils/codebase";
 import { resolveDirectoryWithinAppPath } from "./path_safety";
 import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
 import {
@@ -158,7 +158,7 @@ export const listFilesTool: ToolDefinition<ListFilesArgs> = {
         })),
       );
     } else {
-      const { files } = await extractCodebase({
+      const files = await listCodebaseFileMetadata({
         appPath: targetAppPath,
         chatContext: {
           contextPaths: [{ globPath }],

--- a/src/utils/codebase.ts
+++ b/src/utils/codebase.ts
@@ -115,22 +115,70 @@ const OMITTED_FILES = [
 // Maximum file size to include (in bytes) - 1MB
 const MAX_FILE_SIZE = 1000 * 1024;
 
+export interface CodebaseExtractionLimits {
+  maxFiles: number;
+  maxTotalBytes: number;
+  ioConcurrency: number;
+}
+
+/**
+ * Keep codebase extraction comfortably below the Electron main process heap
+ * ceiling even when callers retain both the formatted prompt and raw files.
+ */
+export const DEFAULT_CODEBASE_EXTRACTION_LIMITS: CodebaseExtractionLimits = {
+  maxFiles: 2_000,
+  maxTotalBytes: 20 * 1024 * 1024,
+  ioConcurrency: 16,
+};
+
 // Maximum size for fileContentCache
 const MAX_FILE_CACHE_SIZE = 500;
+const MAX_FILE_CACHE_BYTES = 50 * 1024 * 1024;
 
 // File content cache with timestamps
 type FileCache = {
   content: string;
   mtime: number;
+  byteLength: number;
 };
 
 // Cache for file contents
 const fileContentCache = new Map<string, FileCache>();
+let fileContentCacheBytes = 0;
 
 // Cache for git ignored paths
 const gitIgnoreCache = new Map<string, boolean>();
 // Map to store .gitignore file paths and their modification times
 const gitIgnoreMtimes = new Map<string, number>();
+
+/**
+ * Map items with bounded concurrency while preserving input order.
+ */
+async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  mapper: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (items.length === 0) {
+    return [];
+  }
+
+  const results: R[] = [];
+  results.length = items.length;
+  let nextIndex = 0;
+  const workerCount = Math.min(Math.max(1, concurrency), items.length);
+
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (nextIndex < items.length) {
+        const index = nextIndex++;
+        results[index] = await mapper(items[index], index);
+      }
+    }),
+  );
+
+  return results;
+}
 
 /**
  * Check if a path should be ignored based on git ignore rules. Uses isomorphic-git
@@ -232,10 +280,17 @@ export async function readFileWithCache(
     // Read file and update cache
     const rawContent = await fsAsync.readFile(filePath, "utf-8");
     const content = rawContent;
+    const previousEntry = fileContentCache.get(filePath);
+    if (previousEntry) {
+      fileContentCacheBytes -= previousEntry.byteLength;
+    }
+    const byteLength = Buffer.byteLength(content, "utf8");
     fileContentCache.set(filePath, {
       content,
       mtime: currentMtime,
+      byteLength,
     });
+    fileContentCacheBytes += byteLength;
 
     // Manage cache size by clearing oldest entries when it gets too large
     if (fileContentCache.size > MAX_FILE_CACHE_SIZE) {
@@ -245,8 +300,27 @@ export async function readFileWithCache(
 
       // Remove oldest entries (first in, first out)
       for (let i = 0; i < entriesToDelete; i++) {
-        fileContentCache.delete(keys[i]);
+        const entry = fileContentCache.get(keys[i]);
+        if (entry) {
+          fileContentCacheBytes -= entry.byteLength;
+          fileContentCache.delete(keys[i]);
+        }
       }
+    }
+
+    while (
+      fileContentCacheBytes > MAX_FILE_CACHE_BYTES &&
+      fileContentCache.size > 0
+    ) {
+      const oldestKey = fileContentCache.keys().next().value;
+      if (oldestKey === undefined) {
+        break;
+      }
+      const entry = fileContentCache.get(oldestKey);
+      if (entry) {
+        fileContentCacheBytes -= entry.byteLength;
+      }
+      fileContentCache.delete(oldestKey);
     }
 
     return content;
@@ -259,7 +333,10 @@ export async function readFileWithCache(
 /**
  * Traverses a directory and collects all relevant files using native Git.
  */
-async function collectFilesNativeGit(dir: string): Promise<string[]> {
+async function collectFilesNativeGit(
+  dir: string,
+  ioConcurrency: number,
+): Promise<string[]> {
   let files: string[] = [];
 
   try {
@@ -280,25 +357,23 @@ async function collectFilesNativeGit(dir: string): Promise<string[]> {
     );
     // Since collectFilesIsoGit traverses the directory tree manually,
     // we'll still be able to collect the files even if git fails
-    return await collectFilesIsoGit(dir, dir);
+    return await collectFilesIsoGit(dir, dir, ioConcurrency);
   }
 
   // Git cannot exclude files by size, so we still need to do that manually
   return (
-    await Promise.all(
-      files.map(async (file) => {
-        try {
-          const stats = await fsAsync.lstat(file);
-          if (!stats.isFile() || stats.size > MAX_FILE_SIZE) {
-            return "";
-          }
-          return file;
-        } catch (error) {
-          logger.error(`Failed to read file ${file}:`, error);
+    await mapWithConcurrency(files, ioConcurrency, async (file) => {
+      try {
+        const stats = await fsAsync.lstat(file);
+        if (!stats.isFile() || stats.size > MAX_FILE_SIZE) {
           return "";
         }
-      }),
-    )
+        return file;
+      } catch (error) {
+        logger.error(`Failed to read file ${file}:`, error);
+        return "";
+      }
+    })
   ).filter(Boolean);
 }
 
@@ -309,6 +384,7 @@ async function collectFilesNativeGit(dir: string): Promise<string[]> {
 async function collectFilesIsoGit(
   dir: string,
   baseDir: string,
+  ioConcurrency: number,
 ): Promise<string[]> {
   const files: string[] = [];
 
@@ -320,53 +396,60 @@ async function collectFilesIsoGit(
     return files;
   }
 
-  try {
-    // Read directory contents
-    const entries = await fsAsync.readdir(dir, { withFileTypes: true });
+  const directories = [dir];
 
-    // Process entries concurrently
-    const promises = entries.map(async (entry) => {
-      const fullPath = path.join(dir, entry.name);
+  while (directories.length > 0) {
+    const currentDir = directories.pop()!;
+    try {
+      const entries = await fsAsync.readdir(currentDir, {
+        withFileTypes: true,
+      });
+      const results = await mapWithConcurrency(
+        entries,
+        ioConcurrency,
+        async (entry) => {
+          const fullPath = path.join(currentDir, entry.name);
 
-      // Skip excluded directories
-      if (entry.isDirectory() && EXCLUDED_DIRS.includes(entry.name)) {
-        return;
-      }
-
-      // Skip if the entry is git ignored
-      if (await isGitIgnoredIso(fullPath, baseDir)) {
-        return;
-      }
-
-      if (entry.isDirectory()) {
-        // Recursively process subdirectories
-        const subDirFiles = await collectFilesIsoGit(fullPath, baseDir);
-        files.push(...subDirFiles);
-      } else if (entry.isFile()) {
-        // Skip excluded files
-        if (EXCLUDED_FILES.includes(entry.name)) {
-          return;
-        }
-
-        // Skip files that are too large
-        try {
-          const stats = await fsAsync.stat(fullPath);
-          if (stats.size > MAX_FILE_SIZE) {
-            return;
+          if (entry.isDirectory() && EXCLUDED_DIRS.includes(entry.name)) {
+            return undefined;
           }
-        } catch (error) {
-          logger.error(`Error checking file size: ${fullPath}`, error);
-          return;
+
+          if (await isGitIgnoredIso(fullPath, baseDir)) {
+            return undefined;
+          }
+
+          if (entry.isDirectory()) {
+            return { directory: fullPath };
+          }
+
+          if (!entry.isFile() || EXCLUDED_FILES.includes(entry.name)) {
+            return undefined;
+          }
+
+          try {
+            const stats = await fsAsync.stat(fullPath);
+            if (stats.size > MAX_FILE_SIZE) {
+              return undefined;
+            }
+          } catch (error) {
+            logger.error(`Error checking file size: ${fullPath}`, error);
+            return undefined;
+          }
+
+          return { file: fullPath };
+        },
+      );
+
+      for (const result of results) {
+        if (result?.directory) {
+          directories.push(result.directory);
+        } else if (result?.file) {
+          files.push(result.file);
         }
-
-        // Include all files in the list
-        files.push(fullPath);
       }
-    });
-
-    await Promise.all(promises);
-  } catch (error) {
-    logger.error(`Error reading directory ${dir}:`, error);
+    } catch (error) {
+      logger.error(`Error reading directory ${currentDir}:`, error);
+    }
   }
 
   return files;
@@ -428,48 +511,36 @@ function shouldReadFileContentsForSmartContext({
 /**
  * Format a file for inclusion in the codebase extract
  */
-async function formatFile({
+function formatFile({
   filePath,
   normalizedRelativePath,
-  virtualFileSystem,
+  content,
 }: {
   filePath: string;
   normalizedRelativePath: string;
-  virtualFileSystem?: AsyncVirtualFileSystem;
-}): Promise<string> {
-  try {
-    // Check if we should read file contents
-    if (!shouldReadFileContents({ filePath, normalizedRelativePath })) {
-      return `<dyad-file path="${normalizedRelativePath}">
+  content: string | undefined;
+}): string {
+  if (!shouldReadFileContents({ filePath, normalizedRelativePath })) {
+    return `<dyad-file path="${normalizedRelativePath}">
 ${OMITTED_FILE_CONTENT}
 </dyad-file>
 
 `;
-    }
+  }
 
-    const content = await readFileWithCache(filePath, virtualFileSystem);
-
-    if (content == null) {
-      return `<dyad-file path="${normalizedRelativePath}">
+  if (content == null) {
+    return `<dyad-file path="${normalizedRelativePath}">
 // Error reading file
 </dyad-file>
 
 `;
-    }
+  }
 
-    return `<dyad-file path="${normalizedRelativePath}">
+  return `<dyad-file path="${normalizedRelativePath}">
 ${content}
 </dyad-file>
 
 `;
-  } catch (error) {
-    logger.error(`Error reading file: ${filePath}`, error);
-    return `<dyad-file path="${normalizedRelativePath}">
-// Error reading file: ${error}
-</dyad-file>
-
-`;
-  }
 }
 
 export interface BaseFile {
@@ -486,6 +557,283 @@ export interface CodebaseFileReference extends BaseFile {
   fileId: string;
 }
 
+export type CodebaseTruncationReason = "file-count" | "total-bytes";
+
+export interface CodebaseTruncation {
+  totalFileCount: number;
+  includedFileCount: number;
+  omittedFileCount: number;
+  includedContentBytes: number;
+  maxFiles: number;
+  maxTotalBytes: number;
+  reasons: CodebaseTruncationReason[];
+}
+
+interface PreparedCodebaseFile {
+  absolutePath: string;
+  path: string;
+  force: boolean;
+  estimatedContentBytes: number;
+}
+
+function resolveExtractionLimits(
+  limits?: Partial<CodebaseExtractionLimits>,
+): CodebaseExtractionLimits {
+  return {
+    maxFiles: Math.max(
+      0,
+      Math.floor(
+        limits?.maxFiles ?? DEFAULT_CODEBASE_EXTRACTION_LIMITS.maxFiles,
+      ),
+    ),
+    maxTotalBytes: Math.max(
+      0,
+      Math.floor(
+        limits?.maxTotalBytes ??
+          DEFAULT_CODEBASE_EXTRACTION_LIMITS.maxTotalBytes,
+      ),
+    ),
+    ioConcurrency: Math.max(
+      1,
+      Math.floor(
+        limits?.ioConcurrency ??
+          DEFAULT_CODEBASE_EXTRACTION_LIMITS.ioConcurrency,
+      ),
+    ),
+  };
+}
+
+async function prepareCodebaseFiles({
+  appPath,
+  chatContext,
+  virtualFileSystem,
+  limits,
+}: {
+  appPath: string;
+  chatContext: AppChatContext;
+  virtualFileSystem?: AsyncVirtualFileSystem;
+  limits: CodebaseExtractionLimits;
+}): Promise<PreparedCodebaseFile[] | undefined> {
+  try {
+    await fsAsync.access(appPath);
+  } catch {
+    return undefined;
+  }
+
+  const settings = readSettings();
+  const isSmartContextEnabled =
+    settings?.enableDyadPro && settings?.enableProSmartFilesContextMode;
+
+  let files = settings.enableNativeGit
+    ? await collectFilesNativeGit(appPath, limits.ioConcurrency)
+    : await collectFilesIsoGit(appPath, appPath, limits.ioConcurrency);
+
+  const virtualContentByPath = new Map<string, string>();
+
+  if (virtualFileSystem) {
+    const deletedFiles = new Set(
+      virtualFileSystem
+        .getDeletedFiles()
+        .map((relativePath) => path.resolve(appPath, relativePath)),
+    );
+    files = files.filter((file) => !deletedFiles.has(file));
+
+    const oversizedVirtualFiles = new Set<string>();
+    for (const virtualFile of virtualFileSystem.getVirtualFiles()) {
+      const absolutePath = path.resolve(appPath, virtualFile.path);
+      const contentBytes = Buffer.byteLength(virtualFile.content, "utf8");
+      if (contentBytes > MAX_FILE_SIZE) {
+        oversizedVirtualFiles.add(absolutePath);
+        continue;
+      }
+
+      virtualContentByPath.set(absolutePath, virtualFile.content);
+      if (!files.includes(absolutePath)) {
+        files.push(absolutePath);
+      }
+    }
+    files = files.filter((file) => !oversizedVirtualFiles.has(file));
+  }
+
+  const { contextPaths, smartContextAutoIncludes, excludePaths } = chatContext;
+  const includedFiles = new Set<string>();
+  const autoIncludedFiles = new Set<string>();
+  const excludedFiles = new Set<string>();
+
+  if (contextPaths && contextPaths.length > 0) {
+    for (const contextPath of contextPaths) {
+      const pattern = createFullGlobPath({
+        appPath,
+        globPath: contextPath.globPath,
+      });
+      const matches = await glob(pattern, {
+        nodir: true,
+        absolute: true,
+        ignore: "**/node_modules/**",
+      });
+      matches.forEach((file) => includedFiles.add(path.normalize(file)));
+    }
+  }
+
+  if (
+    isSmartContextEnabled &&
+    smartContextAutoIncludes &&
+    smartContextAutoIncludes.length > 0
+  ) {
+    for (const contextPath of smartContextAutoIncludes) {
+      const pattern = createFullGlobPath({
+        appPath,
+        globPath: contextPath.globPath,
+      });
+      const matches = await glob(pattern, {
+        nodir: true,
+        absolute: true,
+        ignore: "**/node_modules/**",
+      });
+      matches.forEach((file) => {
+        const normalizedFile = path.normalize(file);
+        autoIncludedFiles.add(normalizedFile);
+        includedFiles.add(normalizedFile);
+      });
+    }
+  }
+
+  if (excludePaths && excludePaths.length > 0) {
+    for (const excludePath of excludePaths) {
+      const pattern = createFullGlobPath({
+        appPath,
+        globPath: excludePath.globPath,
+      });
+      const matches = await glob(pattern, {
+        nodir: true,
+        absolute: true,
+        ignore: "**/node_modules/**",
+      });
+      matches.forEach((file) => excludedFiles.add(path.normalize(file)));
+    }
+  }
+
+  if (contextPaths && contextPaths.length > 0) {
+    files = files.filter((file) => includedFiles.has(path.normalize(file)));
+  }
+
+  if (excludedFiles.size > 0) {
+    files = files.filter((file) => !excludedFiles.has(path.normalize(file)));
+  }
+
+  const sortedFileStats = await sortFilesByModificationTime(
+    [...new Set(files)],
+    Boolean(settings.isTestMode),
+    limits.ioConcurrency,
+  );
+
+  return sortedFileStats.map(({ file, size }) => {
+    const normalizedRelativePath = path
+      .relative(appPath, file)
+      .split(path.sep)
+      .join("/");
+    const needsContent = shouldReadFileContentsForSmartContext({
+      filePath: file,
+      normalizedRelativePath,
+    });
+    const virtualContent = virtualContentByPath.get(file);
+
+    return {
+      absolutePath: file,
+      path: normalizedRelativePath,
+      force:
+        autoIncludedFiles.has(path.normalize(file)) &&
+        !excludedFiles.has(path.normalize(file)),
+      estimatedContentBytes: needsContent
+        ? virtualContent === undefined
+          ? size
+          : Buffer.byteLength(virtualContent, "utf8")
+        : 0,
+    };
+  });
+}
+
+/**
+ * List codebase files without reading their contents. This is used by tools
+ * that only need paths and avoids constructing two full codebase copies.
+ */
+export async function listCodebaseFileMetadata({
+  appPath,
+  chatContext,
+}: {
+  appPath: string;
+  chatContext: AppChatContext;
+}): Promise<BaseFile[]> {
+  const files = await prepareCodebaseFiles({
+    appPath,
+    chatContext,
+    limits: DEFAULT_CODEBASE_EXTRACTION_LIMITS,
+  });
+
+  return (files ?? []).map((file) => ({
+    path: file.path,
+    force: file.force,
+  }));
+}
+
+function selectFilesWithinLimits(
+  files: PreparedCodebaseFile[],
+  limits: CodebaseExtractionLimits,
+): {
+  files: PreparedCodebaseFile[];
+  truncation: Omit<CodebaseTruncation, "includedContentBytes"> | undefined;
+} {
+  const prioritizedFiles = [
+    ...files.filter((file) => file.force),
+    ...files.filter((file) => !file.force),
+  ];
+  const selectedPaths = new Set<string>();
+  const reasons = new Set<CodebaseTruncationReason>();
+  let selectedBytes = 0;
+
+  for (const file of prioritizedFiles) {
+    const exceedsFileLimit = selectedPaths.size >= limits.maxFiles;
+    const exceedsByteLimit =
+      file.estimatedContentBytes > limits.maxTotalBytes - selectedBytes;
+
+    if (exceedsFileLimit || exceedsByteLimit) {
+      if (exceedsFileLimit) {
+        reasons.add("file-count");
+      }
+      if (exceedsByteLimit) {
+        reasons.add("total-bytes");
+      }
+      continue;
+    }
+
+    selectedPaths.add(file.absolutePath);
+    selectedBytes += file.estimatedContentBytes;
+  }
+
+  const selectedFiles = files.filter((file) =>
+    selectedPaths.has(file.absolutePath),
+  );
+  if (selectedFiles.length === files.length) {
+    return { files: selectedFiles, truncation: undefined };
+  }
+
+  return {
+    files: selectedFiles,
+    truncation: {
+      totalFileCount: files.length,
+      includedFileCount: selectedFiles.length,
+      omittedFileCount: files.length - selectedFiles.length,
+      maxFiles: limits.maxFiles,
+      maxTotalBytes: limits.maxTotalBytes,
+      reasons: Array.from(reasons),
+    },
+  };
+}
+
+function formatTruncationMarker(truncation: CodebaseTruncation): string {
+  return `<dyad-codebase-truncated included_files="${truncation.includedFileCount}" omitted_files="${truncation.omittedFileCount}" included_content_bytes="${truncation.includedContentBytes}" max_files="${truncation.maxFiles}" max_total_bytes="${truncation.maxTotalBytes}" reasons="${truncation.reasons.join(",")}" />\n`;
+}
+
 /**
  * Extract and format codebase files as a string to be included in prompts
  * @param appPath - Path to the codebase to extract
@@ -496,187 +844,90 @@ export async function extractCodebase({
   appPath,
   chatContext,
   virtualFileSystem,
+  limits: requestedLimits,
 }: {
   appPath: string;
   chatContext: AppChatContext;
   virtualFileSystem?: AsyncVirtualFileSystem;
+  limits?: Partial<CodebaseExtractionLimits>;
 }): Promise<{
   formattedOutput: string;
   files: CodebaseFile[];
+  truncation?: CodebaseTruncation;
 }> {
-  const settings = readSettings();
-  const isSmartContextEnabled =
-    settings?.enableDyadPro && settings?.enableProSmartFilesContextMode;
+  const limits = resolveExtractionLimits(requestedLimits);
+  const startTime = Date.now();
+  const preparedFiles = await prepareCodebaseFiles({
+    appPath,
+    chatContext,
+    virtualFileSystem,
+    limits,
+  });
 
-  try {
-    await fsAsync.access(appPath);
-  } catch {
+  if (!preparedFiles) {
     return {
       formattedOutput: `# Error: Directory ${appPath} does not exist or is not accessible`,
       files: [],
     };
   }
-  const startTime = Date.now();
 
-  // Collect all relevant files
-  let files = settings.enableNativeGit
-    ? await collectFilesNativeGit(appPath)
-    : await collectFilesIsoGit(appPath, appPath);
-
-  // Apply virtual filesystem modifications if provided
-  if (virtualFileSystem) {
-    // Filter out deleted files
-    const deletedFiles = new Set(
-      virtualFileSystem
-        .getDeletedFiles()
-        .map((relativePath) => path.resolve(appPath, relativePath)),
-    );
-    files = files.filter((file) => !deletedFiles.has(file));
-
-    // Add virtual files
-    const virtualFiles = virtualFileSystem.getVirtualFiles();
-    for (const virtualFile of virtualFiles) {
-      const absolutePath = path.resolve(appPath, virtualFile.path);
-      if (!files.includes(absolutePath)) {
-        files.push(absolutePath);
+  const selection = selectFilesWithinLimits(preparedFiles, limits);
+  const formattedResults = await mapWithConcurrency(
+    selection.files,
+    limits.ioConcurrency,
+    async (file) => {
+      const needsContent = shouldReadFileContentsForSmartContext({
+        filePath: file.absolutePath,
+        normalizedRelativePath: file.path,
+      });
+      let content = needsContent
+        ? await readFileWithCache(file.absolutePath, virtualFileSystem)
+        : undefined;
+      if (
+        content != null &&
+        Buffer.byteLength(content, "utf8") > MAX_FILE_SIZE
+      ) {
+        logger.warn(
+          `Skipping file that grew beyond the size limit: ${file.path}`,
+        );
+        content = undefined;
       }
-    }
-  }
 
-  // Collect files from contextPaths and smartContextAutoIncludes
-  const { contextPaths, smartContextAutoIncludes, excludePaths } = chatContext;
-  const includedFiles = new Set<string>();
-  const autoIncludedFiles = new Set<string>();
-  const excludedFiles = new Set<string>();
-
-  // Add files from contextPaths
-  if (contextPaths && contextPaths.length > 0) {
-    for (const p of contextPaths) {
-      const pattern = createFullGlobPath({
-        appPath,
-        globPath: p.globPath,
-      });
-      const matches = await glob(pattern, {
-        nodir: true,
-        absolute: true,
-        ignore: "**/node_modules/**",
-      });
-      matches.forEach((file) => {
-        const normalizedFile = path.normalize(file);
-        includedFiles.add(normalizedFile);
-      });
-    }
-  }
-
-  // Add files from smartContextAutoIncludes
-  if (
-    isSmartContextEnabled &&
-    smartContextAutoIncludes &&
-    smartContextAutoIncludes.length > 0
-  ) {
-    for (const p of smartContextAutoIncludes) {
-      const pattern = createFullGlobPath({
-        appPath,
-        globPath: p.globPath,
-      });
-      const matches = await glob(pattern, {
-        nodir: true,
-        absolute: true,
-        ignore: "**/node_modules/**",
-      });
-      matches.forEach((file) => {
-        const normalizedFile = path.normalize(file);
-        autoIncludedFiles.add(normalizedFile);
-        includedFiles.add(normalizedFile); // Also add to included files
-      });
-    }
-  }
-
-  // Add files from excludePaths
-  if (excludePaths && excludePaths.length > 0) {
-    for (const p of excludePaths) {
-      const pattern = createFullGlobPath({
-        appPath,
-        globPath: p.globPath,
-      });
-      const matches = await glob(pattern, {
-        nodir: true,
-        absolute: true,
-        ignore: "**/node_modules/**",
-      });
-      matches.forEach((file) => {
-        const normalizedFile = path.normalize(file);
-        excludedFiles.add(normalizedFile);
-      });
-    }
-  }
-
-  // Only filter files if contextPaths are provided
-  // If only smartContextAutoIncludes are provided, keep all files and just mark auto-includes as forced
-  if (contextPaths && contextPaths.length > 0) {
-    files = files.filter((file) => includedFiles.has(path.normalize(file)));
-  }
-
-  // Filter out excluded files (this takes precedence over include paths)
-  if (excludedFiles.size > 0) {
-    files = files.filter((file) => !excludedFiles.has(path.normalize(file)));
-  }
-
-  // Sort files by modification time (oldest first)
-  // This is important for cache-ability.
-  const sortedFiles = await sortFilesByModificationTime(
-    [...new Set(files)],
-    Boolean(settings.isTestMode),
+      return {
+        formattedContent: formatFile({
+          filePath: file.absolutePath,
+          normalizedRelativePath: file.path,
+          content,
+        }),
+        contentBytes: content == null ? 0 : Buffer.byteLength(content, "utf8"),
+        file: {
+          path: file.path,
+          content: needsContent
+            ? (content ?? "// Error reading file")
+            : OMITTED_FILE_CONTENT,
+          force: file.force,
+        } satisfies CodebaseFile,
+      };
+    },
   );
 
-  // Format files and collect individual file contents
-  const formatPromises = sortedFiles.map(async (file) => {
-    // Get raw content for the files array
-    const normalizedRelativePath = path
-      .relative(appPath, file)
-      // Why? Normalize Windows-style paths which causes lots of weird issues (e.g. Git commit)
-      .split(path.sep)
-      .join("/");
-    const formattedContent = await formatFile({
-      filePath: file,
-      normalizedRelativePath,
-      virtualFileSystem,
-    });
-
-    const isForced =
-      autoIncludedFiles.has(path.normalize(file)) &&
-      !excludedFiles.has(path.normalize(file));
-
-    // Determine file content based on whether we should read it
-    let fileContent: string;
-    if (
-      !shouldReadFileContentsForSmartContext({
-        filePath: file,
-        normalizedRelativePath,
-      })
-    ) {
-      fileContent = OMITTED_FILE_CONTENT;
-    } else {
-      const readContent = await readFileWithCache(file, virtualFileSystem);
-      fileContent = readContent ?? "// Error reading file";
-    }
-
-    return {
-      formattedContent,
-      file: {
-        path: normalizedRelativePath,
-        content: fileContent,
-        force: isForced,
-      } satisfies CodebaseFile,
-    };
-  });
-
-  const formattedResults = await Promise.all(formatPromises);
-  const formattedFiles = formattedResults.map(
-    (result) => result.formattedContent,
-  );
+  const truncation = selection.truncation
+    ? {
+        ...selection.truncation,
+        includedContentBytes: formattedResults.reduce(
+          (total, result) => total + result.contentBytes,
+          0,
+        ),
+      }
+    : undefined;
   const filesArray = formattedResults.map((result) => result.file);
-  const formattedOutput = formattedFiles.join("");
+  let formattedOutput = formattedResults
+    .map((result) => result.formattedContent)
+    .join("");
+  if (truncation) {
+    formattedOutput += formatTruncationMarker(truncation);
+    logger.warn("Codebase extraction truncated", truncation);
+  }
 
   const endTime = Date.now();
   logger.debug("extractCodebase: time taken", endTime - startTime);
@@ -690,6 +941,7 @@ export async function extractCodebase({
   return {
     formattedOutput,
     files: filesArray,
+    truncation,
   };
 }
 
@@ -699,20 +951,23 @@ export async function extractCodebase({
 async function sortFilesByModificationTime(
   files: string[],
   forcePathSort = false,
-): Promise<string[]> {
+  ioConcurrency = DEFAULT_CODEBASE_EXTRACTION_LIMITS.ioConcurrency,
+): Promise<Array<{ file: string; mtime: number; size: number }>> {
   // Get stats for all files
-  const fileStats = await Promise.all(
-    files.map(async (file) => {
+  const fileStats = await mapWithConcurrency(
+    files,
+    ioConcurrency,
+    async (file) => {
       try {
         const stats = await fsAsync.stat(file);
-        return { file, mtime: stats.mtimeMs };
+        return { file, mtime: stats.mtimeMs, size: stats.size };
       } catch (error) {
         // If there's an error getting stats, use current time as fallback
         // This can happen with virtual files, so it's not a big deal.
         logger.warn(`Error getting file stats for ${file}:`, error);
-        return { file, mtime: Date.now() };
+        return { file, mtime: Date.now(), size: 0 };
       }
-    }),
+    },
   );
 
   if (IS_TEST_BUILD || forcePathSort) {
@@ -720,14 +975,12 @@ async function sortFilesByModificationTime(
     // This is a workaround to ensure stable ordering, although
     // ideally we'd like to sort it by modification time which is
     // important for cache-ability.
-    return fileStats
-      .sort((a, b) => a.file.localeCompare(b.file))
-      .map((item) => item.file);
+    return fileStats.sort((a, b) => a.file.localeCompare(b.file));
   }
   // Sort by modification time (oldest first)
-  return fileStats
-    .sort((a, b) => a.mtime - b.mtime || a.file.localeCompare(b.file))
-    .map((item) => item.file);
+  return fileStats.sort(
+    (a, b) => a.mtime - b.mtime || a.file.localeCompare(b.file),
+  );
 }
 
 function createFullGlobPath({

--- a/src/utils/codebase.ts
+++ b/src/utils/codebase.ts
@@ -585,6 +585,8 @@ export interface CodebaseTruncation {
   maxFiles: number;
   maxTotalBytes: number;
   reasons: CodebaseTruncationReason[];
+  /** No file scan occurred because a shared caller budget was already spent. */
+  budgetExhaustedBeforeScan?: true;
 }
 
 interface PreparedCodebaseFile {
@@ -853,6 +855,9 @@ function selectFilesWithinLimits(
 
     if (exceedsByteLimit) {
       reasons.add("total-bytes");
+      // Keep scanning intentionally: a later file may fit the remaining byte
+      // budget. This O(n) pass preserves deterministic coverage instead of
+      // letting one oversized file hide every smaller file after it.
       continue;
     }
 
@@ -893,6 +898,9 @@ function selectFilesWithinLimits(
 export function formatCodebaseTruncationWarning(
   truncation: CodebaseTruncation,
 ): string {
+  if (truncation.budgetExhaustedBeforeScan) {
+    return `Codebase context was not scanned because the shared extraction budget was already exhausted (limits reached: ${truncation.reasons.join(", ")}). Results do not include files from this app.`;
+  }
   return `Codebase context is incomplete: ${truncation.includedFileCount} of ${truncation.totalFileCount} files were included (${truncation.omittedFileCount} omitted; limits reached: ${truncation.reasons.join(", ")}). Results based only on the included files may be incomplete.`;
 }
 

--- a/src/utils/codebase.ts
+++ b/src/utils/codebase.ts
@@ -785,20 +785,33 @@ async function prepareCodebaseFiles({
 export async function listCodebaseFileMetadata({
   appPath,
   chatContext,
+  maxFiles = DEFAULT_CODEBASE_EXTRACTION_LIMITS.maxFiles,
 }: {
   appPath: string;
   chatContext: AppChatContext;
-}): Promise<BaseFile[]> {
+  maxFiles?: number;
+}): Promise<{ files: BaseFile[]; totalFileCount: number }> {
   const files = await prepareCodebaseFiles({
     appPath,
     chatContext,
     limits: DEFAULT_CODEBASE_EXTRACTION_LIMITS,
   });
+  const preparedFiles = files ?? [];
+  const selection = selectFilesWithinLimits(preparedFiles, {
+    ...DEFAULT_CODEBASE_EXTRACTION_LIMITS,
+    maxFiles: Math.max(0, Math.floor(maxFiles)),
+    // Metadata listing does not retain contents, so only the file-count limit
+    // should truncate it.
+    maxTotalBytes: Number.MAX_SAFE_INTEGER,
+  });
 
-  return (files ?? []).map((file) => ({
-    path: file.path,
-    force: file.force,
-  }));
+  return {
+    files: selection.files.map((file) => ({
+      path: file.path,
+      force: file.force,
+    })),
+    totalFileCount: preparedFiles.length,
+  };
 }
 
 function selectFilesWithinLimits(
@@ -988,10 +1001,11 @@ async function sortFilesByModificationTime(
         const stats = await fsAsync.stat(file);
         return { file, mtime: stats.mtimeMs, size: stats.size };
       } catch (error) {
-        // If there's an error getting stats, use current time as fallback
+        // Use a stable fallback so concurrent stat failures cannot reorder
+        // virtual files differently between runs.
         // This can happen with virtual files, so it's not a big deal.
         logger.warn(`Error getting file stats for ${file}:`, error);
-        return { file, mtime: Date.now(), size: 0 };
+        return { file, mtime: 0, size: 0 };
       }
     },
   );

--- a/src/utils/codebase.ts
+++ b/src/utils/codebase.ts
@@ -154,7 +154,7 @@ const gitIgnoreMtimes = new Map<string, number>();
 /**
  * Map items with bounded concurrency while preserving input order.
  */
-async function mapWithConcurrency<T, R>(
+export async function mapWithConcurrency<T, R>(
   items: readonly T[],
   concurrency: number,
   mapper: (item: T, index: number) => Promise<R>,
@@ -166,16 +166,29 @@ async function mapWithConcurrency<T, R>(
   const results: R[] = [];
   results.length = items.length;
   let nextIndex = 0;
+  let hasFailed = false;
+  let firstError: unknown;
   const workerCount = Math.min(Math.max(1, concurrency), items.length);
 
   await Promise.all(
     Array.from({ length: workerCount }, async () => {
-      while (nextIndex < items.length) {
+      while (!hasFailed && nextIndex < items.length) {
         const index = nextIndex++;
-        results[index] = await mapper(items[index], index);
+        try {
+          results[index] = await mapper(items[index], index);
+        } catch (error) {
+          if (!hasFailed) {
+            hasFailed = true;
+            firstError = error;
+          }
+        }
       }
     }),
   );
+
+  if (hasFailed) {
+    throw firstError;
+  }
 
   return results;
 }
@@ -273,6 +286,9 @@ export async function readFileWithCache(
     if (fileContentCache.has(filePath)) {
       const cache = fileContentCache.get(filePath)!;
       if (cache.mtime === currentMtime) {
+        // Refresh insertion order so byte/count eviction behaves as an LRU.
+        fileContentCache.delete(filePath);
+        fileContentCache.set(filePath, cache);
         return cache.content;
       }
     }
@@ -283,6 +299,8 @@ export async function readFileWithCache(
     const previousEntry = fileContentCache.get(filePath);
     if (previousEntry) {
       fileContentCacheBytes -= previousEntry.byteLength;
+      // Map#set does not refresh insertion order for an existing key.
+      fileContentCache.delete(filePath);
     }
     const byteLength = Buffer.byteLength(content, "utf8");
     fileContentCache.set(filePath, {
@@ -573,6 +591,7 @@ interface PreparedCodebaseFile {
   absolutePath: string;
   path: string;
   force: boolean;
+  shouldReadContent: boolean;
   estimatedContentBytes: number;
 }
 
@@ -732,10 +751,15 @@ async function prepareCodebaseFiles({
       .relative(appPath, file)
       .split(path.sep)
       .join("/");
-    const needsContent = shouldReadFileContentsForSmartContext({
-      filePath: file,
-      normalizedRelativePath,
-    });
+    const shouldReadContent = isSmartContextEnabled
+      ? shouldReadFileContentsForSmartContext({
+          filePath: file,
+          normalizedRelativePath,
+        })
+      : shouldReadFileContents({
+          filePath: file,
+          normalizedRelativePath,
+        });
     const virtualContent = virtualContentByPath.get(file);
 
     return {
@@ -744,7 +768,8 @@ async function prepareCodebaseFiles({
       force:
         autoIncludedFiles.has(path.normalize(file)) &&
         !excludedFiles.has(path.normalize(file)),
-      estimatedContentBytes: needsContent
+      shouldReadContent,
+      estimatedContentBytes: shouldReadContent
         ? virtualContent === undefined
           ? size
           : Buffer.byteLength(virtualContent, "utf8")
@@ -792,17 +817,16 @@ function selectFilesWithinLimits(
   let selectedBytes = 0;
 
   for (const file of prioritizedFiles) {
-    const exceedsFileLimit = selectedPaths.size >= limits.maxFiles;
+    if (selectedPaths.size >= limits.maxFiles) {
+      reasons.add("file-count");
+      break;
+    }
+
     const exceedsByteLimit =
       file.estimatedContentBytes > limits.maxTotalBytes - selectedBytes;
 
-    if (exceedsFileLimit || exceedsByteLimit) {
-      if (exceedsFileLimit) {
-        reasons.add("file-count");
-      }
-      if (exceedsByteLimit) {
-        reasons.add("total-bytes");
-      }
+    if (exceedsByteLimit) {
+      reasons.add("total-bytes");
       continue;
     }
 
@@ -828,6 +852,12 @@ function selectFilesWithinLimits(
       reasons: Array.from(reasons),
     },
   };
+}
+
+export function formatCodebaseTruncationWarning(
+  truncation: CodebaseTruncation,
+): string {
+  return `Codebase context is incomplete: ${truncation.includedFileCount} of ${truncation.totalFileCount} files were included (${truncation.omittedFileCount} omitted; limits reached: ${truncation.reasons.join(", ")}). Results based only on the included files may be incomplete.`;
 }
 
 function formatTruncationMarker(truncation: CodebaseTruncation): string {
@@ -876,11 +906,7 @@ export async function extractCodebase({
     selection.files,
     limits.ioConcurrency,
     async (file) => {
-      const needsContent = shouldReadFileContentsForSmartContext({
-        filePath: file.absolutePath,
-        normalizedRelativePath: file.path,
-      });
-      let content = needsContent
+      let content = file.shouldReadContent
         ? await readFileWithCache(file.absolutePath, virtualFileSystem)
         : undefined;
       if (
@@ -902,7 +928,7 @@ export async function extractCodebase({
         contentBytes: content == null ? 0 : Buffer.byteLength(content, "utf8"),
         file: {
           path: file.path,
-          content: needsContent
+          content: file.shouldReadContent
             ? (content ?? "// Error reading file")
             : OMITTED_FILE_CONTENT,
           force: file.force,

--- a/src/utils/codebase.ts
+++ b/src/utils/codebase.ts
@@ -785,7 +785,7 @@ async function prepareCodebaseFiles({
 export async function listCodebaseFileMetadata({
   appPath,
   chatContext,
-  maxFiles = DEFAULT_CODEBASE_EXTRACTION_LIMITS.maxFiles,
+  maxFiles,
 }: {
   appPath: string;
   chatContext: AppChatContext;
@@ -797,6 +797,17 @@ export async function listCodebaseFileMetadata({
     limits: DEFAULT_CODEBASE_EXTRACTION_LIMITS,
   });
   const preparedFiles = files ?? [];
+
+  if (maxFiles === undefined) {
+    return {
+      files: preparedFiles.map((file) => ({
+        path: file.path,
+        force: file.force,
+      })),
+      totalFileCount: preparedFiles.length,
+    };
+  }
+
   const selection = selectFilesWithinLimits(preparedFiles, {
     ...DEFAULT_CODEBASE_EXTRACTION_LIMITS,
     maxFiles: Math.max(0, Math.floor(maxFiles)),
@@ -828,8 +839,10 @@ function selectFilesWithinLimits(
   const selectedPaths = new Set<string>();
   const reasons = new Set<CodebaseTruncationReason>();
   let selectedBytes = 0;
+  let nextFileIndex = 0;
 
-  for (const file of prioritizedFiles) {
+  for (; nextFileIndex < prioritizedFiles.length; nextFileIndex++) {
+    const file = prioritizedFiles[nextFileIndex];
     if (selectedPaths.size >= limits.maxFiles) {
       reasons.add("file-count");
       break;
@@ -845,6 +858,16 @@ function selectFilesWithinLimits(
 
     selectedPaths.add(file.absolutePath);
     selectedBytes += file.estimatedContentBytes;
+  }
+
+  if (nextFileIndex < prioritizedFiles.length) {
+    const remainingBytes = limits.maxTotalBytes - selectedBytes;
+    for (let index = nextFileIndex; index < prioritizedFiles.length; index++) {
+      if (prioritizedFiles[index].estimatedContentBytes > remainingBytes) {
+        reasons.add("total-bytes");
+        break;
+      }
+    }
   }
 
   const selectedFiles = files.filter((file) =>
@@ -896,6 +919,7 @@ export async function extractCodebase({
 }): Promise<{
   formattedOutput: string;
   files: CodebaseFile[];
+  includedContentBytes: number;
   truncation?: CodebaseTruncation;
 }> {
   const limits = resolveExtractionLimits(requestedLimits);
@@ -911,6 +935,7 @@ export async function extractCodebase({
     return {
       formattedOutput: `# Error: Directory ${appPath} does not exist or is not accessible`,
       files: [],
+      includedContentBytes: 0,
     };
   }
 
@@ -950,13 +975,14 @@ export async function extractCodebase({
     },
   );
 
+  const includedContentBytes = formattedResults.reduce(
+    (total, result) => total + result.contentBytes,
+    0,
+  );
   const truncation = selection.truncation
     ? {
         ...selection.truncation,
-        includedContentBytes: formattedResults.reduce(
-          (total, result) => total + result.contentBytes,
-          0,
-        ),
+        includedContentBytes,
       }
     : undefined;
   const filesArray = formattedResults.map((result) => result.file);
@@ -980,6 +1006,7 @@ export async function extractCodebase({
   return {
     formattedOutput,
     files: filesArray,
+    includedContentBytes,
     truncation,
   };
 }
@@ -1005,7 +1032,7 @@ async function sortFilesByModificationTime(
         // virtual files differently between runs.
         // This can happen with virtual files, so it's not a big deal.
         logger.warn(`Error getting file stats for ${file}:`, error);
-        return { file, mtime: 0, size: 0 };
+        return { file, mtime: 0, size: MAX_FILE_SIZE };
       }
     },
   );


### PR DESCRIPTION
## Summary
- cap codebase extraction at 2,000 files and 20 MiB of source content
- bound filesystem and formatting concurrency at 16 workers and read each selected file once
- preserve deterministic mtime ordering while prioritizing forced smart-context files under truncation
- expose structured truncation diagnostics in the return value and prompt marker
- use a metadata-only path for list_files and cap the shared file cache at 50 MiB

## Root cause
extractCodebase launched unbounded Promise.all work across every project file and retained raw content, per-file formatted strings, and the final joined prompt simultaneously. A per-file limit did not bound aggregate heap use.

## Compatibility
Normal projects below the limits retain their existing ordering and output. Truncated projects keep forced smart-context entries first for selection, restore the normal deterministic order in results, and receive explicit file, byte, and reason diagnostics.

## Tests
- npm test -- src/__tests__/codebase.test.ts src/pro/main/ipc/handlers/local_agent/tools/list_files.spec.ts
- npm run lint
- npm run ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core chat context and agent tooling paths; truncation can omit files the model previously saw, though behavior below limits should stay the same.
> 
> **Overview**
> **Codebase extraction** is now capped (default **2,000 files**, **20 MiB** content, **16** I/O workers), with deterministic selection that **prioritizes forced smart-context files**, byte budgeting that **ignores placeholder-only paths**, and structured **`truncation`** plus a **`dyad-codebase-truncated`** marker / **`formatCodebaseTruncationWarning`**. The file cache also enforces a **50 MiB** LRU bound; **`listCodebaseFileMetadata`** supports path listing without reading contents.
> 
> **Callers** share one budget across **`@app` mentions**, inject **partial-context warnings** into engine chat prompts, merge **selected components** into smart context via **`includeSelectedComponentsInSmartContext`**, and adjust **`list_files`** / **`code_search`** (referenced-app **`.dyad/**` exclusions, truncation-aware empty results).
> 
> Tests and **`jotai-testing.md`** document partial **`jotai`** mocks for component tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fc3d3bb4da7eba4edba1ac9cce16a35ed3595e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

