### PR TITLE
Bound child-process output memory and timeouts

### DIFF
--- a/src/ipc/handlers/portal_handlers.ts
+++ b/src/ipc/handlers/portal_handlers.ts
@@ -4,11 +4,10 @@ import { db } from "../../db";
 import { apps } from "../../db/schema";
 import { eq } from "drizzle-orm";
 import { getDyadAppPath } from "../../paths/paths";
-import { spawn } from "child_process";
 import { gitService } from "../services/git_service";
 import { storeDbTimestampAtCurrentVersion } from "../utils/neon_timestamp_utils";
 import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
-import { getPackageManagerCommandEnv } from "../utils/socket_firewall";
+import { runPortalMigrationCommand } from "../utils/portal_migration";
 
 const logger = log.scope("portal_handlers");
 const handle = createLoggedHandler(logger);
@@ -33,72 +32,9 @@ export function registerPortalHandlers() {
       const app = await getApp(appId);
       const appPath = getDyadAppPath(app.path);
 
-      // Run the migration command
-      const migrationOutput = await new Promise<string>((resolve, reject) => {
-        logger.info(`Running migrate:create for app ${appId} at ${appPath}`);
-
-        const process = spawn("npm run migrate:create -- --skip-empty", {
-          cwd: appPath,
-          shell: true,
-          stdio: "pipe",
-          env: getPackageManagerCommandEnv(),
-        });
-
-        let stdout = "";
-        let stderr = "";
-
-        process.stdout?.on("data", (data) => {
-          const output = data.toString();
-          stdout += output;
-          logger.info(`migrate:create stdout: ${output}`);
-          if (output.includes("created or renamed from another")) {
-            process.stdin.write(`\r\n`);
-            logger.info(
-              `App ${appId} (PID: ${process.pid}) wrote enter to stdin to automatically respond to drizzle migrate input`,
-            );
-          }
-        });
-
-        process.stderr?.on("data", (data) => {
-          const output = data.toString();
-          stderr += output;
-          logger.warn(`migrate:create stderr: ${output}`);
-        });
-
-        process.on("close", (code) => {
-          const combinedOutput =
-            stdout + (stderr ? `\n\nErrors/Warnings:\n${stderr}` : "");
-
-          if (code === 0) {
-            if (stdout.includes("Migration created at")) {
-              logger.info(
-                `migrate:create completed successfully for app ${appId}`,
-              );
-              resolve(combinedOutput);
-            } else {
-              logger.error(
-                `migrate:create completed successfully for app ${appId} but no migration was created`,
-              );
-              reject(
-                new Error(
-                  "No migration was created because no changes were found.",
-                ),
-              );
-            }
-          } else {
-            logger.error(
-              `migrate:create failed for app ${appId} with exit code ${code}`,
-            );
-            const errorMessage = `Migration creation failed (exit code ${code})\n\n${combinedOutput}`;
-            reject(new Error(errorMessage));
-          }
-        });
-
-        process.on("error", (err) => {
-          logger.error(`Failed to spawn migrate:create for app ${appId}:`, err);
-          const errorMessage = `Failed to run migration command: ${err.message}\n\nOutput:\n${stdout}\n\nErrors:\n${stderr}`;
-          reject(new Error(errorMessage));
-        });
+      const migrationOutput = await runPortalMigrationCommand({
+        appId,
+        appPath,
       });
 
       if (app.neonProjectId && app.neonDevelopmentBranchId) {

--- a/src/ipc/utils/bounded_output_buffer.test.ts
+++ b/src/ipc/utils/bounded_output_buffer.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  BoundedOutputBuffer,
+  OUTPUT_TRUNCATION_MARKER,
+} from "./bounded_output_buffer";
+
+describe("BoundedOutputBuffer", () => {
+  it("keeps only the newest bytes from very large output", () => {
+    const output = new BoundedOutputBuffer(16);
+
+    output.append("a".repeat(1_000_000));
+    output.append("0123456789abcdef");
+
+    expect(output.byteLength).toBe(16);
+    expect(output.wasTruncated).toBe(true);
+    expect(output.toString()).toBe(
+      OUTPUT_TRUNCATION_MARKER + "0123456789abcdef",
+    );
+  });
+
+  it("reconstructs UTF-8 characters split across Buffer chunks", () => {
+    const output = new BoundedOutputBuffer(64);
+    const encoded = Buffer.from("start 🙂 end");
+
+    output.append(encoded.subarray(0, 8));
+    output.append(encoded.subarray(8, 10));
+    output.append(encoded.subarray(10));
+
+    expect(output.toString()).toBe("start 🙂 end");
+  });
+
+  it("does not emit a replacement character when eviction splits UTF-8", () => {
+    const output = new BoundedOutputBuffer(4);
+
+    output.append("x🙂y");
+
+    expect(output.toString()).toBe(OUTPUT_TRUNCATION_MARKER + "y");
+    expect(output.toString()).not.toContain("�");
+  });
+
+  it("releases retained chunks when cleared", () => {
+    const output = new BoundedOutputBuffer(8);
+    output.append("0123456789");
+
+    output.clear();
+
+    expect(output.byteLength).toBe(0);
+    expect(output.wasTruncated).toBe(false);
+    expect(output.toString()).toBe("");
+  });
+});

--- a/src/ipc/utils/bounded_output_buffer.test.ts
+++ b/src/ipc/utils/bounded_output_buffer.test.ts
@@ -18,6 +18,30 @@ describe("BoundedOutputBuffer", () => {
     );
   });
 
+  it("wraps small appends around the ring and reassembles them in order", () => {
+    const output = new BoundedOutputBuffer(8);
+
+    output.append("abcde");
+    // Crosses the physical end of the ring: "fgh" lands at the tail and "ij"
+    // wraps to the front, so toString() must stitch the two regions together.
+    output.append("fghij");
+
+    expect(output.byteLength).toBe(8);
+    expect(output.wasTruncated).toBe(true);
+    expect(output.toString()).toBe(OUTPUT_TRUNCATION_MARKER + "cdefghij");
+  });
+
+  it("does not report truncation when small appends exactly fill the ring", () => {
+    const output = new BoundedOutputBuffer(8);
+
+    output.append("abcde");
+    output.append("fgh");
+
+    expect(output.byteLength).toBe(8);
+    expect(output.wasTruncated).toBe(false);
+    expect(output.toString()).toBe("abcdefgh");
+  });
+
   it("reconstructs UTF-8 characters split across Buffer chunks", () => {
     const output = new BoundedOutputBuffer(64);
     const encoded = Buffer.from("start 🙂 end");

--- a/src/ipc/utils/bounded_output_buffer.ts
+++ b/src/ipc/utils/bounded_output_buffer.ts
@@ -1,0 +1,113 @@
+export const DEFAULT_MAX_BUFFERED_OUTPUT_BYTES = 256_000;
+export const OUTPUT_TRUNCATION_MARKER = "[... earlier output truncated ...]\n";
+
+/**
+ * Retains only the newest bytes from a stream in a fixed-size ring until the
+ * output is decoded. Keeping bytes (instead of repeatedly concatenating
+ * strings) avoids quadratic copies and correctly reconstructs UTF-8
+ * characters split across process-output chunks.
+ */
+export class BoundedOutputBuffer {
+  private storage: Buffer | undefined;
+  private writeOffset = 0;
+  private retainedByteLength = 0;
+  private truncated = false;
+
+  constructor(private readonly maxBytes = DEFAULT_MAX_BUFFERED_OUTPUT_BYTES) {
+    if (!Number.isInteger(maxBytes) || maxBytes < 0) {
+      throw new RangeError("maxBytes must be a non-negative integer");
+    }
+  }
+
+  append(chunk: string | Buffer): void {
+    if (chunk.length === 0) {
+      return;
+    }
+
+    const bytes = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
+
+    if (this.maxBytes === 0) {
+      this.retainedByteLength = 0;
+      this.truncated = true;
+      return;
+    }
+
+    this.storage ??= Buffer.allocUnsafe(this.maxBytes);
+
+    if (bytes.byteLength >= this.maxBytes) {
+      const discardedPreviousOutput = this.retainedByteLength > 0;
+      bytes.copy(this.storage, 0, bytes.byteLength - this.maxBytes);
+      this.writeOffset = 0;
+      this.retainedByteLength = this.maxBytes;
+      this.truncated ||=
+        bytes.byteLength > this.maxBytes || discardedPreviousOutput;
+      return;
+    }
+
+    const bytesUntilEnd = this.maxBytes - this.writeOffset;
+    const firstCopyByteLength = Math.min(bytes.byteLength, bytesUntilEnd);
+    bytes.copy(this.storage, this.writeOffset, 0, firstCopyByteLength);
+    if (firstCopyByteLength < bytes.byteLength) {
+      bytes.copy(this.storage, 0, firstCopyByteLength);
+    }
+
+    this.writeOffset = (this.writeOffset + bytes.byteLength) % this.maxBytes;
+    this.retainedByteLength += bytes.byteLength;
+    if (this.retainedByteLength > this.maxBytes) {
+      this.retainedByteLength = this.maxBytes;
+      this.truncated = true;
+    }
+  }
+
+  get byteLength(): number {
+    return this.retainedByteLength;
+  }
+
+  get wasTruncated(): boolean {
+    return this.truncated;
+  }
+
+  clear(): void {
+    this.storage = undefined;
+    this.writeOffset = 0;
+    this.retainedByteLength = 0;
+    this.truncated = false;
+  }
+
+  toString(): string {
+    if (this.retainedByteLength === 0) {
+      return this.truncated ? OUTPUT_TRUNCATION_MARKER.trimEnd() : "";
+    }
+
+    if (!this.storage) {
+      return this.truncated ? OUTPUT_TRUNCATION_MARKER.trimEnd() : "";
+    }
+
+    let retainedBytes: Buffer;
+    if (this.retainedByteLength < this.maxBytes) {
+      retainedBytes = this.storage.subarray(0, this.retainedByteLength);
+    } else if (this.writeOffset === 0) {
+      retainedBytes = this.storage;
+    } else {
+      retainedBytes = Buffer.allocUnsafe(this.retainedByteLength);
+      const endByteLength = this.maxBytes - this.writeOffset;
+      this.storage.copy(retainedBytes, 0, this.writeOffset, this.maxBytes);
+      this.storage.copy(retainedBytes, endByteLength, 0, this.writeOffset);
+    }
+
+    // If eviction bisected a multi-byte UTF-8 character, discard the leading
+    // continuation bytes rather than returning a replacement character.
+    let start = 0;
+    if (this.truncated) {
+      while (
+        start < retainedBytes.byteLength &&
+        (retainedBytes[start] & 0xc0) === 0x80
+      ) {
+        start += 1;
+      }
+    }
+
+    const output = retainedBytes.subarray(start).toString("utf8");
+    return this.truncated ? OUTPUT_TRUNCATION_MARKER + output : output;
+  }
+}

--- a/src/ipc/utils/buffered_process.test.ts
+++ b/src/ipc/utils/buffered_process.test.ts
@@ -176,6 +176,7 @@ describe("runBufferedProcess", () => {
     await vi.advanceTimersByTimeAsync(BUFFERED_PROCESS_FORCE_KILL_GRACE_MS);
     await expect(promise).resolves.toMatchObject({
       code: null,
+      signal: "SIGKILL",
       timedOut: true,
     });
     expect(treeKillMock).toHaveBeenLastCalledWith(

--- a/src/ipc/utils/buffered_process.test.ts
+++ b/src/ipc/utils/buffered_process.test.ts
@@ -1,0 +1,264 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import type { ChildProcess } from "node:child_process";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  BUFFERED_PROCESS_FORCE_KILL_GRACE_MS,
+  BufferedProcessSpawnError,
+  runBufferedProcess,
+} from "./buffered_process";
+import { OUTPUT_TRUNCATION_MARKER } from "./bounded_output_buffer";
+
+const { spawnMock, treeKillMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
+  treeKillMock: vi.fn(),
+}));
+
+vi.mock("node:child_process", async () => {
+  const actual =
+    await vi.importActual<typeof import("node:child_process")>(
+      "node:child_process",
+    );
+  return {
+    ...actual,
+    default: {
+      ...(("default" in actual ? actual.default : actual) as Record<
+        string,
+        unknown
+      >),
+      spawn: spawnMock,
+    },
+    spawn: spawnMock,
+  };
+});
+
+vi.mock("tree-kill", () => ({
+  default: treeKillMock,
+}));
+
+interface MockChildController {
+  child: ChildProcess;
+  stdout: PassThrough;
+  stderr: PassThrough;
+  kill: ReturnType<typeof vi.fn>;
+  close(code: number | null, signal?: NodeJS.Signals | null): void;
+  error(error: Error): void;
+}
+
+function createMockChildController(): MockChildController {
+  const child = new EventEmitter() as ChildProcess;
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  const stdin = new PassThrough();
+  const kill = vi.fn(() => true);
+
+  Object.assign(child, {
+    pid: 4321,
+    stdin,
+    stdout,
+    stderr,
+    kill,
+  });
+
+  return {
+    child,
+    stdout,
+    stderr,
+    kill,
+    close(code, signal = null) {
+      child.emit("close", code, signal);
+    },
+    error(error) {
+      child.emit("error", error);
+    },
+  };
+}
+
+describe("runBufferedProcess", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+    treeKillMock.mockImplementation(
+      (_pid: number, _signal: string, callback: (error?: Error) => void) =>
+        callback(),
+    );
+  });
+
+  it("enforces independent byte budgets for stdout and stderr", async () => {
+    const controller = createMockChildController();
+    spawnMock.mockReturnValue(controller.child);
+
+    const promise = runBufferedProcess({
+      command: "npm test",
+      cwd: "/tmp/app",
+      maxOutputBytes: 8,
+    });
+
+    controller.stdout.emit("data", Buffer.from("old-stdout-TAILOUT"));
+    controller.stderr.emit("data", Buffer.from("old-stderr-TAILERR"));
+    controller.close(1);
+
+    await expect(promise).resolves.toMatchObject({
+      code: 1,
+      stdout: OUTPUT_TRUNCATION_MARKER + "-TAILOUT",
+      stderr: OUTPUT_TRUNCATION_MARKER + "-TAILERR",
+    });
+  });
+
+  it("decodes split multi-byte chunks for callbacks and returned output", async () => {
+    const controller = createMockChildController();
+    spawnMock.mockReturnValue(controller.child);
+    const onStdout = vi.fn();
+    const encoded = Buffer.from("before 🙂 after");
+
+    const promise = runBufferedProcess({
+      command: "npm test",
+      cwd: "/tmp/app",
+      onStdout,
+    });
+
+    controller.stdout.emit("data", encoded.subarray(0, 9));
+    controller.stdout.emit("data", encoded.subarray(9, 11));
+    controller.stdout.emit("data", encoded.subarray(11));
+    controller.close(0);
+
+    await expect(promise).resolves.toMatchObject({
+      stdout: "before 🙂 after",
+    });
+    expect(onStdout.mock.calls.map(([chunk]) => chunk).join("")).toBe(
+      "before 🙂 after",
+    );
+  });
+
+  it("does not decode retained logs when successful output is unused", async () => {
+    const controller = createMockChildController();
+    spawnMock.mockReturnValue(controller.child);
+
+    const promise = runBufferedProcess({
+      command: "npm test",
+      cwd: "/tmp/app",
+      captureOutputOnSuccess: false,
+    });
+
+    controller.stdout.emit("data", Buffer.from("successful output"));
+    controller.stderr.emit("data", Buffer.from("warning output"));
+    controller.close(0);
+
+    await expect(promise).resolves.toMatchObject({
+      code: 0,
+      stdout: "",
+      stderr: "",
+    });
+  });
+
+  it("tree-kills timed-out commands and removes every listener", async () => {
+    vi.useFakeTimers();
+    const controller = createMockChildController();
+    spawnMock.mockReturnValue(controller.child);
+
+    const promise = runBufferedProcess({
+      command: "npm test",
+      cwd: "/tmp/app",
+      timeoutMs: 25,
+    });
+
+    await vi.advanceTimersByTimeAsync(25);
+    expect(treeKillMock).toHaveBeenCalledWith(
+      4321,
+      "SIGTERM",
+      expect.any(Function),
+    );
+
+    await vi.advanceTimersByTimeAsync(BUFFERED_PROCESS_FORCE_KILL_GRACE_MS);
+    await expect(promise).resolves.toMatchObject({
+      code: null,
+      timedOut: true,
+    });
+    expect(treeKillMock).toHaveBeenLastCalledWith(
+      4321,
+      "SIGKILL",
+      expect.any(Function),
+    );
+    expect(controller.stdout.listenerCount("data")).toBe(0);
+    expect(controller.stderr.listenerCount("data")).toBe(0);
+    expect(controller.child.listenerCount("close")).toBe(0);
+    expect(controller.child.listenerCount("error")).toBe(0);
+  });
+
+  it("aborts a running process and unregisters the AbortSignal listener", async () => {
+    vi.useFakeTimers();
+    const controller = createMockChildController();
+    spawnMock.mockReturnValue(controller.child);
+    const abortController = new AbortController();
+    const removeEventListener = vi.spyOn(
+      abortController.signal,
+      "removeEventListener",
+    );
+
+    const promise = runBufferedProcess({
+      command: "npm test",
+      cwd: "/tmp/app",
+      signal: abortController.signal,
+    });
+
+    abortController.abort();
+    controller.close(null, "SIGTERM");
+
+    await expect(promise).resolves.toMatchObject({
+      aborted: true,
+      signal: "SIGTERM",
+    });
+    expect(removeEventListener).toHaveBeenCalledWith(
+      "abort",
+      expect.any(Function),
+    );
+  });
+
+  it("includes bounded stdout and stderr when spawning fails", async () => {
+    const controller = createMockChildController();
+    spawnMock.mockReturnValue(controller.child);
+
+    const promise = runBufferedProcess({
+      command: "npm test",
+      cwd: "/tmp/app",
+      maxOutputBytes: 8,
+    });
+
+    controller.stdout.emit("data", Buffer.from("stdout tail"));
+    controller.stderr.emit("data", Buffer.from("stderr tail"));
+    controller.error(new Error("spawn failed"));
+
+    await expect(promise).rejects.toMatchObject({
+      message: "spawn failed",
+      name: "BufferedProcessSpawnError",
+      stdout: OUTPUT_TRUNCATION_MARKER + "out tail",
+      stderr: OUTPUT_TRUNCATION_MARKER + "err tail",
+    } satisfies Partial<BufferedProcessSpawnError>);
+  });
+
+  it("kills the child and rejects when an output callback throws", async () => {
+    const controller = createMockChildController();
+    spawnMock.mockReturnValue(controller.child);
+
+    const promise = runBufferedProcess({
+      command: "npm test",
+      cwd: "/tmp/app",
+      onStdout: () => {
+        throw new Error("output callback failed");
+      },
+    });
+
+    controller.stdout.emit("data", Buffer.from("some output"));
+
+    await expect(promise).rejects.toMatchObject({
+      message: "output callback failed",
+      stdout: "some output",
+    } satisfies Partial<BufferedProcessSpawnError>);
+    expect(treeKillMock).toHaveBeenCalledWith(
+      4321,
+      "SIGKILL",
+      expect.any(Function),
+    );
+    expect(controller.stdout.listenerCount("data")).toBe(0);
+  });
+});

--- a/src/ipc/utils/buffered_process.test.ts
+++ b/src/ipc/utils/buffered_process.test.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
+import { StringDecoder } from "node:string_decoder";
 import type { ChildProcess } from "node:child_process";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -133,6 +134,7 @@ describe("runBufferedProcess", () => {
   it("does not decode retained logs when successful output is unused", async () => {
     const controller = createMockChildController();
     spawnMock.mockReturnValue(controller.child);
+    const decoderWriteSpy = vi.spyOn(StringDecoder.prototype, "write");
 
     const promise = runBufferedProcess({
       command: "npm test",
@@ -149,6 +151,8 @@ describe("runBufferedProcess", () => {
       stdout: "",
       stderr: "",
     });
+    expect(decoderWriteSpy).not.toHaveBeenCalled();
+    decoderWriteSpy.mockRestore();
   });
 
   it("tree-kills timed-out commands and removes every listener", async () => {

--- a/src/ipc/utils/buffered_process.ts
+++ b/src/ipc/utils/buffered_process.ts
@@ -82,8 +82,12 @@ export async function runBufferedProcess(
   return new Promise<BufferedProcessResult>((resolve, reject) => {
     const stdoutBuffer = new BoundedOutputBuffer(maxOutputBytes);
     const stderrBuffer = new BoundedOutputBuffer(maxOutputBytes);
-    const stdoutDecoder = new StringDecoder("utf8");
-    const stderrDecoder = new StringDecoder("utf8");
+    const stdoutDecoder = options.onStdout
+      ? new StringDecoder("utf8")
+      : undefined;
+    const stderrDecoder = options.onStderr
+      ? new StringDecoder("utf8")
+      : undefined;
 
     let child: ChildProcess;
     try {
@@ -202,24 +206,30 @@ export async function runBufferedProcess(
     function handleStdout(chunk: unknown) {
       const bytes = toBuffer(chunk);
       stdoutBuffer.append(bytes);
-      const decoded = stdoutDecoder.write(bytes);
-      invokeOutputCallback(options.onStdout, decoded);
+      if (stdoutDecoder) {
+        invokeOutputCallback(options.onStdout, stdoutDecoder.write(bytes));
+      }
     }
 
     function handleStderr(chunk: unknown) {
       const bytes = toBuffer(chunk);
       stderrBuffer.append(bytes);
-      const decoded = stderrDecoder.write(bytes);
-      invokeOutputCallback(options.onStderr, decoded);
+      if (stderrDecoder) {
+        invokeOutputCallback(options.onStderr, stderrDecoder.write(bytes));
+      }
     }
 
     function handleClose(code: number | null, signal: NodeJS.Signals | null) {
-      const stdoutRemainder = stdoutDecoder.end();
-      if (!invokeOutputCallback(options.onStdout, stdoutRemainder)) {
+      if (
+        stdoutDecoder &&
+        !invokeOutputCallback(options.onStdout, stdoutDecoder.end())
+      ) {
         return;
       }
-      const stderrRemainder = stderrDecoder.end();
-      if (!invokeOutputCallback(options.onStderr, stderrRemainder)) {
+      if (
+        stderrDecoder &&
+        !invokeOutputCallback(options.onStderr, stderrDecoder.end())
+      ) {
         return;
       }
       finish(code, signal);

--- a/src/ipc/utils/buffered_process.ts
+++ b/src/ipc/utils/buffered_process.ts
@@ -1,0 +1,254 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { StringDecoder } from "node:string_decoder";
+import treeKill from "tree-kill";
+import {
+  BoundedOutputBuffer,
+  DEFAULT_MAX_BUFFERED_OUTPUT_BYTES,
+} from "./bounded_output_buffer";
+
+export const DEFAULT_BUFFERED_PROCESS_TIMEOUT_MS = 10 * 60 * 1000;
+export const BUFFERED_PROCESS_FORCE_KILL_GRACE_MS = 5_000;
+
+export interface BufferedProcessOptions {
+  command: string;
+  cwd: string;
+  env?: NodeJS.ProcessEnv;
+  shell?: boolean;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  maxOutputBytes?: number;
+  captureOutputOnSuccess?: boolean;
+  onStdout?: (chunk: string, child: ChildProcess) => void;
+  onStderr?: (chunk: string, child: ChildProcess) => void;
+}
+
+export interface BufferedProcessResult {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+  aborted: boolean;
+  timedOut: boolean;
+}
+
+export class BufferedProcessSpawnError extends Error {
+  readonly stdout: string;
+  readonly stderr: string;
+
+  constructor(message: string, stdout: string, stderr: string) {
+    super(message);
+    this.name = "BufferedProcessSpawnError";
+    this.stdout = stdout;
+    this.stderr = stderr;
+  }
+}
+
+function toBuffer(chunk: unknown): Buffer {
+  if (Buffer.isBuffer(chunk)) {
+    return chunk;
+  }
+  if (typeof chunk === "string") {
+    return Buffer.from(chunk);
+  }
+  if (chunk instanceof Uint8Array) {
+    return Buffer.from(chunk);
+  }
+  return Buffer.from(String(chunk));
+}
+
+/**
+ * Runs a piped child process with independent byte budgets for stdout and
+ * stderr. Timeout and abort paths terminate the entire process tree and all
+ * listeners are removed as soon as the promise settles.
+ */
+export async function runBufferedProcess(
+  options: BufferedProcessOptions,
+): Promise<BufferedProcessResult> {
+  if (options.signal?.aborted) {
+    return {
+      code: null,
+      signal: null,
+      stdout: "",
+      stderr: "",
+      aborted: true,
+      timedOut: false,
+    };
+  }
+
+  const maxOutputBytes =
+    options.maxOutputBytes ?? DEFAULT_MAX_BUFFERED_OUTPUT_BYTES;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_BUFFERED_PROCESS_TIMEOUT_MS;
+
+  return new Promise<BufferedProcessResult>((resolve, reject) => {
+    const stdoutBuffer = new BoundedOutputBuffer(maxOutputBytes);
+    const stderrBuffer = new BoundedOutputBuffer(maxOutputBytes);
+    const stdoutDecoder = new StringDecoder("utf8");
+    const stderrDecoder = new StringDecoder("utf8");
+
+    let child: ChildProcess;
+    try {
+      child = spawn(options.command, {
+        cwd: options.cwd,
+        shell: options.shell ?? true,
+        stdio: "pipe",
+        env: options.env,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      reject(new BufferedProcessSpawnError(message, "", ""));
+      return;
+    }
+
+    let settled = false;
+    let aborted = false;
+    let timedOut = false;
+    let timeoutId: NodeJS.Timeout | undefined;
+    let forceKillId: NodeJS.Timeout | undefined;
+
+    const snapshotOutput = (capture: boolean) => {
+      const stdout = capture ? stdoutBuffer.toString() : "";
+      const stderr = capture ? stderrBuffer.toString() : "";
+      stdoutBuffer.clear();
+      stderrBuffer.clear();
+      return { stdout, stderr };
+    };
+
+    const cleanup = () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+      if (forceKillId) {
+        clearTimeout(forceKillId);
+      }
+      options.signal?.removeEventListener("abort", handleAbort);
+      child.stdout?.off("data", handleStdout);
+      child.stderr?.off("data", handleStderr);
+      child.off("close", handleClose);
+      child.off("error", handleError);
+    };
+
+    const finish = (code: number | null, signal: NodeJS.Signals | null) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      const succeeded = code === 0 && !aborted && !timedOut;
+      const output = snapshotOutput(
+        !succeeded || options.captureOutputOnSuccess !== false,
+      );
+      resolve({ code, signal, ...output, aborted, timedOut });
+    };
+
+    const fail = (error: Error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      const { stdout, stderr } = snapshotOutput(true);
+      reject(new BufferedProcessSpawnError(error.message, stdout, stderr));
+    };
+
+    const terminate = (signal: "SIGTERM" | "SIGKILL") => {
+      if (child.pid) {
+        treeKill(child.pid, signal, (error) => {
+          if (error && !child.killed) {
+            try {
+              child.kill(signal);
+            } catch {
+              // Best effort. The force-kill fallback will still settle.
+            }
+          }
+        });
+        return;
+      }
+
+      try {
+        child.kill(signal);
+      } catch {
+        // Best effort. The force-kill fallback will still settle.
+      }
+    };
+
+    const requestTermination = () => {
+      terminate("SIGTERM");
+      forceKillId = setTimeout(() => {
+        terminate("SIGKILL");
+        finish(null, null);
+      }, BUFFERED_PROCESS_FORCE_KILL_GRACE_MS);
+    };
+
+    const invokeOutputCallback = (
+      callback: BufferedProcessOptions["onStdout"],
+      decoded: string,
+    ): boolean => {
+      if (!decoded || !callback) {
+        return true;
+      }
+
+      try {
+        callback(decoded, child);
+        return true;
+      } catch (error) {
+        // A callback failure must not escape an EventEmitter listener and
+        // crash the main process while leaving the child running.
+        terminate("SIGKILL");
+        fail(error instanceof Error ? error : new Error(String(error)));
+        return false;
+      }
+    };
+
+    function handleStdout(chunk: unknown) {
+      const bytes = toBuffer(chunk);
+      stdoutBuffer.append(bytes);
+      const decoded = stdoutDecoder.write(bytes);
+      invokeOutputCallback(options.onStdout, decoded);
+    }
+
+    function handleStderr(chunk: unknown) {
+      const bytes = toBuffer(chunk);
+      stderrBuffer.append(bytes);
+      const decoded = stderrDecoder.write(bytes);
+      invokeOutputCallback(options.onStderr, decoded);
+    }
+
+    function handleClose(code: number | null, signal: NodeJS.Signals | null) {
+      const stdoutRemainder = stdoutDecoder.end();
+      if (!invokeOutputCallback(options.onStdout, stdoutRemainder)) {
+        return;
+      }
+      const stderrRemainder = stderrDecoder.end();
+      if (!invokeOutputCallback(options.onStderr, stderrRemainder)) {
+        return;
+      }
+      finish(code, signal);
+    }
+
+    function handleError(error: Error) {
+      fail(error);
+    }
+
+    function handleAbort() {
+      if (settled || aborted || timedOut) {
+        return;
+      }
+      aborted = true;
+      requestTermination();
+    }
+
+    child.stdout?.on("data", handleStdout);
+    child.stderr?.on("data", handleStderr);
+    child.once("close", handleClose);
+    child.once("error", handleError);
+
+    options.signal?.addEventListener("abort", handleAbort, { once: true });
+    timeoutId = setTimeout(() => {
+      if (settled || aborted) {
+        return;
+      }
+      timedOut = true;
+      requestTermination();
+    }, timeoutMs);
+  });
+}

--- a/src/ipc/utils/buffered_process.ts
+++ b/src/ipc/utils/buffered_process.ts
@@ -179,7 +179,7 @@ export async function runBufferedProcess(
       terminate("SIGTERM");
       forceKillId = setTimeout(() => {
         terminate("SIGKILL");
-        finish(null, null);
+        finish(null, "SIGKILL");
       }, BUFFERED_PROCESS_FORCE_KILL_GRACE_MS);
     };
 

--- a/src/ipc/utils/portal_migration.test.ts
+++ b/src/ipc/utils/portal_migration.test.ts
@@ -1,5 +1,6 @@
 import type { ChildProcess } from "node:child_process";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DyadErrorKind } from "@/errors/dyad_error";
 import { BufferedProcessSpawnError } from "./buffered_process";
 import { runPortalMigrationCommand } from "./portal_migration";
 
@@ -88,9 +89,11 @@ describe("runPortalMigrationCommand", () => {
 
     await expect(
       runPortalMigrationCommand({ appId: 7, appPath: "/tmp/app" }),
-    ).rejects.toThrow(
-      "Migration creation failed (exit code 2)\n\nstdout tail\n\nErrors/Warnings:\nstderr tail",
-    );
+    ).rejects.toMatchObject({
+      kind: DyadErrorKind.External,
+      message:
+        "Migration creation failed (exit code 2)\n\nstdout tail\n\nErrors/Warnings:\nstderr tail",
+    });
 
     runBufferedProcessMock.mockResolvedValueOnce({
       code: null,
@@ -107,9 +110,28 @@ describe("runPortalMigrationCommand", () => {
         appPath: "/tmp/app",
         timeoutMs: 25,
       }),
-    ).rejects.toThrow(
-      "Migration creation timed out after 25 ms\n\ntimeout tail",
-    );
+    ).rejects.toMatchObject({
+      kind: DyadErrorKind.External,
+      message: "Migration creation timed out after 25 ms\n\ntimeout tail",
+    });
+  });
+
+  it("classifies a successful no-op migration as a precondition failure", async () => {
+    runBufferedProcessMock.mockResolvedValue({
+      code: 0,
+      signal: null,
+      stdout: "No schema changes",
+      stderr: "",
+      aborted: false,
+      timedOut: false,
+    });
+
+    await expect(
+      runPortalMigrationCommand({ appId: 7, appPath: "/tmp/app" }),
+    ).rejects.toMatchObject({
+      kind: DyadErrorKind.Precondition,
+      message: "No migration was created because no changes were found.",
+    });
   });
 
   it("preserves bounded output when the migration process cannot spawn", async () => {
@@ -123,8 +145,10 @@ describe("runPortalMigrationCommand", () => {
 
     await expect(
       runPortalMigrationCommand({ appId: 7, appPath: "/tmp/app" }),
-    ).rejects.toThrow(
-      "Failed to run migration command: ENOENT\n\nOutput:\nbounded stdout\n\nErrors:\nbounded stderr",
-    );
+    ).rejects.toMatchObject({
+      kind: DyadErrorKind.External,
+      message:
+        "Failed to run migration command: ENOENT\n\nOutput:\nbounded stdout\n\nErrors:\nbounded stderr",
+    });
   });
 });

--- a/src/ipc/utils/portal_migration.test.ts
+++ b/src/ipc/utils/portal_migration.test.ts
@@ -39,7 +39,7 @@ describe("runPortalMigrationCommand", () => {
     vi.clearAllMocks();
   });
 
-  it("recognizes split status messages and answers the rename prompt once", async () => {
+  it("answers each rename prompt exactly once, including split ones", async () => {
     const write = vi.fn();
     const child = {
       pid: 123,
@@ -66,7 +66,9 @@ describe("runPortalMigrationCommand", () => {
     ).resolves.toBe(
       "bounded stdout tail\n\nErrors/Warnings:\nbounded warning tail",
     );
-    expect(write).toHaveBeenCalledTimes(1);
+    // One answer for the prompt split across chunks and one for the second
+    // prompt; the tail overlap must not re-answer the first prompt.
+    expect(write).toHaveBeenCalledTimes(2);
     expect(write).toHaveBeenCalledWith("\r\n");
     expect(runBufferedProcessMock).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/ipc/utils/portal_migration.test.ts
+++ b/src/ipc/utils/portal_migration.test.ts
@@ -1,0 +1,130 @@
+import type { ChildProcess } from "node:child_process";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { BufferedProcessSpawnError } from "./buffered_process";
+import { runPortalMigrationCommand } from "./portal_migration";
+
+const { logger, runBufferedProcessMock } = vi.hoisted(() => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+  runBufferedProcessMock: vi.fn(),
+}));
+
+vi.mock("electron-log", () => ({
+  default: {
+    scope: () => logger,
+  },
+}));
+
+vi.mock("./socket_firewall", () => ({
+  getPackageManagerCommandEnv: () => ({ PATH: "/managed" }),
+}));
+
+vi.mock("./buffered_process", async () => {
+  const actual =
+    await vi.importActual<typeof import("./buffered_process")>(
+      "./buffered_process",
+    );
+  return {
+    ...actual,
+    runBufferedProcess: runBufferedProcessMock,
+  };
+});
+
+describe("runPortalMigrationCommand", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("recognizes split status messages and answers the rename prompt once", async () => {
+    const write = vi.fn();
+    const child = {
+      pid: 123,
+      stdin: { write },
+    } as unknown as ChildProcess;
+
+    runBufferedProcessMock.mockImplementation(async (options) => {
+      options.onStdout?.("Migration crea", child);
+      options.onStdout?.("ted at drizzle/0001.sql\ncreated or renamed ", child);
+      options.onStdout?.("from another\n", child);
+      options.onStdout?.("created or renamed from another\n", child);
+      return {
+        code: 0,
+        signal: null,
+        stdout: "bounded stdout tail",
+        stderr: "bounded warning tail",
+        aborted: false,
+        timedOut: false,
+      };
+    });
+
+    await expect(
+      runPortalMigrationCommand({ appId: 7, appPath: "/tmp/app" }),
+    ).resolves.toBe(
+      "bounded stdout tail\n\nErrors/Warnings:\nbounded warning tail",
+    );
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(write).toHaveBeenCalledWith("\r\n");
+    expect(runBufferedProcessMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: "npm run migrate:create -- --skip-empty",
+        cwd: "/tmp/app",
+        env: { PATH: "/managed" },
+      }),
+    );
+  });
+
+  it("returns useful bounded tails in exit and timeout failures", async () => {
+    runBufferedProcessMock.mockResolvedValueOnce({
+      code: 2,
+      signal: null,
+      stdout: "stdout tail",
+      stderr: "stderr tail",
+      aborted: false,
+      timedOut: false,
+    });
+
+    await expect(
+      runPortalMigrationCommand({ appId: 7, appPath: "/tmp/app" }),
+    ).rejects.toThrow(
+      "Migration creation failed (exit code 2)\n\nstdout tail\n\nErrors/Warnings:\nstderr tail",
+    );
+
+    runBufferedProcessMock.mockResolvedValueOnce({
+      code: null,
+      signal: null,
+      stdout: "timeout tail",
+      stderr: "",
+      aborted: false,
+      timedOut: true,
+    });
+
+    await expect(
+      runPortalMigrationCommand({
+        appId: 7,
+        appPath: "/tmp/app",
+        timeoutMs: 25,
+      }),
+    ).rejects.toThrow(
+      "Migration creation timed out after 25 ms\n\ntimeout tail",
+    );
+  });
+
+  it("preserves bounded output when the migration process cannot spawn", async () => {
+    runBufferedProcessMock.mockRejectedValue(
+      new BufferedProcessSpawnError(
+        "ENOENT",
+        "bounded stdout",
+        "bounded stderr",
+      ),
+    );
+
+    await expect(
+      runPortalMigrationCommand({ appId: 7, appPath: "/tmp/app" }),
+    ).rejects.toThrow(
+      "Failed to run migration command: ENOENT\n\nOutput:\nbounded stdout\n\nErrors:\nbounded stderr",
+    );
+  });
+});

--- a/src/ipc/utils/portal_migration.ts
+++ b/src/ipc/utils/portal_migration.ts
@@ -26,7 +26,6 @@ export async function runPortalMigrationCommand({
   logger.info(`Running migrate:create for app ${appId} at ${appPath}`);
 
   let createdMigration = false;
-  let respondedToRenamePrompt = false;
   let stdoutSearchTail = "";
 
   let result;
@@ -43,14 +42,21 @@ export async function runPortalMigrationCommand({
           MIGRATION_CREATED_MESSAGE,
         );
 
-        if (
-          !respondedToRenamePrompt &&
-          searchableOutput.includes(MIGRATION_RENAME_PROMPT)
-        ) {
-          child.stdin?.write("\r\n");
-          respondedToRenamePrompt = true;
-          logger.info(
-            `App ${appId} (PID: ${child.pid}) wrote enter to stdin to automatically respond to drizzle migrate input`,
+        // Drizzle prompts once per ambiguous rename, so answer every
+        // occurrence. Skip matches that end inside the carried-over tail:
+        // those were already answered when they first streamed in.
+        let promptIndex = searchableOutput.indexOf(MIGRATION_RENAME_PROMPT);
+        while (promptIndex !== -1) {
+          const promptEnd = promptIndex + MIGRATION_RENAME_PROMPT.length;
+          if (promptEnd > stdoutSearchTail.length) {
+            child.stdin?.write("\r\n");
+            logger.info(
+              `App ${appId} (PID: ${child.pid}) wrote enter to stdin to automatically respond to drizzle migrate input`,
+            );
+          }
+          promptIndex = searchableOutput.indexOf(
+            MIGRATION_RENAME_PROMPT,
+            promptEnd,
           );
         }
 

--- a/src/ipc/utils/portal_migration.ts
+++ b/src/ipc/utils/portal_migration.ts
@@ -1,0 +1,104 @@
+import log from "electron-log";
+import {
+  BufferedProcessSpawnError,
+  DEFAULT_BUFFERED_PROCESS_TIMEOUT_MS,
+  runBufferedProcess,
+} from "./buffered_process";
+import { getPackageManagerCommandEnv } from "./socket_firewall";
+
+const logger = log.scope("portal_migration");
+const MIGRATION_CREATED_MESSAGE = "Migration created at";
+const MIGRATION_RENAME_PROMPT = "created or renamed from another";
+const MIGRATION_SEARCH_TAIL_LENGTH =
+  Math.max(MIGRATION_CREATED_MESSAGE.length, MIGRATION_RENAME_PROMPT.length) -
+  1;
+
+export async function runPortalMigrationCommand({
+  appId,
+  appPath,
+  timeoutMs = DEFAULT_BUFFERED_PROCESS_TIMEOUT_MS,
+}: {
+  appId: number;
+  appPath: string;
+  timeoutMs?: number;
+}): Promise<string> {
+  logger.info(`Running migrate:create for app ${appId} at ${appPath}`);
+
+  let createdMigration = false;
+  let respondedToRenamePrompt = false;
+  let stdoutSearchTail = "";
+
+  let result;
+  try {
+    result = await runBufferedProcess({
+      command: "npm run migrate:create -- --skip-empty",
+      cwd: appPath,
+      env: getPackageManagerCommandEnv(),
+      timeoutMs,
+      onStdout: (output, child) => {
+        logger.info(`migrate:create stdout: ${output}`);
+        const searchableOutput = stdoutSearchTail + output;
+        createdMigration ||= searchableOutput.includes(
+          MIGRATION_CREATED_MESSAGE,
+        );
+
+        if (
+          !respondedToRenamePrompt &&
+          searchableOutput.includes(MIGRATION_RENAME_PROMPT)
+        ) {
+          child.stdin?.write("\r\n");
+          respondedToRenamePrompt = true;
+          logger.info(
+            `App ${appId} (PID: ${child.pid}) wrote enter to stdin to automatically respond to drizzle migrate input`,
+          );
+        }
+
+        stdoutSearchTail = searchableOutput.slice(
+          -MIGRATION_SEARCH_TAIL_LENGTH,
+        );
+      },
+      onStderr: (output) => {
+        logger.warn(`migrate:create stderr: ${output}`);
+      },
+    });
+  } catch (error) {
+    if (error instanceof BufferedProcessSpawnError) {
+      logger.error(`Failed to spawn migrate:create for app ${appId}:`, error);
+      throw new Error(
+        `Failed to run migration command: ${error.message}\n\nOutput:\n${error.stdout}\n\nErrors:\n${error.stderr}`,
+      );
+    }
+    throw error;
+  }
+
+  const combinedOutput =
+    result.stdout +
+    (result.stderr ? `\n\nErrors/Warnings:\n${result.stderr}` : "");
+
+  if (result.timedOut) {
+    logger.error(`migrate:create timed out for app ${appId}`);
+    throw new Error(
+      `Migration creation timed out after ${timeoutMs} ms\n\n${combinedOutput}`,
+    );
+  }
+
+  if (result.code === 0) {
+    if (createdMigration) {
+      logger.info(`migrate:create completed successfully for app ${appId}`);
+      return combinedOutput;
+    }
+
+    logger.error(
+      `migrate:create completed successfully for app ${appId} but no migration was created`,
+    );
+    throw new Error("No migration was created because no changes were found.");
+  }
+
+  const failureReason = result.signal
+    ? `signal ${result.signal}`
+    : `exit code ${result.code}`;
+  logger.error(`migrate:create failed for app ${appId} with ${failureReason}`);
+  throw new Error(
+    `Migration creation failed (${failureReason})\n\n${combinedOutput}`,
+  );
+}

--- a/src/ipc/utils/portal_migration.ts
+++ b/src/ipc/utils/portal_migration.ts
@@ -1,4 +1,5 @@
 import log from "electron-log";
+import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
 import {
   BufferedProcessSpawnError,
   DEFAULT_BUFFERED_PROCESS_TIMEOUT_MS,
@@ -64,8 +65,10 @@ export async function runPortalMigrationCommand({
   } catch (error) {
     if (error instanceof BufferedProcessSpawnError) {
       logger.error(`Failed to spawn migrate:create for app ${appId}:`, error);
-      throw new Error(
+      throw new DyadError(
         `Failed to run migration command: ${error.message}\n\nOutput:\n${error.stdout}\n\nErrors:\n${error.stderr}`,
+        DyadErrorKind.External,
+        { cause: error },
       );
     }
     throw error;
@@ -77,8 +80,9 @@ export async function runPortalMigrationCommand({
 
   if (result.timedOut) {
     logger.error(`migrate:create timed out for app ${appId}`);
-    throw new Error(
+    throw new DyadError(
       `Migration creation timed out after ${timeoutMs} ms\n\n${combinedOutput}`,
+      DyadErrorKind.External,
     );
   }
 
@@ -91,14 +95,18 @@ export async function runPortalMigrationCommand({
     logger.error(
       `migrate:create completed successfully for app ${appId} but no migration was created`,
     );
-    throw new Error("No migration was created because no changes were found.");
+    throw new DyadError(
+      "No migration was created because no changes were found.",
+      DyadErrorKind.Precondition,
+    );
   }
 
   const failureReason = result.signal
     ? `signal ${result.signal}`
     : `exit code ${result.code}`;
   logger.error(`migrate:create failed for app ${appId} with ${failureReason}`);
-  throw new Error(
+  throw new DyadError(
     `Migration creation failed (${failureReason})\n\n${combinedOutput}`,
+    DyadErrorKind.External,
   );
 }

--- a/src/ipc/utils/pty_command_runner.test.ts
+++ b/src/ipc/utils/pty_command_runner.test.ts
@@ -5,6 +5,7 @@ import {
   PtyCommandExecutionError,
   runPtyCommand,
 } from "./pty_command_runner";
+import { OUTPUT_TRUNCATION_MARKER } from "./bounded_output_buffer";
 
 const { processSpawnMock, spawnMock } = vi.hoisted(() => ({
   processSpawnMock: vi.fn(),
@@ -37,6 +38,8 @@ vi.mock("node-pty", () => ({
 interface MockPtyController {
   emitData(data: string): void;
   emitExit(event: { exitCode: number; signal?: number }): void;
+  dataListenerCount(): number;
+  exitListenerCount(): number;
   pty: {
     pid: number;
     kill: ReturnType<typeof vi.fn>;
@@ -62,6 +65,8 @@ function createMockPtyController(): MockPtyController {
         listener(event);
       }
     },
+    dataListenerCount: () => dataListeners.size,
+    exitListenerCount: () => exitListeners.size,
     pty: {
       pid: 1234,
       kill: vi.fn(),
@@ -167,6 +172,25 @@ describe("runPtyCommand", () => {
     await expect(promise).resolves.toEqual({
       output: "Resolved\nadded 1 package",
     });
+    expect(controller.dataListenerCount()).toBe(0);
+    expect(controller.exitListenerCount()).toBe(0);
+  });
+
+  it("retains only the newest output bytes from noisy commands", async () => {
+    const controller = createMockPtyController();
+    spawnMock.mockReturnValue(controller.pty);
+
+    const promise = runPtyCommand("pnpm", ["install"], {
+      maxOutputBytes: 16,
+    });
+
+    controller.emitData("a".repeat(1_000_000));
+    controller.emitData("0123456789abcdef");
+    controller.emitExit({ exitCode: 1 });
+
+    await expect(promise).rejects.toMatchObject({
+      output: OUTPUT_TRUNCATION_MARKER.trimEnd() + "\n0123456789abcdef",
+    } satisfies Partial<PtyCommandExecutionError>);
   });
 
   it("rejects with the captured output when the PTY exits non-zero", async () => {

--- a/src/ipc/utils/pty_command_runner.test.ts
+++ b/src/ipc/utils/pty_command_runner.test.ts
@@ -210,6 +210,21 @@ describe("runPtyCommand", () => {
     } satisfies Partial<PtyCommandExecutionError>);
   });
 
+  it("recovers after an unterminated OSC sequence reaches a new line", async () => {
+    const controller = createMockPtyController();
+    spawnMock.mockReturnValue(controller.pty);
+
+    const promise = runPtyCommand("pnpm", ["install"]);
+
+    controller.emitData("\u001b]0;unterminated title");
+    controller.emitData("\nvisible failure\n");
+    controller.emitExit({ exitCode: 1 });
+
+    await expect(promise).rejects.toMatchObject({
+      output: "visible failure",
+    } satisfies Partial<PtyCommandExecutionError>);
+  });
+
   it("rejects with the captured output when the PTY exits non-zero", async () => {
     const controller = createMockPtyController();
     spawnMock.mockReturnValue(controller.pty);

--- a/src/ipc/utils/pty_command_runner.test.ts
+++ b/src/ipc/utils/pty_command_runner.test.ts
@@ -193,6 +193,23 @@ describe("runPtyCommand", () => {
     } satisfies Partial<PtyCommandExecutionError>);
   });
 
+  it("strips split ANSI sequences before truncating PTY output", async () => {
+    const controller = createMockPtyController();
+    spawnMock.mockReturnValue(controller.pty);
+
+    const promise = runPtyCommand("pnpm", ["install"], {
+      maxOutputBytes: 10,
+    });
+
+    controller.emitData("1234567890\u001b[38;");
+    controller.emitData("5;123mFAILURE");
+    controller.emitExit({ exitCode: 1 });
+
+    await expect(promise).rejects.toMatchObject({
+      output: OUTPUT_TRUNCATION_MARKER.trimEnd() + "\n890FAILURE",
+    } satisfies Partial<PtyCommandExecutionError>);
+  });
+
   it("rejects with the captured output when the PTY exits non-zero", async () => {
     const controller = createMockPtyController();
     spawnMock.mockReturnValue(controller.pty);

--- a/src/ipc/utils/pty_command_runner.ts
+++ b/src/ipc/utils/pty_command_runner.ts
@@ -1,5 +1,9 @@
 import { spawn as spawnProcess } from "node:child_process";
 import { spawn as spawnPty } from "node-pty";
+import {
+  BoundedOutputBuffer,
+  DEFAULT_MAX_BUFFERED_OUTPUT_BYTES,
+} from "./bounded_output_buffer";
 
 const DEFAULT_PTY_NAME = "xterm-color";
 const DEFAULT_PTY_COLS = 160;
@@ -18,6 +22,7 @@ export interface PtyCommandExecutionOptions {
   rows?: number;
   name?: string;
   displayCommand?: string;
+  maxOutputBytes?: number;
 }
 
 export interface PtyCommandExecutionResult {
@@ -237,7 +242,9 @@ export async function runPtyCommand(
     const displayedCommand =
       options.displayCommand ?? buildDisplayedCommand(command, args);
     const timeoutMs = options.timeoutMs ?? DEFAULT_PTY_COMMAND_TIMEOUT_MS;
-    const outputChunks: string[] = [];
+    const outputBuffer = new BoundedOutputBuffer(
+      options.maxOutputBytes ?? DEFAULT_MAX_BUFFERED_OUTPUT_BYTES,
+    );
     let didSettle = false;
     let timeoutId: NodeJS.Timeout | undefined;
     let dataSubscription: { dispose(): void } = { dispose: () => {} };
@@ -279,14 +286,15 @@ export async function runPtyCommand(
     }
 
     dataSubscription = ptyProcess.onData((chunk) => {
-      outputChunks.push(chunk);
+      outputBuffer.append(chunk);
     });
 
     exitSubscription = ptyProcess.onExit(({ exitCode, signal }) => {
       const failed = exitCode !== 0 || hasSignal(signal);
-      const output = normalizePtyOutput(outputChunks.join(""), {
+      const output = normalizePtyOutput(outputBuffer.toString(), {
         preserveCarriageReturnFrames: failed,
       });
+      outputBuffer.clear();
 
       if (!failed) {
         settle(() => resolve({ output }));
@@ -306,19 +314,14 @@ export async function runPtyCommand(
     });
 
     timeoutId = setTimeout(() => {
-      try {
-        terminatePtyProcess(ptyProcess);
-      } catch {
-        // Best effort only. The timeout error below remains the source of truth.
-      }
-
       const timeoutMessage = buildTimeoutMessage(displayedCommand, timeoutMs);
       const output = appendCommandMessage(
-        normalizePtyOutput(outputChunks.join(""), {
+        normalizePtyOutput(outputBuffer.toString(), {
           preserveCarriageReturnFrames: true,
         }),
         timeoutMessage,
       );
+      outputBuffer.clear();
 
       settle(() =>
         reject(
@@ -328,6 +331,12 @@ export async function runPtyCommand(
           }),
         ),
       );
+
+      try {
+        terminatePtyProcess(ptyProcess);
+      } catch {
+        // Best effort only. The timeout error above remains the source of truth.
+      }
     }, timeoutMs);
   });
 }

--- a/src/ipc/utils/pty_command_runner.ts
+++ b/src/ipc/utils/pty_command_runner.ts
@@ -14,6 +14,91 @@ const ANSI_OSC_PATTERN = /\u001B\][^\u0007]*(?:\u0007|\u001B\\)/g;
 const ANSI_CSI_PATTERN = /(?:\u001B\[|\u009B)[0-?]*[ -/]*[@-~]/g;
 const ANSI_SINGLE_CHAR_PATTERN = /\u001B[@-Z\\-_]/g;
 
+type AnsiParserState = "text" | "escape" | "csi" | "osc" | "osc-escape";
+
+/**
+ * Removes terminal control sequences before output enters the bounded buffer.
+ * The parser state spans PTY chunks so truncation can never expose the middle
+ * of an ANSI sequence as user-visible text.
+ */
+class StreamingAnsiStripper {
+  private state: AnsiParserState = "text";
+
+  write(value: string): string {
+    let output = "";
+    let visibleStart = this.state === "text" ? 0 : -1;
+
+    const enterControlSequence = (
+      index: number,
+      state: Exclude<AnsiParserState, "text">,
+    ) => {
+      if (visibleStart >= 0) {
+        output += value.slice(visibleStart, index);
+      }
+      visibleStart = -1;
+      this.state = state;
+    };
+
+    const resumeText = (nextIndex: number) => {
+      this.state = "text";
+      visibleStart = nextIndex;
+    };
+
+    for (let index = 0; index < value.length; index += 1) {
+      const code = value.charCodeAt(index);
+
+      switch (this.state) {
+        case "text":
+          if (code === 0x1b) {
+            enterControlSequence(index, "escape");
+          } else if (code === 0x9b) {
+            enterControlSequence(index, "csi");
+          }
+          break;
+        case "escape":
+          if (value[index] === "[") {
+            this.state = "csi";
+          } else if (value[index] === "]") {
+            this.state = "osc";
+          } else if (code >= 0x40 && code <= 0x5f) {
+            resumeText(index + 1);
+          } else {
+            // Match normalizePtyOutput's behavior for an unknown escape:
+            // discard ESC but preserve the following visible character.
+            output += value[index];
+            resumeText(index + 1);
+          }
+          break;
+        case "csi":
+          if (code >= 0x40 && code <= 0x7e) {
+            resumeText(index + 1);
+          }
+          break;
+        case "osc":
+          if (code === 0x07) {
+            resumeText(index + 1);
+          } else if (code === 0x1b) {
+            this.state = "osc-escape";
+          }
+          break;
+        case "osc-escape":
+          if (value[index] === "\\") {
+            resumeText(index + 1);
+          } else if (code !== 0x1b) {
+            this.state = "osc";
+          }
+          break;
+      }
+    }
+
+    if (this.state === "text" && visibleStart >= 0) {
+      output += value.slice(visibleStart);
+    }
+
+    return output;
+  }
+}
+
 export interface PtyCommandExecutionOptions {
   cwd?: string;
   env?: NodeJS.ProcessEnv;
@@ -245,6 +330,7 @@ export async function runPtyCommand(
     const outputBuffer = new BoundedOutputBuffer(
       options.maxOutputBytes ?? DEFAULT_MAX_BUFFERED_OUTPUT_BYTES,
     );
+    const ansiStripper = new StreamingAnsiStripper();
     let didSettle = false;
     let timeoutId: NodeJS.Timeout | undefined;
     let dataSubscription: { dispose(): void } = { dispose: () => {} };
@@ -286,7 +372,7 @@ export async function runPtyCommand(
     }
 
     dataSubscription = ptyProcess.onData((chunk) => {
-      outputBuffer.append(chunk);
+      outputBuffer.append(ansiStripper.write(chunk));
     });
 
     exitSubscription = ptyProcess.onExit(({ exitCode, signal }) => {

--- a/src/ipc/utils/pty_command_runner.ts
+++ b/src/ipc/utils/pty_command_runner.ts
@@ -13,6 +13,7 @@ export const DEFAULT_PTY_COMMAND_TIMEOUT_MS = 10 * 60 * 1000;
 const ANSI_OSC_PATTERN = /\u001B\][^\u0007]*(?:\u0007|\u001B\\)/g;
 const ANSI_CSI_PATTERN = /(?:\u001B\[|\u009B)[0-?]*[ -/]*[@-~]/g;
 const ANSI_SINGLE_CHAR_PATTERN = /\u001B[@-Z\\-_]/g;
+const MAX_UNTERMINATED_OSC_CHARACTERS = 8 * 1024;
 
 type AnsiParserState = "text" | "escape" | "csi" | "osc" | "osc-escape";
 
@@ -23,6 +24,7 @@ type AnsiParserState = "text" | "escape" | "csi" | "osc" | "osc-escape";
  */
 class StreamingAnsiStripper {
   private state: AnsiParserState = "text";
+  private oscCharacters = 0;
 
   write(value: string): string {
     let output = "";
@@ -41,6 +43,7 @@ class StreamingAnsiStripper {
 
     const resumeText = (nextIndex: number) => {
       this.state = "text";
+      this.oscCharacters = 0;
       visibleStart = nextIndex;
     };
 
@@ -60,6 +63,7 @@ class StreamingAnsiStripper {
             this.state = "csi";
           } else if (value[index] === "]") {
             this.state = "osc";
+            this.oscCharacters = 0;
           } else if (code >= 0x40 && code <= 0x5f) {
             resumeText(index + 1);
           } else {
@@ -75,14 +79,29 @@ class StreamingAnsiStripper {
           }
           break;
         case "osc":
+          this.oscCharacters += 1;
           if (code === 0x07) {
+            resumeText(index + 1);
+          } else if (code === 0x0a) {
+            // OSC payloads cannot contain line feeds. Recover from malformed
+            // output so an unterminated title sequence cannot hide every
+            // later user-visible error line.
+            resumeText(index + 1);
+          } else if (this.oscCharacters >= MAX_UNTERMINATED_OSC_CHARACTERS) {
+            // Also recover when a producer never emits a line break or OSC
+            // terminator. Discard the bounded malformed prefix and resume.
             resumeText(index + 1);
           } else if (code === 0x1b) {
             this.state = "osc-escape";
           }
           break;
         case "osc-escape":
+          this.oscCharacters += 1;
           if (value[index] === "\\") {
+            resumeText(index + 1);
+          } else if (code === 0x0a) {
+            resumeText(index + 1);
+          } else if (this.oscCharacters >= MAX_UNTERMINATED_OSC_CHARACTERS) {
             resumeText(index + 1);
           } else if (code !== 0x1b) {
             this.state = "osc";

--- a/src/ipc/utils/simpleSpawn.test.ts
+++ b/src/ipc/utils/simpleSpawn.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DyadErrorKind } from "@/errors/dyad_error";
 import {
   BufferedProcessSpawnError,
   DEFAULT_BUFFERED_PROCESS_TIMEOUT_MS,
@@ -83,9 +84,11 @@ describe("simpleSpawn", () => {
       errorPrefix: "build failed",
     });
 
-    await expect(promise).rejects.toThrow(
-      "build failed (exit code 2)\n\nSTDOUT:\nstdout tail\n\nSTDERR:\nstderr tail",
-    );
+    await expect(promise).rejects.toMatchObject({
+      kind: DyadErrorKind.External,
+      message:
+        "build failed (exit code 2)\n\nSTDOUT:\nstdout tail\n\nSTDERR:\nstderr tail",
+    });
   });
 
   it("reports timeout and cancellation distinctly", async () => {
@@ -106,7 +109,12 @@ describe("simpleSpawn", () => {
         errorPrefix: "install failed",
         timeoutMs: 25,
       }),
-    ).rejects.toThrow("install failed (timed out after 25 ms)");
+    ).rejects.toMatchObject({
+      kind: DyadErrorKind.External,
+      message: expect.stringContaining(
+        "install failed (timed out after 25 ms)",
+      ),
+    });
 
     runBufferedProcessMock.mockResolvedValueOnce({
       code: null,
@@ -124,7 +132,10 @@ describe("simpleSpawn", () => {
         successMessage: "installed",
         errorPrefix: "install failed",
       }),
-    ).rejects.toThrow("install failed (was cancelled)");
+    ).rejects.toMatchObject({
+      kind: DyadErrorKind.External,
+      message: expect.stringContaining("install failed (was cancelled)"),
+    });
   });
 
   it("preserves captured output from spawn failures", async () => {
@@ -143,8 +154,10 @@ describe("simpleSpawn", () => {
         successMessage: "done",
         errorPrefix: "failed",
       }),
-    ).rejects.toThrow(
-      "Failed to spawn command: ENOENT\n\nSTDOUT:\nbounded stdout\n\nSTDERR:\nbounded stderr",
-    );
+    ).rejects.toMatchObject({
+      kind: DyadErrorKind.External,
+      message:
+        "Failed to spawn command: ENOENT\n\nSTDOUT:\nbounded stdout\n\nSTDERR:\nbounded stderr",
+    });
   });
 });

--- a/src/ipc/utils/simpleSpawn.test.ts
+++ b/src/ipc/utils/simpleSpawn.test.ts
@@ -133,7 +133,7 @@ describe("simpleSpawn", () => {
         errorPrefix: "install failed",
       }),
     ).rejects.toMatchObject({
-      kind: DyadErrorKind.External,
+      kind: DyadErrorKind.UserCancelled,
       message: expect.stringContaining("install failed (was cancelled)"),
     });
   });

--- a/src/ipc/utils/simpleSpawn.test.ts
+++ b/src/ipc/utils/simpleSpawn.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  BufferedProcessSpawnError,
+  DEFAULT_BUFFERED_PROCESS_TIMEOUT_MS,
+} from "./buffered_process";
+import { simpleSpawn } from "./simpleSpawn";
+
+const { logger, runBufferedProcessMock } = vi.hoisted(() => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+  runBufferedProcessMock: vi.fn(),
+}));
+
+vi.mock("electron-log/main", () => ({
+  default: {
+    scope: () => logger,
+  },
+}));
+
+vi.mock("./socket_firewall", () => ({
+  getPackageManagerCommandEnv: () => ({ PATH: "/managed" }),
+}));
+
+vi.mock("./buffered_process", async () => {
+  const actual =
+    await vi.importActual<typeof import("./buffered_process")>(
+      "./buffered_process",
+    );
+  return {
+    ...actual,
+    runBufferedProcess: runBufferedProcessMock,
+  };
+});
+
+describe("simpleSpawn", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("logs the success message without retaining successful output", async () => {
+    runBufferedProcessMock.mockResolvedValue({
+      code: 0,
+      signal: null,
+      stdout: "",
+      stderr: "",
+      aborted: false,
+      timedOut: false,
+    });
+
+    await simpleSpawn({
+      command: "npm run build",
+      cwd: "/tmp/app",
+      successMessage: "built successfully",
+      errorPrefix: "build failed",
+    });
+
+    expect(runBufferedProcessMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        captureOutputOnSuccess: false,
+        env: { PATH: "/managed" },
+        timeoutMs: DEFAULT_BUFFERED_PROCESS_TIMEOUT_MS,
+      }),
+    );
+    expect(logger.info).toHaveBeenCalledWith("built successfully");
+  });
+
+  it("reports bounded stdout and stderr when a command fails", async () => {
+    runBufferedProcessMock.mockResolvedValue({
+      code: 2,
+      signal: null,
+      stdout: "stdout tail",
+      stderr: "stderr tail",
+      aborted: false,
+      timedOut: false,
+    });
+
+    const promise = simpleSpawn({
+      command: "npm run build",
+      cwd: "/tmp/app",
+      successMessage: "built successfully",
+      errorPrefix: "build failed",
+    });
+
+    await expect(promise).rejects.toThrow(
+      "build failed (exit code 2)\n\nSTDOUT:\nstdout tail\n\nSTDERR:\nstderr tail",
+    );
+  });
+
+  it("reports timeout and cancellation distinctly", async () => {
+    runBufferedProcessMock.mockResolvedValueOnce({
+      code: null,
+      signal: null,
+      stdout: "timeout tail",
+      stderr: "",
+      aborted: false,
+      timedOut: true,
+    });
+
+    await expect(
+      simpleSpawn({
+        command: "npm install",
+        cwd: "/tmp/app",
+        successMessage: "installed",
+        errorPrefix: "install failed",
+        timeoutMs: 25,
+      }),
+    ).rejects.toThrow("install failed (timed out after 25 ms)");
+
+    runBufferedProcessMock.mockResolvedValueOnce({
+      code: null,
+      signal: null,
+      stdout: "",
+      stderr: "",
+      aborted: true,
+      timedOut: false,
+    });
+
+    await expect(
+      simpleSpawn({
+        command: "npm install",
+        cwd: "/tmp/app",
+        successMessage: "installed",
+        errorPrefix: "install failed",
+      }),
+    ).rejects.toThrow("install failed (was cancelled)");
+  });
+
+  it("preserves captured output from spawn failures", async () => {
+    runBufferedProcessMock.mockRejectedValue(
+      new BufferedProcessSpawnError(
+        "ENOENT",
+        "bounded stdout",
+        "bounded stderr",
+      ),
+    );
+
+    await expect(
+      simpleSpawn({
+        command: "missing",
+        cwd: "/tmp/app",
+        successMessage: "done",
+        errorPrefix: "failed",
+      }),
+    ).rejects.toThrow(
+      "Failed to spawn command: ENOENT\n\nSTDOUT:\nbounded stdout\n\nSTDERR:\nbounded stderr",
+    );
+  });
+});

--- a/src/ipc/utils/simpleSpawn.ts
+++ b/src/ipc/utils/simpleSpawn.ts
@@ -77,6 +77,8 @@ export async function simpleSpawn({
   logger.error(`${errorPrefix}, ${failureReason}`);
   throw new DyadError(
     `${errorPrefix} (${failureReason})\n\nSTDOUT:\n${result.stdout}\n\nSTDERR:\n${result.stderr}`,
-    DyadErrorKind.External,
+    // An abort comes from the caller's AbortSignal, so it is not an upstream
+    // failure worth reporting to telemetry.
+    result.aborted ? DyadErrorKind.UserCancelled : DyadErrorKind.External,
   );
 }

--- a/src/ipc/utils/simpleSpawn.ts
+++ b/src/ipc/utils/simpleSpawn.ts
@@ -1,4 +1,5 @@
 import log from "electron-log/main";
+import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
 import {
   BufferedProcessSpawnError,
   DEFAULT_BUFFERED_PROCESS_TIMEOUT_MS,
@@ -48,8 +49,10 @@ export async function simpleSpawn({
   } catch (error) {
     if (error instanceof BufferedProcessSpawnError) {
       logger.error(`Failed to spawn command: ${command}`, error);
-      throw new Error(
+      throw new DyadError(
         `Failed to spawn command: ${error.message}\n\nSTDOUT:\n${error.stdout}\n\nSTDERR:\n${error.stderr}`,
+        DyadErrorKind.External,
+        { cause: error },
       );
     }
     throw error;
@@ -72,7 +75,8 @@ export async function simpleSpawn({
   }
 
   logger.error(`${errorPrefix}, ${failureReason}`);
-  throw new Error(
+  throw new DyadError(
     `${errorPrefix} (${failureReason})\n\nSTDOUT:\n${result.stdout}\n\nSTDERR:\n${result.stderr}`,
+    DyadErrorKind.External,
   );
 }

--- a/src/ipc/utils/simpleSpawn.ts
+++ b/src/ipc/utils/simpleSpawn.ts
@@ -1,5 +1,9 @@
-import { spawn } from "child_process";
 import log from "electron-log/main";
+import {
+  BufferedProcessSpawnError,
+  DEFAULT_BUFFERED_PROCESS_TIMEOUT_MS,
+  runBufferedProcess,
+} from "./buffered_process";
 import { getPackageManagerCommandEnv } from "./socket_firewall";
 
 const logger = log.scope("simpleSpawn");
@@ -10,6 +14,8 @@ export async function simpleSpawn({
   successMessage,
   errorPrefix,
   env,
+  signal,
+  timeoutMs = DEFAULT_BUFFERED_PROCESS_TIMEOUT_MS,
 }: {
   command: string;
   cwd: string;
@@ -19,47 +25,54 @@ export async function simpleSpawn({
   // the managed pnpm and the Corepack project-spec disable without every
   // call site having to remember to pass it.
   env?: NodeJS.ProcessEnv;
+  signal?: AbortSignal;
+  timeoutMs?: number;
 }): Promise<void> {
   const spawnEnv = env ?? getPackageManagerCommandEnv();
-  return new Promise<void>((resolve, reject) => {
-    logger.info(`Running: ${command}`);
-    const process = spawn(command, {
+  logger.info(`Running: ${command}`);
+
+  let result;
+  try {
+    result = await runBufferedProcess({
+      command,
       cwd,
-      shell: true,
-      stdio: "pipe",
       env: spawnEnv,
+      signal,
+      timeoutMs,
+      // The output is only needed for failures. On success, release the
+      // bounded byte buffers without decoding them into additional strings.
+      captureOutputOnSuccess: false,
+      onStdout: (output) => logger.info(output),
+      onStderr: (output) => logger.error(output),
     });
+  } catch (error) {
+    if (error instanceof BufferedProcessSpawnError) {
+      logger.error(`Failed to spawn command: ${command}`, error);
+      throw new Error(
+        `Failed to spawn command: ${error.message}\n\nSTDOUT:\n${error.stdout}\n\nSTDERR:\n${error.stderr}`,
+      );
+    }
+    throw error;
+  }
 
-    let stdout = "";
-    let stderr = "";
+  if (result.code === 0 && !result.aborted && !result.timedOut) {
+    logger.info(successMessage);
+    return;
+  }
 
-    process.stdout?.on("data", (data) => {
-      const output = data.toString();
-      stdout += output;
-      logger.info(output);
-    });
+  let failureReason: string;
+  if (result.timedOut) {
+    failureReason = `timed out after ${timeoutMs} ms`;
+  } else if (result.aborted) {
+    failureReason = "was cancelled";
+  } else if (result.signal) {
+    failureReason = `terminated by signal ${result.signal}`;
+  } else {
+    failureReason = `exit code ${result.code}`;
+  }
 
-    process.stderr?.on("data", (data) => {
-      const output = data.toString();
-      stderr += output;
-      logger.error(output);
-    });
-
-    process.on("close", (code) => {
-      if (code === 0) {
-        logger.info(successMessage);
-        resolve();
-      } else {
-        logger.error(`${errorPrefix}, exit code ${code}`);
-        const errorMessage = `${errorPrefix} (exit code ${code})\n\nSTDOUT:\n${stdout}\n\nSTDERR:\n${stderr}`;
-        reject(new Error(errorMessage));
-      }
-    });
-
-    process.on("error", (err) => {
-      logger.error(`Failed to spawn command: ${command}`, err);
-      const errorMessage = `Failed to spawn command: ${err.message}\n\nSTDOUT:\n${stdout}\n\nSTDERR:\n${stderr}`;
-      reject(new Error(errorMessage));
-    });
-  });
+  logger.error(`${errorPrefix}, ${failureReason}`);
+  throw new Error(
+    `${errorPrefix} (${failureReason})\n\nSTDOUT:\n${result.stdout}\n\nSTDERR:\n${result.stderr}`,
+  );
 }


### PR DESCRIPTION
## Summary

- retain only the newest 256 KB of stdout and stderr with a UTF-8-safe ring buffer
- give simpleSpawn and portal migration commands shared timeout, abort, process-tree termination, and listener cleanup behavior
- bound PTY output and preserve deterministic truncation context in user-facing errors

## Tests

- 28 focused unit tests
- 86 related socket firewall, pnpm migration, and app upgrade tests
- npm run fmt
- npm run lint
- npm run ts
- npm run build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how many Electron main-process commands spawn, time out, and report errors (including DyadError types for simpleSpawn), affecting builds, installs, and database migrations if edge cases regress.
> 
> **Overview**
> Introduces a **UTF-8-safe ring buffer** (default **256 KB** per stream) so stdout/stderr from long-running commands no longer grow without limit, and adds a shared **`runBufferedProcess`** helper with **timeouts**, **`AbortSignal` cancellation**, **process-tree kills** (`tree-kill`), listener cleanup, and bounded tails in errors.
> 
> **`simpleSpawn`** and **`portal:migrate-create`** are refactored onto that helper: migration logic moves to **`runPortalMigrationCommand`**, which still auto-answers Drizzle rename prompts but handles prompts **split across stdout chunks** without double-submitting. Failures now surface as **`DyadError`** (including distinct **UserCancelled** vs external failures for aborts).
> 
> **PTY commands** (`runPtyCommand`) now strip ANSI **while streaming** (including split sequences and bad OSC) before buffering, so truncation keeps readable failure text instead of leaking escape codes or hiding errors behind unterminated title sequences.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2123a9fbae3694e3aa93b56c87a5739dc4f5970d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

