### PR TITLE
fix: bound query and search results to prevent OOM

### DIFF
--- a/rules/local-agent-tools.md
+++ b/rules/local-agent-tools.md
@@ -11,6 +11,7 @@ Agent tool definitions live in `src/pro/main/ipc/handlers/local_agent/tools/`. E
 ## Async I/O
 
 - Use `fs.promises` (not sync `fs` methods) in any code running on the Electron main process (e.g., `todo_persistence.ts`) to avoid blocking the event loop.
+- When a parallel ripgrep search enforces a global cap by killing the process early, the retained subset depends on arrival order; sorting afterward only orders that subset. Tests should assert the cap and truncation notice rather than pinning the exact first match unless the producer itself guarantees ordering.
 
 ## User-visible tool output
 

--- a/rules/local-agent-tools.md
+++ b/rules/local-agent-tools.md
@@ -28,6 +28,7 @@ Agent tool definitions live in `src/pro/main/ipc/handlers/local_agent/tools/`. E
 - When changing `execute_sql` consent metadata or safety checks, audit both Agent mode (`shouldAutoApproveAgentTool` / `executeSqlTool.getConsentMetadata`) and Build mode auto-apply (`chat_stream_handlers.ts` with `autoApproveChanges`). A SQL safety rule only on the Agent tool path can still be bypassed by Build mode global auto-approve.
 - SQL destructive-action classifiers that gate auto-approval must be conservative: incomplete/unparseable SQL, opaque dynamic execution (`DO`/`CALL`), and executing wrappers such as `EXPLAIN ANALYZE` should require consent unless the wrapped statement can be proven safe.
 - Treat prepared-statement execution as opaque for SQL auto-approval too: top-level `PREPARE` can hide the statement body and top-level `EXECUTE` runs a previously prepared statement, so both should require consent unless the classifier can prove the executed statement is safe.
+- When bounding Agent SQL results by wrapping a query in an outer `SELECT ... LIMIT`, include classifier-proven read-only `WITH` queries but exclude data-modifying CTEs. PostgreSQL requires a data-modifying CTE at the top level, so nesting one changes a valid write into an execution error.
 
 ## Stream retries
 

--- a/src/components/AppSearchDialog.tsx
+++ b/src/components/AppSearchDialog.tsx
@@ -9,6 +9,7 @@ import {
 import { useState, useEffect } from "react";
 import { useSearchApps } from "@/hooks/useSearchApps";
 import type { AppSearchResult } from "@/lib/schemas";
+import { MIN_APP_SEARCH_QUERY_LENGTH } from "@/ipc/types";
 
 type AppSearchDialogProps = {
   open: boolean;
@@ -37,10 +38,16 @@ export function AppSearchDialog({
 
   const debouncedQuery = useDebouncedValue(searchQuery, 150);
   const { apps: searchResults } = useSearchApps(debouncedQuery);
+  const searchResultsTruncated = searchResults.some(
+    (result) => result.searchTruncated,
+  );
 
-  // Show all apps if search is empty, otherwise show search results
+  // Keep one-character searches local to app names. Database-wide chat
+  // searches start at two characters to avoid very broad result sets.
   const appsToShow: AppSearchResult[] =
-    debouncedQuery.trim() === "" ? allApps : searchResults;
+    debouncedQuery.trim().length < MIN_APP_SEARCH_QUERY_LENGTH
+      ? allApps
+      : searchResults;
 
   const commandFilter = (
     value: string,
@@ -149,6 +156,14 @@ export function AppSearchDialog({
               </CommandItem>
             );
           })}
+          {searchResultsTruncated && (
+            <div
+              className="px-2 py-1 text-xs text-muted-foreground"
+              role="status"
+            >
+              Showing the first 50 results. Refine your search to see more.
+            </div>
+          )}
         </CommandGroup>
       </CommandList>
     </CommandDialog>

--- a/src/components/AppSearchDialog.tsx
+++ b/src/components/AppSearchDialog.tsx
@@ -9,7 +9,11 @@ import {
 import { useState, useEffect } from "react";
 import { useSearchApps } from "@/hooks/useSearchApps";
 import type { AppSearchResult } from "@/lib/schemas";
-import { MIN_APP_SEARCH_QUERY_LENGTH } from "@/ipc/types";
+import {
+  getAppSearchQueryLength,
+  isAppSearchQueryLongEnough,
+  MIN_APP_SEARCH_QUERY_LENGTH,
+} from "@/ipc/types";
 
 type AppSearchDialogProps = {
   open: boolean;
@@ -38,8 +42,10 @@ export function AppSearchDialog({
 
   const debouncedQuery = useDebouncedValue(searchQuery, 150);
   const { apps: searchResults } = useSearchApps(debouncedQuery);
-  const isDatabaseSearch =
-    debouncedQuery.trim().length >= MIN_APP_SEARCH_QUERY_LENGTH;
+  const isDatabaseSearch = isAppSearchQueryLongEnough(debouncedQuery);
+  const currentQueryLength = getAppSearchQueryLength(searchQuery);
+  const showMinimumSearchHint =
+    currentQueryLength > 0 && currentQueryLength < MIN_APP_SEARCH_QUERY_LENGTH;
   const searchResultsTruncated =
     isDatabaseSearch && searchResults.some((result) => result.searchTruncated);
 
@@ -120,6 +126,16 @@ export function AppSearchDialog({
         onValueChange={setSearchQuery}
         data-testid="app-search-input"
       />
+      {showMinimumSearchHint && (
+        <div
+          className="border-b px-3 py-1.5 text-xs text-muted-foreground"
+          role="status"
+          data-testid="app-search-minimum-hint"
+        >
+          Type at least {MIN_APP_SEARCH_QUERY_LENGTH} characters to search chat
+          history.
+        </div>
+      )}
       <CommandList data-testid="app-search-list">
         <CommandEmpty data-testid="app-search-empty">
           No results found.

--- a/src/components/AppSearchDialog.tsx
+++ b/src/components/AppSearchDialog.tsx
@@ -38,16 +38,16 @@ export function AppSearchDialog({
 
   const debouncedQuery = useDebouncedValue(searchQuery, 150);
   const { apps: searchResults } = useSearchApps(debouncedQuery);
-  const searchResultsTruncated = searchResults.some(
-    (result) => result.searchTruncated,
-  );
+  const isDatabaseSearch =
+    debouncedQuery.trim().length >= MIN_APP_SEARCH_QUERY_LENGTH;
+  const searchResultsTruncated =
+    isDatabaseSearch && searchResults.some((result) => result.searchTruncated);
 
   // Keep one-character searches local to app names. Database-wide chat
   // searches start at two characters to avoid very broad result sets.
-  const appsToShow: AppSearchResult[] =
-    debouncedQuery.trim().length < MIN_APP_SEARCH_QUERY_LENGTH
-      ? allApps
-      : searchResults;
+  const appsToShow: AppSearchResult[] = isDatabaseSearch
+    ? searchResults
+    : allApps;
 
   const commandFilter = (
     value: string,
@@ -161,7 +161,8 @@ export function AppSearchDialog({
               className="px-2 py-1 text-xs text-muted-foreground"
               role="status"
             >
-              Showing the first 50 results. Refine your search to see more.
+              Showing the first {appsToShow.length} results. Refine your search
+              to see more.
             </div>
           )}
         </CommandGroup>

--- a/src/components/preview_panel/FileTree.tsx
+++ b/src/components/preview_panel/FileTree.tsx
@@ -245,8 +245,8 @@ export const FileTree = ({ appId, files }: FileTreeProps) => {
                 : t("preview.match", { count: matchesByPath.size })}
             </span>
             {searchResultsTruncated && (
-              <span title="Search results were limited to protect memory">
-                Results limited; refine search
+              <span title={t("preview.searchResultsLimitedTitle")}>
+                {t("preview.searchResultsLimited")}
               </span>
             )}
           </div>

--- a/src/components/preview_panel/FileTree.tsx
+++ b/src/components/preview_panel/FileTree.tsx
@@ -172,6 +172,9 @@ export const FileTree = ({ appId, files }: FileTreeProps) => {
     }
     return map;
   }, [searchResults]);
+  const searchResultsTruncated = searchResults.some(
+    (result) => result.truncated,
+  );
 
   const visibleFiles = useMemo(() => {
     if (!isSearchMode) {
@@ -241,6 +244,11 @@ export const FileTree = ({ appId, files }: FileTreeProps) => {
                 ? t("preview.searchingFiles")
                 : t("preview.match", { count: matchesByPath.size })}
             </span>
+            {searchResultsTruncated && (
+              <span title="Search results were limited to protect memory">
+                Results limited; refine search
+              </span>
+            )}
           </div>
         )}
       </div>

--- a/src/hooks/useSearchApps.ts
+++ b/src/hooks/useSearchApps.ts
@@ -1,10 +1,10 @@
-import { ipc } from "@/ipc/types";
+import { ipc, MIN_APP_SEARCH_QUERY_LENGTH } from "@/ipc/types";
 import { AppSearchResult } from "@/lib/schemas";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { queryKeys } from "@/lib/queryKeys";
 
 export function useSearchApps(query: string) {
-  const enabled = Boolean(query && query.trim().length > 0);
+  const enabled = query.trim().length >= MIN_APP_SEARCH_QUERY_LENGTH;
 
   const { data, isFetching, isLoading } = useQuery({
     queryKey: queryKeys.apps.search({ query }),

--- a/src/hooks/useSearchApps.ts
+++ b/src/hooks/useSearchApps.ts
@@ -1,10 +1,10 @@
-import { ipc, MIN_APP_SEARCH_QUERY_LENGTH } from "@/ipc/types";
+import { ipc, isAppSearchQueryLongEnough } from "@/ipc/types";
 import { AppSearchResult } from "@/lib/schemas";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { queryKeys } from "@/lib/queryKeys";
 
 export function useSearchApps(query: string) {
-  const enabled = query.trim().length >= MIN_APP_SEARCH_QUERY_LENGTH;
+  const enabled = isAppSearchQueryLongEnough(query);
 
   const { data, isFetching, isLoading } = useQuery({
     queryKey: queryKeys.apps.search({ query }),

--- a/src/i18n/locales/en/home.json
+++ b/src/i18n/locales/en/home.json
@@ -226,6 +226,8 @@
     "match_one": "{{count}} match",
     "match_other": "{{count}} matches",
     "noFilesMatchedSearch": "No files matched your search.",
+    "searchResultsLimited": "Results limited; refine search",
+    "searchResultsLimitedTitle": "Search results were limited to protect memory",
     "saveChanges": "Save changes",
     "noUnsavedChanges": "No unsaved changes",
     "fileSaved": "File saved",

--- a/src/i18n/locales/es/home.json
+++ b/src/i18n/locales/es/home.json
@@ -226,6 +226,8 @@
     "match_one": "{{count}} coincidencia",
     "match_other": "{{count}} coincidencias",
     "noFilesMatchedSearch": "Ningún archivo coincidió con tu búsqueda.",
+    "searchResultsLimited": "Resultados limitados; refina la búsqueda",
+    "searchResultsLimitedTitle": "Los resultados de búsqueda se limitaron para proteger la memoria",
     "saveChanges": "Guardar cambios",
     "noUnsavedChanges": "No hay cambios sin guardar",
     "fileSaved": "Archivo guardado",

--- a/src/i18n/locales/pt-BR/home.json
+++ b/src/i18n/locales/pt-BR/home.json
@@ -223,6 +223,8 @@
     "match_one": "{{count}} resultado",
     "match_other": "{{count}} resultados",
     "noFilesMatchedSearch": "Nenhum arquivo corresponde à sua pesquisa.",
+    "searchResultsLimited": "Resultados limitados; refine a pesquisa",
+    "searchResultsLimitedTitle": "Os resultados da pesquisa foram limitados para proteger a memória",
     "saveChanges": "Salvar alterações",
     "noUnsavedChanges": "Sem alterações não salvas",
     "fileSaved": "Arquivo salvo",

--- a/src/i18n/locales/zh-CN/home.json
+++ b/src/i18n/locales/zh-CN/home.json
@@ -223,6 +223,8 @@
     "match_one": "{{count}} 个匹配",
     "match_other": "{{count}} 个匹配",
     "noFilesMatchedSearch": "没有文件匹配您的搜索。",
+    "searchResultsLimited": "结果已限制；请缩小搜索范围",
+    "searchResultsLimitedTitle": "为保护内存，搜索结果已受到限制",
     "saveChanges": "保存更改",
     "noUnsavedChanges": "没有未保存的更改",
     "fileSaved": "文件已保存",

--- a/src/ipc/handlers/app_handlers.ts
+++ b/src/ipc/handlers/app_handlers.ts
@@ -1,15 +1,13 @@
 import { ipcMain, app, dialog } from "electron";
 import { closeDatabase, db, getDatabaseFilePaths } from "../../db";
-import { apps, chats, messages, versions } from "../../db/schema";
-import { desc, eq, inArray, like } from "drizzle-orm";
+import { apps, chats, versions } from "../../db/schema";
+import { desc, eq, inArray } from "drizzle-orm";
 import { createTypedHandler } from "./base";
 import { appContracts } from "../types/app";
-import type { AppFileSearchResult } from "../types/app";
 import { miscContracts } from "../types/misc";
 import { systemContracts } from "../types/system";
 import fs from "node:fs";
 import path from "node:path";
-import { spawn } from "node:child_process";
 import {
   getDyadAppPath,
   getDefaultDyadAppsDirectory,
@@ -112,72 +110,14 @@ import {
 } from "@/supabase_admin/supabase_utils";
 import { getVercelTeamSlug } from "../utils/vercel_utils";
 import { storeDbTimestampAtCurrentVersion } from "../utils/neon_timestamp_utils";
-import type { AppSearchResult } from "@/lib/schemas";
-
 import { getAppPort } from "../../../shared/ports";
-import {
-  getRgExecutablePath,
-  MAX_FILE_SEARCH_SIZE,
-  RIPGREP_EXCLUDED_GLOBS,
-} from "../utils/ripgrep_utils";
+import { searchAppFilesWithRipgrep } from "../utils/app_file_search";
 import { DyadError, DyadErrorKind, isDyadError } from "@/errors/dyad_error";
 import { detectFrameworkType } from "../utils/framework_utils";
+import { searchAppsWithResultLimits } from "../services/app_search_service";
 
 const logger = log.scope("app_handlers");
 const handle = createLoggedHandler(logger);
-
-function sanitizeSnippetText(text: string) {
-  return text.replace(/\s+/g, " ").trim();
-}
-
-/**
- * Converts a byte offset in UTF-8 encoded string to a character index.
- * Ripgrep provides byte offsets, but JavaScript strings use character indices.
- * This handles multi-byte UTF-8 characters (emojis, CJK, accented characters) correctly.
- */
-function byteOffsetToCharIndex(text: string, byteOffset: number): number {
-  // Cap the byte offset to the actual byte length of the string
-  const totalBytes = Buffer.from(text, "utf8").length;
-  const safeByteOffset = Math.min(byteOffset, totalBytes);
-
-  // Find the character index by checking byte counts at each position
-  // This correctly handles multi-byte characters
-  for (let i = 0; i <= text.length; i++) {
-    const bytesUpToIndex = Buffer.from(text.slice(0, i), "utf8").length;
-    if (bytesUpToIndex >= safeByteOffset) {
-      return i;
-    }
-  }
-
-  return text.length;
-}
-
-function buildSnippetFromMatch({
-  lineText,
-  start,
-  end,
-  lineNumber,
-}: {
-  lineText: string;
-  start: number;
-  end: number;
-  lineNumber: number;
-}): NonNullable<AppFileSearchResult["snippets"]>[number] {
-  const safeLine = lineText.replace(/\r?\n$/, "");
-  // Convert byte offsets to character indices for proper UTF-8 handling
-  const startChar = byteOffsetToCharIndex(safeLine, start);
-  const endChar = byteOffsetToCharIndex(safeLine, end);
-  const before = sanitizeSnippetText(safeLine.slice(0, startChar));
-  const match = sanitizeSnippetText(safeLine.slice(startChar, endChar));
-  const after = sanitizeSnippetText(safeLine.slice(endChar));
-
-  return {
-    before,
-    match,
-    after,
-    line: lineNumber,
-  };
-}
 
 async function copyDir(
   source: string,
@@ -199,123 +139,6 @@ async function copyDir(
       }
       return true;
     },
-  });
-}
-
-async function searchAppFilesWithRipgrep({
-  appPath,
-  query,
-}: {
-  appPath: string;
-  query: string;
-}): Promise<AppFileSearchResult[]> {
-  return new Promise((resolve, reject) => {
-    const results = new Map<string, AppFileSearchResult>();
-    const args = [
-      "--json",
-      "--no-config",
-      "--ignore-case",
-      "--fixed-strings",
-      "--max-filesize",
-      `${MAX_FILE_SEARCH_SIZE}`,
-      ...RIPGREP_EXCLUDED_GLOBS.flatMap((glob) => ["--glob", glob]),
-      query,
-      ".",
-    ];
-
-    const rg = spawn(getRgExecutablePath(), args, { cwd: appPath });
-    let buffer = "";
-
-    rg.stdout.on("data", (data) => {
-      buffer += data.toString();
-      const lines = buffer.split("\n");
-      buffer = lines.pop() ?? "";
-
-      for (const line of lines) {
-        if (!line.trim()) continue;
-        try {
-          const event = JSON.parse(line);
-          if (event.type !== "match" || !event.data) {
-            continue;
-          }
-
-          const matchPath = event.data.path?.text as string;
-          if (!matchPath) continue;
-
-          const absolutePath = path.isAbsolute(matchPath)
-            ? matchPath
-            : path.join(appPath, matchPath);
-          const relativePath = normalizePath(
-            path.relative(appPath, absolutePath),
-          );
-          if (relativePath.startsWith("..")) {
-            continue; // outside app directory
-          }
-
-          const lineText = event.data.lines?.text as string;
-          const lineNumber = event.data.line_number as number;
-          const submatch = event.data.submatches?.[0];
-          if (
-            typeof lineText !== "string" ||
-            typeof lineNumber !== "number" ||
-            !submatch
-          ) {
-            continue;
-          }
-
-          const snippet = buildSnippetFromMatch({
-            lineText,
-            start: submatch.start,
-            end: submatch.end,
-            lineNumber,
-          });
-
-          const existing = results.get(relativePath);
-          if (!existing) {
-            results.set(relativePath, {
-              path: relativePath,
-              matchesContent: true,
-              snippets: [snippet],
-            });
-          } else {
-            // Add snippet to existing result if it doesn't already exist (avoid duplicates)
-            if (!existing.snippets) {
-              existing.snippets = [];
-            }
-            // Only add if this line number isn't already in the snippets
-            const existingLine = existing.snippets.find(
-              (s) => s.line === snippet.line,
-            );
-            if (!existingLine) {
-              existing.snippets.push(snippet);
-            }
-          }
-        } catch (error) {
-          logger.warn("Failed to parse ripgrep output line:", line, error);
-        }
-      }
-    });
-
-    rg.stderr.on("data", (data) => {
-      const message = data.toString();
-      if (message.toLowerCase().includes("binary file skipped")) {
-        return;
-      }
-      logger.debug("ripgrep stderr:", message);
-    });
-
-    rg.on("close", (code) => {
-      // rg exits with code 1 when no matches are found; treat as success
-      if (code !== 0 && code !== 1) {
-        reject(new Error(`ripgrep exited with code ${code}`));
-        return;
-      }
-      resolve(Array.from(results.values()));
-    });
-
-    rg.on("error", (error) => {
-      reject(error);
-    });
   });
 }
 
@@ -1577,90 +1400,8 @@ export function registerAppHandlers() {
     return contentMatches;
   });
 
-  // search-app is not in app contracts - keep using handle
-  handle(
-    "search-app",
-    async (_, searchQuery: string): Promise<AppSearchResult[]> => {
-      // Use parameterized query to prevent SQL injection
-      const pattern = `%${searchQuery.replace(/[%_]/g, "\\$&")}%`;
-
-      // 1) Apps whose name matches
-      const appNameMatches = await db
-        .select({
-          id: apps.id,
-          name: apps.name,
-          createdAt: apps.createdAt,
-        })
-        .from(apps)
-        .where(like(apps.name, pattern))
-        .orderBy(desc(apps.createdAt));
-
-      const appNameMatchesResult: AppSearchResult[] = appNameMatches.map(
-        (r) => ({
-          id: r.id,
-          name: r.name,
-          createdAt: r.createdAt,
-          matchedChatTitle: null,
-          matchedChatMessage: null,
-        }),
-      );
-
-      // 2) Apps whose chat title matches
-      const chatTitleMatches = await db
-        .select({
-          id: apps.id,
-          name: apps.name,
-          createdAt: apps.createdAt,
-          matchedChatTitle: chats.title,
-        })
-        .from(apps)
-        .innerJoin(chats, eq(apps.id, chats.appId))
-        .where(like(chats.title, pattern))
-        .orderBy(desc(apps.createdAt));
-
-      const chatTitleMatchesResult: AppSearchResult[] = chatTitleMatches.map(
-        (r) => ({
-          id: r.id,
-          name: r.name,
-          createdAt: r.createdAt,
-          matchedChatTitle: r.matchedChatTitle,
-          matchedChatMessage: null,
-        }),
-      );
-
-      // 3) Apps whose chat message content matches
-      const chatMessageMatches = await db
-        .select({
-          id: apps.id,
-          name: apps.name,
-          createdAt: apps.createdAt,
-          matchedChatTitle: chats.title,
-          matchedChatMessage: messages.content,
-        })
-        .from(apps)
-        .innerJoin(chats, eq(apps.id, chats.appId))
-        .innerJoin(messages, eq(chats.id, messages.chatId))
-        .where(like(messages.content, pattern))
-        .orderBy(desc(apps.createdAt));
-
-      // Flatten and dedupe by app id
-      const allMatches: AppSearchResult[] = [
-        ...appNameMatchesResult,
-        ...chatTitleMatchesResult,
-        ...chatMessageMatches,
-      ];
-      const uniqueApps = Array.from(
-        new Map(allMatches.map((app) => [app.id, app])).values(),
-      );
-
-      // Sort newest apps first
-      uniqueApps.sort(
-        (a, b) =>
-          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-      );
-
-      return uniqueApps;
-    },
+  handle("search-app", async (_, searchQuery: string) =>
+    searchAppsWithResultLimits(searchQuery),
   );
 
   // Handler for adding logs to central store from renderer

--- a/src/ipc/services/app_search_service.test.ts
+++ b/src/ipc/services/app_search_service.test.ts
@@ -38,9 +38,35 @@ beforeEach(() => {
 });
 
 describe("searchAppsWithResultLimits", () => {
-  it("does not run broad one-character database searches", async () => {
-    await expect(searchAppsWithResultLimits("a")).resolves.toEqual([]);
-    expect(mocks.select).not.toHaveBeenCalled();
+  it.each(["a", "😀"])(
+    "does not run broad one-character database searches: %s",
+    async (query) => {
+      await expect(searchAppsWithResultLimits(query)).resolves.toEqual([]);
+      expect(mocks.select).not.toHaveBeenCalled();
+    },
+  );
+
+  it("returns null for projected snippets whose column does not match", async () => {
+    const builders = [
+      queryReturning([]),
+      queryReturning([]),
+      queryReturning([]),
+    ];
+    const queries = [...builders];
+    mocks.select.mockImplementation(() => queries.shift());
+
+    await searchAppsWithResultLimits("needle");
+
+    const messageProjection = mocks.select.mock.calls[2][0] as {
+      matchedChatTitle: unknown;
+    };
+    const compiled = new SQLiteSyncDialect().sqlToQuery(
+      messageProjection.matchedChatTitle as never,
+    );
+    expect(compiled.sql).toMatch(
+      /instr\(lower\(.+\), lower\(\?\)\) = 0\s+THEN NULL/i,
+    );
+    expect(mocks.select).toHaveBeenCalledTimes(3);
   });
 
   it("treats SQLite LIKE wildcard characters as literal search text", async () => {

--- a/src/ipc/services/app_search_service.test.ts
+++ b/src/ipc/services/app_search_service.test.ts
@@ -5,6 +5,7 @@ import {
   searchAppsWithResultLimits,
 } from "./app_search_service";
 import { messages } from "../../db/schema";
+import { SQLiteSyncDialect } from "drizzle-orm/sqlite-core";
 
 const mocks = vi.hoisted(() => ({
   select: vi.fn(),
@@ -40,6 +41,26 @@ describe("searchAppsWithResultLimits", () => {
   it("does not run broad one-character database searches", async () => {
     await expect(searchAppsWithResultLimits("a")).resolves.toEqual([]);
     expect(mocks.select).not.toHaveBeenCalled();
+  });
+
+  it("treats SQLite LIKE wildcard characters as literal search text", async () => {
+    const builders = [
+      queryReturning([]),
+      queryReturning([]),
+      queryReturning([]),
+    ];
+    const queries = [...builders];
+    mocks.select.mockImplementation(() => queries.shift());
+
+    await searchAppsWithResultLimits("100%_\\");
+
+    const dialect = new SQLiteSyncDialect();
+    for (const builder of builders) {
+      const condition = builder.where.mock.calls[0][0];
+      const compiled = dialect.sqlToQuery(condition);
+      expect(compiled.sql).toContain("LIKE ? ESCAPE '\\'");
+      expect(compiled.params).toEqual(["%100\\%\\_\\\\%"]);
+    }
   });
 
   it("limits every source query and reports broad-result truncation", async () => {

--- a/src/ipc/services/app_search_service.test.ts
+++ b/src/ipc/services/app_search_service.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  MAX_APP_SEARCH_RESULTS,
+  MAX_APP_SEARCH_TEXT_BYTES,
+  searchAppsWithResultLimits,
+} from "./app_search_service";
+import { messages } from "../../db/schema";
+
+const mocks = vi.hoisted(() => ({
+  select: vi.fn(),
+}));
+
+vi.mock("../../db", () => ({
+  db: { select: mocks.select },
+}));
+
+function queryReturning(rows: unknown[]) {
+  const query: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const method of ["from", "innerJoin", "where", "groupBy", "orderBy"]) {
+    query[method] = vi.fn(() => query);
+  }
+  query.limit = vi.fn().mockResolvedValue(rows);
+  return query;
+}
+
+function appResult(id: number, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    name: `App ${id}`,
+    createdAt: new Date(2025, 0, id + 1),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("searchAppsWithResultLimits", () => {
+  it("does not run broad one-character database searches", async () => {
+    await expect(searchAppsWithResultLimits("a")).resolves.toEqual([]);
+    expect(mocks.select).not.toHaveBeenCalled();
+  });
+
+  it("limits every source query and reports broad-result truncation", async () => {
+    const nameRows = Array.from(
+      { length: MAX_APP_SEARCH_RESULTS + 1 },
+      (_, index) => appResult(index),
+    );
+    const builders = [
+      queryReturning(nameRows),
+      queryReturning([]),
+      queryReturning([]),
+    ];
+    const queries = [...builders];
+    mocks.select.mockImplementation(() => queries.shift());
+
+    const results = await searchAppsWithResultLimits("app");
+
+    expect(results).toHaveLength(MAX_APP_SEARCH_RESULTS);
+    expect(results.every((result) => result.searchTruncated)).toBe(true);
+    // Each query builder receives LIMIT + 1 so truncation can be detected.
+    expect(mocks.select).toHaveBeenCalledTimes(3);
+    for (const builder of builders) {
+      expect(builder.limit).toHaveBeenCalledWith(MAX_APP_SEARCH_RESULTS + 1);
+    }
+    const messageProjection = mocks.select.mock.calls[2][0] as {
+      matchedChatMessage: unknown;
+    };
+    expect(messageProjection.matchedChatMessage).not.toBe(messages.content);
+  });
+
+  it("bounds projected text again by UTF-8 bytes", async () => {
+    const messageQuery = queryReturning([
+      appResult(1, {
+        matchedChatTitle: null,
+        matchedChatMessage: "😀".repeat(2_000),
+      }),
+    ]);
+    const queries = [queryReturning([]), queryReturning([]), messageQuery];
+    mocks.select.mockImplementation(() => queries.shift());
+
+    const [result] = await searchAppsWithResultLimits("emoji");
+
+    expect(
+      Buffer.byteLength(result.matchedChatMessage ?? "", "utf8"),
+    ).toBeLessThanOrEqual(MAX_APP_SEARCH_TEXT_BYTES);
+    expect(result.matchedChatMessage).not.toContain("�");
+  });
+
+  it("does not report truncation at the exact result boundary", async () => {
+    const nameRows = Array.from(
+      { length: MAX_APP_SEARCH_RESULTS },
+      (_, index) => appResult(index),
+    );
+    const queries = [
+      queryReturning(nameRows),
+      queryReturning([]),
+      queryReturning([]),
+    ];
+    mocks.select.mockImplementation(() => queries.shift());
+
+    const results = await searchAppsWithResultLimits("app");
+
+    expect(results).toHaveLength(MAX_APP_SEARCH_RESULTS);
+    expect(results.some((result) => result.searchTruncated)).toBe(false);
+  });
+});

--- a/src/ipc/services/app_search_service.ts
+++ b/src/ipc/services/app_search_service.ts
@@ -3,7 +3,7 @@ import { apps, chats, messages } from "../../db/schema";
 import { desc, eq, sql } from "drizzle-orm";
 import type { AppSearchResult } from "@/lib/schemas";
 import { truncateUtf8 } from "../utils/result_limits";
-import { MIN_APP_SEARCH_QUERY_LENGTH } from "../types/app";
+import { isAppSearchQueryLongEnough } from "../types/app";
 
 export const MAX_APP_SEARCH_RESULTS = 50;
 export const MAX_APP_SEARCH_TEXT_BYTES = 1024;
@@ -33,7 +33,8 @@ function matchingSnippet(
 ) {
   return sql<string | null>`
     CASE
-      WHEN ${column} IS NULL THEN NULL
+      WHEN ${column} IS NULL
+        OR instr(lower(${column}), lower(${query})) = 0 THEN NULL
       ELSE substr(
         ${column},
         max(1, instr(lower(${column}), lower(${query})) - ${SQL_SNIPPET_RADIUS}),
@@ -48,7 +49,7 @@ export async function searchAppsWithResultLimits(
   rawQuery: string,
 ): Promise<AppSearchResult[]> {
   const query = rawQuery.trim();
-  if (query.length < MIN_APP_SEARCH_QUERY_LENGTH) return [];
+  if (!isAppSearchQueryLongEnough(query)) return [];
 
   const pattern = `%${query.replace(/[\\%_]/g, "\\$&")}%`;
 

--- a/src/ipc/services/app_search_service.ts
+++ b/src/ipc/services/app_search_service.ts
@@ -1,6 +1,6 @@
 import { db } from "../../db";
 import { apps, chats, messages } from "../../db/schema";
-import { desc, eq, like, sql } from "drizzle-orm";
+import { desc, eq, sql } from "drizzle-orm";
 import type { AppSearchResult } from "@/lib/schemas";
 import { truncateUtf8 } from "../utils/result_limits";
 import { MIN_APP_SEARCH_QUERY_LENGTH } from "../types/app";
@@ -50,7 +50,7 @@ export async function searchAppsWithResultLimits(
   const query = rawQuery.trim();
   if (query.length < MIN_APP_SEARCH_QUERY_LENGTH) return [];
 
-  const pattern = `%${query.replace(/[%_]/g, "\\$&")}%`;
+  const pattern = `%${query.replace(/[\\%_]/g, "\\$&")}%`;
 
   const appNameMatches = await db
     .select({
@@ -59,7 +59,7 @@ export async function searchAppsWithResultLimits(
       createdAt: apps.createdAt,
     })
     .from(apps)
-    .where(like(apps.name, pattern))
+    .where(sql`${apps.name} LIKE ${pattern} ESCAPE '\\'`)
     .orderBy(desc(apps.createdAt))
     .limit(SOURCE_QUERY_LIMIT);
 
@@ -72,7 +72,7 @@ export async function searchAppsWithResultLimits(
     })
     .from(apps)
     .innerJoin(chats, eq(apps.id, chats.appId))
-    .where(like(chats.title, pattern))
+    .where(sql`${chats.title} LIKE ${pattern} ESCAPE '\\'`)
     .groupBy(apps.id)
     .orderBy(desc(apps.createdAt))
     .limit(SOURCE_QUERY_LIMIT);
@@ -88,7 +88,7 @@ export async function searchAppsWithResultLimits(
     .from(apps)
     .innerJoin(chats, eq(apps.id, chats.appId))
     .innerJoin(messages, eq(chats.id, messages.chatId))
-    .where(like(messages.content, pattern))
+    .where(sql`${messages.content} LIKE ${pattern} ESCAPE '\\'`)
     .groupBy(apps.id)
     .orderBy(desc(apps.createdAt))
     .limit(SOURCE_QUERY_LIMIT);
@@ -118,9 +118,7 @@ export async function searchAppsWithResultLimits(
   ].map(normalizeResult);
   const uniqueApps = Array.from(
     new Map(allMatches.map((appResult) => [appResult.id, appResult])).values(),
-  ).sort(
-    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-  );
+  ).sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
   const truncated =
     sourceTruncated || uniqueApps.length > MAX_APP_SEARCH_RESULTS;
 

--- a/src/ipc/services/app_search_service.ts
+++ b/src/ipc/services/app_search_service.ts
@@ -1,0 +1,135 @@
+import { db } from "../../db";
+import { apps, chats, messages } from "../../db/schema";
+import { desc, eq, like, sql } from "drizzle-orm";
+import type { AppSearchResult } from "@/lib/schemas";
+import { truncateUtf8 } from "../utils/result_limits";
+import { MIN_APP_SEARCH_QUERY_LENGTH } from "../types/app";
+
+export const MAX_APP_SEARCH_RESULTS = 50;
+export const MAX_APP_SEARCH_TEXT_BYTES = 1024;
+const SOURCE_QUERY_LIMIT = MAX_APP_SEARCH_RESULTS + 1;
+const SQL_SNIPPET_RADIUS = 100;
+const SQL_SNIPPET_CHARACTERS = SQL_SNIPPET_RADIUS * 2 + 200;
+const SQL_APP_NAME_CHARACTERS = 256;
+
+function normalizeSearchText(value: string | null): string | null {
+  return value === null
+    ? null
+    : truncateUtf8(value, MAX_APP_SEARCH_TEXT_BYTES).text;
+}
+
+function normalizeResult(result: AppSearchResult): AppSearchResult {
+  return {
+    ...result,
+    name: normalizeSearchText(result.name) ?? "",
+    matchedChatTitle: normalizeSearchText(result.matchedChatTitle),
+    matchedChatMessage: normalizeSearchText(result.matchedChatMessage),
+  };
+}
+
+function matchingSnippet(
+  column: typeof chats.title | typeof messages.content,
+  query: string,
+) {
+  return sql<string | null>`
+    CASE
+      WHEN ${column} IS NULL THEN NULL
+      ELSE substr(
+        ${column},
+        max(1, instr(lower(${column}), lower(${query})) - ${SQL_SNIPPET_RADIUS}),
+        ${SQL_SNIPPET_CHARACTERS}
+      )
+    END
+  `;
+}
+
+/** Search app names and chat text without loading unbounded matching rows. */
+export async function searchAppsWithResultLimits(
+  rawQuery: string,
+): Promise<AppSearchResult[]> {
+  const query = rawQuery.trim();
+  if (query.length < MIN_APP_SEARCH_QUERY_LENGTH) return [];
+
+  const pattern = `%${query.replace(/[%_]/g, "\\$&")}%`;
+
+  const appNameMatches = await db
+    .select({
+      id: apps.id,
+      name: sql<string>`substr(${apps.name}, 1, ${SQL_APP_NAME_CHARACTERS})`,
+      createdAt: apps.createdAt,
+    })
+    .from(apps)
+    .where(like(apps.name, pattern))
+    .orderBy(desc(apps.createdAt))
+    .limit(SOURCE_QUERY_LIMIT);
+
+  const chatTitleMatches = await db
+    .select({
+      id: apps.id,
+      name: sql<string>`substr(${apps.name}, 1, ${SQL_APP_NAME_CHARACTERS})`,
+      createdAt: apps.createdAt,
+      matchedChatTitle: matchingSnippet(chats.title, query),
+    })
+    .from(apps)
+    .innerJoin(chats, eq(apps.id, chats.appId))
+    .where(like(chats.title, pattern))
+    .groupBy(apps.id)
+    .orderBy(desc(apps.createdAt))
+    .limit(SOURCE_QUERY_LIMIT);
+
+  const chatMessageMatches = await db
+    .select({
+      id: apps.id,
+      name: sql<string>`substr(${apps.name}, 1, ${SQL_APP_NAME_CHARACTERS})`,
+      createdAt: apps.createdAt,
+      matchedChatTitle: matchingSnippet(chats.title, query),
+      matchedChatMessage: matchingSnippet(messages.content, query),
+    })
+    .from(apps)
+    .innerJoin(chats, eq(apps.id, chats.appId))
+    .innerJoin(messages, eq(chats.id, messages.chatId))
+    .where(like(messages.content, pattern))
+    .groupBy(apps.id)
+    .orderBy(desc(apps.createdAt))
+    .limit(SOURCE_QUERY_LIMIT);
+
+  const sourceTruncated = [
+    appNameMatches,
+    chatTitleMatches,
+    chatMessageMatches,
+  ].some((matches) => matches.length > MAX_APP_SEARCH_RESULTS);
+  const appNameResults: AppSearchResult[] = appNameMatches
+    .slice(0, MAX_APP_SEARCH_RESULTS)
+    .map((result) => ({
+      ...result,
+      matchedChatTitle: null,
+      matchedChatMessage: null,
+    }));
+  const chatTitleResults: AppSearchResult[] = chatTitleMatches
+    .slice(0, MAX_APP_SEARCH_RESULTS)
+    .map((result) => ({
+      ...result,
+      matchedChatMessage: null,
+    }));
+  const allMatches = [
+    ...appNameResults,
+    ...chatTitleResults,
+    ...chatMessageMatches.slice(0, MAX_APP_SEARCH_RESULTS),
+  ].map(normalizeResult);
+  const uniqueApps = Array.from(
+    new Map(allMatches.map((appResult) => [appResult.id, appResult])).values(),
+  ).sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  );
+  const truncated =
+    sourceTruncated || uniqueApps.length > MAX_APP_SEARCH_RESULTS;
+
+  return uniqueApps.slice(0, MAX_APP_SEARCH_RESULTS).map((result) =>
+    truncated
+      ? {
+          ...result,
+          searchTruncated: true,
+        }
+      : result,
+  );
+}

--- a/src/ipc/types/app.ts
+++ b/src/ipc/types/app.ts
@@ -345,6 +345,15 @@ export const SelectAppLocationResultSchema = z.object({
  */
 export const MIN_APP_SEARCH_QUERY_LENGTH = 2;
 
+/** Count user-visible code points rather than UTF-16 code units. */
+export function getAppSearchQueryLength(query: string): number {
+  return Array.from(query.trim()).length;
+}
+
+export function isAppSearchQueryLongEnough(query: string): boolean {
+  return getAppSearchQueryLength(query) >= MIN_APP_SEARCH_QUERY_LENGTH;
+}
+
 export const AppSearchResultSchema = z.object({
   id: z.number(),
   name: z.string(),

--- a/src/ipc/types/app.ts
+++ b/src/ipc/types/app.ts
@@ -252,6 +252,7 @@ export const AppFileSearchResultSchema = z.object({
   path: z.string(),
   matchesContent: z.boolean(),
   snippets: z.array(FileSearchSnippetSchema).optional(),
+  truncated: z.boolean().optional(),
 });
 
 /**
@@ -342,12 +343,15 @@ export const SelectAppLocationResultSchema = z.object({
 /**
  * Schema for app search result.
  */
+export const MIN_APP_SEARCH_QUERY_LENGTH = 2;
+
 export const AppSearchResultSchema = z.object({
   id: z.number(),
   name: z.string(),
   createdAt: z.date(),
   matchedChatTitle: z.string().nullable(),
   matchedChatMessage: z.string().nullable(),
+  searchTruncated: z.boolean().optional(),
 });
 
 // =============================================================================

--- a/src/ipc/types/index.ts
+++ b/src/ipc/types/index.ts
@@ -27,7 +27,7 @@
 // =============================================================================
 
 export { settingsContracts } from "./settings";
-export { appContracts } from "./app";
+export { appContracts, MIN_APP_SEARCH_QUERY_LENGTH } from "./app";
 export { chatContracts, chatStreamContract } from "./chat";
 export { agentContracts, agentEvents } from "./agent";
 export { githubContracts, gitContracts, githubEvents } from "./github";

--- a/src/ipc/types/index.ts
+++ b/src/ipc/types/index.ts
@@ -27,7 +27,12 @@
 // =============================================================================
 
 export { settingsContracts } from "./settings";
-export { appContracts, MIN_APP_SEARCH_QUERY_LENGTH } from "./app";
+export {
+  appContracts,
+  getAppSearchQueryLength,
+  isAppSearchQueryLongEnough,
+  MIN_APP_SEARCH_QUERY_LENGTH,
+} from "./app";
 export { chatContracts, chatStreamContract } from "./chat";
 export { agentContracts, agentEvents } from "./agent";
 export { githubContracts, gitContracts, githubEvents } from "./github";

--- a/src/ipc/utils/app_file_search.test.ts
+++ b/src/ipc/utils/app_file_search.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  MAX_APP_FILE_SEARCH_FILES,
+  MAX_APP_FILE_SEARCH_SNIPPET_BYTES,
+  searchAppFilesWithRipgrep,
+} from "./app_file_search";
+
+vi.mock("electron-log", () => ({
+  default: {
+    scope: () => ({ debug: vi.fn(), warn: vi.fn() }),
+  },
+}));
+
+vi.mock("./ripgrep_utils", () => ({
+  getRgExecutablePath: () =>
+    path.join(
+      process.cwd(),
+      "node_modules",
+      "@vscode",
+      "ripgrep",
+      "bin",
+      process.platform === "win32" ? "rg.exe" : "rg",
+    ),
+  MAX_FILE_SEARCH_SIZE: 1024 * 1024,
+  RIPGREP_EXCLUDED_GLOBS: ["!node_modules/**", "!.git/**", "!.next/**"],
+}));
+
+const tempDirs: string[] = [];
+
+async function makeTempDir() {
+  const directory = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), "app-file-search-"),
+  );
+  tempDirs.push(directory);
+  return directory;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs
+      .splice(0)
+      .map((directory) =>
+        fs.promises.rm(directory, { recursive: true, force: true }),
+      ),
+  );
+});
+
+describe("searchAppFilesWithRipgrep", () => {
+  it("stops the producer when a broad search reaches the file cap", async () => {
+    const directory = await makeTempDir();
+    await Promise.all(
+      Array.from({ length: MAX_APP_FILE_SEARCH_FILES + 25 }, (_, index) =>
+        fs.promises.writeFile(
+          path.join(
+            directory,
+            `match-${index.toString().padStart(3, "0")}.txt`,
+          ),
+          "broad-search-needle\n",
+        ),
+      ),
+    );
+
+    const results = await searchAppFilesWithRipgrep({
+      appPath: directory,
+      query: "broad-search-needle",
+    });
+
+    expect(results).toHaveLength(MAX_APP_FILE_SEARCH_FILES);
+    expect(results.every((result) => result.truncated)).toBe(true);
+  });
+
+  it("caps a Unicode snippet by UTF-8 bytes", async () => {
+    const directory = await makeTempDir();
+    await fs.promises.writeFile(
+      path.join(directory, "unicode.txt"),
+      `${"😀".repeat(2_000)}needle${"界".repeat(2_000)}\n`,
+    );
+
+    const [result] = await searchAppFilesWithRipgrep({
+      appPath: directory,
+      query: "needle",
+    });
+    const snippet = result.snippets?.[0];
+    const snippetBytes = Buffer.byteLength(
+      `${snippet?.before}${snippet?.match}${snippet?.after}`,
+      "utf8",
+    );
+
+    expect(snippetBytes).toBeLessThanOrEqual(MAX_APP_FILE_SEARCH_SNIPPET_BYTES);
+    expect(
+      `${snippet?.before}${snippet?.match}${snippet?.after}`,
+    ).not.toContain("�");
+  });
+
+  it("does not mark an ordinary result as truncated", async () => {
+    const directory = await makeTempDir();
+    await fs.promises.writeFile(path.join(directory, "one.txt"), "needle\n");
+
+    const results = await searchAppFilesWithRipgrep({
+      appPath: directory,
+      query: "needle",
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].truncated).toBeUndefined();
+  });
+});

--- a/src/ipc/utils/app_file_search.ts
+++ b/src/ipc/utils/app_file_search.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import path from "node:path";
+import { StringDecoder } from "node:string_decoder";
 import log from "electron-log";
 import type { AppFileSearchResult } from "../types/app";
 import { normalizePath } from "../../../shared/normalizePath";
@@ -27,10 +28,19 @@ function byteOffsetToCharIndex(text: string, byteOffset: number): number {
   const safeByteOffset = Math.max(0, byteOffset);
   let bytes = 0;
   let characterIndex = 0;
-  for (const character of text) {
+  while (characterIndex < text.length) {
     if (bytes >= safeByteOffset) return characterIndex;
-    bytes += Buffer.byteLength(character, "utf8");
-    characterIndex += character.length;
+    const codePoint = text.codePointAt(characterIndex);
+    if (codePoint === undefined) break;
+    bytes +=
+      codePoint <= 0x7f
+        ? 1
+        : codePoint <= 0x7ff
+          ? 2
+          : codePoint <= 0xffff
+            ? 3
+            : 4;
+    characterIndex += codePoint > 0xffff ? 2 : 1;
   }
   return text.length;
 }
@@ -116,6 +126,7 @@ export async function searchAppFilesWithRipgrep({
     ];
 
     const rg = spawn(getRgExecutablePath(), args, { cwd: appPath });
+    const stdoutDecoder = new StringDecoder("utf8");
     let buffer = "";
     let resultBytes = 0;
     let snippetCount = 0;
@@ -128,11 +139,11 @@ export async function searchAppFilesWithRipgrep({
       rg.kill();
     };
 
-    rg.stdout.on("data", (data) => {
+    const consumeStdout = (decoded: string, flush = false) => {
       if (stoppedEarly) return;
-      buffer += data.toString();
+      buffer += decoded;
       const lines = buffer.split("\n");
-      buffer = lines.pop() ?? "";
+      buffer = flush ? "" : (lines.pop() ?? "");
 
       for (const line of lines) {
         if (!line.trim()) continue;
@@ -203,6 +214,10 @@ export async function searchAppFilesWithRipgrep({
           logger.warn("Failed to parse ripgrep output line:", line, error);
         }
       }
+    };
+
+    rg.stdout.on("data", (data) => {
+      consumeStdout(stdoutDecoder.write(data));
     });
 
     rg.stderr.on("data", (data) => {
@@ -212,6 +227,9 @@ export async function searchAppFilesWithRipgrep({
     });
 
     rg.on("close", (code) => {
+      if (!stoppedEarly) {
+        consumeStdout(stdoutDecoder.end(), true);
+      }
       if (!stoppedEarly && code !== 0 && code !== 1) {
         reject(new Error(`ripgrep exited with code ${code}`));
         return;
@@ -223,6 +241,8 @@ export async function searchAppFilesWithRipgrep({
       resolve(values);
     });
 
-    rg.on("error", reject);
+    rg.on("error", (error) => {
+      if (!stoppedEarly) reject(error);
+    });
   });
 }

--- a/src/ipc/utils/app_file_search.ts
+++ b/src/ipc/utils/app_file_search.ts
@@ -1,0 +1,228 @@
+import { spawn } from "node:child_process";
+import path from "node:path";
+import log from "electron-log";
+import type { AppFileSearchResult } from "../types/app";
+import { normalizePath } from "../../../shared/normalizePath";
+import {
+  getRgExecutablePath,
+  MAX_FILE_SEARCH_SIZE,
+  RIPGREP_EXCLUDED_GLOBS,
+} from "./ripgrep_utils";
+import { takeUtf8Prefix, takeUtf8Suffix, truncateUtf8 } from "./result_limits";
+
+const logger = log.scope("app_file_search");
+
+export const MAX_APP_FILE_SEARCH_FILES = 100;
+export const MAX_APP_FILE_SEARCH_SNIPPETS = 300;
+export const MAX_APP_FILE_SEARCH_RESULT_BYTES = 256 * 1024;
+export const MAX_APP_FILE_SEARCH_SNIPPET_BYTES = 2 * 1024;
+const MAX_MATCH_BYTES = 512;
+
+function sanitizeSnippetText(text: string) {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+/** Convert ripgrep's UTF-8 byte offset to a JavaScript string index. */
+function byteOffsetToCharIndex(text: string, byteOffset: number): number {
+  const safeByteOffset = Math.max(0, byteOffset);
+  let bytes = 0;
+  let characterIndex = 0;
+  for (const character of text) {
+    if (bytes >= safeByteOffset) return characterIndex;
+    bytes += Buffer.byteLength(character, "utf8");
+    characterIndex += character.length;
+  }
+  return text.length;
+}
+
+function buildSnippetFromMatch({
+  lineText,
+  start,
+  end,
+  lineNumber,
+}: {
+  lineText: string;
+  start: number;
+  end: number;
+  lineNumber: number;
+}): NonNullable<AppFileSearchResult["snippets"]>[number] {
+  const safeLine = lineText.replace(/\r?\n$/, "");
+  const startChar = byteOffsetToCharIndex(safeLine, start);
+  const endChar = byteOffsetToCharIndex(safeLine, end);
+  const match = truncateUtf8(
+    sanitizeSnippetText(safeLine.slice(startChar, endChar)),
+    MAX_MATCH_BYTES,
+  ).text;
+  const remainingBytes = Math.max(
+    0,
+    MAX_APP_FILE_SEARCH_SNIPPET_BYTES - Buffer.byteLength(match, "utf8"),
+  );
+  const beforeBudget = Math.floor(remainingBytes / 2);
+  const afterBudget = remainingBytes - beforeBudget;
+  const before = truncateUtf8(
+    sanitizeSnippetText(
+      takeUtf8Suffix(safeLine.slice(0, startChar), beforeBudget),
+    ),
+    beforeBudget,
+    "",
+  ).text;
+  const after = truncateUtf8(
+    sanitizeSnippetText(takeUtf8Prefix(safeLine.slice(endChar), afterBudget)),
+    afterBudget,
+    "",
+  ).text;
+
+  return { before, match, after, line: lineNumber };
+}
+
+function estimateSnippetBytes(
+  pathName: string,
+  snippet: NonNullable<AppFileSearchResult["snippets"]>[number],
+  includePath: boolean,
+): number {
+  return (
+    (includePath ? Buffer.byteLength(pathName, "utf8") : 0) +
+    Buffer.byteLength(snippet.before, "utf8") +
+    Buffer.byteLength(snippet.match, "utf8") +
+    Buffer.byteLength(snippet.after, "utf8") +
+    64
+  );
+}
+
+/**
+ * Search app files while bounding retained paths, snippets, and UTF-8 bytes.
+ * Ripgrep is terminated as soon as the next unique match would exceed a cap.
+ */
+export async function searchAppFilesWithRipgrep({
+  appPath,
+  query,
+}: {
+  appPath: string;
+  query: string;
+}): Promise<AppFileSearchResult[]> {
+  return new Promise((resolve, reject) => {
+    const results = new Map<string, AppFileSearchResult>();
+    const args = [
+      "--json",
+      "--no-config",
+      "--ignore-case",
+      "--fixed-strings",
+      "--max-filesize",
+      `${MAX_FILE_SEARCH_SIZE}`,
+      ...RIPGREP_EXCLUDED_GLOBS.flatMap((glob) => ["--glob", glob]),
+      "--",
+      query,
+      ".",
+    ];
+
+    const rg = spawn(getRgExecutablePath(), args, { cwd: appPath });
+    let buffer = "";
+    let resultBytes = 0;
+    let snippetCount = 0;
+    let stoppedEarly = false;
+
+    const stopEarly = () => {
+      if (stoppedEarly) return;
+      stoppedEarly = true;
+      buffer = "";
+      rg.kill();
+    };
+
+    rg.stdout.on("data", (data) => {
+      if (stoppedEarly) return;
+      buffer += data.toString();
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const event = JSON.parse(line);
+          if (event.type !== "match" || !event.data) continue;
+
+          const matchPath = event.data.path?.text as string;
+          if (!matchPath) continue;
+          const absolutePath = path.isAbsolute(matchPath)
+            ? matchPath
+            : path.join(appPath, matchPath);
+          const relativePath = normalizePath(
+            path.relative(appPath, absolutePath),
+          );
+          if (relativePath.startsWith("..")) continue;
+
+          const lineText = event.data.lines?.text as string;
+          const lineNumber = event.data.line_number as number;
+          const submatch = event.data.submatches?.[0];
+          if (
+            typeof lineText !== "string" ||
+            typeof lineNumber !== "number" ||
+            !submatch
+          ) {
+            continue;
+          }
+
+          const existing = results.get(relativePath);
+          if (
+            existing?.snippets?.some((snippet) => snippet.line === lineNumber)
+          ) {
+            continue;
+          }
+          const snippet = buildSnippetFromMatch({
+            lineText,
+            start: submatch.start,
+            end: submatch.end,
+            lineNumber,
+          });
+          const incrementalBytes = estimateSnippetBytes(
+            relativePath,
+            snippet,
+            !existing,
+          );
+          if (
+            snippetCount >= MAX_APP_FILE_SEARCH_SNIPPETS ||
+            (!existing && results.size >= MAX_APP_FILE_SEARCH_FILES) ||
+            resultBytes + incrementalBytes > MAX_APP_FILE_SEARCH_RESULT_BYTES
+          ) {
+            stopEarly();
+            break;
+          }
+
+          if (existing) {
+            existing.snippets ??= [];
+            existing.snippets.push(snippet);
+          } else {
+            results.set(relativePath, {
+              path: relativePath,
+              matchesContent: true,
+              snippets: [snippet],
+            });
+          }
+          snippetCount += 1;
+          resultBytes += incrementalBytes;
+        } catch (error) {
+          logger.warn("Failed to parse ripgrep output line:", line, error);
+        }
+      }
+    });
+
+    rg.stderr.on("data", (data) => {
+      const message = data.toString();
+      if (message.toLowerCase().includes("binary file skipped")) return;
+      logger.debug("ripgrep stderr:", message);
+    });
+
+    rg.on("close", (code) => {
+      if (!stoppedEarly && code !== 0 && code !== 1) {
+        reject(new Error(`ripgrep exited with code ${code}`));
+        return;
+      }
+      const values = Array.from(results.values());
+      if (stoppedEarly) {
+        for (const result of values) result.truncated = true;
+      }
+      resolve(values);
+    });
+
+    rg.on("error", reject);
+  });
+}

--- a/src/ipc/utils/app_file_search.ts
+++ b/src/ipc/utils/app_file_search.ts
@@ -159,7 +159,13 @@ export async function searchAppFilesWithRipgrep({
           const relativePath = normalizePath(
             path.relative(appPath, absolutePath),
           );
-          if (relativePath.startsWith("..")) continue;
+          if (
+            relativePath === ".." ||
+            relativePath.startsWith("../") ||
+            path.isAbsolute(relativePath)
+          ) {
+            continue;
+          }
 
           const lineText = event.data.lines?.text as string;
           const lineNumber = event.data.line_number as number;

--- a/src/ipc/utils/app_file_search_stream.test.ts
+++ b/src/ipc/utils/app_file_search_stream.test.ts
@@ -100,4 +100,23 @@ describe("searchAppFilesWithRipgrep stream handling", () => {
     expect(results).toHaveLength(MAX_APP_FILE_SEARCH_FILES);
     expect(results.every((result) => result.truncated)).toBe(true);
   });
+
+  it("keeps legal names beginning with two dots while rejecting traversal", async () => {
+    const search = searchAppFilesWithRipgrep({
+      appPath: "/tmp/test-app",
+      query: "needle",
+    });
+
+    child.stdout.emit(
+      "data",
+      Buffer.from(
+        `${matchEvent("..config", "needle", "needle")}\n${matchEvent("../outside.txt", "needle", "needle")}\n`,
+      ),
+    );
+    child.emit("close", 0);
+
+    await expect(search).resolves.toEqual([
+      expect.objectContaining({ path: "..config" }),
+    ]);
+  });
 });

--- a/src/ipc/utils/app_file_search_stream.test.ts
+++ b/src/ipc/utils/app_file_search_stream.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
+
+const mocks = vi.hoisted(() => ({
+  spawn: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  default: { spawn: mocks.spawn },
+  spawn: mocks.spawn,
+}));
+vi.mock("electron-log", () => ({
+  default: {
+    scope: () => ({ debug: vi.fn(), warn: vi.fn() }),
+  },
+}));
+vi.mock("./ripgrep_utils", () => ({
+  getRgExecutablePath: () => "rg",
+  MAX_FILE_SEARCH_SIZE: 1024 * 1024,
+  RIPGREP_EXCLUDED_GLOBS: ["!node_modules/**", "!.git/**", "!.next/**"],
+}));
+
+import {
+  MAX_APP_FILE_SEARCH_FILES,
+  searchAppFilesWithRipgrep,
+} from "./app_file_search";
+
+class FakeRipgrepProcess extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  kill = vi.fn(() => true);
+}
+
+function matchEvent(path: string, lineText: string, query: string) {
+  const start = Buffer.byteLength(lineText.slice(0, lineText.indexOf(query)));
+  return JSON.stringify({
+    type: "match",
+    data: {
+      path: { text: path },
+      lines: { text: `${lineText}\n` },
+      line_number: 1,
+      submatches: [
+        {
+          match: { text: query },
+          start,
+          end: start + Buffer.byteLength(query),
+        },
+      ],
+    },
+  });
+}
+
+describe("searchAppFilesWithRipgrep stream handling", () => {
+  let child: FakeRipgrepProcess;
+
+  beforeEach(() => {
+    child = new FakeRipgrepProcess();
+    mocks.spawn.mockReset();
+    mocks.spawn.mockReturnValue(child);
+  });
+
+  it("preserves UTF-8 characters split across stdout chunks", async () => {
+    const search = searchAppFilesWithRipgrep({
+      appPath: "/tmp/test-app",
+      query: "needle",
+    });
+    const encoded = Buffer.from(
+      `${matchEvent("unicode.txt", "😀needle界", "needle")}\n`,
+    );
+    const emojiOffset = encoded.indexOf(Buffer.from("😀"));
+
+    child.stdout.emit("data", encoded.subarray(0, emojiOffset + 2));
+    child.stdout.emit("data", encoded.subarray(emojiOffset + 2));
+    child.emit("close", 0);
+
+    const [result] = await search;
+    const snippet = result.snippets?.[0];
+    expect(`${snippet?.before}${snippet?.match}${snippet?.after}`).toContain(
+      "😀needle界",
+    );
+    expect(JSON.stringify(result)).not.toContain("�");
+  });
+
+  it("ignores a process error emitted after an intentional early kill", async () => {
+    const search = searchAppFilesWithRipgrep({
+      appPath: "/tmp/test-app",
+      query: "needle",
+    });
+    const output = Array.from(
+      { length: MAX_APP_FILE_SEARCH_FILES + 1 },
+      (_, index) => matchEvent(`file-${index}.txt`, "needle", "needle"),
+    ).join("\n");
+
+    child.stdout.emit("data", Buffer.from(`${output}\n`));
+    expect(child.kill).toHaveBeenCalledOnce();
+    child.emit("error", new Error("kill race"));
+    child.emit("close", null);
+
+    const results = await search;
+    expect(results).toHaveLength(MAX_APP_FILE_SEARCH_FILES);
+    expect(results.every((result) => result.truncated)).toBe(true);
+  });
+});

--- a/src/ipc/utils/result_limits.test.ts
+++ b/src/ipc/utils/result_limits.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { takeUtf8Prefix, takeUtf8Suffix, truncateUtf8 } from "./result_limits";
+
+describe("UTF-8 result limits", () => {
+  it("keeps exact byte boundaries intact", () => {
+    expect(takeUtf8Prefix("ab😀cd", 6)).toBe("ab😀");
+    expect(takeUtf8Suffix("ab😀cd", 6)).toBe("😀cd");
+  });
+
+  it("never splits multi-byte characters", () => {
+    const result = truncateUtf8("😀😀😀", 9);
+
+    expect(Buffer.byteLength(result.text, "utf8")).toBeLessThanOrEqual(9);
+    expect(result.text).not.toContain("�");
+    expect(result.truncated).toBe(true);
+  });
+
+  it("does not mark a value at the boundary as truncated", () => {
+    expect(truncateUtf8("é", 2)).toEqual({
+      text: "é",
+      truncated: false,
+    });
+  });
+});

--- a/src/ipc/utils/result_limits.ts
+++ b/src/ipc/utils/result_limits.ts
@@ -1,0 +1,85 @@
+export type Utf8Truncation = {
+  text: string;
+  truncated: boolean;
+};
+
+/**
+ * Return a prefix that is at most maxBytes when encoded as UTF-8. Iterating by
+ * code point prevents a truncation boundary from splitting a surrogate pair.
+ */
+export function takeUtf8Prefix(text: string, maxBytes: number): string {
+  if (maxBytes <= 0) return "";
+  if (Buffer.byteLength(text, "utf8") <= maxBytes) return text;
+
+  let bytes = 0;
+  let result = "";
+  for (const character of text) {
+    const characterBytes = Buffer.byteLength(character, "utf8");
+    if (bytes + characterBytes > maxBytes) break;
+    result += character;
+    bytes += characterBytes;
+  }
+  return result;
+}
+
+/** Return a UTF-8-safe suffix no larger than maxBytes. */
+export function takeUtf8Suffix(text: string, maxBytes: number): string {
+  if (maxBytes <= 0) return "";
+  if (Buffer.byteLength(text, "utf8") <= maxBytes) return text;
+
+  let bytes = 0;
+  let start = text.length;
+  while (start > 0) {
+    let characterStart = start - 1;
+    const lastCodeUnit = text.charCodeAt(characterStart);
+    if (
+      lastCodeUnit >= 0xdc00 &&
+      lastCodeUnit <= 0xdfff &&
+      characterStart > 0
+    ) {
+      const previousCodeUnit = text.charCodeAt(characterStart - 1);
+      if (previousCodeUnit >= 0xd800 && previousCodeUnit <= 0xdbff) {
+        characterStart -= 1;
+      }
+    }
+
+    const character = text.slice(characterStart, start);
+    const characterBytes = Buffer.byteLength(character, "utf8");
+    if (bytes + characterBytes > maxBytes) break;
+    bytes += characterBytes;
+    start = characterStart;
+  }
+
+  return text.slice(start);
+}
+
+/**
+ * Truncate text to an exact UTF-8 byte budget and include a suffix when space
+ * permits. The returned text never contains a broken Unicode code point.
+ */
+export function truncateUtf8(
+  text: string,
+  maxBytes: number,
+  suffix = "...",
+): Utf8Truncation {
+  if (Buffer.byteLength(text, "utf8") <= maxBytes) {
+    return { text, truncated: false };
+  }
+
+  if (maxBytes <= 0) {
+    return { text: "", truncated: true };
+  }
+
+  const suffixBytes = Buffer.byteLength(suffix, "utf8");
+  if (suffixBytes >= maxBytes) {
+    return {
+      text: takeUtf8Prefix(suffix, maxBytes),
+      truncated: true,
+    };
+  }
+
+  return {
+    text: takeUtf8Prefix(text, maxBytes - suffixBytes) + suffix,
+    truncated: true,
+  };
+}

--- a/src/ipc/utils/sql_result_limits.test.ts
+++ b/src/ipc/utils/sql_result_limits.test.ts
@@ -49,9 +49,11 @@ describe("agent SQL query limiting", () => {
   it("wraps a single read SELECT with a sentinel row", () => {
     const result = limitAgentSqlQuery("SELECT * FROM users;", 100);
 
-    expect(result.limited).toBe(true);
-    expect(result.query).toContain("SELECT * FROM users");
-    expect(result.query).toContain("LIMIT 101");
+    expect(result).toEqual({
+      limited: true,
+      query:
+        'SELECT * FROM (\nSELECT * FROM users\n) AS "dyad_limited_result"\nLIMIT 101',
+    });
   });
 
   it.each([

--- a/src/ipc/utils/sql_result_limits.test.ts
+++ b/src/ipc/utils/sql_result_limits.test.ts
@@ -56,10 +56,24 @@ describe("agent SQL query limiting", () => {
     });
   });
 
+  it("wraps a single read-only CTE with a sentinel row", () => {
+    const result = limitAgentSqlQuery(
+      "WITH active AS (SELECT * FROM users) SELECT * FROM active;",
+      100,
+    );
+
+    expect(result).toEqual({
+      limited: true,
+      query:
+        'SELECT * FROM (\nWITH active AS (SELECT * FROM users) SELECT * FROM active\n) AS "dyad_limited_result"\nLIMIT 101',
+    });
+  });
+
   it.each([
     "CREATE TABLE users (id bigint);",
     "UPDATE users SET name = 'Ada';",
     "DELETE FROM users;",
+    "WITH inserted AS (INSERT INTO users (name) VALUES ('Ada') RETURNING *) SELECT * FROM inserted;",
     "SELECT 1; SELECT 2;",
     "DO $$ BEGIN DELETE FROM users; END $$;",
   ])("does not rewrite non-read or multi-statement SQL: %s", (query) => {

--- a/src/ipc/utils/sql_result_limits.test.ts
+++ b/src/ipc/utils/sql_result_limits.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { limitAgentSqlQuery, serializeSqlResult } from "./sql_result_limits";
+
+const limits = {
+  maxRows: 2,
+  maxBytes: 512,
+  maxCellBytes: 48,
+};
+
+describe("SQL result limits", () => {
+  it("caps rows and reports truncation", () => {
+    const result = serializeSqlResult(
+      [{ id: 1 }, { id: 2 }, { id: 3 }],
+      limits,
+    );
+
+    expect(JSON.parse(result.json)).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(result.text).toContain("2 of 3 rows");
+    expect(result.truncated).toBe(true);
+    expect(Buffer.byteLength(result.text, "utf8")).toBeLessThanOrEqual(512);
+  });
+
+  it("enforces UTF-8 byte caps without broken characters", () => {
+    const result = serializeSqlResult([{ value: "😀".repeat(200) }], limits);
+
+    expect(result.truncated).toBe(true);
+    expect(result.text).not.toContain("�");
+    expect(Buffer.byteLength(result.text, "utf8")).toBeLessThanOrEqual(512);
+    expect(() => JSON.parse(result.json)).not.toThrow();
+  });
+
+  it("keeps heavily escaped JSON within the byte budget", () => {
+    const result = serializeSqlResult([{ value: "\0".repeat(2_000) }], limits);
+
+    expect(result.truncated).toBe(true);
+    expect(Buffer.byteLength(result.text, "utf8")).toBeLessThanOrEqual(512);
+    expect(() => JSON.parse(result.json)).not.toThrow();
+  });
+
+  it("preserves a result exactly at the row boundary", () => {
+    const result = serializeSqlResult([{ id: 1 }, { id: 2 }], limits);
+
+    expect(result.truncated).toBe(false);
+    expect(result.notice).toBe("");
+  });
+});
+
+describe("agent SQL query limiting", () => {
+  it("wraps a single read SELECT with a sentinel row", () => {
+    const result = limitAgentSqlQuery("SELECT * FROM users;", 100);
+
+    expect(result.limited).toBe(true);
+    expect(result.query).toContain("SELECT * FROM users");
+    expect(result.query).toContain("LIMIT 101");
+  });
+
+  it.each([
+    "CREATE TABLE users (id bigint);",
+    "UPDATE users SET name = 'Ada';",
+    "DELETE FROM users;",
+    "SELECT 1; SELECT 2;",
+    "DO $$ BEGIN DELETE FROM users; END $$;",
+  ])("does not rewrite non-read or multi-statement SQL: %s", (query) => {
+    expect(limitAgentSqlQuery(query, 100)).toEqual({
+      query,
+      limited: false,
+    });
+  });
+});

--- a/src/ipc/utils/sql_result_limits.ts
+++ b/src/ipc/utils/sql_result_limits.ts
@@ -1,0 +1,232 @@
+import {
+  getSqlDataDeletionAnalysis,
+  getSqlSchemaMutationAnalysis,
+} from "@/lib/sqlSchemaMutation";
+import { takeUtf8Prefix, truncateUtf8 } from "./result_limits";
+
+export type SqlResultLimits = {
+  maxRows: number;
+  maxBytes: number;
+  maxCellBytes: number;
+};
+
+export const AGENT_SQL_RESULT_LIMITS: SqlResultLimits = {
+  maxRows: 100,
+  maxBytes: 128 * 1024,
+  maxCellBytes: 8 * 1024,
+};
+
+export type SerializedSqlResult = {
+  json: string;
+  notice: string;
+  text: string;
+  truncated: boolean;
+  totalRows: number | null;
+  returnedRows: number | null;
+};
+
+type SanitizeState = {
+  limits: SqlResultLimits;
+  remainingStringBytes: number;
+  nodes: number;
+  truncated: boolean;
+  seen: WeakSet<object>;
+};
+
+const MAX_RESULT_DEPTH = 8;
+const MAX_COLLECTION_ITEMS = 200;
+const MAX_RESULT_NODES = 2_000;
+const MAX_OBJECT_KEY_BYTES = 256;
+
+function markTruncated(state: SanitizeState, marker: string): string {
+  state.truncated = true;
+  return marker;
+}
+
+function sanitizeString(value: string, state: SanitizeState): string {
+  const allowedBytes = Math.max(
+    0,
+    Math.min(state.limits.maxCellBytes, state.remainingStringBytes),
+  );
+  const result = truncateUtf8(value, allowedBytes);
+  state.remainingStringBytes -= Buffer.byteLength(result.text, "utf8");
+  if (result.truncated) state.truncated = true;
+  return result.text;
+}
+
+function sanitizeSqlValue(
+  value: unknown,
+  state: SanitizeState,
+  depth: number,
+): unknown {
+  state.nodes += 1;
+  if (state.nodes > MAX_RESULT_NODES) {
+    return markTruncated(state, "[result item limit reached]");
+  }
+  if (depth > MAX_RESULT_DEPTH) {
+    return markTruncated(state, "[result depth limit reached]");
+  }
+
+  if (value === null || typeof value === "boolean") return value;
+  if (typeof value === "string") return sanitizeString(value, state);
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : String(value);
+  }
+  if (typeof value === "bigint") {
+    return sanitizeString(value.toString(), state);
+  }
+  if (typeof value === "undefined") return null;
+  if (typeof value === "function" || typeof value === "symbol") {
+    return sanitizeString(String(value), state);
+  }
+  if (value instanceof Date) return value.toISOString();
+  if (ArrayBuffer.isView(value)) {
+    return markTruncated(
+      state,
+      `[binary value omitted: ${value.byteLength} bytes]`,
+    );
+  }
+  if (value instanceof ArrayBuffer) {
+    return markTruncated(
+      state,
+      `[binary value omitted: ${value.byteLength} bytes]`,
+    );
+  }
+
+  if (typeof value !== "object") return String(value);
+  if (state.seen.has(value)) {
+    return markTruncated(state, "[circular value omitted]");
+  }
+  state.seen.add(value);
+
+  if (Array.isArray(value)) {
+    const itemLimit = depth === 0 ? state.limits.maxRows : MAX_COLLECTION_ITEMS;
+    const result: unknown[] = [];
+    const count = Math.min(value.length, itemLimit);
+    for (let index = 0; index < count; index += 1) {
+      result.push(sanitizeSqlValue(value[index], state, depth + 1));
+    }
+    if (value.length > count) state.truncated = true;
+    return result;
+  }
+
+  const result: Record<string, unknown> = {};
+  let keyCount = 0;
+  for (const rawKey in value) {
+    if (!Object.prototype.hasOwnProperty.call(value, rawKey)) continue;
+    if (keyCount >= MAX_COLLECTION_ITEMS) {
+      state.truncated = true;
+      break;
+    }
+    const key = truncateUtf8(rawKey, MAX_OBJECT_KEY_BYTES).text;
+    if (key !== rawKey) state.truncated = true;
+    result[key] = sanitizeSqlValue(
+      (value as Record<string, unknown>)[rawKey],
+      state,
+      depth + 1,
+    );
+    keyCount += 1;
+  }
+  return result;
+}
+
+function fitJsonPreview(json: string, maxBytes: number): string {
+  if (Buffer.byteLength(json, "utf8") <= maxBytes) return json;
+
+  // JSON escaping can expand a character to six bytes (for example, a control
+  // character becomes `\u0000`). Keep the fallback comfortably inside the
+  // budget while still returning valid JSON.
+  const previewBytes = Math.max(0, Math.floor((maxBytes - 64) / 6));
+  const fallback = JSON.stringify({
+    preview: takeUtf8Prefix(json, previewBytes),
+    truncated: true,
+  });
+  if (Buffer.byteLength(fallback, "utf8") <= maxBytes) return fallback;
+  return '{"truncated":true}';
+}
+
+/**
+ * Serialize a database result without materializing an unbounded JSON string.
+ * The bounded clone limits rows, nested collections, cell text, and depth
+ * before JSON.stringify runs.
+ */
+export function serializeSqlResult(
+  value: unknown,
+  limits: SqlResultLimits,
+): SerializedSqlResult {
+  const totalRows = Array.isArray(value) ? value.length : null;
+  const noticeReserve = Math.min(256, Math.floor(limits.maxBytes / 3));
+  const jsonBudget = Math.max(20, limits.maxBytes - noticeReserve);
+  const state: SanitizeState = {
+    limits,
+    remainingStringBytes: limits.maxBytes,
+    nodes: 0,
+    truncated: false,
+    seen: new WeakSet(),
+  };
+  const sanitized = sanitizeSqlValue(value, state, 0);
+  let json = JSON.stringify(sanitized);
+  if (Buffer.byteLength(json, "utf8") > jsonBudget) {
+    state.truncated = true;
+    json = fitJsonPreview(json, jsonBudget);
+  }
+
+  const returnedRows = Array.isArray(sanitized) ? sanitized.length : null;
+  let notice = "";
+  if (state.truncated) {
+    const rowText =
+      totalRows === null
+        ? `at most ${limits.maxRows} rows`
+        : `${returnedRows} of ${totalRows} rows`;
+    const fullNotice = `\n\n[TRUNCATED: SQL result limited to ${rowText} and ${limits.maxBytes} UTF-8 bytes.]`;
+    notice = takeUtf8Prefix(
+      fullNotice,
+      Math.max(0, limits.maxBytes - Buffer.byteLength(json, "utf8")),
+    );
+  }
+
+  return {
+    json,
+    notice,
+    text: json + notice,
+    truncated: state.truncated,
+    totalRows,
+    returnedRows,
+  };
+}
+
+export type LimitedSqlQuery = {
+  query: string;
+  limited: boolean;
+};
+
+/**
+ * Bound only a classifier-proven, single SELECT. DDL, DML, dynamic SQL,
+ * multiple statements, and incomplete SQL are returned byte-for-byte so a
+ * safety limit never changes their execution semantics.
+ */
+export function limitAgentSqlQuery(
+  query: string,
+  maxRows: number,
+): LimitedSqlQuery {
+  const schemaAnalysis = getSqlSchemaMutationAnalysis(query);
+  const deletionAnalysis = getSqlDataDeletionAnalysis(query);
+  const schemaStatement = schemaAnalysis.statements[0];
+  const deletionStatement = deletionAnalysis.statements[0];
+  const isSingleReadSelect =
+    !schemaAnalysis.mutatesSchema &&
+    !deletionAnalysis.deletesData &&
+    schemaAnalysis.statements.length === 1 &&
+    deletionAnalysis.statements.length === 1 &&
+    schemaStatement?.command === "SELECT" &&
+    deletionStatement?.command === "SELECT";
+
+  if (!isSingleReadSelect || !schemaStatement) {
+    return { query, limited: false };
+  }
+
+  return {
+    query: `SELECT * FROM (\n${schemaStatement.sql}\n) AS "dyad_limited_result"\nLIMIT ${maxRows + 1}`,
+    limited: true,
+  };
+}

--- a/src/ipc/utils/sql_result_limits.ts
+++ b/src/ipc/utils/sql_result_limits.ts
@@ -201,9 +201,11 @@ export type LimitedSqlQuery = {
 };
 
 /**
- * Bound only a classifier-proven, single SELECT. DDL, DML, dynamic SQL,
+ * Bound only a classifier-proven single read query. DDL, DML, dynamic SQL,
  * multiple statements, and incomplete SQL are returned byte-for-byte so a
- * safety limit never changes their execution semantics.
+ * safety limit never changes their execution semantics. WITH statements are
+ * handled conservatively because a data-modifying CTE cannot be nested inside
+ * the outer limiting SELECT in PostgreSQL.
  */
 export function limitAgentSqlQuery(
   query: string,
@@ -213,15 +215,20 @@ export function limitAgentSqlQuery(
   const deletionAnalysis = getSqlDataDeletionAnalysis(query);
   const schemaStatement = schemaAnalysis.statements[0];
   const deletionStatement = deletionAnalysis.statements[0];
-  const isSingleReadSelect =
+  const command = schemaStatement?.command;
+  const isReadCommand =
+    command === "SELECT" ||
+    (command === "WITH" &&
+      !/\b(?:INSERT|UPDATE|DELETE|MERGE)\b/i.test(schemaStatement.sql));
+  const isSingleReadQuery =
     !schemaAnalysis.mutatesSchema &&
     !deletionAnalysis.deletesData &&
     schemaAnalysis.statements.length === 1 &&
     deletionAnalysis.statements.length === 1 &&
-    schemaStatement?.command === "SELECT" &&
-    deletionStatement?.command === "SELECT";
+    command === deletionStatement?.command &&
+    isReadCommand;
 
-  if (!isSingleReadSelect || !schemaStatement) {
+  if (!isSingleReadQuery || !schemaStatement) {
     return { query, limited: false };
   }
 

--- a/src/ipc/utils/sql_result_limits.ts
+++ b/src/ipc/utils/sql_result_limits.ts
@@ -225,8 +225,9 @@ export function limitAgentSqlQuery(
     return { query, limited: false };
   }
 
+  const cleanSql = schemaStatement.sql.trim().replace(/;+$/, "");
   return {
-    query: `SELECT * FROM (\n${schemaStatement.sql}\n) AS "dyad_limited_result"\nLIMIT ${maxRows + 1}`,
+    query: `SELECT * FROM (\n${cleanSql}\n) AS "dyad_limited_result"\nLIMIT ${maxRows + 1}`,
     limited: true,
   };
 }

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -53,6 +53,7 @@ export const AppSearchResultSchema = z.object({
   createdAt: z.date(),
   matchedChatTitle: z.string().nullable(),
   matchedChatMessage: z.string().nullable(),
+  searchTruncated: z.boolean().optional(),
 });
 
 // Type derived from AppSearchResultSchema

--- a/src/neon_admin/neon_context.ts
+++ b/src/neon_admin/neon_context.ts
@@ -4,6 +4,10 @@ import { getNeonClient } from "./neon_management_client";
 import { IS_TEST_BUILD } from "@/ipc/utils/test_utils";
 import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
 import type { AppFrameworkType } from "@/lib/framework_constants";
+import {
+  serializeSqlResult,
+  type SqlResultLimits,
+} from "@/ipc/utils/sql_result_limits";
 
 const logger = log.scope("neon_context");
 
@@ -140,10 +144,12 @@ export async function executeNeonSql({
   projectId,
   branchId,
   query,
+  resultLimits,
 }: {
   projectId: string;
   branchId: string;
   query: string;
+  resultLimits?: SqlResultLimits;
 }): Promise<string> {
   if (IS_TEST_BUILD) {
     return `[[TEST_NEON_SQL_RESULT: ${query.slice(0, 50)}]]`;
@@ -153,7 +159,9 @@ export async function executeNeonSql({
     const connectionUri = await getConnectionUri({ projectId, branchId });
     const sql = neon(connectionUri);
     const result = await sql.query(query, []);
-    return JSON.stringify(result, null, 2);
+    return resultLimits
+      ? serializeSqlResult(result, resultLimits).text
+      : JSON.stringify(result, null, 2);
   } catch (error) {
     logger.error("Error executing Neon SQL:", error);
     throw new DyadError(

--- a/src/pro/main/ipc/handlers/local_agent/tools/execute_sql.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/execute_sql.spec.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { executeSqlTool } from "./execute_sql";
+import { AGENT_SQL_RESULT_LIMITS } from "@/ipc/utils/sql_result_limits";
 
 const mocks = vi.hoisted(() => ({
   executeSupabaseSqlMock: vi.fn(),
@@ -28,6 +29,7 @@ describe("executeSqlTool", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.executeSupabaseSqlMock.mockResolvedValue("[]");
+    mocks.executeNeonSqlMock.mockResolvedValue("[]");
     mocks.writeMigrationFileMock.mockResolvedValue(
       "supabase/migrations/0000_test.sql",
     );
@@ -105,6 +107,7 @@ describe("executeSqlTool", () => {
       supabaseProjectId: "project",
       query: "CREATE TABLE users (id bigint);",
       organizationSlug: "org",
+      resultLimits: AGENT_SQL_RESULT_LIMITS,
     });
     expect(mocks.writeMigrationFileMock).toHaveBeenCalledWith(
       "/app",
@@ -128,9 +131,47 @@ describe("executeSqlTool", () => {
 
     expect(mocks.executeSupabaseSqlMock).toHaveBeenCalledWith({
       supabaseProjectId: "project",
-      query: "SELECT * FROM users;",
+      query: expect.stringMatching(
+        /SELECT \* FROM \([\s\S]*SELECT \* FROM users[\s\S]*LIMIT 101/,
+      ),
       organizationSlug: null,
+      resultLimits: AGENT_SQL_RESULT_LIMITS,
     });
     expect(mocks.writeMigrationFileMock).not.toHaveBeenCalled();
+  });
+
+  it("does not rewrite data-changing SQL to add a result limit", async () => {
+    await executeSqlTool.execute(
+      {
+        query: "UPDATE users SET active = false RETURNING *;",
+      },
+      {
+        appPath: "/app",
+        supabaseProjectId: "project",
+        supabaseOrganizationSlug: null,
+      } as any,
+    );
+
+    expect(mocks.executeSupabaseSqlMock).toHaveBeenCalledWith({
+      supabaseProjectId: "project",
+      query: "UPDATE users SET active = false RETURNING *;",
+      organizationSlug: null,
+      resultLimits: AGENT_SQL_RESULT_LIMITS,
+    });
+  });
+
+  it("applies the same bounded SELECT policy to Neon", async () => {
+    await executeSqlTool.execute({ query: "SELECT * FROM users;" }, {
+      appPath: "/app",
+      neonProjectId: "neon-project",
+      neonActiveBranchId: "branch",
+    } as any);
+
+    expect(mocks.executeNeonSqlMock).toHaveBeenCalledWith({
+      projectId: "neon-project",
+      branchId: "branch",
+      query: expect.stringContaining("LIMIT 101"),
+      resultLimits: AGENT_SQL_RESULT_LIMITS,
+    });
   });
 });

--- a/src/pro/main/ipc/handlers/local_agent/tools/execute_sql.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/execute_sql.ts
@@ -14,6 +14,10 @@ import {
   doesSqlDeleteData,
   doesSqlMutateSchema,
 } from "@/lib/sqlSchemaMutation";
+import {
+  AGENT_SQL_RESULT_LIMITS,
+  limitAgentSqlQuery,
+} from "@/ipc/utils/sql_result_limits";
 
 const executeSqlSchema = z.object({
   query: z.string().describe("The SQL query to execute"),
@@ -50,11 +54,17 @@ export const executeSqlTool: ToolDefinition<z.infer<typeof executeSqlSchema>> =
     },
 
     execute: async (args, ctx: AgentContext) => {
+      const limitedQuery = limitAgentSqlQuery(
+        args.query,
+        AGENT_SQL_RESULT_LIMITS.maxRows,
+      );
+
       if (ctx.neonProjectId && ctx.neonActiveBranchId) {
         const sqlResult = await executeNeonSql({
           projectId: ctx.neonProjectId,
           branchId: ctx.neonActiveBranchId,
-          query: args.query,
+          query: limitedQuery.query,
+          resultLimits: AGENT_SQL_RESULT_LIMITS,
         });
         return `Successfully executed SQL query.\n\nSQL result:\n${sqlResult}`;
       }
@@ -69,8 +79,9 @@ export const executeSqlTool: ToolDefinition<z.infer<typeof executeSqlSchema>> =
       if (ctx.supabaseProjectId) {
         const sqlResult = await executeSupabaseSql({
           supabaseProjectId: ctx.supabaseProjectId,
-          query: args.query,
+          query: limitedQuery.query,
           organizationSlug: ctx.supabaseOrganizationSlug ?? null,
+          resultLimits: AGENT_SQL_RESULT_LIMITS,
         });
 
         const settings = readSettings();

--- a/src/pro/main/ipc/handlers/local_agent/tools/grep.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/grep.spec.ts
@@ -590,6 +590,20 @@ function deepHello() {
       expect(result).not.toContain("�");
       expect(matchLine).not.toContain("......");
     });
+
+    it("does not split a surrogate pair at the character limit", async () => {
+      const query = "unicodeBoundaryNeedle";
+      const beforeEmoji = query + "a".repeat(499 - query.length);
+      await fs.promises.writeFile(
+        path.join(testDir, "unicode-boundary.ts"),
+        `${beforeEmoji}😀tail\n`,
+      );
+
+      const result = await grepTool.execute({ query }, mockContext);
+
+      expect(result).toContain("😀...");
+      expect(result).not.toContain("�");
+    });
   });
 
   describe("execute - result sorting", () => {

--- a/src/pro/main/ipc/handlers/local_agent/tools/grep.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/grep.spec.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import { grepTool, normalizeRipgrepMatchPath } from "./grep";
+import {
+  grepTool,
+  MAX_GREP_LINE_BYTES,
+  MAX_GREP_OUTPUT_BYTES,
+  normalizeRipgrepMatchPath,
+} from "./grep";
 import type { AgentContext } from "./types";
 
 // Mock electron-log
@@ -494,11 +499,11 @@ function deepHello() {
         mockContext,
       );
 
-      expect(result).toMatchInlineSnapshot(`
-        "nested/deep.ts:2: function deepHello() {
-
-        [TRUNCATED: Showing 1 of 8 matches. Use include_pattern to narrow your search (e.g., include_pattern="*.tsx") or use a more specific query.]"
-      `);
+      const matchLines = result
+        .split("\n")
+        .filter((line) => line.match(/:\d+:/));
+      expect(matchLines).toHaveLength(1);
+      expect(result).toContain("[TRUNCATED: Showing 1 of at least 2 matches.");
     });
 
     it("includes truncation info in XML attributes", async () => {
@@ -539,6 +544,50 @@ function deepHello() {
         .filter((line) => line.match(/:\d+:/));
       expect(matchLines).toHaveLength(3);
       expect(result).toContain("[TRUNCATED: Showing 3 of at least 4 matches.");
+    });
+
+    it("stops ordinary searches at the default producer limit", async () => {
+      await fs.promises.writeFile(
+        path.join(testDir, "broad.ts"),
+        Array.from({ length: 125 }, () => "defaultLimitNeedle").join("\n"),
+      );
+
+      const result = await grepTool.execute(
+        { query: "defaultLimitNeedle" },
+        mockContext,
+      );
+      const matchLines = result
+        .split("\n")
+        .filter((line) => line.match(/:\d+:/));
+
+      expect(matchLines).toHaveLength(100);
+      expect(result).toContain(
+        "[TRUNCATED: Showing 100 of at least 101 matches.",
+      );
+    });
+
+    it("caps retained Unicode lines and the total UTF-8 output", async () => {
+      await fs.promises.writeFile(
+        path.join(testDir, "unicode.ts"),
+        `unicodeLimitNeedle ${"😀".repeat(600)}\n`,
+      );
+
+      const result = await grepTool.execute(
+        { query: "unicodeLimitNeedle" },
+        mockContext,
+      );
+      const matchLine = result
+        .split("\n")
+        .find((line) => line.includes("unicodeLimitNeedle"));
+
+      expect(matchLine).toBeDefined();
+      expect(Buffer.byteLength(matchLine!, "utf8")).toBeLessThanOrEqual(
+        MAX_GREP_LINE_BYTES + 64,
+      );
+      expect(Buffer.byteLength(result, "utf8")).toBeLessThanOrEqual(
+        MAX_GREP_OUTPUT_BYTES,
+      );
+      expect(result).not.toContain("�");
     });
   });
 

--- a/src/pro/main/ipc/handlers/local_agent/tools/grep.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/grep.spec.ts
@@ -588,6 +588,7 @@ function deepHello() {
         MAX_GREP_OUTPUT_BYTES,
       );
       expect(result).not.toContain("�");
+      expect(matchLine).not.toContain("......");
     });
   });
 

--- a/src/pro/main/ipc/handlers/local_agent/tools/grep.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/grep.ts
@@ -17,12 +17,17 @@ import {
 } from "./resolve_app_context";
 import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
 import log from "electron-log";
+import { truncateUtf8 } from "@/ipc/utils/result_limits";
 
 const logger = log.scope("grep");
 
 const DEFAULT_LIMIT = 100;
 const MAX_LIMIT = 250;
 const MAX_LINE_LENGTH = 500;
+export const MAX_GREP_LINE_BYTES = 1024;
+export const MAX_GREP_OUTPUT_BYTES = 128 * 1024;
+const MAX_RETAINED_MATCH_BYTES = MAX_GREP_OUTPUT_BYTES - 2 * 1024;
+const MAX_RIPGREP_STDERR_BYTES = 64 * 1024;
 
 const grepSchema = z.object({
   query: z
@@ -92,6 +97,7 @@ function buildGrepAttributes(
   args: Partial<z.infer<typeof grepSchema>>,
   count?: number,
   totalCount?: number,
+  truncated = false,
 ): string {
   const attrs: string[] = [];
   if (args.query) {
@@ -118,7 +124,7 @@ function buildGrepAttributes(
   if (count !== undefined) {
     attrs.push(`count="${count}"`);
   }
-  if (totalCount !== undefined && totalCount > (count ?? 0)) {
+  if (totalCount !== undefined && (truncated || totalCount > (count ?? 0))) {
     attrs.push(`total="${totalCount}"`);
     attrs.push(`truncated="true"`);
   }
@@ -126,10 +132,11 @@ function buildGrepAttributes(
 }
 
 function truncateLineText(text: string): string {
-  if (text.length <= MAX_LINE_LENGTH) {
-    return text;
-  }
-  return text.slice(0, MAX_LINE_LENGTH) + "...";
+  const characterLimited =
+    text.length <= MAX_LINE_LENGTH
+      ? text
+      : text.slice(0, MAX_LINE_LENGTH) + "...";
+  return truncateUtf8(characterLimited, MAX_GREP_LINE_BYTES).text;
 }
 
 export function normalizeRipgrepMatchPath(matchPath: string): string {
@@ -145,6 +152,7 @@ async function runRipgrep({
   caseSensitive,
   literal,
   maxMatches,
+  maxResultBytes,
   excludeDyadFolder,
 }: {
   appPath: string;
@@ -155,11 +163,18 @@ async function runRipgrep({
   caseSensitive?: boolean;
   literal?: boolean;
   maxMatches?: number;
+  maxResultBytes: number;
   excludeDyadFolder?: boolean;
-}): Promise<{ matches: RipgrepMatch[]; stoppedEarly: boolean }> {
+}): Promise<{
+  matches: RipgrepMatch[];
+  stoppedEarly: boolean;
+  observedCount: number;
+}> {
   return new Promise((resolve, reject) => {
     const results: RipgrepMatch[] = [];
     let stoppedEarly = false;
+    let observedCount = 0;
+    let resultBytes = 0;
     const args: string[] = [
       "--json",
       "--no-config",
@@ -236,8 +251,19 @@ async function runRipgrep({
           }
 
           const normalizedPath = normalizeRipgrepMatchPath(matchPath);
+          const truncatedLine = truncateLineText(
+            lineText.replace(/\r?\n$/, ""),
+          );
+          const matchBytes =
+            Buffer.byteLength(normalizedPath, "utf8") +
+            Buffer.byteLength(truncatedLine, "utf8") +
+            32;
+          observedCount += 1;
 
-          if (maxMatches !== undefined && results.length >= maxMatches) {
+          if (
+            (maxMatches !== undefined && results.length >= maxMatches) ||
+            resultBytes + matchBytes > maxResultBytes
+          ) {
             stoppedEarly = true;
             rg.kill();
             break;
@@ -246,8 +272,9 @@ async function runRipgrep({
           results.push({
             path: normalizedPath,
             lineNumber,
-            lineText: lineText.replace(/\r?\n$/, ""),
+            lineText: truncatedLine,
           });
+          resultBytes += matchBytes;
 
           if (maxMatches !== undefined && results.length >= maxMatches) {
             stoppedEarly = true;
@@ -262,13 +289,13 @@ async function runRipgrep({
 
     rg.stderr.on("data", (data) => {
       const text = data.toString();
-      stderr += text;
+      stderr = truncateUtf8(stderr + text, MAX_RIPGREP_STDERR_BYTES, "").text;
       logger.warn("ripgrep stderr", text);
     });
 
     rg.on("close", (code) => {
       if (stoppedEarly) {
-        resolve({ matches: results, stoppedEarly });
+        resolve({ matches: results, stoppedEarly, observedCount });
         return;
       }
 
@@ -277,7 +304,7 @@ async function runRipgrep({
         reject(new RipgrepError(`ripgrep exited with code ${code}`, stderr));
         return;
       }
-      resolve({ matches: results, stoppedEarly });
+      resolve({ matches: results, stoppedEarly, observedCount });
     });
 
     rg.on("error", (error) => {
@@ -338,6 +365,7 @@ export const grepTool: ToolDefinition<z.infer<typeof grepSchema>> = {
     // behavior). We never infer literal from the query's shape.
     let allMatches: RipgrepMatch[];
     let stoppedEarly: boolean;
+    let observedCount: number;
     try {
       const result = await runRipgrep({
         appPath: targetAppPath,
@@ -347,11 +375,13 @@ export const grepTool: ToolDefinition<z.infer<typeof grepSchema>> = {
         includeIgnored: args.include_ignored,
         caseSensitive: args.case_sensitive,
         literal: args.literal,
-        maxMatches: args.include_ignored ? limit + 1 : undefined,
+        maxMatches: limit + 1,
+        maxResultBytes: MAX_RETAINED_MATCH_BYTES,
         excludeDyadFolder: Boolean(args.app_name),
       });
       allMatches = result.matches;
       stoppedEarly = result.stoppedEarly;
+      observedCount = result.observedCount;
     } catch (error) {
       // A bad regex is thrown as a clear, regex-specific error (with a hint to
       // retry with literal=true) rather than silently re-running the query as a
@@ -370,7 +400,7 @@ export const grepTool: ToolDefinition<z.infer<typeof grepSchema>> = {
       throw error;
     }
 
-    const totalCount = allMatches.length;
+    const totalCount = observedCount;
     // Sort for deterministic output (ripgrep's parallel execution can produce varying order)
     const sortedMatches = [...allMatches].sort(
       (a, b) => a.path.localeCompare(b.path) || a.lineNumber - b.lineNumber,
@@ -378,7 +408,12 @@ export const grepTool: ToolDefinition<z.infer<typeof grepSchema>> = {
     const matches = sortedMatches.slice(0, limit);
     const wasTruncated = stoppedEarly || totalCount > limit;
 
-    const attrs = buildGrepAttributes(args, matches.length, totalCount);
+    const attrs = buildGrepAttributes(
+      args,
+      matches.length,
+      totalCount,
+      wasTruncated,
+    );
 
     if (matches.length === 0) {
       ctx.onXmlComplete(`<dyad-grep ${attrs}>No matches found.</dyad-grep>`);
@@ -387,7 +422,7 @@ export const grepTool: ToolDefinition<z.infer<typeof grepSchema>> = {
 
     // Format output: path:line: content (with truncated line text)
     const lines = matches.map(
-      (m) => `${m.path}:${m.lineNumber}: ${truncateLineText(m.lineText)}`,
+      (m) => `${m.path}:${m.lineNumber}: ${m.lineText}`,
     );
     let resultText = lines.join("\n");
 

--- a/src/pro/main/ipc/handlers/local_agent/tools/grep.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/grep.ts
@@ -134,9 +134,17 @@ function buildGrepAttributes(
 function truncateLineText(text: string): string {
   const byteLimited = truncateUtf8(text, MAX_GREP_LINE_BYTES);
   if (byteLimited.truncated) return byteLimited.text;
-  return text.length <= MAX_LINE_LENGTH
-    ? text
-    : text.slice(0, MAX_LINE_LENGTH) + "...";
+
+  let end = 0;
+  let codePoints = 0;
+  for (const character of text) {
+    if (codePoints === MAX_LINE_LENGTH) {
+      return text.slice(0, end) + "...";
+    }
+    end += character.length;
+    codePoints += 1;
+  }
+  return text;
 }
 
 export function normalizeRipgrepMatchPath(matchPath: string): string {
@@ -308,7 +316,7 @@ async function runRipgrep({
     });
 
     rg.on("error", (error) => {
-      reject(error);
+      if (!stoppedEarly) reject(error);
     });
   });
 }

--- a/src/pro/main/ipc/handlers/local_agent/tools/grep.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/grep.ts
@@ -132,11 +132,11 @@ function buildGrepAttributes(
 }
 
 function truncateLineText(text: string): string {
-  const characterLimited =
-    text.length <= MAX_LINE_LENGTH
-      ? text
-      : text.slice(0, MAX_LINE_LENGTH) + "...";
-  return truncateUtf8(characterLimited, MAX_GREP_LINE_BYTES).text;
+  const byteLimited = truncateUtf8(text, MAX_GREP_LINE_BYTES);
+  if (byteLimited.truncated) return byteLimited.text;
+  return text.length <= MAX_LINE_LENGTH
+    ? text
+    : text.slice(0, MAX_LINE_LENGTH) + "...";
 }
 
 export function normalizeRipgrepMatchPath(matchPath: string): string {

--- a/src/pro/main/ipc/handlers/local_agent/tools/grep_stream.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/grep_stream.spec.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import type { AgentContext } from "./types";
+
+const mocks = vi.hoisted(() => ({
+  spawn: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  default: { spawn: mocks.spawn },
+  spawn: mocks.spawn,
+}));
+vi.mock("electron-log", () => ({
+  default: {
+    scope: () => ({ warn: vi.fn() }),
+  },
+}));
+vi.mock("@/ipc/utils/ripgrep_utils", () => ({
+  getRgExecutablePath: () => "rg",
+  MAX_FILE_SEARCH_SIZE: 1024 * 1024,
+  RIPGREP_EXCLUDED_GLOBS: ["!node_modules/**", "!.git/**", "!.next/**"],
+}));
+
+import { grepTool } from "./grep";
+
+class FakeRipgrepProcess extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  kill = vi.fn(() => true);
+}
+
+function matchEvent(path: string) {
+  return JSON.stringify({
+    type: "match",
+    data: {
+      path: { text: path },
+      lines: { text: "needle\n" },
+      line_number: 1,
+    },
+  });
+}
+
+describe("grepTool stream handling", () => {
+  let child: FakeRipgrepProcess;
+
+  beforeEach(() => {
+    child = new FakeRipgrepProcess();
+    mocks.spawn.mockReset();
+    mocks.spawn.mockReturnValue(child);
+  });
+
+  it("ignores a process error emitted after an intentional early kill", async () => {
+    const context = {
+      appPath: "/tmp/test-app",
+      referencedApps: new Map(),
+      onXmlComplete: vi.fn(),
+    } as unknown as AgentContext;
+    const search = grepTool.execute({ query: "needle", limit: 1 }, context);
+
+    child.stdout.emit(
+      "data",
+      Buffer.from(`${matchEvent("one.ts")}\n${matchEvent("two.ts")}\n`),
+    );
+    expect(child.kill).toHaveBeenCalledOnce();
+    child.emit("error", new Error("kill race"));
+    child.emit("close", null);
+
+    await expect(search).resolves.toContain("one.ts:1: needle");
+  });
+});

--- a/src/supabase_admin/supabase_management_client.ts
+++ b/src/supabase_admin/supabase_management_client.ts
@@ -16,6 +16,10 @@ import {
 } from "../ipc/utils/retryWithRateLimit";
 import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
 import { enqueueSupabaseDeploy } from "./supabase_deploy_queue";
+import {
+  serializeSqlResult,
+  type SqlResultLimits,
+} from "@/ipc/utils/sql_result_limits";
 
 const fsPromises = fs.promises;
 
@@ -608,10 +612,12 @@ export async function executeSupabaseSql({
   supabaseProjectId,
   query,
   organizationSlug,
+  resultLimits,
 }: {
   supabaseProjectId: string;
   query: string;
   organizationSlug: string | null;
+  resultLimits?: SqlResultLimits;
 }): Promise<string> {
   if (IS_TEST_BUILD) {
     return "{}";
@@ -622,7 +628,9 @@ export async function executeSupabaseSql({
     () => supabase.runQuery(supabaseProjectId, query),
     `Execute SQL on ${supabaseProjectId}`,
   );
-  return JSON.stringify(result);
+  return resultLimits
+    ? serializeSqlResult(result, resultLimits).text
+    : JSON.stringify(result);
 }
 
 export async function deleteSupabaseFunction({


### PR DESCRIPTION
## Summary

- stop app-file and local-agent ripgrep producers at explicit match and UTF-8 byte budgets
- limit global app search in SQL and return bounded matching snippets with visible truncation state
- cap Agent SQL SELECT rows and serialize database results within row, cell, and byte budgets while leaving mutations and DDL unchanged
- add focused boundary, broad-query, early-stop, and Unicode coverage

## Verification

- npm test -- six focused result-limit suites (83 tests)
- npm run fmt
- npm run lint
- npm run ts
- npm run build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> SQL limiting only rewrites proven read-only queries, but changes agent and integration SQL paths; search behavior shifts (2-char DB search, truncated ripgrep subsets) may surprise users expecting full result sets.
> 
> **Overview**
> Adds **memory-safe caps** across app search, file search, agent `grep`, and SQL execution so broad queries cannot load unbounded data into the main process or the model context.
> 
> **App & file search:** Global app search moves into `app_search_service` with a **2-character minimum** for chat-history DB queries, per-source `LIMIT`, SQL-projected snippets, UTF-8 text bounds, and `searchTruncated` flags. The UI shows a minimum-length hint and a refine-your-search notice. Preview file search ripgrep logic is extracted to `app_file_search`, which **kills ripgrep early** when file/snippet/byte caps are hit and surfaces `truncated` in the file tree (with i18n).
> 
> **Agent tools:** `grep` now enforces match count, per-line UTF-8 limits, and total output bytes (with improved truncation messaging). **`execute_sql`** wraps classifier-proven single read `SELECT`/`WITH` queries in a limited subquery; mutations, multi-statement, and data-modifying CTEs are left unchanged. Supabase and Neon paths serialize results via new **`serializeSqlResult`** row/cell/depth/byte limits.
> 
> Shared **`result_limits`** helpers and focused tests cover Unicode boundaries, early ripgrep stop, and SQL rewrite edge cases. Internal docs note ripgrep cap ordering and SQL `WITH` nesting rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0faf107e86a83e24bba5122cb82b7ac571021c08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

