### PR TITLE
Stream upgrade backup checksums

### DIFF
--- a/src/backup_manager.ts
+++ b/src/backup_manager.ts
@@ -1,10 +1,10 @@
 import * as path from "path";
 import * as fs from "fs/promises";
 import { app } from "electron";
-import * as crypto from "crypto";
 import log from "electron-log";
 import Database from "better-sqlite3";
 import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
+import { calculateFileChecksum } from "@/utils/file_checksum";
 
 const logger = log.scope("backup_manager");
 
@@ -332,10 +332,7 @@ export class BackupManager {
    */
   private async getFileChecksum(filePath: string): Promise<string | null> {
     try {
-      const fileBuffer = await fs.readFile(filePath);
-      const hash = crypto.createHash("sha256");
-      hash.update(fileBuffer);
-      const checksum = hash.digest("hex");
+      const checksum = await calculateFileChecksum(filePath);
       logger.debug(
         `Checksum calculated for ${filePath}: ${checksum.substring(0, 8)}...`,
       );

--- a/src/utils/file_checksum.test.ts
+++ b/src/utils/file_checksum.test.ts
@@ -1,0 +1,63 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { calculateFileChecksum } from "@/utils/file_checksum";
+
+describe("calculateFileChecksum", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "file-checksum-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("hashes files across multiple stream chunks", async () => {
+    const file = path.join(dir, "database.sqlite");
+    const contents = Buffer.concat([
+      Buffer.alloc(64 * 1024, 0x11),
+      Buffer.alloc(64 * 1024, 0x22),
+      Buffer.alloc(17, 0x33),
+    ]);
+    fs.writeFileSync(file, contents);
+
+    await expect(calculateFileChecksum(file)).resolves.toBe(
+      createHash("sha256").update(contents).digest("hex"),
+    );
+  });
+
+  it("streams a large sparse database without materializing the file", async () => {
+    const file = path.join(dir, "large.sqlite");
+    const fd = fs.openSync(file, "w");
+    try {
+      fs.ftruncateSync(fd, 128 * 1024 * 1024);
+      fs.writeSync(
+        fd,
+        Buffer.from("sqlite-tail"),
+        0,
+        11,
+        128 * 1024 * 1024 - 11,
+      );
+    } finally {
+      fs.closeSync(fd);
+    }
+
+    const checksum = await calculateFileChecksum(file);
+    expect(checksum).toMatch(/^[a-f0-9]{64}$/);
+    expect(fs.statSync(file).size).toBe(128 * 1024 * 1024);
+  });
+
+  it("closes the stream when hashing fails", async () => {
+    const missing = path.join(dir, "missing.sqlite");
+    await expect(calculateFileChecksum(missing)).rejects.toThrow();
+
+    // A subsequent file operation succeeds; in particular this catches open
+    // handles on Windows, where leaked file streams prevent cleanup/rename.
+    fs.writeFileSync(missing, "created after failure");
+    fs.renameSync(missing, `${missing}.moved`);
+  });
+});

--- a/src/utils/file_checksum.ts
+++ b/src/utils/file_checksum.ts
@@ -1,0 +1,29 @@
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { Writable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+
+const CHECKSUM_CHUNK_BYTES = 64 * 1024;
+
+// Hash a file without materializing it in memory. pipeline() closes both
+// streams on success or failure, which is important during early startup when
+// a failed upgrade backup must not leave file descriptors behind.
+export async function calculateFileChecksum(filePath: string): Promise<string> {
+  const hash = createHash("sha256");
+  const hashSink = new Writable({
+    write(chunk: Buffer, _encoding, callback) {
+      try {
+        hash.update(chunk);
+        callback();
+      } catch (error) {
+        callback(error as Error);
+      }
+    },
+  });
+
+  await pipeline(
+    createReadStream(filePath, { highWaterMark: CHECKSUM_CHUNK_BYTES }),
+    hashSink,
+  );
+  return hash.digest("hex");
+}


### PR DESCRIPTION
## Summary
- calculate upgrade-backup SHA-256 checksums using 64 KiB stream chunks
- avoid loading an entire SQLite database into the Electron main-process heap
- close file streams on both success and failure through pipeline

## Scope
This is the checksum-only extraction from #3881. It intentionally excludes minidump parsing, crash-dump pruning, and startup telemetry changes.

## Verification
- npm test -- src/utils/file_checksum.test.ts: 3 passed
- npm run build: passed
- npm run fmt: passed
- npm run lint:fix: passed with 2 existing warnings
- npm run ts: blocked by existing fake-LLM Express/CORS type errors on unchanged main files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized refactor of backup checksum computation with the same SHA-256 output and added tests; no auth, data migration, or backup copy logic changes.
> 
> **Overview**
> Upgrade-backup metadata still records SHA-256 checksums for settings and database copies, but **hashing no longer loads whole files into the Electron main-process heap**.
> 
> A shared **`calculateFileChecksum`** helper streams files in **64 KiB** chunks via `createReadStream` and `pipeline`, so large SQLite backups are hashed incrementally. **`BackupManager.getFileChecksum`** delegates to that helper instead of inline `fs.readFile` + `crypto.createHash`. The pipeline path is meant to **close read streams on success and failure**, avoiding leaked handles during early startup when a failed upgrade backup runs.
> 
> Vitest coverage checks multi-chunk correctness against a one-shot hash, a **128 MiB sparse** file without full materialization, and that a missing-file error does not leave streams open (relevant on Windows for rename/cleanup).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d426f5ad3d047c6d4c7a8b36e3ab3abb936fd5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->