### PR TITLE
Fix Node.js external dependency detection

### DIFF
--- a/src/supabase_admin/supabase_utils.test.ts
+++ b/src/supabase_admin/supabase_utils.test.ts
@@ -238,6 +238,25 @@ describe("getSupabaseFunctionsAffectedBySharedModules", () => {
     expect(impact).toEqual({ kind: "partial", functionNames: ["alpha"] });
   });
 
+  it("ignores Node built-ins when finding affected functions", async () => {
+    await writeAppFile(
+      "supabase/functions/_shared/foo.ts",
+      "export const foo = 1;",
+    );
+    await writeFunction(
+      "alpha",
+      "import { text } from 'node:stream/consumers'; import '../_shared/foo.ts';",
+    );
+    await writeFunction("beta", "export const beta = 1;");
+
+    const impact = await getSupabaseFunctionsAffectedBySharedModules({
+      appPath,
+      changedSharedModulePaths: ["supabase/functions/_shared/foo.ts"],
+    });
+
+    expect(impact).toEqual({ kind: "partial", functionNames: ["alpha"] });
+  });
+
   it("follows transitive imports and re-exports", async () => {
     await writeAppFile(
       "supabase/functions/_shared/foo.ts",

--- a/src/supabase_admin/supabase_utils.ts
+++ b/src/supabase_admin/supabase_utils.ts
@@ -215,6 +215,7 @@ function isClearlyExternalSpecifier(specifier: string): boolean {
   return (
     specifier.startsWith("npm:") ||
     specifier.startsWith("jsr:") ||
+    specifier.startsWith("node:") ||
     specifier.startsWith("http://") ||
     specifier.startsWith("https://") ||
     specifier.startsWith("@supabase/")


### PR DESCRIPTION
## Summary
- Fix Node.js external dependency detection
- Primary files: native/keychain-reader/bin/darwin-arm64-143/keychain-reader.node, src/supabase_admin/supabase_utils.test.ts, src/supabase_admin/supabase_utils.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to import classification plus a unit test; no auth, data, or deploy API behavior beyond more accurate partial redeploy selection.
> 
> **Overview**
> **Fixes partial Supabase redeploys when edge functions import Node built-ins alongside `_shared` modules.**
> 
> `isClearlyExternalSpecifier` now treats `node:` specifiers like other externals (`npm:`, `jsr:`, etc.), so dependency walking no longer falls back to **deploy all functions** with `unknown_bare_specifier` when a function uses imports such as `node:stream/consumers`.
> 
> A test covers a function that imports both a Node built-in and a changed shared module, expecting a **partial** impact result (`alpha` only) instead of a full fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3849c81ead7d7573f45b88a8d9db439ae73cb4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

