### PR TITLE
feat: extract exception details from crash minidumps

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -693,6 +693,11 @@ const createWindow = () => {
         ...(nativeCrash && {
           crash_reason: nativeCrash.crashReason,
           exception_code: nativeCrash.exceptionCode,
+          fault_address: nativeCrash.faultAddress,
+          access_type: nativeCrash.accessType,
+          in_page_error_status: nativeCrash.inPageErrorStatus,
+          oom_allocation_size_bytes: nativeCrash.oomAllocationSizeBytes,
+          fast_fail_code: nativeCrash.fastFailCode,
           faulting_module: nativeCrash.faultingModule,
           faulting_offset: nativeCrash.faultingOffset,
         }),

--- a/src/utils/minidump_summary.test.ts
+++ b/src/utils/minidump_summary.test.ts
@@ -20,6 +20,7 @@ import { parseMinidumpBuffer } from "@/utils/minidump_summary";
 function buildMinidump(opts: {
   modules: { base: bigint; size: number; name: string }[];
   exceptionCode: number;
+  exceptionFlags?: number; // si_code on Linux dumps
   exceptionAddress?: bigint;
   exceptionParams?: bigint[]; // info[] values, with numberParameters set to length
   ip: bigint;
@@ -81,11 +82,12 @@ function buildMinidump(opts: {
   cursor = (contextRva + contextSize + 7) & ~7;
 
   // --- Exception stream ---
-  // exceptionCode @ +8; exceptionAddress @ +24; numberParameters @ +32 with
-  // info[] @ +40; then a location descriptor for the CPU context above
-  // (its size @ +160, its RVA @ +164).
+  // exceptionCode @ +8; exceptionFlags @ +12; exceptionAddress @ +24;
+  // numberParameters @ +32 with info[] @ +40; then a location descriptor
+  // for the CPU context above (its size @ +160, its RVA @ +164).
   const exceptionRva = cursor;
   dv.setUint32(exceptionRva + 8, opts.exceptionCode, true);
+  dv.setUint32(exceptionRva + 12, opts.exceptionFlags ?? 0, true);
   dv.setBigUint64(exceptionRva + 24, opts.exceptionAddress ?? 0n, true);
   if (opts.exceptionParams) {
     if (opts.exceptionParams.length > 15) {
@@ -208,11 +210,43 @@ describe("parseMinidumpBuffer", () => {
     );
   });
 
+  it("omits the fault address for Linux kernel-origin faults", () => {
+    // A general protection fault (e.g. from a non-canonical address)
+    // arrives as SIGSEGV with SI_KERNEL and si_addr 0. Reporting that 0
+    // would disguise pointer corruption as a null dereference.
+    const dump = buildMinidump({
+      modules: oneModule,
+      exceptionCode: 11, // SIGSEGV
+      exceptionFlags: 0x80, // SI_KERNEL
+      exceptionAddress: 0n,
+      ip: 0x10010n,
+      ipOffset: 248,
+    });
+    expect(
+      parseMinidumpBuffer(dump, "linux", "x64")!.faultAddress,
+    ).toBeUndefined();
+  });
+
   it("omits the fault address for macOS general protection faults", () => {
     const dump = buildMinidump({
       modules: oneModule,
       exceptionCode: 1, // EXC_BAD_ACCESS
       exceptionParams: [1n, 13n, 0n], // code0 13 is EXC_I386_GPFLT
+      // Crashpad stores the instruction pointer here, not a data address.
+      exceptionAddress: 0x10010n,
+      ip: 0x10010n,
+      ipOffset: 248,
+    });
+    expect(
+      parseMinidumpBuffer(dump, "darwin", "x64")!.faultAddress,
+    ).toBeUndefined();
+  });
+
+  it("omits the fault address for macOS read|execute protection collisions", () => {
+    const dump = buildMinidump({
+      modules: oneModule,
+      exceptionCode: 1, // EXC_BAD_ACCESS
+      exceptionParams: [1n, 5n, 0n], // code0 5 is VM_PROT_READ | VM_PROT_EXECUTE
       // Crashpad stores the instruction pointer here, not a data address.
       exceptionAddress: 0x10010n,
       ip: 0x10010n,
@@ -329,6 +363,20 @@ describe("parseMinidumpBuffer", () => {
     expect(s!.accessType).toBe("read");
     expect(s!.faultAddress).toBe("0x18");
     expect(s!.inPageErrorStatus).toBe("0xc000009c");
+  });
+
+  it("masks a sign-extended in-page error status to 32 bits", () => {
+    const dump = buildMinidump({
+      modules: oneModule,
+      exceptionCode: 0xc0000006,
+      // The negative NTSTATUS sign extends into the 64-bit slot.
+      exceptionParams: [0n, 0x18n, 0xffffffffc000009cn],
+      ip: 0x10010n,
+      ipOffset: 248,
+    });
+    expect(parseMinidumpBuffer(dump, "win32", "x64")!.inPageErrorStatus).toBe(
+      "0xc000009c",
+    );
   });
 
   it("reads the failed allocation size for a Chromium OOM crash", () => {

--- a/src/utils/minidump_summary.test.ts
+++ b/src/utils/minidump_summary.test.ts
@@ -21,6 +21,7 @@ function buildMinidump(opts: {
   modules: { base: bigint; size: number; name: string }[];
   exceptionCode: number;
   exceptionAddress?: bigint;
+  exceptionParams?: bigint[]; // info[] values, with numberParameters set to length
   ip: bigint;
   ipOffset: number; // where the IP sits in the CPU context: 248 (x64) / 264 (arm64)
   ptype?: string;
@@ -80,11 +81,18 @@ function buildMinidump(opts: {
   cursor = (contextRva + contextSize + 7) & ~7;
 
   // --- Exception stream ---
-  // exceptionCode @ +8; exceptionAddress @ +24; then a location descriptor for
-  // the CPU context above (its size @ +160, its RVA @ +164).
+  // exceptionCode @ +8; exceptionAddress @ +24; numberParameters @ +32 with
+  // info[] @ +40; then a location descriptor for the CPU context above
+  // (its size @ +160, its RVA @ +164).
   const exceptionRva = cursor;
   dv.setUint32(exceptionRva + 8, opts.exceptionCode, true);
   dv.setBigUint64(exceptionRva + 24, opts.exceptionAddress ?? 0n, true);
+  if (opts.exceptionParams) {
+    dv.setUint32(exceptionRva + 32, opts.exceptionParams.length, true);
+    opts.exceptionParams.forEach((param, i) => {
+      dv.setBigUint64(exceptionRva + 40 + i * 8, param, true);
+    });
+  }
   dv.setUint32(exceptionRva + 160, contextSize, true);
   dv.setUint32(exceptionRva + 164, contextRva, true);
   const exceptionSize = 168;
@@ -180,6 +188,99 @@ describe("parseMinidumpBuffer", () => {
     expect(parseMinidumpBuffer(dump, "linux", "x64")!.crashReason).toBe(
       "SIGABRT",
     );
+  });
+
+  it("reads the fault address for a POSIX memory fault", () => {
+    const dump = buildMinidump({
+      modules: oneModule,
+      exceptionCode: 11, // SIGSEGV
+      exceptionAddress: 0x18n,
+      ip: 0x10010n,
+      ipOffset: 248,
+    });
+    expect(parseMinidumpBuffer(dump, "linux", "x64")!.faultAddress).toBe(
+      "0x18",
+    );
+  });
+
+  it("leaves the fault address undefined for non-memory signals", () => {
+    // For SIGABRT the address field carries no meaningful fault address.
+    const dump = buildMinidump({
+      modules: oneModule,
+      exceptionCode: 6,
+      exceptionAddress: 0x18n,
+      ip: 0x10010n,
+      ipOffset: 248,
+    });
+    expect(
+      parseMinidumpBuffer(dump, "linux", "x64")!.faultAddress,
+    ).toBeUndefined();
+  });
+
+  it("decodes Windows access violation parameters", () => {
+    const dump = buildMinidump({
+      modules: oneModule,
+      exceptionCode: 0xc0000005,
+      exceptionParams: [1n, 0x18n], // write to address 0x18
+      ip: 0x10010n,
+      ipOffset: 248,
+    });
+    const s = parseMinidumpBuffer(dump, "win32", "x64");
+    expect(s!.accessType).toBe("write");
+    expect(s!.faultAddress).toBe("0x18");
+  });
+
+  it("decodes Windows in-page error parameters", () => {
+    const dump = buildMinidump({
+      modules: oneModule,
+      exceptionCode: 0xc0000006,
+      // read of address 0x18, paging failed with STATUS_DEVICE_DATA_ERROR
+      exceptionParams: [0n, 0x18n, 0xc000009cn],
+      ip: 0x10010n,
+      ipOffset: 248,
+    });
+    const s = parseMinidumpBuffer(dump, "win32", "x64");
+    expect(s!.crashReason).toBe("IN_PAGE_ERROR");
+    expect(s!.accessType).toBe("read");
+    expect(s!.faultAddress).toBe("0x18");
+    expect(s!.inPageErrorStatus).toBe(0xc000009c);
+  });
+
+  it("reads the failed allocation size for a Chromium OOM crash", () => {
+    const dump = buildMinidump({
+      modules: oneModule,
+      exceptionCode: 0xe0000008,
+      // Chromium passes the allocation size and page file state.
+      exceptionParams: [2147483648n, 0n, 0n],
+      ip: 0x10010n,
+      ipOffset: 248,
+    });
+    expect(
+      parseMinidumpBuffer(dump, "win32", "x64")!.oomAllocationSizeBytes,
+    ).toBe(2147483648);
+  });
+
+  it("reads the FAST_FAIL code for Windows 0xC0000409", () => {
+    const dump = buildMinidump({
+      modules: oneModule,
+      exceptionCode: 0xc0000409,
+      exceptionParams: [7n], // FAST_FAIL_FATAL_APP_EXIT, i.e. abort()
+      ip: 0x10010n,
+      ipOffset: 248,
+    });
+    expect(parseMinidumpBuffer(dump, "win32", "x64")!.fastFailCode).toBe(7);
+  });
+
+  it("leaves detail fields undefined when the exception has no parameters", () => {
+    const dump = buildMinidump({
+      modules: oneModule,
+      exceptionCode: 0xc0000005,
+      ip: 0x10010n,
+      ipOffset: 248,
+    });
+    const s = parseMinidumpBuffer(dump, "win32", "x64");
+    expect(s!.accessType).toBeUndefined();
+    expect(s!.faultAddress).toBeUndefined();
   });
 
   it("decodes a macOS Mach exception code (not a POSIX signal)", () => {

--- a/src/utils/minidump_summary.test.ts
+++ b/src/utils/minidump_summary.test.ts
@@ -203,6 +203,21 @@ describe("parseMinidumpBuffer", () => {
     );
   });
 
+  it("strips arm64 tag bits from the fault address using the address mask", () => {
+    const dump = buildMinidump({
+      modules: oneModule,
+      exceptionCode: 1, // EXC_BAD_ACCESS
+      exceptionAddress: 0xb400000000000018n, // tagged pointer to 0x18
+      ip: 0x10010n,
+      ipOffset: 264,
+      ptype: "browser",
+      addressMask: 0xff00000000000000n,
+    });
+    expect(parseMinidumpBuffer(dump, "darwin", "arm64")!.faultAddress).toBe(
+      "0x18",
+    );
+  });
+
   it("leaves the fault address undefined for non-memory signals", () => {
     // For SIGABRT the address field carries no meaningful fault address.
     const dump = buildMinidump({

--- a/src/utils/minidump_summary.test.ts
+++ b/src/utils/minidump_summary.test.ts
@@ -234,6 +234,19 @@ describe("parseMinidumpBuffer", () => {
     expect(parseMinidumpBuffer(dump, "linux", "x64")!.faultAddress).toBe("0x0");
   });
 
+  it("reduces a POSIX fault address past the null page to non-null", () => {
+    const dump = buildMinidump({
+      modules: oneModule,
+      exceptionCode: 11, // SIGSEGV
+      exceptionAddress: 0x7f3a91c2b418n,
+      ip: 0x10010n,
+      ipOffset: 248,
+    });
+    expect(parseMinidumpBuffer(dump, "linux", "x64")!.faultAddress).toBe(
+      "non-null",
+    );
+  });
+
   it("strips arm64 tag bits from the fault address using the address mask", () => {
     const dump = buildMinidump({
       modules: oneModule,
@@ -274,6 +287,19 @@ describe("parseMinidumpBuffer", () => {
     const s = parseMinidumpBuffer(dump, "win32", "x64");
     expect(s!.accessType).toBe("write");
     expect(s!.faultAddress).toBe("0x18");
+  });
+
+  it("reduces a Windows fault address past the null page to non-null", () => {
+    const dump = buildMinidump({
+      modules: oneModule,
+      exceptionCode: 0xc0000005,
+      exceptionParams: [0n, 0x7f3a91c2b418n], // read of a heap-range address
+      ip: 0x10010n,
+      ipOffset: 248,
+    });
+    const s = parseMinidumpBuffer(dump, "win32", "x64");
+    expect(s!.accessType).toBe("read");
+    expect(s!.faultAddress).toBe("non-null");
   });
 
   it("leaves accessType undefined for unknown access type values", () => {

--- a/src/utils/minidump_summary.test.ts
+++ b/src/utils/minidump_summary.test.ts
@@ -88,6 +88,11 @@ function buildMinidump(opts: {
   dv.setUint32(exceptionRva + 8, opts.exceptionCode, true);
   dv.setBigUint64(exceptionRva + 24, opts.exceptionAddress ?? 0n, true);
   if (opts.exceptionParams) {
+    if (opts.exceptionParams.length > 15) {
+      throw new Error(
+        "info[] holds at most 15 params; more would overwrite the context descriptor",
+      );
+    }
     dv.setUint32(exceptionRva + 32, opts.exceptionParams.length, true);
     opts.exceptionParams.forEach((param, i) => {
       dv.setBigUint64(exceptionRva + 40 + i * 8, param, true);
@@ -203,6 +208,21 @@ describe("parseMinidumpBuffer", () => {
     );
   });
 
+  it("omits the fault address for macOS general protection faults", () => {
+    const dump = buildMinidump({
+      modules: oneModule,
+      exceptionCode: 1, // EXC_BAD_ACCESS
+      exceptionParams: [1n, 13n, 0n], // code0 13 is EXC_I386_GPFLT
+      // Crashpad stores the instruction pointer here, not a data address.
+      exceptionAddress: 0x10010n,
+      ip: 0x10010n,
+      ipOffset: 248,
+    });
+    expect(
+      parseMinidumpBuffer(dump, "darwin", "x64")!.faultAddress,
+    ).toBeUndefined();
+  });
+
   it("reports a zero fault address for null pointer dereferences", () => {
     const dump = buildMinidump({
       modules: oneModule,
@@ -282,7 +302,7 @@ describe("parseMinidumpBuffer", () => {
     expect(s!.crashReason).toBe("IN_PAGE_ERROR");
     expect(s!.accessType).toBe("read");
     expect(s!.faultAddress).toBe("0x18");
-    expect(s!.inPageErrorStatus).toBe(0xc000009c);
+    expect(s!.inPageErrorStatus).toBe("0xc000009c");
   });
 
   it("reads the failed allocation size for a Chromium OOM crash", () => {

--- a/src/utils/minidump_summary.test.ts
+++ b/src/utils/minidump_summary.test.ts
@@ -383,6 +383,19 @@ describe("parseMinidumpBuffer", () => {
     expect(parseMinidumpBuffer(dump, "linux", "x64")!.ptype).toBeUndefined();
   });
 
+  it("rejects an exception stream whose declared size is too small", () => {
+    const dump = buildMinidump({
+      modules: oneModule,
+      exceptionCode: 11,
+      ip: 0x10500n,
+      ipOffset: 248,
+    });
+    // Corrupt the directory: entry [1] is the exception stream, dataSize @48.
+    const dv = new DataView(dump.buffer, dump.byteOffset, dump.byteLength);
+    dv.setUint32(48, 40, true);
+    expect(parseMinidumpBuffer(dump, "linux", "x64")).toBeNull();
+  });
+
   it("rejects a buffer without the MDMP signature", () => {
     expect(parseMinidumpBuffer(Buffer.alloc(64), "linux", "x64")).toBeNull();
   });

--- a/src/utils/minidump_summary.test.ts
+++ b/src/utils/minidump_summary.test.ts
@@ -203,6 +203,17 @@ describe("parseMinidumpBuffer", () => {
     );
   });
 
+  it("reports a zero fault address for null pointer dereferences", () => {
+    const dump = buildMinidump({
+      modules: oneModule,
+      exceptionCode: 11, // SIGSEGV
+      exceptionAddress: 0n,
+      ip: 0x10010n,
+      ipOffset: 248,
+    });
+    expect(parseMinidumpBuffer(dump, "linux", "x64")!.faultAddress).toBe("0x0");
+  });
+
   it("strips arm64 tag bits from the fault address using the address mask", () => {
     const dump = buildMinidump({
       modules: oneModule,

--- a/src/utils/minidump_summary.test.ts
+++ b/src/utils/minidump_summary.test.ts
@@ -245,6 +245,19 @@ describe("parseMinidumpBuffer", () => {
     expect(s!.faultAddress).toBe("0x18");
   });
 
+  it("leaves accessType undefined for unknown access type values", () => {
+    const dump = buildMinidump({
+      modules: oneModule,
+      exceptionCode: 0xc0000005,
+      exceptionParams: [5n, 0x18n], // 5 is not a documented access type
+      ip: 0x10010n,
+      ipOffset: 248,
+    });
+    const s = parseMinidumpBuffer(dump, "win32", "x64");
+    expect(s!.accessType).toBeUndefined();
+    expect(s!.faultAddress).toBe("0x18");
+  });
+
   it("decodes Windows in-page error parameters", () => {
     const dump = buildMinidump({
       modules: oneModule,

--- a/src/utils/minidump_summary.ts
+++ b/src/utils/minidump_summary.ts
@@ -68,6 +68,9 @@ const EXC_NUM_PARAMS_OFF = 32;
 const EXC_PARAMS_OFF = 40;
 const EXC_MAX_PARAMS = 15;
 const EXC_CONTEXT_RVA_OFF = 164;
+// The stream is a fixed-size struct. A smaller declared size means the dump
+// is corrupt, and reads past it would land in a neighboring stream's bytes.
+const EXC_STREAM_SIZE = 168;
 
 // Exception codes whose parameters carry extra detail on Windows.
 const EXC_CODE_ACCESS_VIOLATION = 0xc0000005;
@@ -208,6 +211,7 @@ export function parseMinidumpBuffer(
     // we care about.
     let moduleListRva = 0;
     let exceptionRva = 0;
+    let exceptionSize = 0;
     let crashpadInfoRva = 0;
     let crashpadInfoSize = 0;
     for (let i = 0; i < numStreams; i++) {
@@ -217,14 +221,20 @@ export function parseMinidumpBuffer(
       const size = view.getUint32(entry + DIR_ENTRY_SIZE_OFF, true);
       const rva = view.getUint32(entry + DIR_ENTRY_RVA_OFF, true);
       if (type === STREAM_MODULE_LIST) moduleListRva = rva;
-      else if (type === STREAM_EXCEPTION) exceptionRva = rva;
-      else if (type === STREAM_CRASHPAD_INFO) {
+      else if (type === STREAM_EXCEPTION) {
+        exceptionRva = rva;
+        exceptionSize = size;
+      } else if (type === STREAM_CRASHPAD_INFO) {
         crashpadInfoRva = rva;
         crashpadInfoSize = size;
       }
     }
 
-    if (exceptionRva === 0 || exceptionRva + EXC_CONTEXT_RVA_OFF > buf.length) {
+    if (
+      exceptionRva === 0 ||
+      exceptionSize < EXC_STREAM_SIZE ||
+      exceptionRva + EXC_STREAM_SIZE > buf.length
+    ) {
       return null;
     }
     const exceptionCode = view.getUint32(exceptionRva + EXC_CODE_OFF, true);

--- a/src/utils/minidump_summary.ts
+++ b/src/utils/minidump_summary.ts
@@ -8,7 +8,7 @@ import fs from "node:fs";
 export interface MinidumpSummary {
   crashReason?: string; // e.g. "SIGABRT" / "SIGSEGV" (POSIX) or NTSTATUS name
   exceptionCode: number; // raw code, in case the name table misses it
-  faultAddress?: string; // for memory faults: hex address if near null, else "non-null"
+  faultAddress?: `0x${string}` | "non-null"; // for memory faults; exact only near null
   accessType?: "read" | "write" | "execute"; // Windows access violations and in-page errors
   inPageErrorStatus?: string; // NTSTATUS of the paging failure, hex (e.g. "0xc000009c")
   oomAllocationSizeBytes?: number; // failed allocation size for Chromium OOM crashes
@@ -63,6 +63,7 @@ const DIR_ENTRY_RVA_OFF = 8;
 //   u32 dataSize          @160
 //   u32 rva               @164  -> file offset of the crashing thread's CPU context
 const EXC_CODE_OFF = 8;
+const EXC_FLAGS_OFF = 12;
 const EXC_ADDRESS_OFF = 24;
 const EXC_NUM_PARAMS_OFF = 32;
 const EXC_PARAMS_OFF = 40;
@@ -89,6 +90,7 @@ const ACCESS_TYPES: Record<number, "read" | "write" | "execute"> = {
 // address; Crashpad stores the instruction pointer instead.
 const MACH_BAD_ACCESS_GPFLT = 13n; // EXC_I386_GPFLT
 const MACH_BAD_ACCESS_PROT_COLLISION = 5n; // VM_PROT_READ | VM_PROT_EXECUTE
+const LINUX_SI_KERNEL = 0x80; // si_code of kernel-origin faults without si_addr
 
 // MINIDUMP_MODULE record: u64 base @0, u32 size @8, ... u32 nameRva @20, with
 // the whole record being 108 bytes (so module N starts at N * 108).
@@ -354,7 +356,11 @@ function parseExceptionDetails(
       return {
         accessType: ACCESS_TYPES[Number(params[0])],
         faultAddress: redactFaultAddress(params[1], addressMask),
-        ...(params.length >= 3 && { inPageErrorStatus: toHex(params[2]) }),
+        // The 32-bit NTSTATUS is sign extended into the 64-bit slot;
+        // mask it so every dump prints the status the same way.
+        ...(params.length >= 3 && {
+          inPageErrorStatus: toHex(params[2] & 0xffffffffn),
+        }),
       };
     }
     if (exceptionCode === EXC_CODE_CHROMIUM_OOM && params.length >= 1) {
@@ -374,12 +380,18 @@ function parseExceptionDetails(
   // no data fault address and Crashpad stores the instruction pointer
   // instead, so skip the field for those code0 values.
   const machCode0 = params.length >= 2 ? params[1] : undefined;
+  // On Linux the exception flags field holds si_code. Kernel-origin
+  // faults (SI_KERNEL, e.g. a general protection fault from a
+  // non-canonical address) have no valid fault address and store 0,
+  // which would read as a null dereference.
+  const siCode = view.getUint32(exceptionRva + EXC_FLAGS_OFF, true);
   const isMemoryFault =
     platform === "darwin"
       ? exceptionCode === 1 && // EXC_BAD_ACCESS
         machCode0 !== MACH_BAD_ACCESS_GPFLT &&
         machCode0 !== MACH_BAD_ACCESS_PROT_COLLISION
-      : exceptionCode === 11 || exceptionCode === 7; // SIGSEGV, SIGBUS
+      : (exceptionCode === 11 || exceptionCode === 7) && // SIGSEGV, SIGBUS
+        siCode !== LINUX_SI_KERNEL;
   if (isMemoryFault) {
     return {
       faultAddress: redactFaultAddress(
@@ -391,8 +403,8 @@ function parseExceptionDetails(
   return {};
 }
 
-function toHex(value: bigint): string {
-  return "0x" + value.toString(16);
+function toHex(value: bigint): `0x${string}` {
+  return `0x${value.toString(16)}`;
 }
 
 // Fault addresses are only diagnostic near null, where they mean a field
@@ -402,7 +414,10 @@ function toHex(value: bigint): string {
 // they can reach telemetry or logs.
 const NULL_PAGE_LIMIT = 0xffffn;
 
-function redactFaultAddress(address: bigint, mask: bigint): string {
+function redactFaultAddress(
+  address: bigint,
+  mask: bigint,
+): `0x${string}` | "non-null" {
   const masked = applyAddressMask(address, mask);
   return masked <= NULL_PAGE_LIMIT ? toHex(masked) : "non-null";
 }

--- a/src/utils/minidump_summary.ts
+++ b/src/utils/minidump_summary.ts
@@ -10,7 +10,7 @@ export interface MinidumpSummary {
   exceptionCode: number; // raw code, in case the name table misses it
   faultAddress?: string; // hex data address the crash touched, for memory faults
   accessType?: "read" | "write" | "execute"; // Windows access violations and in-page errors
-  inPageErrorStatus?: number; // underlying NTSTATUS for Windows in-page errors
+  inPageErrorStatus?: string; // NTSTATUS of the paging failure, hex (e.g. "0xc000009c")
   oomAllocationSizeBytes?: number; // failed allocation size for Chromium OOM crashes
   fastFailCode?: number; // FAST_FAIL reason for Windows 0xC0000409, e.g. 7 is abort()
   faultingModule?: string; // basename of the module containing the crash address
@@ -84,6 +84,11 @@ const ACCESS_TYPES: Record<number, "read" | "write" | "execute"> = {
   1: "write",
   8: "execute",
 };
+
+// macOS EXC_BAD_ACCESS code values whose subcode carries no data fault
+// address; Crashpad stores the instruction pointer instead.
+const MACH_BAD_ACCESS_GPFLT = 13n; // EXC_I386_GPFLT
+const MACH_BAD_ACCESS_PROT_COLLISION = 5n; // VM_PROT_READ | VM_PROT_EXECUTE
 
 // MINIDUMP_MODULE record: u64 base @0, u32 size @8, ... u32 nameRva @20, with
 // the whole record being 108 bytes (so module N starts at N * 108).
@@ -349,7 +354,7 @@ function parseExceptionDetails(
       return {
         accessType: ACCESS_TYPES[Number(params[0])],
         faultAddress: toHex(applyAddressMask(params[1], addressMask)),
-        ...(params.length >= 3 && { inPageErrorStatus: Number(params[2]) }),
+        ...(params.length >= 3 && { inPageErrorStatus: toHex(params[2]) }),
       };
     }
     if (exceptionCode === EXC_CODE_CHROMIUM_OOM && params.length >= 1) {
@@ -364,9 +369,16 @@ function parseExceptionDetails(
 
   // On POSIX, Crashpad stores the data fault address in ExceptionAddress.
   // Only memory faults have one; for other signals the field is meaningless.
+  // On macOS the parameters are [exception, code0, code1]. For general
+  // protection faults and the read|execute protection collision, there is
+  // no data fault address and Crashpad stores the instruction pointer
+  // instead, so skip the field for those code0 values.
+  const machCode0 = params.length >= 2 ? params[1] : undefined;
   const isMemoryFault =
     platform === "darwin"
-      ? exceptionCode === 1 // EXC_BAD_ACCESS
+      ? exceptionCode === 1 && // EXC_BAD_ACCESS
+        machCode0 !== MACH_BAD_ACCESS_GPFLT &&
+        machCode0 !== MACH_BAD_ACCESS_PROT_COLLISION
       : exceptionCode === 11 || exceptionCode === 7; // SIGSEGV, SIGBUS
   if (isMemoryFault) {
     return {

--- a/src/utils/minidump_summary.ts
+++ b/src/utils/minidump_summary.ts
@@ -8,7 +8,7 @@ import fs from "node:fs";
 export interface MinidumpSummary {
   crashReason?: string; // e.g. "SIGABRT" / "SIGSEGV" (POSIX) or NTSTATUS name
   exceptionCode: number; // raw code, in case the name table misses it
-  faultAddress?: string; // hex data address the crash touched, for memory faults
+  faultAddress?: string; // for memory faults: hex address if near null, else "non-null"
   accessType?: "read" | "write" | "execute"; // Windows access violations and in-page errors
   inPageErrorStatus?: string; // NTSTATUS of the paging failure, hex (e.g. "0xc000009c")
   oomAllocationSizeBytes?: number; // failed allocation size for Chromium OOM crashes
@@ -345,7 +345,7 @@ function parseExceptionDetails(
     if (exceptionCode === EXC_CODE_ACCESS_VIOLATION && params.length >= 2) {
       return {
         accessType: ACCESS_TYPES[Number(params[0])],
-        faultAddress: toHex(applyAddressMask(params[1], addressMask)),
+        faultAddress: redactFaultAddress(params[1], addressMask),
       };
     }
     if (exceptionCode === EXC_CODE_IN_PAGE_ERROR && params.length >= 2) {
@@ -353,7 +353,7 @@ function parseExceptionDetails(
       // of the paging failure (e.g. a failing disk or dropped network share).
       return {
         accessType: ACCESS_TYPES[Number(params[0])],
-        faultAddress: toHex(applyAddressMask(params[1], addressMask)),
+        faultAddress: redactFaultAddress(params[1], addressMask),
         ...(params.length >= 3 && { inPageErrorStatus: toHex(params[2]) }),
       };
     }
@@ -382,11 +382,9 @@ function parseExceptionDetails(
       : exceptionCode === 11 || exceptionCode === 7; // SIGSEGV, SIGBUS
   if (isMemoryFault) {
     return {
-      faultAddress: toHex(
-        applyAddressMask(
-          view.getBigUint64(exceptionRva + EXC_ADDRESS_OFF, true),
-          addressMask,
-        ),
+      faultAddress: redactFaultAddress(
+        view.getBigUint64(exceptionRva + EXC_ADDRESS_OFF, true),
+        addressMask,
       ),
     };
   }
@@ -395,6 +393,18 @@ function parseExceptionDetails(
 
 function toHex(value: bigint): string {
   return "0x" + value.toString(16);
+}
+
+// Fault addresses are only diagnostic near null, where they mean a field
+// access off a null pointer. An exact address past the null page would
+// expose ASLR layout, and after memory corruption the "pointer" can hold
+// application bytes, so those values are reduced to "non-null" before
+// they can reach telemetry or logs.
+const NULL_PAGE_LIMIT = 0xffffn;
+
+function redactFaultAddress(address: bigint, mask: bigint): string {
+  const masked = applyAddressMask(address, mask);
+  return masked <= NULL_PAGE_LIMIT ? toHex(masked) : "non-null";
 }
 
 // Read the "ptype" Crashpad annotation (the crashing process type) from the

--- a/src/utils/minidump_summary.ts
+++ b/src/utils/minidump_summary.ts
@@ -8,6 +8,11 @@ import fs from "node:fs";
 export interface MinidumpSummary {
   crashReason?: string; // e.g. "SIGABRT" / "SIGSEGV" (POSIX) or NTSTATUS name
   exceptionCode: number; // raw code, in case the name table misses it
+  faultAddress?: string; // hex data address the crash touched, for memory faults
+  accessType?: "read" | "write" | "execute"; // Windows access violations and in-page errors
+  inPageErrorStatus?: number; // underlying NTSTATUS for Windows in-page errors
+  oomAllocationSizeBytes?: number; // failed allocation size for Chromium OOM crashes
+  fastFailCode?: number; // FAST_FAIL reason for Windows 0xC0000409, e.g. 7 is abort()
   faultingModule?: string; // basename of the module containing the crash address
   faultingOffset?: string; // hex offset of the crash address within that module
   ptype?: string; // crashing process type: "browser" (main) / "renderer" / "gpu-process" / …
@@ -58,7 +63,24 @@ const DIR_ENTRY_RVA_OFF = 8;
 //   u32 dataSize          @160
 //   u32 rva               @164  -> file offset of the crashing thread's CPU context
 const EXC_CODE_OFF = 8;
+const EXC_ADDRESS_OFF = 24;
+const EXC_NUM_PARAMS_OFF = 32;
+const EXC_PARAMS_OFF = 40;
+const EXC_MAX_PARAMS = 15;
 const EXC_CONTEXT_RVA_OFF = 164;
+
+// Exception codes whose parameters carry extra detail on Windows.
+const EXC_CODE_ACCESS_VIOLATION = 0xc0000005;
+const EXC_CODE_IN_PAGE_ERROR = 0xc0000006;
+const EXC_CODE_CHROMIUM_OOM = 0xe0000008; // Chromium's kOomExceptionCode
+const EXC_CODE_FAST_FAIL = 0xc0000409;
+
+// ACCESS_VIOLATION parameter 0: how the faulting address was accessed.
+const ACCESS_TYPES: Record<number, "read" | "write" | "execute"> = {
+  0: "read",
+  1: "write",
+  8: "execute",
+};
 
 // MINIDUMP_MODULE record: u64 base @0, u32 size @8, ... u32 nameRva @20, with
 // the whole record being 108 bytes (so module N starts at N * 108).
@@ -105,6 +127,7 @@ const MACH_EXCEPTION_NAMES: Record<number, string> = {
 // Windows uses NTSTATUS exception codes; degrades to the raw code when unmatched.
 const NTSTATUS_NAMES: Record<number, string> = {
   0xc0000005: "ACCESS_VIOLATION",
+  0xc0000006: "IN_PAGE_ERROR",
   0xc000001d: "ILLEGAL_INSTRUCTION",
   0xc0000094: "INTEGER_DIVIDE_BY_ZERO",
   0xc00000fd: "STACK_OVERFLOW",
@@ -205,6 +228,12 @@ export function parseMinidumpBuffer(
       return null;
     }
     const exceptionCode = view.getUint32(exceptionRva + EXC_CODE_OFF, true);
+    const details = parseExceptionDetails(
+      view,
+      exceptionRva,
+      exceptionCode,
+      platform,
+    );
 
     const crashReason =
       platform === "win32"
@@ -261,6 +290,7 @@ export function parseMinidumpBuffer(
     return {
       crashReason,
       exceptionCode,
+      ...details,
       faultingModule,
       faultingOffset,
       ptype: crashpadInfoRva
@@ -270,6 +300,78 @@ export function parseMinidumpBuffer(
   } catch {
     return null;
   }
+}
+
+// Read the extra detail the exception record carries: the parameter array
+// (ExceptionInformation) and the data fault address. Parameter meaning depends
+// on the exception code; only codes where they say something useful are
+// mapped. All reads stay within the bounds already checked by the caller
+// (the exception stream spans at least EXC_CONTEXT_RVA_OFF bytes).
+function parseExceptionDetails(
+  view: DataView,
+  exceptionRva: number,
+  exceptionCode: number,
+  platform: NodeJS.Platform,
+): Pick<
+  MinidumpSummary,
+  | "faultAddress"
+  | "accessType"
+  | "inPageErrorStatus"
+  | "oomAllocationSizeBytes"
+  | "fastFailCode"
+> {
+  const numParams = Math.min(
+    view.getUint32(exceptionRva + EXC_NUM_PARAMS_OFF, true),
+    EXC_MAX_PARAMS,
+  );
+  const params: bigint[] = [];
+  for (let i = 0; i < numParams; i++) {
+    params.push(view.getBigUint64(exceptionRva + EXC_PARAMS_OFF + i * 8, true));
+  }
+
+  if (platform === "win32") {
+    if (exceptionCode === EXC_CODE_ACCESS_VIOLATION && params.length >= 2) {
+      return {
+        accessType: ACCESS_TYPES[Number(params[0])],
+        faultAddress: toHex(params[1]),
+      };
+    }
+    if (exceptionCode === EXC_CODE_IN_PAGE_ERROR && params.length >= 2) {
+      // Same first two parameters as an access violation, plus the NTSTATUS
+      // of the paging failure (e.g. a failing disk or dropped network share).
+      return {
+        accessType: ACCESS_TYPES[Number(params[0])],
+        faultAddress: toHex(params[1]),
+        ...(params.length >= 3 && { inPageErrorStatus: Number(params[2]) }),
+      };
+    }
+    if (exceptionCode === EXC_CODE_CHROMIUM_OOM && params.length >= 1) {
+      return { oomAllocationSizeBytes: Number(params[0]) };
+    }
+    if (exceptionCode === EXC_CODE_FAST_FAIL && params.length >= 1) {
+      return { fastFailCode: Number(params[0]) };
+    }
+    return {};
+  }
+
+  // On POSIX, Crashpad stores the data fault address in ExceptionAddress.
+  // Only memory faults have one; for other signals the field is meaningless.
+  const isMemoryFault =
+    platform === "darwin"
+      ? exceptionCode === 1 // EXC_BAD_ACCESS
+      : exceptionCode === 11 || exceptionCode === 7; // SIGSEGV, SIGBUS
+  if (isMemoryFault) {
+    return {
+      faultAddress: toHex(
+        view.getBigUint64(exceptionRva + EXC_ADDRESS_OFF, true),
+      ),
+    };
+  }
+  return {};
+}
+
+function toHex(value: bigint): string {
+  return "0x" + value.toString(16);
 }
 
 // Read the "ptype" Crashpad annotation (the crashing process type) from the

--- a/src/utils/minidump_summary.ts
+++ b/src/utils/minidump_summary.ts
@@ -266,10 +266,7 @@ export function parseMinidumpBuffer(
     // context; the IP sits at an arch-specific offset within it.
     let instructionPointer = 0n;
     const ipOffset = IP_OFFSET_IN_CONTEXT[arch];
-    if (
-      ipOffset !== undefined &&
-      exceptionRva + EXC_CONTEXT_RVA_OFF + 4 <= buf.length
-    ) {
+    if (ipOffset !== undefined) {
       const contextRva = view.getUint32(
         exceptionRva + EXC_CONTEXT_RVA_OFF,
         true,
@@ -315,7 +312,7 @@ export function parseMinidumpBuffer(
 // (ExceptionInformation) and the data fault address. Parameter meaning depends
 // on the exception code; only codes where they say something useful are
 // mapped. All reads stay within the bounds already checked by the caller
-// (the exception stream spans at least EXC_CONTEXT_RVA_OFF bytes).
+// (the exception stream spans at least EXC_STREAM_SIZE bytes).
 function parseExceptionDetails(
   view: DataView,
   exceptionRva: number,
@@ -356,6 +353,7 @@ function parseExceptionDetails(
       };
     }
     if (exceptionCode === EXC_CODE_CHROMIUM_OOM && params.length >= 1) {
+      // Number is exact below 2^53 bytes (9 PB), far beyond any real allocation.
       return { oomAllocationSizeBytes: Number(params[0]) };
     }
     if (exceptionCode === EXC_CODE_FAST_FAIL && params.length >= 1) {

--- a/src/utils/minidump_summary.ts
+++ b/src/utils/minidump_summary.ts
@@ -238,11 +238,19 @@ export function parseMinidumpBuffer(
       return null;
     }
     const exceptionCode = view.getUint32(exceptionRva + EXC_CODE_OFF, true);
+
+    // On arm64, saved addresses can carry pointer-auth / top-byte tag bits.
+    // Crashpad records an address_mask to recover the real address.
+    const addressMask = crashpadInfoRva
+      ? readAddressMask(view, buf, crashpadInfoRva, crashpadInfoSize)
+      : 0n;
+
     const details = parseExceptionDetails(
       view,
       exceptionRva,
       exceptionCode,
       platform,
+      addressMask,
     );
 
     const crashReason =
@@ -271,17 +279,8 @@ export function parseMinidumpBuffer(
       }
     }
 
-    // On arm64 the saved pointer can carry pointer-auth / top-byte tag bits.
-    // Crashpad records an address_mask to recover the real address before module
-    // lookup.
-    if (instructionPointer !== 0n && crashpadInfoRva) {
-      const mask = readAddressMask(
-        view,
-        buf,
-        crashpadInfoRva,
-        crashpadInfoSize,
-      );
-      instructionPointer = applyAddressMask(instructionPointer, mask);
+    if (instructionPointer !== 0n) {
+      instructionPointer = applyAddressMask(instructionPointer, addressMask);
     }
 
     let faultingModule: string | undefined;
@@ -322,6 +321,7 @@ function parseExceptionDetails(
   exceptionRva: number,
   exceptionCode: number,
   platform: NodeJS.Platform,
+  addressMask: bigint,
 ): Pick<
   MinidumpSummary,
   | "faultAddress"
@@ -343,7 +343,7 @@ function parseExceptionDetails(
     if (exceptionCode === EXC_CODE_ACCESS_VIOLATION && params.length >= 2) {
       return {
         accessType: ACCESS_TYPES[Number(params[0])],
-        faultAddress: toHex(params[1]),
+        faultAddress: toHex(applyAddressMask(params[1], addressMask)),
       };
     }
     if (exceptionCode === EXC_CODE_IN_PAGE_ERROR && params.length >= 2) {
@@ -351,7 +351,7 @@ function parseExceptionDetails(
       // of the paging failure (e.g. a failing disk or dropped network share).
       return {
         accessType: ACCESS_TYPES[Number(params[0])],
-        faultAddress: toHex(params[1]),
+        faultAddress: toHex(applyAddressMask(params[1], addressMask)),
         ...(params.length >= 3 && { inPageErrorStatus: Number(params[2]) }),
       };
     }
@@ -373,7 +373,10 @@ function parseExceptionDetails(
   if (isMemoryFault) {
     return {
       faultAddress: toHex(
-        view.getBigUint64(exceptionRva + EXC_ADDRESS_OFF, true),
+        applyAddressMask(
+          view.getBigUint64(exceptionRva + EXC_ADDRESS_OFF, true),
+          addressMask,
+        ),
       ),
     };
   }


### PR DESCRIPTION
*This description was written by Claude but is human-reviewed*

Crash dumps record extra details about each exception that our parser never read. This reads them and adds them to app:crash_detected.

- Memory faults now report the address that was touched (fault_address) and, on Windows, whether it was a read, write, or execute (access_type). An address near zero means a null pointer bug; a freed-memory fill pattern means a use-after-free.
- Windows in-page errors report why the OS failed to load the page (in_page_error_status), which usually means a bad disk rather than a Dyad bug.
- Chromium OOM crashes report the size of the allocation that failed (oom_allocation_size_bytes). A huge size points at one bad call site; a tiny size means memory was already exhausted overall.
- Windows 0xC0000409 crashes report fast_fail_code, which separates deliberate abort() calls from real stack corruption. Today both share the misleading STACK_BUFFER_OVERRUN label.

These are all the exception codes with documented parameter meanings; parameters of other codes are undefined and stay unread.

Verified against Microsoft's minidump documentation, unit tests with synthetic dumps, and real retained dumps on Linux. The Windows-only fields are covered by the synthetic tests; real Windows dumps will exercise them later.

The stream-size guard also tightens a pre-existing bounds check that validated 4 fewer bytes than the parser reads (previously harmless — the read would throw and be caught — now rejected cleanly).

A follow-up PR will extract Crashpad annotations from the same dumps.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
