### PR TITLE
improve code editor

### DIFF
--- a/e2e-tests/code_workspace.spec.ts
+++ b/e2e-tests/code_workspace.spec.ts
@@ -1,0 +1,116 @@
+import { expect, type Page } from "@playwright/test";
+import { test, Timeout } from "./helpers/test_helper";
+import fs from "fs";
+import path from "path";
+
+async function getActiveEditorModelPath(page: Page): Promise<string | null> {
+  return page.evaluate(() => {
+    // Monaco is attached to the window by the packaged application.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const monaco = (window as any).monaco;
+    if (!monaco) return null;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const editor = monaco.editor
+      .getEditors()
+      .find((candidate: any) => candidate.getModel());
+    return editor?.getModel()?.uri?.path ?? null;
+  });
+}
+
+async function quickOpenFile(page: Page, path: string) {
+  await page.keyboard.press("ControlOrMeta+p");
+  const dialog = page.getByTestId("code-quick-open-dialog");
+  await expect(dialog).toBeVisible();
+  const input = page.getByTestId("code-quick-open-input");
+  await input.fill(path);
+  await input.press("Enter");
+  await expect(dialog).toBeHidden();
+  await expect
+    .poll(() => getActiveEditorModelPath(page), { timeout: Timeout.MEDIUM })
+    .toContain(path);
+}
+
+test("code workspace supports focused layout, quick open, and tabs", async ({
+  po,
+}) => {
+  await po.setUp({ autoApprove: true });
+  await po.importApp("minimal");
+  await po.navigation.goToChatTab();
+  const appPath = await po.appManagement.getCurrentAppPath();
+  await po.previewPanel.selectPreviewMode("code");
+  await expect(po.page.getByTestId("code-workspace")).toBeVisible({
+    timeout: Timeout.LONG,
+  });
+
+  const chatPanel = po.page.locator("#chat-panel");
+  const previewPanel = po.page.locator("#preview-panel");
+  await expect
+    .poll(async () => {
+      const chatBox = await chatPanel.boundingBox();
+      const previewBox = await previewPanel.boundingBox();
+      if (!chatBox || !previewBox) return 0;
+      return previewBox.width / chatBox.width;
+    })
+    .toBeGreaterThan(1.5);
+
+  await po.page.getByTestId("code-workspace").click();
+  await quickOpenFile(po.page, "src/main.tsx");
+  await quickOpenFile(po.page, "src/App.tsx");
+
+  const tabs = po.page.getByTestId("code-editor-tabs");
+  await expect(tabs.getByRole("tab")).toHaveCount(2);
+  await expect(
+    po.page.getByTestId("code-editor-tab-src/App.tsx").getByRole("tab"),
+  ).toHaveAttribute("aria-selected", "true");
+
+  const editor = po.page.locator(".monaco-editor textarea").first();
+  const saveMarker = "\n// saved with the code workspace shortcut\n";
+  await po.page.evaluate((marker) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const monaco = (window as any).monaco;
+    const activeEditor = monaco.editor
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .getEditors()
+      .find((candidate: any) => candidate.getModel());
+    activeEditor.setValue(`${activeEditor.getValue()}${marker}`);
+    activeEditor.focus();
+  }, saveMarker);
+  await po.page.keyboard.press("ControlOrMeta+s");
+  await expect
+    .poll(
+      () => fs.readFileSync(path.join(appPath, "src", "App.tsx"), "utf8"),
+      { timeout: Timeout.MEDIUM },
+    )
+    .toContain(saveMarker.trim());
+
+  await editor.focus();
+  await po.page.keyboard.press("Control+Tab");
+  await expect
+    .poll(() => getActiveEditorModelPath(po.page), {
+      timeout: Timeout.MEDIUM,
+    })
+    .toContain("src/main.tsx");
+
+  await po.page.getByRole("button", { name: "Close main.tsx" }).click();
+  await expect(tabs.getByRole("tab")).toHaveCount(1);
+
+  await po.page.getByTestId("code-toggle-explorer-button").click();
+  await expect(po.page.getByTestId("file-tree-search")).toBeHidden();
+  await po.page.getByTestId("code-toggle-explorer-button").click();
+  await expect(po.page.getByTestId("file-tree-search")).toBeVisible();
+
+  await po.page.getByTestId("code-toggle-chat-button").click();
+  await expect
+    .poll(async () => (await chatPanel.boundingBox())?.width ?? 100)
+    .toBeLessThan(20);
+  await po.page.getByTestId("code-toggle-chat-button").click();
+  await expect
+    .poll(async () => {
+      const chatBox = await chatPanel.boundingBox();
+      const previewBox = await previewPanel.boundingBox();
+      if (!chatBox || !previewBox) return 0;
+      return previewBox.width / chatBox.width;
+    })
+    .toBeGreaterThan(1.5);
+});

--- a/e2e-tests/file_tree_search.spec.ts
+++ b/e2e-tests/file_tree_search.spec.ts
@@ -23,7 +23,16 @@ test("file tree search finds content matches and surfaces line numbers", async (
 
   // Content search should find files whose contents match the query and show line info
   await searchInput.fill("import");
+<<<<<<< Updated upstream
   const resultItem = fileTree.getByText("src/main.tsx").first();
+||||||| Stash base
+  const resultItem = fileTree.locator('[title="src/main.tsx"]').first();
+=======
+  await expect(fileTree.getByText(/\d+ matches?/)).toBeVisible({
+    timeout: Timeout.MEDIUM,
+  });
+  const resultItem = fileTree.locator('[title="src/main.tsx"]').first();
+>>>>>>> Stashed changes
   await expect(resultItem).toBeVisible({ timeout: Timeout.MEDIUM });
 
   // Click on the file path text to expand the accordion and show snippets.

--- a/src/components/preview_panel/CodeView.tsx
+++ b/src/components/preview_panel/CodeView.tsx
@@ -1,3 +1,36 @@
+<<<<<<< Updated upstream
+||||||| Stash base
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import {
+  Files,
+  Maximize2,
+  MessageSquare,
+  Minimize2,
+  RefreshCw,
+  Search,
+} from "lucide-react";
+import {
+  Panel,
+  PanelGroup,
+  PanelResizeHandle,
+  type ImperativePanelHandle,
+} from "react-resizable-panels";
+import { useTranslation } from "react-i18next";
+=======
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import {
+  Files,
+  Maximize2,
+  MessageSquare,
+  Minimize2,
+  RefreshCw,
+  Search,
+} from "lucide-react";
+import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
+import { useTranslation } from "react-i18next";
+>>>>>>> Stashed changes
 import { FileEditor } from "./FileEditor";
 import { FileTree } from "./FileTree";
 import { useEffect, useState } from "react";
@@ -32,6 +65,52 @@ export const CodeView = ({ loading, app }: CodeViewProps) => {
   const selectedVersionId = useAtomValue(selectedVersionIdAtom);
   const { refreshApp } = useLoadApp(app?.id ?? null);
   const [isFullscreen, setIsFullscreen] = useState(false);
+<<<<<<< Updated upstream
+||||||| Stash base
+  const [isQuickOpen, setIsQuickOpen] = useState(false);
+  const workspaceRef = useRef<HTMLDivElement>(null);
+  const explorerPanelRef = useRef<ImperativePanelHandle>(null);
+
+  const selectedFile =
+    appId === null ? null : (selectedFilesByAppId.get(appId) ?? null);
+  const openFiles = appId === null ? [] : (openFilesByAppId.get(appId) ?? []);
+  const isVersionDiffMode = selectedVersionId != null && appId != null;
+
+  useEffect(() => {
+    reconcileFiles({ appId, files });
+  }, [appId, files, reconcileFiles]);
+
+  useEffect(() => {
+    setIsQuickOpen(false);
+  }, [appId]);
+
+  useEffect(() => {
+    if (isVersionDiffMode || !explorerPanelRef.current) return;
+    if (isExplorerOpen) {
+      explorerPanelRef.current.expand();
+    } else {
+      explorerPanelRef.current.collapse();
+    }
+  }, [isExplorerOpen, isVersionDiffMode]);
+
+  useEffect(() => {
+=======
+  const [isQuickOpen, setIsQuickOpen] = useState(false);
+  const workspaceRef = useRef<HTMLDivElement>(null);
+
+  const selectedFile =
+    appId === null ? null : (selectedFilesByAppId.get(appId) ?? null);
+  const openFiles = appId === null ? [] : (openFilesByAppId.get(appId) ?? []);
+  const isVersionDiffMode = selectedVersionId != null && appId != null;
+
+  useEffect(() => {
+    reconcileFiles({ appId, files });
+  }, [appId, files, reconcileFiles]);
+
+  useEffect(() => {
+    setIsQuickOpen(false);
+  }, [appId]);
+>>>>>>> Stashed changes
 
   useEffect(() => {
     if (!isFullscreen) return;
@@ -155,8 +234,419 @@ export const CodeView = ({ loading, app }: CodeViewProps) => {
   }
 
   return (
+<<<<<<< Updated upstream
     <div className="text-center py-4 text-gray-500">
       {t("preview.noFilesFound")}
+||||||| Stash base
+    <div
+      ref={workspaceRef}
+      className={`flex flex-col bg-background ${isFullscreen ? "fixed inset-0 z-50 h-screen w-screen shadow-2xl" : "h-full"}`}
+      data-testid="code-workspace"
+    >
+      <div className="flex min-h-10 items-center gap-1 border-b px-2">
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <button
+                type="button"
+                onClick={() => refreshApp()}
+                aria-label={t("preview.refreshFiles")}
+                className="rounded p-1.5 hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+                disabled={loading || !appId}
+                data-testid="code-refresh-files-button"
+              />
+            }
+          >
+            <RefreshCw size={16} />
+          </TooltipTrigger>
+          <TooltipContent>{t("preview.refreshFiles")}</TooltipContent>
+        </Tooltip>
+        <div className="mr-1 text-xs text-muted-foreground">
+          {isVersionDiffMode
+            ? t("preview.viewingVersionChanges")
+            : `${files.length} ${t("preview.files")}`}
+        </div>
+
+        {!isVersionDiffMode && (
+          <>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <button
+                    type="button"
+                    onClick={() => setIsQuickOpen(true)}
+                    aria-label={t("preview.quickOpen")}
+                    className="flex items-center gap-1.5 rounded px-2 py-1.5 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
+                    data-testid="code-quick-open-button"
+                  />
+                }
+              >
+                <Search size={15} />
+                <span className="hidden sm:inline">
+                  {t("preview.quickOpen")}
+                </span>
+                <kbd className="hidden rounded border bg-background px-1 text-[10px] 2xl:inline">
+                  {navigator.platform.includes("Mac") ? "⌘P" : "Ctrl+P"}
+                </kbd>
+              </TooltipTrigger>
+              <TooltipContent>{t("preview.quickOpen")}</TooltipContent>
+            </Tooltip>
+            <div className="flex-1" />
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <button
+                    type="button"
+                    onClick={() => setIsExplorerOpen((value) => !value)}
+                    aria-label={
+                      isExplorerOpen
+                        ? t("preview.hideExplorer")
+                        : t("preview.showExplorer")
+                    }
+                    aria-pressed={isExplorerOpen}
+                    className={`rounded p-1.5 hover:bg-muted ${isExplorerOpen ? "bg-primary/10 text-primary" : "text-muted-foreground"}`}
+                    data-testid="code-toggle-explorer-button"
+                  />
+                }
+              >
+                <Files size={16} />
+              </TooltipTrigger>
+              <TooltipContent>
+                {isExplorerOpen
+                  ? t("preview.hideExplorer")
+                  : t("preview.showExplorer")}
+              </TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <button
+                    type="button"
+                    onClick={() => setIsChatPanelHidden(!isChatPanelHidden)}
+                    aria-label={
+                      isChatPanelHidden
+                        ? t("preview.showChat")
+                        : t("preview.focusCode")
+                    }
+                    aria-pressed={isChatPanelHidden}
+                    className={`rounded p-1.5 hover:bg-muted ${isChatPanelHidden ? "bg-primary/10 text-primary" : "text-muted-foreground"}`}
+                    data-testid="code-toggle-chat-button"
+                  />
+                }
+              >
+                <MessageSquare size={16} />
+              </TooltipTrigger>
+              <TooltipContent>
+                {isChatPanelHidden
+                  ? t("preview.showChat")
+                  : t("preview.focusCode")}
+              </TooltipContent>
+            </Tooltip>
+          </>
+        )}
+        {isVersionDiffMode && <div className="flex-1" />}
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <button
+                type="button"
+                onClick={() => setIsFullscreen((value) => !value)}
+                aria-label={
+                  isFullscreen
+                    ? t("preview.exitFullScreen")
+                    : t("preview.enterFullScreen")
+                }
+                aria-pressed={isFullscreen}
+                className="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+                data-testid="code-toggle-fullscreen-button"
+              />
+            }
+          >
+            {isFullscreen ? <Minimize2 size={16} /> : <Maximize2 size={16} />}
+          </TooltipTrigger>
+          <TooltipContent>
+            {isFullscreen
+              ? t("preview.exitFullScreen")
+              : t("preview.enterFullScreen")}
+          </TooltipContent>
+        </Tooltip>
+      </div>
+
+      {isVersionDiffMode ? (
+        <VersionDiffView appId={appId} versionId={selectedVersionId} />
+      ) : (
+        <PanelGroup
+          direction="horizontal"
+          autoSaveId="code-view-file-tree-v3"
+          className="flex-1 overflow-hidden"
+        >
+          <Panel
+            ref={explorerPanelRef}
+            defaultSize={25}
+            minSize={18}
+            maxSize={45}
+            collapsible
+            collapsedSize={0}
+            onCollapse={() => setIsExplorerOpen(false)}
+            onExpand={() => setIsExplorerOpen(true)}
+          >
+            <div className="h-full min-h-0 overflow-hidden border-r">
+              <FileTree appId={appId} files={files} />
+            </div>
+          </Panel>
+          <PanelResizeHandle
+            aria-label={t("preview.resizeFileTree")}
+            title={t("preview.resizeFileTree")}
+            className={`${isExplorerOpen ? "w-1" : "w-0"} cursor-col-resize bg-border transition-[width,background-color] hover:bg-primary/40`}
+          />
+          <Panel defaultSize={75} minSize={40}>
+            <div className="flex h-full min-w-0 flex-col">
+              <CodeEditorTabs
+                activePath={selectedFile?.path ?? null}
+                paths={openFiles}
+                onSelect={(path) => handleSelectFile(path)}
+                onClose={handleCloseFile}
+              />
+              <div className="min-h-0 flex-1">
+                {selectedFile ? (
+                  <FileEditor
+                    key={`${appId ?? "unknown"}:${selectedFile.path}`}
+                    appId={appId}
+                    filePath={selectedFile.path}
+                    initialLine={selectedFile.line ?? null}
+                    saveRequestEvent={SAVE_ACTIVE_FILE_EVENT}
+                  />
+                ) : (
+                  <div className="flex h-full flex-col items-center justify-center gap-3 text-muted-foreground">
+                    <Files className="size-8 opacity-50" />
+                    <span className="text-sm">
+                      {t("preview.selectFileToView")}
+                    </span>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setIsQuickOpen(true)}
+                    >
+                      <Search className="size-4" />
+                      {t("preview.quickOpen")}
+                    </Button>
+                  </div>
+                )}
+              </div>
+            </div>
+          </Panel>
+        </PanelGroup>
+      )}
+
+      {!isVersionDiffMode && (
+        <CodeQuickOpen
+          files={files}
+          open={isQuickOpen}
+          onOpenChange={setIsQuickOpen}
+          onSelect={(path) => handleSelectFile(path)}
+        />
+      )}
+=======
+    <div
+      ref={workspaceRef}
+      className={`flex flex-col bg-background ${isFullscreen ? "fixed inset-0 z-50 h-screen w-screen shadow-2xl" : "h-full"}`}
+      data-testid="code-workspace"
+    >
+      <div className="flex min-h-10 items-center gap-1 border-b px-2">
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <button
+                type="button"
+                onClick={() => refreshApp()}
+                aria-label={t("preview.refreshFiles")}
+                className="rounded p-1.5 hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+                disabled={loading || !appId}
+                data-testid="code-refresh-files-button"
+              />
+            }
+          >
+            <RefreshCw size={16} />
+          </TooltipTrigger>
+          <TooltipContent>{t("preview.refreshFiles")}</TooltipContent>
+        </Tooltip>
+        <div className="mr-1 text-xs text-muted-foreground">
+          {isVersionDiffMode
+            ? t("preview.viewingVersionChanges")
+            : `${files.length} ${t("preview.files")}`}
+        </div>
+
+        {!isVersionDiffMode && (
+          <>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <button
+                    type="button"
+                    onClick={() => setIsQuickOpen(true)}
+                    aria-label={t("preview.quickOpen")}
+                    className="flex items-center gap-1.5 rounded px-2 py-1.5 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
+                    data-testid="code-quick-open-button"
+                  />
+                }
+              >
+                <Search size={15} />
+                <span className="hidden sm:inline">
+                  {t("preview.quickOpen")}
+                </span>
+                <kbd className="hidden rounded border bg-background px-1 text-[10px] 2xl:inline">
+                  {navigator.platform.includes("Mac") ? "⌘P" : "Ctrl+P"}
+                </kbd>
+              </TooltipTrigger>
+              <TooltipContent>{t("preview.quickOpen")}</TooltipContent>
+            </Tooltip>
+            <div className="flex-1" />
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <button
+                    type="button"
+                    onClick={() => setIsExplorerOpen((value) => !value)}
+                    aria-label={
+                      isExplorerOpen
+                        ? t("preview.hideExplorer")
+                        : t("preview.showExplorer")
+                    }
+                    aria-pressed={isExplorerOpen}
+                    className={`rounded p-1.5 hover:bg-muted ${isExplorerOpen ? "bg-primary/10 text-primary" : "text-muted-foreground"}`}
+                    data-testid="code-toggle-explorer-button"
+                  />
+                }
+              >
+                <Files size={16} />
+              </TooltipTrigger>
+              <TooltipContent>
+                {isExplorerOpen
+                  ? t("preview.hideExplorer")
+                  : t("preview.showExplorer")}
+              </TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <button
+                    type="button"
+                    onClick={() => setIsChatPanelHidden(!isChatPanelHidden)}
+                    aria-label={
+                      isChatPanelHidden
+                        ? t("preview.showChat")
+                        : t("preview.focusCode")
+                    }
+                    aria-pressed={isChatPanelHidden}
+                    className={`rounded p-1.5 hover:bg-muted ${isChatPanelHidden ? "bg-primary/10 text-primary" : "text-muted-foreground"}`}
+                    data-testid="code-toggle-chat-button"
+                  />
+                }
+              >
+                <MessageSquare size={16} />
+              </TooltipTrigger>
+              <TooltipContent>
+                {isChatPanelHidden
+                  ? t("preview.showChat")
+                  : t("preview.focusCode")}
+              </TooltipContent>
+            </Tooltip>
+          </>
+        )}
+        {isVersionDiffMode && <div className="flex-1" />}
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <button
+                type="button"
+                onClick={() => setIsFullscreen((value) => !value)}
+                aria-label={
+                  isFullscreen
+                    ? t("preview.exitFullScreen")
+                    : t("preview.enterFullScreen")
+                }
+                aria-pressed={isFullscreen}
+                className="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+                data-testid="code-toggle-fullscreen-button"
+              />
+            }
+          >
+            {isFullscreen ? <Minimize2 size={16} /> : <Maximize2 size={16} />}
+          </TooltipTrigger>
+          <TooltipContent>
+            {isFullscreen
+              ? t("preview.exitFullScreen")
+              : t("preview.enterFullScreen")}
+          </TooltipContent>
+        </Tooltip>
+      </div>
+
+      {isVersionDiffMode ? (
+        <VersionDiffView appId={appId} versionId={selectedVersionId} />
+      ) : (
+        <PanelGroup direction="horizontal" className="flex-1 overflow-hidden">
+          {isExplorerOpen && (
+            <>
+              <Panel defaultSize={25} minSize={18} maxSize={45}>
+                <div className="h-full min-h-0 overflow-hidden border-r">
+                  <FileTree appId={appId} files={files} />
+                </div>
+              </Panel>
+              <PanelResizeHandle
+                aria-label={t("preview.resizeFileTree")}
+                title={t("preview.resizeFileTree")}
+                className="w-1 cursor-col-resize bg-border transition-colors hover:bg-primary/40"
+              />
+            </>
+          )}
+          <Panel defaultSize={isExplorerOpen ? 75 : 100} minSize={40}>
+            <div className="flex h-full min-w-0 flex-col">
+              <CodeEditorTabs
+                activePath={selectedFile?.path ?? null}
+                paths={openFiles}
+                onSelect={(path) => handleSelectFile(path)}
+                onClose={handleCloseFile}
+              />
+              <div className="min-h-0 flex-1">
+                {selectedFile ? (
+                  <FileEditor
+                    key={`${appId ?? "unknown"}:${selectedFile.path}`}
+                    appId={appId}
+                    filePath={selectedFile.path}
+                    initialLine={selectedFile.line ?? null}
+                    saveRequestEvent={SAVE_ACTIVE_FILE_EVENT}
+                  />
+                ) : (
+                  <div className="flex h-full flex-col items-center justify-center gap-3 text-muted-foreground">
+                    <Files className="size-8 opacity-50" />
+                    <span className="text-sm">
+                      {t("preview.selectFileToView")}
+                    </span>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setIsQuickOpen(true)}
+                    >
+                      <Search className="size-4" />
+                      {t("preview.quickOpen")}
+                    </Button>
+                  </div>
+                )}
+              </div>
+            </div>
+          </Panel>
+        </PanelGroup>
+      )}
+
+      {!isVersionDiffMode && (
+        <CodeQuickOpen
+          files={files}
+          open={isQuickOpen}
+          onOpenChange={setIsQuickOpen}
+          onSelect={(path) => handleSelectFile(path)}
+        />
+      )}
+>>>>>>> Stashed changes
     </div>
   );
 };

--- a/src/components/preview_panel/FileTree.tsx
+++ b/src/components/preview_panel/FileTree.tsx
@@ -213,7 +213,8 @@ export const FileTree = ({ appId, files }: FileTreeProps) => {
           <Input
             value={searchValue}
             onChange={(event) => setSearchValue(event.target.value)}
-            placeholder={t("preview.searchFileContents")}
+            placeholder={t("preview.search")}
+            aria-label={t("preview.searchFileContents")}
             className="h-8 pl-7 pr-16 text-sm"
             data-testid="file-tree-search"
             disabled={!appId}

--- a/src/i18n/locales/en/home.json
+++ b/src/i18n/locales/en/home.json
@@ -221,6 +221,23 @@
     "selectFileToView": "Select a file to view",
     "noFilesFound": "No files found",
     "searchFileContents": "Search file contents",
+<<<<<<< Updated upstream
+||||||| Stash base
+    "quickOpen": "Quick open",
+    "hideExplorer": "Hide file explorer",
+    "showExplorer": "Show file explorer",
+    "focusCode": "Focus code",
+    "showChat": "Show chat",
+    "resizeFileTree": "Resize file explorer",
+=======
+    "search": "Search",
+    "quickOpen": "Quick open",
+    "hideExplorer": "Hide file explorer",
+    "showExplorer": "Show file explorer",
+    "focusCode": "Focus code",
+    "showChat": "Show chat",
+    "resizeFileTree": "Resize file explorer",
+>>>>>>> Stashed changes
     "clearSearch": "Clear search",
     "searchingFiles": "Searching files...",
     "match_one": "{{count}} match",

--- a/src/i18n/locales/es/home.json
+++ b/src/i18n/locales/es/home.json
@@ -221,6 +221,23 @@
     "selectFileToView": "Selecciona un archivo para ver",
     "noFilesFound": "No se encontraron archivos",
     "searchFileContents": "Buscar contenido en archivos",
+<<<<<<< Updated upstream
+||||||| Stash base
+    "quickOpen": "Apertura rápida",
+    "hideExplorer": "Ocultar explorador de archivos",
+    "showExplorer": "Mostrar explorador de archivos",
+    "focusCode": "Enfocar código",
+    "showChat": "Mostrar chat",
+    "resizeFileTree": "Cambiar tamaño del explorador",
+=======
+    "search": "Buscar",
+    "quickOpen": "Apertura rápida",
+    "hideExplorer": "Ocultar explorador de archivos",
+    "showExplorer": "Mostrar explorador de archivos",
+    "focusCode": "Enfocar código",
+    "showChat": "Mostrar chat",
+    "resizeFileTree": "Cambiar tamaño del explorador",
+>>>>>>> Stashed changes
     "clearSearch": "Borrar búsqueda",
     "searchingFiles": "Buscando archivos...",
     "match_one": "{{count}} coincidencia",

--- a/src/i18n/locales/pt-BR/home.json
+++ b/src/i18n/locales/pt-BR/home.json
@@ -218,6 +218,23 @@
     "selectFileToView": "Selecione um arquivo para visualizar",
     "noFilesFound": "Nenhum arquivo encontrado",
     "searchFileContents": "Pesquisar conteúdo dos arquivos",
+<<<<<<< Updated upstream
+||||||| Stash base
+    "quickOpen": "Abertura rápida",
+    "hideExplorer": "Ocultar explorador de arquivos",
+    "showExplorer": "Mostrar explorador de arquivos",
+    "focusCode": "Focar no código",
+    "showChat": "Mostrar chat",
+    "resizeFileTree": "Redimensionar explorador de arquivos",
+=======
+    "search": "Pesquisar",
+    "quickOpen": "Abertura rápida",
+    "hideExplorer": "Ocultar explorador de arquivos",
+    "showExplorer": "Mostrar explorador de arquivos",
+    "focusCode": "Focar no código",
+    "showChat": "Mostrar chat",
+    "resizeFileTree": "Redimensionar explorador de arquivos",
+>>>>>>> Stashed changes
     "clearSearch": "Limpar pesquisa",
     "searchingFiles": "Pesquisando arquivos...",
     "match_one": "{{count}} resultado",

--- a/src/i18n/locales/zh-CN/home.json
+++ b/src/i18n/locales/zh-CN/home.json
@@ -218,6 +218,23 @@
     "selectFileToView": "选择要查看的文件",
     "noFilesFound": "未找到文件",
     "searchFileContents": "搜索文件内容",
+<<<<<<< Updated upstream
+||||||| Stash base
+    "quickOpen": "快速打开",
+    "hideExplorer": "隐藏文件资源管理器",
+    "showExplorer": "显示文件资源管理器",
+    "focusCode": "聚焦代码",
+    "showChat": "显示聊天",
+    "resizeFileTree": "调整文件资源管理器大小",
+=======
+    "search": "搜索",
+    "quickOpen": "快速打开",
+    "hideExplorer": "隐藏文件资源管理器",
+    "showExplorer": "显示文件资源管理器",
+    "focusCode": "聚焦代码",
+    "showChat": "显示聊天",
+    "resizeFileTree": "调整文件资源管理器大小",
+>>>>>>> Stashed changes
     "clearSearch": "清除搜索",
     "searchingFiles": "正在搜索文件...",
     "match_one": "{{count}} 个匹配",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Unresolved merge conflicts would break the build; the intended CodeView refactor is a large, conflicted change to core preview editing behavior.
> 
> **Overview**
> This PR targets a **richer preview code workspace** (quick open, multi-tab editing, explorer/chat toggles, keyboard save) and adds **Playwright coverage** in `code_workspace.spec.ts` for layout, ⌘/Ctrl+P quick open, tabs, save-to-disk, and panel toggles.
> 
> **File tree search** gets a small UX tweak: the input shows a short **“Search”** placeholder while **`aria-label`** still describes content search; the file-tree e2e test is updated to wait for match counts and locate results by **`title`**.
> 
> Locale files add **`preview.search`**, **`quickOpen`**, explorer/chat/focus strings, and related toolbar copy in **en / es / pt-BR / zh-CN**.
> 
> **Blocker:** The diff still contains **unresolved merge conflict markers** in `CodeView.tsx`, `file_tree_search.spec.ts`, and all touched `home.json` locales. Until those are resolved and the workspace UI is wired to a clean `CodeView` (the conflict side references `CodeEditorTabs`, `CodeQuickOpen`, and per-app open-file state that is not integrated with the current upstream component), the branch is not merge-ready.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19b9f16b911828c32925bdf539fcaa04f2bd273c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->