### PR TITLE
Bound voice-to-text recording memory

### DIFF
--- a/src/hooks/useVoiceToText.test.ts
+++ b/src/hooks/useVoiceToText.test.ts
@@ -71,6 +71,7 @@ describe("useVoiceToText", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it("stops the active microphone stream when unmounted mid-recording", async () => {

--- a/src/hooks/useVoiceToText.test.ts
+++ b/src/hooks/useVoiceToText.test.ts
@@ -1,6 +1,11 @@
 import { renderHook, act, waitFor } from "@testing-library/react";
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { useVoiceToText } from "@/hooks/useVoiceToText";
+import {
+  AUDIO_RECORDING_TIMESLICE_MS,
+  MAX_AUDIO_RECORDING_BYTES,
+  MAX_AUDIO_RECORDING_DURATION_MS,
+} from "@/ipc/types/audio";
 
 const { transcribeAudioMock } = vi.hoisted(() => ({
   transcribeAudioMock: vi.fn(),
@@ -19,13 +24,15 @@ class MockMediaRecorder {
   public ondataavailable: ((event: { data: Blob }) => void) | null = null;
   public onstop: (() => void | Promise<void>) | null = null;
 
-  public start = vi.fn(() => {
+  public stopPromise: Promise<void> = Promise.resolve();
+
+  public start = vi.fn((_timeslice?: number) => {
     this.state = "recording";
   });
 
   public stop = vi.fn(() => {
     this.state = "inactive";
-    void this.onstop?.();
+    this.stopPromise = Promise.resolve(this.onstop?.());
   });
 }
 
@@ -60,6 +67,10 @@ describe("useVoiceToText", () => {
       configurable: true,
       writable: true,
     });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("stops the active microphone stream when unmounted mid-recording", async () => {
@@ -115,7 +126,130 @@ describe("useVoiceToText", () => {
       expect(transcribeAudioMock).toHaveBeenCalledTimes(1);
     });
 
+    const request = transcribeAudioMock.mock.calls[0][0];
+    expect(request.audioData).toBeInstanceOf(Uint8Array);
+    expect(request.audioData.byteLength).toBe(10);
+    expect(recorder.start).toHaveBeenCalledWith(AUDIO_RECORDING_TIMESLICE_MS);
     expect(onTranscription).toHaveBeenCalledWith("hello world");
     expect(trackStopMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("automatically stops and transcribes when the duration limit is reached", async () => {
+    vi.useFakeTimers();
+    transcribeAudioMock.mockResolvedValue({ text: "from timer" });
+    const onTranscription = vi.fn();
+    const onError = vi.fn();
+
+    const { result } = renderHook(() =>
+      useVoiceToText({
+        enabled: true,
+        onTranscription,
+        onError,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.toggleRecording();
+    });
+
+    const recorder = mediaRecorderInstances[0];
+    recorder.ondataavailable?.({
+      data: new Blob(["timer audio"], { type: "audio/webm" }),
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(MAX_AUDIO_RECORDING_DURATION_MS);
+      await recorder.stopPromise;
+    });
+
+    expect(recorder.stop).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(
+      expect.stringContaining("maximum duration"),
+    );
+    expect(transcribeAudioMock).toHaveBeenCalledTimes(1);
+    expect(onTranscription).toHaveBeenCalledWith("from timer");
+    expect(result.current.isRecording).toBe(false);
+  });
+
+  it("stops before retaining a chunk that would exceed the byte limit", async () => {
+    transcribeAudioMock.mockResolvedValue({ text: "bounded audio" });
+    const onTranscription = vi.fn();
+    const onError = vi.fn();
+
+    const { result } = renderHook(() =>
+      useVoiceToText({
+        enabled: true,
+        onTranscription,
+        onError,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.toggleRecording();
+    });
+
+    const recorder = mediaRecorderInstances[0];
+    recorder.ondataavailable?.({
+      data: new Blob([new Uint8Array(MAX_AUDIO_RECORDING_BYTES - 1)], {
+        type: "audio/webm",
+      }),
+    });
+    recorder.ondataavailable?.({
+      data: new Blob([new Uint8Array([1, 2])], { type: "audio/webm" }),
+    });
+
+    await act(async () => {
+      await recorder.stopPromise;
+    });
+
+    expect(recorder.stop).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(
+      expect.stringContaining("maximum size"),
+    );
+    expect(transcribeAudioMock).toHaveBeenCalledTimes(1);
+    expect(transcribeAudioMock.mock.calls[0][0].audioData).toHaveLength(
+      MAX_AUDIO_RECORDING_BYTES - 1,
+    );
+    expect(onTranscription).toHaveBeenCalledWith("bounded audio");
+  });
+
+  it("ignores a transcription result that resolves after unmount", async () => {
+    let resolveTranscription: ((value: { text: string }) => void) | undefined;
+    transcribeAudioMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveTranscription = resolve;
+      }),
+    );
+    const onTranscription = vi.fn();
+
+    const { result, unmount } = renderHook(() =>
+      useVoiceToText({
+        enabled: true,
+        onTranscription,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.toggleRecording();
+    });
+
+    const recorder = mediaRecorderInstances[0];
+    recorder.ondataavailable?.({
+      data: new Blob(["test audio"], { type: "audio/webm" }),
+    });
+    await act(async () => {
+      await result.current.toggleRecording();
+    });
+    await waitFor(() => {
+      expect(transcribeAudioMock).toHaveBeenCalledTimes(1);
+    });
+
+    unmount();
+    await act(async () => {
+      resolveTranscription?.({ text: "too late" });
+      await recorder.stopPromise;
+    });
+
+    expect(onTranscription).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/useVoiceToText.test.ts
+++ b/src/hooks/useVoiceToText.test.ts
@@ -252,4 +252,45 @@ describe("useVoiceToText", () => {
 
     expect(onTranscription).not.toHaveBeenCalled();
   });
+
+  it("does not start transcription after unmount during audio conversion", async () => {
+    let resolveArrayBuffer: ((value: ArrayBuffer) => void) | undefined;
+    vi.spyOn(Blob.prototype, "arrayBuffer").mockReturnValue(
+      new Promise((resolve) => {
+        resolveArrayBuffer = resolve;
+      }),
+    );
+    const onTranscription = vi.fn();
+
+    const { result, unmount } = renderHook(() =>
+      useVoiceToText({
+        enabled: true,
+        onTranscription,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.toggleRecording();
+    });
+
+    const recorder = mediaRecorderInstances[0];
+    recorder.ondataavailable?.({
+      data: new Blob(["test audio"], { type: "audio/webm" }),
+    });
+    await act(async () => {
+      await result.current.toggleRecording();
+    });
+    await waitFor(() => {
+      expect(Blob.prototype.arrayBuffer).toHaveBeenCalledTimes(1);
+    });
+
+    unmount();
+    await act(async () => {
+      resolveArrayBuffer?.(new Uint8Array([1, 2, 3]).buffer);
+      await recorder.stopPromise;
+    });
+
+    expect(transcribeAudioMock).not.toHaveBeenCalled();
+    expect(onTranscription).not.toHaveBeenCalled();
+  });
 });

--- a/src/hooks/useVoiceToText.ts
+++ b/src/hooks/useVoiceToText.ts
@@ -170,6 +170,10 @@ export function useVoiceToText({
             throw new Error("Recording exceeded the maximum audio size");
           }
 
+          if (!isMountedRef.current) {
+            return;
+          }
+
           const result = await ipc.audio.transcribeAudio({
             audioData,
             filename: "recording.webm",

--- a/src/hooks/useVoiceToText.ts
+++ b/src/hooks/useVoiceToText.ts
@@ -1,5 +1,10 @@
 import { useState, useRef, useCallback, useEffect } from "react";
 import { ipc } from "@/ipc/types";
+import {
+  AUDIO_RECORDING_TIMESLICE_MS,
+  MAX_AUDIO_RECORDING_BYTES,
+  MAX_AUDIO_RECORDING_DURATION_MS,
+} from "@/ipc/types/audio";
 import { v4 as uuidv4 } from "uuid";
 
 interface UseVoiceToTextOptions {
@@ -7,6 +12,17 @@ interface UseVoiceToTextOptions {
   onTranscription: (text: string) => void;
   onError?: (error: string) => void;
 }
+
+type RecordingStopReason = "duration" | "size" | null;
+
+const RECORDING_LIMIT_MESSAGES: Record<
+  Exclude<RecordingStopReason, null>,
+  string
+> = {
+  duration:
+    "Recording reached the maximum duration and was stopped. Any captured audio will still be transcribed.",
+  size: "Recording reached the maximum size and was stopped. Any captured audio will still be transcribed.",
+};
 
 export function useVoiceToText({
   enabled,
@@ -17,8 +33,21 @@ export function useVoiceToText({
   const [isTranscribing, setIsTranscribing] = useState(false);
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const chunksRef = useRef<Blob[]>([]);
+  const recordedBytesRef = useRef(0);
   const streamRef = useRef<MediaStream | null>(null);
+  const recordingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const stopReasonRef = useRef<RecordingStopReason>(null);
   const skipOnStopProcessingRef = useRef(false);
+  const isMountedRef = useRef(true);
+  const isStartingRef = useRef(false);
+  const startAttemptRef = useRef(0);
+
+  const clearRecordingTimer = useCallback(() => {
+    if (recordingTimerRef.current !== null) {
+      clearTimeout(recordingTimerRef.current);
+      recordingTimerRef.current = null;
+    }
+  }, []);
 
   const stopMediaStream = useCallback(() => {
     if (streamRef.current) {
@@ -27,9 +56,29 @@ export function useVoiceToText({
     }
   }, []);
 
+  const stopActiveRecording = useCallback(
+    (reason: RecordingStopReason) => {
+      const mediaRecorder = mediaRecorderRef.current;
+      if (mediaRecorder?.state === "recording") {
+        stopReasonRef.current = reason;
+        clearRecordingTimer();
+        mediaRecorder.stop();
+      }
+    },
+    [clearRecordingTimer],
+  );
+
   useEffect(() => {
+    isMountedRef.current = true;
+    skipOnStopProcessingRef.current = false;
+
     return () => {
+      isMountedRef.current = false;
+      isStartingRef.current = false;
+      startAttemptRef.current += 1;
       skipOnStopProcessingRef.current = true;
+      clearRecordingTimer();
+
       const mediaRecorder = mediaRecorderRef.current;
       if (mediaRecorder && mediaRecorder.state !== "inactive") {
         mediaRecorder.stop();
@@ -37,25 +86,31 @@ export function useVoiceToText({
       mediaRecorderRef.current = null;
       stopMediaStream();
       chunksRef.current = [];
+      recordedBytesRef.current = 0;
     };
-  }, [stopMediaStream]);
+  }, [clearRecordingTimer, stopMediaStream]);
 
   const toggleRecording = useCallback(async () => {
-    if (isTranscribing) return;
+    if (isTranscribing || isStartingRef.current) return;
 
-    if (isRecording) {
-      // Stop recording
-      if (mediaRecorderRef.current?.state === "recording") {
-        mediaRecorderRef.current.stop();
-      }
+    if (isRecording || mediaRecorderRef.current?.state === "recording") {
+      stopActiveRecording(null);
       return;
     }
 
     if (!enabled) return;
 
-    // Start recording
+    const startAttempt = startAttemptRef.current + 1;
+    startAttemptRef.current = startAttempt;
+    isStartingRef.current = true;
+
     try {
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      if (!isMountedRef.current || startAttempt !== startAttemptRef.current) {
+        stream.getTracks().forEach((track) => track.stop());
+        return;
+      }
+
       streamRef.current = stream;
 
       const mediaRecorder = new MediaRecorder(stream, {
@@ -63,34 +118,57 @@ export function useVoiceToText({
       });
       mediaRecorderRef.current = mediaRecorder;
       chunksRef.current = [];
+      recordedBytesRef.current = 0;
+      stopReasonRef.current = null;
+      skipOnStopProcessingRef.current = false;
 
       mediaRecorder.ondataavailable = (event) => {
-        if (event.data.size > 0) {
-          chunksRef.current.push(event.data);
+        if (event.data.size === 0) return;
+
+        const nextRecordedBytes = recordedBytesRef.current + event.data.size;
+        if (nextRecordedBytes > MAX_AUDIO_RECORDING_BYTES) {
+          stopActiveRecording("size");
+          return;
+        }
+
+        chunksRef.current.push(event.data);
+        recordedBytesRef.current = nextRecordedBytes;
+        if (nextRecordedBytes >= MAX_AUDIO_RECORDING_BYTES) {
+          stopActiveRecording("size");
         }
       };
 
       mediaRecorder.onstop = async () => {
+        clearRecordingTimer();
         mediaRecorderRef.current = null;
         stopMediaStream();
-        if (skipOnStopProcessingRef.current) {
-          chunksRef.current = [];
+
+        const stopReason = stopReasonRef.current;
+        stopReasonRef.current = null;
+        const chunks = chunksRef.current;
+        chunksRef.current = [];
+        recordedBytesRef.current = 0;
+
+        if (skipOnStopProcessingRef.current || !isMountedRef.current) {
           return;
         }
 
         setIsRecording(false);
+        if (stopReason) {
+          onError?.(RECORDING_LIMIT_MESSAGES[stopReason]);
+        }
 
-        const blob = new Blob(chunksRef.current, { type: "audio/webm" });
-        chunksRef.current = [];
-
+        const blob = new Blob(chunks, { type: "audio/webm" });
         if (blob.size === 0) {
           return;
         }
 
         setIsTranscribing(true);
         try {
-          const arrayBuffer = await blob.arrayBuffer();
-          const audioData = Array.from(new Uint8Array(arrayBuffer));
+          const audioData = new Uint8Array(await blob.arrayBuffer());
+          if (audioData.byteLength > MAX_AUDIO_RECORDING_BYTES) {
+            throw new Error("Recording exceeded the maximum audio size");
+          }
 
           const result = await ipc.audio.transcribeAudio({
             audioData,
@@ -98,25 +176,38 @@ export function useVoiceToText({
             requestId: uuidv4(),
           });
 
-          if (result.text.trim()) {
+          if (isMountedRef.current && result.text.trim()) {
             onTranscription(result.text.trim());
           }
         } catch (err) {
-          const message =
-            err instanceof Error ? err.message : "Transcription failed";
-          onError?.(message);
+          if (isMountedRef.current) {
+            const message =
+              err instanceof Error ? err.message : "Transcription failed";
+            onError?.(message);
+          }
         } finally {
-          setIsTranscribing(false);
+          if (isMountedRef.current) {
+            setIsTranscribing(false);
+          }
         }
       };
 
-      mediaRecorder.start();
+      mediaRecorder.start(AUDIO_RECORDING_TIMESLICE_MS);
+      recordingTimerRef.current = setTimeout(() => {
+        stopActiveRecording("duration");
+      }, MAX_AUDIO_RECORDING_DURATION_MS);
       setIsRecording(true);
     } catch (err) {
       stopMediaStream();
-      const message =
-        err instanceof Error ? err.message : "Failed to access microphone";
-      onError?.(message);
+      if (isMountedRef.current) {
+        const message =
+          err instanceof Error ? err.message : "Failed to access microphone";
+        onError?.(message);
+      }
+    } finally {
+      if (startAttempt === startAttemptRef.current) {
+        isStartingRef.current = false;
+      }
     }
   }, [
     enabled,
@@ -124,7 +215,9 @@ export function useVoiceToText({
     isTranscribing,
     onTranscription,
     onError,
+    stopActiveRecording,
     stopMediaStream,
+    clearRecordingTimer,
   ]);
 
   return {

--- a/src/ipc/handlers/pro_handlers.test.ts
+++ b/src/ipc/handlers/pro_handlers.test.ts
@@ -122,6 +122,22 @@ describe("pro audio transcription handler", () => {
         requestId: "r".repeat(MAX_AUDIO_REQUEST_ID_LENGTH + 1),
       },
     },
+    {
+      name: "traversal filename",
+      input: {
+        audioData: new Uint8Array([1]),
+        filename: "..",
+        requestId: "request-123",
+      },
+    },
+    {
+      name: "header-unsafe request ID",
+      input: {
+        audioData: new Uint8Array([1]),
+        filename: "recording.webm",
+        requestId: "request\r\nX-Injected: true",
+      },
+    },
   ])("rejects $name before calling the engine", async ({ input }) => {
     await expect(transcribeAudio({} as never, input)).rejects.toMatchObject({
       kind: DyadErrorKind.Validation,

--- a/src/ipc/handlers/pro_handlers.test.ts
+++ b/src/ipc/handlers/pro_handlers.test.ts
@@ -1,0 +1,131 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DyadErrorKind } from "@/errors/dyad_error";
+import {
+  audioContracts,
+  MAX_AUDIO_FILENAME_LENGTH,
+  MAX_AUDIO_RECORDING_BYTES,
+  MAX_AUDIO_REQUEST_ID_LENGTH,
+} from "../types/audio";
+
+const mocks = vi.hoisted(() => ({
+  readSettings: vi.fn(),
+  transcribeWithDyadEngine: vi.fn(),
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("electron", () => ({
+  ipcMain: { handle: vi.fn() },
+}));
+
+vi.mock("electron-log", () => ({
+  default: { scope: () => mocks.logger },
+}));
+
+vi.mock("../../main/settings", () => ({
+  readSettings: mocks.readSettings,
+}));
+
+vi.mock("../utils/llm_engine_provider", () => ({
+  transcribeWithDyadEngine: mocks.transcribeWithDyadEngine,
+}));
+
+vi.mock("../utils/dyad_engine_url", () => ({
+  getDyadEngineBaseUrl: () => "https://engine.example/v1",
+}));
+
+vi.mock("../utils/telemetry", () => ({
+  sendTelemetryException: vi.fn(),
+}));
+
+vi.mock("../utils/test_utils", () => ({
+  IS_TEST_BUILD: true,
+}));
+
+const { getRegisteredHandlerForTesting } = await import("./base");
+const { registerProHandlers } = await import("./pro_handlers");
+
+registerProHandlers();
+
+const transcribeAudio = getRegisteredHandlerForTesting(
+  audioContracts.transcribeAudio.channel,
+);
+
+describe("pro audio transcription handler", () => {
+  beforeEach(() => {
+    mocks.readSettings.mockReset();
+    mocks.readSettings.mockReturnValue({
+      enableDyadPro: true,
+      providerSettings: {
+        auto: { apiKey: { value: "test-api-key" } },
+      },
+    });
+    mocks.transcribeWithDyadEngine.mockReset();
+    mocks.transcribeWithDyadEngine.mockResolvedValue("transcribed text");
+  });
+
+  it("transcribes a bounded typed array through a zero-copy Buffer view", async () => {
+    const audioData = new Uint8Array([1, 2, 3, 4]);
+
+    await expect(
+      transcribeAudio({} as never, {
+        audioData,
+        filename: "recording.webm",
+        requestId: "request-123",
+      }),
+    ).resolves.toEqual({ text: "transcribed text" });
+
+    expect(mocks.transcribeWithDyadEngine).toHaveBeenCalledTimes(1);
+    const audioBuffer = mocks.transcribeWithDyadEngine.mock.calls[0][0];
+    expect(Buffer.isBuffer(audioBuffer)).toBe(true);
+    expect([...audioBuffer]).toEqual([1, 2, 3, 4]);
+    audioData[0] = 9;
+    expect(audioBuffer[0]).toBe(9);
+    expect(mocks.transcribeWithDyadEngine).toHaveBeenCalledWith(
+      audioBuffer,
+      "recording.webm",
+      "request-123",
+      expect.objectContaining({
+        apiKey: "test-api-key",
+        baseURL: "https://engine.example/v1",
+      }),
+    );
+  });
+
+  it.each([
+    {
+      name: "oversized audio",
+      input: {
+        audioData: new Uint8Array(MAX_AUDIO_RECORDING_BYTES + 1),
+        filename: "recording.webm",
+        requestId: "request-123",
+      },
+    },
+    {
+      name: "oversized filename",
+      input: {
+        audioData: new Uint8Array([1]),
+        filename: "a".repeat(MAX_AUDIO_FILENAME_LENGTH + 1),
+        requestId: "request-123",
+      },
+    },
+    {
+      name: "oversized request ID",
+      input: {
+        audioData: new Uint8Array([1]),
+        filename: "recording.webm",
+        requestId: "r".repeat(MAX_AUDIO_REQUEST_ID_LENGTH + 1),
+      },
+    },
+  ])("rejects $name before calling the engine", async ({ input }) => {
+    await expect(transcribeAudio({} as never, input)).rejects.toMatchObject({
+      kind: DyadErrorKind.Validation,
+    });
+    expect(mocks.transcribeWithDyadEngine).not.toHaveBeenCalled();
+  });
+});

--- a/src/ipc/handlers/pro_handlers.test.ts
+++ b/src/ipc/handlers/pro_handlers.test.ts
@@ -131,6 +131,14 @@ describe("pro audio transcription handler", () => {
       },
     },
     {
+      name: "whitespace-padded traversal filename",
+      input: {
+        audioData: new Uint8Array([1]),
+        filename: " .. ",
+        requestId: "request-123",
+      },
+    },
+    {
       name: "header-unsafe request ID",
       input: {
         audioData: new Uint8Array([1]),
@@ -142,6 +150,22 @@ describe("pro audio transcription handler", () => {
     await expect(transcribeAudio({} as never, input)).rejects.toMatchObject({
       kind: DyadErrorKind.Validation,
     });
+    expect(mocks.transcribeWithDyadEngine).not.toHaveBeenCalled();
+  });
+
+  it("classifies a missing Pro subscription as an auth error", async () => {
+    mocks.readSettings.mockReturnValue({
+      enableDyadPro: false,
+      providerSettings: {},
+    });
+
+    await expect(
+      transcribeAudio({} as never, {
+        audioData: new Uint8Array([1]),
+        filename: "recording.webm",
+        requestId: "request-123",
+      }),
+    ).rejects.toMatchObject({ kind: DyadErrorKind.Auth });
     expect(mocks.transcribeWithDyadEngine).not.toHaveBeenCalled();
   });
 });

--- a/src/ipc/handlers/pro_handlers.ts
+++ b/src/ipc/handlers/pro_handlers.ts
@@ -42,13 +42,14 @@ function validateAudioTranscriptionRequest(input: TranscribeAudioParams) {
     );
   }
 
+  const trimmedFilename = input.filename.trim();
   if (
-    input.filename.trim().length === 0 ||
-    input.filename.length > MAX_AUDIO_FILENAME_LENGTH ||
-    input.filename.includes("/") ||
-    input.filename.includes("\\") ||
-    input.filename === "." ||
-    input.filename === ".."
+    trimmedFilename.length === 0 ||
+    trimmedFilename.length > MAX_AUDIO_FILENAME_LENGTH ||
+    trimmedFilename.includes("/") ||
+    trimmedFilename.includes("\\") ||
+    trimmedFilename === "." ||
+    trimmedFilename === ".."
   ) {
     throw new DyadError("Invalid audio filename", DyadErrorKind.Validation);
   }
@@ -158,8 +159,9 @@ export function registerProHandlers() {
       const apiKey = settings.providerSettings?.auto?.apiKey?.value;
 
       if (!apiKey || !settings.enableDyadPro) {
-        throw new Error(
+        throw new DyadError(
           "Dyad Pro is not enabled. Voice-to-text requires a Pro subscription.",
+          DyadErrorKind.Auth,
         );
       }
 

--- a/src/ipc/handlers/pro_handlers.ts
+++ b/src/ipc/handlers/pro_handlers.ts
@@ -7,6 +7,7 @@ import { UserBudgetInfo, UserBudgetInfoSchema } from "@/ipc/types";
 import { IS_TEST_BUILD } from "../utils/test_utils";
 import { z } from "zod";
 import {
+  AUDIO_REQUEST_ID_PATTERN,
   audioContracts,
   MAX_AUDIO_FILENAME_LENGTH,
   MAX_AUDIO_RECORDING_BYTES,
@@ -45,14 +46,17 @@ function validateAudioTranscriptionRequest(input: TranscribeAudioParams) {
     input.filename.trim().length === 0 ||
     input.filename.length > MAX_AUDIO_FILENAME_LENGTH ||
     input.filename.includes("/") ||
-    input.filename.includes("\\")
+    input.filename.includes("\\") ||
+    input.filename === "." ||
+    input.filename === ".."
   ) {
     throw new DyadError("Invalid audio filename", DyadErrorKind.Validation);
   }
 
   if (
     input.requestId.trim().length === 0 ||
-    input.requestId.length > MAX_AUDIO_REQUEST_ID_LENGTH
+    input.requestId.length > MAX_AUDIO_REQUEST_ID_LENGTH ||
+    !AUDIO_REQUEST_ID_PATTERN.test(input.requestId)
   ) {
     throw new DyadError(
       "Invalid transcription request ID",

--- a/src/ipc/handlers/pro_handlers.ts
+++ b/src/ipc/handlers/pro_handlers.ts
@@ -6,10 +6,16 @@ import { readSettings } from "../../main/settings"; // Assuming settings are rea
 import { UserBudgetInfo, UserBudgetInfoSchema } from "@/ipc/types";
 import { IS_TEST_BUILD } from "../utils/test_utils";
 import { z } from "zod";
-import { audioContracts } from "../types/audio";
+import {
+  audioContracts,
+  MAX_AUDIO_FILENAME_LENGTH,
+  MAX_AUDIO_RECORDING_BYTES,
+  MAX_AUDIO_REQUEST_ID_LENGTH,
+} from "../types/audio";
 import type { TranscribeAudioParams } from "../types/audio";
 import { transcribeWithDyadEngine } from "../utils/llm_engine_provider";
 import { getDyadEngineBaseUrl } from "../utils/dyad_engine_url";
+import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
 
 export const UserInfoResponseSchema = z.object({
   usedCredits: z.number(),
@@ -23,6 +29,37 @@ export type UserInfoResponse = z.infer<typeof UserInfoResponseSchema>;
 const logger = log.scope("pro_handlers");
 const handle = createLoggedHandler(logger);
 const typedHandle = createLoggedTypedHandler(logger);
+
+function validateAudioTranscriptionRequest(input: TranscribeAudioParams) {
+  if (
+    input.audioData.byteLength === 0 ||
+    input.audioData.byteLength > MAX_AUDIO_RECORDING_BYTES
+  ) {
+    throw new DyadError(
+      `Audio data must be between 1 and ${MAX_AUDIO_RECORDING_BYTES} bytes`,
+      DyadErrorKind.Validation,
+    );
+  }
+
+  if (
+    input.filename.trim().length === 0 ||
+    input.filename.length > MAX_AUDIO_FILENAME_LENGTH ||
+    input.filename.includes("/") ||
+    input.filename.includes("\\")
+  ) {
+    throw new DyadError("Invalid audio filename", DyadErrorKind.Validation);
+  }
+
+  if (
+    input.requestId.trim().length === 0 ||
+    input.requestId.length > MAX_AUDIO_REQUEST_ID_LENGTH
+  ) {
+    throw new DyadError(
+      "Invalid transcription request ID",
+      DyadErrorKind.Validation,
+    );
+  }
+}
 
 function getUserInfoUrl() {
   // Overridable so tests point at the fake LLM server instead of the real API.
@@ -122,7 +159,13 @@ export function registerProHandlers() {
         );
       }
 
-      const audioBuffer = Buffer.from(input.audioData);
+      validateAudioTranscriptionRequest(input);
+
+      const audioBuffer = Buffer.from(
+        input.audioData.buffer,
+        input.audioData.byteOffset,
+        input.audioData.byteLength,
+      );
 
       const text = await transcribeWithDyadEngine(
         audioBuffer,

--- a/src/ipc/types/audio.test.ts
+++ b/src/ipc/types/audio.test.ts
@@ -72,4 +72,38 @@ describe("TranscribeAudioParamsSchema", () => {
       }).success,
     ).toBe(false);
   });
+
+  it.each([".", "..", " . ", " .. "])(
+    "rejects the traversal filename %j",
+    (filename) => {
+      expect(
+        TranscribeAudioParamsSchema.safeParse({
+          ...validRequest,
+          filename,
+        }).success,
+      ).toBe(false);
+    },
+  );
+
+  it("accepts header-safe request IDs and rejects invalid characters", () => {
+    expect(
+      TranscribeAudioParamsSchema.safeParse({
+        ...validRequest,
+        requestId: "request-123_abc.def:ghi",
+      }).success,
+    ).toBe(true);
+
+    for (const requestId of [
+      "request id",
+      "request\r\nX-Injected: true",
+      "request-id-💥",
+    ]) {
+      expect(
+        TranscribeAudioParamsSchema.safeParse({
+          ...validRequest,
+          requestId,
+        }).success,
+      ).toBe(false);
+    }
+  });
 });

--- a/src/ipc/types/audio.test.ts
+++ b/src/ipc/types/audio.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_AUDIO_FILENAME_LENGTH,
+  MAX_AUDIO_RECORDING_BYTES,
+  MAX_AUDIO_REQUEST_ID_LENGTH,
+  TranscribeAudioParamsSchema,
+} from "./audio";
+
+const validRequest = {
+  audioData: new Uint8Array([1, 2, 3]),
+  filename: "recording.webm",
+  requestId: "request-id",
+};
+
+describe("TranscribeAudioParamsSchema", () => {
+  it("accepts a typed array at the byte limit", () => {
+    const bytes = new Uint8Array(MAX_AUDIO_RECORDING_BYTES + 1);
+
+    expect(
+      TranscribeAudioParamsSchema.safeParse({
+        ...validRequest,
+        audioData: bytes.subarray(0, MAX_AUDIO_RECORDING_BYTES),
+      }).success,
+    ).toBe(true);
+    expect(
+      TranscribeAudioParamsSchema.safeParse({
+        ...validRequest,
+        audioData: bytes,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects empty audio and boxed number arrays", () => {
+    expect(
+      TranscribeAudioParamsSchema.safeParse({
+        ...validRequest,
+        audioData: new Uint8Array(),
+      }).success,
+    ).toBe(false);
+    expect(
+      TranscribeAudioParamsSchema.safeParse({
+        ...validRequest,
+        audioData: [1, 2, 3],
+      }).success,
+    ).toBe(false);
+  });
+
+  it("enforces filename and request ID length boundaries", () => {
+    expect(
+      TranscribeAudioParamsSchema.safeParse({
+        ...validRequest,
+        filename: `${"a".repeat(MAX_AUDIO_FILENAME_LENGTH - 5)}.webm`,
+        requestId: "r".repeat(MAX_AUDIO_REQUEST_ID_LENGTH),
+      }).success,
+    ).toBe(true);
+    expect(
+      TranscribeAudioParamsSchema.safeParse({
+        ...validRequest,
+        filename: "a".repeat(MAX_AUDIO_FILENAME_LENGTH + 1),
+      }).success,
+    ).toBe(false);
+    expect(
+      TranscribeAudioParamsSchema.safeParse({
+        ...validRequest,
+        requestId: "r".repeat(MAX_AUDIO_REQUEST_ID_LENGTH + 1),
+      }).success,
+    ).toBe(false);
+    expect(
+      TranscribeAudioParamsSchema.safeParse({
+        ...validRequest,
+        filename: "../recording.webm",
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/src/ipc/types/audio.ts
+++ b/src/ipc/types/audio.ts
@@ -10,6 +10,7 @@ export const MAX_AUDIO_RECORDING_DURATION_MS = 5 * 60 * 1000;
 export const AUDIO_RECORDING_TIMESLICE_MS = 1000;
 export const MAX_AUDIO_FILENAME_LENGTH = 255;
 export const MAX_AUDIO_REQUEST_ID_LENGTH = 128;
+export const AUDIO_REQUEST_ID_PATTERN = /^[A-Za-z0-9._:-]+$/;
 
 export const TranscribeAudioParamsSchema = z.object({
   audioData: z
@@ -25,10 +26,19 @@ export const TranscribeAudioParamsSchema = z.object({
     .min(1)
     .max(MAX_AUDIO_FILENAME_LENGTH)
     .refine(
-      (filename) => !filename.includes("/") && !filename.includes("\\"),
-      "Filename must not contain path separators",
+      (filename) =>
+        !filename.includes("/") &&
+        !filename.includes("\\") &&
+        filename !== "." &&
+        filename !== "..",
+      "Filename must not contain path separators or traversal segments",
     ),
-  requestId: z.string().trim().min(1).max(MAX_AUDIO_REQUEST_ID_LENGTH),
+  requestId: z
+    .string()
+    .trim()
+    .min(1)
+    .max(MAX_AUDIO_REQUEST_ID_LENGTH)
+    .regex(AUDIO_REQUEST_ID_PATTERN, "Request ID contains invalid characters"),
 });
 
 export type TranscribeAudioParams = z.infer<typeof TranscribeAudioParamsSchema>;

--- a/src/ipc/types/audio.ts
+++ b/src/ipc/types/audio.ts
@@ -5,10 +5,30 @@ import { defineContract, createClient } from "../contracts/core";
 // Transcription Schemas
 // =============================================================================
 
+export const MAX_AUDIO_RECORDING_BYTES = 10 * 1024 * 1024;
+export const MAX_AUDIO_RECORDING_DURATION_MS = 5 * 60 * 1000;
+export const AUDIO_RECORDING_TIMESLICE_MS = 1000;
+export const MAX_AUDIO_FILENAME_LENGTH = 255;
+export const MAX_AUDIO_REQUEST_ID_LENGTH = 128;
+
 export const TranscribeAudioParamsSchema = z.object({
-  audioData: z.array(z.number()),
-  filename: z.string(),
-  requestId: z.string(),
+  audioData: z
+    .instanceof(Uint8Array)
+    .refine((data) => data.byteLength > 0, "Audio data cannot be empty")
+    .refine(
+      (data) => data.byteLength <= MAX_AUDIO_RECORDING_BYTES,
+      `Audio data cannot exceed ${MAX_AUDIO_RECORDING_BYTES} bytes`,
+    ),
+  filename: z
+    .string()
+    .trim()
+    .min(1)
+    .max(MAX_AUDIO_FILENAME_LENGTH)
+    .refine(
+      (filename) => !filename.includes("/") && !filename.includes("\\"),
+      "Filename must not contain path separators",
+    ),
+  requestId: z.string().trim().min(1).max(MAX_AUDIO_REQUEST_ID_LENGTH),
 });
 
 export type TranscribeAudioParams = z.infer<typeof TranscribeAudioParamsSchema>;

--- a/src/ipc/utils/llm_engine_provider.ts
+++ b/src/ipc/utils/llm_engine_provider.ts
@@ -374,7 +374,12 @@ export async function transcribeWithDyadEngine(
         : filename.endsWith(".m4a")
           ? "audio/mp4"
           : "audio/webm";
-  const blob = new Blob([new Uint8Array(audioBuffer)], { type: mimeType });
+  const audioBytes = new Uint8Array(
+    audioBuffer.buffer as ArrayBuffer,
+    audioBuffer.byteOffset,
+    audioBuffer.byteLength,
+  );
+  const blob = new Blob([audioBytes], { type: mimeType });
   formData.append("file", blob, filename);
   formData.append("model", "gpt-4o-mini-transcribe");
 


### PR DESCRIPTION
## Summary

- stop voice recordings after five minutes or 10 MiB using one-second MediaRecorder chunks
- replace boxed number arrays with bounded Uint8Array IPC and zero-copy Buffer views
- validate audio size, filename, and request IDs in both the IPC contract and main handler
- preserve cleanup and transcribe audio captured before an automatic stop

## Testing

- npm test -- src/hooks/useVoiceToText.test.ts src/ipc/types/audio.test.ts src/ipc/handlers/pro_handlers.test.ts src/ipc/handlers/__tests__/voice_to_text.integration.test.tsx
- npm run fmt
- npm run lint
- npm run ts
- npm run build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the transcription IPC payload shape and main-process validation on a Pro feature path; behavior is well tested but alters how large audio is handled end-to-end.
> 
> **Overview**
> **Voice recording** now caps capture at **5 minutes** and **10 MiB** using 1s `MediaRecorder` timeslices, auto-stopping when limits hit while still transcribing audio already buffered. Limit hits surface user-facing messages via `onError`.
> 
> The **IPC contract** switches `audioData` from boxed `number[]` to bounded **`Uint8Array`**, with shared limits and stricter **filename** (no path/traversal) and **request ID** (header-safe charset) validation in Zod and the main **`pro_handlers`** path. Audio is passed through **zero-copy** `Buffer`/`Uint8Array` views into the engine upload instead of copying whole arrays.
> 
> **`useVoiceToText`** adds mount/start race guards so late `getUserMedia`, blob conversion, or transcription results do not update state or call IPC after unmount. Missing Pro is classified as **`DyadErrorKind.Auth`** instead of a generic error.
> 
> New tests cover hook limits, unmount races, schema boundaries, and handler validation/rejection before the engine runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7168caa53f2a36e1ab810ef594e96a8d58458aff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

