### PR TITLE
fix: bound chat attachment memory usage

### DIFF
--- a/src/hooks/useAttachments.test.tsx
+++ b/src/hooks/useAttachments.test.tsx
@@ -1,0 +1,114 @@
+import { act, renderHook } from "@testing-library/react";
+import { createStore, Provider } from "jotai";
+import type { PropsWithChildren } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { attachmentsAtom } from "@/atoms/chatAtoms";
+import type { FileAttachment } from "@/ipc/types";
+import { showError } from "@/lib/toast";
+import {
+  MAX_CHAT_ATTACHMENT_BYTES,
+  MAX_CHAT_ATTACHMENTS,
+} from "@/shared/chatAttachmentLimits";
+import { useAttachments } from "./useAttachments";
+
+vi.mock("@/lib/toast", () => ({
+  showError: vi.fn(),
+}));
+
+function makeFile(name: string, size = 0): File {
+  return { name, size } as File;
+}
+
+function makeWrapper() {
+  const store = createStore();
+  const Wrapper = ({ children }: PropsWithChildren) => (
+    <Provider store={store}>{children}</Provider>
+  );
+  return { store, Wrapper };
+}
+
+describe("useAttachments", () => {
+  beforeEach(() => {
+    vi.mocked(showError).mockReset();
+  });
+
+  it("validates rapid additions against the latest atom state", () => {
+    const { store, Wrapper } = makeWrapper();
+    const { result } = renderHook(useAttachments, { wrapper: Wrapper });
+    const hookSnapshot = result.current;
+    const firstBatch = Array.from({ length: 6 }, (_, index) =>
+      makeFile(`first-${index}.txt`),
+    );
+    const secondBatch = Array.from({ length: 5 }, (_, index) =>
+      makeFile(`second-${index}.txt`),
+    );
+    let firstAdded = false;
+    let secondAdded = false;
+
+    act(() => {
+      firstAdded = hookSnapshot.addAttachments(firstBatch);
+      secondAdded = hookSnapshot.addAttachments(secondBatch);
+    });
+
+    expect(firstAdded).toBe(true);
+    expect(secondAdded).toBe(false);
+    expect(store.get(attachmentsAtom)).toHaveLength(6);
+    expect(showError).toHaveBeenCalledWith(
+      `You can attach up to ${MAX_CHAT_ATTACHMENTS} files at a time.`,
+    );
+  });
+
+  it("keeps the aggregate byte limit under rapid additions", () => {
+    const { store, Wrapper } = makeWrapper();
+    const { result } = renderHook(useAttachments, { wrapper: Wrapper });
+    const hookSnapshot = result.current;
+    let firstAdded = false;
+    let secondAdded = false;
+
+    act(() => {
+      firstAdded = hookSnapshot.addAttachments([
+        makeFile("first.bin", MAX_CHAT_ATTACHMENT_BYTES),
+        makeFile("second.bin", MAX_CHAT_ATTACHMENT_BYTES),
+      ]);
+      secondAdded = hookSnapshot.addAttachments([
+        makeFile("third.bin", 6 * 1024 * 1024),
+      ]);
+    });
+
+    expect(firstAdded).toBe(true);
+    expect(secondAdded).toBe(false);
+    expect(store.get(attachmentsAtom)).toHaveLength(2);
+    expect(showError).toHaveBeenCalledWith(
+      "Attachments total 26 MiB. The combined limit is 25 MiB.",
+    );
+  });
+
+  it("clears stale draft attachments when a queued replacement is invalid", () => {
+    const { store, Wrapper } = makeWrapper();
+    const { result } = renderHook(useAttachments, { wrapper: Wrapper });
+    let replaced = true;
+
+    act(() => {
+      result.current.addAttachments([makeFile("current.txt")]);
+    });
+    expect(store.get(attachmentsAtom)).toHaveLength(1);
+
+    const invalidReplacement: FileAttachment[] = Array.from(
+      { length: MAX_CHAT_ATTACHMENTS + 1 },
+      (_, index) => ({
+        file: makeFile(`queued-${index}.txt`),
+        type: "chat-context",
+      }),
+    );
+    act(() => {
+      replaced = result.current.replaceAttachments(invalidReplacement);
+    });
+
+    expect(replaced).toBe(false);
+    expect(store.get(attachmentsAtom)).toEqual([]);
+    expect(showError).toHaveBeenCalledWith(
+      `You can attach up to ${MAX_CHAT_ATTACHMENTS} files at a time.`,
+    );
+  });
+});

--- a/src/hooks/useAttachments.ts
+++ b/src/hooks/useAttachments.ts
@@ -2,6 +2,8 @@ import React, { useCallback, useRef, useState } from "react";
 import type { FileAttachment } from "@/ipc/types";
 import { useAtom } from "jotai";
 import { attachmentsAtom } from "@/atoms/chatAtoms";
+import { showError } from "@/lib/toast";
+import { validateChatAttachmentFiles } from "@/shared/chatAttachmentLimits";
 
 export function useAttachments() {
   const [attachments, setAttachments] = useAtom(attachmentsAtom);
@@ -13,17 +15,46 @@ export function useAttachments() {
     fileInputRef.current?.click();
   };
 
+  const validateFiles = useCallback(
+    (files: readonly File[], existingAttachments = attachments): boolean => {
+      const validation = validateChatAttachmentFiles([
+        ...existingAttachments.map(({ file }) => file),
+        ...files,
+      ]);
+      if (!validation.ok) {
+        showError(validation.message);
+        return false;
+      }
+      return true;
+    },
+    [attachments],
+  );
+
+  const addAttachments = useCallback(
+    (
+      files: File[],
+      type: "chat-context" | "upload-to-codebase" = "chat-context",
+    ): boolean => {
+      if (!validateFiles(files)) {
+        return false;
+      }
+      const fileAttachments: FileAttachment[] = files.map((file) => ({
+        file,
+        type,
+      }));
+      setAttachments((current) => [...current, ...fileAttachments]);
+      return true;
+    },
+    [setAttachments, validateFiles],
+  );
+
   const handleFileChange = (
     e: React.ChangeEvent<HTMLInputElement>,
     type: "chat-context" | "upload-to-codebase" = "chat-context",
   ) => {
     if (e.target.files && e.target.files.length > 0) {
       const files = Array.from(e.target.files);
-      const fileAttachments: FileAttachment[] = files.map((file) => ({
-        file,
-        type,
-      }));
-      setAttachments((attachments) => [...attachments, ...fileAttachments]);
+      addAttachments(files, type);
       // Clear the input value so the same file can be selected again
       e.target.value = "";
     }
@@ -34,11 +65,7 @@ export function useAttachments() {
     type: "chat-context" | "upload-to-codebase",
   ) => {
     const files = Array.from(fileList);
-    const fileAttachments: FileAttachment[] = files.map((file) => ({
-      file,
-      type,
-    }));
-    setAttachments((attachments) => [...attachments, ...fileAttachments]);
+    addAttachments(files, type);
   };
 
   const removeAttachment = (index: number) => {
@@ -64,25 +91,15 @@ export function useAttachments() {
 
     if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
       const files = Array.from(e.dataTransfer.files);
-      setPendingFiles(files);
+      if (validateFiles(files)) {
+        setPendingFiles(files);
+      }
     }
-  };
-
-  const addAttachments = (
-    files: File[],
-    type: "chat-context" | "upload-to-codebase" = "chat-context",
-  ) => {
-    const fileAttachments: FileAttachment[] = files.map((file) => ({
-      file,
-      type,
-    }));
-    setAttachments((attachments) => [...attachments, ...fileAttachments]);
   };
 
   const confirmPendingFiles = useCallback(
     (type: "chat-context" | "upload-to-codebase") => {
-      if (pendingFiles) {
-        addAttachments(pendingFiles, type);
+      if (pendingFiles && addAttachments(pendingFiles, type)) {
         setPendingFiles(null);
       }
     },
@@ -99,8 +116,16 @@ export function useAttachments() {
   };
 
   const replaceAttachments = (newAttachments: FileAttachment[]) => {
+    const validation = validateChatAttachmentFiles(
+      newAttachments.map(({ file }) => file),
+    );
+    if (!validation.ok) {
+      showError(validation.message);
+      return false;
+    }
     setAttachments(newAttachments);
     setPendingFiles(null);
+    return true;
   };
 
   const handlePaste = async (e: React.ClipboardEvent) => {
@@ -137,7 +162,7 @@ export function useAttachments() {
         }
       }
 
-      if (imageFiles.length > 0) {
+      if (imageFiles.length > 0 && validateFiles(imageFiles)) {
         setPendingFiles(imageFiles);
       }
     }

--- a/src/hooks/useAttachments.ts
+++ b/src/hooks/useAttachments.ts
@@ -16,7 +16,10 @@ export function useAttachments() {
   };
 
   const validateFiles = useCallback(
-    (files: readonly File[], existingAttachments = attachments): boolean => {
+    (
+      files: readonly File[],
+      existingAttachments: readonly FileAttachment[],
+    ): boolean => {
       const validation = validateChatAttachmentFiles([
         ...existingAttachments.map(({ file }) => file),
         ...files,
@@ -27,7 +30,7 @@ export function useAttachments() {
       }
       return true;
     },
-    [attachments],
+    [],
   );
 
   const addAttachments = useCallback(
@@ -35,15 +38,19 @@ export function useAttachments() {
       files: File[],
       type: "chat-context" | "upload-to-codebase" = "chat-context",
     ): boolean => {
-      if (!validateFiles(files)) {
-        return false;
-      }
       const fileAttachments: FileAttachment[] = files.map((file) => ({
         file,
         type,
       }));
-      setAttachments((current) => [...current, ...fileAttachments]);
-      return true;
+      let didAdd = false;
+      setAttachments((current) => {
+        if (!validateFiles(files, current)) {
+          return current;
+        }
+        didAdd = true;
+        return [...current, ...fileAttachments];
+      });
+      return didAdd;
     },
     [setAttachments, validateFiles],
   );
@@ -91,7 +98,7 @@ export function useAttachments() {
 
     if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
       const files = Array.from(e.dataTransfer.files);
-      if (validateFiles(files)) {
+      if (validateFiles(files, attachments)) {
         setPendingFiles(files);
       }
     }
@@ -121,6 +128,8 @@ export function useAttachments() {
     );
     if (!validation.ok) {
       showError(validation.message);
+      setAttachments([]);
+      setPendingFiles(null);
       return false;
     }
     setAttachments(newAttachments);
@@ -162,7 +171,7 @@ export function useAttachments() {
         }
       }
 
-      if (imageFiles.length > 0 && validateFiles(imageFiles)) {
+      if (imageFiles.length > 0 && validateFiles(imageFiles, attachments)) {
         setPendingFiles(imageFiles);
       }
     }

--- a/src/hooks/useStreamChat.ts
+++ b/src/hooks/useStreamChat.ts
@@ -1,9 +1,5 @@
 import { useCallback } from "react";
-import type {
-  ComponentSelection,
-  FileAttachment,
-  ChatAttachment,
-} from "@/ipc/types";
+import type { ComponentSelection, FileAttachment } from "@/ipc/types";
 import { useAtom, useAtomValue, useSetAtom, useStore } from "jotai";
 import {
   chatErrorByIdAtom,
@@ -37,7 +33,7 @@ import {
 import { selectedAppIdAtom } from "@/atoms/appAtoms";
 import { setPackageManagerWarningForAppAtom } from "@/atoms/previewRuntimeAtoms";
 import { useVersions } from "./useVersions";
-import { showExtraFilesToast, showWarning } from "@/lib/toast";
+import { showError, showExtraFilesToast, showWarning } from "@/lib/toast";
 import { useSearch } from "@tanstack/react-router";
 import { useRunApp } from "./useRunApp";
 import { useCountTokens } from "./useCountTokens";
@@ -53,6 +49,8 @@ import { resolveAppIdForChat } from "@/lib/chatUtils";
 import { PNPM_MINIMUM_RELEASE_AGE_WARNING_PREFIX } from "@/shared/packageManagerWarnings";
 import { shouldShowPnpmMinimumReleaseAgeWarning } from "@/lib/schemas";
 import { isFreeProModel } from "@/lib/freeProModel";
+import { validateChatAttachmentFiles } from "@/shared/chatAttachmentLimits";
+import { convertFileAttachmentsToChatAttachments } from "@/lib/chatAttachmentConversion";
 
 export function getRandomNumberId() {
   return Math.floor(Math.random() * 1_000_000_000_000_000);
@@ -196,6 +194,15 @@ export function useStreamChat({
         return;
       }
 
+      const attachmentValidation = validateChatAttachmentFiles(
+        (attachments ?? []).map(({ file }) => file),
+      );
+      if (!attachmentValidation.ok) {
+        showError(attachmentValidation.message);
+        onSettled?.({ success: false });
+        return;
+      }
+
       // Prevent duplicate streams - check module-level set to avoid race conditions
       if (pendingStreamChatIds.has(chatId)) {
         console.warn(
@@ -232,44 +239,10 @@ export function useStreamChat({
         return next;
       });
 
-      // Convert FileAttachment[] (with File objects) to ChatAttachment[] (base64 encoded)
-      let convertedAttachments: ChatAttachment[] | undefined;
-      if (attachments && attachments.length > 0) {
-        convertedAttachments = await Promise.all(
-          attachments.map(
-            (attachment) =>
-              new Promise<ChatAttachment>((resolve, reject) => {
-                const reader = new FileReader();
-                reader.onload = () => {
-                  resolve({
-                    name: attachment.file.name,
-                    type: attachment.file.type,
-                    data: reader.result as string,
-                    attachmentType: attachment.type,
-                  });
-                };
-                reader.onerror = () => reject(reader.error);
-                reader.readAsDataURL(attachment.file);
-              }),
-          ),
-        );
-      }
-
       let hasIncrementedStreamCount = false;
       const shouldInvalidateFreeModelQuota = isFreeProModel(
         settings?.selectedModel,
       );
-      // Resolve the target app from the chat itself when the caller didn't
-      // pass one. Falling back to `selectedAppId` is wrong for background
-      // queue processing, where the user may have switched to a different
-      // app while a queued message streams for the original chat.
-      const resolvedAppIdFromChat =
-        appId === undefined
-          ? await resolveAppIdForChat(chatId, queryClient)
-          : null;
-      const targetAppId =
-        appId ?? resolvedAppIdFromChat ?? selectedAppId ?? null;
-
       const finalizeStream = (chatId: number) => {
         pendingStreamChatIds.delete(chatId);
         latestChunkByChatId.delete(chatId);
@@ -278,6 +251,24 @@ export function useStreamChat({
       };
 
       try {
+        // Convert one file at a time so FileReader does not hold every source
+        // buffer concurrently alongside all encoded strings.
+        const convertedAttachments =
+          attachments && attachments.length > 0
+            ? await convertFileAttachmentsToChatAttachments(attachments)
+            : undefined;
+
+        // Resolve the target app from the chat itself when the caller didn't
+        // pass one. Falling back to `selectedAppId` is wrong for background
+        // queue processing, where the user may have switched to a different
+        // app while a queued message streams for the original chat.
+        const resolvedAppIdFromChat =
+          appId === undefined
+            ? await resolveAppIdForChat(chatId, queryClient)
+            : null;
+        const targetAppId =
+          appId ?? resolvedAppIdFromChat ?? selectedAppId ?? null;
+
         const cachedChat =
           requestedChatMode === null
             ? undefined

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -5,7 +5,7 @@ import {
   computeStreamingPatch,
   fastTextOutput,
 } from "../utils/stream_text_utils";
-import { chatContracts } from "../types/chat";
+import { chatContracts, ChatStreamParamsSchema } from "../types/chat";
 import {
   ModelMessage,
   TextPart,
@@ -36,7 +36,7 @@ import { buildNeonPromptForApp } from "../../neon_admin/neon_prompt_context";
 import { getDyadAppPath } from "../../paths/paths";
 import { buildDyadMediaUrl } from "../../lib/dyadMediaUrl";
 import type { ChatResponseEnd, ChatStreamParams } from "@/ipc/types";
-import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
+import { DyadError, DyadErrorKind, isDyadError } from "@/errors/dyad_error";
 import {
   CodebaseFile,
   extractCodebase,
@@ -157,6 +157,7 @@ import {
   type PendingStoredChatAttachment,
   type StoredChatAttachment,
 } from "../utils/chat_attachment_utils";
+import { inspectBase64DataUrl } from "../../shared/chatAttachmentLimits";
 
 type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
 
@@ -287,6 +288,17 @@ export function registerChatStreamHandlers() {
   ipcMain.handle("chat:stream", async (event, req: ChatStreamParams) => {
     let attachmentPaths: string[] = [];
     try {
+      // This legacy stream handler predates createTypedHandler, so enforce the
+      // contract explicitly before any attachment string is decoded.
+      const parsedRequest = ChatStreamParamsSchema.safeParse(req);
+      if (!parsedRequest.success) {
+        throw new DyadError(
+          parsedRequest.error.issues[0]?.message ?? "Invalid chat request.",
+          DyadErrorKind.Validation,
+        );
+      }
+      req = parsedRequest.data;
+
       let dyadRequestId: string | undefined;
       // Create an AbortController for this stream
       const abortController = new AbortController();
@@ -366,7 +378,12 @@ export function registerChatStreamHandlers() {
       const usedLogicalNames = new Set<string>();
       const appPath = getDyadAppPath(chat.app.path);
 
-      if (req.attachments && req.attachments.length > 0) {
+      // Detach the serialized payloads from the long-lived stream request as
+      // soon as they are persisted. Otherwise every base64 string remains
+      // reachable for the entire LLM turn and duplicates later disk reads.
+      let incomingAttachments = req.attachments;
+      req.attachments = undefined;
+      if (incomingAttachments && incomingAttachments.length > 0) {
         attachmentInfo = "\n\nAttachments:\n";
 
         // Create persistent .dyad/media directory for this app
@@ -376,9 +393,15 @@ export function registerChatStreamHandlers() {
         }
         await ensureDyadGitignored(appPath);
 
-        for (const attachment of req.attachments) {
-          // Extract the base64 data (remove the data:mime/type;base64, prefix)
-          const base64Data = attachment.data.split(";base64,").pop() || "";
+        for (const attachment of incomingAttachments) {
+          const inspection = inspectBase64DataUrl(attachment.data);
+          if (!inspection.ok) {
+            throw new DyadError(
+              `"${attachment.name}" is not a valid base64 attachment.`,
+              DyadErrorKind.Validation,
+            );
+          }
+          const base64Data = attachment.data.slice(inspection.payloadStart);
           const fileBuffer = Buffer.from(base64Data, "base64");
           const hash = crypto
             .createHash("sha256")
@@ -443,6 +466,7 @@ export function registerChatStreamHandlers() {
           }
         }
       }
+      incomingAttachments = undefined;
 
       // Build the full AI prompt. Attachment-specific instructions are added
       // to the user message, never the system prompt.
@@ -1977,9 +2001,10 @@ ${problemReport.problems
       return req.chatId;
     } catch (error) {
       logger.error("Error calling LLM:", error);
+      const errorMessage = isDyadError(error) ? error.message : String(error);
       safeSend(event.sender, "chat:response:error", {
         chatId: req.chatId,
-        error: `Sorry, there was an error processing your request: ${error}`,
+        error: `Sorry, there was an error processing your request: ${errorMessage}`,
       });
 
       return "error";

--- a/src/ipc/types/chat.test.ts
+++ b/src/ipc/types/chat.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { MAX_CHAT_ATTACHMENTS } from "../../shared/chatAttachmentLimits";
+import { ChatStreamParamsSchema } from "./chat";
+
+const validAttachment = {
+  name: "notes.txt",
+  type: "text/plain",
+  data: "data:text/plain;base64,SGVsbG8=",
+  attachmentType: "chat-context" as const,
+};
+
+describe("ChatStreamParamsSchema attachment limits", () => {
+  it("accepts valid base64 attachment input", () => {
+    expect(
+      ChatStreamParamsSchema.safeParse({
+        chatId: 1,
+        prompt: "hello",
+        attachments: [validAttachment],
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects too many attachments", () => {
+    expect(
+      ChatStreamParamsSchema.safeParse({
+        chatId: 1,
+        prompt: "hello",
+        attachments: Array.from(
+          { length: MAX_CHAT_ATTACHMENTS + 1 },
+          () => validAttachment,
+        ),
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects attachments without a base64 data URL prefix", () => {
+    expect(
+      ChatStreamParamsSchema.safeParse({
+        chatId: 1,
+        prompt: "hello",
+        attachments: [{ ...validAttachment, data: "SGVsbG8=" }],
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/src/ipc/types/chat.test.ts
+++ b/src/ipc/types/chat.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { MAX_CHAT_ATTACHMENTS } from "../../shared/chatAttachmentLimits";
-import { ChatStreamParamsSchema } from "./chat";
+import {
+  CHAT_ATTACHMENT_COUNT_LIMIT_MESSAGE,
+  MAX_CHAT_ATTACHMENTS,
+  MAX_CHAT_ATTACHMENT_DATA_URL_CHARS,
+} from "../../shared/chatAttachmentLimits";
+import { ChatAttachmentSchema, ChatStreamParamsSchema } from "./chat";
 
 const validAttachment = {
   name: "notes.txt",
@@ -22,16 +26,63 @@ describe("ChatStreamParamsSchema attachment limits", () => {
   });
 
   it("rejects too many attachments", () => {
-    expect(
-      ChatStreamParamsSchema.safeParse({
-        chatId: 1,
-        prompt: "hello",
-        attachments: Array.from(
-          { length: MAX_CHAT_ATTACHMENTS + 1 },
-          () => validAttachment,
-        ),
-      }).success,
-    ).toBe(false);
+    const result = ChatStreamParamsSchema.safeParse({
+      chatId: 1,
+      prompt: "hello",
+      attachments: Array.from(
+        { length: MAX_CHAT_ATTACHMENTS + 1 },
+        () => validAttachment,
+      ),
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe(
+        CHAT_ATTACHMENT_COUNT_LIMIT_MESSAGE,
+      );
+    }
+  });
+
+  it("rejects excessive counts before reading attachment payloads", () => {
+    const unreadAttachment = new Proxy(
+      {},
+      {
+        get() {
+          throw new Error("attachment payload should not be read");
+        },
+      },
+    );
+
+    const result = ChatStreamParamsSchema.safeParse({
+      chatId: 1,
+      prompt: "hello",
+      attachments: Array.from(
+        { length: MAX_CHAT_ATTACHMENTS + 1 },
+        () => unreadAttachment,
+      ),
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe(
+        CHAT_ATTACHMENT_COUNT_LIMIT_MESSAGE,
+      );
+    }
+  });
+
+  it("uses an attachment-specific message for oversized serialized data", () => {
+    const result = ChatAttachmentSchema.safeParse({
+      ...validAttachment,
+      name: "oversized.bin",
+      data: "A".repeat(MAX_CHAT_ATTACHMENT_DATA_URL_CHARS + 1),
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe(
+        '"oversized.bin" exceeds the 10 MiB attachment limit.',
+      );
+    }
   });
 
   it("rejects attachments without a base64 data URL prefix", () => {

--- a/src/ipc/types/chat.ts
+++ b/src/ipc/types/chat.ts
@@ -11,6 +11,11 @@ import {
   migrateStoredChatMode,
   type ChatMode,
 } from "../../lib/schemas";
+import {
+  MAX_CHAT_ATTACHMENTS,
+  MAX_CHAT_ATTACHMENT_DATA_URL_CHARS,
+  validateSerializedChatAttachments,
+} from "../../shared/chatAttachmentLimits";
 
 // =============================================================================
 // Chat Schemas
@@ -71,12 +76,23 @@ export type ComponentSelection = z.infer<typeof ComponentSelectionSchema>;
 /**
  * Schema for file attachment in chat (base64 encoded for IPC transfer).
  */
-export const ChatAttachmentSchema = z.object({
-  name: z.string(),
-  type: z.string(),
-  data: z.string(), // Base64 encoded
-  attachmentType: z.enum(["upload-to-codebase", "chat-context"]),
-});
+export const ChatAttachmentSchema = z
+  .object({
+    name: z.string(),
+    type: z.string(),
+    data: z.string().max(MAX_CHAT_ATTACHMENT_DATA_URL_CHARS), // Base64 encoded
+    attachmentType: z.enum(["upload-to-codebase", "chat-context"]),
+  })
+  .superRefine((attachment, context) => {
+    const validation = validateSerializedChatAttachments([attachment]);
+    if (!validation.ok) {
+      context.addIssue({
+        code: "custom",
+        path: ["data"],
+        message: validation.message,
+      });
+    }
+  });
 
 export type ChatAttachment = z.infer<typeof ChatAttachmentSchema>;
 
@@ -92,14 +108,30 @@ export interface FileAttachment {
 /**
  * Schema for chat stream parameters.
  */
-export const ChatStreamParamsSchema = z.object({
-  chatId: z.number(),
-  prompt: z.string(),
-  redo: z.boolean().optional(),
-  attachments: z.array(ChatAttachmentSchema).optional(),
-  selectedComponents: z.array(ComponentSelectionSchema).optional(),
-  requestedChatMode: ChatModeSchema.optional(),
-});
+export const ChatStreamParamsSchema = z
+  .object({
+    chatId: z.number(),
+    prompt: z.string(),
+    redo: z.boolean().optional(),
+    attachments: z
+      .array(ChatAttachmentSchema)
+      .max(MAX_CHAT_ATTACHMENTS)
+      .optional(),
+    selectedComponents: z.array(ComponentSelectionSchema).optional(),
+    requestedChatMode: ChatModeSchema.optional(),
+  })
+  .superRefine((params, context) => {
+    const validation = validateSerializedChatAttachments(
+      params.attachments ?? [],
+    );
+    if (!validation.ok) {
+      context.addIssue({
+        code: "custom",
+        path: ["attachments"],
+        message: validation.message,
+      });
+    }
+  });
 
 export type ChatStreamParams = z.infer<typeof ChatStreamParamsSchema>;
 

--- a/src/ipc/types/chat.ts
+++ b/src/ipc/types/chat.ts
@@ -12,8 +12,8 @@ import {
   type ChatMode,
 } from "../../lib/schemas";
 import {
+  CHAT_ATTACHMENT_COUNT_LIMIT_MESSAGE,
   MAX_CHAT_ATTACHMENTS,
-  MAX_CHAT_ATTACHMENT_DATA_URL_CHARS,
   validateSerializedChatAttachments,
 } from "../../shared/chatAttachmentLimits";
 
@@ -80,7 +80,7 @@ export const ChatAttachmentSchema = z
   .object({
     name: z.string(),
     type: z.string(),
-    data: z.string().max(MAX_CHAT_ATTACHMENT_DATA_URL_CHARS), // Base64 encoded
+    data: z.string(), // Base64 encoded
     attachmentType: z.enum(["upload-to-codebase", "chat-context"]),
   })
   .superRefine((attachment, context) => {
@@ -106,6 +106,23 @@ export interface FileAttachment {
 }
 
 /**
+ * Reject excessive counts before Zod parses any attachment payloads. Keeping
+ * this as an outer pipeline avoids walking arbitrarily many large base64
+ * strings before reporting the count violation.
+ */
+const ChatAttachmentsSchema = z
+  .unknown()
+  .superRefine((value, context) => {
+    if (Array.isArray(value) && value.length > MAX_CHAT_ATTACHMENTS) {
+      context.addIssue({
+        code: "custom",
+        message: CHAT_ATTACHMENT_COUNT_LIMIT_MESSAGE,
+      });
+    }
+  })
+  .pipe(z.array(ChatAttachmentSchema));
+
+/**
  * Schema for chat stream parameters.
  */
 export const ChatStreamParamsSchema = z
@@ -113,10 +130,7 @@ export const ChatStreamParamsSchema = z
     chatId: z.number(),
     prompt: z.string(),
     redo: z.boolean().optional(),
-    attachments: z
-      .array(ChatAttachmentSchema)
-      .max(MAX_CHAT_ATTACHMENTS)
-      .optional(),
+    attachments: ChatAttachmentsSchema.optional(),
     selectedComponents: z.array(ComponentSelectionSchema).optional(),
     requestedChatMode: ChatModeSchema.optional(),
   })

--- a/src/lib/chatAttachmentConversion.test.ts
+++ b/src/lib/chatAttachmentConversion.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { convertFileAttachmentsToChatAttachments } from "./chatAttachmentConversion";
+
+describe("convertFileAttachmentsToChatAttachments", () => {
+  it("reads files sequentially and preserves their order", async () => {
+    const files = ["first.txt", "second.txt", "third.txt"].map(
+      (name) => new File([name], name, { type: "text/plain" }),
+    );
+    let activeReaders = 0;
+    let maxActiveReaders = 0;
+
+    const converted = await convertFileAttachmentsToChatAttachments(
+      files.map((file) => ({ file, type: "chat-context" })),
+      async (file) => {
+        activeReaders += 1;
+        maxActiveReaders = Math.max(maxActiveReaders, activeReaders);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        activeReaders -= 1;
+        return `data:${file.type};base64,${file.name}`;
+      },
+    );
+
+    expect(maxActiveReaders).toBe(1);
+    expect(converted.map(({ name }) => name)).toEqual([
+      "first.txt",
+      "second.txt",
+      "third.txt",
+    ]);
+  });
+});

--- a/src/lib/chatAttachmentConversion.ts
+++ b/src/lib/chatAttachmentConversion.ts
@@ -1,0 +1,34 @@
+import type { ChatAttachment, FileAttachment } from "../ipc/types/chat";
+
+export type ReadFileAsDataUrl = (file: File) => Promise<string>;
+
+export function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () =>
+      reject(reader.error ?? new Error(`Could not read "${file.name}".`));
+    reader.readAsDataURL(file);
+  });
+}
+
+/**
+ * Read attachments one at a time. Reading all files with Promise.all makes the
+ * browser retain every FileReader buffer at once in addition to the resulting
+ * base64 strings and the subsequent IPC structured clone.
+ */
+export async function convertFileAttachmentsToChatAttachments(
+  attachments: readonly FileAttachment[],
+  readFile: ReadFileAsDataUrl = readFileAsDataUrl,
+): Promise<ChatAttachment[]> {
+  const converted: ChatAttachment[] = [];
+  for (const attachment of attachments) {
+    converted.push({
+      name: attachment.file.name,
+      type: attachment.file.type,
+      data: await readFile(attachment.file),
+      attachmentType: attachment.type,
+    });
+  }
+  return converted;
+}

--- a/src/shared/chatAttachmentLimits.test.ts
+++ b/src/shared/chatAttachmentLimits.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  inspectBase64DataUrl,
+  MAX_CHAT_ATTACHMENT_BYTES,
+  MAX_CHAT_ATTACHMENTS,
+  MAX_CHAT_ATTACHMENTS_TOTAL_BYTES,
+  validateChatAttachmentFiles,
+  validateSerializedChatAttachments,
+} from "./chatAttachmentLimits";
+
+function dataUrlForDecodedBytes(bytes: number): string {
+  const padding = bytes === 0 ? 0 : (3 - (bytes % 3)) % 3;
+  const encodedLength = 4 * Math.ceil(bytes / 3);
+  return `data:application/octet-stream;base64,${"A".repeat(encodedLength - padding)}${"=".repeat(padding)}`;
+}
+
+describe("chat attachment file limits", () => {
+  it("accepts the count, per-file, and aggregate boundaries", () => {
+    expect(
+      validateChatAttachmentFiles(
+        Array.from({ length: MAX_CHAT_ATTACHMENTS }, (_, index) => ({
+          name: `${index}.txt`,
+          size: 0,
+        })),
+      ),
+    ).toEqual({ ok: true, totalBytes: 0 });
+
+    expect(
+      validateChatAttachmentFiles([
+        { name: "first.bin", size: MAX_CHAT_ATTACHMENT_BYTES },
+        { name: "second.bin", size: MAX_CHAT_ATTACHMENT_BYTES },
+        {
+          name: "third.bin",
+          size:
+            MAX_CHAT_ATTACHMENTS_TOTAL_BYTES - 2 * MAX_CHAT_ATTACHMENT_BYTES,
+        },
+      ]),
+    ).toEqual({
+      ok: true,
+      totalBytes: MAX_CHAT_ATTACHMENTS_TOTAL_BYTES,
+    });
+  });
+
+  it("rejects too many files", () => {
+    const result = validateChatAttachmentFiles(
+      Array.from({ length: MAX_CHAT_ATTACHMENTS + 1 }, (_, index) => ({
+        name: `${index}.txt`,
+        size: 0,
+      })),
+    );
+    expect(result).toMatchObject({ ok: false, code: "too-many-files" });
+  });
+
+  it("rejects a file over the per-file limit", () => {
+    const result = validateChatAttachmentFiles([
+      { name: "large.bin", size: MAX_CHAT_ATTACHMENT_BYTES + 1 },
+    ]);
+    expect(result).toMatchObject({ ok: false, code: "file-too-large" });
+  });
+
+  it("rejects attachments over the aggregate limit", () => {
+    const result = validateChatAttachmentFiles([
+      { name: "first.bin", size: MAX_CHAT_ATTACHMENT_BYTES },
+      { name: "second.bin", size: MAX_CHAT_ATTACHMENT_BYTES },
+      {
+        name: "third.bin",
+        size:
+          MAX_CHAT_ATTACHMENTS_TOTAL_BYTES - 2 * MAX_CHAT_ATTACHMENT_BYTES + 1,
+      },
+    ]);
+    expect(result).toMatchObject({ ok: false, code: "total-too-large" });
+  });
+});
+
+describe("serialized chat attachment limits", () => {
+  it("calculates decoded bytes without decoding the payload", () => {
+    expect(inspectBase64DataUrl("data:text/plain;base64,SGVsbG8=")).toEqual({
+      ok: true,
+      decodedBytes: 5,
+      payloadStart: 23,
+    });
+  });
+
+  it.each([
+    "SGVsbG8=",
+    "http:text/plain;base64,SGVsbG8=",
+    "data:text/plain,SGVsbG8=",
+    "data:text/plain;base64,SGVsbG8",
+    "data:text/plain;base64,SGVsbG8*",
+    "data:text/plain;base64,SG=VsbG8",
+  ])("rejects a malformed base64 data URL: %s", (data) => {
+    const result = validateSerializedChatAttachments([
+      { name: "bad.txt", data },
+    ]);
+    expect(result).toMatchObject({ ok: false, code: "invalid-data-url" });
+  });
+
+  it("accepts an attachment exactly at the decoded per-file boundary", () => {
+    const result = validateSerializedChatAttachments([
+      {
+        name: "boundary.bin",
+        data: dataUrlForDecodedBytes(MAX_CHAT_ATTACHMENT_BYTES),
+      },
+    ]);
+    expect(result).toEqual({
+      ok: true,
+      totalBytes: MAX_CHAT_ATTACHMENT_BYTES,
+    });
+  });
+
+  it("rejects based on decoded size, including equal-length padded payloads", () => {
+    const result = validateSerializedChatAttachments([
+      {
+        name: "too-large.bin",
+        data: dataUrlForDecodedBytes(MAX_CHAT_ATTACHMENT_BYTES + 1),
+      },
+    ]);
+    expect(result).toMatchObject({ ok: false, code: "file-too-large" });
+  });
+
+  it("accepts attachments exactly at the aggregate decoded-byte boundary", () => {
+    const tenMiB = dataUrlForDecodedBytes(MAX_CHAT_ATTACHMENT_BYTES);
+    const remaining = dataUrlForDecodedBytes(
+      MAX_CHAT_ATTACHMENTS_TOTAL_BYTES - 2 * MAX_CHAT_ATTACHMENT_BYTES,
+    );
+    const result = validateSerializedChatAttachments([
+      { name: "first.bin", data: tenMiB },
+      { name: "second.bin", data: tenMiB },
+      { name: "third.bin", data: remaining },
+    ]);
+    expect(result).toEqual({
+      ok: true,
+      totalBytes: MAX_CHAT_ATTACHMENTS_TOTAL_BYTES,
+    });
+  });
+
+  it("enforces the aggregate decoded-byte limit", () => {
+    const tenMiB = dataUrlForDecodedBytes(MAX_CHAT_ATTACHMENT_BYTES);
+    const remainingPlusOne = dataUrlForDecodedBytes(
+      MAX_CHAT_ATTACHMENTS_TOTAL_BYTES - 2 * MAX_CHAT_ATTACHMENT_BYTES + 1,
+    );
+    const result = validateSerializedChatAttachments([
+      { name: "first.bin", data: tenMiB },
+      { name: "second.bin", data: tenMiB },
+      { name: "third.bin", data: remainingPlusOne },
+    ]);
+    expect(result).toMatchObject({ ok: false, code: "total-too-large" });
+  });
+});

--- a/src/shared/chatAttachmentLimits.ts
+++ b/src/shared/chatAttachmentLimits.ts
@@ -3,6 +3,7 @@ const MEBIBYTE = 1024 * 1024;
 export const MAX_CHAT_ATTACHMENTS = 10;
 export const MAX_CHAT_ATTACHMENT_BYTES = 10 * MEBIBYTE;
 export const MAX_CHAT_ATTACHMENTS_TOTAL_BYTES = 25 * MEBIBYTE;
+export const CHAT_ATTACHMENT_COUNT_LIMIT_MESSAGE = `You can attach up to ${MAX_CHAT_ATTACHMENTS} files at a time.`;
 
 const BASE64_MARKER = ";base64,";
 const MAX_DATA_URL_PREFIX_CHARS = 1024;
@@ -126,7 +127,7 @@ export function validateChatAttachmentFiles(
     return {
       ok: false,
       code: "too-many-files",
-      message: `You can attach up to ${MAX_CHAT_ATTACHMENTS} files at a time.`,
+      message: CHAT_ATTACHMENT_COUNT_LIMIT_MESSAGE,
     };
   }
 
@@ -167,7 +168,7 @@ export function validateSerializedChatAttachments(
     return {
       ok: false,
       code: "too-many-files",
-      message: `You can attach up to ${MAX_CHAT_ATTACHMENTS} files at a time.`,
+      message: CHAT_ATTACHMENT_COUNT_LIMIT_MESSAGE,
     };
   }
 

--- a/src/shared/chatAttachmentLimits.ts
+++ b/src/shared/chatAttachmentLimits.ts
@@ -1,0 +1,211 @@
+const MEBIBYTE = 1024 * 1024;
+
+export const MAX_CHAT_ATTACHMENTS = 10;
+export const MAX_CHAT_ATTACHMENT_BYTES = 10 * MEBIBYTE;
+export const MAX_CHAT_ATTACHMENTS_TOTAL_BYTES = 25 * MEBIBYTE;
+
+const BASE64_MARKER = ";base64,";
+const MAX_DATA_URL_PREFIX_CHARS = 1024;
+const MAX_BASE64_PAYLOAD_CHARS = 4 * Math.ceil(MAX_CHAT_ATTACHMENT_BYTES / 3);
+
+/**
+ * A cheap upper bound that lets the IPC contract reject oversized strings
+ * before walking their base64 payload. Exact decoded sizes are checked below.
+ */
+export const MAX_CHAT_ATTACHMENT_DATA_URL_CHARS =
+  MAX_DATA_URL_PREFIX_CHARS + BASE64_MARKER.length + MAX_BASE64_PAYLOAD_CHARS;
+
+export type ChatAttachmentValidationErrorCode =
+  | "too-many-files"
+  | "file-too-large"
+  | "total-too-large"
+  | "invalid-file-size"
+  | "invalid-data-url";
+
+export type ChatAttachmentValidationResult =
+  | { ok: true; totalBytes: number }
+  | {
+      ok: false;
+      code: ChatAttachmentValidationErrorCode;
+      message: string;
+    };
+
+export interface ChatAttachmentFileMetadata {
+  name: string;
+  size: number;
+}
+
+export interface SerializedChatAttachmentMetadata {
+  name: string;
+  data: string;
+}
+
+export type Base64DataUrlInspection =
+  | { ok: true; decodedBytes: number; payloadStart: number }
+  | { ok: false };
+
+function formatBytes(bytes: number): string {
+  const mebibytes = bytes / MEBIBYTE;
+  return `${Number.isInteger(mebibytes) ? mebibytes : mebibytes.toFixed(1)} MiB`;
+}
+
+function displayName(name: string): string {
+  return name.trim() || "Unnamed attachment";
+}
+
+function isBase64Character(code: number): boolean {
+  return (
+    (code >= 65 && code <= 90) ||
+    (code >= 97 && code <= 122) ||
+    (code >= 48 && code <= 57) ||
+    code === 43 ||
+    code === 47
+  );
+}
+
+/**
+ * Validate a base64 data URL and calculate its decoded byte length without
+ * allocating a decoded Buffer. The payload is walked by index so malformed or
+ * hostile input does not create another large substring during validation.
+ */
+export function inspectBase64DataUrl(dataUrl: string): Base64DataUrlInspection {
+  if (!dataUrl.startsWith("data:")) {
+    return { ok: false };
+  }
+
+  const markerIndex = dataUrl.indexOf(BASE64_MARKER);
+  if (
+    markerIndex < "data:".length ||
+    markerIndex > MAX_DATA_URL_PREFIX_CHARS ||
+    dataUrl.indexOf(",") !== markerIndex + BASE64_MARKER.length - 1
+  ) {
+    return { ok: false };
+  }
+
+  const payloadStart = markerIndex + BASE64_MARKER.length;
+  const encodedLength = dataUrl.length - payloadStart;
+  if (encodedLength === 0) {
+    return { ok: true, decodedBytes: 0, payloadStart };
+  }
+  if (encodedLength % 4 !== 0) {
+    return { ok: false };
+  }
+
+  let padding = 0;
+  if (dataUrl.charCodeAt(dataUrl.length - 1) === 61) {
+    padding = 1;
+    if (dataUrl.charCodeAt(dataUrl.length - 2) === 61) {
+      padding = 2;
+    }
+  }
+
+  const payloadEnd = dataUrl.length - padding;
+  for (let index = payloadStart; index < payloadEnd; index += 1) {
+    if (!isBase64Character(dataUrl.charCodeAt(index))) {
+      return { ok: false };
+    }
+  }
+
+  for (let index = payloadEnd; index < dataUrl.length; index += 1) {
+    if (dataUrl.charCodeAt(index) !== 61) {
+      return { ok: false };
+    }
+  }
+
+  return {
+    ok: true,
+    decodedBytes: (encodedLength / 4) * 3 - padding,
+    payloadStart,
+  };
+}
+
+export function validateChatAttachmentFiles(
+  attachments: readonly ChatAttachmentFileMetadata[],
+): ChatAttachmentValidationResult {
+  if (attachments.length > MAX_CHAT_ATTACHMENTS) {
+    return {
+      ok: false,
+      code: "too-many-files",
+      message: `You can attach up to ${MAX_CHAT_ATTACHMENTS} files at a time.`,
+    };
+  }
+
+  let totalBytes = 0;
+  for (const attachment of attachments) {
+    if (!Number.isSafeInteger(attachment.size) || attachment.size < 0) {
+      return {
+        ok: false,
+        code: "invalid-file-size",
+        message: `Could not determine the size of "${displayName(attachment.name)}".`,
+      };
+    }
+    if (attachment.size > MAX_CHAT_ATTACHMENT_BYTES) {
+      return {
+        ok: false,
+        code: "file-too-large",
+        message: `"${displayName(attachment.name)}" is ${formatBytes(attachment.size)}. Each attachment must be ${formatBytes(MAX_CHAT_ATTACHMENT_BYTES)} or smaller.`,
+      };
+    }
+
+    totalBytes += attachment.size;
+    if (totalBytes > MAX_CHAT_ATTACHMENTS_TOTAL_BYTES) {
+      return {
+        ok: false,
+        code: "total-too-large",
+        message: `Attachments total ${formatBytes(totalBytes)}. The combined limit is ${formatBytes(MAX_CHAT_ATTACHMENTS_TOTAL_BYTES)}.`,
+      };
+    }
+  }
+
+  return { ok: true, totalBytes };
+}
+
+export function validateSerializedChatAttachments(
+  attachments: readonly SerializedChatAttachmentMetadata[],
+): ChatAttachmentValidationResult {
+  if (attachments.length > MAX_CHAT_ATTACHMENTS) {
+    return {
+      ok: false,
+      code: "too-many-files",
+      message: `You can attach up to ${MAX_CHAT_ATTACHMENTS} files at a time.`,
+    };
+  }
+
+  let totalBytes = 0;
+  for (const attachment of attachments) {
+    if (attachment.data.length > MAX_CHAT_ATTACHMENT_DATA_URL_CHARS) {
+      return {
+        ok: false,
+        code: "file-too-large",
+        message: `"${displayName(attachment.name)}" exceeds the ${formatBytes(MAX_CHAT_ATTACHMENT_BYTES)} attachment limit.`,
+      };
+    }
+
+    const inspection = inspectBase64DataUrl(attachment.data);
+    if (!inspection.ok) {
+      return {
+        ok: false,
+        code: "invalid-data-url",
+        message: `"${displayName(attachment.name)}" is not a valid base64 attachment.`,
+      };
+    }
+    if (inspection.decodedBytes > MAX_CHAT_ATTACHMENT_BYTES) {
+      return {
+        ok: false,
+        code: "file-too-large",
+        message: `"${displayName(attachment.name)}" is ${formatBytes(inspection.decodedBytes)}. Each attachment must be ${formatBytes(MAX_CHAT_ATTACHMENT_BYTES)} or smaller.`,
+      };
+    }
+
+    totalBytes += inspection.decodedBytes;
+    if (totalBytes > MAX_CHAT_ATTACHMENTS_TOTAL_BYTES) {
+      return {
+        ok: false,
+        code: "total-too-large",
+        message: `Attachments total ${formatBytes(totalBytes)}. The combined limit is ${formatBytes(MAX_CHAT_ATTACHMENTS_TOTAL_BYTES)}.`,
+      };
+    }
+  }
+
+  return { ok: true, totalBytes };
+}


### PR DESCRIPTION
## Summary
- Enforce a maximum of 10 chat attachments, 10 MiB per file, and 25 MiB combined before FileReader work and again at the main-process IPC boundary.
- Validate base64 data URL syntax and decoded size without allocating a Buffer, encode files sequentially, and release serialized payloads after persistence.
- Surface clear validation messages while preserving existing chat-context and upload-to-codebase flows.

## Root cause
Chat attachments had no count or byte limits. The renderer encoded every selected File concurrently, IPC cloned all base64 strings, and main decoded them into Buffers while retaining the serialized request for the full LLM turn. A single large selection could therefore create several simultaneous representations and exhaust either process heap.

The selected limits cap encoded payloads to roughly 33.4 MiB combined and each decode to 10 MiB, while still supporting normal screenshots, documents, and the existing large-attachment local-agent flow.

## Tests
- npm test -- src/shared/chatAttachmentLimits.test.ts src/lib/chatAttachmentConversion.test.ts src/ipc/types/chat.test.ts src/ipc/handlers/__tests__/local_agent_large_attachment.integration.test.tsx (20 passed)
- npm run lint
- npm run ts
- npm run build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the chat stream and IPC attachment path; invalid or oversized attachments now fail fast instead of proceeding, but limits are well-tested and mostly defensive.
> 
> **Overview**
> Adds **hard limits** on chat attachments (**10 files**, **10 MiB** each, **25 MiB** combined) and enforces them in the renderer, at stream start, and in the main-process IPC contract so oversized payloads are rejected before heavy work.
> 
> **Renderer:** `useAttachments` validates adds/replaces/drops/pastes against current atom state (including rapid back-to-back adds) and shows toast errors; invalid queued replacements clear draft attachments. `useStreamChat` re-validates before encoding and converts files **one at a time** via `convertFileAttachmentsToChatAttachments` instead of parallel `FileReader` + concurrent base64 strings.
> 
> **IPC / main:** `ChatStreamParamsSchema` / `ChatAttachmentSchema` use shared validators; attachment count is checked before walking large base64 strings. The legacy `chat:stream` handler runs the same schema up front, validates data URLs with `inspectBase64DataUrl` (decoded size without extra Buffer allocation), drops serialized attachment payloads from the request after persisting to disk, and surfaces validation messages from `DyadError` in stream errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 892638e4b80b9fbbbe2918747db5e7ff600e9a2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

