### PR TITLE
Prevent unbounded visual editing response memory

### DIFF
--- a/src/components/preview_panel/VisualEditingChangesDialog.test.tsx
+++ b/src/components/preview_panel/VisualEditingChangesDialog.test.tsx
@@ -1,0 +1,380 @@
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { createStore, Provider } from "jotai";
+import type { PropsWithChildren, RefObject } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { selectedAppIdAtom } from "@/atoms/appAtoms";
+import { pendingVisualChangesAtom } from "@/atoms/previewAtoms";
+import type { VisualEditingChange } from "@/ipc/types";
+import {
+  MAX_VISUAL_TEXT_CACHE_ENTRIES,
+  MAX_VISUAL_TEXT_ENTRY_BYTES,
+  VISUAL_TEXT_RESPONSE_TIMEOUT_MS,
+  VisualEditingChangesDialog,
+} from "./VisualEditingChangesDialog";
+
+const { applyChangesMock, showErrorMock, showSuccessMock } = vi.hoisted(() => ({
+  applyChangesMock: vi.fn(),
+  showErrorMock: vi.fn(),
+  showSuccessMock: vi.fn(),
+}));
+
+vi.mock("@/ipc/types", () => ({
+  ipc: {
+    visualEditing: {
+      applyChanges: applyChangesMock,
+    },
+  },
+}));
+
+vi.mock("@/lib/toast", () => ({
+  showError: showErrorMock,
+  showSuccess: showSuccessMock,
+}));
+
+function makeChange(componentId: string): VisualEditingChange {
+  return {
+    componentId,
+    componentName: `Component ${componentId}`,
+    relativePath: "src/App.tsx",
+    lineNumber: 1,
+    styles: {},
+  };
+}
+
+function createIframe() {
+  const iframe = document.createElement("iframe");
+  document.body.appendChild(iframe);
+  if (!iframe.contentWindow) {
+    throw new Error("Expected test iframe to have a contentWindow");
+  }
+  const postMessageMock = vi
+    .spyOn(iframe.contentWindow, "postMessage")
+    .mockImplementation(() => undefined);
+  return { iframe, iframeWindow: iframe.contentWindow, postMessageMock };
+}
+
+function sendTextResponse(
+  source: MessageEventSource,
+  componentId: unknown,
+  text: unknown,
+) {
+  act(() => {
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        source,
+        data: {
+          type: "dyad-text-content-response",
+          componentId,
+          text,
+        },
+      }),
+    );
+  });
+}
+
+function renderDialog({
+  changes = [makeChange("component-a")],
+  appId = 1,
+  iframe = createIframe().iframe,
+  onReset = vi.fn(),
+}: {
+  changes?: VisualEditingChange[];
+  appId?: number;
+  iframe?: HTMLIFrameElement;
+  onReset?: () => void;
+} = {}) {
+  const store = createStore();
+  store.set(selectedAppIdAtom, appId);
+  store.set(
+    pendingVisualChangesAtom,
+    new Map(changes.map((change) => [change.componentId, change])),
+  );
+  const iframeRef: RefObject<HTMLIFrameElement | null> = { current: iframe };
+  const Wrapper = ({ children }: PropsWithChildren) => (
+    <Provider store={store}>{children}</Provider>
+  );
+  const view = render(
+    <VisualEditingChangesDialog iframeRef={iframeRef} onReset={onReset} />,
+    { wrapper: Wrapper },
+  );
+
+  return { ...view, store, iframeRef, onReset };
+}
+
+describe("VisualEditingChangesDialog", () => {
+  beforeEach(() => {
+    applyChangesMock.mockReset();
+    applyChangesMock.mockResolvedValue(undefined);
+    showErrorMock.mockReset();
+    showSuccessMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.querySelectorAll("iframe").forEach((iframe) => iframe.remove());
+  });
+
+  it("saves expected text returned by the current preview iframe", async () => {
+    const { iframe, iframeWindow, postMessageMock } = createIframe();
+    const { store, onReset } = renderDialog({ iframe });
+
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    expect(postMessageMock).toHaveBeenCalledWith(
+      {
+        type: "get-dyad-text-content",
+        data: { componentId: "component-a" },
+      },
+      "*",
+    );
+    sendTextResponse(iframeWindow, "component-a", "Saved text");
+
+    await waitFor(() => {
+      expect(applyChangesMock).toHaveBeenCalledWith({
+        appId: 1,
+        changes: [
+          expect.objectContaining({
+            componentId: "component-a",
+            textContent: "Saved text",
+          }),
+        ],
+      });
+    });
+    expect(store.get(pendingVisualChangesAtom).size).toBe(0);
+    expect(showSuccessMock).toHaveBeenCalledWith(
+      "Visual changes saved to source files",
+    );
+    expect(onReset).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores responses from windows other than the current iframe", async () => {
+    const { iframe, iframeWindow } = createIframe();
+    renderDialog({ iframe });
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    sendTextResponse(window, "component-a", "Untrusted text");
+    expect(applyChangesMock).not.toHaveBeenCalled();
+
+    sendTextResponse(iframeWindow, "component-a", "Trusted text");
+    await waitFor(() => expect(applyChangesMock).toHaveBeenCalledTimes(1));
+    expect(applyChangesMock.mock.calls[0][0].changes[0].textContent).toBe(
+      "Trusted text",
+    );
+  });
+
+  it("ignores unsolicited, malformed, and duplicate component responses", async () => {
+    const { iframe, iframeWindow } = createIframe();
+    renderDialog({
+      iframe,
+      changes: [makeChange("component-a"), makeChange("component-b")],
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    sendTextResponse(iframeWindow, "unexpected", "Unsolicited");
+    sendTextResponse(iframeWindow, 123, "Malformed ID");
+    sendTextResponse(iframeWindow, "component-a", { malformed: true });
+    sendTextResponse(iframeWindow, "component-a", "First response");
+    sendTextResponse(iframeWindow, "component-a", "Duplicate response");
+    expect(applyChangesMock).not.toHaveBeenCalled();
+
+    sendTextResponse(iframeWindow, "component-b", null);
+    await waitFor(() => expect(applyChangesMock).toHaveBeenCalledTimes(1));
+    expect(applyChangesMock.mock.calls[0][0].changes).toEqual([
+      expect.objectContaining({
+        componentId: "component-a",
+        textContent: "First response",
+      }),
+      expect.objectContaining({ componentId: "component-b" }),
+    ]);
+    expect(
+      applyChangesMock.mock.calls[0][0].changes[1].textContent,
+    ).toBeUndefined();
+  });
+
+  it("rejects a text response over the per-entry byte limit", () => {
+    const { iframe, iframeWindow } = createIframe();
+    renderDialog({ iframe });
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    sendTextResponse(
+      iframeWindow,
+      "component-a",
+      "x".repeat(MAX_VISUAL_TEXT_ENTRY_BYTES + 1),
+    );
+
+    expect(applyChangesMock).not.toHaveBeenCalled();
+    expect(showErrorMock).toHaveBeenCalledWith(
+      expect.stringContaining("exceeds the 1 MiB limit"),
+    );
+    expect(
+      screen.queryByRole("button", { name: "Save Changes" }),
+    ).not.toBeNull();
+    sendTextResponse(iframeWindow, "component-a", "Late response");
+    expect(applyChangesMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects responses that exceed the aggregate byte limit", () => {
+    const { iframe, iframeWindow } = createIframe();
+    const changes = Array.from({ length: 6 }, (_, index) =>
+      makeChange(`component-${index}`),
+    );
+    renderDialog({ iframe, changes });
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    const oneMiBText = "x".repeat(MAX_VISUAL_TEXT_ENTRY_BYTES);
+    for (let index = 0; index < changes.length; index++) {
+      sendTextResponse(iframeWindow, `component-${index}`, oneMiBText);
+    }
+
+    expect(applyChangesMock).not.toHaveBeenCalled();
+    expect(showErrorMock).toHaveBeenCalledWith(
+      expect.stringContaining("exceeds the 5 MiB limit"),
+    );
+  });
+
+  it("rejects more pending components than the cache entry budget", () => {
+    const { iframe, postMessageMock } = createIframe();
+    renderDialog({
+      iframe,
+      changes: Array.from(
+        { length: MAX_VISUAL_TEXT_CACHE_ENTRIES + 1 },
+        (_, index) => makeChange(`component-${index}`),
+      ),
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    expect(postMessageMock).not.toHaveBeenCalled();
+    expect(applyChangesMock).not.toHaveBeenCalled();
+    expect(showErrorMock).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `more than ${MAX_VISUAL_TEXT_CACHE_ENTRIES} visual changes`,
+      ),
+    );
+  });
+
+  it("times out cleanly and allows a fresh retry", async () => {
+    vi.useFakeTimers();
+    const { iframe, iframeWindow } = createIframe();
+    renderDialog({ iframe });
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    act(() => {
+      vi.advanceTimersByTime(VISUAL_TEXT_RESPONSE_TIMEOUT_MS);
+    });
+
+    expect(showErrorMock).toHaveBeenCalledWith(
+      expect.stringContaining("Timed out waiting for text content"),
+    );
+    sendTextResponse(iframeWindow, "component-a", "Stale response");
+    expect(applyChangesMock).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+    sendTextResponse(iframeWindow, "component-a", "Fresh response");
+    await vi.waitFor(() => expect(applyChangesMock).toHaveBeenCalledTimes(1));
+    expect(applyChangesMock.mock.calls[0][0].changes[0].textContent).toBe(
+      "Fresh response",
+    );
+  });
+
+  it("clears partial responses when the save is discarded", async () => {
+    const { iframe, iframeWindow } = createIframe();
+    const changes = [makeChange("component-a"), makeChange("component-b")];
+    const { store } = renderDialog({ iframe, changes });
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+    sendTextResponse(iframeWindow, "component-a", "Discarded text");
+
+    fireEvent.click(screen.getByRole("button", { name: "Discard" }));
+    sendTextResponse(iframeWindow, "component-b", "Late text");
+    expect(applyChangesMock).not.toHaveBeenCalled();
+
+    act(() => {
+      store.set(
+        pendingVisualChangesAtom,
+        new Map(changes.map((change) => [change.componentId, change])),
+      );
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+    sendTextResponse(iframeWindow, "component-b", "Fresh B");
+    expect(applyChangesMock).not.toHaveBeenCalled();
+    sendTextResponse(iframeWindow, "component-a", "Fresh A");
+
+    await waitFor(() => expect(applyChangesMock).toHaveBeenCalledTimes(1));
+    expect(applyChangesMock.mock.calls[0][0].changes).toEqual([
+      expect.objectContaining({ textContent: "Fresh A" }),
+      expect.objectContaining({ textContent: "Fresh B" }),
+    ]);
+  });
+
+  it("clears partial responses when the selected app changes", async () => {
+    const { iframe, iframeWindow } = createIframe();
+    const changes = [makeChange("component-a"), makeChange("component-b")];
+    const { store } = renderDialog({ iframe, changes });
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+    sendTextResponse(iframeWindow, "component-a", "Old app text");
+
+    act(() => store.set(selectedAppIdAtom, 2));
+    sendTextResponse(iframeWindow, "component-b", "Late old app text");
+    expect(applyChangesMock).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+    sendTextResponse(iframeWindow, "component-a", "New app A");
+    sendTextResponse(iframeWindow, "component-b", "New app B");
+
+    await waitFor(() => expect(applyChangesMock).toHaveBeenCalledTimes(1));
+    expect(applyChangesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ appId: 2 }),
+    );
+  });
+
+  it("clears partial responses when the iframe is replaced", async () => {
+    const first = createIframe();
+    const second = createIframe();
+    const changes = [makeChange("component-a"), makeChange("component-b")];
+    const { iframeRef, rerender } = renderDialog({
+      iframe: first.iframe,
+      changes,
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+    sendTextResponse(first.iframeWindow, "component-a", "Old iframe text");
+
+    iframeRef.current = second.iframe;
+    rerender(
+      <VisualEditingChangesDialog iframeRef={iframeRef} onReset={vi.fn()} />,
+    );
+    sendTextResponse(first.iframeWindow, "component-b", "Late old text");
+    expect(applyChangesMock).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+    sendTextResponse(second.iframeWindow, "component-a", "New iframe A");
+    sendTextResponse(second.iframeWindow, "component-b", "New iframe B");
+    await waitFor(() => expect(applyChangesMock).toHaveBeenCalledTimes(1));
+  });
+
+  it("clears pending request state and its timeout on unmount", () => {
+    vi.useFakeTimers();
+    const { iframe, iframeWindow } = createIframe();
+    const { unmount } = renderDialog({
+      iframe,
+      changes: [makeChange("component-a"), makeChange("component-b")],
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+    sendTextResponse(iframeWindow, "component-a", "Cached before unmount");
+
+    unmount();
+    expect(vi.getTimerCount()).toBe(0);
+    sendTextResponse(iframeWindow, "component-b", "Late after unmount");
+    act(() => {
+      vi.advanceTimersByTime(VISUAL_TEXT_RESPONSE_TIMEOUT_MS);
+    });
+
+    expect(applyChangesMock).not.toHaveBeenCalled();
+    expect(showErrorMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/preview_panel/VisualEditingChangesDialog.test.tsx
+++ b/src/components/preview_panel/VisualEditingChangesDialog.test.tsx
@@ -14,6 +14,7 @@ import type { VisualEditingChange } from "@/ipc/types";
 import {
   MAX_VISUAL_TEXT_CACHE_ENTRIES,
   MAX_VISUAL_TEXT_ENTRY_BYTES,
+  MAX_VISUAL_TEXT_TOTAL_BYTES,
   VISUAL_TEXT_RESPONSE_TIMEOUT_MS,
   VisualEditingChangesDialog,
 } from "./VisualEditingChangesDialog";
@@ -86,7 +87,7 @@ function renderDialog({
 }: {
   changes?: VisualEditingChange[];
   appId?: number;
-  iframe?: HTMLIFrameElement;
+  iframe?: HTMLIFrameElement | null;
   onReset?: () => void;
 } = {}) {
   const store = createStore();
@@ -238,6 +239,64 @@ describe("VisualEditingChangesDialog", () => {
     );
   });
 
+  it("rejects oversized pre-existing text before applying without an iframe", () => {
+    renderDialog({
+      iframe: null,
+      changes: [
+        {
+          ...makeChange("component-a"),
+          textContent: "x".repeat(MAX_VISUAL_TEXT_ENTRY_BYTES + 1),
+        },
+      ],
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    expect(applyChangesMock).not.toHaveBeenCalled();
+    expect(showErrorMock).toHaveBeenCalledWith(
+      expect.stringContaining("exceeds the 1 MiB limit"),
+    );
+  });
+
+  it("rejects aggregate pre-existing text before applying", () => {
+    const textLength = MAX_VISUAL_TEXT_TOTAL_BYTES / 5;
+    renderDialog({
+      iframe: null,
+      changes: Array.from({ length: 6 }, (_, index) => ({
+        ...makeChange(`component-${index}`),
+        textContent: "x".repeat(textLength),
+      })),
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    expect(applyChangesMock).not.toHaveBeenCalled();
+    expect(showErrorMock).toHaveBeenCalledWith(
+      expect.stringContaining("exceeds the 5 MiB limit"),
+    );
+  });
+
+  it("applies bounded pre-existing text directly without an iframe", async () => {
+    renderDialog({
+      iframe: null,
+      changes: [{ ...makeChange("component-a"), textContent: "Existing text" }],
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    await waitFor(() => {
+      expect(applyChangesMock).toHaveBeenCalledWith({
+        appId: 1,
+        changes: [
+          expect.objectContaining({
+            componentId: "component-a",
+            textContent: "Existing text",
+          }),
+        ],
+      });
+    });
+  });
+
   it("rejects more pending components than the cache entry budget", () => {
     const { iframe, postMessageMock } = createIframe();
     renderDialog({
@@ -331,6 +390,140 @@ describe("VisualEditingChangesDialog", () => {
     expect(applyChangesMock).toHaveBeenCalledWith(
       expect.objectContaining({ appId: 2 }),
     );
+  });
+
+  it("keeps save disabled until an invalidated apply call settles", async () => {
+    let resolveApply: (() => void) | undefined;
+    applyChangesMock.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveApply = resolve;
+      }),
+    );
+    const { iframe, iframeWindow } = createIframe();
+    const { store } = renderDialog({ iframe });
+
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+    sendTextResponse(iframeWindow, "component-a", "Saved text");
+    await waitFor(() => expect(applyChangesMock).toHaveBeenCalledTimes(1));
+
+    act(() => store.set(selectedAppIdAtom, 2));
+    const savingButton = screen.getByRole("button", { name: "Saving..." });
+    expect((savingButton as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.click(savingButton);
+    expect(applyChangesMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveApply?.();
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      expect(
+        (
+          screen.getByRole("button", {
+            name: "Save Changes",
+          }) as HTMLButtonElement
+        ).disabled,
+      ).toBe(false);
+    });
+    expect(store.get(pendingVisualChangesAtom).size).toBe(1);
+    expect(showSuccessMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves edits added or replaced while apply is in flight", async () => {
+    let resolveApply: (() => void) | undefined;
+    applyChangesMock.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveApply = resolve;
+      }),
+    );
+    const originalChange = makeChange("component-a");
+    const { iframe, iframeWindow } = createIframe();
+    const { store, onReset } = renderDialog({
+      iframe,
+      changes: [originalChange],
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+    sendTextResponse(iframeWindow, "component-a", "Saved text");
+    await waitFor(() => expect(applyChangesMock).toHaveBeenCalledTimes(1));
+
+    const newerSameComponent = {
+      ...originalChange,
+      textContent: "Newer text",
+    };
+    const newComponent = makeChange("component-b");
+    act(() => {
+      store.set(
+        pendingVisualChangesAtom,
+        new Map([
+          [newerSameComponent.componentId, newerSameComponent],
+          [newComponent.componentId, newComponent],
+        ]),
+      );
+    });
+
+    await act(async () => {
+      resolveApply?.();
+      await Promise.resolve();
+    });
+
+    expect(store.get(pendingVisualChangesAtom)).toEqual(
+      new Map([
+        [newerSameComponent.componentId, newerSameComponent],
+        [newComponent.componentId, newComponent],
+      ]),
+    );
+    expect(showSuccessMock).toHaveBeenCalledTimes(1);
+    expect(onReset).not.toHaveBeenCalled();
+  });
+
+  it("uses the latest onReset callback without replacing the message listener", async () => {
+    const addEventListenerSpy = vi.spyOn(window, "addEventListener");
+    const firstOnReset = vi.fn();
+    const latestOnReset = vi.fn();
+    const { iframe, iframeWindow } = createIframe();
+    const { iframeRef, rerender } = renderDialog({
+      iframe,
+      onReset: firstOnReset,
+    });
+    const initialMessageListenerAdds = addEventListenerSpy.mock.calls.filter(
+      ([eventName]) => eventName === "message",
+    ).length;
+
+    rerender(
+      <VisualEditingChangesDialog
+        iframeRef={iframeRef}
+        onReset={latestOnReset}
+      />,
+    );
+    expect(
+      addEventListenerSpy.mock.calls.filter(
+        ([eventName]) => eventName === "message",
+      ).length,
+    ).toBe(initialMessageListenerAdds);
+
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+    sendTextResponse(iframeWindow, "component-a", "Saved text");
+    await waitFor(() => expect(latestOnReset).toHaveBeenCalledTimes(1));
+    expect(firstOnReset).not.toHaveBeenCalled();
+    addEventListenerSpy.mockRestore();
+  });
+
+  it("shows a readable message for structured apply errors", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    applyChangesMock.mockRejectedValueOnce({ message: "Structured failure" });
+    renderDialog({ iframe: null });
+
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    await waitFor(() => {
+      expect(showErrorMock).toHaveBeenCalledWith(
+        "Failed to save changes: Structured failure",
+      );
+    });
+    consoleErrorSpy.mockRestore();
   });
 
   it("clears partial responses when the iframe is replaced", async () => {

--- a/src/components/preview_panel/VisualEditingChangesDialog.tsx
+++ b/src/components/preview_panel/VisualEditingChangesDialog.tsx
@@ -1,15 +1,68 @@
 import { useAtom, useAtomValue } from "jotai";
 import { pendingVisualChangesAtom } from "@/atoms/previewAtoms";
 import { Button } from "@/components/ui/button";
-import { ipc } from "@/ipc/types";
+import { ipc, type VisualEditingChange } from "@/ipc/types";
 import { Check, X } from "lucide-react";
-import { useState, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { showError, showSuccess } from "@/lib/toast";
 import { selectedAppIdAtom } from "@/atoms/appAtoms";
+
+export const MAX_VISUAL_TEXT_CACHE_ENTRIES = 500;
+export const MAX_VISUAL_TEXT_ENTRY_BYTES = 1024 * 1024;
+export const MAX_VISUAL_TEXT_TOTAL_BYTES = 5 * 1024 * 1024;
+export const VISUAL_TEXT_RESPONSE_TIMEOUT_MS = 10_000;
 
 interface VisualEditingChangesDialogProps {
   onReset?: () => void;
   iframeRef?: React.RefObject<HTMLIFrameElement | null>;
+}
+
+interface TextContentRequest {
+  generation: number;
+  source: Window;
+  appId: number;
+  changes: VisualEditingChange[];
+  expectedComponentIds: Set<string>;
+  textContentByComponentId: Map<string, string>;
+  totalTextBytes: number;
+  timeoutId: ReturnType<typeof setTimeout> | null;
+}
+
+type SavePhase = "idle" | "collecting-text" | "applying";
+
+function utf8ByteLengthWithinLimit(
+  value: string,
+  limit: number,
+): number | null {
+  let byteLength = 0;
+
+  for (let index = 0; index < value.length; index++) {
+    const codeUnit = value.charCodeAt(index);
+
+    if (codeUnit <= 0x7f) {
+      byteLength += 1;
+    } else if (codeUnit <= 0x7ff) {
+      byteLength += 2;
+    } else if (
+      codeUnit >= 0xd800 &&
+      codeUnit <= 0xdbff &&
+      index + 1 < value.length &&
+      value.charCodeAt(index + 1) >= 0xdc00 &&
+      value.charCodeAt(index + 1) <= 0xdfff
+    ) {
+      byteLength += 4;
+      index += 1;
+    } else {
+      // TextEncoder replaces unpaired surrogates with U+FFFD, which is 3 bytes.
+      byteLength += 3;
+    }
+
+    if (byteLength > limit) {
+      return null;
+    }
+  }
+
+  return byteLength;
 }
 
 export function VisualEditingChangesDialog({
@@ -18,137 +71,264 @@ export function VisualEditingChangesDialog({
 }: VisualEditingChangesDialogProps) {
   const [pendingChanges, setPendingChanges] = useAtom(pendingVisualChangesAtom);
   const selectedAppId = useAtomValue(selectedAppIdAtom);
-  const [isSaving, setIsSaving] = useState(false);
-  const textContentCache = useRef<Map<string, string>>(new Map());
-  const [allResponsesReceived, setAllResponsesReceived] = useState(false);
-  const expectedResponsesRef = useRef<Set<string>>(new Set());
-  const isWaitingForResponses = useRef(false);
+  const [savePhase, setSavePhase] = useState<SavePhase>("idle");
+  const activeTextRequestRef = useRef<TextContentRequest | null>(null);
+  const saveGenerationRef = useRef(0);
+  const iframeWindow = iframeRef?.current?.contentWindow ?? null;
 
-  // Listen for text content responses
+  const clearTextRequest = useCallback((request: TextContentRequest) => {
+    if (request.timeoutId !== null) {
+      clearTimeout(request.timeoutId);
+      request.timeoutId = null;
+    }
+    request.expectedComponentIds.clear();
+    request.textContentByComponentId.clear();
+    request.totalTextBytes = 0;
+    if (activeTextRequestRef.current === request) {
+      activeTextRequestRef.current = null;
+    }
+  }, []);
+
+  const invalidateSave = useCallback(
+    (updateUi: boolean) => {
+      saveGenerationRef.current += 1;
+      const request = activeTextRequestRef.current;
+      if (request) {
+        clearTextRequest(request);
+      }
+      if (updateUi) {
+        setSavePhase("idle");
+      }
+    },
+    [clearTextRequest],
+  );
+
+  const applyChanges = useCallback(
+    async (request: TextContentRequest) => {
+      const updatedChanges = request.changes.map((change) => {
+        const cachedText = request.textContentByComponentId.get(
+          change.componentId,
+        );
+        return cachedText === undefined
+          ? change
+          : { ...change, textContent: cachedText };
+      });
+
+      request.expectedComponentIds.clear();
+      request.textContentByComponentId.clear();
+      request.totalTextBytes = 0;
+
+      try {
+        await ipc.visualEditing.applyChanges({
+          appId: request.appId,
+          changes: updatedChanges,
+        });
+
+        if (saveGenerationRef.current !== request.generation) {
+          return;
+        }
+
+        setPendingChanges(new Map());
+        showSuccess("Visual changes saved to source files");
+        onReset?.();
+      } catch (error) {
+        if (saveGenerationRef.current !== request.generation) {
+          return;
+        }
+        console.error("Failed to save visual editing changes:", error);
+        showError(`Failed to save changes: ${error}`);
+      } finally {
+        if (saveGenerationRef.current === request.generation) {
+          setSavePhase("idle");
+        }
+      }
+    },
+    [onReset, setPendingChanges],
+  );
+
+  const finishTextRequest = useCallback(
+    (request: TextContentRequest) => {
+      if (activeTextRequestRef.current !== request) {
+        return;
+      }
+
+      if (request.timeoutId !== null) {
+        clearTimeout(request.timeoutId);
+        request.timeoutId = null;
+      }
+      activeTextRequestRef.current = null;
+      setSavePhase("applying");
+      void applyChanges(request);
+    },
+    [applyChanges],
+  );
+
+  const failTextRequest = useCallback(
+    (request: TextContentRequest, message: string) => {
+      if (activeTextRequestRef.current !== request) {
+        return;
+      }
+
+      clearTextRequest(request);
+      saveGenerationRef.current += 1;
+      setSavePhase("idle");
+      showError(message);
+    },
+    [clearTextRequest],
+  );
+
+  // Only the current preview iframe may answer an active, expected request.
   useEffect(() => {
     const handleMessage = (event: MessageEvent) => {
-      if (event.data?.type === "dyad-text-content-response") {
-        const { componentId, text } = event.data;
-        if (text !== null) {
-          textContentCache.current.set(componentId, text);
-        }
+      const request = activeTextRequestRef.current;
+      if (
+        !request ||
+        !iframeWindow ||
+        request.source !== iframeWindow ||
+        event.source !== iframeWindow
+      ) {
+        return;
+      }
 
-        // Mark this response as received
-        expectedResponsesRef.current.delete(componentId);
+      const data: unknown = event.data;
+      if (
+        typeof data !== "object" ||
+        data === null ||
+        !("type" in data) ||
+        data.type !== "dyad-text-content-response" ||
+        !("componentId" in data) ||
+        typeof data.componentId !== "string" ||
+        !("text" in data) ||
+        (data.text !== null && typeof data.text !== "string") ||
+        !request.expectedComponentIds.has(data.componentId)
+      ) {
+        return;
+      }
 
-        // Check if all responses received (only if we're actually waiting)
+      if (typeof data.text === "string") {
         if (
-          isWaitingForResponses.current &&
-          expectedResponsesRef.current.size === 0
+          request.textContentByComponentId.size >= MAX_VISUAL_TEXT_CACHE_ENTRIES
         ) {
-          setAllResponsesReceived(true);
+          failTextRequest(
+            request,
+            `Could not save visual changes: more than ${MAX_VISUAL_TEXT_CACHE_ENTRIES} text responses were received.`,
+          );
+          return;
         }
+
+        const textBytes = utf8ByteLengthWithinLimit(
+          data.text,
+          MAX_VISUAL_TEXT_ENTRY_BYTES,
+        );
+        if (textBytes === null) {
+          failTextRequest(
+            request,
+            `Could not save visual changes: text content for component "${data.componentId}" exceeds the 1 MiB limit.`,
+          );
+          return;
+        }
+        if (request.totalTextBytes + textBytes > MAX_VISUAL_TEXT_TOTAL_BYTES) {
+          failTextRequest(
+            request,
+            "Could not save visual changes: collected text content exceeds the 5 MiB limit.",
+          );
+          return;
+        }
+
+        request.textContentByComponentId.set(data.componentId, data.text);
+        request.totalTextBytes += textBytes;
+      }
+
+      request.expectedComponentIds.delete(data.componentId);
+      if (request.expectedComponentIds.size === 0) {
+        finishTextRequest(request);
       }
     };
 
     window.addEventListener("message", handleMessage);
     return () => window.removeEventListener("message", handleMessage);
-  }, []);
+  }, [failTextRequest, finishTextRequest, iframeWindow]);
 
-  // Execute when all responses are received
+  // Changing app/iframe invalidates stale responses. Cleanup also covers unmount.
   useEffect(() => {
-    if (allResponsesReceived && isSaving) {
-      const applyChanges = async () => {
-        try {
-          const changesToSave = Array.from(pendingChanges.values());
-
-          // Update changes with cached text content
-          const updatedChanges = changesToSave.map((change) => {
-            const cachedText = textContentCache.current.get(change.componentId);
-            if (cachedText !== undefined) {
-              return { ...change, textContent: cachedText };
-            }
-            return change;
-          });
-
-          await ipc.visualEditing.applyChanges({
-            appId: selectedAppId!,
-            changes: updatedChanges,
-          });
-
-          setPendingChanges(new Map());
-          textContentCache.current.clear();
-          showSuccess("Visual changes saved to source files");
-          onReset?.();
-        } catch (error) {
-          console.error("Failed to save visual editing changes:", error);
-          showError(`Failed to save changes: ${error}`);
-        } finally {
-          setIsSaving(false);
-          setAllResponsesReceived(false);
-          isWaitingForResponses.current = false;
-        }
-      };
-
-      applyChanges();
-    }
-  }, [
-    allResponsesReceived,
-    isSaving,
-    pendingChanges,
-    selectedAppId,
-    onReset,
-    setPendingChanges,
-  ]);
+    invalidateSave(true);
+    return () => invalidateSave(false);
+  }, [iframeWindow, invalidateSave, selectedAppId]);
 
   if (pendingChanges.size === 0) return null;
 
-  const handleSave = async () => {
-    setIsSaving(true);
+  const handleSave = () => {
+    if (savePhase !== "idle") {
+      return;
+    }
+    if (selectedAppId === null) {
+      showError("Could not save visual changes: no app is selected.");
+      return;
+    }
+
+    const changesToSave = Array.from(pendingChanges.values());
+    if (changesToSave.length > MAX_VISUAL_TEXT_CACHE_ENTRIES) {
+      showError(
+        `Could not save more than ${MAX_VISUAL_TEXT_CACHE_ENTRIES} visual changes at once.`,
+      );
+      return;
+    }
+
+    const generation = saveGenerationRef.current + 1;
+    saveGenerationRef.current = generation;
+
+    const request: TextContentRequest = {
+      generation,
+      source: iframeWindow ?? window,
+      appId: selectedAppId,
+      changes: changesToSave,
+      expectedComponentIds: new Set(
+        changesToSave.map((change) => change.componentId),
+      ),
+      textContentByComponentId: new Map(),
+      totalTextBytes: 0,
+      timeoutId: null,
+    };
+
+    if (!iframeWindow) {
+      setSavePhase("applying");
+      void applyChanges(request);
+      return;
+    }
+
+    setSavePhase("collecting-text");
+    activeTextRequestRef.current = request;
+    request.timeoutId = setTimeout(() => {
+      failTextRequest(
+        request,
+        "Timed out waiting for text content from the preview. Please try again.",
+      );
+    }, VISUAL_TEXT_RESPONSE_TIMEOUT_MS);
+
     try {
-      const changesToSave = Array.from(pendingChanges.values());
+      for (const change of changesToSave) {
+        iframeWindow.postMessage(
+          {
+            type: "get-dyad-text-content",
+            data: { componentId: change.componentId },
+          },
+          "*",
+        );
+      }
 
-      if (iframeRef?.current?.contentWindow) {
-        // Reset state for new request
-        setAllResponsesReceived(false);
-        expectedResponsesRef.current.clear();
-        isWaitingForResponses.current = true;
-
-        // Track which components we're expecting responses from
-        for (const change of changesToSave) {
-          expectedResponsesRef.current.add(change.componentId);
-        }
-
-        // Request text content for each component
-        for (const change of changesToSave) {
-          iframeRef.current.contentWindow.postMessage(
-            {
-              type: "get-dyad-text-content",
-              data: { componentId: change.componentId },
-            },
-            "*",
-          );
-        }
-
-        // If no responses are expected, trigger immediately
-        if (expectedResponsesRef.current.size === 0) {
-          setAllResponsesReceived(true);
-        }
-      } else {
-        await ipc.visualEditing.applyChanges({
-          appId: selectedAppId!,
-          changes: changesToSave,
-        });
-
-        setPendingChanges(new Map());
-        textContentCache.current.clear();
-        showSuccess("Visual changes saved to source files");
-        onReset?.();
+      if (request.expectedComponentIds.size === 0) {
+        finishTextRequest(request);
       }
     } catch (error) {
-      console.error("Failed to save visual editing changes:", error);
-      showError(`Failed to save changes: ${error}`);
-      setIsSaving(false);
-      isWaitingForResponses.current = false;
+      failTextRequest(
+        request,
+        `Failed to request text content from the preview: ${error}`,
+      );
     }
   };
 
   const handleDiscard = () => {
+    invalidateSave(true);
     setPendingChanges(new Map());
     onReset?.();
   };
@@ -160,15 +340,15 @@ export function VisualEditingChangesDialog({
         {pendingChanges.size > 1 ? "s" : ""} modified
       </p>
       <div className="flex gap-1 lg:gap-2 w-full lg:w-auto flex-wrap">
-        <Button size="sm" onClick={handleSave} disabled={isSaving}>
+        <Button size="sm" onClick={handleSave} disabled={savePhase !== "idle"}>
           <Check size={14} className="mr-1" />
-          <span>{isSaving ? "Saving..." : "Save Changes"}</span>
+          <span>{savePhase !== "idle" ? "Saving..." : "Save Changes"}</span>
         </Button>
         <Button
           size="sm"
           variant="outline"
           onClick={handleDiscard}
-          disabled={isSaving}
+          disabled={savePhase === "applying"}
         >
           <X size={14} className="mr-1" />
           <span>Discard</span>

--- a/src/components/preview_panel/VisualEditingChangesDialog.tsx
+++ b/src/components/preview_panel/VisualEditingChangesDialog.tsx
@@ -19,11 +19,12 @@ interface VisualEditingChangesDialogProps {
 
 interface TextContentRequest {
   generation: number;
-  source: Window;
+  source: Window | null;
   appId: number;
   changes: VisualEditingChange[];
   expectedComponentIds: Set<string>;
   textContentByComponentId: Map<string, string>;
+  textBytesByComponentId: Map<string, number>;
   totalTextBytes: number;
   timeoutId: ReturnType<typeof setTimeout> | null;
 }
@@ -65,16 +66,87 @@ function utf8ByteLengthWithinLimit(
   return byteLength;
 }
 
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    typeof error.message === "string"
+  ) {
+    return error.message;
+  }
+  return "Unknown error";
+}
+
+function getInitialTextContent(changes: VisualEditingChange[]):
+  | {
+      ok: true;
+      textContentByComponentId: Map<string, string>;
+      textBytesByComponentId: Map<string, number>;
+      totalTextBytes: number;
+    }
+  | { ok: false; message: string } {
+  const textContentByComponentId = new Map<string, string>();
+  const textBytesByComponentId = new Map<string, number>();
+  let totalTextBytes = 0;
+
+  for (const change of changes) {
+    if (typeof change.textContent !== "string") {
+      continue;
+    }
+
+    const textBytes = utf8ByteLengthWithinLimit(
+      change.textContent,
+      MAX_VISUAL_TEXT_ENTRY_BYTES,
+    );
+    if (textBytes === null) {
+      return {
+        ok: false,
+        message: `Could not save visual changes: text content for component "${change.componentId}" exceeds the 1 MiB limit.`,
+      };
+    }
+    if (totalTextBytes + textBytes > MAX_VISUAL_TEXT_TOTAL_BYTES) {
+      return {
+        ok: false,
+        message:
+          "Could not save visual changes: collected text content exceeds the 5 MiB limit.",
+      };
+    }
+
+    textContentByComponentId.set(change.componentId, change.textContent);
+    textBytesByComponentId.set(change.componentId, textBytes);
+    totalTextBytes += textBytes;
+  }
+
+  return {
+    ok: true,
+    textContentByComponentId,
+    textBytesByComponentId,
+    totalTextBytes,
+  };
+}
+
 export function VisualEditingChangesDialog({
   onReset,
   iframeRef,
 }: VisualEditingChangesDialogProps) {
   const [pendingChanges, setPendingChanges] = useAtom(pendingVisualChangesAtom);
   const selectedAppId = useAtomValue(selectedAppIdAtom);
+  const iframeWindow = iframeRef?.current?.contentWindow ?? null;
   const [savePhase, setSavePhase] = useState<SavePhase>("idle");
   const activeTextRequestRef = useRef<TextContentRequest | null>(null);
+  const activeApplyRequestRef = useRef<TextContentRequest | null>(null);
   const saveGenerationRef = useRef(0);
-  const iframeWindow = iframeRef?.current?.contentWindow ?? null;
+  const isMountedRef = useRef(true);
+  const previousContextRef = useRef({ selectedAppId, iframeWindow });
+  const onResetRef = useRef(onReset);
+  onResetRef.current = onReset;
 
   const clearTextRequest = useCallback((request: TextContentRequest) => {
     if (request.timeoutId !== null) {
@@ -83,6 +155,7 @@ export function VisualEditingChangesDialog({
     }
     request.expectedComponentIds.clear();
     request.textContentByComponentId.clear();
+    request.textBytesByComponentId.clear();
     request.totalTextBytes = 0;
     if (activeTextRequestRef.current === request) {
       activeTextRequestRef.current = null;
@@ -96,7 +169,7 @@ export function VisualEditingChangesDialog({
       if (request) {
         clearTextRequest(request);
       }
-      if (updateUi) {
+      if (updateUi && activeApplyRequestRef.current === null) {
         setSavePhase("idle");
       }
     },
@@ -105,6 +178,7 @@ export function VisualEditingChangesDialog({
 
   const applyChanges = useCallback(
     async (request: TextContentRequest) => {
+      activeApplyRequestRef.current = request;
       const updatedChanges = request.changes.map((change) => {
         const cachedText = request.textContentByComponentId.get(
           change.componentId,
@@ -116,6 +190,7 @@ export function VisualEditingChangesDialog({
 
       request.expectedComponentIds.clear();
       request.textContentByComponentId.clear();
+      request.textBytesByComponentId.clear();
       request.totalTextBytes = 0;
 
       try {
@@ -128,22 +203,41 @@ export function VisualEditingChangesDialog({
           return;
         }
 
-        setPendingChanges(new Map());
+        let hasRemainingChanges = false;
+        setPendingChanges((currentChanges) => {
+          const nextChanges = new Map(currentChanges);
+          for (const savedChange of request.changes) {
+            if (nextChanges.get(savedChange.componentId) === savedChange) {
+              nextChanges.delete(savedChange.componentId);
+            }
+          }
+          hasRemainingChanges = nextChanges.size > 0;
+          return nextChanges;
+        });
         showSuccess("Visual changes saved to source files");
-        onReset?.();
+        if (!hasRemainingChanges) {
+          onResetRef.current?.();
+        }
       } catch (error) {
         if (saveGenerationRef.current !== request.generation) {
           return;
         }
         console.error("Failed to save visual editing changes:", error);
-        showError(`Failed to save changes: ${error}`);
+        showError(`Failed to save changes: ${getErrorMessage(error)}`);
       } finally {
-        if (saveGenerationRef.current === request.generation) {
+        const wasActiveApply = activeApplyRequestRef.current === request;
+        if (wasActiveApply) {
+          activeApplyRequestRef.current = null;
+        }
+        if (
+          isMountedRef.current &&
+          (saveGenerationRef.current === request.generation || wasActiveApply)
+        ) {
           setSavePhase("idle");
         }
       }
     },
-    [onReset, setPendingChanges],
+    [setPendingChanges],
   );
 
   const finishTextRequest = useCallback(
@@ -206,16 +300,6 @@ export function VisualEditingChangesDialog({
       }
 
       if (typeof data.text === "string") {
-        if (
-          request.textContentByComponentId.size >= MAX_VISUAL_TEXT_CACHE_ENTRIES
-        ) {
-          failTextRequest(
-            request,
-            `Could not save visual changes: more than ${MAX_VISUAL_TEXT_CACHE_ENTRIES} text responses were received.`,
-          );
-          return;
-        }
-
         const textBytes = utf8ByteLengthWithinLimit(
           data.text,
           MAX_VISUAL_TEXT_ENTRY_BYTES,
@@ -227,7 +311,11 @@ export function VisualEditingChangesDialog({
           );
           return;
         }
-        if (request.totalTextBytes + textBytes > MAX_VISUAL_TEXT_TOTAL_BYTES) {
+        const previousTextBytes =
+          request.textBytesByComponentId.get(data.componentId) ?? 0;
+        const nextTotalTextBytes =
+          request.totalTextBytes - previousTextBytes + textBytes;
+        if (nextTotalTextBytes > MAX_VISUAL_TEXT_TOTAL_BYTES) {
           failTextRequest(
             request,
             "Could not save visual changes: collected text content exceeds the 5 MiB limit.",
@@ -236,7 +324,8 @@ export function VisualEditingChangesDialog({
         }
 
         request.textContentByComponentId.set(data.componentId, data.text);
-        request.totalTextBytes += textBytes;
+        request.textBytesByComponentId.set(data.componentId, textBytes);
+        request.totalTextBytes = nextTotalTextBytes;
       }
 
       request.expectedComponentIds.delete(data.componentId);
@@ -249,11 +338,25 @@ export function VisualEditingChangesDialog({
     return () => window.removeEventListener("message", handleMessage);
   }, [failTextRequest, finishTextRequest, iframeWindow]);
 
-  // Changing app/iframe invalidates stale responses. Cleanup also covers unmount.
+  // Changing app/iframe invalidates stale responses, but not on initial mount.
   useEffect(() => {
-    invalidateSave(true);
-    return () => invalidateSave(false);
+    const previousContext = previousContextRef.current;
+    previousContextRef.current = { selectedAppId, iframeWindow };
+    if (
+      previousContext.selectedAppId !== selectedAppId ||
+      previousContext.iframeWindow !== iframeWindow
+    ) {
+      invalidateSave(true);
+    }
   }, [iframeWindow, invalidateSave, selectedAppId]);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      invalidateSave(false);
+    };
+  }, [invalidateSave]);
 
   if (pendingChanges.size === 0) return null;
 
@@ -274,19 +377,26 @@ export function VisualEditingChangesDialog({
       return;
     }
 
+    const initialTextContent = getInitialTextContent(changesToSave);
+    if (!initialTextContent.ok) {
+      showError(initialTextContent.message);
+      return;
+    }
+
     const generation = saveGenerationRef.current + 1;
     saveGenerationRef.current = generation;
 
     const request: TextContentRequest = {
       generation,
-      source: iframeWindow ?? window,
+      source: iframeWindow,
       appId: selectedAppId,
       changes: changesToSave,
       expectedComponentIds: new Set(
         changesToSave.map((change) => change.componentId),
       ),
-      textContentByComponentId: new Map(),
-      totalTextBytes: 0,
+      textContentByComponentId: initialTextContent.textContentByComponentId,
+      textBytesByComponentId: initialTextContent.textBytesByComponentId,
+      totalTextBytes: initialTextContent.totalTextBytes,
       timeoutId: null,
     };
 
@@ -322,7 +432,7 @@ export function VisualEditingChangesDialog({
     } catch (error) {
       failTextRequest(
         request,
-        `Failed to request text content from the preview: ${error}`,
+        `Failed to request text content from the preview: ${getErrorMessage(error)}`,
       );
     }
   };
@@ -330,7 +440,7 @@ export function VisualEditingChangesDialog({
   const handleDiscard = () => {
     invalidateSave(true);
     setPendingChanges(new Map());
-    onReset?.();
+    onResetRef.current?.();
   };
 
   return (


### PR DESCRIPTION
## Summary
- accept visual editing text responses only from the current preview iframe and only for actively requested component IDs
- cap collection at 500 entries, 1 MiB per response, and 5 MiB total, with a 10-second timeout and lifecycle cleanup
- guard stale save completions across discard, app changes, iframe replacement, and unmount
- add focused React coverage for trusted and hostile message flows plus cleanup and retry behavior

## Testing
- npm test -- src/components/preview_panel/VisualEditingChangesDialog.test.tsx
- npm run fmt
- npm run lint (0 errors; 2 existing no-thenable warnings)
- npm run ts
- npm run build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes preview-to-host messaging and when visual edits persist to source via IPC; mistakes could drop edits or accept bad text, but behavior is heavily tested and scoped to the preview panel dialog.
> 
> **Overview**
> **Visual editing save** in `VisualEditingChangesDialog` is reworked so preview `postMessage` text collection is bounded, validated, and safe against stale or hostile responses.
> 
> Save now runs in phases (`collecting-text` → `applying`) with a **generation counter** so completions from discard, app switch, iframe swap, or unmount do not clear pending edits or call `onReset` incorrectly. Only the **current preview iframe** may answer, and only for **actively requested component IDs**; malformed, duplicate, and unsolicited messages are ignored.
> 
> **Limits** are enforced before and during collection: 500 components, 1 MiB per entry, 5 MiB total (UTF-8 byte counting), plus a **10s timeout** with cleanup. Pre-existing `textContent` on changes is validated the same way; saves without an iframe skip messaging and apply directly when within bounds. Apply errors surface readable messages; pending map updates only remove entries that still match the saved snapshot, preserving edits made while apply is in flight.
> 
> A new **Vitest suite** covers trusted/untrusted flows, limits, timeout/retry, lifecycle invalidation, and UI disable behavior during apply.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7f19cc3ced03f6fe6a4987567aa8d31768bfe6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

