### PR TITLE
Bound preview console memory usage

### DIFF
--- a/src/__tests__/dyad_logs.test.ts
+++ b/src/__tests__/dyad_logs.test.ts
@@ -100,6 +100,43 @@ describe("dyad console interception", () => {
     );
   });
 
+  it("applies the depth limit to chained toJSON results", () => {
+    const { messages, scriptConsole } = loadConsoleInterceptor();
+    const createToJsonChain = (remainingDepth: number): unknown => ({
+      toJSON: () =>
+        remainingDepth === 0 ? "leaf" : createToJsonChain(remainingDepth - 1),
+    });
+
+    scriptConsole.log(createToJsonChain(20));
+
+    expect(messages[0].args[0]).toContain("[Maximum log depth reached]");
+  });
+
+  it("preserves empty object keys without skipping later properties", () => {
+    const { messages, scriptConsole } = loadConsoleInterceptor();
+
+    scriptConsole.log({ "": "empty-key value", after: "later value" });
+
+    expect(JSON.parse(messages[0].args[0])).toEqual({
+      "": "empty-key value",
+      after: "later value",
+    });
+  });
+
+  it("marks arrays and objects when their inner byte budget is exhausted", () => {
+    const { messages, scriptConsole } = loadConsoleInterceptor();
+    const hugeValue = "x".repeat(20_000);
+
+    scriptConsole.log([hugeValue, hugeValue, "omitted array value"], {
+      first: hugeValue,
+      second: hugeValue,
+      third: "omitted object value",
+    });
+
+    expect(messages[0].args[0]).toContain("[console value truncated]");
+    expect(messages[0].args[1]).toContain("[console value truncated]");
+  });
+
   it("stops reading nested values when the argument byte budget is exhausted", () => {
     const { messages, scriptConsole } = loadConsoleInterceptor();
     let getterReads = 0;

--- a/src/__tests__/dyad_logs.test.ts
+++ b/src/__tests__/dyad_logs.test.ts
@@ -1,0 +1,86 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { runInNewContext } from "node:vm";
+import { describe, expect, it, vi } from "vitest";
+
+interface PostedConsoleMessage {
+  type: string;
+  args: string[];
+}
+
+type ConsoleMethod = (...args: unknown[]) => void;
+
+const DYAD_LOGS_SCRIPT = readFileSync(
+  resolve(__dirname, "../../worker/dyad_logs.js"),
+  "utf8",
+);
+
+function loadConsoleInterceptor() {
+  const messages: PostedConsoleMessage[] = [];
+  const originalLog = vi.fn<ConsoleMethod>();
+  const scriptConsole: Record<
+    "log" | "warn" | "error" | "info" | "debug",
+    ConsoleMethod
+  > = {
+    log: originalLog,
+    warn: vi.fn<ConsoleMethod>(),
+    error: vi.fn<ConsoleMethod>(),
+    info: vi.fn<ConsoleMethod>(),
+    debug: vi.fn<ConsoleMethod>(),
+  };
+
+  runInNewContext(DYAD_LOGS_SCRIPT, {
+    console: scriptConsole,
+    window: {
+      parent: {
+        postMessage(message: PostedConsoleMessage) {
+          messages.push(message);
+        },
+      },
+    },
+  });
+
+  return { messages, originalLog, scriptConsole };
+}
+
+describe("dyad console interception", () => {
+  it("bounds giant values and argument lists before posting to the parent", () => {
+    const { messages, originalLog, scriptConsole } = loadConsoleInterceptor();
+    const args = Array.from(
+      { length: 20 },
+      (_, index) => `${index}:${"x".repeat(20_000)}`,
+    );
+
+    scriptConsole.log(...args);
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0].type).toBe("console-log");
+    expect(messages[0].args).toHaveLength(11);
+    expect(messages[0].args[0]).toContain("[console value truncated]");
+    expect(messages[0].args.at(-1)).toBe("… [10 arguments omitted]");
+    expect(
+      messages[0].args.every(
+        (arg) => Buffer.byteLength(arg, "utf8") <= 8 * 1024,
+      ),
+    ).toBe(true);
+    expect(originalLog).toHaveBeenCalledWith(...args);
+  });
+
+  it("bounds deep and circular object traversal", () => {
+    const { messages, scriptConsole } = loadConsoleInterceptor();
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    let deep: Record<string, unknown> = { value: "leaf" };
+    for (let index = 0; index < 20; index++) {
+      deep = { child: deep };
+    }
+    const hugeKey = `key-${"x".repeat(10_000)}`;
+
+    scriptConsole.log(circular, deep, { [hugeKey]: "value" });
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0].args[0]).toContain("[Circular]");
+    expect(messages[0].args[1]).toContain("[Maximum log depth reached]");
+    expect(messages[0].args[2]).toContain("[console value truncated]");
+  });
+});

--- a/src/__tests__/dyad_logs.test.ts
+++ b/src/__tests__/dyad_logs.test.ts
@@ -83,4 +83,47 @@ describe("dyad console interception", () => {
     expect(messages[0].args[1]).toContain("[Maximum log depth reached]");
     expect(messages[0].args[2]).toContain("[console value truncated]");
   });
+
+  it("honors toJSON while retaining the output byte limit", () => {
+    const { messages, scriptConsole } = loadConsoleInterceptor();
+    const date = new Date("2026-07-10T00:00:00.000Z");
+    const custom = {
+      toJSON: () => ({ value: "x".repeat(20_000) }),
+    };
+
+    scriptConsole.log(date, custom);
+
+    expect(JSON.parse(messages[0].args[0])).toBe(date.toISOString());
+    expect(messages[0].args[1]).toContain("[console value truncated]");
+    expect(Buffer.byteLength(messages[0].args[1], "utf8")).toBeLessThanOrEqual(
+      8 * 1024,
+    );
+  });
+
+  it("stops reading nested values when the argument byte budget is exhausted", () => {
+    const { messages, scriptConsole } = loadConsoleInterceptor();
+    let getterReads = 0;
+    const nested: Record<string, unknown> = {};
+
+    for (let outer = 0; outer < 20; outer++) {
+      const child: Record<string, unknown> = {};
+      for (let inner = 0; inner < 20; inner++) {
+        Object.defineProperty(child, `value-${inner}`, {
+          enumerable: true,
+          get() {
+            getterReads++;
+            return "x".repeat(4 * 1024);
+          },
+        });
+      }
+      nested[`child-${outer}`] = child;
+    }
+
+    scriptConsole.log(nested);
+
+    expect(getterReads).toBeLessThan(10);
+    expect(Buffer.byteLength(messages[0].args[0], "utf8")).toBeLessThanOrEqual(
+      8 * 1024,
+    );
+  });
 });

--- a/src/__tests__/dyad_logs.test.ts
+++ b/src/__tests__/dyad_logs.test.ts
@@ -47,7 +47,7 @@ describe("dyad console interception", () => {
   it("bounds giant values and argument lists before posting to the parent", () => {
     const { messages, originalLog, scriptConsole } = loadConsoleInterceptor();
     const args = Array.from(
-      { length: 20 },
+      { length: 25 },
       (_, index) => `${index}:${"x".repeat(20_000)}`,
     );
 
@@ -55,15 +55,30 @@ describe("dyad console interception", () => {
 
     expect(messages).toHaveLength(1);
     expect(messages[0].type).toBe("console-log");
-    expect(messages[0].args).toHaveLength(11);
     expect(messages[0].args[0]).toContain("[console value truncated]");
-    expect(messages[0].args.at(-1)).toBe("… [10 arguments omitted]");
+    expect(messages[0].args.at(-1)).toMatch(/arguments omitted\]$/);
     expect(
       messages[0].args.every(
         (arg) => Buffer.byteLength(arg, "utf8") <= 8 * 1024,
       ),
     ).toBe(true);
+    expect(
+      messages[0].args.reduce(
+        (total, arg) => total + Buffer.byteLength(arg, "utf8"),
+        0,
+      ),
+    ).toBeLessThanOrEqual(64 * 1024);
     expect(originalLog).toHaveBeenCalledWith(...args);
+  });
+
+  it("preserves up to 20 small arguments before adding an omission marker", () => {
+    const { messages, scriptConsole } = loadConsoleInterceptor();
+    const args = Array.from({ length: 25 }, (_, index) => `arg-${index}`);
+
+    scriptConsole.log(...args);
+
+    expect(messages[0].args.slice(0, 20)).toEqual(args.slice(0, 20));
+    expect(messages[0].args.at(-1)).toBe("… [5 arguments omitted]");
   });
 
   it("bounds deep and circular object traversal", () => {
@@ -82,6 +97,20 @@ describe("dyad console interception", () => {
     expect(messages[0].args[0]).toContain("[Circular]");
     expect(messages[0].args[1]).toContain("[Maximum log depth reached]");
     expect(messages[0].args[2]).toContain("[console value truncated]");
+  });
+
+  it("preserves up to 50 object keys before marking additional keys", () => {
+    const { messages, scriptConsole } = loadConsoleInterceptor();
+    const wideObject = Object.fromEntries(
+      Array.from({ length: 60 }, (_, index) => [`key-${index}`, index]),
+    );
+
+    scriptConsole.log(wideObject);
+
+    const serialized = JSON.parse(messages[0].args[0]);
+    expect(serialized["key-49"]).toBe(49);
+    expect(serialized["key-50"]).toBeUndefined();
+    expect(serialized.__dyad_truncated__).toBe("Additional keys omitted");
   });
 
   it("honors toJSON while retaining the output byte limit", () => {

--- a/src/atoms/previewRuntimeAtoms.test.ts
+++ b/src/atoms/previewRuntimeAtoms.test.ts
@@ -91,6 +91,7 @@ describe("preview runtime atoms", () => {
     expect(retained).toHaveLength(MAX_PREVIEW_CONSOLE_ENTRIES_PER_APP);
     expect(retained[0].message).toBe(PREVIEW_CONSOLE_OMISSION_MESSAGE);
     expect(retained[1].message).toBe("log-3");
+    expect(retained[0].timestamp).toBe(retained[1].timestamp);
     expect(retained.at(-1)?.message).toBe(
       `log-${MAX_PREVIEW_CONSOLE_ENTRIES_PER_APP + 1}`,
     );

--- a/src/atoms/previewRuntimeAtoms.test.ts
+++ b/src/atoms/previewRuntimeAtoms.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { createStore } from "jotai";
 import { selectedAppIdAtom } from "@/atoms/appAtoms";
+import type { ConsoleEntry } from "@/ipc/types";
 import {
   appendConsoleEntriesForAppAtom,
   clearPreviewRuntimeForAppAtom,
+  consoleEntriesByAppIdAtom,
   currentAppUrlAtom,
   currentConsoleEntriesAtom,
   currentPackageManagerWarningAtom,
@@ -14,9 +16,34 @@ import {
   previewRunStateByAppIdAtom,
   setAppUrlForAppAtom,
   setPackageManagerWarningForAppAtom,
+  setConsoleEntriesForAppAtom,
   setPreviewErrorForAppAtom,
   setPreviewRunStateForAppAtom,
 } from "@/atoms/previewRuntimeAtoms";
+import {
+  getPreviewConsoleEntryByteLength,
+  MAX_PREVIEW_CONSOLE_BYTES_PER_APP,
+  MAX_PREVIEW_CONSOLE_ENTRIES_PER_APP,
+  MAX_PREVIEW_CONSOLE_MESSAGE_BYTES,
+  MAX_PREVIEW_CONSOLE_SOURCE_NAME_BYTES,
+  PREVIEW_CONSOLE_OMISSION_MESSAGE,
+} from "@/lib/preview_console_buffer";
+
+function consoleEntry(
+  message: string,
+  timestamp: number,
+  appId = 1,
+  sourceName?: string,
+): ConsoleEntry {
+  return {
+    level: "info",
+    type: "server",
+    message,
+    timestamp,
+    appId,
+    sourceName,
+  };
+}
 
 describe("preview runtime atoms", () => {
   it("derives current preview state from the selected app", () => {
@@ -51,6 +78,104 @@ describe("preview runtime atoms", () => {
     ).toEqual(["App 2 log"]);
   });
 
+  it("keeps the newest entries when a batch exceeds the count limit", () => {
+    const store = createStore();
+    const entries = Array.from(
+      { length: MAX_PREVIEW_CONSOLE_ENTRIES_PER_APP + 2 },
+      (_, index) => consoleEntry(`log-${index}`, index),
+    );
+
+    store.set(appendConsoleEntriesForAppAtom, { appId: 1, entries });
+
+    const retained = store.get(consoleEntriesByAppIdAtom).get(1) ?? [];
+    expect(retained).toHaveLength(MAX_PREVIEW_CONSOLE_ENTRIES_PER_APP);
+    expect(retained[0].message).toBe(PREVIEW_CONSOLE_OMISSION_MESSAGE);
+    expect(retained[1].message).toBe("log-3");
+    expect(retained.at(-1)?.message).toBe(
+      `log-${MAX_PREVIEW_CONSOLE_ENTRIES_PER_APP + 1}`,
+    );
+  });
+
+  it("keeps the newest entries within the UTF-8 byte budget", () => {
+    const store = createStore();
+    const entryCount =
+      Math.floor(
+        MAX_PREVIEW_CONSOLE_BYTES_PER_APP / MAX_PREVIEW_CONSOLE_MESSAGE_BYTES,
+      ) + 2;
+    const entries = Array.from({ length: entryCount }, (_, index) =>
+      consoleEntry("x".repeat(MAX_PREVIEW_CONSOLE_MESSAGE_BYTES), index),
+    );
+
+    store.set(appendConsoleEntriesForAppAtom, { appId: 1, entries });
+
+    const retained = store.get(consoleEntriesByAppIdAtom).get(1) ?? [];
+    const retainedBytes = retained.reduce(
+      (total, entry) => total + getPreviewConsoleEntryByteLength(entry),
+      0,
+    );
+    expect(retainedBytes).toBeLessThanOrEqual(
+      MAX_PREVIEW_CONSOLE_BYTES_PER_APP,
+    );
+    expect(retained[0].message).toBe(PREVIEW_CONSOLE_OMISSION_MESSAGE);
+    expect(retained.at(-1)?.timestamp).toBe(entryCount - 1);
+  });
+
+  it("truncates a giant multibyte entry and source with explicit markers", () => {
+    const store = createStore();
+    store.set(appendConsoleEntriesForAppAtom, {
+      appId: 1,
+      entries: [
+        consoleEntry(
+          "🙂".repeat(MAX_PREVIEW_CONSOLE_MESSAGE_BYTES),
+          1,
+          1,
+          "源".repeat(MAX_PREVIEW_CONSOLE_SOURCE_NAME_BYTES),
+        ),
+      ],
+    });
+
+    const [retained] = store.get(consoleEntriesByAppIdAtom).get(1) ?? [];
+    expect(getPreviewConsoleEntryByteLength(retained)).toBeLessThanOrEqual(
+      MAX_PREVIEW_CONSOLE_MESSAGE_BYTES + MAX_PREVIEW_CONSOLE_SOURCE_NAME_BYTES,
+    );
+    expect(retained.message).toContain("[log payload truncated]");
+    expect(retained.sourceName).toContain("[source truncated]");
+    const retainedPrefix = retained.message.slice(
+      0,
+      retained.message.indexOf("\n… [log payload truncated]"),
+    );
+    expect(retainedPrefix.endsWith("🙂")).toBe(true);
+  });
+
+  it("preserves delivery order across append batches", () => {
+    const store = createStore();
+    store.set(appendConsoleEntriesForAppAtom, {
+      appId: 1,
+      entries: [consoleEntry("first", 300), consoleEntry("second", 100)],
+    });
+    store.set(appendConsoleEntriesForAppAtom, {
+      appId: 1,
+      entries: [consoleEntry("third", 200), consoleEntry("fourth", 50)],
+    });
+
+    expect(
+      (store.get(consoleEntriesByAppIdAtom).get(1) ?? []).map(
+        (entry) => entry.message,
+      ),
+    ).toEqual(["first", "second", "third", "fourth"]);
+  });
+
+  it("removes the per-app buffer when logs are reset", () => {
+    const store = createStore();
+    store.set(setConsoleEntriesForAppAtom, {
+      appId: 1,
+      entries: [consoleEntry("before reset", 1)],
+    });
+    store.set(setConsoleEntriesForAppAtom, { appId: 1, entries: [] });
+
+    expect(store.get(consoleEntriesByAppIdAtom).has(1)).toBe(false);
+  });
+
   it("clears all preview runtime state for one app", () => {
     const store = createStore();
     store.set(selectedAppIdAtom, 1);
@@ -78,6 +203,14 @@ describe("preview runtime atoms", () => {
         message: "Install pnpm 10.16.0 or newer",
       },
     });
+    store.set(appendConsoleEntriesForAppAtom, {
+      appId: 1,
+      entries: [consoleEntry("deleted app log", 100)],
+    });
+    store.set(appendConsoleEntriesForAppAtom, {
+      appId: 2,
+      entries: [consoleEntry("other app log", 100, 2)],
+    });
 
     expect(store.get(currentPreviewLoadingAtom)).toBe(true);
     expect(store.get(currentAppUrlAtom).appUrl).toBe("http://localhost:3000");
@@ -94,6 +227,8 @@ describe("preview runtime atoms", () => {
     expect(store.get(currentAppUrlAtom).appUrl).toBeNull();
     expect(store.get(currentPackageManagerWarningAtom)).toBeUndefined();
     expect(store.get(previewCurrentUrlAtom).has(1)).toBe(false);
+    expect(store.get(consoleEntriesByAppIdAtom).has(1)).toBe(false);
+    expect(store.get(consoleEntriesByAppIdAtom).has(2)).toBe(true);
   });
 
   it("scopes the package manager warning display to the selected app", () => {

--- a/src/atoms/previewRuntimeAtoms.ts
+++ b/src/atoms/previewRuntimeAtoms.ts
@@ -2,6 +2,7 @@ import { atom } from "jotai";
 import type { ConsoleEntry } from "@/ipc/types";
 import type { RuntimeMode2 } from "@/lib/schemas";
 import { selectedAppIdAtom } from "@/atoms/appAtoms";
+import { createPreviewConsoleTail } from "@/lib/preview_console_buffer";
 
 export type AppUrlState =
   | {
@@ -246,7 +247,7 @@ export const setConsoleEntriesForAppAtom = atom(
       if (entries.length === 0) {
         next.delete(appId);
       } else {
-        next.set(appId, entries);
+        next.set(appId, createPreviewConsoleTail(appId, [], entries));
       }
       return next;
     });
@@ -265,7 +266,10 @@ export const appendConsoleEntriesForAppAtom = atom(
     }
     set(consoleEntriesByAppIdAtom, (prev) => {
       const next = new Map(prev);
-      next.set(appId, [...(next.get(appId) ?? []), ...entries]);
+      next.set(
+        appId,
+        createPreviewConsoleTail(appId, next.get(appId) ?? [], entries),
+      );
       return next;
     });
   },

--- a/src/components/preview_panel/Console.tsx
+++ b/src/components/preview_panel/Console.tsx
@@ -161,28 +161,23 @@ export const Console = () => {
     return Array.from(sources).sort();
   }, [consoleEntries]);
 
-  // Producers append in chronological delivery order. Avoid sorting a copy of
-  // the complete console on every update; filtering only allocates when active.
+  // The bounded buffer keeps this copy small. Sort at display time because
+  // browser and dev-server producers can deliver timestamped entries out of
+  // order relative to each other.
   const filteredEntries = useMemo(() => {
-    if (
-      levelFilter === "all" &&
-      typeFilter === "all" &&
-      (!sourceFilter || sourceFilter === "all")
-    ) {
-      return consoleEntries;
-    }
-
-    return consoleEntries.filter((entry) => {
-      if (levelFilter !== "all" && entry.level !== levelFilter) return false;
-      if (typeFilter !== "all" && entry.type !== typeFilter) return false;
-      if (
-        sourceFilter &&
-        sourceFilter !== "all" &&
-        entry.sourceName !== sourceFilter
-      )
-        return false;
-      return true;
-    });
+    return consoleEntries
+      .filter((entry) => {
+        if (levelFilter !== "all" && entry.level !== levelFilter) return false;
+        if (typeFilter !== "all" && entry.type !== typeFilter) return false;
+        if (
+          sourceFilter &&
+          sourceFilter !== "all" &&
+          entry.sourceName !== sourceFilter
+        )
+          return false;
+        return true;
+      })
+      .sort((a, b) => a.timestamp - b.timestamp);
   }, [consoleEntries, levelFilter, typeFilter, sourceFilter]);
 
   // Generate unique key for each entry

--- a/src/components/preview_panel/Console.tsx
+++ b/src/components/preview_panel/Console.tsx
@@ -161,21 +161,28 @@ export const Console = () => {
     return Array.from(sources).sort();
   }, [consoleEntries]);
 
-  // Filter and sort console entries by timestamp
+  // Producers append in chronological delivery order. Avoid sorting a copy of
+  // the complete console on every update; filtering only allocates when active.
   const filteredEntries = useMemo(() => {
-    return consoleEntries
-      .filter((entry) => {
-        if (levelFilter !== "all" && entry.level !== levelFilter) return false;
-        if (typeFilter !== "all" && entry.type !== typeFilter) return false;
-        if (
-          sourceFilter &&
-          sourceFilter !== "all" &&
-          entry.sourceName !== sourceFilter
-        )
-          return false;
-        return true;
-      })
-      .sort((a, b) => a.timestamp - b.timestamp);
+    if (
+      levelFilter === "all" &&
+      typeFilter === "all" &&
+      (!sourceFilter || sourceFilter === "all")
+    ) {
+      return consoleEntries;
+    }
+
+    return consoleEntries.filter((entry) => {
+      if (levelFilter !== "all" && entry.level !== levelFilter) return false;
+      if (typeFilter !== "all" && entry.type !== typeFilter) return false;
+      if (
+        sourceFilter &&
+        sourceFilter !== "all" &&
+        entry.sourceName !== sourceFilter
+      )
+        return false;
+      return true;
+    });
   }, [consoleEntries, levelFilter, typeFilter, sourceFilter]);
 
   // Generate unique key for each entry

--- a/src/components/preview_panel/PreviewIframe.tsx
+++ b/src/components/preview_panel/PreviewIframe.tsx
@@ -81,6 +81,7 @@ import type { DeviceMode } from "@/lib/schemas";
 import {
   boundPreviewConsoleEntry,
   formatPreviewConsoleMessage,
+  formatPreviewNetworkStatus,
 } from "@/lib/preview_console_buffer";
 import { queryKeys } from "@/lib/queryKeys";
 import { AnnotatorOnlyForPro } from "./AnnotatorOnlyForPro";
@@ -725,7 +726,9 @@ export const PreviewIframe = ({ loading }: { loading: boolean }) => {
 
       // Handle console logs from the iframe
       if (event.data?.type === "console-log") {
-        const { level, args } = event.data;
+        const { level } = event.data;
+        const rawArgs: unknown = event.data.args;
+        const args: unknown[] = Array.isArray(rawArgs) ? rawArgs : [rawArgs];
         const levelLabel =
           level === "log" ||
           level === "warn" ||
@@ -788,7 +791,7 @@ export const PreviewIframe = ({ loading }: { loading: boolean }) => {
             ? `(${duration}ms)`
             : "(unknown duration)";
         const formattedMessage = formatPreviewConsoleMessage(
-          numericStatus ? `[${numericStatus}]` : "[unknown status]",
+          formatPreviewNetworkStatus(status),
           [method, url, durationLabel],
         );
         const level: "info" | "warn" | "error" =

--- a/src/components/preview_panel/PreviewIframe.tsx
+++ b/src/components/preview_panel/PreviewIframe.tsx
@@ -78,6 +78,10 @@ import { cn } from "@/lib/utils";
 import { normalizePath } from "../../../shared/normalizePath";
 import { showError, showSuccess } from "@/lib/toast";
 import type { DeviceMode } from "@/lib/schemas";
+import {
+  boundPreviewConsoleEntry,
+  formatPreviewConsoleMessage,
+} from "@/lib/preview_console_buffer";
 import { queryKeys } from "@/lib/queryKeys";
 import { AnnotatorOnlyForPro } from "./AnnotatorOnlyForPro";
 import { useAttachments } from "@/hooks/useAttachments";
@@ -722,16 +726,27 @@ export const PreviewIframe = ({ loading }: { loading: boolean }) => {
       // Handle console logs from the iframe
       if (event.data?.type === "console-log") {
         const { level, args } = event.data;
-        const formattedMessage = `[${level.toUpperCase()}] ${args.join(" ")}`;
+        const levelLabel =
+          level === "log" ||
+          level === "warn" ||
+          level === "error" ||
+          level === "info" ||
+          level === "debug"
+            ? level.toUpperCase()
+            : "LOG";
+        const formattedMessage = formatPreviewConsoleMessage(
+          `[${levelLabel}]`,
+          args,
+        );
         const logLevel: "info" | "warn" | "error" =
           level === "error" ? "error" : level === "warn" ? "warn" : "info";
-        const logEntry = {
+        const logEntry = boundPreviewConsoleEntry({
           level: logLevel,
           type: "client" as const,
           message: formattedMessage,
           appId: selectedAppId!,
           timestamp: Date.now(),
-        };
+        });
 
         // Send to central log store
         ipc.misc.addLog(logEntry);
@@ -744,14 +759,17 @@ export const PreviewIframe = ({ loading }: { loading: boolean }) => {
       // Handle network requests from the iframe
       if (event.data?.type === "network-request") {
         const { method, url } = event.data;
-        const formattedMessage = `→ ${method} ${url}`;
-        const logEntry = {
+        const formattedMessage = formatPreviewConsoleMessage("→", [
+          method,
+          url,
+        ]);
+        const logEntry = boundPreviewConsoleEntry({
           level: "info" as const,
           type: "network-requests" as const,
           message: formattedMessage,
           appId: selectedAppId!,
           timestamp: Date.now(),
-        };
+        });
 
         // Send to central log store
         ipc.misc.addLog(logEntry);
@@ -764,16 +782,28 @@ export const PreviewIframe = ({ loading }: { loading: boolean }) => {
       // Handle network responses from the iframe
       if (event.data?.type === "network-response") {
         const { method, url, status, duration } = event.data;
-        const formattedMessage = `[${status}] ${method} ${url} (${duration}ms)`;
+        const numericStatus = typeof status === "number" ? status : 0;
+        const durationLabel =
+          typeof duration === "number"
+            ? `(${duration}ms)`
+            : "(unknown duration)";
+        const formattedMessage = formatPreviewConsoleMessage(
+          numericStatus ? `[${numericStatus}]` : "[unknown status]",
+          [method, url, durationLabel],
+        );
         const level: "info" | "warn" | "error" =
-          status >= 400 ? "error" : status >= 300 ? "warn" : "info";
-        const logEntry = {
+          numericStatus >= 400
+            ? "error"
+            : numericStatus >= 300
+              ? "warn"
+              : "info";
+        const logEntry = boundPreviewConsoleEntry({
           level,
           type: "network-requests" as const,
           message: formattedMessage,
           appId: selectedAppId!,
           timestamp: Date.now(),
-        };
+        });
 
         // Send to central log store
         ipc.misc.addLog(logEntry);
@@ -786,15 +816,26 @@ export const PreviewIframe = ({ loading }: { loading: boolean }) => {
       // Handle network errors from the iframe
       if (event.data?.type === "network-error") {
         const { method, url, status, error, duration } = event.data;
-        const statusCode = status && status !== 0 ? `[${status}] ` : "";
-        const formattedMessage = `${statusCode}${method} ${url} - ${error} (${duration}ms)`;
-        const logEntry = {
+        const statusCode =
+          typeof status === "number" && status !== 0 ? `[${status}]` : "";
+        const durationLabel =
+          typeof duration === "number"
+            ? `(${duration}ms)`
+            : "(unknown duration)";
+        const formattedMessage = formatPreviewConsoleMessage(statusCode, [
+          method,
+          url,
+          "-",
+          error,
+          durationLabel,
+        ]);
+        const logEntry = boundPreviewConsoleEntry({
           level: "error" as const,
           type: "network-requests" as const,
           message: formattedMessage,
           appId: selectedAppId!,
           timestamp: Date.now(),
-        };
+        });
 
         // Send to central log store
         ipc.misc.addLog(logEntry);
@@ -1064,13 +1105,13 @@ export const PreviewIframe = ({ loading }: { loading: boolean }) => {
         const errorMessage = `Error ${payload?.message || payload?.reason}\nStack trace: ${stack}`;
         console.error("Iframe error:", errorMessage);
         setErrorMessage({ message: errorMessage, source: "preview-app" });
-        const logEntry = {
+        const logEntry = boundPreviewConsoleEntry({
           level: "error" as const,
           type: "client" as const,
           message: `Iframe error: ${errorMessage}`,
           appId: selectedAppId!,
           timestamp: Date.now(),
-        };
+        });
 
         // Send to central log store
         ipc.misc.addLog(logEntry);
@@ -1081,13 +1122,19 @@ export const PreviewIframe = ({ loading }: { loading: boolean }) => {
         console.debug(`Build error report: ${payload}`);
         const errorMessage = `${payload?.message} from file ${payload?.file}.\n\nSource code:\n${payload?.frame}`;
         setErrorMessage({ message: errorMessage, source: "preview-app" });
-        const logEntry = {
+        const logEntry = boundPreviewConsoleEntry({
           level: "error" as const,
           type: "client" as const,
-          message: `Build error report: ${JSON.stringify(payload)}`,
+          message: formatPreviewConsoleMessage("Build error report:", [
+            payload?.message,
+            "from file",
+            payload?.file,
+            "Source code:",
+            payload?.frame,
+          ]),
           appId: selectedAppId!,
           timestamp: Date.now(),
-        };
+        });
 
         // Send to central log store
         ipc.misc.addLog(logEntry);

--- a/src/lib/preview_console_buffer.test.ts
+++ b/src/lib/preview_console_buffer.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  boundUtf8String,
+  formatPreviewConsoleMessage,
+  formatPreviewNetworkStatus,
+  getUtf8ByteLength,
+} from "./preview_console_buffer";
+
+describe("preview console formatting", () => {
+  it("bounds the truncation suffix itself when it exceeds the byte limit", () => {
+    const bounded = boundUtf8String(
+      "value that must be truncated",
+      2,
+      "marker",
+    );
+
+    expect(bounded).toEqual({ value: "ma", byteLength: 2 });
+    expect(getUtf8ByteLength(bounded.value)).toBeLessThanOrEqual(2);
+  });
+
+  it("does not split a multibyte suffix to fill an undersized budget", () => {
+    const bounded = boundUtf8String("value that must be truncated", 2, "🙂");
+
+    expect(bounded).toEqual({ value: "", byteLength: 0 });
+  });
+
+  it("preserves HTTP status zero while labeling non-numeric statuses unknown", () => {
+    expect(formatPreviewNetworkStatus(0)).toBe("[0]");
+    expect(formatPreviewNetworkStatus(204)).toBe("[204]");
+    expect(formatPreviewNetworkStatus(undefined)).toBe("[unknown status]");
+    expect(formatPreviewNetworkStatus("200")).toBe("[unknown status]");
+  });
+
+  it("formats only explicit value arrays", () => {
+    expect(formatPreviewConsoleMessage("[LOG]", ["hello", 42])).toBe(
+      "[LOG] hello 42",
+    );
+  });
+});

--- a/src/lib/preview_console_buffer.test.ts
+++ b/src/lib/preview_console_buffer.test.ts
@@ -36,4 +36,27 @@ describe("preview console formatting", () => {
       "[LOG] hello 42",
     );
   });
+
+  it("formats up to 20 values before adding an omission marker", () => {
+    const values = Array.from({ length: 25 }, (_, index) => `value-${index}`);
+
+    const formatted = formatPreviewConsoleMessage("[LOG]", values);
+
+    expect(formatted).toContain("value-19");
+    expect(formatted).not.toContain("value-20");
+    expect(formatted).toContain("… [5 values omitted]");
+  });
+
+  it("does not count the worker omission marker as an extra argument", () => {
+    const values = [
+      ...Array.from({ length: 20 }, (_, index) => `value-${index}`),
+      "… [5 arguments omitted]",
+    ];
+
+    const formatted = formatPreviewConsoleMessage("[LOG]", values);
+
+    expect(formatted).toContain("value-19");
+    expect(formatted).toContain("… [5 arguments omitted]");
+    expect(formatted).not.toContain("1 values omitted");
+  });
 });

--- a/src/lib/preview_console_buffer.ts
+++ b/src/lib/preview_console_buffer.ts
@@ -230,11 +230,11 @@ export function createPreviewConsoleTail(
   }
 
   if (omittedEntries && retainedNewestFirst.length > 0) {
-    const marker = createOmissionMarker(
+    const markerForSizing = createOmissionMarker(
       appId,
       retainedNewestFirst[retainedNewestFirst.length - 1],
     );
-    const markerBytes = getPreviewConsoleEntryByteLength(marker);
+    const markerBytes = getPreviewConsoleEntryByteLength(markerForSizing);
 
     // The marker is part of both budgets. Remove the oldest retained entries
     // until it fits, while always preserving the newest useful log.
@@ -249,7 +249,21 @@ export function createPreviewConsoleTail(
       }
     }
 
-    retainedNewestFirst.push(marker);
+    // Build the marker after trimming so its timestamp matches the actual
+    // oldest retained entry. Keep the final guard even though the current
+    // per-entry limit is smaller than the aggregate byte budget: it preserves
+    // both invariants if those constants change independently in the future.
+    if (
+      retainedNewestFirst.length + 1 <= MAX_PREVIEW_CONSOLE_ENTRIES_PER_APP &&
+      retainedBytes + markerBytes <= MAX_PREVIEW_CONSOLE_BYTES_PER_APP
+    ) {
+      retainedNewestFirst.push(
+        createOmissionMarker(
+          appId,
+          retainedNewestFirst[retainedNewestFirst.length - 1],
+        ),
+      );
+    }
   }
 
   retainedNewestFirst.reverse();

--- a/src/lib/preview_console_buffer.ts
+++ b/src/lib/preview_console_buffer.ts
@@ -1,0 +1,257 @@
+import type { ConsoleEntry } from "@/ipc/types";
+
+// Keep the renderer's long-lived preview history small enough that a noisy dev
+// server cannot exhaust the renderer heap. The main-process log store has its
+// own policy and intentionally remains independent from this UI buffer.
+export const MAX_PREVIEW_CONSOLE_ENTRIES_PER_APP = 1_000;
+export const MAX_PREVIEW_CONSOLE_BYTES_PER_APP = 2 * 1024 * 1024;
+export const MAX_PREVIEW_CONSOLE_MESSAGE_BYTES = 64 * 1024;
+export const MAX_PREVIEW_CONSOLE_SOURCE_NAME_BYTES = 1_024;
+
+export const PREVIEW_CONSOLE_OMISSION_MESSAGE =
+  "… [older preview logs omitted to stay within the console memory limit]";
+
+const MESSAGE_TRUNCATION_SUFFIX = "\n… [log payload truncated]";
+const SOURCE_NAME_TRUNCATION_SUFFIX = "… [source truncated]";
+const OMISSION_MARKER_SOURCE = "Dyad";
+const MAX_FORMATTED_ARGUMENTS = 10;
+const MAX_FORMATTED_ARGUMENT_BYTES = 8 * 1024;
+const CONSOLE_OMISSION_MARKER_FIELD = "__dyadConsoleOmissionMarker";
+
+type BufferedConsoleEntry = ConsoleEntry & {
+  [CONSOLE_OMISSION_MARKER_FIELD]?: true;
+};
+
+interface BoundedUtf8String {
+  value: string;
+  byteLength: number;
+}
+
+function utf8CodePointByteLength(codePoint: number): number {
+  if (codePoint <= 0x7f) return 1;
+  if (codePoint <= 0x7ff) return 2;
+  if (codePoint <= 0xffff) return 3;
+  return 4;
+}
+
+/**
+ * Measures and, when necessary, truncates without first allocating a full
+ * UTF-8 copy of an attacker-controlled string.
+ */
+function boundUtf8String(
+  value: string,
+  maxBytes: number,
+  truncationSuffix: string,
+): BoundedUtf8String {
+  let byteLength = 0;
+  let prefixByteLength = 0;
+  let prefixEnd = 0;
+  const suffixByteLength = getUtf8ByteLength(truncationSuffix);
+  const prefixLimit = Math.max(0, maxBytes - suffixByteLength);
+
+  for (let index = 0; index < value.length; ) {
+    const codePoint = value.codePointAt(index) ?? 0;
+    const codeUnitLength = codePoint > 0xffff ? 2 : 1;
+    const codePointByteLength = utf8CodePointByteLength(codePoint);
+    const nextIndex = index + codeUnitLength;
+
+    byteLength += codePointByteLength;
+    if (byteLength <= prefixLimit) {
+      prefixEnd = nextIndex;
+      prefixByteLength = byteLength;
+    }
+
+    if (byteLength > maxBytes) {
+      return {
+        value: value.slice(0, prefixEnd) + truncationSuffix,
+        byteLength: prefixByteLength + suffixByteLength,
+      };
+    }
+
+    index = nextIndex;
+  }
+
+  return { value, byteLength };
+}
+
+export function getUtf8ByteLength(value: string): number {
+  let byteLength = 0;
+  for (let index = 0; index < value.length; ) {
+    const codePoint = value.codePointAt(index) ?? 0;
+    byteLength += utf8CodePointByteLength(codePoint);
+    index += codePoint > 0xffff ? 2 : 1;
+  }
+  return byteLength;
+}
+
+export function getPreviewConsoleEntryByteLength(entry: ConsoleEntry): number {
+  return (
+    getUtf8ByteLength(entry.message) +
+    (entry.sourceName ? getUtf8ByteLength(entry.sourceName) : 0)
+  );
+}
+
+export function boundPreviewConsoleEntry(
+  entry: ConsoleEntry,
+  appId = entry.appId,
+): ConsoleEntry {
+  const message = boundUtf8String(
+    entry.message,
+    MAX_PREVIEW_CONSOLE_MESSAGE_BYTES,
+    MESSAGE_TRUNCATION_SUFFIX,
+  ).value;
+  const sourceName = entry.sourceName
+    ? boundUtf8String(
+        entry.sourceName,
+        MAX_PREVIEW_CONSOLE_SOURCE_NAME_BYTES,
+        SOURCE_NAME_TRUNCATION_SUFFIX,
+      ).value
+    : undefined;
+
+  if (
+    message === entry.message &&
+    sourceName === entry.sourceName &&
+    appId === entry.appId
+  ) {
+    return entry;
+  }
+
+  return { ...entry, appId, message, sourceName };
+}
+
+export function formatPreviewConsoleMessage(
+  prefix: string,
+  values: unknown,
+): string {
+  const boundedPrefix = boundUtf8String(
+    prefix,
+    MAX_FORMATTED_ARGUMENT_BYTES,
+    MESSAGE_TRUNCATION_SUFFIX,
+  ).value;
+  const rawValues = Array.isArray(values) ? values : [values];
+  const formattedValues: string[] = [];
+  const valueCount = Math.min(rawValues.length, MAX_FORMATTED_ARGUMENTS);
+
+  for (let index = 0; index < valueCount; index++) {
+    const value = rawValues[index];
+    let stringValue: string;
+    try {
+      stringValue = typeof value === "string" ? value : String(value);
+    } catch {
+      stringValue = "[unable to format console value]";
+    }
+    formattedValues.push(
+      boundUtf8String(
+        stringValue,
+        MAX_FORMATTED_ARGUMENT_BYTES,
+        MESSAGE_TRUNCATION_SUFFIX,
+      ).value,
+    );
+  }
+
+  if (rawValues.length > valueCount) {
+    formattedValues.push(`… [${rawValues.length - valueCount} values omitted]`);
+  }
+
+  return boundUtf8String(
+    [boundedPrefix, ...formattedValues].filter(Boolean).join(" "),
+    MAX_PREVIEW_CONSOLE_MESSAGE_BYTES,
+    MESSAGE_TRUNCATION_SUFFIX,
+  ).value;
+}
+
+function isOmissionMarker(entry: ConsoleEntry): boolean {
+  return (
+    (entry as BufferedConsoleEntry)[CONSOLE_OMISSION_MARKER_FIELD] === true
+  );
+}
+
+function createOmissionMarker(
+  appId: number,
+  oldestRetainedEntry: ConsoleEntry,
+): BufferedConsoleEntry {
+  return {
+    appId,
+    level: "warn",
+    type: "server",
+    message: PREVIEW_CONSOLE_OMISSION_MESSAGE,
+    sourceName: OMISSION_MARKER_SOURCE,
+    timestamp: oldestRetainedEntry.timestamp,
+    [CONSOLE_OMISSION_MARKER_FIELD]: true,
+  };
+}
+
+/**
+ * Builds a chronological, newest-first-selected tail without materializing an
+ * unbounded concatenation. Incoming entries are inspected from newest to
+ * oldest, so an oversized batch never causes its discarded prefix to be
+ * normalized or copied.
+ */
+export function createPreviewConsoleTail(
+  appId: number,
+  existingEntries: readonly ConsoleEntry[],
+  incomingEntries: readonly ConsoleEntry[],
+): ConsoleEntry[] {
+  const retainedNewestFirst: ConsoleEntry[] = [];
+  let retainedBytes = 0;
+  let omittedEntries = false;
+  let reachedLimit = false;
+
+  const retain = (rawEntry: ConsoleEntry): boolean => {
+    if (isOmissionMarker(rawEntry)) {
+      omittedEntries = true;
+      return true;
+    }
+
+    const entry = boundPreviewConsoleEntry(rawEntry, appId);
+    const entryBytes = getPreviewConsoleEntryByteLength(entry);
+    if (
+      retainedNewestFirst.length >= MAX_PREVIEW_CONSOLE_ENTRIES_PER_APP ||
+      retainedBytes + entryBytes > MAX_PREVIEW_CONSOLE_BYTES_PER_APP
+    ) {
+      omittedEntries = true;
+      reachedLimit = true;
+      return false;
+    }
+
+    retainedNewestFirst.push(entry);
+    retainedBytes += entryBytes;
+    return true;
+  };
+
+  for (let index = incomingEntries.length - 1; index >= 0; index--) {
+    if (!retain(incomingEntries[index])) break;
+  }
+
+  if (!reachedLimit) {
+    for (let index = existingEntries.length - 1; index >= 0; index--) {
+      if (!retain(existingEntries[index])) break;
+    }
+  }
+
+  if (omittedEntries && retainedNewestFirst.length > 0) {
+    const marker = createOmissionMarker(
+      appId,
+      retainedNewestFirst[retainedNewestFirst.length - 1],
+    );
+    const markerBytes = getPreviewConsoleEntryByteLength(marker);
+
+    // The marker is part of both budgets. Remove the oldest retained entries
+    // until it fits, while always preserving the newest useful log.
+    while (
+      retainedNewestFirst.length > 1 &&
+      (retainedNewestFirst.length + 1 > MAX_PREVIEW_CONSOLE_ENTRIES_PER_APP ||
+        retainedBytes + markerBytes > MAX_PREVIEW_CONSOLE_BYTES_PER_APP)
+    ) {
+      const removed = retainedNewestFirst.pop();
+      if (removed) {
+        retainedBytes -= getPreviewConsoleEntryByteLength(removed);
+      }
+    }
+
+    retainedNewestFirst.push(marker);
+  }
+
+  retainedNewestFirst.reverse();
+  return retainedNewestFirst;
+}

--- a/src/lib/preview_console_buffer.ts
+++ b/src/lib/preview_console_buffer.ts
@@ -14,8 +14,9 @@ export const PREVIEW_CONSOLE_OMISSION_MESSAGE =
 const MESSAGE_TRUNCATION_SUFFIX = "\n… [log payload truncated]";
 const SOURCE_NAME_TRUNCATION_SUFFIX = "… [source truncated]";
 const OMISSION_MARKER_SOURCE = "Dyad";
-const MAX_FORMATTED_ARGUMENTS = 10;
+const MAX_FORMATTED_ARGUMENTS = 20;
 const MAX_FORMATTED_ARGUMENT_BYTES = 8 * 1024;
+const FORWARDED_ARGUMENT_OMISSION_PATTERN = /^… \[\d+ arguments omitted\]$/;
 const CONSOLE_OMISSION_MARKER_FIELD = "__dyadConsoleOmissionMarker";
 
 type BufferedConsoleEntry = ConsoleEntry & {
@@ -155,7 +156,14 @@ export function formatPreviewConsoleMessage(
     MESSAGE_TRUNCATION_SUFFIX,
   ).value;
   const formattedValues: string[] = [];
-  const valueCount = Math.min(values.length, MAX_FORMATTED_ARGUMENTS);
+  const lastValue = values.at(-1);
+  const forwardedOmissionMarker =
+    typeof lastValue === "string" &&
+    FORWARDED_ARGUMENT_OMISSION_PATTERN.test(lastValue)
+      ? lastValue
+      : undefined;
+  const candidateValueCount = values.length - (forwardedOmissionMarker ? 1 : 0);
+  const valueCount = Math.min(candidateValueCount, MAX_FORMATTED_ARGUMENTS);
 
   for (let index = 0; index < valueCount; index++) {
     const value = values[index];
@@ -174,8 +182,12 @@ export function formatPreviewConsoleMessage(
     );
   }
 
-  if (values.length > valueCount) {
-    formattedValues.push(`… [${values.length - valueCount} values omitted]`);
+  if (candidateValueCount > valueCount) {
+    formattedValues.push(
+      `… [${candidateValueCount - valueCount} values omitted]`,
+    );
+  } else if (forwardedOmissionMarker) {
+    formattedValues.push(forwardedOmissionMarker);
   }
 
   return boundUtf8String(

--- a/src/lib/preview_console_buffer.ts
+++ b/src/lib/preview_console_buffer.ts
@@ -38,11 +38,15 @@ function utf8CodePointByteLength(codePoint: number): number {
  * Measures and, when necessary, truncates without first allocating a full
  * UTF-8 copy of an attacker-controlled string.
  */
-function boundUtf8String(
+export function boundUtf8String(
   value: string,
   maxBytes: number,
   truncationSuffix: string,
 ): BoundedUtf8String {
+  if (maxBytes <= 0) {
+    return { value: "", byteLength: 0 };
+  }
+
   let byteLength = 0;
   let prefixByteLength = 0;
   let prefixEnd = 0;
@@ -62,6 +66,28 @@ function boundUtf8String(
     }
 
     if (byteLength > maxBytes) {
+      if (suffixByteLength > maxBytes) {
+        let boundedSuffixByteLength = 0;
+        let suffixEnd = 0;
+
+        for (let suffixIndex = 0; suffixIndex < truncationSuffix.length; ) {
+          const suffixCodePoint =
+            truncationSuffix.codePointAt(suffixIndex) ?? 0;
+          const codeUnitLength = suffixCodePoint > 0xffff ? 2 : 1;
+          const nextByteLength =
+            boundedSuffixByteLength + utf8CodePointByteLength(suffixCodePoint);
+          if (nextByteLength > maxBytes) break;
+          boundedSuffixByteLength = nextByteLength;
+          suffixIndex += codeUnitLength;
+          suffixEnd = suffixIndex;
+        }
+
+        return {
+          value: truncationSuffix.slice(0, suffixEnd),
+          byteLength: boundedSuffixByteLength,
+        };
+      }
+
       return {
         value: value.slice(0, prefixEnd) + truncationSuffix,
         byteLength: prefixByteLength + suffixByteLength,
@@ -121,19 +147,18 @@ export function boundPreviewConsoleEntry(
 
 export function formatPreviewConsoleMessage(
   prefix: string,
-  values: unknown,
+  values: readonly unknown[],
 ): string {
   const boundedPrefix = boundUtf8String(
     prefix,
     MAX_FORMATTED_ARGUMENT_BYTES,
     MESSAGE_TRUNCATION_SUFFIX,
   ).value;
-  const rawValues = Array.isArray(values) ? values : [values];
   const formattedValues: string[] = [];
-  const valueCount = Math.min(rawValues.length, MAX_FORMATTED_ARGUMENTS);
+  const valueCount = Math.min(values.length, MAX_FORMATTED_ARGUMENTS);
 
   for (let index = 0; index < valueCount; index++) {
-    const value = rawValues[index];
+    const value = values[index];
     let stringValue: string;
     try {
       stringValue = typeof value === "string" ? value : String(value);
@@ -149,8 +174,8 @@ export function formatPreviewConsoleMessage(
     );
   }
 
-  if (rawValues.length > valueCount) {
-    formattedValues.push(`… [${rawValues.length - valueCount} values omitted]`);
+  if (values.length > valueCount) {
+    formattedValues.push(`… [${values.length - valueCount} values omitted]`);
   }
 
   return boundUtf8String(
@@ -158,6 +183,10 @@ export function formatPreviewConsoleMessage(
     MAX_PREVIEW_CONSOLE_MESSAGE_BYTES,
     MESSAGE_TRUNCATION_SUFFIX,
   ).value;
+}
+
+export function formatPreviewNetworkStatus(status: unknown): string {
+  return typeof status === "number" ? `[${status}]` : "[unknown status]";
 }
 
 function isOmissionMarker(entry: ConsoleEntry): boolean {

--- a/src/pages/app-details.tsx
+++ b/src/pages/app-details.tsx
@@ -3,6 +3,7 @@ import { normalizePath } from "../../shared/normalizePath";
 import { useSetAtom } from "jotai";
 import { selectedAppIdAtom } from "@/atoms/appAtoms";
 import { selectedChatIdAtom } from "@/atoms/chatAtoms";
+import { clearPreviewRuntimeForAppAtom } from "@/atoms/previewRuntimeAtoms";
 import { ipc } from "@/ipc/types";
 import { useLoadApps } from "@/hooks/useLoadApps";
 import { useChats } from "@/hooks/useChats";
@@ -117,6 +118,7 @@ export default function AppDetailsPage() {
   const queryClient = useQueryClient();
   const setSelectedAppId = useSetAtom(selectedAppIdAtom);
   const setSelectedChatId = useSetAtom(selectedChatIdAtom);
+  const clearPreviewRuntimeForApp = useSetAtom(clearPreviewRuntimeForAppAtom);
 
   const debouncedNewCopyAppName = useDebounce(newCopyAppName, 150);
   const { data: checkNameResult, isLoading: isCheckingName } = useCheckName(
@@ -170,6 +172,7 @@ export default function AppDetailsPage() {
       setIsDeleting(true);
       await ipc.app.deleteApp({ appId });
       setIsDeleteDialogOpen(false);
+      clearPreviewRuntimeForApp(appId);
       setSelectedAppId(null);
       setSelectedChatId(null);
       await refreshApps();

--- a/worker/dyad_logs.js
+++ b/worker/dyad_logs.js
@@ -147,7 +147,7 @@
       if (typeof value.toJSON === "function") {
         const jsonValue = value.toJSON();
         if (jsonValue !== value) {
-          return sanitizeValue(jsonValue, state, depth);
+          return sanitizeValue(jsonValue, state, depth + 1);
         }
       }
     } catch {
@@ -217,7 +217,7 @@
           state,
           MAX_OBJECT_KEY_BYTES,
         );
-        if (!safeKey) {
+        if (!safeKey && key !== "") {
           hasMoreKeys = true;
           break;
         }

--- a/worker/dyad_logs.js
+++ b/worker/dyad_logs.js
@@ -38,6 +38,8 @@
   }
 
   function truncateUtf8(value, maxBytes) {
+    if (maxBytes <= 0) return "";
+
     let byteLength = 0;
     let prefixEnd = 0;
     const suffixByteLength = utf8ByteLength(VALUE_TRUNCATION_SUFFIX);
@@ -49,6 +51,26 @@
       byteLength += utf8CodePointByteLength(codePoint);
       if (byteLength <= prefixLimit) prefixEnd = nextIndex;
       if (byteLength > maxBytes) {
+        if (suffixByteLength > maxBytes) {
+          let suffixEnd = 0;
+          let usedBytes = 0;
+          for (
+            let suffixIndex = 0;
+            suffixIndex < VALUE_TRUNCATION_SUFFIX.length;
+          ) {
+            const suffixCodePoint =
+              VALUE_TRUNCATION_SUFFIX.codePointAt(suffixIndex) ?? 0;
+            const nextSuffixIndex =
+              suffixIndex + (suffixCodePoint > 0xffff ? 2 : 1);
+            const nextBytes =
+              usedBytes + utf8CodePointByteLength(suffixCodePoint);
+            if (nextBytes > maxBytes) break;
+            usedBytes = nextBytes;
+            suffixEnd = nextSuffixIndex;
+            suffixIndex = nextSuffixIndex;
+          }
+          return VALUE_TRUNCATION_SUFFIX.slice(0, suffixEnd);
+        }
         return value.slice(0, prefixEnd) + VALUE_TRUNCATION_SUFFIX;
       }
       index = nextIndex;
@@ -57,33 +79,98 @@
     return value;
   }
 
+  function takeStringWithinBudget(value, state, maxBytes) {
+    const availableBytes = Math.min(maxBytes, state.remainingBytes);
+    const boundedValue = truncateUtf8(value, availableBytes);
+    state.remainingBytes = Math.max(
+      0,
+      state.remainingBytes - utf8ByteLength(boundedValue),
+    );
+    return boundedValue;
+  }
+
   function sanitizeValue(value, state, depth) {
     if (value === null || value === undefined) return value;
     if (typeof value === "string") {
-      return truncateUtf8(value, MAX_STRING_VALUE_BYTES);
+      return takeStringWithinBudget(value, state, MAX_STRING_VALUE_BYTES);
     }
     if (typeof value === "number" || typeof value === "boolean") {
       return value;
     }
-    if (typeof value === "bigint") return `${value}n`;
+    if (typeof value === "bigint") {
+      return takeStringWithinBudget(`${value}n`, state, MAX_STRING_VALUE_BYTES);
+    }
     if (typeof value === "function") {
-      return `[Function ${truncateUtf8(value.name || "anonymous", MAX_OBJECT_KEY_BYTES)}]`;
+      return takeStringWithinBudget(
+        `[Function ${value.name || "anonymous"}]`,
+        state,
+        MAX_OBJECT_KEY_BYTES,
+      );
     }
     if (typeof value === "symbol") {
-      return String(value);
+      return takeStringWithinBudget(
+        String(value),
+        state,
+        MAX_STRING_VALUE_BYTES,
+      );
     }
-    if (depth >= MAX_OBJECT_DEPTH) return "[Maximum log depth reached]";
-    if (state.remainingNodes <= 0) return "[Log value node limit reached]";
-    if (state.seen.has(value)) return "[Circular]";
+    if (state.remainingBytes <= 0) return "";
+    if (depth >= MAX_OBJECT_DEPTH) {
+      return takeStringWithinBudget(
+        "[Maximum log depth reached]",
+        state,
+        MAX_STRING_VALUE_BYTES,
+      );
+    }
+    if (state.remainingNodes <= 0) {
+      return takeStringWithinBudget(
+        "[Log value node limit reached]",
+        state,
+        MAX_STRING_VALUE_BYTES,
+      );
+    }
+    if (state.seen.has(value)) {
+      return takeStringWithinBudget(
+        "[Circular]",
+        state,
+        MAX_STRING_VALUE_BYTES,
+      );
+    }
 
     state.remainingNodes--;
     state.seen.add(value);
 
+    // Match JSON.stringify semantics for built-ins such as Date and URL while
+    // retaining the traversal and byte limits for the value returned by
+    // user-defined toJSON implementations.
+    try {
+      if (typeof value.toJSON === "function") {
+        const jsonValue = value.toJSON();
+        if (jsonValue !== value) {
+          return sanitizeValue(jsonValue, state, depth);
+        }
+      }
+    } catch {
+      // Fall back to bounded property serialization when toJSON throws.
+    }
+
     if (value instanceof Error) {
       return {
-        name: truncateUtf8(String(value.name), MAX_STRING_VALUE_BYTES),
-        message: truncateUtf8(String(value.message), MAX_STRING_VALUE_BYTES),
-        stack: truncateUtf8(String(value.stack ?? ""), MAX_STRING_VALUE_BYTES),
+        name: takeStringWithinBudget(
+          String(value.name),
+          state,
+          MAX_STRING_VALUE_BYTES,
+        ),
+        message: takeStringWithinBudget(
+          String(value.message),
+          state,
+          MAX_STRING_VALUE_BYTES,
+        ),
+        stack: takeStringWithinBudget(
+          String(value.stack ?? ""),
+          state,
+          MAX_STRING_VALUE_BYTES,
+        ),
       };
     }
 
@@ -94,11 +181,18 @@
         state.remainingNodes,
       );
       const result = [];
-      for (let index = 0; index < itemCount; index++) {
+      let index = 0;
+      for (; index < itemCount && state.remainingBytes > 0; index++) {
         result.push(sanitizeValue(value[index], state, depth + 1));
       }
-      if (itemCount < value.length) {
-        result.push(`… [${value.length - itemCount} array items omitted]`);
+      if (index < value.length && state.remainingBytes > 0) {
+        result.push(
+          takeStringWithinBudget(
+            `… [${value.length - index} array items omitted]`,
+            state,
+            MAX_STRING_VALUE_BYTES,
+          ),
+        );
       }
       return result;
     }
@@ -109,22 +203,48 @@
     try {
       for (const key in value) {
         if (!Object.prototype.hasOwnProperty.call(value, key)) continue;
-        if (includedKeys >= MAX_OBJECT_KEYS || state.remainingNodes <= 0) {
+        if (
+          includedKeys >= MAX_OBJECT_KEYS ||
+          state.remainingNodes <= 0 ||
+          state.remainingBytes <= 0
+        ) {
           hasMoreKeys = true;
           break;
         }
         includedKeys++;
-        const safeKey = truncateUtf8(key, MAX_OBJECT_KEY_BYTES);
+        const safeKey = takeStringWithinBudget(
+          key,
+          state,
+          MAX_OBJECT_KEY_BYTES,
+        );
+        if (!safeKey) {
+          hasMoreKeys = true;
+          break;
+        }
         try {
           result[safeKey] = sanitizeValue(value[key], state, depth + 1);
         } catch {
-          result[safeKey] = "[Unable to read property]";
+          result[safeKey] = takeStringWithinBudget(
+            "[Unable to read property]",
+            state,
+            MAX_STRING_VALUE_BYTES,
+          );
         }
       }
     } catch {
-      return "[Object: unable to enumerate]";
+      return takeStringWithinBudget(
+        "[Object: unable to enumerate]",
+        state,
+        MAX_STRING_VALUE_BYTES,
+      );
     }
-    if (hasMoreKeys) result.__dyad_truncated__ = "Additional keys omitted";
+    if (hasMoreKeys && state.remainingBytes > 0) {
+      result.__dyad_truncated__ = takeStringWithinBudget(
+        "Additional keys omitted",
+        state,
+        MAX_STRING_VALUE_BYTES,
+      );
+    }
     return result;
   }
 
@@ -144,7 +264,11 @@
     try {
       const sanitized = sanitizeValue(
         arg,
-        { seen: new WeakSet(), remainingNodes: MAX_SERIALIZED_NODES },
+        {
+          seen: new WeakSet(),
+          remainingNodes: MAX_SERIALIZED_NODES,
+          remainingBytes: MAX_ARGUMENT_BYTES,
+        },
         0,
       );
       return truncateUtf8(

--- a/worker/dyad_logs.js
+++ b/worker/dyad_logs.js
@@ -4,13 +4,15 @@
  */
 
 (function () {
-  const MAX_ARGUMENTS = 10;
+  const MAX_ARGUMENTS = 20;
   const MAX_ARGUMENT_BYTES = 8 * 1024;
+  const MAX_CONSOLE_CALL_BYTES = 64 * 1024;
+  const ARGUMENT_OMISSION_MARKER_RESERVE_BYTES = 64;
   const MAX_STRING_VALUE_BYTES = 4 * 1024;
-  const MAX_OBJECT_DEPTH = 4;
-  const MAX_OBJECT_KEYS = 20;
+  const MAX_OBJECT_DEPTH = 6;
+  const MAX_OBJECT_KEYS = 50;
   const MAX_OBJECT_KEY_BYTES = 256;
-  const MAX_SERIALIZED_NODES = 100;
+  const MAX_SERIALIZED_NODES = 250;
   const VALUE_TRUNCATION_SUFFIX = "… [console value truncated]";
 
   // Store original console methods
@@ -248,17 +250,25 @@
     return result;
   }
 
-  function stringifyArg(arg) {
-    if (arg === null) return "null";
-    if (arg === undefined) return "undefined";
+  function stringifyArg(arg, maxBytes = MAX_ARGUMENT_BYTES) {
+    const argumentByteBudget = Math.min(
+      MAX_ARGUMENT_BYTES,
+      Math.max(0, maxBytes),
+    );
+    if (argumentByteBudget === 0) return "";
+    if (arg === null) return truncateUtf8("null", argumentByteBudget);
+    if (arg === undefined) return truncateUtf8("undefined", argumentByteBudget);
     if (typeof arg === "string") {
-      return truncateUtf8(arg, MAX_ARGUMENT_BYTES);
+      return truncateUtf8(arg, argumentByteBudget);
     }
     if (typeof arg !== "object") {
       if (typeof arg === "function") {
-        return `[Function ${truncateUtf8(arg.name || "anonymous", MAX_OBJECT_KEY_BYTES)}]`;
+        return truncateUtf8(
+          `[Function ${truncateUtf8(arg.name || "anonymous", MAX_OBJECT_KEY_BYTES)}]`,
+          argumentByteBudget,
+        );
       }
-      return truncateUtf8(String(arg), MAX_ARGUMENT_BYTES);
+      return truncateUtf8(String(arg), argumentByteBudget);
     }
 
     try {
@@ -267,13 +277,13 @@
         {
           seen: new WeakSet(),
           remainingNodes: MAX_SERIALIZED_NODES,
-          remainingBytes: MAX_ARGUMENT_BYTES,
+          remainingBytes: argumentByteBudget,
         },
         0,
       );
       return truncateUtf8(
         JSON.stringify(sanitized, null, 2),
-        MAX_ARGUMENT_BYTES,
+        argumentByteBudget,
       );
     } catch {
       return "[Object: unable to stringify]";
@@ -284,10 +294,35 @@
   // structured-clone boundary so a single console call cannot balloon either
   // the preview iframe or the parent renderer.
   function stringifyArgs(args) {
-    const includedArgs = args.slice(0, MAX_ARGUMENTS).map(stringifyArg);
-    if (args.length > MAX_ARGUMENTS) {
-      includedArgs.push(`… [${args.length - MAX_ARGUMENTS} arguments omitted]`);
+    const includedArgs = [];
+    const valueCount = Math.min(args.length, MAX_ARGUMENTS);
+    const valueByteBudget = Math.max(
+      0,
+      MAX_CONSOLE_CALL_BYTES - ARGUMENT_OMISSION_MARKER_RESERVE_BYTES,
+    );
+    let usedBytes = 0;
+
+    for (let index = 0; index < valueCount; index++) {
+      const remainingBytes = valueByteBudget - usedBytes;
+      if (remainingBytes <= 0) break;
+
+      const stringified = stringifyArg(
+        args[index],
+        Math.min(MAX_ARGUMENT_BYTES, remainingBytes),
+      );
+      includedArgs.push(stringified);
+      usedBytes += utf8ByteLength(stringified);
     }
+
+    const omittedArgumentCount = args.length - includedArgs.length;
+    if (omittedArgumentCount > 0) {
+      const marker = truncateUtf8(
+        `… [${omittedArgumentCount} arguments omitted]`,
+        MAX_CONSOLE_CALL_BYTES - usedBytes,
+      );
+      if (marker) includedArgs.push(marker);
+    }
+
     return includedArgs;
   }
 

--- a/worker/dyad_logs.js
+++ b/worker/dyad_logs.js
@@ -4,6 +4,15 @@
  */
 
 (function () {
+  const MAX_ARGUMENTS = 10;
+  const MAX_ARGUMENT_BYTES = 8 * 1024;
+  const MAX_STRING_VALUE_BYTES = 4 * 1024;
+  const MAX_OBJECT_DEPTH = 4;
+  const MAX_OBJECT_KEYS = 20;
+  const MAX_OBJECT_KEY_BYTES = 256;
+  const MAX_SERIALIZED_NODES = 100;
+  const VALUE_TRUNCATION_SUFFIX = "… [console value truncated]";
+
   // Store original console methods
   const originalLog = console.log;
   const originalWarn = console.warn;
@@ -11,20 +20,151 @@
   const originalInfo = console.info;
   const originalDebug = console.debug;
 
-  // Helper function to safely stringify arguments
-  function stringifyArgs(args) {
-    return args.map((arg) => {
-      if (arg === null) return "null";
-      if (arg === undefined) return "undefined";
-      if (typeof arg === "object") {
+  function utf8CodePointByteLength(codePoint) {
+    if (codePoint <= 0x7f) return 1;
+    if (codePoint <= 0x7ff) return 2;
+    if (codePoint <= 0xffff) return 3;
+    return 4;
+  }
+
+  function utf8ByteLength(value) {
+    let byteLength = 0;
+    for (let index = 0; index < value.length; ) {
+      const codePoint = value.codePointAt(index) ?? 0;
+      byteLength += utf8CodePointByteLength(codePoint);
+      index += codePoint > 0xffff ? 2 : 1;
+    }
+    return byteLength;
+  }
+
+  function truncateUtf8(value, maxBytes) {
+    let byteLength = 0;
+    let prefixEnd = 0;
+    const suffixByteLength = utf8ByteLength(VALUE_TRUNCATION_SUFFIX);
+    const prefixLimit = Math.max(0, maxBytes - suffixByteLength);
+
+    for (let index = 0; index < value.length; ) {
+      const codePoint = value.codePointAt(index) ?? 0;
+      const nextIndex = index + (codePoint > 0xffff ? 2 : 1);
+      byteLength += utf8CodePointByteLength(codePoint);
+      if (byteLength <= prefixLimit) prefixEnd = nextIndex;
+      if (byteLength > maxBytes) {
+        return value.slice(0, prefixEnd) + VALUE_TRUNCATION_SUFFIX;
+      }
+      index = nextIndex;
+    }
+
+    return value;
+  }
+
+  function sanitizeValue(value, state, depth) {
+    if (value === null || value === undefined) return value;
+    if (typeof value === "string") {
+      return truncateUtf8(value, MAX_STRING_VALUE_BYTES);
+    }
+    if (typeof value === "number" || typeof value === "boolean") {
+      return value;
+    }
+    if (typeof value === "bigint") return `${value}n`;
+    if (typeof value === "function") {
+      return `[Function ${truncateUtf8(value.name || "anonymous", MAX_OBJECT_KEY_BYTES)}]`;
+    }
+    if (typeof value === "symbol") {
+      return String(value);
+    }
+    if (depth >= MAX_OBJECT_DEPTH) return "[Maximum log depth reached]";
+    if (state.remainingNodes <= 0) return "[Log value node limit reached]";
+    if (state.seen.has(value)) return "[Circular]";
+
+    state.remainingNodes--;
+    state.seen.add(value);
+
+    if (value instanceof Error) {
+      return {
+        name: truncateUtf8(String(value.name), MAX_STRING_VALUE_BYTES),
+        message: truncateUtf8(String(value.message), MAX_STRING_VALUE_BYTES),
+        stack: truncateUtf8(String(value.stack ?? ""), MAX_STRING_VALUE_BYTES),
+      };
+    }
+
+    if (Array.isArray(value)) {
+      const itemCount = Math.min(
+        value.length,
+        MAX_OBJECT_KEYS,
+        state.remainingNodes,
+      );
+      const result = [];
+      for (let index = 0; index < itemCount; index++) {
+        result.push(sanitizeValue(value[index], state, depth + 1));
+      }
+      if (itemCount < value.length) {
+        result.push(`… [${value.length - itemCount} array items omitted]`);
+      }
+      return result;
+    }
+
+    const result = {};
+    let includedKeys = 0;
+    let hasMoreKeys = false;
+    try {
+      for (const key in value) {
+        if (!Object.prototype.hasOwnProperty.call(value, key)) continue;
+        if (includedKeys >= MAX_OBJECT_KEYS || state.remainingNodes <= 0) {
+          hasMoreKeys = true;
+          break;
+        }
+        includedKeys++;
+        const safeKey = truncateUtf8(key, MAX_OBJECT_KEY_BYTES);
         try {
-          return JSON.stringify(arg, null, 2);
+          result[safeKey] = sanitizeValue(value[key], state, depth + 1);
         } catch {
-          return "[Object: unable to stringify]";
+          result[safeKey] = "[Unable to read property]";
         }
       }
-      return String(arg);
-    });
+    } catch {
+      return "[Object: unable to enumerate]";
+    }
+    if (hasMoreKeys) result.__dyad_truncated__ = "Additional keys omitted";
+    return result;
+  }
+
+  function stringifyArg(arg) {
+    if (arg === null) return "null";
+    if (arg === undefined) return "undefined";
+    if (typeof arg === "string") {
+      return truncateUtf8(arg, MAX_ARGUMENT_BYTES);
+    }
+    if (typeof arg !== "object") {
+      if (typeof arg === "function") {
+        return `[Function ${truncateUtf8(arg.name || "anonymous", MAX_OBJECT_KEY_BYTES)}]`;
+      }
+      return truncateUtf8(String(arg), MAX_ARGUMENT_BYTES);
+    }
+
+    try {
+      const sanitized = sanitizeValue(
+        arg,
+        { seen: new WeakSet(), remainingNodes: MAX_SERIALIZED_NODES },
+        0,
+      );
+      return truncateUtf8(
+        JSON.stringify(sanitized, null, 2),
+        MAX_ARGUMENT_BYTES,
+      );
+    } catch {
+      return "[Object: unable to stringify]";
+    }
+  }
+
+  // Bound argument count, object traversal, depth, and string size before the
+  // structured-clone boundary so a single console call cannot balloon either
+  // the preview iframe or the parent renderer.
+  function stringifyArgs(args) {
+    const includedArgs = args.slice(0, MAX_ARGUMENTS).map(stringifyArg);
+    if (args.length > MAX_ARGUMENTS) {
+      includedArgs.push(`… [${args.length - MAX_ARGUMENTS} arguments omitted]`);
+    }
+    return includedArgs;
   }
 
   // Intercept console.log


### PR DESCRIPTION
## Summary
- keep each app preview console within a 1000-entry and 2 MiB newest-tail budget
- truncate giant UTF-8 log payloads and iframe console serialization with explicit markers
- avoid redundant console sorting and clear preview logs on every app deletion or reset path

## Tests
- npm test -- src/atoms/previewRuntimeAtoms.test.ts src/__tests__/dyad_logs.test.ts src/hooks/useRunApp.test.tsx
- npm test -- src/ipc/handlers/__tests__/app_details_actions.integration.test.tsx
- npm run lint
- npm run ts
- npm run build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all preview log ingestion and display paths; behavior changes include truncation and dropped older logs, though the main-process log store stays separate and limits are defensive.
> 
> **Overview**
> Caps **preview console memory** so noisy dev servers cannot grow unbounded renderer state. Per-app UI history is limited to **1,000 entries** and **2 MiB** (newest tail), with a visible omission marker when older logs are dropped; giant messages and source names are **UTF-8 truncated** with explicit suffixes.
> 
> **Iframe → parent path:** `worker/dyad_logs.js` no longer naively `JSON.stringify`s console args. It bounds argument count, per-call bytes, object depth/keys, circular refs, and getter-driven payloads before `postMessage`. **PreviewIframe** formats and bounds entries via shared helpers (`boundPreviewConsoleEntry`, `formatPreviewConsoleMessage`) for console, network, and error logs.
> 
> **State:** `setConsoleEntriesForAppAtom` / `appendConsoleEntriesForAppAtom` merge through `createPreviewConsoleTail` instead of storing raw arrays. **App delete** clears preview runtime (including console buffer) via `clearPreviewRuntimeForApp`. The console panel still sorts by timestamp at display time; the comment notes the buffer stays small enough that this is acceptable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c46dbda629465dd189c94dbe1e0abc0f5428ff61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

