### PR TITLE
Bound MCP tool results to prevent context bloat

### DIFF
--- a/rules/git-workflow.md
+++ b/rules/git-workflow.md
@@ -100,6 +100,12 @@ Add `#skip-bugbot` to the PR description for trivial PRs that won't affect end-u
 
 ## Cross-repo PR workflows (forks)
 
+- `git fetch --all` can return nonzero after successfully refreshing
+  `upstream/main` when unrelated collaborator remotes have clashing historical
+  tags (`would clobber existing tag`). Verify the base ref was updated, then
+  rebase onto it; do not treat an unrelated remote's tag rejection as a stale
+  upstream fetch.
+
 When running GitHub Actions with `pull_request_target` on cross-repo PRs (from forks):
 
 - The checkout action sets `origin` to the **fork** (head repo), not the base repo

--- a/rules/local-agent-tools.md
+++ b/rules/local-agent-tools.md
@@ -21,6 +21,7 @@ Agent tool definitions live in `src/pro/main/ipc/handlers/local_agent/tools/`. E
 ## MCP consent results
 
 - `requireMcpToolConsent` resolves to a structured result, not a bare boolean. If `npm run ts` reports `Argument of type 'boolean' is not assignable to parameter of type 'McpConsentResult'`, update mocks to return `{ approved: true/false }`.
+- Treat MCP tool results as untrusted-size input. Every execution path (direct Agent tools, sandbox host functions, and Build-mode tools) must pass the raw result through `sanitizeMcpToolResult` before JSON serialization, XML emission, SDK return, or persistence; directly stringifying a result can multiply large text or base64 media across main-process memory.
 
 ## SQL consent and auto-approval
 

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -235,7 +235,7 @@ async function processStreamChunks({
       chunk = `<dyad-mcp-tool-call server="${escapeXmlAttr(serverName)}" tool="${escapeXmlAttr(toolName)}" call-id="${escapeXmlAttr(part.toolCallId)}">\n${content}\n</dyad-mcp-tool-call>\n`;
     } else if (part.type === "tool-result") {
       const { serverName, toolName } = parseMcpToolKey(part.toolName);
-      const content = escapeDyadTags(part.output);
+      const content = escapeXmlContent(part.output);
       chunk = `<dyad-mcp-tool-result server="${escapeXmlAttr(serverName)}" tool="${escapeXmlAttr(toolName)}" call-id="${escapeXmlAttr(part.toolCallId)}">\n${content}\n</dyad-mcp-tool-result>\n`;
     } else if (part.type === "tool-error") {
       // Emit an errored result so the merged card terminates in an error
@@ -243,7 +243,9 @@ async function processStreamChunks({
       const { serverName, toolName } = parseMcpToolKey(part.toolName);
       const message =
         part.error instanceof Error ? part.error.message : String(part.error);
-      const content = escapeDyadTags(sanitizeMcpToolResult(message).serialized);
+      const content = escapeXmlContent(
+        sanitizeMcpToolResult(message).serialized,
+      );
       chunk = `<dyad-mcp-tool-result server="${escapeXmlAttr(serverName)}" tool="${escapeXmlAttr(toolName)}" call-id="${escapeXmlAttr(part.toolCallId)}" is-error="true">\n${content}\n</dyad-mcp-tool-result>\n`;
     }
 

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -75,6 +75,7 @@ import {
   requireMcpToolConsent,
   clearPendingMcpConsentsForChat,
 } from "../utils/mcp_consent";
+import { sanitizeMcpToolResult } from "../utils/mcp_result_sanitizer";
 
 import { handleLocalAgentStream } from "../../pro/main/ipc/handlers/local_agent/local_agent_handler";
 
@@ -242,7 +243,7 @@ async function processStreamChunks({
       const { serverName, toolName } = parseMcpToolKey(part.toolName);
       const message =
         part.error instanceof Error ? part.error.message : String(part.error);
-      const content = escapeDyadTags(message);
+      const content = escapeDyadTags(sanitizeMcpToolResult(message).serialized);
       chunk = `<dyad-mcp-tool-result server="${escapeXmlAttr(serverName)}" tool="${escapeXmlAttr(toolName)}" call-id="${escapeXmlAttr(part.toolCallId)}" is-error="true">\n${content}\n</dyad-mcp-tool-result>\n`;
     }
 
@@ -2312,8 +2313,7 @@ async function getMcpTools(
                 DyadErrorKind.UserCancelled,
               );
             const res = await mcpTool.execute(args, execCtx);
-
-            return typeof res === "string" ? res : JSON.stringify(res);
+            return sanitizeMcpToolResult(res).serialized;
           },
         };
       }

--- a/src/ipc/utils/mcp_result_sanitizer.test.ts
+++ b/src/ipc/utils/mcp_result_sanitizer.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
   MCP_RESULT_MAX_BYTES,
-  MCP_RESULT_MAX_EMBEDDED_MEDIA_BYTES,
-  MCP_RESULT_MAX_ITEMS,
   sanitizeMcpToolResult,
 } from "./mcp_result_sanitizer";
 
@@ -51,112 +49,37 @@ describe("sanitizeMcpToolResult", () => {
     );
   });
 
-  it("bounds nested JSON by depth and aggregate item count", () => {
+  it("does not impose depth or item-count limits", () => {
     const nested: Record<string, unknown> = {};
     let cursor = nested;
     for (let i = 0; i < 30; i += 1) {
       cursor.next = {};
       cursor = cursor.next as Record<string, unknown>;
     }
-    nested.rows = Array.from({ length: MCP_RESULT_MAX_ITEMS * 3 }, (_, i) => ({
-      id: i,
-    }));
+    cursor.rows = Array.from({ length: 300 }, (_, i) => ({ id: i }));
 
     const result = sanitizeMcpToolResult(nested);
-    const parsed = JSON.parse(result.serialized);
-    expect(result.truncated).toBe(true);
-    expect(parsed._dyadMcpTruncation.reasons).toEqual(
-      expect.arrayContaining(["depth-limit", "item-limit"]),
-    );
-    expect(Buffer.byteLength(result.serialized, "utf8")).toBeLessThanOrEqual(
-      MCP_RESULT_MAX_BYTES,
-    );
+    expect(result.truncated).toBe(false);
+    expect(JSON.parse(result.serialized)).toEqual(nested);
   });
 
-  it("replaces oversized image and resource blobs while retaining metadata references", () => {
-    const hugeBase64 = "A".repeat(
-      Math.ceil((MCP_RESULT_MAX_EMBEDDED_MEDIA_BYTES * 8) / 3) * 4,
-    );
+  it("does not impose a separate embedded-media limit", () => {
+    const base64 = "A".repeat(32 * 1024);
     const input = {
       content: [
-        { type: "image", data: hugeBase64, mimeType: "image/png" },
+        { type: "image", data: base64, mimeType: "image/png" },
         {
           type: "resource",
           resource: {
             uri: "file:///report.bin",
             mimeType: "application/octet-stream",
-            blob: hugeBase64,
+            blob: base64,
           },
         },
       ],
     };
 
     const result = sanitizeMcpToolResult(input);
-    const parsed = JSON.parse(result.serialized);
-    expect(result.truncated).toBe(true);
-    expect(result.serialized).not.toContain(hugeBase64);
-    expect(parsed.content[0]).toMatchObject({
-      type: "image",
-      data: "",
-      mimeType: "image/png",
-      _dyadOmittedMedia: { omitted: true, kind: "image" },
-    });
-    expect(parsed.content[1].resource).toMatchObject({
-      uri: "file:///report.bin",
-      blob: "",
-      _dyadOmittedMedia: { omitted: true, kind: "resource-blob" },
-    });
-  });
-
-  it("replaces oversized base64 fields inside arbitrary structured content", () => {
-    const hugeBase64 = "B".repeat(
-      Math.ceil((MCP_RESULT_MAX_EMBEDDED_MEDIA_BYTES * 8) / 3) * 4,
-    );
-    const result = sanitizeMcpToolResult({
-      structuredContent: { nested: { blob: hugeBase64 } },
-    });
-    const parsed = JSON.parse(result.serialized);
-
-    expect(result.truncated).toBe(true);
-    expect(result.serialized).not.toContain(hugeBase64);
-    expect(parsed.structuredContent.nested.blob).toMatchObject({
-      _dyadOmittedMedia: { omitted: true, kind: "blob" },
-    });
-  });
-
-  it("enforces the aggregate media item limit without reprocessing summaries", () => {
-    const tinyBlob = "AAAA";
-    const result = sanitizeMcpToolResult({
-      content: Array.from({ length: 6 }, (_, index) => ({
-        type: "resource",
-        resource: {
-          uri: `file:///resource-${index}.bin`,
-          blob: tinyBlob,
-        },
-      })),
-    });
-    const parsed = JSON.parse(result.serialized);
-
-    expect(result.truncated).toBe(true);
-    expect(parsed._dyadMcpTruncation.reasons).toContain("media-item-limit");
-    expect(parsed.content[4].resource._dyadOmittedMedia.reason).toBe(
-      "media-item-limit",
-    );
-    expect(parsed.content[5].resource._dyadOmittedMedia.reason).toBe(
-      "media-item-limit",
-    );
-  });
-
-  it("does not count ordinary data and blob strings as embedded media", () => {
-    const input = {
-      rows: Array.from({ length: 8 }, (_, index) => ({
-        data: index % 2 === 0 ? "success" : "pending",
-        blob: `record-${index}`,
-      })),
-    };
-
-    const result = sanitizeMcpToolResult(input);
-
     expect(result).toEqual({
       value: input,
       serialized: JSON.stringify(input),
@@ -164,10 +87,10 @@ describe("sanitizeMcpToolResult", () => {
     });
   });
 
-  it("counts discarded overlong keys against the aggregate item limit", () => {
+  it("bounds results with keys that exhaust the byte budget", () => {
     const input = Object.fromEntries(
-      Array.from({ length: MCP_RESULT_MAX_ITEMS * 2 }, (_, index) => [
-        `${index}-${"k".repeat(600)}`,
+      Array.from({ length: 300 }, (_, index) => [
+        `${index}-${"k".repeat(1024)}`,
         index,
       ]),
     );
@@ -176,12 +99,10 @@ describe("sanitizeMcpToolResult", () => {
     const parsed = JSON.parse(result.serialized);
 
     expect(result.truncated).toBe(true);
-    expect(parsed._dyadMcpTruncation.reasons).toEqual(
-      expect.arrayContaining(["byte-budget", "item-limit"]),
-    );
-    expect(parsed._dyadMcpTruncation.omittedItems).toBeGreaterThanOrEqual(
-      MCP_RESULT_MAX_ITEMS,
-    );
+    expect(parsed._dyadMcpTruncation.reasons).toEqual(["byte-budget"]);
+    expect(parsed._dyadMcpTruncation.limits).toEqual({
+      maxBytes: MCP_RESULT_MAX_BYTES,
+    });
   });
 
   it("preserves __proto__ as an own data property without mutating prototypes", () => {

--- a/src/ipc/utils/mcp_result_sanitizer.test.ts
+++ b/src/ipc/utils/mcp_result_sanitizer.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+import {
+  MCP_RESULT_MAX_BYTES,
+  MCP_RESULT_MAX_EMBEDDED_MEDIA_BYTES,
+  MCP_RESULT_MAX_ITEMS,
+  sanitizeMcpToolResult,
+} from "./mcp_result_sanitizer";
+
+describe("sanitizeMcpToolResult", () => {
+  it("preserves ordinary text and structured MCP results", () => {
+    expect(sanitizeMcpToolResult("hello")).toEqual({
+      value: "hello",
+      serialized: "hello",
+      truncated: false,
+    });
+
+    const input = {
+      content: [{ type: "text", text: "hello" }],
+      structuredContent: { count: 2, names: ["a", "b"] },
+      isError: false,
+    };
+    const result = sanitizeMcpToolResult(input);
+    expect(result.value).toEqual(input);
+    expect(JSON.parse(result.serialized)).toEqual(input);
+    expect(result.truncated).toBe(false);
+  });
+
+  it("caps huge strings at the hard UTF-8 byte budget", () => {
+    const result = sanitizeMcpToolResult("x".repeat(MCP_RESULT_MAX_BYTES * 4));
+
+    expect(result.truncated).toBe(true);
+    expect(result.serialized).toContain("Dyad truncated MCP result");
+    expect(Buffer.byteLength(result.serialized, "utf8")).toBeLessThanOrEqual(
+      MCP_RESULT_MAX_BYTES,
+    );
+  });
+
+  it("never splits a multi-byte character or surrogate pair", () => {
+    const result = sanitizeMcpToolResult("🧠".repeat(MCP_RESULT_MAX_BYTES));
+
+    expect(result.truncated).toBe(true);
+    expect(result.serialized).not.toContain("�");
+    expect(result.serialized).not.toMatch(
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])/u,
+    );
+    expect(result.serialized).not.toMatch(
+      /(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u,
+    );
+    expect(Buffer.byteLength(result.serialized, "utf8")).toBeLessThanOrEqual(
+      MCP_RESULT_MAX_BYTES,
+    );
+  });
+
+  it("bounds nested JSON by depth and aggregate item count", () => {
+    const nested: Record<string, unknown> = {};
+    let cursor = nested;
+    for (let i = 0; i < 30; i += 1) {
+      cursor.next = {};
+      cursor = cursor.next as Record<string, unknown>;
+    }
+    nested.rows = Array.from({ length: MCP_RESULT_MAX_ITEMS * 3 }, (_, i) => ({
+      id: i,
+    }));
+
+    const result = sanitizeMcpToolResult(nested);
+    const parsed = JSON.parse(result.serialized);
+    expect(result.truncated).toBe(true);
+    expect(parsed._dyadMcpTruncation.reasons).toEqual(
+      expect.arrayContaining(["depth-limit", "item-limit"]),
+    );
+    expect(Buffer.byteLength(result.serialized, "utf8")).toBeLessThanOrEqual(
+      MCP_RESULT_MAX_BYTES,
+    );
+  });
+
+  it("replaces oversized image and resource blobs while retaining metadata references", () => {
+    const hugeBase64 = "A".repeat(
+      Math.ceil((MCP_RESULT_MAX_EMBEDDED_MEDIA_BYTES * 8) / 3) * 4,
+    );
+    const input = {
+      content: [
+        { type: "image", data: hugeBase64, mimeType: "image/png" },
+        {
+          type: "resource",
+          resource: {
+            uri: "file:///report.bin",
+            mimeType: "application/octet-stream",
+            blob: hugeBase64,
+          },
+        },
+      ],
+    };
+
+    const result = sanitizeMcpToolResult(input);
+    const parsed = JSON.parse(result.serialized);
+    expect(result.truncated).toBe(true);
+    expect(result.serialized).not.toContain(hugeBase64);
+    expect(parsed.content[0]).toMatchObject({
+      type: "image",
+      data: "",
+      mimeType: "image/png",
+      _dyadOmittedMedia: { omitted: true, kind: "image" },
+    });
+    expect(parsed.content[1].resource).toMatchObject({
+      uri: "file:///report.bin",
+      blob: "",
+      _dyadOmittedMedia: { omitted: true, kind: "resource-blob" },
+    });
+  });
+
+  it("replaces oversized base64 fields inside arbitrary structured content", () => {
+    const hugeBase64 = "B".repeat(
+      Math.ceil((MCP_RESULT_MAX_EMBEDDED_MEDIA_BYTES * 8) / 3) * 4,
+    );
+    const result = sanitizeMcpToolResult({
+      structuredContent: { nested: { blob: hugeBase64 } },
+    });
+    const parsed = JSON.parse(result.serialized);
+
+    expect(result.truncated).toBe(true);
+    expect(result.serialized).not.toContain(hugeBase64);
+    expect(parsed.structuredContent.nested.blob).toMatchObject({
+      _dyadOmittedMedia: { omitted: true, kind: "blob" },
+    });
+  });
+
+  it("enforces the aggregate media item limit without reprocessing summaries", () => {
+    const tinyBlob = "AAAA";
+    const result = sanitizeMcpToolResult({
+      content: Array.from({ length: 6 }, (_, index) => ({
+        type: "resource",
+        resource: {
+          uri: `file:///resource-${index}.bin`,
+          blob: tinyBlob,
+        },
+      })),
+    });
+    const parsed = JSON.parse(result.serialized);
+
+    expect(result.truncated).toBe(true);
+    expect(parsed._dyadMcpTruncation.reasons).toContain("media-item-limit");
+    expect(parsed.content[4].resource._dyadOmittedMedia.reason).toBe(
+      "media-item-limit",
+    );
+    expect(parsed.content[5].resource._dyadOmittedMedia.reason).toBe(
+      "media-item-limit",
+    );
+  });
+
+  it("handles circular structures and binary values without serializing their contents", () => {
+    const input: Record<string, unknown> = {
+      bytes: new Uint8Array(MCP_RESULT_MAX_BYTES * 2),
+    };
+    input.self = input;
+
+    const result = sanitizeMcpToolResult(input);
+    const parsed = JSON.parse(result.serialized);
+    expect(result.truncated).toBe(true);
+    expect(parsed.bytes._dyadOmittedBinary.bytes).toBe(
+      MCP_RESULT_MAX_BYTES * 2,
+    );
+    expect(parsed.self).toContain("circular");
+    expect(Buffer.byteLength(result.serialized, "utf8")).toBeLessThanOrEqual(
+      MCP_RESULT_MAX_BYTES,
+    );
+  });
+});

--- a/src/ipc/utils/mcp_result_sanitizer.test.ts
+++ b/src/ipc/utils/mcp_result_sanitizer.test.ts
@@ -147,6 +147,60 @@ describe("sanitizeMcpToolResult", () => {
     );
   });
 
+  it("does not count ordinary data and blob strings as embedded media", () => {
+    const input = {
+      rows: Array.from({ length: 8 }, (_, index) => ({
+        data: index % 2 === 0 ? "success" : "pending",
+        blob: `record-${index}`,
+      })),
+    };
+
+    const result = sanitizeMcpToolResult(input);
+
+    expect(result).toEqual({
+      value: input,
+      serialized: JSON.stringify(input),
+      truncated: false,
+    });
+  });
+
+  it("counts discarded overlong keys against the aggregate item limit", () => {
+    const input = Object.fromEntries(
+      Array.from({ length: MCP_RESULT_MAX_ITEMS * 2 }, (_, index) => [
+        `${index}-${"k".repeat(600)}`,
+        index,
+      ]),
+    );
+
+    const result = sanitizeMcpToolResult(input);
+    const parsed = JSON.parse(result.serialized);
+
+    expect(result.truncated).toBe(true);
+    expect(parsed._dyadMcpTruncation.reasons).toEqual(
+      expect.arrayContaining(["byte-budget", "item-limit"]),
+    );
+    expect(parsed._dyadMcpTruncation.omittedItems).toBeGreaterThanOrEqual(
+      MCP_RESULT_MAX_ITEMS,
+    );
+  });
+
+  it("preserves __proto__ as an own data property without mutating prototypes", () => {
+    const input = JSON.parse(
+      '{"__proto__":{"polluted":true},"safe":"value"}',
+    ) as Record<string, unknown>;
+
+    const result = sanitizeMcpToolResult(input);
+    const value = result.value as Record<string, unknown>;
+    const parsed = JSON.parse(result.serialized);
+
+    expect(result.truncated).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(value, "__proto__")).toBe(true);
+    expect(value.__proto__).toEqual({ polluted: true });
+    expect(Object.getPrototypeOf(value)).toBe(Object.prototype);
+    expect(parsed).toEqual(input);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
   it("handles circular structures and binary values without serializing their contents", () => {
     const input: Record<string, unknown> = {
       bytes: new Uint8Array(MCP_RESULT_MAX_BYTES * 2),

--- a/src/ipc/utils/mcp_result_sanitizer.ts
+++ b/src/ipc/utils/mcp_result_sanitizer.ts
@@ -1,0 +1,581 @@
+/**
+ * MCP servers are external processes and their tool results are untrusted.
+ * Keep a single result from being copied into the SDK, XML stream, renderer,
+ * and persisted history at an unbounded size.
+ */
+
+export const MCP_RESULT_MAX_BYTES = 64 * 1024;
+export const MCP_RESULT_MAX_ITEMS = 100;
+export const MCP_RESULT_MAX_MEDIA_ITEMS = 4;
+export const MCP_RESULT_MAX_EMBEDDED_MEDIA_BYTES = 16 * 1024;
+export const MCP_RESULT_MAX_DEPTH = 12;
+
+const MCP_RESULT_CONTENT_BUDGET = 60 * 1024;
+const TRUNCATION_KEY = "_dyadMcpTruncation";
+const BASE64_PROPERTY_NAMES = new Set(["base64", "blob", "data"]);
+
+type TruncationReason =
+  | "byte-budget"
+  | "depth-limit"
+  | "item-limit"
+  | "media-byte-limit"
+  | "media-item-limit"
+  | "binary-content"
+  | "circular-reference"
+  | "unreadable-property";
+
+interface SanitizeState {
+  itemCount: number;
+  mediaItemCount: number;
+  omittedItems: number;
+  omittedMediaItems: number;
+  reasons: Set<TruncationReason>;
+  ancestors: WeakSet<object>;
+}
+
+interface SanitizedNode {
+  value: unknown;
+  jsonBytes: number;
+}
+
+export interface SanitizedMcpResult {
+  /** A JSON-safe, bounded value suitable for returning to sandbox scripts. */
+  value: unknown;
+  /** Bounded text suitable for the model, XML output, and persistence. */
+  serialized: string;
+  truncated: boolean;
+}
+
+interface MediaContent {
+  type: "image" | "audio";
+  data: string;
+  mimeType?: unknown;
+}
+
+interface BlobResourceContent {
+  type: "resource";
+  resource: Record<string, unknown> & { blob: string };
+}
+
+function utf8ByteLengthForCodePoint(codePoint: number): number {
+  if (codePoint <= 0x7f) return 1;
+  if (codePoint <= 0x7ff) return 2;
+  if (codePoint <= 0xffff) return 3;
+  return 4;
+}
+
+function jsonByteLengthForCharacter(character: string): number {
+  const codePoint = character.codePointAt(0) ?? 0;
+  if (character === '"' || character === "\\") return 2;
+  if (
+    character === "\b" ||
+    character === "\t" ||
+    character === "\n" ||
+    character === "\f" ||
+    character === "\r"
+  ) {
+    return 2;
+  }
+  // JSON.stringify escapes the other control characters and lone surrogates.
+  if (codePoint <= 0x1f || (codePoint >= 0xd800 && codePoint <= 0xdfff)) {
+    return 6;
+  }
+  return utf8ByteLengthForCodePoint(codePoint);
+}
+
+function takeJsonStringPrefix(
+  input: string,
+  maxJsonBytes: number,
+): { value: string; jsonBytes: number; truncated: boolean } {
+  // Account for the surrounding JSON quotes.
+  if (maxJsonBytes < 2) {
+    return { value: "", jsonBytes: 2, truncated: input.length > 0 };
+  }
+
+  let jsonBytes = 2;
+  let end = 0;
+  for (const character of input) {
+    const nextBytes = jsonByteLengthForCharacter(character);
+    if (jsonBytes + nextBytes > maxJsonBytes) break;
+    jsonBytes += nextBytes;
+    end += character.length;
+  }
+
+  return {
+    value: input.slice(0, end),
+    jsonBytes,
+    truncated: end < input.length,
+  };
+}
+
+function takeUtf8Prefix(
+  input: string,
+  maxBytes: number,
+): { value: string; bytes: number; truncated: boolean } {
+  let bytes = 0;
+  let end = 0;
+  for (const character of input) {
+    const codePoint = character.codePointAt(0) ?? 0;
+    const nextBytes = utf8ByteLengthForCodePoint(codePoint);
+    if (bytes + nextBytes > maxBytes) break;
+    bytes += nextBytes;
+    end += character.length;
+  }
+  return {
+    value: input.slice(0, end),
+    bytes,
+    truncated: end < input.length,
+  };
+}
+
+function approximateDecodedBase64Bytes(data: string): number {
+  const padding = data.endsWith("==") ? 2 : data.endsWith("=") ? 1 : 0;
+  return Math.max(0, Math.floor((data.length * 3) / 4) - padding);
+}
+
+function approximateDecodedBase64PayloadBytes(
+  payloadLength: number,
+  source: string,
+): number {
+  const padding = source.endsWith("==") ? 2 : source.endsWith("=") ? 1 : 0;
+  return Math.max(0, Math.floor((payloadLength * 3) / 4) - padding);
+}
+
+function getBase64PayloadLength(value: string): number | undefined {
+  const dataUrlMarker = ";base64,";
+  const dataUrlMarkerIndex = value.startsWith("data:")
+    ? value.indexOf(dataUrlMarker, 5)
+    : -1;
+  if (dataUrlMarkerIndex !== -1 && dataUrlMarkerIndex < 512) {
+    return value.length - dataUrlMarkerIndex - dataUrlMarker.length;
+  }
+  if (value.length < 4) return undefined;
+  const firstSample = value.slice(0, Math.min(128, value.length));
+  const lastSample = value.slice(Math.max(0, value.length - 128));
+  const base64Characters = /^[A-Za-z0-9+/_=-]+$/;
+  return base64Characters.test(firstSample) && base64Characters.test(lastSample)
+    ? value.length
+    : undefined;
+}
+
+function isMediaContent(value: object): value is MediaContent {
+  const record = value as Record<string, unknown>;
+  return (
+    (record.type === "image" || record.type === "audio") &&
+    typeof record.data === "string"
+  );
+}
+
+function isBlobResourceContent(value: object): value is BlobResourceContent {
+  const record = value as Record<string, unknown>;
+  if (record.type !== "resource" || !isObject(record.resource)) return false;
+  return typeof record.resource.blob === "string";
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isBinary(value: unknown): value is ArrayBufferView | ArrayBuffer {
+  return value instanceof ArrayBuffer || ArrayBuffer.isView(value);
+}
+
+function binaryByteLength(value: ArrayBufferView | ArrayBuffer): number {
+  return value.byteLength;
+}
+
+function markTruncated(state: SanitizeState, reason: TruncationReason): void {
+  state.reasons.add(reason);
+}
+
+function createMediaSummary(params: {
+  kind: string;
+  byteLength: number;
+  mimeType?: unknown;
+  reason: "media-byte-limit" | "media-item-limit";
+}): Record<string, unknown> {
+  return {
+    omitted: true,
+    kind: params.kind,
+    ...(typeof params.mimeType === "string"
+      ? { mimeType: params.mimeType }
+      : {}),
+    approximateBytes: params.byteLength,
+    reason: params.reason,
+  };
+}
+
+function replaceLargeEmbeddedMedia(
+  value: object,
+  state: SanitizeState,
+): object | undefined {
+  if (!isMediaContent(value) && !isBlobResourceContent(value)) {
+    return undefined;
+  }
+
+  const nextMediaItemCount = state.mediaItemCount + 1;
+  const exceedsItemLimit = nextMediaItemCount > MCP_RESULT_MAX_MEDIA_ITEMS;
+  const data = isMediaContent(value) ? value.data : value.resource.blob;
+  const decodedBytes = approximateDecodedBase64Bytes(data);
+  const exceedsByteLimit = decodedBytes > MCP_RESULT_MAX_EMBEDDED_MEDIA_BYTES;
+  if (!exceedsItemLimit && !exceedsByteLimit) {
+    // The generic data/blob property path below will count this item without
+    // requiring another traversal or marker on ordinary small media.
+    return undefined;
+  }
+
+  state.mediaItemCount = nextMediaItemCount;
+  const reason = exceedsItemLimit ? "media-item-limit" : "media-byte-limit";
+  markTruncated(state, reason);
+  state.omittedMediaItems += 1;
+
+  if (isMediaContent(value)) {
+    return {
+      type: value.type,
+      data: "",
+      ...(typeof value.mimeType === "string"
+        ? { mimeType: value.mimeType }
+        : {}),
+      _dyadOmittedMedia: createMediaSummary({
+        kind: value.type,
+        byteLength: decodedBytes,
+        mimeType: value.mimeType,
+        reason,
+      }),
+    };
+  }
+
+  return {
+    type: "resource",
+    resource: {
+      ...(typeof value.resource.uri === "string"
+        ? { uri: value.resource.uri }
+        : {}),
+      ...(typeof value.resource.name === "string"
+        ? { name: value.resource.name }
+        : {}),
+      ...(typeof value.resource.title === "string"
+        ? { title: value.resource.title }
+        : {}),
+      ...(typeof value.resource.description === "string"
+        ? { description: value.resource.description }
+        : {}),
+      ...(typeof value.resource.mimeType === "string"
+        ? { mimeType: value.resource.mimeType }
+        : {}),
+      ...(typeof value.resource.size === "number"
+        ? { size: value.resource.size }
+        : {}),
+      blob: "",
+      _dyadOmittedMedia: createMediaSummary({
+        kind: "resource-blob",
+        byteLength: decodedBytes,
+        mimeType: value.resource.mimeType,
+        reason,
+      }),
+    },
+  };
+}
+
+function replaceLargeBase64Property(
+  key: string,
+  value: unknown,
+  state: SanitizeState,
+): unknown {
+  if (typeof value !== "string") return value;
+  const normalizedKey = key.toLowerCase();
+  if (!BASE64_PROPERTY_NAMES.has(normalizedKey)) return value;
+  const payloadLength = getBase64PayloadLength(value);
+  if (payloadLength === undefined) return value;
+
+  const decodedBytes = approximateDecodedBase64PayloadBytes(
+    payloadLength,
+    value,
+  );
+  state.mediaItemCount += 1;
+  const exceedsItemLimit = state.mediaItemCount > MCP_RESULT_MAX_MEDIA_ITEMS;
+  if (
+    !exceedsItemLimit &&
+    decodedBytes <= MCP_RESULT_MAX_EMBEDDED_MEDIA_BYTES
+  ) {
+    return value;
+  }
+
+  const reason = exceedsItemLimit ? "media-item-limit" : "media-byte-limit";
+  markTruncated(state, reason);
+  state.omittedMediaItems += 1;
+  return {
+    _dyadOmittedMedia: createMediaSummary({
+      kind: normalizedKey,
+      byteLength: decodedBytes,
+      reason,
+    }),
+  };
+}
+
+function hasOmittedMediaMarker(value: Record<string, unknown>): boolean {
+  if (Object.prototype.hasOwnProperty.call(value, "_dyadOmittedMedia")) {
+    return true;
+  }
+  return (
+    value.type === "resource" &&
+    isObject(value.resource) &&
+    Object.prototype.hasOwnProperty.call(value.resource, "_dyadOmittedMedia")
+  );
+}
+
+function sanitizeNode(
+  input: unknown,
+  state: SanitizeState,
+  maxJsonBytes: number,
+  depth: number,
+): SanitizedNode {
+  if (input === null) return { value: null, jsonBytes: 4 };
+  if (typeof input === "boolean") {
+    return { value: input, jsonBytes: input ? 4 : 5 };
+  }
+  if (typeof input === "number") {
+    const value = Number.isFinite(input) ? input : null;
+    const serialized = JSON.stringify(value);
+    return { value, jsonBytes: Buffer.byteLength(serialized, "utf8") };
+  }
+  if (typeof input === "bigint") {
+    return sanitizeNode(`${input.toString()}n`, state, maxJsonBytes, depth);
+  }
+  if (typeof input === "string") {
+    const prefix = takeJsonStringPrefix(input, Math.max(2, maxJsonBytes));
+    if (prefix.truncated) markTruncated(state, "byte-budget");
+    return { value: prefix.value, jsonBytes: prefix.jsonBytes };
+  }
+  if (
+    typeof input === "undefined" ||
+    typeof input === "symbol" ||
+    typeof input === "function"
+  ) {
+    return { value: null, jsonBytes: 4 };
+  }
+
+  if (depth >= MCP_RESULT_MAX_DEPTH) {
+    markTruncated(state, "depth-limit");
+    return sanitizeNode(
+      "[omitted: MCP result depth limit reached]",
+      state,
+      maxJsonBytes,
+      depth,
+    );
+  }
+
+  if (isBinary(input)) {
+    markTruncated(state, "binary-content");
+    state.omittedMediaItems += 1;
+    return sanitizeNode(
+      {
+        _dyadOmittedBinary: {
+          kind: input.constructor.name,
+          bytes: binaryByteLength(input),
+        },
+      },
+      state,
+      maxJsonBytes,
+      depth + 1,
+    );
+  }
+
+  if (state.ancestors.has(input)) {
+    markTruncated(state, "circular-reference");
+    return sanitizeNode(
+      "[omitted: circular MCP result reference]",
+      state,
+      maxJsonBytes,
+      depth,
+    );
+  }
+
+  const mediaReplacement = hasOmittedMediaMarker(
+    input as Record<string, unknown>,
+  )
+    ? undefined
+    : replaceLargeEmbeddedMedia(input, state);
+  if (mediaReplacement) {
+    return sanitizeNode(mediaReplacement, state, maxJsonBytes, depth);
+  }
+
+  state.ancestors.add(input);
+  try {
+    if (Array.isArray(input)) {
+      const result: unknown[] = [];
+      let bytes = 2;
+      for (let index = 0; index < input.length; index += 1) {
+        if (state.itemCount >= MCP_RESULT_MAX_ITEMS) {
+          state.omittedItems += input.length - index;
+          markTruncated(state, "item-limit");
+          break;
+        }
+        const separatorBytes = result.length > 0 ? 1 : 0;
+        const remaining = maxJsonBytes - bytes - separatorBytes;
+        if (remaining < 4) {
+          state.omittedItems += input.length - index;
+          markTruncated(state, "byte-budget");
+          break;
+        }
+        state.itemCount += 1;
+        const child = sanitizeNode(input[index], state, remaining, depth + 1);
+        if (child.jsonBytes > remaining) {
+          state.omittedItems += input.length - index;
+          markTruncated(state, "byte-budget");
+          break;
+        }
+        result.push(child.value);
+        bytes += separatorBytes + child.jsonBytes;
+      }
+      return { value: result, jsonBytes: bytes };
+    }
+
+    const result: Record<string, unknown> = {};
+    const inputRecord = input as Record<string, unknown>;
+    let bytes = 2;
+    let includedProperties = 0;
+    try {
+      for (const key in inputRecord) {
+        if (!Object.prototype.hasOwnProperty.call(inputRecord, key)) continue;
+        if (state.itemCount >= MCP_RESULT_MAX_ITEMS) {
+          state.omittedItems += 1;
+          markTruncated(state, "item-limit");
+          break;
+        }
+
+        const keyResult = takeJsonStringPrefix(key, 512);
+        if (keyResult.truncated) {
+          state.omittedItems += 1;
+          markTruncated(state, "byte-budget");
+          continue;
+        }
+        const separatorBytes = includedProperties > 0 ? 1 : 0;
+        const propertyOverhead =
+          separatorBytes + keyResult.jsonBytes + 1 /* colon */;
+        const remaining = maxJsonBytes - bytes - propertyOverhead;
+        if (remaining < 4) {
+          state.omittedItems += 1;
+          markTruncated(state, "byte-budget");
+          break;
+        }
+
+        let propertyValue: unknown;
+        try {
+          propertyValue = replaceLargeBase64Property(
+            key,
+            inputRecord[key],
+            state,
+          );
+        } catch {
+          propertyValue = "[omitted: unreadable MCP result property]";
+          markTruncated(state, "unreadable-property");
+        }
+        state.itemCount += 1;
+        const child = sanitizeNode(propertyValue, state, remaining, depth + 1);
+        if (child.jsonBytes > remaining) {
+          state.omittedItems += 1;
+          markTruncated(state, "byte-budget");
+          break;
+        }
+        result[keyResult.value] = child.value;
+        includedProperties += 1;
+        bytes += propertyOverhead + child.jsonBytes;
+      }
+    } catch {
+      markTruncated(state, "unreadable-property");
+      result._dyadUnreadableResult = true;
+      bytes = Buffer.byteLength(JSON.stringify(result), "utf8");
+    }
+    return { value: result, jsonBytes: bytes };
+  } finally {
+    state.ancestors.delete(input);
+  }
+}
+
+function buildTruncationMetadata(state: SanitizeState) {
+  return {
+    truncated: true,
+    reasons: [...state.reasons].sort(),
+    omittedItems: state.omittedItems,
+    omittedMediaItems: state.omittedMediaItems,
+    limits: {
+      maxBytes: MCP_RESULT_MAX_BYTES,
+      maxItems: MCP_RESULT_MAX_ITEMS,
+      maxMediaItems: MCP_RESULT_MAX_MEDIA_ITEMS,
+      maxEmbeddedMediaBytes: MCP_RESULT_MAX_EMBEDDED_MEDIA_BYTES,
+      maxDepth: MCP_RESULT_MAX_DEPTH,
+    },
+  };
+}
+
+function attachTruncationMetadata(
+  value: unknown,
+  state: SanitizeState,
+): unknown {
+  const metadata = buildTruncationMetadata(state);
+  if (typeof value === "string") {
+    return `${value}\n[Dyad truncated MCP result: ${metadata.reasons.join(", ")}]`;
+  }
+  if (Array.isArray(value)) {
+    value.push({ [TRUNCATION_KEY]: metadata });
+    return value;
+  }
+  if (isObject(value)) {
+    value[TRUNCATION_KEY] = metadata;
+    return value;
+  }
+  return { value, [TRUNCATION_KEY]: metadata };
+}
+
+function createBoundedFallback(serialized: string): SanitizedMcpResult {
+  const metadata = {
+    truncated: true,
+    reasons: ["byte-budget"],
+    limits: { maxBytes: MCP_RESULT_MAX_BYTES },
+  };
+  // JSON escaping can grow a preview by up to six bytes per input byte. Use a
+  // conservative prefix and shrink if a future metadata change grows it.
+  let previewBytes = Math.floor((MCP_RESULT_MAX_BYTES - 1024) / 6);
+  let value: Record<string, unknown>;
+  let output: string;
+  do {
+    const preview = takeUtf8Prefix(serialized, previewBytes).value;
+    value = { preview, [TRUNCATION_KEY]: metadata };
+    output = JSON.stringify(value);
+    previewBytes = Math.floor(previewBytes * 0.75);
+  } while (
+    Buffer.byteLength(output, "utf8") > MCP_RESULT_MAX_BYTES &&
+    previewBytes > 0
+  );
+  return { value, serialized: output, truncated: true };
+}
+
+/**
+ * Convert an arbitrary MCP result into bounded JSON-safe data without first
+ * stringifying the untrusted result. The returned text never exceeds the hard
+ * UTF-8 byte limit and truncation is explicit to both scripts and the model.
+ */
+export function sanitizeMcpToolResult(input: unknown): SanitizedMcpResult {
+  const state: SanitizeState = {
+    itemCount: 0,
+    mediaItemCount: 0,
+    omittedItems: 0,
+    omittedMediaItems: 0,
+    reasons: new Set(),
+    ancestors: new WeakSet(),
+  };
+  const node = sanitizeNode(input, state, MCP_RESULT_CONTENT_BUDGET, 0);
+  const truncated = state.reasons.size > 0;
+  const value = truncated
+    ? attachTruncationMetadata(node.value, state)
+    : node.value;
+  const serialized =
+    typeof value === "string" ? value : JSON.stringify(value ?? null);
+
+  if (Buffer.byteLength(serialized, "utf8") > MCP_RESULT_MAX_BYTES) {
+    return createBoundedFallback(serialized);
+  }
+
+  return { value, serialized, truncated };
+}

--- a/src/ipc/utils/mcp_result_sanitizer.ts
+++ b/src/ipc/utils/mcp_result_sanitizer.ts
@@ -218,13 +218,14 @@ function replaceLargeEmbeddedMedia(
   const data = isMediaContent(value) ? value.data : value.resource.blob;
   const decodedBytes = approximateDecodedBase64Bytes(data);
   const exceedsByteLimit = decodedBytes > MCP_RESULT_MAX_EMBEDDED_MEDIA_BYTES;
+  state.mediaItemCount = nextMediaItemCount;
   if (!exceedsItemLimit && !exceedsByteLimit) {
-    // The generic data/blob property path below will count this item without
-    // requiring another traversal or marker on ordinary small media.
+    // The explicit MCP media shape is enough to count this item. The generic
+    // data/blob path only removes oversized payloads, so ordinary structured
+    // strings cannot consume the media item budget.
     return undefined;
   }
 
-  state.mediaItemCount = nextMediaItemCount;
   const reason = exceedsItemLimit ? "media-item-limit" : "media-byte-limit";
   markTruncated(state, reason);
   state.omittedMediaItems += 1;
@@ -292,15 +293,16 @@ function replaceLargeBase64Property(
     payloadLength,
     value,
   );
-  state.mediaItemCount += 1;
-  const exceedsItemLimit = state.mediaItemCount > MCP_RESULT_MAX_MEDIA_ITEMS;
-  if (
-    !exceedsItemLimit &&
-    decodedBytes <= MCP_RESULT_MAX_EMBEDDED_MEDIA_BYTES
-  ) {
+  // Generic data/blob/base64 keys are common in ordinary structured output.
+  // Only treat them as media when the payload is independently large enough
+  // to violate the embedded-media byte limit. Explicit MCP media shapes are
+  // counted by replaceLargeEmbeddedMedia instead.
+  if (decodedBytes <= MCP_RESULT_MAX_EMBEDDED_MEDIA_BYTES) {
     return value;
   }
 
+  state.mediaItemCount += 1;
+  const exceedsItemLimit = state.mediaItemCount > MCP_RESULT_MAX_MEDIA_ITEMS;
   const reason = exceedsItemLimit ? "media-item-limit" : "media-byte-limit";
   markTruncated(state, reason);
   state.omittedMediaItems += 1;
@@ -443,6 +445,10 @@ function sanitizeNode(
           markTruncated(state, "item-limit");
           break;
         }
+        // Count every visited own property, including keys that cannot be
+        // retained. Otherwise an attacker can bypass the traversal bound with
+        // an arbitrary number of overlong keys.
+        state.itemCount += 1;
 
         const keyResult = takeJsonStringPrefix(key, 512);
         if (keyResult.truncated) {
@@ -471,14 +477,18 @@ function sanitizeNode(
           propertyValue = "[omitted: unreadable MCP result property]";
           markTruncated(state, "unreadable-property");
         }
-        state.itemCount += 1;
         const child = sanitizeNode(propertyValue, state, remaining, depth + 1);
         if (child.jsonBytes > remaining) {
           state.omittedItems += 1;
           markTruncated(state, "byte-budget");
           break;
         }
-        result[keyResult.value] = child.value;
+        Object.defineProperty(result, keyResult.value, {
+          value: child.value,
+          enumerable: true,
+          writable: true,
+          configurable: true,
+        });
         includedProperties += 1;
         bytes += propertyOverhead + child.jsonBytes;
       }

--- a/src/ipc/utils/mcp_result_sanitizer.ts
+++ b/src/ipc/utils/mcp_result_sanitizer.ts
@@ -4,31 +4,21 @@
  * and persisted history at an unbounded size.
  */
 
-export const MCP_RESULT_MAX_BYTES = 64 * 1024;
-export const MCP_RESULT_MAX_ITEMS = 100;
-export const MCP_RESULT_MAX_MEDIA_ITEMS = 4;
-export const MCP_RESULT_MAX_EMBEDDED_MEDIA_BYTES = 16 * 1024;
-export const MCP_RESULT_MAX_DEPTH = 12;
+export const MCP_RESULT_MAX_BYTES = 128 * 1024;
 
-const MCP_RESULT_CONTENT_BUDGET = 60 * 1024;
+// Leave room for truncation metadata while keeping MCP_RESULT_MAX_BYTES as the
+// only result limit.
+const MCP_RESULT_CONTENT_BUDGET = MCP_RESULT_MAX_BYTES - 4 * 1024;
 const TRUNCATION_KEY = "_dyadMcpTruncation";
-const BASE64_PROPERTY_NAMES = new Set(["base64", "blob", "data"]);
 
 type TruncationReason =
   | "byte-budget"
-  | "depth-limit"
-  | "item-limit"
-  | "media-byte-limit"
-  | "media-item-limit"
   | "binary-content"
   | "circular-reference"
   | "unreadable-property";
 
 interface SanitizeState {
-  itemCount: number;
-  mediaItemCount: number;
   omittedItems: number;
-  omittedMediaItems: number;
   reasons: Set<TruncationReason>;
   ancestors: WeakSet<object>;
 }
@@ -44,17 +34,6 @@ export interface SanitizedMcpResult {
   /** Bounded text suitable for the model, XML output, and persistence. */
   serialized: string;
   truncated: boolean;
-}
-
-interface MediaContent {
-  type: "image" | "audio";
-  data: string;
-  mimeType?: unknown;
-}
-
-interface BlobResourceContent {
-  type: "resource";
-  resource: Record<string, unknown> & { blob: string };
 }
 
 function utf8ByteLengthForCodePoint(codePoint: number): number {
@@ -128,50 +107,6 @@ function takeUtf8Prefix(
   };
 }
 
-function approximateDecodedBase64Bytes(data: string): number {
-  const padding = data.endsWith("==") ? 2 : data.endsWith("=") ? 1 : 0;
-  return Math.max(0, Math.floor((data.length * 3) / 4) - padding);
-}
-
-function approximateDecodedBase64PayloadBytes(
-  payloadLength: number,
-  source: string,
-): number {
-  const padding = source.endsWith("==") ? 2 : source.endsWith("=") ? 1 : 0;
-  return Math.max(0, Math.floor((payloadLength * 3) / 4) - padding);
-}
-
-function getBase64PayloadLength(value: string): number | undefined {
-  const dataUrlMarker = ";base64,";
-  const dataUrlMarkerIndex = value.startsWith("data:")
-    ? value.indexOf(dataUrlMarker, 5)
-    : -1;
-  if (dataUrlMarkerIndex !== -1 && dataUrlMarkerIndex < 512) {
-    return value.length - dataUrlMarkerIndex - dataUrlMarker.length;
-  }
-  if (value.length < 4) return undefined;
-  const firstSample = value.slice(0, Math.min(128, value.length));
-  const lastSample = value.slice(Math.max(0, value.length - 128));
-  const base64Characters = /^[A-Za-z0-9+/_=-]+$/;
-  return base64Characters.test(firstSample) && base64Characters.test(lastSample)
-    ? value.length
-    : undefined;
-}
-
-function isMediaContent(value: object): value is MediaContent {
-  const record = value as Record<string, unknown>;
-  return (
-    (record.type === "image" || record.type === "audio") &&
-    typeof record.data === "string"
-  );
-}
-
-function isBlobResourceContent(value: object): value is BlobResourceContent {
-  const record = value as Record<string, unknown>;
-  if (record.type !== "resource" || !isObject(record.resource)) return false;
-  return typeof record.resource.blob === "string";
-}
-
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
@@ -188,149 +123,10 @@ function markTruncated(state: SanitizeState, reason: TruncationReason): void {
   state.reasons.add(reason);
 }
 
-function createMediaSummary(params: {
-  kind: string;
-  byteLength: number;
-  mimeType?: unknown;
-  reason: "media-byte-limit" | "media-item-limit";
-}): Record<string, unknown> {
-  return {
-    omitted: true,
-    kind: params.kind,
-    ...(typeof params.mimeType === "string"
-      ? { mimeType: params.mimeType }
-      : {}),
-    approximateBytes: params.byteLength,
-    reason: params.reason,
-  };
-}
-
-function replaceLargeEmbeddedMedia(
-  value: object,
-  state: SanitizeState,
-): object | undefined {
-  if (!isMediaContent(value) && !isBlobResourceContent(value)) {
-    return undefined;
-  }
-
-  const nextMediaItemCount = state.mediaItemCount + 1;
-  const exceedsItemLimit = nextMediaItemCount > MCP_RESULT_MAX_MEDIA_ITEMS;
-  const data = isMediaContent(value) ? value.data : value.resource.blob;
-  const decodedBytes = approximateDecodedBase64Bytes(data);
-  const exceedsByteLimit = decodedBytes > MCP_RESULT_MAX_EMBEDDED_MEDIA_BYTES;
-  state.mediaItemCount = nextMediaItemCount;
-  if (!exceedsItemLimit && !exceedsByteLimit) {
-    // The explicit MCP media shape is enough to count this item. The generic
-    // data/blob path only removes oversized payloads, so ordinary structured
-    // strings cannot consume the media item budget.
-    return undefined;
-  }
-
-  const reason = exceedsItemLimit ? "media-item-limit" : "media-byte-limit";
-  markTruncated(state, reason);
-  state.omittedMediaItems += 1;
-
-  if (isMediaContent(value)) {
-    return {
-      type: value.type,
-      data: "",
-      ...(typeof value.mimeType === "string"
-        ? { mimeType: value.mimeType }
-        : {}),
-      _dyadOmittedMedia: createMediaSummary({
-        kind: value.type,
-        byteLength: decodedBytes,
-        mimeType: value.mimeType,
-        reason,
-      }),
-    };
-  }
-
-  return {
-    type: "resource",
-    resource: {
-      ...(typeof value.resource.uri === "string"
-        ? { uri: value.resource.uri }
-        : {}),
-      ...(typeof value.resource.name === "string"
-        ? { name: value.resource.name }
-        : {}),
-      ...(typeof value.resource.title === "string"
-        ? { title: value.resource.title }
-        : {}),
-      ...(typeof value.resource.description === "string"
-        ? { description: value.resource.description }
-        : {}),
-      ...(typeof value.resource.mimeType === "string"
-        ? { mimeType: value.resource.mimeType }
-        : {}),
-      ...(typeof value.resource.size === "number"
-        ? { size: value.resource.size }
-        : {}),
-      blob: "",
-      _dyadOmittedMedia: createMediaSummary({
-        kind: "resource-blob",
-        byteLength: decodedBytes,
-        mimeType: value.resource.mimeType,
-        reason,
-      }),
-    },
-  };
-}
-
-function replaceLargeBase64Property(
-  key: string,
-  value: unknown,
-  state: SanitizeState,
-): unknown {
-  if (typeof value !== "string") return value;
-  const normalizedKey = key.toLowerCase();
-  if (!BASE64_PROPERTY_NAMES.has(normalizedKey)) return value;
-  const payloadLength = getBase64PayloadLength(value);
-  if (payloadLength === undefined) return value;
-
-  const decodedBytes = approximateDecodedBase64PayloadBytes(
-    payloadLength,
-    value,
-  );
-  // Generic data/blob/base64 keys are common in ordinary structured output.
-  // Only treat them as media when the payload is independently large enough
-  // to violate the embedded-media byte limit. Explicit MCP media shapes are
-  // counted by replaceLargeEmbeddedMedia instead.
-  if (decodedBytes <= MCP_RESULT_MAX_EMBEDDED_MEDIA_BYTES) {
-    return value;
-  }
-
-  state.mediaItemCount += 1;
-  const exceedsItemLimit = state.mediaItemCount > MCP_RESULT_MAX_MEDIA_ITEMS;
-  const reason = exceedsItemLimit ? "media-item-limit" : "media-byte-limit";
-  markTruncated(state, reason);
-  state.omittedMediaItems += 1;
-  return {
-    _dyadOmittedMedia: createMediaSummary({
-      kind: normalizedKey,
-      byteLength: decodedBytes,
-      reason,
-    }),
-  };
-}
-
-function hasOmittedMediaMarker(value: Record<string, unknown>): boolean {
-  if (Object.prototype.hasOwnProperty.call(value, "_dyadOmittedMedia")) {
-    return true;
-  }
-  return (
-    value.type === "resource" &&
-    isObject(value.resource) &&
-    Object.prototype.hasOwnProperty.call(value.resource, "_dyadOmittedMedia")
-  );
-}
-
 function sanitizeNode(
   input: unknown,
   state: SanitizeState,
   maxJsonBytes: number,
-  depth: number,
 ): SanitizedNode {
   if (input === null) return { value: null, jsonBytes: 4 };
   if (typeof input === "boolean") {
@@ -342,7 +138,7 @@ function sanitizeNode(
     return { value, jsonBytes: Buffer.byteLength(serialized, "utf8") };
   }
   if (typeof input === "bigint") {
-    return sanitizeNode(`${input.toString()}n`, state, maxJsonBytes, depth);
+    return sanitizeNode(`${input.toString()}n`, state, maxJsonBytes);
   }
   if (typeof input === "string") {
     const prefix = takeJsonStringPrefix(input, Math.max(2, maxJsonBytes));
@@ -357,19 +153,8 @@ function sanitizeNode(
     return { value: null, jsonBytes: 4 };
   }
 
-  if (depth >= MCP_RESULT_MAX_DEPTH) {
-    markTruncated(state, "depth-limit");
-    return sanitizeNode(
-      "[omitted: MCP result depth limit reached]",
-      state,
-      maxJsonBytes,
-      depth,
-    );
-  }
-
   if (isBinary(input)) {
     markTruncated(state, "binary-content");
-    state.omittedMediaItems += 1;
     return sanitizeNode(
       {
         _dyadOmittedBinary: {
@@ -379,7 +164,6 @@ function sanitizeNode(
       },
       state,
       maxJsonBytes,
-      depth + 1,
     );
   }
 
@@ -389,17 +173,7 @@ function sanitizeNode(
       "[omitted: circular MCP result reference]",
       state,
       maxJsonBytes,
-      depth,
     );
-  }
-
-  const mediaReplacement = hasOmittedMediaMarker(
-    input as Record<string, unknown>,
-  )
-    ? undefined
-    : replaceLargeEmbeddedMedia(input, state);
-  if (mediaReplacement) {
-    return sanitizeNode(mediaReplacement, state, maxJsonBytes, depth);
   }
 
   state.ancestors.add(input);
@@ -408,11 +182,6 @@ function sanitizeNode(
       const result: unknown[] = [];
       let bytes = 2;
       for (let index = 0; index < input.length; index += 1) {
-        if (state.itemCount >= MCP_RESULT_MAX_ITEMS) {
-          state.omittedItems += input.length - index;
-          markTruncated(state, "item-limit");
-          break;
-        }
         const separatorBytes = result.length > 0 ? 1 : 0;
         const remaining = maxJsonBytes - bytes - separatorBytes;
         if (remaining < 4) {
@@ -420,8 +189,7 @@ function sanitizeNode(
           markTruncated(state, "byte-budget");
           break;
         }
-        state.itemCount += 1;
-        const child = sanitizeNode(input[index], state, remaining, depth + 1);
+        const child = sanitizeNode(input[index], state, remaining);
         if (child.jsonBytes > remaining) {
           state.omittedItems += input.length - index;
           markTruncated(state, "byte-budget");
@@ -440,23 +208,14 @@ function sanitizeNode(
     try {
       for (const key in inputRecord) {
         if (!Object.prototype.hasOwnProperty.call(inputRecord, key)) continue;
-        if (state.itemCount >= MCP_RESULT_MAX_ITEMS) {
-          state.omittedItems += 1;
-          markTruncated(state, "item-limit");
-          break;
-        }
-        // Count every visited own property, including keys that cannot be
-        // retained. Otherwise an attacker can bypass the traversal bound with
-        // an arbitrary number of overlong keys.
-        state.itemCount += 1;
-
-        const keyResult = takeJsonStringPrefix(key, 512);
+        const separatorBytes = includedProperties > 0 ? 1 : 0;
+        const keyBudget = maxJsonBytes - bytes - separatorBytes - 1;
+        const keyResult = takeJsonStringPrefix(key, Math.max(2, keyBudget));
         if (keyResult.truncated) {
           state.omittedItems += 1;
           markTruncated(state, "byte-budget");
-          continue;
+          break;
         }
-        const separatorBytes = includedProperties > 0 ? 1 : 0;
         const propertyOverhead =
           separatorBytes + keyResult.jsonBytes + 1 /* colon */;
         const remaining = maxJsonBytes - bytes - propertyOverhead;
@@ -468,16 +227,12 @@ function sanitizeNode(
 
         let propertyValue: unknown;
         try {
-          propertyValue = replaceLargeBase64Property(
-            key,
-            inputRecord[key],
-            state,
-          );
+          propertyValue = inputRecord[key];
         } catch {
           propertyValue = "[omitted: unreadable MCP result property]";
           markTruncated(state, "unreadable-property");
         }
-        const child = sanitizeNode(propertyValue, state, remaining, depth + 1);
+        const child = sanitizeNode(propertyValue, state, remaining);
         if (child.jsonBytes > remaining) {
           state.omittedItems += 1;
           markTruncated(state, "byte-budget");
@@ -508,14 +263,7 @@ function buildTruncationMetadata(state: SanitizeState) {
     truncated: true,
     reasons: [...state.reasons].sort(),
     omittedItems: state.omittedItems,
-    omittedMediaItems: state.omittedMediaItems,
-    limits: {
-      maxBytes: MCP_RESULT_MAX_BYTES,
-      maxItems: MCP_RESULT_MAX_ITEMS,
-      maxMediaItems: MCP_RESULT_MAX_MEDIA_ITEMS,
-      maxEmbeddedMediaBytes: MCP_RESULT_MAX_EMBEDDED_MEDIA_BYTES,
-      maxDepth: MCP_RESULT_MAX_DEPTH,
-    },
+    limits: { maxBytes: MCP_RESULT_MAX_BYTES },
   };
 }
 
@@ -568,14 +316,11 @@ function createBoundedFallback(serialized: string): SanitizedMcpResult {
  */
 export function sanitizeMcpToolResult(input: unknown): SanitizedMcpResult {
   const state: SanitizeState = {
-    itemCount: 0,
-    mediaItemCount: 0,
     omittedItems: 0,
-    omittedMediaItems: 0,
     reasons: new Set(),
     ancestors: new WeakSet(),
   };
-  const node = sanitizeNode(input, state, MCP_RESULT_CONTENT_BUDGET, 0);
+  const node = sanitizeNode(input, state, MCP_RESULT_CONTENT_BUDGET);
   const truncated = state.reasons.size > 0;
   const value = truncated
     ? attachTruncationMetadata(node.value, state)

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.test.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.test.ts
@@ -176,6 +176,8 @@ const dbOperations: {
 } = { updates: [], queries: [] };
 
 let mockChatData: ReturnType<typeof buildTestChat> | null = null;
+let mockMcpServers: Array<{ id: number; name: string }> = [];
+let mockMcpToolSet: Record<string, Record<string, unknown>> = {};
 
 vi.mock("@/db", () => ({
   db: {
@@ -198,7 +200,7 @@ vi.mock("@/db", () => ({
     })),
     select: vi.fn(() => ({
       from: vi.fn(() => ({
-        where: vi.fn(() => Promise.resolve([])),
+        where: vi.fn(() => Promise.resolve(mockMcpServers)),
       })),
     })),
   },
@@ -264,9 +266,15 @@ vi.mock("@/ipc/utils/provider_options", () => ({
 vi.mock("@/ipc/utils/mcp_manager", () => ({
   mcpManager: {
     getClient: vi.fn(async () => ({
-      tools: vi.fn(async () => ({})),
+      tools: vi.fn(async () => mockMcpToolSet),
     })),
   },
+}));
+
+const mockRequireMcpToolConsent = vi.hoisted(() => vi.fn());
+vi.mock("@/ipc/utils/mcp_consent", () => ({
+  requireMcpToolConsent: mockRequireMcpToolConsent,
+  clearPendingMcpConsentsForChat: vi.fn(),
 }));
 
 vi.mock("@/pro/main/ipc/handlers/local_agent/tool_definitions", () => ({
@@ -325,6 +333,7 @@ import {
   commitAllChanges,
   deployAllFunctionsIfNeeded,
 } from "@/pro/main/ipc/handlers/local_agent/processors/file_operations";
+import { MCP_RESULT_MAX_BYTES } from "@/ipc/utils/mcp_result_sanitizer";
 
 // ============================================================================
 // Tests
@@ -337,6 +346,8 @@ describe("handleLocalAgentStream", () => {
     dbOperations.updates = [];
     dbOperations.queries = [];
     mockChatData = null;
+    mockMcpServers = [];
+    mockMcpToolSet = {};
     mockSettings = buildTestSettings();
     mockStreamResult = null;
     mockStreamTextImpl = null;
@@ -344,6 +355,74 @@ describe("handleLocalAgentStream", () => {
     mockPerformCompaction.mockResolvedValue({ success: true });
     mockCheckAndMarkForCompaction.mockResolvedValue(false);
     vi.mocked(streamText).mockClear();
+    mockRequireMcpToolConsent.mockResolvedValue({ approved: true });
+  });
+
+  describe("MCP result limits", () => {
+    it("bounds direct MCP tool output before it reaches XML or model history", async () => {
+      const { event } = createFakeEvent();
+      mockSettings = buildTestSettings({ enableDyadPro: true });
+      mockChatData = buildTestChat();
+      mockMcpServers = [{ id: 42, name: "srv" }];
+      const hugeText = "m".repeat(MCP_RESULT_MAX_BYTES * 3);
+      mockMcpToolSet = {
+        huge: {
+          description: "Return a large result",
+          inputSchema: { type: "object" },
+          execute: vi.fn().mockResolvedValue({
+            content: [{ type: "text", text: hugeText }],
+          }),
+        },
+      };
+
+      let returnedOutput = "";
+      mockStreamTextImpl = (options) => ({
+        fullStream: (async function* () {
+          const mcpTool = options.tools.srv__huge;
+          returnedOutput = await mcpTool.execute(
+            {},
+            { toolCallId: "call-1", messages: [] },
+          );
+          yield {
+            type: "tool-call",
+            toolCallId: "call-1",
+            toolName: "srv__huge",
+            input: {},
+          };
+          yield {
+            type: "tool-result",
+            toolCallId: "call-1",
+            toolName: "srv__huge",
+            output: returnedOutput,
+          };
+        })(),
+        response: Promise.resolve({ messages: [] }),
+        steps: Promise.resolve([{ toolCalls: [{ toolName: "srv__huge" }] }]),
+      });
+
+      await handleLocalAgentStream(
+        event,
+        { chatId: 1, prompt: "use the MCP tool" },
+        new AbortController(),
+        {
+          placeholderMessageId: 10,
+          systemPrompt: "You are helpful",
+          dyadRequestId,
+        },
+      );
+
+      expect(Buffer.byteLength(returnedOutput, "utf8")).toBeLessThanOrEqual(
+        MCP_RESULT_MAX_BYTES,
+      );
+      expect(returnedOutput).toContain("_dyadMcpTruncation");
+      expect(returnedOutput).not.toContain(hugeText);
+      const persistedContent = dbOperations.updates
+        .filter((operation) => typeof operation.data.content === "string")
+        .map((operation) => operation.data.content as string)
+        .join("\n");
+      expect(persistedContent).toContain("_dyadMcpTruncation");
+      expect(persistedContent).not.toContain(hugeText);
+    });
   });
 
   describe("Pro status validation", () => {

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -24,6 +24,7 @@ import {
 } from "@/ipc/utils/mcp_consent";
 import { buildMcpAutoApprove } from "./mcp_auto_consent";
 import { parseMcpToolKey, sanitizeMcpName } from "@/ipc/utils/mcp_tool_utils";
+import { sanitizeMcpToolResult } from "@/ipc/utils/mcp_result_sanitizer";
 
 import {
   isDyadProEnabled,
@@ -2151,28 +2152,32 @@ async function getMcpTools(
               callEmitted = true;
 
               const res = await mcpTool.execute(args, execCtx);
-              const resultStr =
-                typeof res === "string" ? res : JSON.stringify(res);
+              const safeResult = sanitizeMcpToolResult(res);
 
               ctx.onXmlComplete(
-                `<dyad-mcp-tool-result server="${escapeXmlAttr(serverName)}" tool="${escapeXmlAttr(toolName)}" call-id="${escapeXmlAttr(callId)}">\n${escapeXmlContent(resultStr)}\n</dyad-mcp-tool-result>`,
+                `<dyad-mcp-tool-result server="${escapeXmlAttr(serverName)}" tool="${escapeXmlAttr(toolName)}" call-id="${escapeXmlAttr(callId)}">\n${escapeXmlContent(safeResult.serialized)}\n</dyad-mcp-tool-result>`,
               );
 
-              return resultStr;
+              return safeResult.serialized;
             } catch (error) {
               const errorMessage =
                 error instanceof Error ? error.message : String(error);
               const errorStack =
                 error instanceof Error && error.stack ? error.stack : "";
+              const safeErrorMessage =
+                sanitizeMcpToolResult(errorMessage).serialized;
+              const safeErrorDetails = sanitizeMcpToolResult(
+                errorStack || errorMessage,
+              ).serialized;
               // Terminate the merged card in an error state instead of leaving
               // it stuck on "Running" (only when its call card was emitted).
               if (callEmitted) {
                 ctx.onXmlComplete(
-                  `<dyad-mcp-tool-result server="${escapeXmlAttr(serverName)}" tool="${escapeXmlAttr(toolName)}" call-id="${escapeXmlAttr(callId)}" is-error="true">\n${escapeXmlContent(errorMessage)}\n</dyad-mcp-tool-result>`,
+                  `<dyad-mcp-tool-result server="${escapeXmlAttr(serverName)}" tool="${escapeXmlAttr(toolName)}" call-id="${escapeXmlAttr(callId)}" is-error="true">\n${escapeXmlContent(safeErrorMessage)}\n</dyad-mcp-tool-result>`,
                 );
               }
               ctx.onXmlComplete(
-                `<dyad-output type="error" message="MCP tool '${key}' failed: ${escapeXmlAttr(errorMessage)}">${escapeXmlContent(errorStack || errorMessage)}</dyad-output>`,
+                `<dyad-output type="error" message="MCP tool '${key}' failed: ${escapeXmlAttr(safeErrorMessage)}">${escapeXmlContent(safeErrorDetails)}</dyad-output>`,
               );
               throw error;
             }

--- a/src/pro/main/ipc/handlers/local_agent/tools/mcp_type_defs.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/mcp_type_defs.spec.ts
@@ -13,6 +13,10 @@ import { mcpManager } from "@/ipc/utils/mcp_manager";
 import { requireMcpToolConsent } from "@/ipc/utils/mcp_consent";
 import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
 import type { AgentContext } from "./types";
+import {
+  MCP_RESULT_MAX_BYTES,
+  MCP_RESULT_MAX_EMBEDDED_MEDIA_BYTES,
+} from "@/ipc/utils/mcp_result_sanitizer";
 
 vi.mock("@/ipc/utils/mcp_manager", () => ({
   mcpManager: {
@@ -361,6 +365,48 @@ describe("buildMcpCapabilityMap", () => {
       .mock.calls.map((c) => c[0])
       .find((x) => x.startsWith("<dyad-mcp-tool-result"));
     expect(resultXml).toContain("hello world");
+  });
+
+  it("bounds oversized text and embedded media before returning or emitting the result", async () => {
+    vi.mocked(requireMcpToolConsent).mockResolvedValue({ approved: true });
+    const hugeText = "z".repeat(MCP_RESULT_MAX_BYTES * 3);
+    const hugeImage = "A".repeat(
+      Math.ceil((MCP_RESULT_MAX_EMBEDDED_MEDIA_BYTES * 8) / 3) * 4,
+    );
+    const execute = vi.fn().mockResolvedValue({
+      content: [
+        { type: "image", data: hugeImage, mimeType: "image/png" },
+        { type: "text", text: hugeText },
+      ],
+    });
+    vi.mocked(mcpManager.getClient).mockResolvedValue({
+      tools: async () => ({ hello: { execute } }),
+    } as any);
+
+    const ctx = createCtx();
+    const map = buildMcpCapabilityMap({
+      event: {} as any,
+      ctx,
+      defs: [makeDef()],
+    });
+
+    const result = await map.srv__hello({});
+    const serializedResult = JSON.stringify(result);
+    expect(Buffer.byteLength(serializedResult, "utf8")).toBeLessThanOrEqual(
+      MCP_RESULT_MAX_BYTES,
+    );
+    expect(serializedResult).not.toContain(hugeText);
+    expect(serializedResult).not.toContain(hugeImage);
+    expect(serializedResult).toContain("_dyadMcpTruncation");
+    expect(serializedResult).toContain("_dyadOmittedMedia");
+
+    const resultXml = vi
+      .mocked(ctx.onXmlComplete)
+      .mock.calls.map((call) => call[0])
+      .find((xml) => xml.startsWith("<dyad-mcp-tool-result"));
+    expect(resultXml).toContain("_dyadMcpTruncation");
+    expect(resultXml).not.toContain(hugeText);
+    expect(resultXml).not.toContain(hugeImage);
   });
 
   it("throws a DyadError(UserCancelled) and skips execution when consent is denied", async () => {

--- a/src/pro/main/ipc/handlers/local_agent/tools/mcp_type_defs.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/mcp_type_defs.spec.ts
@@ -13,10 +13,7 @@ import { mcpManager } from "@/ipc/utils/mcp_manager";
 import { requireMcpToolConsent } from "@/ipc/utils/mcp_consent";
 import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
 import type { AgentContext } from "./types";
-import {
-  MCP_RESULT_MAX_BYTES,
-  MCP_RESULT_MAX_EMBEDDED_MEDIA_BYTES,
-} from "@/ipc/utils/mcp_result_sanitizer";
+import { MCP_RESULT_MAX_BYTES } from "@/ipc/utils/mcp_result_sanitizer";
 
 vi.mock("@/ipc/utils/mcp_manager", () => ({
   mcpManager: {
@@ -370,9 +367,7 @@ describe("buildMcpCapabilityMap", () => {
   it("bounds oversized text and embedded media before returning or emitting the result", async () => {
     vi.mocked(requireMcpToolConsent).mockResolvedValue({ approved: true });
     const hugeText = "z".repeat(MCP_RESULT_MAX_BYTES * 3);
-    const hugeImage = "A".repeat(
-      Math.ceil((MCP_RESULT_MAX_EMBEDDED_MEDIA_BYTES * 8) / 3) * 4,
-    );
+    const hugeImage = "A".repeat(MCP_RESULT_MAX_BYTES * 3);
     const execute = vi.fn().mockResolvedValue({
       content: [
         { type: "image", data: hugeImage, mimeType: "image/png" },
@@ -398,7 +393,6 @@ describe("buildMcpCapabilityMap", () => {
     expect(serializedResult).not.toContain(hugeText);
     expect(serializedResult).not.toContain(hugeImage);
     expect(serializedResult).toContain("_dyadMcpTruncation");
-    expect(serializedResult).toContain("_dyadOmittedMedia");
 
     const resultXml = vi
       .mocked(ctx.onXmlComplete)

--- a/src/pro/main/ipc/handlers/local_agent/tools/mcp_type_defs.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/mcp_type_defs.ts
@@ -15,6 +15,7 @@ import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
 import { AgentContext, escapeXmlAttr, escapeXmlContent } from "./types";
 import { jsonSchemaToTs } from "./json_schema_to_ts";
 import { buildMcpAutoApprove } from "../mcp_auto_consent";
+import { sanitizeMcpToolResult } from "@/ipc/utils/mcp_result_sanitizer";
 
 const MCP_RESULT_TYPE = `type McpResult = {
   content: Array<
@@ -203,23 +204,27 @@ export function buildMcpCapabilityMap(params: {
           typeof res === "string"
             ? { content: [{ type: "text", text: res }] }
             : res;
-        const resultStr = typeof res === "string" ? res : JSON.stringify(res);
+        const safeResult = sanitizeMcpToolResult(normalized);
         params.ctx.onXmlComplete(
-          `<dyad-mcp-tool-result server="${escapeXmlAttr(def.serverName)}" tool="${escapeXmlAttr(def.toolName)}" call-id="${escapeXmlAttr(callId)}">\n${escapeXmlContent(resultStr)}\n</dyad-mcp-tool-result>`,
+          `<dyad-mcp-tool-result server="${escapeXmlAttr(def.serverName)}" tool="${escapeXmlAttr(def.toolName)}" call-id="${escapeXmlAttr(callId)}">\n${escapeXmlContent(safeResult.serialized)}\n</dyad-mcp-tool-result>`,
         );
-        return normalized;
+        return safeResult.value;
       } catch (error) {
         const errorMessage =
           error instanceof Error ? error.message : String(error);
         const errorStack =
           error instanceof Error && error.stack ? error.stack : "";
+        const safeErrorMessage = sanitizeMcpToolResult(errorMessage).serialized;
+        const safeErrorDetails = sanitizeMcpToolResult(
+          errorStack || errorMessage,
+        ).serialized;
         // Terminate the merged card in an error state instead of leaving it
         // stuck on "Running".
         params.ctx.onXmlComplete(
-          `<dyad-mcp-tool-result server="${escapeXmlAttr(def.serverName)}" tool="${escapeXmlAttr(def.toolName)}" call-id="${escapeXmlAttr(callId)}" is-error="true">\n${escapeXmlContent(errorMessage)}\n</dyad-mcp-tool-result>`,
+          `<dyad-mcp-tool-result server="${escapeXmlAttr(def.serverName)}" tool="${escapeXmlAttr(def.toolName)}" call-id="${escapeXmlAttr(callId)}" is-error="true">\n${escapeXmlContent(safeErrorMessage)}\n</dyad-mcp-tool-result>`,
         );
         params.ctx.onXmlComplete(
-          `<dyad-output type="error" message="MCP tool '${escapeXmlAttr(def.toolKey)}' failed: ${escapeXmlAttr(errorMessage)}">${escapeXmlContent(errorStack || errorMessage)}</dyad-output>`,
+          `<dyad-output type="error" message="MCP tool '${escapeXmlAttr(def.toolKey)}' failed: ${escapeXmlAttr(safeErrorMessage)}">${escapeXmlContent(safeErrorDetails)}</dyad-output>`,
         );
         throw error;
       }


### PR DESCRIPTION
## Summary

- cap MCP tool results at 64 KiB before they reach model context, XML output, renderer state, or persisted history
- bound nested items, depth, and embedded media while replacing oversized base64 and binary content with deterministic metadata
- apply the shared sanitizer to direct Agent tools, sandbox MCP host functions, and legacy Build-mode MCP tools

## Tests

- npm test -- src/ipc/utils/mcp_result_sanitizer.test.ts src/pro/main/ipc/handlers/local_agent/tools/mcp_type_defs.spec.ts src/pro/main/ipc/handlers/local_agent/local_agent_handler.test.ts
- npm run lint
- npm run ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes every MCP result path in the main process and chat stream; behavior shifts when tools return very large payloads (truncation vs full content), but the change is defensive and well-tested rather than altering auth or data writes.
> 
> **Overview**
> Adds a shared **`sanitizeMcpToolResult`** path that caps MCP tool output at **128 KiB UTF-8** without blindly `JSON.stringify`ing untrusted payloads first. Oversized text, huge object graphs, circular refs, and binary values are trimmed or replaced with explicit **`_dyadMcpTruncation`** / omission metadata so the model, UI XML, SDK returns, and chat persistence stay bounded.
> 
> That sanitizer is wired into **Build-mode MCP tools** (`getMcpTools` execute + streamed tool-error handling), **Local Agent direct MCP** execution and error XML, and **sandbox MCP host functions** (bounded `value` back to scripts, bounded `serialized` in cards). Build streaming also stops double-escaping MCP tool-result bodies by using **`escapeXmlContent`** on already-bounded output instead of **`escapeDyadTags`**.
> 
> Docs note treating MCP results as untrusted-size input and a small git-workflow tip for **`git fetch --all`** tag clobber failures. Unit/integration tests cover the sanitizer and end-to-end persistence/XML for huge MCP results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dbeda56d3956aef3d35e37d66f78e56749781a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

