### PR TITLE
Ignore generated keychain reader binaries

### DIFF
--- a/native/keychain-reader/.gitignore
+++ b/native/keychain-reader/.gitignore
@@ -1,1 +1,2 @@
 build/
+bin/


### PR DESCRIPTION
## Summary
- ignore ABI-specific native binaries generated by Electron Rebuild
- keep generated keychain reader artifacts out of Git status

## Verification
- Not run (not requested)

#skip-bugbot

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

