### PR TITLE
feat: record memory stats, session peaks, and activity in crash reports

### DIFF
--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -167,6 +167,12 @@ const logger = log.scope("chat_stream_handlers");
 // Track active streams for cancellation
 const activeStreams = new Map<number, AbortController>();
 
+// How many chats are currently streaming a response. Used by the
+// performance monitor to record activity alongside memory snapshots.
+export function getActiveStreamCount(): number {
+  return activeStreams.size;
+}
+
 // Track partial responses for cancelled streams
 const partialResponses = new Map<number, string>();
 

--- a/src/ipc/processors/typescript_utility_process_scheduler.ts
+++ b/src/ipc/processors/typescript_utility_process_scheduler.ts
@@ -39,6 +39,12 @@ export class TypeScriptUtilityProcessScheduler {
   private activeKind: TypeScriptUtilityProcessKind | null = null;
   private resident: ResidentProcess | null = null;
 
+  // The kind of operation currently running, or null when idle. Used by the
+  // performance monitor to record activity alongside memory snapshots.
+  activeOperationKind(): TypeScriptUtilityProcessKind | null {
+    return this.activeKind;
+  }
+
   runExclusive<T>(
     kind: TypeScriptUtilityProcessKind,
     operation: () => Promise<T>,

--- a/src/ipc/processors/typescript_utility_process_scheduler.ts
+++ b/src/ipc/processors/typescript_utility_process_scheduler.ts
@@ -1,7 +1,5 @@
 import type { TypeScriptUtilityProcessKind } from "@/lib/schemas";
 
-export type { TypeScriptUtilityProcessKind } from "@/lib/schemas";
-
 const RESIDENT_PROCESS_STOP_TIMEOUT_MS = 30_000;
 
 interface QueuedOperation {

--- a/src/ipc/processors/typescript_utility_process_scheduler.ts
+++ b/src/ipc/processors/typescript_utility_process_scheduler.ts
@@ -1,4 +1,6 @@
-export type TypeScriptUtilityProcessKind = "code-explorer" | "tsc";
+import type { TypeScriptUtilityProcessKind } from "@/lib/schemas";
+
+export type { TypeScriptUtilityProcessKind } from "@/lib/schemas";
 
 const RESIDENT_PROCESS_STOP_TIMEOUT_MS = 30_000;
 

--- a/src/lib/schemas.test.ts
+++ b/src/lib/schemas.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { StoredUserSettingsSchema } from "@/lib/schemas";
+
+const baseSettings = {
+  selectedModel: { name: "auto", provider: "auto" },
+  providerSettings: {},
+  selectedTemplateId: "react",
+  enableAutoUpdate: true,
+  releaseChannel: "stable",
+};
+
+// Pins that the lastKnownPerformance shape written by the performance
+// monitor survives the validation parse in writeSettings, and that old
+// records without the newer optional fields still parse.
+describe("StoredUserSettingsSchema lastKnownPerformance", () => {
+  it("preserves memory, activity, and peak fields through a parse", () => {
+    const lastKnownPerformance = {
+      timestamp: 1751500000000,
+      memoryUsageMB: 400,
+      cpuUsagePercent: 12.5,
+      systemMemoryUsageMB: 8000,
+      systemMemoryTotalMB: 16000,
+      systemCpuPercent: 33,
+      heapUsedMB: 512,
+      heapLimitMB: 4144,
+      processWorkingSetsMB: { browser: 400, tab: 900, utility: 300 },
+      activity: {
+        activeStreams: 1,
+        runningApps: 2,
+        extractCodebase: true,
+        tsUtilityProcess: null,
+      },
+      peakHeapUsedMB: 1024,
+      peakHeapPct: 24.7,
+      peakRssMB: 2048,
+      peakProcessWorkingSetsMB: { browser: 900, tab: 2000, utility: 800 },
+      peakActivity: {
+        activeStreams: 2,
+        runningApps: 3,
+        extractCodebase: false,
+        tsUtilityProcess: "tsc",
+      },
+      peakTimestamp: 1751499970000,
+    };
+
+    const parsed = StoredUserSettingsSchema.parse({
+      ...baseSettings,
+      lastKnownPerformance,
+    });
+
+    expect(parsed.lastKnownPerformance).toEqual(lastKnownPerformance);
+  });
+
+  it("still accepts records without the new optional fields", () => {
+    const parsed = StoredUserSettingsSchema.parse({
+      ...baseSettings,
+      lastKnownPerformance: {
+        timestamp: 1751500000000,
+        memoryUsageMB: 400,
+      },
+    });
+
+    expect(parsed.lastKnownPerformance).toEqual({
+      timestamp: 1751500000000,
+      memoryUsageMB: 400,
+    });
+  });
+});

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -307,6 +307,33 @@ export const PerformanceActivitySchema = z.object({
   tsUtilityProcess: z.enum(["tsc", "code-explorer"]).nullable(),
 });
 
+// Performance snapshot written by the performance monitor every 30s. Also
+// used to parse the snapshot embedded in renderer crash records.
+export const LastKnownPerformanceSchema = z.object({
+  timestamp: z.number(),
+  memoryUsageMB: z.number(),
+  cpuUsagePercent: z.number().optional(),
+  systemMemoryUsageMB: z.number().optional(),
+  systemMemoryTotalMB: z.number().optional(),
+  systemCpuPercent: z.number().optional(),
+  // Main process V8 heap, from v8.getHeapStatistics().
+  heapUsedMB: z.number().optional(),
+  heapLimitMB: z.number().optional(),
+  // Working set per Electron process type (browser, tab, gpu, utility).
+  processWorkingSetsMB: z.record(z.string(), z.number()).optional(),
+  // What was running at this snapshot.
+  activity: PerformanceActivitySchema.optional(),
+  // Session highs. peakRssMB is exact (kernel tracked); the rest are
+  // maxima over 30s samples and can miss short spikes.
+  peakHeapUsedMB: z.number().optional(),
+  peakHeapPct: z.number().optional(),
+  peakRssMB: z.number().optional(),
+  peakProcessWorkingSetsMB: z.record(z.string(), z.number()).optional(),
+  // What was running when a peak was last set, and when.
+  peakActivity: PerformanceActivitySchema.optional(),
+  peakTimestamp: z.number().optional(),
+});
+
 /**
  * Base fields shared between StoredUserSettings and UserSettings
  */
@@ -380,32 +407,7 @@ const BaseUserSettingsFields = {
   disablePreviewNodeAutoInstall: z.boolean().optional(),
   customAppsFolder: z.string().optional().nullable(),
   isRunning: z.boolean().optional(),
-  lastKnownPerformance: z
-    .object({
-      timestamp: z.number(),
-      memoryUsageMB: z.number(),
-      cpuUsagePercent: z.number().optional(),
-      systemMemoryUsageMB: z.number().optional(),
-      systemMemoryTotalMB: z.number().optional(),
-      systemCpuPercent: z.number().optional(),
-      // Main process V8 heap, from v8.getHeapStatistics().
-      heapUsedMB: z.number().optional(),
-      heapLimitMB: z.number().optional(),
-      // Working set per Electron process type (browser, tab, gpu, utility).
-      processWorkingSetsMB: z.record(z.string(), z.number()).optional(),
-      // What was running at this snapshot.
-      activity: PerformanceActivitySchema.optional(),
-      // Session highs. peakRssMB is exact (kernel tracked); the rest are
-      // maxima over 30s samples and can miss short spikes.
-      peakHeapUsedMB: z.number().optional(),
-      peakHeapPct: z.number().optional(),
-      peakRssMB: z.number().optional(),
-      peakProcessWorkingSetsMB: z.record(z.string(), z.number()).optional(),
-      // What was running when a peak was last set, and when.
-      peakActivity: PerformanceActivitySchema.optional(),
-      peakTimestamp: z.number().optional(),
-    })
-    .optional(),
+  lastKnownPerformance: LastKnownPerformanceSchema.optional(),
   hideLocalAgentNewChatToast: z.boolean().optional(),
   enableContextCompaction: z.boolean().optional(),
   skipNotificationBanner: z.boolean().optional(),

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -329,7 +329,9 @@ export const LastKnownPerformanceSchema = z.object({
   peakHeapPct: z.number().optional(),
   peakRssMB: z.number().optional(),
   peakProcessWorkingSetsMB: z.record(z.string(), z.number()).optional(),
-  // What was running when a peak was last set, and when.
+  // What was running when a main process peak (heap, RSS) was last set,
+  // and when. The per-type working set peaks above are not stamped; they
+  // can come from different moments than this pair.
   peakActivity: PerformanceActivitySchema.optional(),
   peakTimestamp: z.number().optional(),
 });

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -299,12 +299,22 @@ export type SmartContextMode = z.infer<typeof SmartContextModeSchema>;
 export const AgentToolConsentSchema = z.enum(["ask", "always", "never"]);
 export type AgentToolConsent = z.infer<typeof AgentToolConsentSchema>;
 
+// The kinds of TypeScript utility process the scheduler can run. Source of
+// truth for the TypeScriptUtilityProcessKind type.
+export const TypeScriptUtilityProcessKindSchema = z.enum([
+  "code-explorer",
+  "tsc",
+]);
+export type TypeScriptUtilityProcessKind = z.infer<
+  typeof TypeScriptUtilityProcessKindSchema
+>;
+
 // What the main process was doing when a performance snapshot was taken.
 export const PerformanceActivitySchema = z.object({
   activeStreams: z.number(),
   runningApps: z.number(),
   extractCodebase: z.boolean(),
-  tsUtilityProcess: z.enum(["tsc", "code-explorer"]).nullable(),
+  tsUtilityProcess: TypeScriptUtilityProcessKindSchema.nullable(),
 });
 
 // Performance snapshot written by the performance monitor every 30s. Also

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -299,8 +299,7 @@ export type SmartContextMode = z.infer<typeof SmartContextModeSchema>;
 export const AgentToolConsentSchema = z.enum(["ask", "always", "never"]);
 export type AgentToolConsent = z.infer<typeof AgentToolConsentSchema>;
 
-// The kinds of TypeScript utility process the scheduler can run. Source of
-// truth for the TypeScriptUtilityProcessKind type.
+// The kinds of TypeScript utility process the scheduler can run.
 export const TypeScriptUtilityProcessKindSchema = z.enum([
   "code-explorer",
   "tsc",

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -299,6 +299,14 @@ export type SmartContextMode = z.infer<typeof SmartContextModeSchema>;
 export const AgentToolConsentSchema = z.enum(["ask", "always", "never"]);
 export type AgentToolConsent = z.infer<typeof AgentToolConsentSchema>;
 
+// What the main process was doing when a performance snapshot was taken.
+export const PerformanceActivitySchema = z.object({
+  activeStreams: z.number(),
+  runningApps: z.number(),
+  extractCodebase: z.boolean(),
+  tsUtilityProcess: z.enum(["tsc", "code-explorer"]).nullable(),
+});
+
 /**
  * Base fields shared between StoredUserSettings and UserSettings
  */
@@ -380,6 +388,22 @@ const BaseUserSettingsFields = {
       systemMemoryUsageMB: z.number().optional(),
       systemMemoryTotalMB: z.number().optional(),
       systemCpuPercent: z.number().optional(),
+      // Main process V8 heap, from v8.getHeapStatistics().
+      heapUsedMB: z.number().optional(),
+      heapLimitMB: z.number().optional(),
+      // Working set per Electron process type (browser, tab, gpu, utility).
+      processWorkingSetsMB: z.record(z.string(), z.number()).optional(),
+      // What was running at this snapshot.
+      activity: PerformanceActivitySchema.optional(),
+      // Session highs. peakRssMB is exact (kernel tracked); the rest are
+      // maxima over 30s samples and can miss short spikes.
+      peakHeapUsedMB: z.number().optional(),
+      peakHeapPct: z.number().optional(),
+      peakRssMB: z.number().optional(),
+      peakProcessWorkingSetsMB: z.record(z.string(), z.number()).optional(),
+      // What was running when a peak was last set, and when.
+      peakActivity: PerformanceActivitySchema.optional(),
+      peakTimestamp: z.number().optional(),
     })
     .optional(),
   hideLocalAgentNewChatToast: z.boolean().optional(),

--- a/src/main.ts
+++ b/src/main.ts
@@ -66,6 +66,7 @@ import {
   moveDump,
   pruneDumps,
 } from "./utils/crash_dumps";
+import { crashPerformanceEventFields } from "./utils/crash_telemetry_fields";
 import {
   DYAD_INTERNAL_DIR_NAME,
   DYAD_MEDIA_SUBDIR,
@@ -675,30 +676,8 @@ const createWindow = () => {
         // drop 90% of events for non-Pro users (see src/renderer.tsx).
         error: true,
         has_performance_data: !!pendingForceCloseData,
-        ...(pendingForceCloseData && {
-          last_known_memory_mb: pendingForceCloseData.memoryUsageMB,
-          last_known_cpu_pct: pendingForceCloseData.cpuUsagePercent,
-          last_known_system_memory_mb:
-            pendingForceCloseData.systemMemoryUsageMB,
-          last_known_system_memory_total_mb:
-            pendingForceCloseData.systemMemoryTotalMB,
-          last_known_system_cpu_pct: pendingForceCloseData.systemCpuPercent,
-          last_known_snapshot_timestamp: pendingForceCloseData.timestamp,
-          time_since_last_heartbeat_ms:
-            Date.now() - pendingForceCloseData.timestamp,
-          last_known_heap_used_mb: pendingForceCloseData.heapUsedMB,
-          last_known_heap_limit_mb: pendingForceCloseData.heapLimitMB,
-          last_known_process_working_sets_mb:
-            pendingForceCloseData.processWorkingSetsMB,
-          last_known_activity: pendingForceCloseData.activity,
-          peak_heap_used_mb: pendingForceCloseData.peakHeapUsedMB,
-          peak_heap_pct: pendingForceCloseData.peakHeapPct,
-          peak_rss_mb: pendingForceCloseData.peakRssMB,
-          peak_process_working_sets_mb:
-            pendingForceCloseData.peakProcessWorkingSetsMB,
-          peak_activity: pendingForceCloseData.peakActivity,
-          peak_timestamp: pendingForceCloseData.peakTimestamp,
-        }),
+        ...(pendingForceCloseData &&
+          crashPerformanceEventFields(pendingForceCloseData)),
         // "native" when a main-process minidump was captured for this crash,
         // else "unknown" (no dump: force-kill / OOM-kill / power loss / missed).
         crash_cause: nativeCrash ? "native" : "unknown",
@@ -733,27 +712,7 @@ const createWindow = () => {
         // Mirror the `app:crash_detected` performance fields so the two
         // events can be unioned in PostHog without per-event field mapping.
         has_performance_data: !!perf,
-        ...(perf && {
-          last_known_memory_mb: perf.memoryUsageMB,
-          last_known_cpu_pct: perf.cpuUsagePercent,
-          last_known_system_memory_mb: perf.systemMemoryUsageMB,
-          last_known_system_memory_total_mb: perf.systemMemoryTotalMB,
-          last_known_system_cpu_pct: perf.systemCpuPercent,
-          last_known_snapshot_timestamp: perf.timestamp,
-          // Match `app:crash_detected` semantics: measured at send time, not
-          // crash time. `ms_since_crash` already covers the crash → send gap.
-          time_since_last_heartbeat_ms: Date.now() - perf.timestamp,
-          last_known_heap_used_mb: perf.heapUsedMB,
-          last_known_heap_limit_mb: perf.heapLimitMB,
-          last_known_process_working_sets_mb: perf.processWorkingSetsMB,
-          last_known_activity: perf.activity,
-          peak_heap_used_mb: perf.peakHeapUsedMB,
-          peak_heap_pct: perf.peakHeapPct,
-          peak_rss_mb: perf.peakRssMB,
-          peak_process_working_sets_mb: perf.peakProcessWorkingSetsMB,
-          peak_activity: perf.peakActivity,
-          peak_timestamp: perf.peakTimestamp,
-        }),
+        ...(perf && crashPerformanceEventFields(perf)),
       });
       clearRendererCrashRecord();
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -686,6 +686,18 @@ const createWindow = () => {
           last_known_snapshot_timestamp: pendingForceCloseData.timestamp,
           time_since_last_heartbeat_ms:
             Date.now() - pendingForceCloseData.timestamp,
+          last_known_heap_used_mb: pendingForceCloseData.heapUsedMB,
+          last_known_heap_limit_mb: pendingForceCloseData.heapLimitMB,
+          last_known_process_working_sets_mb:
+            pendingForceCloseData.processWorkingSetsMB,
+          last_known_activity: pendingForceCloseData.activity,
+          peak_heap_used_mb: pendingForceCloseData.peakHeapUsedMB,
+          peak_heap_pct: pendingForceCloseData.peakHeapPct,
+          peak_rss_mb: pendingForceCloseData.peakRssMB,
+          peak_process_working_sets_mb:
+            pendingForceCloseData.peakProcessWorkingSetsMB,
+          peak_activity: pendingForceCloseData.peakActivity,
+          peak_timestamp: pendingForceCloseData.peakTimestamp,
         }),
         // "native" when a main-process minidump was captured for this crash,
         // else "unknown" (no dump: force-kill / OOM-kill / power loss / missed).
@@ -731,6 +743,16 @@ const createWindow = () => {
           // Match `app:crash_detected` semantics: measured at send time, not
           // crash time. `ms_since_crash` already covers the crash → send gap.
           time_since_last_heartbeat_ms: Date.now() - perf.timestamp,
+          last_known_heap_used_mb: perf.heapUsedMB,
+          last_known_heap_limit_mb: perf.heapLimitMB,
+          last_known_process_working_sets_mb: perf.processWorkingSetsMB,
+          last_known_activity: perf.activity,
+          peak_heap_used_mb: perf.peakHeapUsedMB,
+          peak_heap_pct: perf.peakHeapPct,
+          peak_rss_mb: perf.peakRssMB,
+          peak_process_working_sets_mb: perf.peakProcessWorkingSetsMB,
+          peak_activity: perf.peakActivity,
+          peak_timestamp: perf.peakTimestamp,
         }),
       });
       clearRendererCrashRecord();

--- a/src/main/settings.test.ts
+++ b/src/main/settings.test.ts
@@ -7,6 +7,8 @@ import {
   resolveEffectiveSettings,
   readEffectiveSettings,
   getSettingsFilePath,
+  recordRendererCrash,
+  readRendererCrashRecord,
   writeSettings,
   tryWriteSettings,
   encrypt,
@@ -1542,5 +1544,85 @@ describe("legacy keychain recovery integration", () => {
       encryptionType: "electron-safe-storage",
     });
     expect(mockRecover).toHaveBeenCalledWith(locked.value);
+  });
+});
+
+describe("renderer crash record", () => {
+  const mockUserDataPath = "/mock/user/data";
+  const crashPath = `${mockUserDataPath}/renderer-crash.json`;
+  let store: Record<string, string>;
+
+  const performance = {
+    timestamp: 1751500000000,
+    memoryUsageMB: 400,
+    cpuUsagePercent: 12.5,
+    systemMemoryUsageMB: 8000,
+    systemMemoryTotalMB: 16000,
+    systemCpuPercent: 33,
+    heapUsedMB: 512,
+    heapLimitMB: 4144,
+    processWorkingSetsMB: { browser: 400, tab: 900 },
+    activity: {
+      activeStreams: 1,
+      runningApps: 2,
+      extractCodebase: true,
+      tsUtilityProcess: "tsc" as const,
+    },
+    peakHeapUsedMB: 1024,
+    peakHeapPct: 24.7,
+    peakRssMB: 2048,
+    peakProcessWorkingSetsMB: { browser: 900, tab: 2000 },
+    peakActivity: {
+      activeStreams: 2,
+      runningApps: 3,
+      extractCodebase: false,
+      tsUtilityProcess: null,
+    },
+    peakTimestamp: 1751499970000,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUserDataPath.mockReturnValue(mockUserDataPath);
+    mockPath.join.mockImplementation((...args: string[]) => args.join("/"));
+    store = {};
+    mockFs.writeFileSync.mockImplementation((p, data) => {
+      store[p as string] = data as string;
+    });
+    mockFs.renameSync.mockImplementation((from, to) => {
+      store[to as string] = store[from as string];
+      delete store[from as string];
+    });
+    mockFs.existsSync.mockImplementation(
+      (p) => store[p as string] !== undefined,
+    );
+    mockFs.readFileSync.mockImplementation((p) => {
+      const value = store[p as string];
+      if (value === undefined) {
+        const err = new Error("ENOENT") as NodeJS.ErrnoException;
+        err.code = "ENOENT";
+        throw err;
+      }
+      return value;
+    });
+  });
+
+  it("round-trips the full performance block, including memory and peak fields", () => {
+    recordRendererCrash({ reason: "oom", exitCode: 1, performance });
+    const record = readRendererCrashRecord();
+    expect(record?.reason).toBe("oom");
+    expect(record?.performance).toEqual(performance);
+  });
+
+  it("drops a malformed performance block but keeps the crash record", () => {
+    store[crashPath] = JSON.stringify({
+      reason: "crashed",
+      timestamp: 1751500000000,
+      count: 1,
+      performance: { timestamp: "not-a-number" },
+    });
+    const record = readRendererCrashRecord();
+    expect(record?.reason).toBe("crashed");
+    expect(record?.performance).toBeUndefined();
   });
 });

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { getUserDataPath } from "../paths/paths";
 import {
+  LastKnownPerformanceSchema,
   SecretSchema,
   StoredUserSettingsSchema,
   UserSettingsSchema,
@@ -272,33 +273,15 @@ export function clearRendererCrashRecord(): void {
   }
 }
 
-// Lenient parser for the performance block on a renderer-crash record.
-// We deliberately accept partial data rather than throwing: the record may
-// have been written by an older build, and the fields are best-effort
-// telemetry — losing one of them shouldn't drop the whole crash report.
+// Parse the performance block on a renderer-crash record with the same
+// schema the performance monitor writes, so the two cannot drift. Best
+// effort: a record from a different build may not match the current
+// schema; drop the performance block rather than the whole crash record.
 function parseRendererCrashPerformance(
   raw: unknown,
 ): RendererCrashPerformanceSnapshot | undefined {
-  if (typeof raw !== "object" || raw === null) {
-    return undefined;
-  }
-  const candidate = raw as Record<string, unknown>;
-  if (typeof candidate.timestamp !== "number") {
-    return undefined;
-  }
-  if (typeof candidate.memoryUsageMB !== "number") {
-    return undefined;
-  }
-  const optionalNumber = (key: string): number | undefined =>
-    typeof candidate[key] === "number" ? (candidate[key] as number) : undefined;
-  return {
-    timestamp: candidate.timestamp,
-    memoryUsageMB: candidate.memoryUsageMB,
-    cpuUsagePercent: optionalNumber("cpuUsagePercent"),
-    systemMemoryUsageMB: optionalNumber("systemMemoryUsageMB"),
-    systemMemoryTotalMB: optionalNumber("systemMemoryTotalMB"),
-    systemCpuPercent: optionalNumber("systemCpuPercent"),
-  };
+  const parsed = LastKnownPerformanceSchema.safeParse(raw);
+  return parsed.success ? parsed.data : undefined;
 }
 
 export function readSettings(): UserSettings {

--- a/src/utils/codebase.ts
+++ b/src/utils/codebase.ts
@@ -7,6 +7,10 @@ import { glob } from "glob";
 import { AppChatContext } from "../lib/schemas";
 import { readSettings } from "@/main/settings";
 import { AsyncVirtualFileSystem } from "../../shared/VirtualFilesystem";
+import {
+  extractCodebaseStarted,
+  extractCodebaseFinished,
+} from "./memory_activity";
 
 const logger = log.scope("utils/codebase");
 
@@ -633,7 +637,24 @@ export async function listCodebaseFileMetadata({
  * @param virtualFileSystem - Optional virtual filesystem to apply modifications
  * @returns Object containing formatted output and individual files
  */
-export async function extractCodebase({
+export async function extractCodebase(params: {
+  appPath: string;
+  chatContext: AppChatContext;
+  virtualFileSystem?: AsyncVirtualFileSystem;
+}): Promise<{
+  formattedOutput: string;
+  files: CodebaseFile[];
+}> {
+  // Tracked so memory snapshots can tell when an extraction was running.
+  extractCodebaseStarted();
+  try {
+    return await extractCodebaseInner(params);
+  } finally {
+    extractCodebaseFinished();
+  }
+}
+
+async function extractCodebaseInner({
   appPath,
   chatContext,
   virtualFileSystem,

--- a/src/utils/codebase.ts
+++ b/src/utils/codebase.ts
@@ -633,8 +633,9 @@ export async function listCodebaseFileMetadata({
 
 /**
  * Extract and format codebase files as a string to be included in prompts
- * @param appPath - Path to the codebase to extract
- * @param virtualFileSystem - Optional virtual filesystem to apply modifications
+ * @param params.appPath - Path to the codebase to extract
+ * @param params.chatContext - Chat context selecting which paths to include
+ * @param params.virtualFileSystem - Optional virtual filesystem to apply modifications
  * @returns Object containing formatted output and individual files
  */
 export async function extractCodebase(params: {

--- a/src/utils/crash_telemetry_fields.test.ts
+++ b/src/utils/crash_telemetry_fields.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { crashPerformanceEventFields } from "@/utils/crash_telemetry_fields";
+
+describe("crashPerformanceEventFields", () => {
+  it("flattens working sets and activity into scalar fields", () => {
+    const fields = crashPerformanceEventFields({
+      timestamp: 1751500000000,
+      memoryUsageMB: 400,
+      heapUsedMB: 512,
+      heapLimitMB: 4144,
+      processWorkingSetsMB: { browser: 400, tab: 900, zygote: 30, unknown: 20 },
+      activity: {
+        activeStreams: 1,
+        runningApps: 2,
+        extractCodebase: true,
+        tsUtilityProcess: "tsc",
+      },
+      peakHeapUsedMB: 1024,
+      peakHeapPct: 24.7,
+      peakRssMB: 2048,
+      peakProcessWorkingSetsMB: { browser: 900, utility: 800 },
+      peakActivity: {
+        activeStreams: 2,
+        runningApps: 3,
+        extractCodebase: false,
+        tsUtilityProcess: null,
+      },
+      peakTimestamp: 1751499970000,
+    });
+
+    expect(fields.last_known_working_set_browser_mb).toBe(400);
+    expect(fields.last_known_working_set_tab_mb).toBe(900);
+    // Rare process types are summed into "other" to keep columns stable.
+    expect(fields.last_known_working_set_other_mb).toBe(50);
+    expect(fields.last_known_active_streams).toBe(1);
+    expect(fields.last_known_extract_codebase).toBe(true);
+    expect(fields.last_known_ts_utility_process).toBe("tsc");
+    expect(fields.peak_working_set_browser_mb).toBe(900);
+    expect(fields.peak_working_set_utility_mb).toBe(800);
+    expect(fields.peak_working_set_other_mb).toBeUndefined();
+    expect(fields.peak_active_streams).toBe(2);
+    expect(fields.peak_ts_utility_process).toBeNull();
+    expect(fields.peak_heap_used_mb).toBe(1024);
+
+    // No object-valued properties: PostHog cannot filter nested JSON.
+    for (const value of Object.values(fields)) {
+      expect(typeof value === "object" && value !== null).toBe(false);
+    }
+  });
+
+  it("omits working set and activity fields when absent", () => {
+    const fields = crashPerformanceEventFields({
+      timestamp: 1751500000000,
+      memoryUsageMB: 400,
+    });
+
+    expect(fields.last_known_memory_mb).toBe(400);
+    expect(fields.last_known_working_set_browser_mb).toBeUndefined();
+    expect(fields.last_known_active_streams).toBeUndefined();
+    expect(fields.peak_active_streams).toBeUndefined();
+  });
+});

--- a/src/utils/crash_telemetry_fields.ts
+++ b/src/utils/crash_telemetry_fields.ts
@@ -1,0 +1,75 @@
+import type { UserSettings } from "../lib/schemas";
+import type { ActivitySnapshot } from "./memory_activity";
+
+type PerformanceSnapshot = NonNullable<UserSettings["lastKnownPerformance"]>;
+
+// Known Electron process types get their own telemetry field; anything else
+// is summed into "other" so the set of PostHog columns stays stable.
+const KNOWN_PROCESS_TYPES = new Set(["browser", "tab", "gpu", "utility"]);
+
+/**
+ * Flat telemetry fields for a performance snapshot, shared by
+ * app:crash_detected and renderer:crash_detected. Everything is a scalar
+ * because PostHog cannot easily filter or aggregate nested JSON.
+ * time_since_last_heartbeat_ms is measured at send time, not crash time.
+ */
+export function crashPerformanceEventFields(
+  perf: PerformanceSnapshot,
+): Record<string, unknown> {
+  return {
+    last_known_memory_mb: perf.memoryUsageMB,
+    last_known_cpu_pct: perf.cpuUsagePercent,
+    last_known_system_memory_mb: perf.systemMemoryUsageMB,
+    last_known_system_memory_total_mb: perf.systemMemoryTotalMB,
+    last_known_system_cpu_pct: perf.systemCpuPercent,
+    last_known_snapshot_timestamp: perf.timestamp,
+    time_since_last_heartbeat_ms: Date.now() - perf.timestamp,
+    last_known_heap_used_mb: perf.heapUsedMB,
+    last_known_heap_limit_mb: perf.heapLimitMB,
+    ...workingSetFields("last_known_working_set", perf.processWorkingSetsMB),
+    ...activityFields("last_known", perf.activity),
+    peak_heap_used_mb: perf.peakHeapUsedMB,
+    peak_heap_pct: perf.peakHeapPct,
+    peak_rss_mb: perf.peakRssMB,
+    ...workingSetFields("peak_working_set", perf.peakProcessWorkingSetsMB),
+    ...activityFields("peak", perf.peakActivity),
+    peak_timestamp: perf.peakTimestamp,
+  };
+}
+
+function workingSetFields(
+  prefix: string,
+  sets: Record<string, number> | undefined,
+): Record<string, number> {
+  if (!sets) {
+    return {};
+  }
+  const fields: Record<string, number> = {};
+  let other = 0;
+  for (const [key, value] of Object.entries(sets)) {
+    if (KNOWN_PROCESS_TYPES.has(key)) {
+      fields[`${prefix}_${key}_mb`] = value;
+    } else {
+      other += value;
+    }
+  }
+  if (other > 0) {
+    fields[`${prefix}_other_mb`] = other;
+  }
+  return fields;
+}
+
+function activityFields(
+  prefix: string,
+  activity: ActivitySnapshot | undefined,
+): Record<string, unknown> {
+  if (!activity) {
+    return {};
+  }
+  return {
+    [`${prefix}_active_streams`]: activity.activeStreams,
+    [`${prefix}_running_apps`]: activity.runningApps,
+    [`${prefix}_extract_codebase`]: activity.extractCodebase,
+    [`${prefix}_ts_utility_process`]: activity.tsUtilityProcess,
+  };
+}

--- a/src/utils/memory_activity.test.ts
+++ b/src/utils/memory_activity.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  extractCodebaseStarted,
+  extractCodebaseFinished,
+  isExtractCodebaseActive,
+  resetExtractCodebaseCount,
+} from "@/utils/memory_activity";
+
+describe("memory_activity", () => {
+  beforeEach(() => {
+    resetExtractCodebaseCount();
+  });
+
+  it("is inactive by default", () => {
+    expect(isExtractCodebaseActive()).toBe(false);
+  });
+
+  it("is active while at least one extraction is in flight", () => {
+    extractCodebaseStarted();
+    extractCodebaseStarted();
+    extractCodebaseFinished();
+    expect(isExtractCodebaseActive()).toBe(true);
+    extractCodebaseFinished();
+    expect(isExtractCodebaseActive()).toBe(false);
+  });
+
+  it("does not go negative on unbalanced finishes", () => {
+    extractCodebaseFinished();
+    extractCodebaseStarted();
+    expect(isExtractCodebaseActive()).toBe(true);
+  });
+});

--- a/src/utils/memory_activity.ts
+++ b/src/utils/memory_activity.ts
@@ -1,0 +1,31 @@
+// Tracks memory-heavy work in flight in the main process, so performance
+// snapshots and crash reports can say what was running at the time.
+// This module must stay import-free to avoid dependency cycles: it is
+// imported both by the operations being tracked and by the monitor.
+
+export interface ActivitySnapshot {
+  activeStreams: number;
+  runningApps: number;
+  extractCodebase: boolean;
+  // The scheduler serializes these processes, so at most one kind runs.
+  tsUtilityProcess: "tsc" | "code-explorer" | null;
+}
+
+let extractCodebaseCount = 0;
+
+export function extractCodebaseStarted(): void {
+  extractCodebaseCount++;
+}
+
+export function extractCodebaseFinished(): void {
+  extractCodebaseCount = Math.max(0, extractCodebaseCount - 1);
+}
+
+export function isExtractCodebaseActive(): boolean {
+  return extractCodebaseCount > 0;
+}
+
+// For tests.
+export function resetExtractCodebaseCount(): void {
+  extractCodebaseCount = 0;
+}

--- a/src/utils/memory_activity.ts
+++ b/src/utils/memory_activity.ts
@@ -1,14 +1,16 @@
 // Tracks memory-heavy work in flight in the main process, so performance
 // snapshots and crash reports can say what was running at the time.
-// This module must stay import-free to avoid dependency cycles: it is
-// imported both by the operations being tracked and by the monitor.
+// This module must stay free of runtime imports to avoid dependency
+// cycles: it is imported both by the tracked operations and the monitor.
+
+import type { TypeScriptUtilityProcessKind } from "../ipc/processors/typescript_utility_process_scheduler";
 
 export interface ActivitySnapshot {
   activeStreams: number;
   runningApps: number;
   extractCodebase: boolean;
   // The scheduler serializes these processes, so at most one kind runs.
-  tsUtilityProcess: "tsc" | "code-explorer" | null;
+  tsUtilityProcess: TypeScriptUtilityProcessKind | null;
 }
 
 let extractCodebaseCount = 0;

--- a/src/utils/memory_activity.ts
+++ b/src/utils/memory_activity.ts
@@ -3,7 +3,7 @@
 // This module must stay free of runtime imports to avoid dependency
 // cycles: it is imported both by the tracked operations and the monitor.
 
-import type { TypeScriptUtilityProcessKind } from "../ipc/processors/typescript_utility_process_scheduler";
+import type { TypeScriptUtilityProcessKind } from "../lib/schemas";
 
 export interface ActivitySnapshot {
   activeStreams: number;

--- a/src/utils/performance_monitor.ts
+++ b/src/utils/performance_monitor.ts
@@ -2,6 +2,14 @@ import log from "electron-log";
 import { app } from "electron";
 import { writeSettings } from "../main/settings";
 import os from "node:os";
+import v8 from "node:v8";
+import {
+  isExtractCodebaseActive,
+  type ActivitySnapshot,
+} from "./memory_activity";
+import { getActiveStreamCount } from "../ipc/handlers/chat_stream_handlers";
+import { runningApps } from "../ipc/utils/process_manager";
+import { typescriptUtilityProcessScheduler } from "../ipc/processors/typescript_utility_process_scheduler";
 
 const logger = log.scope("performance-monitor");
 
@@ -14,6 +22,15 @@ let lastCpuUsage: NodeJS.CpuUsage | null = null;
 let lastTimestamp: number | null = null;
 let lastSystemCpuInfo: os.CpuInfo[] | null = null;
 let lastSystemTimestamp: number | null = null;
+
+// Session memory highs. peakRssMB comes from the kernel and is exact; the
+// others are maxima over sampled values and can miss short spikes.
+let peakHeapUsedMB = 0;
+let peakHeapPct = 0;
+let peakRssMB = 0;
+const peakProcessWorkingSetsMB: Record<string, number> = {};
+let peakActivity: ActivitySnapshot | null = null;
+let peakTimestamp: number | null = null;
 
 /**
  * Get current memory usage in MB
@@ -38,6 +55,58 @@ function getAllProcessesMemoryMB(): number | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * Get main process V8 heap usage and limit in MB
+ */
+function getHeapStatsMB(): { heapUsedMB: number; heapLimitMB: number } {
+  const stats = v8.getHeapStatistics();
+  return {
+    heapUsedMB: Math.round(stats.used_heap_size / BYTES_PER_MB),
+    heapLimitMB: Math.round(stats.heap_size_limit / BYTES_PER_MB),
+  };
+}
+
+/**
+ * Get working set per Electron process type in MB, e.g.
+ * { browser: 400, tab: 900, gpu: 120, utility: 300 }
+ */
+function getProcessWorkingSetsMB(): Record<string, number> | null {
+  try {
+    const sets: Record<string, number> = {};
+    for (const metric of app.getAppMetrics()) {
+      const key = metric.type.toLowerCase();
+      sets[key] = (sets[key] ?? 0) + metric.memory.workingSetSize / 1024;
+    }
+    for (const key of Object.keys(sets)) {
+      sets[key] = Math.round(sets[key]);
+    }
+    return sets;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get the kernel-tracked peak RSS of the main process in MB.
+ * Exact for the whole process lifetime, even between samples.
+ */
+function getKernelPeakRssMB(): number {
+  // maxRSS is reported in kilobytes
+  return Math.round(process.resourceUsage().maxRSS / 1024);
+}
+
+/**
+ * What the main process is doing right now
+ */
+function snapshotActivity(): ActivitySnapshot {
+  return {
+    activeStreams: getActiveStreamCount(),
+    runningApps: runningApps.size,
+    extractCodebase: isExtractCodebaseActive(),
+    tsUtilityProcess: typescriptUtilityProcessScheduler.activeOperationKind(),
+  };
 }
 
 /**
@@ -166,9 +235,44 @@ function capturePerformanceMetrics() {
       return;
     }
 
+    const { heapUsedMB, heapLimitMB } = getHeapStatsMB();
+    const heapPct =
+      heapLimitMB > 0
+        ? Math.round((heapUsedMB / heapLimitMB) * 10000) / 100
+        : 0;
+    const processWorkingSetsMB = getProcessWorkingSetsMB();
+    const kernelPeakRssMB = getKernelPeakRssMB();
+
     logger.debug(
-      `Performance: Memory=${memoryUsageMB}MB, All Processes=${allProcessesMemoryMB ?? "?"}MB, CPU=${cpuUsagePercent}%, System Memory=${systemMemory.usedMemoryMB}/${systemMemory.totalMemoryMB}MB (${systemMemory.usagePercent}%), System CPU=${systemCpuPercent}%`,
+      `Performance: Memory=${memoryUsageMB}MB, Heap=${heapUsedMB}/${heapLimitMB}MB, All Processes=${allProcessesMemoryMB ?? "?"}MB, CPU=${cpuUsagePercent}%, System Memory=${systemMemory.usedMemoryMB}/${systemMemory.totalMemoryMB}MB (${systemMemory.usagePercent}%), System CPU=${systemCpuPercent}%`,
     );
+
+    // Update session peaks, and record what was running whenever one advances.
+    let peakAdvanced = false;
+    if (heapUsedMB > peakHeapUsedMB) {
+      peakHeapUsedMB = heapUsedMB;
+      peakAdvanced = true;
+    }
+    if (heapPct > peakHeapPct) {
+      peakHeapPct = heapPct;
+      peakAdvanced = true;
+    }
+    if (kernelPeakRssMB > peakRssMB) {
+      peakRssMB = kernelPeakRssMB;
+      peakAdvanced = true;
+    }
+    if (processWorkingSetsMB) {
+      for (const [key, value] of Object.entries(processWorkingSetsMB)) {
+        if (value > (peakProcessWorkingSetsMB[key] ?? 0)) {
+          peakProcessWorkingSetsMB[key] = value;
+          peakAdvanced = true;
+        }
+      }
+    }
+    if (peakAdvanced) {
+      peakActivity = snapshotActivity();
+      peakTimestamp = Date.now();
+    }
 
     writeSettings({
       lastKnownPerformance: {
@@ -178,6 +282,16 @@ function capturePerformanceMetrics() {
         systemMemoryUsageMB: systemMemory.usedMemoryMB,
         systemMemoryTotalMB: systemMemory.totalMemoryMB,
         systemCpuPercent,
+        heapUsedMB,
+        heapLimitMB,
+        ...(processWorkingSetsMB && { processWorkingSetsMB }),
+        activity: snapshotActivity(),
+        peakHeapUsedMB,
+        peakHeapPct,
+        peakRssMB,
+        peakProcessWorkingSetsMB: { ...peakProcessWorkingSetsMB },
+        ...(peakActivity && { peakActivity }),
+        ...(peakTimestamp !== null && { peakTimestamp }),
       },
     });
   } catch (error) {

--- a/src/utils/performance_monitor.ts
+++ b/src/utils/performance_monitor.ts
@@ -42,22 +42,6 @@ function getMemoryUsageMB(): number {
 }
 
 /**
- * Get total memory (working set) across ALL Electron processes in MB
- * (Browser + renderers + GPU + utility). Main-process RSS alone dramatically
- * understates real usage. Cheap (no shell-outs); safe for periodic capture.
- */
-function getAllProcessesMemoryMB(): number | null {
-  try {
-    const totalWorkingSetSizeKB = app
-      .getAppMetrics()
-      .reduce((sum, metric) => sum + metric.memory.workingSetSize, 0);
-    return Math.round(totalWorkingSetSizeKB / 1024);
-  } catch {
-    return null;
-  }
-}
-
-/**
  * Get main process V8 heap usage and limit in MB
  */
 function getHeapStatsMB(): { heapUsedMB: number; heapLimitMB: number } {
@@ -70,7 +54,9 @@ function getHeapStatsMB(): { heapUsedMB: number; heapLimitMB: number } {
 
 /**
  * Get working set per Electron process type in MB, e.g.
- * { browser: 400, tab: 900, gpu: 120, utility: 300 }
+ * { browser: 400, tab: 900, gpu: 120, utility: 300 }.
+ * Main process RSS alone dramatically understates real usage.
+ * Cheap (no shell-outs); safe for periodic capture.
  */
 function getProcessWorkingSetsMB(): Record<string, number> | null {
   try {
@@ -222,7 +208,10 @@ function getSystemCpuUsagePercent(): number | null {
 function capturePerformanceMetrics() {
   try {
     const memoryUsageMB = getMemoryUsageMB();
-    const allProcessesMemoryMB = getAllProcessesMemoryMB();
+    const processWorkingSetsMB = getProcessWorkingSetsMB();
+    const allProcessesMemoryMB = processWorkingSetsMB
+      ? Object.values(processWorkingSetsMB).reduce((sum, mb) => sum + mb, 0)
+      : null;
     const cpuUsagePercent = getCpuUsagePercent();
     const systemMemory = getSystemMemoryUsage();
     const systemCpuPercent = getSystemCpuUsagePercent();
@@ -240,8 +229,8 @@ function capturePerformanceMetrics() {
       heapLimitMB > 0
         ? Math.round((heapUsedMB / heapLimitMB) * 10000) / 100
         : 0;
-    const processWorkingSetsMB = getProcessWorkingSetsMB();
     const kernelPeakRssMB = getKernelPeakRssMB();
+    const activity = snapshotActivity();
 
     logger.debug(
       `Performance: Memory=${memoryUsageMB}MB, Heap=${heapUsedMB}/${heapLimitMB}MB, All Processes=${allProcessesMemoryMB ?? "?"}MB, CPU=${cpuUsagePercent}%, System Memory=${systemMemory.usedMemoryMB}/${systemMemory.totalMemoryMB}MB (${systemMemory.usagePercent}%), System CPU=${systemCpuPercent}%`,
@@ -270,7 +259,7 @@ function capturePerformanceMetrics() {
       }
     }
     if (mainPeakAdvanced) {
-      peakActivity = snapshotActivity();
+      peakActivity = activity;
       peakTimestamp = Date.now();
     }
 
@@ -285,7 +274,7 @@ function capturePerformanceMetrics() {
         heapUsedMB,
         heapLimitMB,
         ...(processWorkingSetsMB && { processWorkingSetsMB }),
-        activity: snapshotActivity(),
+        activity,
         peakHeapUsedMB,
         peakHeapPct,
         peakRssMB,

--- a/src/utils/performance_monitor.ts
+++ b/src/utils/performance_monitor.ts
@@ -247,29 +247,29 @@ function capturePerformanceMetrics() {
       `Performance: Memory=${memoryUsageMB}MB, Heap=${heapUsedMB}/${heapLimitMB}MB, All Processes=${allProcessesMemoryMB ?? "?"}MB, CPU=${cpuUsagePercent}%, System Memory=${systemMemory.usedMemoryMB}/${systemMemory.totalMemoryMB}MB (${systemMemory.usagePercent}%), System CPU=${systemCpuPercent}%`,
     );
 
-    // Update session peaks, and record what was running whenever one advances.
-    let peakAdvanced = false;
+    // Child process working sets drift constantly, so only main process
+    // peaks (heap, RSS) stamp peakActivity and peakTimestamp.
+    let mainPeakAdvanced = false;
     if (heapUsedMB > peakHeapUsedMB) {
       peakHeapUsedMB = heapUsedMB;
-      peakAdvanced = true;
+      mainPeakAdvanced = true;
     }
     if (heapPct > peakHeapPct) {
       peakHeapPct = heapPct;
-      peakAdvanced = true;
+      mainPeakAdvanced = true;
     }
     if (kernelPeakRssMB > peakRssMB) {
       peakRssMB = kernelPeakRssMB;
-      peakAdvanced = true;
+      mainPeakAdvanced = true;
     }
     if (processWorkingSetsMB) {
       for (const [key, value] of Object.entries(processWorkingSetsMB)) {
         if (value > (peakProcessWorkingSetsMB[key] ?? 0)) {
           peakProcessWorkingSetsMB[key] = value;
-          peakAdvanced = true;
         }
       }
     }
-    if (peakAdvanced) {
+    if (mainPeakAdvanced) {
       peakActivity = snapshotActivity();
       peakTimestamp = Date.now();
     }


### PR DESCRIPTION
*This description was written by Claude but is human-reviewed*

The performance heartbeat currently records main-process RSS and CPU every 30 seconds. That is not enough to tell whether a crash was memory related, which process was heavy, or what the app was doing at the time.

This extends the heartbeat to also record:

- Main-process V8 heap used and limit, the numbers that predict a JavaScript heap OOM.
- Working set per Electron process type (browser, renderer, gpu, utility), so renderer or tsc-worker bloat shows up separately.
- Session peaks of all of the above. Peak RSS comes from process.resourceUsage().maxRSS, which the kernel tracks exactly, so short spikes between heartbeat samples still register.
- What was running whenever a peak advanced: streaming chat count, running preview apps, extractCodebase in flight, and the active TypeScript utility process kind.

All new fields are persisted in lastKnownPerformance and attached to the existing app:crash_detected and renderer:crash_detected telemetry events, so questions like "did the heap approach its limit before this crash, and what was running" become answerable in PostHog.

Part of a broader improvement to OOM crash detection. A follow-up PR will use these fields to classify crashes as OOM or not at next launch.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

