### PR TITLE
feat: add the faulting module's debug identity to crash telemetry

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -695,6 +695,8 @@ const createWindow = () => {
           exception_code: nativeCrash.exceptionCode,
           faulting_module: nativeCrash.faultingModule,
           faulting_offset: nativeCrash.faultingOffset,
+          faulting_debug_file: nativeCrash.faultingDebugFile,
+          faulting_debug_id: nativeCrash.faultingDebugId,
         }),
       });
 

--- a/src/utils/minidump_summary.test.ts
+++ b/src/utils/minidump_summary.test.ts
@@ -19,6 +19,10 @@ import { parseMinidumpBuffer } from "@/utils/minidump_summary";
 // parser reads — see the struct layouts documented in minidump_summary.ts.
 function buildMinidump(opts: {
   modules: { base: bigint; size: number; name: string }[];
+  // CodeView record attached to the first module.
+  cvRecord?:
+    | { kind: "pdb70"; guid: number[]; age: number; name: string }
+    | { kind: "build-id"; bytes: number[] };
   exceptionCode: number;
   exceptionAddress?: bigint;
   ip: bigint;
@@ -57,8 +61,32 @@ function buildMinidump(opts: {
     nameRvas.push(rva);
   }
 
+  // --- Optional CodeView record for the first module ---
+  // pdb70: "RSDS" + GUID (16) + u32 age + NUL-terminated name.
+  // build-id: "BpEL" + raw build id bytes.
+  let cvRva = 0;
+  let cvSize = 0;
+  if (opts.cvRecord) {
+    cvRva = cursor;
+    if (opts.cvRecord.kind === "pdb70") {
+      // 0x53445352 is "RSDS" as a little endian u32.
+      dv.setUint32(cvRva, 0x53445352, true);
+      opts.cvRecord.guid.forEach((b, i) => buf.writeUInt8(b, cvRva + 4 + i));
+      dv.setUint32(cvRva + 20, opts.cvRecord.age, true);
+      const nameBytes = Buffer.from(opts.cvRecord.name, "utf8");
+      nameBytes.copy(buf, cvRva + 24);
+      cvSize = 24 + nameBytes.length + 1;
+    } else {
+      // 0x4270454c is Crashpad's ELF build id signature.
+      dv.setUint32(cvRva, 0x4270454c, true);
+      opts.cvRecord.bytes.forEach((b, i) => buf.writeUInt8(b, cvRva + 4 + i));
+      cvSize = 4 + opts.cvRecord.bytes.length;
+    }
+    cursor = (cvRva + cvSize + 3) & ~3;
+  }
+
   // --- Module list stream (u32 count, then one 108-byte record per module) ---
-  // Each record: base @ +0, size @ +8, name RVA @ +20.
+  // Each record: base @ +0, size @ +8, name RVA @ +20, CvRecord @ +76/+80.
   const moduleListRva = cursor;
   dv.setUint32(moduleListRva, opts.modules.length, true);
   let mc = moduleListRva + 4;
@@ -66,6 +94,10 @@ function buildMinidump(opts: {
     dv.setBigUint64(mc, m.base, true);
     dv.setUint32(mc + 8, m.size, true);
     dv.setUint32(mc + 20, nameRvas[i], true);
+    if (i === 0 && cvRva !== 0) {
+      dv.setUint32(mc + 76, cvSize, true);
+      dv.setUint32(mc + 80, cvRva, true);
+    }
     mc += 108;
   });
   const moduleListSize = mc - moduleListRva;
@@ -247,6 +279,77 @@ describe("parseMinidumpBuffer", () => {
     const s = parseMinidumpBuffer(dump, "linux", "x64");
     expect(s!.crashReason).toBe("SIGSEGV");
     expect(s!.faultingModule).toBeUndefined();
+  });
+
+  it("extracts the debug identity from a pdb70 CodeView record", () => {
+    const dump = buildMinidump({
+      modules: [{ base: 0x400000n, size: 0x1000, name: "C:\\app\\dyad.exe" }],
+      cvRecord: {
+        kind: "pdb70",
+        // Little endian GUID fields print big endian, so bytes
+        // 01 23 45 67 come out as 67452301 in the expected id.
+        guid: [
+          0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45,
+          0x67, 0x89, 0xab, 0xcd, 0xef,
+        ],
+        age: 1,
+        name: "C:\\out\\electron.exe.pdb",
+      },
+      exceptionCode: 0xc0000005,
+      ip: 0x400100n,
+      ipOffset: 248,
+    });
+    const s = parseMinidumpBuffer(dump, "win32", "x64");
+    expect(s!.faultingModule).toBe("dyad.exe");
+    expect(s!.faultingDebugFile).toBe("electron.exe.pdb");
+    expect(s!.faultingDebugId).toBe("67452301AB89EFCD0123456789ABCDEF1");
+  });
+
+  it("extracts the debug identity from an ELF build id record", () => {
+    // Real values from a retained production dump: the id is the build id's
+    // first 16 bytes GUID-swapped with age 0, and the file name falls back
+    // to the module name.
+    const dump = buildMinidump({
+      modules: oneModule,
+      cvRecord: {
+        kind: "build-id",
+        bytes: [
+          0x90, 0xc4, 0x23, 0xdf, 0x7c, 0x7a, 0x1b, 0x23, 0xea, 0x2d, 0x19,
+          0x62, 0xbe, 0xd7, 0x25, 0x29,
+        ],
+      },
+      exceptionCode: 11,
+      ip: 0x10500n,
+      ipOffset: 248,
+    });
+    const s = parseMinidumpBuffer(dump, "linux", "x64");
+    expect(s!.faultingDebugId).toBe("DF23C4907A7C231BEA2D1962BED725290");
+    expect(s!.faultingDebugFile).toBe("libc.so.6");
+  });
+
+  it("zero pads short ELF build ids", () => {
+    const dump = buildMinidump({
+      modules: oneModule,
+      cvRecord: { kind: "build-id", bytes: [0x90, 0xc4, 0x23, 0xdf] },
+      exceptionCode: 11,
+      ip: 0x10500n,
+      ipOffset: 248,
+    });
+    expect(parseMinidumpBuffer(dump, "linux", "x64")!.faultingDebugId).toBe(
+      "DF23C4900000000000000000000000000",
+    );
+  });
+
+  it("leaves the debug identity undefined without a CodeView record", () => {
+    const dump = buildMinidump({
+      modules: oneModule,
+      exceptionCode: 11,
+      ip: 0x10500n,
+      ipOffset: 248,
+    });
+    const s = parseMinidumpBuffer(dump, "linux", "x64");
+    expect(s!.faultingDebugId).toBeUndefined();
+    expect(s!.faultingDebugFile).toBeUndefined();
   });
 
   it("returns the raw code when the signal is unmapped", () => {

--- a/src/utils/minidump_summary.ts
+++ b/src/utils/minidump_summary.ts
@@ -10,6 +10,8 @@ export interface MinidumpSummary {
   exceptionCode: number; // raw code, in case the name table misses it
   faultingModule?: string; // basename of the module containing the crash address
   faultingOffset?: string; // hex offset of the crash address within that module
+  faultingDebugFile?: string; // name keying the module's symbol file, e.g. "electron.exe.pdb"
+  faultingDebugId?: string; // build fingerprint keying the module's symbol file
   ptype?: string; // crashing process type: "browser" (main) / "renderer" / "gpu-process" / …
 }
 
@@ -62,10 +64,18 @@ const EXC_CONTEXT_RVA_OFF = 164;
 
 // MINIDUMP_MODULE record: u64 base @0, u32 size @8, ... u32 nameRva @20, with
 // the whole record being 108 bytes (so module N starts at N * 108).
+// VS_FIXEDFILEINFO (52 bytes) sits at @24, so the CvRecord
+// LOCATION_DESCRIPTOR follows at @76 (dataSize) and @80 (rva).
 const MODULE_RECORD_SIZE = 108;
 const MODULE_BASE_OFF = 0;
 const MODULE_SIZE_OFF = 8;
 const MODULE_NAME_RVA_OFF = 20;
+const MODULE_CV_SIZE_OFF = 76;
+const MODULE_CV_RVA_OFF = 80;
+
+// CodeView record signatures.
+const CV_SIG_PDB70 = 0x53445352; // "RSDS": GUID + age + debug file name
+const CV_SIG_ELF_BUILD_ID = 0x4270454c; // Crashpad's ELF build id record
 
 // MinidumpCrashpadInfo: u32 version @0 | UUID report_id (16) @4 | UUID client_id
 // (16) @20 | LOCATION_DESCRIPTOR simple_annotations (8) @36 | LOCATION_DESCRIPTOR
@@ -116,6 +126,7 @@ interface MinidumpModule {
   base: bigint;
   size: number;
   name: string;
+  recordRva: number; // file offset of this module's 108-byte record
 }
 
 // Byte offset of the instruction pointer (where the crash happened) within each
@@ -247,6 +258,8 @@ export function parseMinidumpBuffer(
 
     let faultingModule: string | undefined;
     let faultingOffset: string | undefined;
+    let faultingDebugFile: string | undefined;
+    let faultingDebugId: string | undefined;
     if (moduleListRva !== 0 && instructionPointer !== 0n) {
       const module = findModule(
         parseModules(view, buf, moduleListRva),
@@ -255,6 +268,12 @@ export function parseMinidumpBuffer(
       if (module) {
         faultingModule = basename(module.name);
         faultingOffset = "0x" + (instructionPointer - module.base).toString(16);
+        const identity = parseDebugIdentity(view, buf, module.recordRva);
+        faultingDebugId = identity.debugId;
+        // ELF build id records carry no name; the module name keys the file.
+        faultingDebugFile = identity.debugId
+          ? (identity.debugFile ?? faultingModule)
+          : undefined;
       }
     }
 
@@ -263,6 +282,8 @@ export function parseMinidumpBuffer(
       exceptionCode,
       faultingModule,
       faultingOffset,
+      faultingDebugFile,
+      faultingDebugId,
       ptype: crashpadInfoRva
         ? parsePtype(view, buf, crashpadInfoRva)
         : undefined,
@@ -376,7 +397,12 @@ function parseModules(
     const base = view.getBigUint64(m + MODULE_BASE_OFF, true);
     const size = view.getUint32(m + MODULE_SIZE_OFF, true);
     const nameRva = view.getUint32(m + MODULE_NAME_RVA_OFF, true);
-    modules.push({ base, size, name: readMinidumpString(view, buf, nameRva) });
+    modules.push({
+      base,
+      size,
+      name: readMinidumpString(view, buf, nameRva),
+      recordRva: m,
+    });
   }
   return modules;
 }
@@ -390,6 +416,80 @@ function findModule(
   return modules.find(
     (m) => address >= m.base && address < m.base + BigInt(m.size),
   );
+}
+
+// Debug identity from a module's CodeView record: the file name and the
+// Breakpad debug id that key the module's symbol file on a symbol server.
+function parseDebugIdentity(
+  view: DataView,
+  buf: Buffer,
+  moduleRecordRva: number,
+): { debugFile?: string; debugId?: string } {
+  try {
+    if (moduleRecordRva + MODULE_CV_RVA_OFF + 4 > buf.length) {
+      return {};
+    }
+    const cvSize = view.getUint32(moduleRecordRva + MODULE_CV_SIZE_OFF, true);
+    const cvRva = view.getUint32(moduleRecordRva + MODULE_CV_RVA_OFF, true);
+    if (cvRva === 0 || cvSize < 4 || cvRva + cvSize > buf.length) {
+      return {};
+    }
+    const signature = view.getUint32(cvRva, true);
+    // Minimum pdb70 size: 4 signature + 16 GUID + 4 age + 1 for the name's
+    // NUL terminator.
+    if (signature === CV_SIG_PDB70 && cvSize >= 25) {
+      // "RSDS" | GUID (16) | u32 age | debug file name, NUL terminated.
+      const guid = buf.subarray(cvRva + 4, cvRva + 20);
+      const age = view.getUint32(cvRva + 20, true);
+      const nameStart = cvRva + 24;
+      let nameEnd = buf.indexOf(0, nameStart);
+      if (nameEnd < 0 || nameEnd > cvRva + cvSize) {
+        nameEnd = cvRva + cvSize;
+      }
+      const debugFile = basename(buf.toString("utf8", nameStart, nameEnd));
+      return {
+        debugFile: debugFile || undefined,
+        debugId: formatDebugId(guid, age),
+      };
+    }
+    if (signature === CV_SIG_ELF_BUILD_ID && cvSize > 4) {
+      // "BpEL" | raw build id. The id is the first 16 bytes with age 0,
+      // and there is no name field. Buffer.alloc zero fills, so a build
+      // id shorter than 16 bytes comes out zero padded; Math.min stops
+      // the copy at whichever ends first, the 16 bytes or the record.
+      const raw = Buffer.alloc(16);
+      buf.copy(raw, 0, cvRva + 4, Math.min(cvRva + 20, cvRva + cvSize));
+      return { debugId: formatDebugId(raw, 0) };
+    }
+  } catch {
+    // best effort: the debug identity is optional
+  }
+  return {};
+}
+
+// Breakpad debug id: the GUID's first three fields are stored little
+// endian and printed byte swapped, then the rest in order, then the age
+// in hex, all uppercase.
+function formatDebugId(guid: Buffer, age: number): string {
+  const ordered = [
+    // A GUID is u32 + u16 + u16 + 8 raw bytes. The integers are stored
+    // little endian but print big endian, so reverse the bytes within
+    // each one. Data1, 4 bytes:
+    guid[3],
+    guid[2],
+    guid[1],
+    guid[0],
+    // Data2 and Data3, 2 bytes each:
+    guid[5],
+    guid[4],
+    guid[7],
+    guid[6],
+    // Data4 is raw bytes with no internal order to fix.
+    ...guid.subarray(8, 16),
+  ];
+  // Two hex digits per byte, zero padded so 0x5 prints as "05".
+  const hex = ordered.map((b) => b.toString(16).padStart(2, "0")).join("");
+  return (hex + age.toString(16)).toUpperCase();
 }
 
 // MINIDUMP_STRING: u32 byte-length followed by UTF-16LE.


### PR DESCRIPTION
*This description was written by Claude but is human-reviewed*

Crash telemetry identifies a native crash by module name and offset, but an offset can only be resolved to a function name with the symbol file for the exact build, and nothing in the event says which build that is. The module's CodeView record in the dump carries exactly that: a debug file name and a debug id, the two values symbol servers key on.

The parser now reads the faulting module's CodeView record and adds faulting_debug_file and faulting_debug_id to app:crash_detected. Both record formats are handled: RSDS (Windows and macOS: GUID, age, and the embedded debug file name, which survives binary renaming) and Crashpad's ELF build id record (Linux; the module name keys the file). The Breakpad id string requires byte swapping the GUID's first three fields; tests pin known-answer vectors for both formats.

Both record formats were verified against rust-minidump as an oracle: on real dumps, the extracted identity matches minidump-stackwalk's byte for byte.

With these fields, an offline resolver can turn telemetry frames into function names, retroactively for all events sent after this ships. A follow-up PR adds that resolver.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

