### PR TITLE
Improve local agent file listing performance

### DIFF
--- a/src/__tests__/codebase.test.ts
+++ b/src/__tests__/codebase.test.ts
@@ -2,10 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import {
-  extractCodebase,
-  listCodebaseFileMetadata,
-} from "@/utils/codebase";
+import { extractCodebase, listCodebaseFileMetadata } from "@/utils/codebase";
 
 vi.mock("electron-log", () => ({
   default: {

--- a/src/__tests__/codebase.test.ts
+++ b/src/__tests__/codebase.test.ts
@@ -2,7 +2,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { extractCodebase } from "@/utils/codebase";
+import {
+  extractCodebase,
+  listCodebaseFileMetadata,
+} from "@/utils/codebase";
 
 vi.mock("electron-log", () => ({
   default: {
@@ -106,5 +109,24 @@ describe("extractCodebase", () => {
       "src.ts",
     ]);
     expect(result.formattedOutput).not.toContain(".gitattributes");
+  });
+
+  it("lists file metadata without reading file contents", async () => {
+    appDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "codebase-"));
+    await fs.promises.writeFile(path.join(appDir, "a.ts"), "secret content");
+    await fs.promises.writeFile(path.join(appDir, "b.ts"), "more content");
+    const readFileSpy = vi.spyOn(fs.promises, "readFile");
+
+    const result = await listCodebaseFileMetadata({
+      appPath: appDir,
+      chatContext: {
+        contextPaths: [],
+        smartContextAutoIncludes: [],
+      },
+    });
+
+    expect(result.files.map((file) => file.path)).toEqual(["a.ts", "b.ts"]);
+    expect(result.totalFileCount).toBe(2);
+    expect(readFileSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/pro/main/ipc/handlers/local_agent/tools/list_files.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/list_files.ts
@@ -7,7 +7,7 @@ import {
   escapeXmlAttr,
   escapeXmlContent,
 } from "./types";
-import { extractCodebase } from "../../../../../../utils/codebase";
+import { listCodebaseFileMetadata } from "../../../../../../utils/codebase";
 import { resolveDirectoryWithinAppPath } from "./path_safety";
 import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
 import {
@@ -158,7 +158,7 @@ export const listFilesTool: ToolDefinition<ListFilesArgs> = {
         })),
       );
     } else {
-      const { files } = await extractCodebase({
+      const { files } = await listCodebaseFileMetadata({
         appPath: targetAppPath,
         chatContext: {
           contextPaths: [{ globPath }],

--- a/src/utils/codebase.ts
+++ b/src/utils/codebase.ts
@@ -486,6 +486,157 @@ export interface CodebaseFileReference extends BaseFile {
   fileId: string;
 }
 
+interface PreparedCodebaseFile extends BaseFile {
+  absolutePath: string;
+}
+
+async function prepareCodebaseFiles({
+  appPath,
+  chatContext,
+  virtualFileSystem,
+}: {
+  appPath: string;
+  chatContext: AppChatContext;
+  virtualFileSystem?: AsyncVirtualFileSystem;
+}): Promise<PreparedCodebaseFile[] | undefined> {
+  const settings = readSettings();
+  const isSmartContextEnabled =
+    settings?.enableDyadPro && settings?.enableProSmartFilesContextMode;
+
+  try {
+    await fsAsync.access(appPath);
+  } catch {
+    return undefined;
+  }
+
+  let files = settings.enableNativeGit
+    ? await collectFilesNativeGit(appPath)
+    : await collectFilesIsoGit(appPath, appPath);
+
+  if (virtualFileSystem) {
+    const deletedFiles = new Set(
+      virtualFileSystem
+        .getDeletedFiles()
+        .map((relativePath) => path.resolve(appPath, relativePath)),
+    );
+    files = files.filter((file) => !deletedFiles.has(file));
+
+    for (const virtualFile of virtualFileSystem.getVirtualFiles()) {
+      const absolutePath = path.resolve(appPath, virtualFile.path);
+      if (!files.includes(absolutePath)) {
+        files.push(absolutePath);
+      }
+    }
+  }
+
+  const { contextPaths, smartContextAutoIncludes, excludePaths } = chatContext;
+  const includedFiles = new Set<string>();
+  const autoIncludedFiles = new Set<string>();
+  const excludedFiles = new Set<string>();
+
+  if (contextPaths && contextPaths.length > 0) {
+    for (const contextPath of contextPaths) {
+      const matches = await glob(
+        createFullGlobPath({ appPath, globPath: contextPath.globPath }),
+        {
+          nodir: true,
+          absolute: true,
+          ignore: "**/node_modules/**",
+        },
+      );
+      matches.forEach((file) => includedFiles.add(path.normalize(file)));
+    }
+  }
+
+  if (
+    isSmartContextEnabled &&
+    smartContextAutoIncludes &&
+    smartContextAutoIncludes.length > 0
+  ) {
+    for (const autoInclude of smartContextAutoIncludes) {
+      const matches = await glob(
+        createFullGlobPath({ appPath, globPath: autoInclude.globPath }),
+        {
+          nodir: true,
+          absolute: true,
+          ignore: "**/node_modules/**",
+        },
+      );
+      matches.forEach((file) => {
+        const normalizedFile = path.normalize(file);
+        autoIncludedFiles.add(normalizedFile);
+        includedFiles.add(normalizedFile);
+      });
+    }
+  }
+
+  if (excludePaths && excludePaths.length > 0) {
+    for (const excludePath of excludePaths) {
+      const matches = await glob(
+        createFullGlobPath({ appPath, globPath: excludePath.globPath }),
+        {
+          nodir: true,
+          absolute: true,
+          ignore: "**/node_modules/**",
+        },
+      );
+      matches.forEach((file) => excludedFiles.add(path.normalize(file)));
+    }
+  }
+
+  if (contextPaths && contextPaths.length > 0) {
+    files = files.filter((file) => includedFiles.has(path.normalize(file)));
+  }
+  if (excludedFiles.size > 0) {
+    files = files.filter((file) => !excludedFiles.has(path.normalize(file)));
+  }
+
+  const sortedFiles = await sortFilesByModificationTime(
+    [...new Set(files)],
+    Boolean(settings.isTestMode),
+  );
+
+  return sortedFiles.map((file) => ({
+    absolutePath: file,
+    path: path.relative(appPath, file).split(path.sep).join("/"),
+    force:
+      autoIncludedFiles.has(path.normalize(file)) &&
+      !excludedFiles.has(path.normalize(file)),
+  }));
+}
+
+/**
+ * List codebase files without reading their contents.
+ */
+export async function listCodebaseFileMetadata({
+  appPath,
+  chatContext,
+  maxFiles,
+}: {
+  appPath: string;
+  chatContext: AppChatContext;
+  maxFiles?: number;
+}): Promise<{ files: BaseFile[]; totalFileCount: number }> {
+  const preparedFiles =
+    (await prepareCodebaseFiles({ appPath, chatContext })) ?? [];
+  const prioritizedFiles = [
+    ...preparedFiles.filter((file) => file.force),
+    ...preparedFiles.filter((file) => !file.force),
+  ];
+  const selectedFiles =
+    maxFiles === undefined
+      ? preparedFiles
+      : prioritizedFiles.slice(0, Math.max(0, Math.floor(maxFiles)));
+
+  return {
+    files: selectedFiles.map(({ path: filePath, force }) => ({
+      path: filePath,
+      force,
+    })),
+    totalFileCount: preparedFiles.length,
+  };
+}
+
 /**
  * Extract and format codebase files as a string to be included in prompts
  * @param appPath - Path to the codebase to extract
@@ -504,148 +655,28 @@ export async function extractCodebase({
   formattedOutput: string;
   files: CodebaseFile[];
 }> {
-  const settings = readSettings();
-  const isSmartContextEnabled =
-    settings?.enableDyadPro && settings?.enableProSmartFilesContextMode;
-
-  try {
-    await fsAsync.access(appPath);
-  } catch {
+  const startTime = Date.now();
+  const preparedFiles = await prepareCodebaseFiles({
+    appPath,
+    chatContext,
+    virtualFileSystem,
+  });
+  if (!preparedFiles) {
     return {
       formattedOutput: `# Error: Directory ${appPath} does not exist or is not accessible`,
       files: [],
     };
   }
-  const startTime = Date.now();
-
-  // Collect all relevant files
-  let files = settings.enableNativeGit
-    ? await collectFilesNativeGit(appPath)
-    : await collectFilesIsoGit(appPath, appPath);
-
-  // Apply virtual filesystem modifications if provided
-  if (virtualFileSystem) {
-    // Filter out deleted files
-    const deletedFiles = new Set(
-      virtualFileSystem
-        .getDeletedFiles()
-        .map((relativePath) => path.resolve(appPath, relativePath)),
-    );
-    files = files.filter((file) => !deletedFiles.has(file));
-
-    // Add virtual files
-    const virtualFiles = virtualFileSystem.getVirtualFiles();
-    for (const virtualFile of virtualFiles) {
-      const absolutePath = path.resolve(appPath, virtualFile.path);
-      if (!files.includes(absolutePath)) {
-        files.push(absolutePath);
-      }
-    }
-  }
-
-  // Collect files from contextPaths and smartContextAutoIncludes
-  const { contextPaths, smartContextAutoIncludes, excludePaths } = chatContext;
-  const includedFiles = new Set<string>();
-  const autoIncludedFiles = new Set<string>();
-  const excludedFiles = new Set<string>();
-
-  // Add files from contextPaths
-  if (contextPaths && contextPaths.length > 0) {
-    for (const p of contextPaths) {
-      const pattern = createFullGlobPath({
-        appPath,
-        globPath: p.globPath,
-      });
-      const matches = await glob(pattern, {
-        nodir: true,
-        absolute: true,
-        ignore: "**/node_modules/**",
-      });
-      matches.forEach((file) => {
-        const normalizedFile = path.normalize(file);
-        includedFiles.add(normalizedFile);
-      });
-    }
-  }
-
-  // Add files from smartContextAutoIncludes
-  if (
-    isSmartContextEnabled &&
-    smartContextAutoIncludes &&
-    smartContextAutoIncludes.length > 0
-  ) {
-    for (const p of smartContextAutoIncludes) {
-      const pattern = createFullGlobPath({
-        appPath,
-        globPath: p.globPath,
-      });
-      const matches = await glob(pattern, {
-        nodir: true,
-        absolute: true,
-        ignore: "**/node_modules/**",
-      });
-      matches.forEach((file) => {
-        const normalizedFile = path.normalize(file);
-        autoIncludedFiles.add(normalizedFile);
-        includedFiles.add(normalizedFile); // Also add to included files
-      });
-    }
-  }
-
-  // Add files from excludePaths
-  if (excludePaths && excludePaths.length > 0) {
-    for (const p of excludePaths) {
-      const pattern = createFullGlobPath({
-        appPath,
-        globPath: p.globPath,
-      });
-      const matches = await glob(pattern, {
-        nodir: true,
-        absolute: true,
-        ignore: "**/node_modules/**",
-      });
-      matches.forEach((file) => {
-        const normalizedFile = path.normalize(file);
-        excludedFiles.add(normalizedFile);
-      });
-    }
-  }
-
-  // Only filter files if contextPaths are provided
-  // If only smartContextAutoIncludes are provided, keep all files and just mark auto-includes as forced
-  if (contextPaths && contextPaths.length > 0) {
-    files = files.filter((file) => includedFiles.has(path.normalize(file)));
-  }
-
-  // Filter out excluded files (this takes precedence over include paths)
-  if (excludedFiles.size > 0) {
-    files = files.filter((file) => !excludedFiles.has(path.normalize(file)));
-  }
-
-  // Sort files by modification time (oldest first)
-  // This is important for cache-ability.
-  const sortedFiles = await sortFilesByModificationTime(
-    [...new Set(files)],
-    Boolean(settings.isTestMode),
-  );
 
   // Format files and collect individual file contents
-  const formatPromises = sortedFiles.map(async (file) => {
-    // Get raw content for the files array
-    const normalizedRelativePath = path
-      .relative(appPath, file)
-      // Why? Normalize Windows-style paths which causes lots of weird issues (e.g. Git commit)
-      .split(path.sep)
-      .join("/");
+  const formatPromises = preparedFiles.map(async (preparedFile) => {
+    const file = preparedFile.absolutePath;
+    const normalizedRelativePath = preparedFile.path;
     const formattedContent = await formatFile({
       filePath: file,
       normalizedRelativePath,
       virtualFileSystem,
     });
-
-    const isForced =
-      autoIncludedFiles.has(path.normalize(file)) &&
-      !excludedFiles.has(path.normalize(file));
 
     // Determine file content based on whether we should read it
     let fileContent: string;
@@ -666,7 +697,7 @@ export async function extractCodebase({
       file: {
         path: normalizedRelativePath,
         content: fileContent,
-        force: isForced,
+        force: preparedFile.force,
       } satisfies CodebaseFile,
     };
   });

--- a/src/utils/codebase.ts
+++ b/src/utils/codebase.ts
@@ -611,25 +611,15 @@ async function prepareCodebaseFiles({
 export async function listCodebaseFileMetadata({
   appPath,
   chatContext,
-  maxFiles,
 }: {
   appPath: string;
   chatContext: AppChatContext;
-  maxFiles?: number;
 }): Promise<{ files: BaseFile[]; totalFileCount: number }> {
   const preparedFiles =
     (await prepareCodebaseFiles({ appPath, chatContext })) ?? [];
-  const prioritizedFiles = [
-    ...preparedFiles.filter((file) => file.force),
-    ...preparedFiles.filter((file) => !file.force),
-  ];
-  const selectedFiles =
-    maxFiles === undefined
-      ? preparedFiles
-      : prioritizedFiles.slice(0, Math.max(0, Math.floor(maxFiles)));
 
   return {
-    files: selectedFiles.map(({ path: filePath, force }) => ({
+    files: preparedFiles.map(({ path: filePath, force }) => ({
       path: filePath,
       force,
     })),


### PR DESCRIPTION
## Summary
- add a metadata-only codebase listing path that preserves existing filtering and ordering
- use it in the local agent list_files tool to avoid reading every matching file body
- add a regression test proving metadata listing performs no content reads

## Tests
- npm test -- src/__tests__/codebase.test.ts src/pro/main/ipc/handlers/local_agent/tools/list_files.spec.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance refactor with shared preparation logic; list_files output should match prior filtering, and extractCodebase still reads content only when needed.
> 
> **Overview**
> Refactors codebase file discovery into shared **`prepareCodebaseFiles`**, then adds **`listCodebaseFileMetadata`** to return paths (and `force` flags) using the same git ignore, glob context, exclude rules, and mtime ordering—**without reading file bodies**.
> 
> The local agent **`list_files`** tool now calls **`listCodebaseFileMetadata`** instead of **`extractCodebase`**, so listing large trees no longer loads every matching file into memory. **`extractCodebase`** behavior is preserved by building on the same preparation step before formatting and content reads.
> 
> A regression test asserts **`listCodebaseFileMetadata`** never invokes **`fs.promises.readFile`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7a920b92da321687b5967eed9bfbcc4ed069882. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

