### PR TITLE
feat: report unexpected utility process deaths via telemetry

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1151,7 +1151,7 @@ app.on("child-process-gone", (_event, details) => {
   if (details.reason === "clean-exit" || details.reason === "killed") {
     return;
   }
-  logger.warn(
+  logger.error(
     "Utility process gone:",
     details.serviceName,
     details.reason,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1140,6 +1140,35 @@ async function handleDeepLinkReturn(url: string) {
   dialog.showErrorBox("Invalid deep link URL", url);
 }
 
+// Report unexpected utility process deaths (tsc worker, code explorer).
+// These do not take down the app, so we can report them right away.
+// Skip clean-exit and killed: routine teardown stops these workers with
+// kill(), and reporting that would flood telemetry with non-crashes.
+app.on("child-process-gone", (_event, details) => {
+  if (details.type !== "Utility" || isAppQuitting) {
+    return;
+  }
+  if (details.reason === "clean-exit" || details.reason === "killed") {
+    return;
+  }
+  logger.warn(
+    "Utility process gone:",
+    details.serviceName,
+    details.reason,
+    "exitCode=",
+    details.exitCode,
+  );
+  sendTelemetryEvent("utility_process:crash_detected", {
+    // Mark as error so renderer PostHog before_send sampling does not
+    // drop 90% of events for non-Pro users (see src/renderer.tsx).
+    error: true,
+    reason: details.reason,
+    exit_code: details.exitCode,
+    service_name: details.serviceName,
+    process_name: details.name,
+  });
+});
+
 // Quit when all windows are closed, except on macOS. There, it's common
 // for applications and their menu bar to stay active until the user quits
 // explicitly with Cmd + Q.

--- a/src/main.ts
+++ b/src/main.ts
@@ -750,7 +750,7 @@ const createWindow = () => {
     if (details.reason === "clean-exit") {
       return;
     }
-    logger.warn(
+    logger.error(
       "Renderer process gone:",
       details.reason,
       "exitCode=",


### PR DESCRIPTION
*This description was written by Claude but is human-reviewed*

Dyad runs some work in Electron utility processes — currently the TypeScript checker (`dyad-tsc-worker`) and the code explorer (`dyad-code-explorer`). Since #3861, a crash in one of these (for example an OOM during a type-check on a large app) no longer takes down the app — which also means it currently produces no telemetry at all.

This adds a `child-process-gone` handler that sends a `utility_process:crash_detected` event with the death reason (including `oom` where Chromium detects it), exit code, and the service/process name. Clean exits and kills are skipped, since both workers are routinely stopped with `kill()` during normal operation.

Part of a broader improvement to OOM crash detection; main-process crashes are covered separately by minidump parsing and memory monitoring in other PRs.

Tested by SIGSEGV-ing the tsc worker on spawn: the event arrives with
`reason: "crashed"` and the worker's service and process name.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

