### PR TITLE
Bound startup file memory usage

### DIFF
--- a/src/backup_manager.ts
+++ b/src/backup_manager.ts
@@ -1,10 +1,10 @@
 import * as path from "path";
 import * as fs from "fs/promises";
 import { app } from "electron";
-import * as crypto from "crypto";
 import log from "electron-log";
 import Database from "better-sqlite3";
 import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
+import { calculateFileChecksum } from "@/utils/file_checksum";
 
 const logger = log.scope("backup_manager");
 
@@ -332,10 +332,7 @@ export class BackupManager {
    */
   private async getFileChecksum(filePath: string): Promise<string | null> {
     try {
-      const fileBuffer = await fs.readFile(filePath);
-      const hash = crypto.createHash("sha256");
-      hash.update(fileBuffer);
-      const checksum = hash.digest("hex");
+      const checksum = await calculateFileChecksum(filePath);
       logger.debug(
         `Checksum calculated for ${filePath}: ${checksum.substring(0, 8)}...`,
       );

--- a/src/main.ts
+++ b/src/main.ts
@@ -62,8 +62,8 @@ import {
   type MinidumpSummary,
 } from "./utils/minidump_summary";
 import {
-  listDumpFilesRecursive,
   moveDump,
+  pruneAndListNewestDumpFilesRecursive,
   pruneDumps,
 } from "./utils/crash_dumps";
 import {
@@ -185,6 +185,7 @@ const logger = log.scope("main");
 // Cap retained dumps so they don't accumulate indefinitely; keep only a few
 // recent ones for examination/export.
 const MAX_RETAINED_DUMPS = 5;
+const MAX_PENDING_DUMPS_TO_PROCESS = 10;
 let nativeCrashDumpsProcessed = false;
 let pendingNativeBrowserCrash: MinidumpSummary | null = null;
 
@@ -213,7 +214,10 @@ function processNativeCrashDumps(): void {
     return;
   }
 
-  for (const file of listDumpFilesRecursive(crashDumpsDir)) {
+  for (const file of pruneAndListNewestDumpFilesRecursive(
+    crashDumpsDir,
+    MAX_PENDING_DUMPS_TO_PROCESS,
+  )) {
     const summary = parseMinidumpSummary(file);
     if (summary) {
       logger.info(

--- a/src/utils/crash_dumps.test.ts
+++ b/src/utils/crash_dumps.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -84,6 +84,18 @@ describe("crash_dumps", () => {
 
     expect(pruneAndListNewestDumpFilesRecursive(dir, 0)).toEqual([]);
     expect(listDumpFilesRecursive(dir)).toEqual([]);
+  });
+
+  it("leaves a dump untouched when its modification time cannot be read", () => {
+    const dump = makeDump("still-rotating.dmp", 1);
+    const statSpy = vi.spyOn(fs, "statSync").mockImplementation(() => {
+      throw new Error("report rotated during stat");
+    });
+
+    expect(pruneAndListNewestDumpFilesRecursive(dir, 0)).toEqual([]);
+    statSpy.mockRestore();
+    expect(fs.existsSync(dump)).toBe(true);
+    expect(fs.existsSync(dump.replace(/\.dmp$/, ".meta"))).toBe(true);
   });
 
   it("deletes a dump and its .meta sidecar", () => {

--- a/src/utils/crash_dumps.test.ts
+++ b/src/utils/crash_dumps.test.ts
@@ -7,6 +7,7 @@ import {
   listDumpFilesRecursive,
   deleteDump,
   moveDump,
+  pruneAndListNewestDumpFilesRecursive,
   pruneDumps,
 } from "@/utils/crash_dumps";
 
@@ -57,6 +58,32 @@ describe("crash_dumps", () => {
 
     const files = listDumpFilesRecursive(dir).map((f) => path.basename(f));
     expect(files).toEqual(["b.dmp", "a.dmp"]);
+  });
+
+  it("bounds a large pending backlog to the newest dumps while scanning", () => {
+    fs.mkdirSync(path.join(dir, "pending"));
+    fs.mkdirSync(path.join(dir, "reports"));
+    for (let i = 0; i < 30; i++) {
+      const subdir = i % 2 === 0 ? "pending" : "reports";
+      makeDump(path.join(subdir, `${i}.dmp`), i + 1);
+    }
+
+    const kept = pruneAndListNewestDumpFilesRecursive(dir, 5).map((file) =>
+      path.basename(file),
+    );
+
+    expect(kept).toEqual(["0.dmp", "1.dmp", "2.dmp", "3.dmp", "4.dmp"]);
+    expect(listDumpFilesRecursive(dir)).toHaveLength(5);
+    expect(fs.existsSync(path.join(dir, "reports", "29.meta"))).toBe(false);
+  });
+
+  it("can drain a pending dump tree without retaining candidates", () => {
+    fs.mkdirSync(path.join(dir, "pending"));
+    makeDump(path.join("pending", "a.dmp"), 1);
+    makeDump(path.join("pending", "b.dmp"), 2);
+
+    expect(pruneAndListNewestDumpFilesRecursive(dir, 0)).toEqual([]);
+    expect(listDumpFilesRecursive(dir)).toEqual([]);
   });
 
   it("deletes a dump and its .meta sidecar", () => {

--- a/src/utils/crash_dumps.ts
+++ b/src/utils/crash_dumps.ts
@@ -64,7 +64,13 @@ export function pruneAndListNewestDumpFilesRecursive(
         if (entry.isDirectory()) {
           directories.push(entryPath);
         } else if (entry.name.endsWith(".dmp")) {
-          const candidate = { path: entryPath, mtime: mtimeMs(entryPath) };
+          const mtime = mtimeMs(entryPath);
+          // Crashpad may still be rotating this report. If stat fails, leave the
+          // dump untouched for a later launch rather than treating it as the
+          // oldest entry and deleting a potentially fresh report.
+          if (mtime === undefined) continue;
+
+          const candidate = { path: entryPath, mtime };
           const insertAt = newest.findIndex(
             (existing) => candidate.mtime > existing.mtime,
           );
@@ -113,16 +119,16 @@ export function pruneDumps(dir: string, max: number): void {
 // comparator, which would re-stat on every comparison).
 function sortNewestFirst(paths: string[]): string[] {
   return paths
-    .map((p) => ({ p, mtime: mtimeMs(p) }))
+    .map((p) => ({ p, mtime: mtimeMs(p) ?? 0 }))
     .sort((a, b) => b.mtime - a.mtime)
     .map((x) => x.p);
 }
 
-function mtimeMs(p: string): number {
+function mtimeMs(p: string): number | undefined {
   try {
     return fs.statSync(p).mtimeMs;
   } catch {
-    return 0;
+    return undefined;
   }
 }
 

--- a/src/utils/crash_dumps.ts
+++ b/src/utils/crash_dumps.ts
@@ -38,6 +38,58 @@ export function listDumpFilesRecursive(dir: string): string[] {
   return sortNewestFirst(found);
 }
 
+// Keep only the `max` newest pending dumps while scanning, deleting older
+// dumps (and sidecars) as soon as they fall outside the bounded candidate set.
+// This preserves the eventual prune behavior without first retaining every
+// path in memory or parsing an unbounded backlog during startup.
+export function pruneAndListNewestDumpFilesRecursive(
+  dir: string,
+  max: number,
+): string[] {
+  if (!Number.isSafeInteger(max) || max < 0) {
+    throw new RangeError("max must be a non-negative safe integer");
+  }
+
+  const newest: Array<{ path: string; mtime: number }> = [];
+  const directories = [dir];
+
+  while (directories.length > 0) {
+    const currentDir = directories.pop()!;
+    let directory: fs.Dir | undefined;
+    try {
+      directory = fs.opendirSync(currentDir);
+      let entry: fs.Dirent | null;
+      while ((entry = directory.readSync()) !== null) {
+        const entryPath = path.join(currentDir, entry.name);
+        if (entry.isDirectory()) {
+          directories.push(entryPath);
+        } else if (entry.name.endsWith(".dmp")) {
+          const candidate = { path: entryPath, mtime: mtimeMs(entryPath) };
+          const insertAt = newest.findIndex(
+            (existing) => candidate.mtime > existing.mtime,
+          );
+          if (insertAt === -1) newest.push(candidate);
+          else newest.splice(insertAt, 0, candidate);
+
+          if (newest.length > max) {
+            deleteDump(newest.pop()!.path);
+          }
+        }
+      }
+    } catch {
+      // Crashpad directories can disappear while it rotates reports.
+    } finally {
+      try {
+        directory?.closeSync();
+      } catch {
+        // Best effort; startup crash reporting must never prevent app launch.
+      }
+    }
+  }
+
+  return newest.map((candidate) => candidate.path);
+}
+
 // Delete a dump and its Crashpad metadata sidecar (best effort).
 export function deleteDump(dumpPath: string): void {
   unlinkQuiet(dumpPath);

--- a/src/utils/file_checksum.test.ts
+++ b/src/utils/file_checksum.test.ts
@@ -1,0 +1,63 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { calculateFileChecksum } from "@/utils/file_checksum";
+
+describe("calculateFileChecksum", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "file-checksum-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("hashes files across multiple stream chunks", async () => {
+    const file = path.join(dir, "database.sqlite");
+    const contents = Buffer.concat([
+      Buffer.alloc(64 * 1024, 0x11),
+      Buffer.alloc(64 * 1024, 0x22),
+      Buffer.alloc(17, 0x33),
+    ]);
+    fs.writeFileSync(file, contents);
+
+    await expect(calculateFileChecksum(file)).resolves.toBe(
+      createHash("sha256").update(contents).digest("hex"),
+    );
+  });
+
+  it("streams a large sparse database without materializing the file", async () => {
+    const file = path.join(dir, "large.sqlite");
+    const fd = fs.openSync(file, "w");
+    try {
+      fs.ftruncateSync(fd, 128 * 1024 * 1024);
+      fs.writeSync(
+        fd,
+        Buffer.from("sqlite-tail"),
+        0,
+        11,
+        128 * 1024 * 1024 - 11,
+      );
+    } finally {
+      fs.closeSync(fd);
+    }
+
+    const checksum = await calculateFileChecksum(file);
+    expect(checksum).toMatch(/^[a-f0-9]{64}$/);
+    expect(fs.statSync(file).size).toBe(128 * 1024 * 1024);
+  });
+
+  it("closes the stream when hashing fails", async () => {
+    const missing = path.join(dir, "missing.sqlite");
+    await expect(calculateFileChecksum(missing)).rejects.toThrow();
+
+    // A subsequent file operation succeeds; in particular this catches open
+    // handles on Windows, where leaked file streams prevent cleanup/rename.
+    fs.writeFileSync(missing, "created after failure");
+    fs.renameSync(missing, `${missing}.moved`);
+  });
+});

--- a/src/utils/file_checksum.ts
+++ b/src/utils/file_checksum.ts
@@ -1,0 +1,29 @@
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { Writable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+
+const CHECKSUM_CHUNK_BYTES = 64 * 1024;
+
+// Hash a file without materializing it in memory. pipeline() closes both
+// streams on success or failure, which is important during early startup when
+// a failed upgrade backup must not leave file descriptors behind.
+export async function calculateFileChecksum(filePath: string): Promise<string> {
+  const hash = createHash("sha256");
+  const hashSink = new Writable({
+    write(chunk: Buffer, _encoding, callback) {
+      try {
+        hash.update(chunk);
+        callback();
+      } catch (error) {
+        callback(error as Error);
+      }
+    },
+  });
+
+  await pipeline(
+    createReadStream(filePath, { highWaterMark: CHECKSUM_CHUNK_BYTES }),
+    hashSink,
+  );
+  return hash.digest("hex");
+}

--- a/src/utils/minidump_summary.test.ts
+++ b/src/utils/minidump_summary.test.ts
@@ -32,6 +32,8 @@ function buildMinidump(opts: {
   ipOffset: number; // where the IP sits in the CPU context: 248 (x64) / 264 (arm64)
   ptype?: string;
   addressMask?: bigint; // Crashpad address_mask, written into the CrashpadInfo stream
+  crashpadVersion?: number;
+  exceptionStreamSize?: number;
 }): Buffer {
   const buf = Buffer.alloc(16384);
   const dv = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
@@ -128,6 +130,7 @@ function buildMinidump(opts: {
 
     // CrashpadInfo: module_list RVA @ +48, optional address_mask u64 @ +56.
     crashpadInfoRva = cursor;
+    dv.setUint32(crashpadInfoRva, opts.crashpadVersion ?? 1, true);
     dv.setUint32(crashpadInfoRva + 48, cpModListRva, true);
     if (opts.addressMask !== undefined) {
       dv.setBigUint64(crashpadInfoRva + 56, opts.addressMask, true);
@@ -149,7 +152,7 @@ function buildMinidump(opts: {
   dv.setUint32(36, moduleListSize, true);
   dv.setUint32(40, moduleListRva, true);
   dv.setUint32(44, 6, true);
-  dv.setUint32(48, exceptionSize, true);
+  dv.setUint32(48, opts.exceptionStreamSize ?? exceptionSize, true);
   dv.setUint32(52, exceptionRva, true);
   if (opts.ptype !== undefined) {
     dv.setUint32(56, 0x43500001, true);
@@ -244,6 +247,20 @@ describe("parseMinidumpBuffer", () => {
     expect(s!.faultingOffset).toBe("0x800");
   });
 
+  it("ignores an address mask from an unsupported CrashpadInfo version", () => {
+    const dump = buildMinidump({
+      modules: oneModule,
+      exceptionCode: 11,
+      ip: 0xab00000000010800n,
+      ipOffset: 264,
+      ptype: "browser",
+      addressMask: 0xff00000000000000n,
+      crashpadVersion: 0,
+    });
+    const s = parseMinidumpBuffer(dump, "darwin", "arm64");
+    expect(s!.faultingModule).toBeUndefined();
+  });
+
   it("omits the module when the IP is outside every module", () => {
     const dump = buildMinidump({
       modules: oneModule,
@@ -295,6 +312,18 @@ describe("parseMinidumpBuffer", () => {
 
   it("rejects a truncated buffer", () => {
     expect(parseMinidumpBuffer(Buffer.alloc(8), "linux", "x64")).toBeNull();
+  });
+
+  it("rejects an exception stream whose declared size is truncated", () => {
+    const dump = buildMinidump({
+      modules: oneModule,
+      exceptionCode: 11,
+      ip: 0x10500n,
+      ipOffset: 248,
+      exceptionStreamSize: 12,
+    });
+
+    expect(parseMinidumpBuffer(dump, "linux", "x64")).toBeNull();
   });
 });
 

--- a/src/utils/minidump_summary.test.ts
+++ b/src/utils/minidump_summary.test.ts
@@ -388,4 +388,99 @@ describe("parseMinidumpSummary", () => {
     expect(parseMinidumpSummary(file, "linux", "x64")).toBeNull();
     fs.renameSync(file, path.join(dir, "handled.dmp"));
   });
+
+  it("charges partial reads to the cumulative file I/O budget", () => {
+    const file = path.join(dir, "concurrently-truncated.dmp");
+    const dump = buildReadBudgetMinidump();
+    fs.writeFileSync(file, dump.buffer);
+
+    const realReadSync = fs.readSync.bind(fs);
+    let contextReadCount = 0;
+    let actualBytesRead = 0;
+    vi.spyOn(fs, "readSync").mockImplementation(
+      (
+        fd: number,
+        buffer: NodeJS.ArrayBufferView,
+        offsetOrOptions?: number | fs.ReadSyncOptions,
+        length?: number,
+        position?: fs.ReadPosition | null,
+      ) => {
+        let bytesRead: number;
+        if (typeof offsetOrOptions !== "number") {
+          bytesRead = realReadSync(fd, buffer, offsetOrOptions);
+        } else if (length === undefined) {
+          bytesRead = realReadSync(fd, buffer, { offset: offsetOrOptions });
+        } else if (position === dump.contextIpRva && contextReadCount === 0) {
+          contextReadCount++;
+          bytesRead = realReadSync(
+            fd,
+            buffer,
+            offsetOrOptions,
+            4,
+            position ?? null,
+          );
+        } else if (
+          position === dump.contextIpRva + 4 &&
+          contextReadCount === 1
+        ) {
+          contextReadCount++;
+          bytesRead = 0;
+        } else {
+          bytesRead = realReadSync(
+            fd,
+            buffer,
+            offsetOrOptions,
+            length,
+            position ?? null,
+          );
+        }
+        actualBytesRead += bytesRead;
+        return bytesRead;
+      },
+    );
+
+    expect(parseMinidumpSummary(file, "linux", "x64")).not.toBeNull();
+    expect(contextReadCount).toBe(2);
+    expect(actualBytesRead).toBeLessThanOrEqual(2 * 1024 * 1024);
+  });
 });
+
+// Build a valid minidump whose optional Crashpad annotation traversal consumes
+// the entire 2 MiB random-access read budget. The CPU context read is made
+// partial by the test above; charging those four bytes is what prevents one
+// additional read after the budget is exhausted.
+function buildReadBudgetMinidump(): { buffer: Buffer; contextIpRva: number } {
+  const exceptionRva = 80;
+  const contextRva = 300;
+  const crashpadInfoRva = 400;
+  const crashpadModuleListRva = 500;
+  const moduleInfoRva = 4_000;
+  const annotationObjectsRva = 5_000;
+  const moduleCount = 203;
+  const annotationCount = 969;
+  const buffer = Buffer.alloc(annotationObjectsRva + 4 + annotationCount * 12);
+
+  buffer.writeUInt32LE(0x504d444d, 0);
+  buffer.writeUInt32LE(2, 8);
+  buffer.writeUInt32LE(32, 12);
+
+  buffer.writeUInt32LE(6, 32);
+  buffer.writeUInt32LE(168, 36);
+  buffer.writeUInt32LE(exceptionRva, 40);
+  buffer.writeUInt32LE(0x43500001, 44);
+  buffer.writeUInt32LE(52, 48);
+  buffer.writeUInt32LE(crashpadInfoRva, 52);
+
+  buffer.writeUInt32LE(11, exceptionRva + 8);
+  buffer.writeUInt32LE(contextRva, exceptionRva + 164);
+  buffer.writeUInt32LE(crashpadModuleListRva, crashpadInfoRva + 48);
+
+  buffer.writeUInt32LE(moduleCount, crashpadModuleListRva);
+  for (let i = 0; i < moduleCount; i++) {
+    buffer.writeUInt32LE(moduleInfoRva, crashpadModuleListRva + 4 + i * 12 + 8);
+  }
+  buffer.writeUInt32LE(annotationObjectsRva, moduleInfoRva + 24);
+  buffer.writeUInt32LE(annotationCount, annotationObjectsRva);
+
+  return { buffer, contextIpRva: contextRva + 248 };
+}

--- a/src/utils/minidump_summary.test.ts
+++ b/src/utils/minidump_summary.test.ts
@@ -1,5 +1,12 @@
-import { describe, it, expect } from "vitest";
-import { parseMinidumpBuffer } from "@/utils/minidump_summary";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
+import {
+  MAX_MINIDUMP_FILE_BYTES,
+  parseMinidumpBuffer,
+  parseMinidumpSummary,
+} from "@/utils/minidump_summary";
 
 // Build a minimal but valid minidump containing only the streams the parser
 // reads (module list + exception, and optionally a CrashpadInfo stream with a
@@ -288,5 +295,68 @@ describe("parseMinidumpBuffer", () => {
 
   it("rejects a truncated buffer", () => {
     expect(parseMinidumpBuffer(Buffer.alloc(8), "linux", "x64")).toBeNull();
+  });
+});
+
+describe("parseMinidumpSummary", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "minidump-summary-test-"));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("parses a normal dump from bounded random-access reads", () => {
+    const file = path.join(dir, "normal.dmp");
+    const dump = buildMinidump({
+      modules: oneModule,
+      exceptionCode: 11,
+      ip: 0x10500n,
+      ipOffset: 248,
+      ptype: "browser",
+    });
+    fs.writeFileSync(file, dump);
+    const readSpy = vi.spyOn(fs, "readSync");
+
+    expect(parseMinidumpSummary(file, "linux", "x64")).toEqual({
+      crashReason: "SIGSEGV",
+      exceptionCode: 11,
+      faultingModule: "libc.so.6",
+      faultingOffset: "0x500",
+      ptype: "browser",
+    });
+    expect(readSpy).toHaveBeenCalled();
+    expect(
+      readSpy.mock.calls.every((call) => {
+        const length = (call as unknown[])[3];
+        return typeof length === "number" && length < dump.length;
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects an oversized sparse dump before reading its contents", () => {
+    const file = path.join(dir, "oversized.dmp");
+    fs.writeFileSync(file, "");
+    fs.truncateSync(file, MAX_MINIDUMP_FILE_BYTES + 1);
+    const readSpy = vi.spyOn(fs, "readSync");
+
+    expect(parseMinidumpSummary(file, "linux", "x64")).toBeNull();
+    expect(readSpy).not.toHaveBeenCalled();
+  });
+
+  it("handles corrupt and truncated ranges without leaking the file", () => {
+    const file = path.join(dir, "truncated.dmp");
+    const header = Buffer.alloc(32);
+    header.writeUInt32LE(0x504d444d, 0);
+    header.writeUInt32LE(1, 8);
+    header.writeUInt32LE(0xfffffff0, 12);
+    fs.writeFileSync(file, header);
+
+    expect(parseMinidumpSummary(file, "linux", "x64")).toBeNull();
+    fs.renameSync(file, path.join(dir, "handled.dmp"));
   });
 });

--- a/src/utils/minidump_summary.ts
+++ b/src/utils/minidump_summary.ts
@@ -84,6 +84,7 @@ const MODULE_NAME_RVA_OFF = 20;
 const CRASHPAD_MODULE_LIST_RVA_OFF = 48; // rva field of module_list (@44 + 4)
 const CRASHPAD_ADDRESS_MASK_OFF = 56;
 const CRASHPAD_INFO_MIN_SIZE_FOR_MASK = 64; // through the end of address_mask
+const CRASHPAD_INFO_VERSION_WITH_ADDRESS_MASK = 1;
 
 // On Linux, Crashpad stores the POSIX signal number in ExceptionCode.
 const SIGNAL_NAMES: Record<number, string> = {
@@ -270,6 +271,7 @@ function parseMinidumpSource(
     // we care about.
     let moduleListRva = 0;
     let exceptionRva = 0;
+    let exceptionSize = 0;
     let crashpadInfoRva = 0;
     let crashpadInfoSize = 0;
     for (let i = 0; i < numStreams; i++) {
@@ -278,14 +280,18 @@ function parseMinidumpSource(
       const size = directory.readUInt32LE(entry + DIR_ENTRY_SIZE_OFF);
       const rva = directory.readUInt32LE(entry + DIR_ENTRY_RVA_OFF);
       if (type === STREAM_MODULE_LIST) moduleListRva = rva;
-      else if (type === STREAM_EXCEPTION) exceptionRva = rva;
-      else if (type === STREAM_CRASHPAD_INFO) {
+      else if (type === STREAM_EXCEPTION) {
+        exceptionRva = rva;
+        exceptionSize = size;
+      } else if (type === STREAM_CRASHPAD_INFO) {
         crashpadInfoRva = rva;
         crashpadInfoSize = size;
       }
     }
 
-    if (exceptionRva === 0) return null;
+    if (exceptionRva === 0 || exceptionSize < EXC_CONTEXT_RVA_OFF + 4) {
+      return null;
+    }
     const exception = source.read(exceptionRva, EXC_CONTEXT_RVA_OFF + 4);
     if (!exception) return null;
     const exceptionCode = exception.readUInt32LE(EXC_CODE_OFF);
@@ -400,6 +406,13 @@ function readAddressMask(
   infoSize: number,
 ): bigint {
   if (infoSize < CRASHPAD_INFO_MIN_SIZE_FOR_MASK) {
+    return 0n;
+  }
+  const version = readUInt32(source, infoRva);
+  if (
+    version === undefined ||
+    version < CRASHPAD_INFO_VERSION_WITH_ADDRESS_MASK
+  ) {
     return 0n;
   }
   return readBigUInt64(source, infoRva + CRASHPAD_ADDRESS_MASK_OFF) ?? 0n;

--- a/src/utils/minidump_summary.ts
+++ b/src/utils/minidump_summary.ts
@@ -168,10 +168,10 @@ class FileMinidumpSource implements MinidumpSource {
         length - position,
         offset + position,
       );
+      this.bytesRead += bytesRead;
       if (bytesRead === 0) return null;
       position += bytesRead;
     }
-    this.bytesRead += length;
     return buffer;
   }
 }

--- a/src/utils/minidump_summary.ts
+++ b/src/utils/minidump_summary.ts
@@ -36,6 +36,17 @@ const HEADER_STREAM_COUNT_OFF = 8;
 const HEADER_DIR_RVA_OFF = 12;
 const HEADER_SIZE = 32;
 
+// Crashpad dumps are normally only a few megabytes. Refuse pathological files
+// before following any of their RVAs, and cap the amount of data the random-
+// access parser may materialize even for an otherwise valid dump.
+export const MAX_MINIDUMP_FILE_BYTES = 128 * 1024 * 1024;
+const MAX_MINIDUMP_BYTES_READ = 2 * 1024 * 1024;
+const MAX_STREAM_COUNT = 1024;
+const MAX_MODULE_COUNT = 4096;
+const MAX_CRASHPAD_MODULE_COUNT = 1024;
+const MAX_ANNOTATION_COUNT = 1024;
+const MAX_STRING_BYTES = 16 * 1024;
+
 // MINIDUMP_DIRECTORY entry (one per stream): a u32 stream type, then a
 // LOCATION_DESCRIPTOR { u32 dataSize @4, u32 rva @8 }. 12 bytes total.
 const DIR_ENTRY_SIZE = 12;
@@ -112,10 +123,56 @@ const NTSTATUS_NAMES: Record<number, string> = {
   0x80000003: "BREAKPOINT",
 };
 
-interface MinidumpModule {
-  base: bigint;
-  size: number;
-  name: string;
+interface MinidumpSource {
+  readonly length: number;
+  read(offset: number, length: number): Buffer | null;
+}
+
+class BufferMinidumpSource implements MinidumpSource {
+  readonly length: number;
+
+  constructor(private readonly buffer: Buffer) {
+    this.length = buffer.length;
+  }
+
+  read(offset: number, length: number): Buffer | null {
+    if (!isValidRange(this.length, offset, length)) return null;
+    return this.buffer.subarray(offset, offset + length);
+  }
+}
+
+class FileMinidumpSource implements MinidumpSource {
+  private bytesRead = 0;
+
+  constructor(
+    private readonly fd: number,
+    readonly length: number,
+  ) {}
+
+  read(offset: number, length: number): Buffer | null {
+    if (
+      !isValidRange(this.length, offset, length) ||
+      this.bytesRead + length > MAX_MINIDUMP_BYTES_READ
+    ) {
+      return null;
+    }
+
+    const buffer = Buffer.allocUnsafe(length);
+    let position = 0;
+    while (position < length) {
+      const bytesRead = fs.readSync(
+        this.fd,
+        buffer,
+        position,
+        length - position,
+        offset + position,
+      );
+      if (bytesRead === 0) return null;
+      position += bytesRead;
+    }
+    this.bytesRead += length;
+    return buffer;
+  }
 }
 
 // Byte offset of the instruction pointer (where the crash happened) within each
@@ -151,13 +208,33 @@ export function parseMinidumpSummary(
   platform: NodeJS.Platform = process.platform,
   arch: NodeJS.Architecture = process.arch,
 ): MinidumpSummary | null {
-  let buf: Buffer;
+  let fd: number | undefined;
   try {
-    buf = fs.readFileSync(filePath);
+    fd = fs.openSync(filePath, "r");
+    const stat = fs.fstatSync(fd);
+    if (
+      !stat.isFile() ||
+      stat.size < HEADER_SIZE ||
+      stat.size > MAX_MINIDUMP_FILE_BYTES
+    ) {
+      return null;
+    }
+    return parseMinidumpSource(
+      new FileMinidumpSource(fd, stat.size),
+      platform,
+      arch,
+    );
   } catch {
     return null;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        fs.closeSync(fd);
+      } catch {
+        // Best effort. Parsing has already completed or failed.
+      }
+    }
   }
-  return parseMinidumpBuffer(buf, platform, arch);
 }
 
 // Parse an in-memory minidump into a MinidumpSummary. Finds the streams it needs
@@ -170,16 +247,24 @@ export function parseMinidumpBuffer(
   platform: NodeJS.Platform = process.platform,
   arch: NodeJS.Architecture = process.arch,
 ): MinidumpSummary | null {
+  return parseMinidumpSource(new BufferMinidumpSource(buf), platform, arch);
+}
+
+function parseMinidumpSource(
+  source: MinidumpSource,
+  platform: NodeJS.Platform,
+  arch: NodeJS.Architecture,
+): MinidumpSummary | null {
   try {
-    const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
-    if (
-      buf.length < HEADER_SIZE ||
-      view.getUint32(0, true) !== MINIDUMP_SIGNATURE
-    ) {
+    const header = source.read(0, HEADER_SIZE);
+    if (!header || header.readUInt32LE(0) !== MINIDUMP_SIGNATURE) {
       return null;
     }
-    const numStreams = view.getUint32(HEADER_STREAM_COUNT_OFF, true);
-    const dirRva = view.getUint32(HEADER_DIR_RVA_OFF, true);
+    const numStreams = header.readUInt32LE(HEADER_STREAM_COUNT_OFF);
+    const dirRva = header.readUInt32LE(HEADER_DIR_RVA_OFF);
+    if (numStreams > MAX_STREAM_COUNT) return null;
+    const directory = source.read(dirRva, numStreams * DIR_ENTRY_SIZE);
+    if (!directory) return null;
 
     // Walk the stream directory, recording the file offset (rva) of each stream
     // we care about.
@@ -188,11 +273,10 @@ export function parseMinidumpBuffer(
     let crashpadInfoRva = 0;
     let crashpadInfoSize = 0;
     for (let i = 0; i < numStreams; i++) {
-      const entry = dirRva + i * DIR_ENTRY_SIZE;
-      if (entry + DIR_ENTRY_SIZE > buf.length) break;
-      const type = view.getUint32(entry + DIR_ENTRY_TYPE_OFF, true);
-      const size = view.getUint32(entry + DIR_ENTRY_SIZE_OFF, true);
-      const rva = view.getUint32(entry + DIR_ENTRY_RVA_OFF, true);
+      const entry = i * DIR_ENTRY_SIZE;
+      const type = directory.readUInt32LE(entry + DIR_ENTRY_TYPE_OFF);
+      const size = directory.readUInt32LE(entry + DIR_ENTRY_SIZE_OFF);
+      const rva = directory.readUInt32LE(entry + DIR_ENTRY_RVA_OFF);
       if (type === STREAM_MODULE_LIST) moduleListRva = rva;
       else if (type === STREAM_EXCEPTION) exceptionRva = rva;
       else if (type === STREAM_CRASHPAD_INFO) {
@@ -201,10 +285,10 @@ export function parseMinidumpBuffer(
       }
     }
 
-    if (exceptionRva === 0 || exceptionRva + EXC_CONTEXT_RVA_OFF > buf.length) {
-      return null;
-    }
-    const exceptionCode = view.getUint32(exceptionRva + EXC_CODE_OFF, true);
+    if (exceptionRva === 0) return null;
+    const exception = source.read(exceptionRva, EXC_CONTEXT_RVA_OFF + 4);
+    if (!exception) return null;
+    const exceptionCode = exception.readUInt32LE(EXC_CODE_OFF);
 
     const crashReason =
       platform === "win32"
@@ -219,39 +303,23 @@ export function parseMinidumpBuffer(
     // context; the IP sits at an arch-specific offset within it.
     let instructionPointer = 0n;
     const ipOffset = IP_OFFSET_IN_CONTEXT[arch];
-    if (
-      ipOffset !== undefined &&
-      exceptionRva + EXC_CONTEXT_RVA_OFF + 4 <= buf.length
-    ) {
-      const contextRva = view.getUint32(
-        exceptionRva + EXC_CONTEXT_RVA_OFF,
-        true,
-      );
-      if (contextRva + ipOffset + 8 <= buf.length) {
-        instructionPointer = view.getBigUint64(contextRva + ipOffset, true);
-      }
+    if (ipOffset !== undefined) {
+      const contextRva = exception.readUInt32LE(EXC_CONTEXT_RVA_OFF);
+      instructionPointer = readBigUInt64(source, contextRva + ipOffset) ?? 0n;
     }
 
     // On arm64 the saved pointer can carry pointer-auth / top-byte tag bits.
     // Crashpad records an address_mask to recover the real address before module
     // lookup.
     if (instructionPointer !== 0n && crashpadInfoRva) {
-      const mask = readAddressMask(
-        view,
-        buf,
-        crashpadInfoRva,
-        crashpadInfoSize,
-      );
+      const mask = readAddressMask(source, crashpadInfoRva, crashpadInfoSize);
       instructionPointer = applyAddressMask(instructionPointer, mask);
     }
 
     let faultingModule: string | undefined;
     let faultingOffset: string | undefined;
     if (moduleListRva !== 0 && instructionPointer !== 0n) {
-      const module = findModule(
-        parseModules(view, buf, moduleListRva),
-        instructionPointer,
-      );
+      const module = findModule(source, moduleListRva, instructionPointer);
       if (module) {
         faultingModule = basename(module.name);
         faultingOffset = "0x" + (instructionPointer - module.base).toString(16);
@@ -263,9 +331,7 @@ export function parseMinidumpBuffer(
       exceptionCode,
       faultingModule,
       faultingOffset,
-      ptype: crashpadInfoRva
-        ? parsePtype(view, buf, crashpadInfoRva)
-        : undefined,
+      ptype: crashpadInfoRva ? parsePtype(source, crashpadInfoRva) : undefined,
     };
   } catch {
     return null;
@@ -285,35 +351,37 @@ export function parseMinidumpBuffer(
 //
 // name and value are length-prefixed UTF-8; return the value named "ptype".
 function parsePtype(
-  view: DataView,
-  buf: Buffer,
+  source: MinidumpSource,
   infoRva: number,
 ): string | undefined {
   try {
-    if (infoRva + CRASHPAD_MODULE_LIST_RVA_OFF + 4 > buf.length) {
+    const modListRva = readUInt32(
+      source,
+      infoRva + CRASHPAD_MODULE_LIST_RVA_OFF,
+    );
+    if (!modListRva) return undefined;
+    const moduleCount = readUInt32(source, modListRva);
+    if (moduleCount === undefined || moduleCount > MAX_CRASHPAD_MODULE_COUNT) {
       return undefined;
     }
-    const modListRva = view.getUint32(
-      infoRva + CRASHPAD_MODULE_LIST_RVA_OFF,
-      true,
-    );
-    if (modListRva === 0 || modListRva + 4 > buf.length) return undefined;
-    const moduleCount = view.getUint32(modListRva, true);
+    const links = source.read(modListRva + 4, moduleCount * 12);
+    if (!links) return undefined;
+
     for (let i = 0; i < moduleCount; i++) {
-      const link = modListRva + 4 + i * 12;
-      if (link + 12 > buf.length) break;
-      const moduleInfoRva = view.getUint32(link + 8, true);
-      if (moduleInfoRva + 28 > buf.length) continue;
-      const objectsRva = view.getUint32(moduleInfoRva + 24, true);
-      if (objectsRva === 0 || objectsRva + 4 > buf.length) continue;
-      const objectCount = view.getUint32(objectsRva, true);
+      const moduleInfoRva = links.readUInt32LE(i * 12 + 8);
+      const objectsRva = readUInt32(source, moduleInfoRva + 24);
+      if (!objectsRva) continue;
+      const objectCount = readUInt32(source, objectsRva);
+      if (objectCount === undefined || objectCount > MAX_ANNOTATION_COUNT) {
+        continue;
+      }
+      const objects = source.read(objectsRva + 4, objectCount * 12);
+      if (!objects) continue;
+
       for (let j = 0; j < objectCount; j++) {
-        const obj = objectsRva + 4 + j * 12;
-        if (obj + 12 > buf.length) break;
-        if (
-          readLengthPrefixed(view, buf, view.getUint32(obj, true)) === "ptype"
-        ) {
-          return readLengthPrefixed(view, buf, view.getUint32(obj + 8, true));
+        const obj = j * 12;
+        if (readLengthPrefixed(source, objects.readUInt32LE(obj)) === "ptype") {
+          return readLengthPrefixed(source, objects.readUInt32LE(obj + 8));
         }
       }
     }
@@ -327,18 +395,14 @@ function parsePtype(
 // pointer-tag bits from addresses (arm64). Returns 0n when absent — older dumps
 // don't have the field, so only read it when the stream is long enough.
 function readAddressMask(
-  view: DataView,
-  buf: Buffer,
+  source: MinidumpSource,
   infoRva: number,
   infoSize: number,
 ): bigint {
-  if (
-    infoSize < CRASHPAD_INFO_MIN_SIZE_FOR_MASK ||
-    infoRva + CRASHPAD_ADDRESS_MASK_OFF + 8 > buf.length
-  ) {
+  if (infoSize < CRASHPAD_INFO_MIN_SIZE_FOR_MASK) {
     return 0n;
   }
-  return view.getBigUint64(infoRva + CRASHPAD_ADDRESS_MASK_OFF, true);
+  return readBigUInt64(source, infoRva + CRASHPAD_ADDRESS_MASK_OFF) ?? 0n;
 }
 
 // Recover a real address from a tagged arm64 pointer using Crashpad's mask. Per
@@ -351,54 +415,72 @@ function applyAddressMask(pointer: bigint, mask: bigint): bigint {
 }
 
 // A u32 byte-length followed by UTF-8 bytes (MinidumpUTF8String / ByteArray).
-function readLengthPrefixed(view: DataView, buf: Buffer, rva: number): string {
-  if (rva === 0 || rva + 4 > buf.length) return "";
-  const len = view.getUint32(rva, true);
-  const start = rva + 4;
-  if (len <= 0 || start + len > buf.length) return "";
-  return buf.toString("utf8", start, start + len);
+function readLengthPrefixed(source: MinidumpSource, rva: number): string {
+  if (rva === 0) return "";
+  const length = readUInt32(source, rva);
+  if (!length || length > MAX_STRING_BYTES) return "";
+  return source.read(rva + 4, length)?.toString("utf8") ?? "";
 }
 
 // Parse the module list stream into the base address, size, and name of each
 // loaded module. (MINIDUMP_MODULE_LIST: a u32 count, then `count` fixed-size
 // module records.)
-function parseModules(
-  view: DataView,
-  buf: Buffer,
-  rva: number,
-): MinidumpModule[] {
-  if (rva + 4 > buf.length) return [];
-  const count = view.getUint32(rva, true);
-  const modules: MinidumpModule[] = [];
-  for (let i = 0; i < count; i++) {
-    const m = rva + 4 + i * MODULE_RECORD_SIZE;
-    if (m + MODULE_RECORD_SIZE > buf.length) break;
-    const base = view.getBigUint64(m + MODULE_BASE_OFF, true);
-    const size = view.getUint32(m + MODULE_SIZE_OFF, true);
-    const nameRva = view.getUint32(m + MODULE_NAME_RVA_OFF, true);
-    modules.push({ base, size, name: readMinidumpString(view, buf, nameRva) });
-  }
-  return modules;
-}
-
-// Find the loaded module whose address range contains the given address (the
-// crash IP), or undefined if it falls outside every module.
 function findModule(
-  modules: MinidumpModule[],
+  source: MinidumpSource,
+  rva: number,
   address: bigint,
-): MinidumpModule | undefined {
-  return modules.find(
-    (m) => address >= m.base && address < m.base + BigInt(m.size),
-  );
+): { base: bigint; size: number; name: string } | undefined {
+  const count = readUInt32(source, rva);
+  if (count === undefined || count > MAX_MODULE_COUNT) return undefined;
+  const records = source.read(rva + 4, count * MODULE_RECORD_SIZE);
+  if (!records) return undefined;
+
+  for (let i = 0; i < count; i++) {
+    const m = i * MODULE_RECORD_SIZE;
+    const base = records.readBigUInt64LE(m + MODULE_BASE_OFF);
+    const size = records.readUInt32LE(m + MODULE_SIZE_OFF);
+    if (address >= base && address < base + BigInt(size)) {
+      const nameRva = records.readUInt32LE(m + MODULE_NAME_RVA_OFF);
+      return { base, size, name: readMinidumpString(source, nameRva) };
+    }
+  }
+  return undefined;
 }
 
 // MINIDUMP_STRING: u32 byte-length followed by UTF-16LE.
-function readMinidumpString(view: DataView, buf: Buffer, rva: number): string {
-  if (rva === 0 || rva + 4 > buf.length) return "";
-  const byteLength = view.getUint32(rva, true);
-  const start = rva + 4;
-  if (byteLength <= 0 || start + byteLength > buf.length) return "";
-  return buf.toString("utf16le", start, start + byteLength);
+function readMinidumpString(source: MinidumpSource, rva: number): string {
+  if (rva === 0) return "";
+  const byteLength = readUInt32(source, rva);
+  if (!byteLength || byteLength > MAX_STRING_BYTES) return "";
+  return source.read(rva + 4, byteLength)?.toString("utf16le") ?? "";
+}
+
+function readUInt32(
+  source: MinidumpSource,
+  offset: number,
+): number | undefined {
+  return source.read(offset, 4)?.readUInt32LE(0);
+}
+
+function readBigUInt64(
+  source: MinidumpSource,
+  offset: number,
+): bigint | undefined {
+  return source.read(offset, 8)?.readBigUInt64LE(0);
+}
+
+function isValidRange(
+  sourceLength: number,
+  offset: number,
+  length: number,
+): boolean {
+  return (
+    Number.isSafeInteger(offset) &&
+    Number.isSafeInteger(length) &&
+    offset >= 0 &&
+    length >= 0 &&
+    offset <= sourceLength - length
+  );
 }
 
 // Last path segment of a module path, handling both / and \ separators (module


### PR DESCRIPTION
## Summary
- stream upgrade backup checksums instead of reading the entire SQLite database into memory
- parse minidumps with bounded random-access reads and strict file and structure limits
- process only the newest pending crash dumps while draining older dump and sidecar backlogs

## Tests
- npm test -- src/utils/file_checksum.test.ts src/utils/minidump_summary.test.ts src/utils/crash_dumps.test.ts
- npm run lint
- npm run ts
- npm run build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes early-startup backup checksums and native crash telemetry parsing, but behavior is defensive (bounds, best-effort deletes) and should not block app launch if parsing fails.
> 
> **Overview**
> Startup work no longer loads whole SQLite databases or minidumps into RAM. **Upgrade backup checksums** use a new streaming `calculateFileChecksum` helper (64 KiB chunks, `pipeline` so streams close on failure) instead of reading the full DB in `BackupManager`.
> 
> **Minidump summarization** stops using `readFileSync` and walks dumps through a `MinidumpSource` with random-access reads, a **128 MiB** file-size ceiling, a **2 MiB** cumulative read budget, and caps on stream/module/annotation/string sizes. Crashpad **address_mask** is only applied when CrashpadInfo version ≥ 1.
> 
> **Crash dump startup** replaces scanning every pending `.dmp` with `pruneAndListNewestDumpFilesRecursive` (main process keeps **10** newest), deleting older dumps and `.meta` sidecars while walking the tree; dumps whose mtime cannot be read are left alone for a later launch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfa47116e79a6fa298126878411077113579ef2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

