### PR TITLE
Report Windows OOM crashes with a named crash reason

### DIFF
--- a/src/utils/minidump_summary.test.ts
+++ b/src/utils/minidump_summary.test.ts
@@ -208,6 +208,20 @@ describe("parseMinidumpBuffer", () => {
     expect(s!.faultingModule).toBe("app.exe");
   });
 
+  it("decodes Chromium's Windows OOM exception code", () => {
+    // 0xE0000008 is kOomExceptionCode, raised only when a process is
+    // terminated because an allocation failed.
+    const dump = buildMinidump({
+      modules: [{ base: 0x400000n, size: 0x1000, name: "C:\\app\\app.exe" }],
+      exceptionCode: 0xe0000008,
+      ip: 0x400100n,
+      ipOffset: 248,
+    });
+    const s = parseMinidumpBuffer(dump, "win32", "x64");
+    expect(s!.crashReason).toBe("OUT_OF_MEMORY");
+    expect(s!.exceptionCode).toBe(0xe0000008);
+  });
+
   it("reads the arm64 IP at the documented offset (264)", () => {
     const dump = buildMinidump({
       modules: oneModule,

--- a/src/utils/minidump_summary.ts
+++ b/src/utils/minidump_summary.ts
@@ -110,6 +110,8 @@ const NTSTATUS_NAMES: Record<number, string> = {
   0xc00000fd: "STACK_OVERFLOW",
   0xc0000409: "STACK_BUFFER_OVERRUN",
   0x80000003: "BREAKPOINT",
+  // Not a real NTSTATUS value. This is Chromium's kOomExceptionCode.
+  0xe0000008: "OUT_OF_MEMORY",
 };
 
 interface MinidumpModule {


### PR DESCRIPTION
On Windows, when a Chromium-based process dies because a memory allocation failed, it raises a custom exception code: 0xE0000008 (kOomExceptionCode in Chromium's partition_alloc/oom.h). This covers native allocation failures and also V8 heap exhaustion in the main process, which Electron's OOM handler routes into the same termination path. Other platforms do not produce this code.

Our minidump parser didn't recognize the code, so these crashes showed up in the app:crash_detected telemetry event with an empty crash_reason and only a raw exception_code. Add the code to the parser's Windows table so they now report crash_reason: "OUT_OF_MEMORY".

This is one part of a broader improvement to OOM crash detection: it makes Windows OOM crashes self-identifying with no new machinery. A follow-up PR will add an explicit OOM classification (OOM or not, plus which evidence decided it) that combines this exception code with heap-usage data recorded before the crash, extending coverage to macOS and Linux.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

