### PR TITLE
Improve security review actions

### DIFF
--- a/e2e-tests/helpers/page-objects/components/SecurityReview.ts
+++ b/e2e-tests/helpers/page-objects/components/SecurityReview.ts
@@ -15,13 +15,13 @@ export class SecurityReview {
 
   async clickRunSecurityReview() {
     const runSecurityReviewButton = this.page
-      .getByRole("button", { name: "Run Security Review" })
+      .getByRole("button", { name: "Run review" })
       .first();
     await runSecurityReviewButton.click();
-    // Wait for the "Running Security Review..." button to appear and then disappear
+    // Wait for the "Running review..." button to appear and then disappear
     // This indicates the security review has completed
     const runningButton = this.page.getByRole("button", {
-      name: "Running Security Review...",
+      name: "Running review...",
     });
     await runningButton.waitFor({ state: "visible" });
     await runningButton.waitFor({ state: "hidden" });

--- a/src/components/preview_panel/SecurityPanel.test.tsx
+++ b/src/components/preview_panel/SecurityPanel.test.tsx
@@ -127,6 +127,7 @@ describe("SecurityPanel", () => {
       created: true,
     });
     mocks.streamMessage.mockResolvedValue(undefined);
+    mocks.createChat.mockResolvedValue(99);
     mocks.reviewData.findings[0].fixChatId = undefined;
   });
 
@@ -294,6 +295,24 @@ describe("SecurityPanel", () => {
         }),
       );
     });
+  });
+
+  it("disables fixes from stale review data while a new review is running", async () => {
+    mocks.streamMessage.mockImplementation(async () => {});
+
+    render(<SecurityPanel />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Run review" }));
+
+    await screen.findByRole("button", { name: "Running review..." });
+    expect(
+      (
+        screen.getByRole("button", {
+          name: "Fix all issues",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+    expect(mocks.getOrCreateSecurityFixChat).not.toHaveBeenCalled();
   });
 
   it("shows an existing fix and offers re-run from its overflow menu", async () => {

--- a/src/components/preview_panel/SecurityPanel.test.tsx
+++ b/src/components/preview_panel/SecurityPanel.test.tsx
@@ -150,7 +150,7 @@ describe("SecurityPanel", () => {
       expect(mocks.streamMessage).toHaveBeenCalledTimes(1);
     });
     expect(
-      screen.getByRole("button", { name: /Fixing 2 issues/ }),
+      screen.getByRole("button", { name: /Fixing all issues/ }),
     ).toBeTruthy();
 
     // Persisting the fix-chat mapping refetches the same review with new
@@ -158,7 +158,7 @@ describe("SecurityPanel", () => {
     mocks.reviewData = { ...mocks.reviewData };
     rerender(<SecurityPanel />);
     expect(
-      screen.getByRole("button", { name: /Fixing 2 issues/ }),
+      screen.getByRole("button", { name: /Fixing all issues/ }),
     ).toBeTruthy();
 
     act(() => {
@@ -167,7 +167,7 @@ describe("SecurityPanel", () => {
 
     await waitFor(() => {
       expect(
-        screen.queryByRole("button", { name: /Fixing 2 issues/ }),
+        screen.queryByRole("button", { name: /Fixing all issues/ }),
       ).toBeNull();
     });
     expect(
@@ -230,7 +230,7 @@ describe("SecurityPanel", () => {
       );
     });
     expect(
-      screen.getByRole("button", { name: /Fixing 2 issues/ }),
+      screen.getByRole("button", { name: /Fixing all issues/ }),
     ).toBeTruthy();
 
     act(() => {
@@ -242,6 +242,35 @@ describe("SecurityPanel", () => {
         screen.getByRole("button", { name: "Show fix for all issues" }),
       ).toBeTruthy();
     });
+  });
+
+  it("uses the reused subset scope while a bulk fix is re-running", async () => {
+    mocks.getOrCreateSecurityFixChat.mockResolvedValue({
+      chatId: 85,
+      created: false,
+    });
+    mocks.streamMessage.mockImplementation(async () => {});
+
+    render(<SecurityPanel />);
+
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: "Select SQL injection" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Fix 1 issue" }));
+
+    expect(
+      await screen.findByRole("button", { name: "Show fix for 1 issue" }),
+    ).toBeTruthy();
+    fireEvent.click(
+      screen.getByRole("button", { name: "More fix actions for 1 issue" }),
+    );
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "Re-run fix" }),
+    );
+
+    expect(
+      await screen.findByRole("button", { name: "Fixing 1 issue..." }),
+    ).toBeTruthy();
   });
 
   it("offers to fix all findings when none are selected", async () => {

--- a/src/components/preview_panel/SecurityPanel.test.tsx
+++ b/src/components/preview_panel/SecurityPanel.test.tsx
@@ -287,11 +287,13 @@ describe("SecurityPanel", () => {
         }),
       );
     });
-    expect(mocks.streamMessage).toHaveBeenCalledWith(
-      expect.objectContaining({
-        prompt: expect.stringContaining("2 security issues"),
-      }),
-    );
+    await waitFor(() => {
+      expect(mocks.streamMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          prompt: expect.stringContaining("2 security issues"),
+        }),
+      );
+    });
   });
 
   it("shows an existing fix and offers re-run from its overflow menu", async () => {

--- a/src/components/preview_panel/SecurityPanel.test.tsx
+++ b/src/components/preview_panel/SecurityPanel.test.tsx
@@ -144,13 +144,13 @@ describe("SecurityPanel", () => {
       screen.getByRole("checkbox", { name: "Select SQL injection" }),
     );
     fireEvent.click(screen.getByRole("checkbox", { name: "Select XSS" }));
-    fireEvent.click(screen.getByRole("button", { name: "Fix 2 Issues" }));
+    fireEvent.click(screen.getByRole("button", { name: "Fix 2 issues" }));
 
     await waitFor(() => {
       expect(mocks.streamMessage).toHaveBeenCalledTimes(1);
     });
     expect(
-      screen.getByRole("button", { name: /Fixing 2 Issues/ }),
+      screen.getByRole("button", { name: /Fixing 2 issues/ }),
     ).toBeTruthy();
 
     // Persisting the fix-chat mapping refetches the same review with new
@@ -158,7 +158,7 @@ describe("SecurityPanel", () => {
     mocks.reviewData = { ...mocks.reviewData };
     rerender(<SecurityPanel />);
     expect(
-      screen.getByRole("button", { name: /Fixing 2 Issues/ }),
+      screen.getByRole("button", { name: /Fixing 2 issues/ }),
     ).toBeTruthy();
 
     act(() => {
@@ -167,13 +167,15 @@ describe("SecurityPanel", () => {
 
     await waitFor(() => {
       expect(
-        screen.queryByRole("button", { name: /Fixing 2 Issues/ }),
+        screen.queryByRole("button", { name: /Fixing 2 issues/ }),
       ).toBeNull();
     });
-    expect(screen.queryByRole("button", { name: "Fix 2 Issues" })).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Show fix for all issues" }),
+    ).toBeTruthy();
   });
 
-  it("offers to re-run a reused bulk fix chat with the selected findings", async () => {
+  it("shows a reused all-issues fix chat and offers re-run from its dropdown", async () => {
     mocks.getOrCreateSecurityFixChat.mockResolvedValue({
       chatId: 84,
       created: false,
@@ -191,18 +193,31 @@ describe("SecurityPanel", () => {
       screen.getByRole("checkbox", { name: "Select SQL injection" }),
     );
     fireEvent.click(screen.getByRole("checkbox", { name: "Select XSS" }));
-    fireEvent.click(screen.getByRole("button", { name: "Fix 2 Issues" }));
+    fireEvent.click(screen.getByRole("button", { name: "Fix 2 issues" }));
 
     expect(
       await screen.findByRole("button", {
-        name: "Re-run Fix for 2 Issues",
+        name: "Show fix for all issues",
       }),
     ).toBeTruthy();
     expect(mocks.streamMessage).not.toHaveBeenCalled();
     expect(mocks.selectChat).toHaveBeenLastCalledWith({ chatId: 84, appId: 1 });
+    expect(
+      screen.getByRole("button", { name: "Run review" }).className,
+    ).toContain("bg-primary");
 
     fireEvent.click(
-      screen.getByRole("button", { name: "Re-run Fix for 2 Issues" }),
+      screen.getByRole("button", { name: "Show fix for all issues" }),
+    );
+    expect(mocks.toastInfo).toHaveBeenCalledWith("Opened fix chat");
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "More fix actions for all issues",
+      }),
+    );
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "Re-run fix" }),
     );
 
     await waitFor(() => {
@@ -215,7 +230,7 @@ describe("SecurityPanel", () => {
       );
     });
     expect(
-      screen.getByRole("button", { name: /Fixing 2 Issues/ }),
+      screen.getByRole("button", { name: /Fixing 2 issues/ }),
     ).toBeTruthy();
 
     act(() => {
@@ -223,8 +238,31 @@ describe("SecurityPanel", () => {
     });
 
     await waitFor(() => {
-      expect(screen.queryByRole("button", { name: /2 Issues/ })).toBeNull();
+      expect(
+        screen.getByRole("button", { name: "Show fix for all issues" }),
+      ).toBeTruthy();
     });
+  });
+
+  it("offers to fix all findings when none are selected", async () => {
+    render(<SecurityPanel />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Fix all issues" }));
+
+    await waitFor(() => {
+      expect(mocks.getOrCreateSecurityFixChat).toHaveBeenCalledWith(
+        expect.objectContaining({
+          appId: 1,
+          reviewChatId: 7,
+          findings: mocks.reviewData.findings,
+        }),
+      );
+    });
+    expect(mocks.streamMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: expect.stringContaining("2 security issues"),
+      }),
+    );
   });
 
   it("shows an existing fix and offers re-run from its overflow menu", async () => {

--- a/src/components/preview_panel/SecurityPanel.tsx
+++ b/src/components/preview_panel/SecurityPanel.tsx
@@ -255,6 +255,9 @@ function SecurityHeader({
       : `${selectedFixCount} issue${selectedFixCount === 1 ? "" : "s"}`;
   const hasSelectedFix = selectedFixCount !== undefined;
   const showSelectedFixActions = hasSelectedFix && !isFixingSelected;
+  const activeIssueLabel = hasSelectedFix
+    ? existingFixIssueLabel
+    : selectedIssueLabel;
 
   return (
     <div className="sticky top-0 z-10 space-y-2.5 bg-background py-3">
@@ -325,12 +328,9 @@ function SecurityHeader({
                   <ChevronDown className="size-4" />
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">
-                  <DropdownMenuItem
-                    onClick={onRerunSelectedFix}
-                    disabled={isFixingSelected}
-                  >
+                  <DropdownMenuItem onClick={onRerunSelectedFix}>
                     <Wrench className="size-4" />
-                    {isFixingSelected ? "Re-running fix..." : "Re-run fix"}
+                    Re-run fix
                   </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>
@@ -368,7 +368,7 @@ function SecurityHeader({
                       d="m4 12a8 8 0 0 1 8-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 0 1 4 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
                     />
                   </svg>
-                  Fixing {selectedIssueLabel}...
+                  Fixing {activeIssueLabel}...
                 </>
               ) : (
                 <>

--- a/src/components/preview_panel/SecurityPanel.tsx
+++ b/src/components/preview_panel/SecurityPanel.tsx
@@ -15,12 +15,22 @@ import {
   DialogTitle,
   DialogClose,
 } from "@/components/ui/dialog";
-import { Shield, ChevronDown, Pencil, Wrench } from "lucide-react";
+import {
+  Shield,
+  ChevronDown,
+  ExternalLink,
+  Pencil,
+  Wrench,
+} from "lucide-react";
 import { getSeverityIcon, SeverityBadge } from "@/components/security/severity";
 import { useStreamChat } from "@/hooks/useStreamChat";
 import { showError } from "@/lib/toast";
-import { Badge } from "@/components/ui/badge";
 import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import type {
   SecurityFinding,
   SecurityReviewFinding,
@@ -110,15 +120,35 @@ const getSeverityOrder = (level: SecurityFinding["level"]): number => {
   }
 };
 
+const getSeveritySummaryColor = (level: SecurityFinding["level"]): string => {
+  switch (level) {
+    case "critical":
+      return "border-red-500/20 bg-red-500/8 text-red-700 dark:border-red-400/20 dark:bg-red-400/10 dark:text-red-300";
+    case "high":
+      return "border-orange-500/20 bg-orange-500/8 text-orange-700 dark:border-orange-400/20 dark:bg-orange-400/10 dark:text-orange-300";
+    case "medium":
+      return "border-amber-500/20 bg-amber-500/8 text-amber-800 dark:border-amber-400/20 dark:bg-amber-400/10 dark:text-amber-300";
+    case "low":
+      return "border-slate-500/15 bg-slate-500/8 text-slate-700 dark:border-slate-400/20 dark:bg-slate-400/10 dark:text-slate-300";
+  }
+};
+
 function RunReviewButton({
   isRunning,
   onRun,
+  secondary = false,
 }: {
   isRunning: boolean;
   onRun: () => void;
+  secondary?: boolean;
 }) {
   return (
-    <Button onClick={onRun} className="gap-2" disabled={isRunning}>
+    <Button
+      onClick={onRun}
+      className="gap-2"
+      disabled={isRunning}
+      variant={secondary ? "outline" : "default"}
+    >
       {isRunning ? (
         <>
           <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
@@ -136,12 +166,12 @@ function RunReviewButton({
               d="m4 12a8 8 0 0 1 8-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 0 1 4 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
             />
           </svg>
-          Running Security Review...
+          Running review...
         </>
       ) : (
         <>
           <Shield className="w-4 h-4" />
-          Run Security Review
+          Run review
         </>
       )}
     </Button>
@@ -165,22 +195,24 @@ function ReviewSummary({ data }: { data: SecurityReviewResult }) {
   ];
 
   return (
-    <div className="space-y-1 mt-1">
-      <div className="text-sm text-gray-600 dark:text-gray-400">
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+      <div className="text-xs text-muted-foreground">
         Last reviewed {formatTimeAgo(data.timestamp)}
       </div>
-      <div className="flex items-center gap-3 text-sm">
+      <div className="flex flex-wrap items-center gap-1.5 text-xs">
         {severityLevels
           .filter((level) => counts[level] > 0)
           .map((level) => (
-            <span key={level} className="flex items-center gap-1.5">
+            <span
+              key={level}
+              className={cn(
+                "flex items-center gap-1.5 rounded-md border px-2 py-1 font-medium",
+                getSeveritySummaryColor(level),
+              )}
+            >
               <span className="flex-shrink-0">{getSeverityIcon(level)}</span>
-              <span className="font-medium text-gray-900 dark:text-gray-100">
-                {counts[level]}
-              </span>
-              <span className="text-gray-600 dark:text-gray-400 capitalize">
-                {level}
-              </span>
+              <span>{counts[level]}</span>
+              <span className="capitalize">{level}</span>
             </span>
           ))}
       </div>
@@ -195,8 +227,10 @@ function SecurityHeader({
   onOpenEditRules,
   selectedCount,
   onFixSelected,
+  onShowSelectedFix,
+  onRerunSelectedFix,
   isFixingSelected,
-  canRerunSelectedFix,
+  selectedFixCount,
 }: {
   isRunning: boolean;
   onRun: () => void;
@@ -204,73 +238,114 @@ function SecurityHeader({
   onOpenEditRules: () => void;
   selectedCount: number;
   onFixSelected: () => void;
+  onShowSelectedFix: () => void;
+  onRerunSelectedFix: () => void;
   isFixingSelected: boolean;
-  canRerunSelectedFix: boolean;
+  selectedFixCount?: number;
 }) {
-  const [isButtonVisible, setIsButtonVisible] = useState(false);
-  const [shouldRender, setShouldRender] = useState(false);
-
-  useEffect(() => {
-    if (selectedCount > 0) {
-      // Show immediately
-      setShouldRender(true);
-      // Trigger animation after render
-      setTimeout(() => setIsButtonVisible(true), 10);
-    } else {
-      // Trigger exit animation
-      setIsButtonVisible(false);
-      // Hide after animation completes
-      const timer = setTimeout(() => setShouldRender(false), 300);
-      return () => clearTimeout(timer);
-    }
-  }, [selectedCount]);
+  const hasFindings = Boolean(data?.findings.length);
+  const totalFindingCount = data?.findings.length ?? 0;
+  const selectedIssueLabel =
+    selectedCount > 0
+      ? `${selectedCount} issue${selectedCount === 1 ? "" : "s"}`
+      : "all issues";
+  const existingFixIssueLabel =
+    selectedFixCount === totalFindingCount
+      ? "all issues"
+      : `${selectedFixCount} issue${selectedFixCount === 1 ? "" : "s"}`;
+  const hasSelectedFix = selectedFixCount !== undefined;
+  const showSelectedFixActions = hasSelectedFix && !isFixingSelected;
 
   return (
-    <div className="sticky top-0 z-10 bg-background pt-3 pb-3 space-y-2">
-      <div className="flex items-center justify-between gap-2">
-        <div>
-          <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100 mb-1 flex items-center gap-2">
-            <Shield className="w-5 h-5" />
+    <div className="sticky top-0 z-10 space-y-2.5 bg-background py-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="flex min-w-48 flex-1 items-center gap-1">
+          <Shield className="size-5 shrink-0" />
+          <h1 className="truncate text-lg font-semibold text-foreground">
             Security Review
-            <Badge variant="secondary" className="uppercase tracking-wide">
-              experimental
-            </Badge>
           </h1>
-          <div className="text-sm">
-            <p>
-              <a
-                className="text-blue-600 dark:text-blue-400 hover:underline cursor-pointer"
-                onClick={() =>
-                  ipc.system.openExternalUrl(
-                    "https://www.dyad.sh/docs/guides/security-review",
-                  )
-                }
-              >
-                Open Security Review docs
-              </a>
-            </p>
-          </div>
-          {data && data.findings.length > 0 && <ReviewSummary data={data} />}
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="size-8 text-muted-foreground"
+                  aria-label="Open Security Review documentation"
+                  onClick={() =>
+                    ipc.system.openExternalUrl(
+                      "https://www.dyad.sh/docs/guides/security-review",
+                    )
+                  }
+                />
+              }
+            >
+              <ExternalLink className="size-4" />
+            </TooltipTrigger>
+            <TooltipContent>Open Security Review docs</TooltipContent>
+          </Tooltip>
         </div>
-        <div className="flex flex-col items-end gap-2">
-          <Button variant="outline" onClick={onOpenEditRules}>
-            <Pencil className="w-4 h-4" />
-            Edit Security Rules
-          </Button>
-          <div className="flex items-center gap-2">
+        <div className="ml-auto flex flex-wrap items-center justify-end gap-2">
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="text-muted-foreground"
+                  aria-label="Edit security rules"
+                  onClick={onOpenEditRules}
+                />
+              }
+            >
+              <Pencil className="size-4" />
+              Edit rules
+            </TooltipTrigger>
+            <TooltipContent>Edit security rules</TooltipContent>
+          </Tooltip>
+          {showSelectedFixActions && (
+            <div className="inline-flex">
+              <Button
+                onClick={onShowSelectedFix}
+                variant="outline"
+                className="rounded-r-none"
+              >
+                Show fix for {existingFixIssueLabel}
+              </Button>
+              <DropdownMenu>
+                <DropdownMenuTrigger
+                  render={
+                    <Button
+                      variant="outline"
+                      className="rounded-l-none border-l-0 px-2"
+                      aria-label={`More fix actions for ${existingFixIssueLabel}`}
+                    />
+                  }
+                >
+                  <ChevronDown className="size-4" />
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem
+                    onClick={onRerunSelectedFix}
+                    disabled={isFixingSelected}
+                  >
+                    <Wrench className="size-4" />
+                    {isFixingSelected ? "Re-running fix..." : "Re-run fix"}
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          )}
+          <RunReviewButton
+            isRunning={isRunning}
+            onRun={onRun}
+            secondary={hasFindings && !showSelectedFixActions}
+          />
+          {hasFindings && !showSelectedFixActions && (
             <Button
-              variant="outline"
               onClick={onFixSelected}
-              className="gap-2 transition-all duration-300"
+              className="gap-2"
               disabled={isFixingSelected}
-              style={{
-                visibility: shouldRender ? "visible" : "hidden",
-                opacity: isButtonVisible ? 1 : 0,
-                transform: isButtonVisible
-                  ? "translateY(0)"
-                  : "translateY(-8px)",
-                pointerEvents: shouldRender ? "auto" : "none",
-              }}
             >
               {isFixingSelected ? (
                 <>
@@ -293,21 +368,19 @@ function SecurityHeader({
                       d="m4 12a8 8 0 0 1 8-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 0 1 4 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
                     />
                   </svg>
-                  Fixing {selectedCount} Issue{selectedCount !== 1 ? "s" : ""}
-                  ...
+                  Fixing {selectedIssueLabel}...
                 </>
               ) : (
                 <>
                   <Wrench className="w-4 h-4" />
-                  {canRerunSelectedFix ? "Re-run Fix for" : "Fix"}{" "}
-                  {selectedCount} Issue{selectedCount !== 1 ? "s" : ""}
+                  Fix {selectedIssueLabel}
                 </>
               )}
             </Button>
-            <RunReviewButton isRunning={isRunning} onRun={onRun} />
-          </div>
+          )}
         </div>
       </div>
+      {hasFindings && data && <ReviewSummary data={data} />}
     </div>
   );
 }
@@ -1019,34 +1092,19 @@ export const SecurityPanel = () => {
       showError("No app selected");
       return;
     }
-    if (selectedFindings.size === 0) {
-      showError("No issues selected");
-      return;
-    }
     if (!data?.findings) {
       showError("No security review loaded");
       return;
     }
 
-    // Get the selected findings
-    const findingsToFix = data.findings.filter((finding) =>
-      selectedFindings.has(createFindingKey(finding)),
-    );
+    const findingsToFix =
+      selectedFindings.size > 0
+        ? data.findings.filter((finding) =>
+            selectedFindings.has(createFindingKey(finding)),
+          )
+        : data.findings;
     if (findingsToFix.length === 0) {
       showError("No valid issues selected");
-      return;
-    }
-
-    if (selectedFixChat) {
-      await streamFixPrompt({
-        chatId: selectedFixChat.chatId,
-        findingsToFix: selectedFixChat.findings,
-        setFixing: setIsFixingSelected,
-        onFixSettled: () => {
-          setSelectedFindings(new Set());
-          setSelectedFixChat(null);
-        },
-      });
       return;
     }
 
@@ -1055,12 +1113,30 @@ export const SecurityPanel = () => {
       setFixing: setIsFixingSelected,
       onFixSettled: () => {
         setSelectedFindings(new Set());
-        setSelectedFixChat(null);
       },
     });
-    if (result && !result.created) {
+    if (result) {
       setSelectedFixChat({ chatId: result.chatId, findings: findingsToFix });
     }
+  };
+
+  const handleShowSelectedFix = () => {
+    if (!selectedFixChat) {
+      return;
+    }
+    showFixChat(selectedFixChat.chatId);
+    toast.info("Opened fix chat");
+  };
+
+  const handleRerunSelectedFix = async () => {
+    if (!selectedFixChat) {
+      return;
+    }
+    await streamFixPrompt({
+      chatId: selectedFixChat.chatId,
+      findingsToFix: selectedFixChat.findings,
+      setFixing: setIsFixingSelected,
+    });
   };
 
   if (isLoading) {
@@ -1086,8 +1162,10 @@ export const SecurityPanel = () => {
           }}
           selectedCount={selectedFindings.size}
           onFixSelected={handleFixSelected}
+          onShowSelectedFix={handleShowSelectedFix}
+          onRerunSelectedFix={handleRerunSelectedFix}
           isFixingSelected={isFixingSelected}
-          canRerunSelectedFix={selectedFixChat !== null}
+          selectedFixCount={selectedFixChat?.findings.length}
         />
 
         {isRunningReview ? (

--- a/src/components/preview_panel/SecurityPanel.tsx
+++ b/src/components/preview_panel/SecurityPanel.tsx
@@ -251,9 +251,11 @@ function SecurityHeader({
       ? `${selectedCount} issue${selectedCount === 1 ? "" : "s"}`
       : "all issues";
   const existingFixIssueLabel =
-    selectedFixCount === totalFindingCount
-      ? "all issues"
-      : `${selectedFixCount} issue${selectedFixCount === 1 ? "" : "s"}`;
+    selectedFixCount === undefined
+      ? ""
+      : selectedFixCount === totalFindingCount
+        ? "all issues"
+        : `${selectedFixCount} issue${selectedFixCount === 1 ? "" : "s"}`;
   const hasSelectedFix = selectedFixCount !== undefined;
   const showSelectedFixActions = hasSelectedFix && !isFixingSelected;
   const activeIssueLabel = hasSelectedFix
@@ -313,6 +315,7 @@ function SecurityHeader({
                 onClick={onShowSelectedFix}
                 variant="outline"
                 className="rounded-r-none"
+                disabled={isRunning}
               >
                 Show fix for {existingFixIssueLabel}
               </Button>
@@ -323,13 +326,17 @@ function SecurityHeader({
                       variant="outline"
                       className="rounded-l-none border-l-0 px-2"
                       aria-label={`More fix actions for ${existingFixIssueLabel}`}
+                      disabled={isRunning}
                     />
                   }
                 >
                   <ChevronDown className="size-4" />
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">
-                  <DropdownMenuItem onClick={onRerunSelectedFix}>
+                  <DropdownMenuItem
+                    onClick={onRerunSelectedFix}
+                    disabled={isRunning}
+                  >
                     <Wrench className="size-4" />
                     Re-run fix
                   </DropdownMenuItem>
@@ -346,7 +353,7 @@ function SecurityHeader({
             <Button
               onClick={onFixSelected}
               className="gap-2"
-              disabled={isFixingSelected}
+              disabled={isRunning || isFixingSelected}
             >
               {isFixingSelected ? (
                 <>

--- a/src/components/preview_panel/SecurityPanel.tsx
+++ b/src/components/preview_panel/SecurityPanel.tsx
@@ -148,6 +148,7 @@ function RunReviewButton({
       className="gap-2"
       disabled={isRunning}
       variant={secondary ? "outline" : "default"}
+      data-variant={secondary ? "secondary" : "primary"}
     >
       {isRunning ? (
         <>

--- a/src/ipc/handlers/__tests__/security_review.integration.test.ts
+++ b/src/ipc/handlers/__tests__/security_review.integration.test.ts
@@ -266,8 +266,10 @@ ${finding.description}`;
         screen.getByRole("button", { name: "Show fix for all issues" }),
       ).toBeTruthy();
       expect(
-        screen.getByRole("button", { name: "Run review" }).className,
-      ).toContain("bg-primary");
+        screen
+          .getByRole("button", { name: "Run review" })
+          .getAttribute("data-variant"),
+      ).toBe("primary");
     });
 
     fireEvent.click(

--- a/src/ipc/handlers/__tests__/security_review.integration.test.ts
+++ b/src/ipc/handlers/__tests__/security_review.integration.test.ts
@@ -27,16 +27,16 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
-import { screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
 
 import {
   setupHybridChatHarness,
   type HybridChatHarness,
 } from "@/testing/hybrid_chat_harness";
 import { h } from "@/testing/hybrid.setup";
-import { messages as messagesTable } from "@/db/schema";
+import { messages as messagesTable, security_fix_chats } from "@/db/schema";
 import type { SecurityFinding } from "@/ipc/types/security";
-import { asc, eq } from "drizzle-orm";
+import { and, asc, desc, eq } from "drizzle-orm";
 
 describe("security review (integration)", () => {
   let harness: HybridChatHarness;
@@ -205,13 +205,11 @@ ${finding.description}`;
     await harness.bridge.settleInFlight();
   }, 60_000);
 
-  it("multi-select fix: streams a combined 2-issue prompt in a new chat", async () => {
+  it("fixes all issues, shows the bulk fix, and re-runs it in the same chat", async () => {
     expect(findings.length).toBeGreaterThanOrEqual(2);
-    const findingsToFix = findings.slice(0, 2);
 
-    // The previous test already committed the canned file1.txt write; perturb
-    // and commit it so this turn's identical canned write is a real change
-    // again (each e2e test ran against a fresh app).
+    // The previous test committed the canned file1.txt write. Perturb and
+    // commit it so this UI-driven bulk fix produces another real change.
     await harness.bridge.settleInFlight();
     fs.writeFileSync(path.join(harness.appDir, "file1.txt"), "perturbed\n");
     execFileSync("git", ["add", "-A"], { cwd: harness.appDir });
@@ -229,49 +227,108 @@ ${finding.description}`;
       { cwd: harness.appDir },
     );
 
-    // Prompt built exactly like SecurityPanel.handleFixSelected.
-    const issuesList = findingsToFix
-      .map(
-        (finding, index) =>
-          `${index + 1}. **${finding.title}** (${finding.level} severity)\n${finding.description}`,
-      )
-      .join("\n\n");
-    const prompt = `Please fix the following ${findingsToFix.length} security issue${findingsToFix.length !== 1 ? "s" : ""} in a simple and effective way:
-
-${issuesList}`;
-
-    const fixChatId = await harness.createChat();
-    harness.mount({ chatId: fixChatId });
-    await waitFor(
-      () => expect(screen.getByTestId("chat-input-container")).toBeTruthy(),
-      { timeout: 15_000 },
-    );
-
-    const fixEnd = harness.waitForNextStreamEnd(fixChatId);
-    const { send } = await harness.typeInChat(prompt, { chatId: fixChatId });
-    send();
-
+    cleanup();
+    harness.mount({ withSecurityPanel: true });
     await waitFor(
       () =>
         expect(
-          screen.getByText(/Please fix the following 2 security issues/),
+          screen.getByRole("button", { name: "Fix all issues" }),
         ).toBeTruthy(),
       { timeout: 15_000 },
     );
-    await waitFor(() => expect(screen.getByText(/EOM/)).toBeTruthy(), {
-      timeout: 20_000,
+
+    fireEvent.click(screen.getByRole("button", { name: "Fix all issues" }));
+
+    let bulkFixChatId: number | undefined;
+    await waitFor(async () => {
+      const [bulkFix] = await harness.db
+        .select()
+        .from(security_fix_chats)
+        .where(
+          and(
+            eq(security_fix_chats.appId, harness.appId),
+            eq(
+              security_fix_chats.reviewChatId,
+              (await getLatestSecurityReview()).chatId,
+            ),
+          ),
+        )
+        .orderBy(desc(security_fix_chats.id))
+        .limit(1);
+      expect(bulkFix).toBeTruthy();
+      bulkFixChatId = bulkFix.fixChatId;
     });
-    await fixEnd;
+    expect(bulkFixChatId).toBeDefined();
+    await harness.waitForStreamEnd(bulkFixChatId);
 
-    const messages = await loadChatMessages(fixChatId);
-    const user = messages.find((m) => m.role === "user")!;
-    expect(user.content).toMatch(/^Please fix the following 2 security issues/);
-    expect(user.content).toContain(findingsToFix[0].title);
-    expect(user.content).toContain(findingsToFix[1].title);
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Show fix for all issues" }),
+      ).toBeTruthy();
+      expect(
+        screen.getByRole("button", { name: "Run review" }).className,
+      ).toContain("bg-primary");
+    });
 
-    const assistant = messages.find((m) => m.role === "assistant")!;
-    expect(assistant.approvalState).toBe("approved");
-    expect(assistant.commitHash).toBeTruthy();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Show fix for all issues" }),
+    );
+    await waitFor(() => {
+      expect(harness.currentLocation().search.id).toBe(bulkFixChatId);
+    });
+
+    // Make the canned rerun write produce a fresh commit too.
+    await harness.bridge.settleInFlight();
+    fs.writeFileSync(
+      path.join(harness.appDir, "file1.txt"),
+      "perturbed again\n",
+    );
+    execFileSync("git", ["add", "-A"], { cwd: harness.appDir });
+    execFileSync(
+      "git",
+      [
+        "-c",
+        "user.email=test@example.com",
+        "-c",
+        "user.name=Test User",
+        "commit",
+        "-m",
+        "perturb file1.txt again",
+      ],
+      { cwd: harness.appDir },
+    );
+
+    const rerunEnd = harness.waitForNextStreamEnd(bulkFixChatId);
+    const moreActions = screen.getByRole("button", {
+      name: "More fix actions for all issues",
+    });
+    await harness.openPopover(moreActions);
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "Re-run fix" }),
+    );
+    await rerunEnd;
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Show fix for all issues" }),
+      ).toBeTruthy(),
+    );
+    const bulkMessages = await loadChatMessages(bulkFixChatId!);
+    const bulkPrompts = bulkMessages.filter(
+      (message) => message.role === "user",
+    );
+    expect(bulkPrompts).toHaveLength(2);
+    for (const prompt of bulkPrompts) {
+      expect(prompt.content).toContain(
+        `Please fix the following ${findings.length} security issues`,
+      );
+    }
+
+    const matchingFixChats = await harness.db
+      .select()
+      .from(security_fix_chats)
+      .where(eq(security_fix_chats.fixChatId, bulkFixChatId!));
+    expect(matchingFixChats).toHaveLength(1);
   }, 60_000);
 
   it("edit and use knowledge: SECURITY_RULES.md is added to the review context", async () => {

--- a/src/testing/hybrid_chat_harness.tsx
+++ b/src/testing/hybrid_chat_harness.tsx
@@ -83,6 +83,7 @@ import { AppList } from "@/components/AppList";
 import { ChatList } from "@/components/ChatList";
 import { PrivacyBanner } from "@/components/TelemetryBanner";
 import { PlanPanel } from "@/components/preview_panel/PlanPanel";
+import { SecurityPanel } from "@/components/preview_panel/SecurityPanel";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import { TitleBar } from "@/app/TitleBar";
 import { DeepLinkProvider } from "@/contexts/DeepLinkContext";
@@ -198,6 +199,8 @@ export interface MountOptions {
   wireAppEvents?: boolean;
   /** Render the plan preview panel alongside ChatPanel for plan-mode tests. */
   withPlanPanel?: boolean;
+  /** Render the security preview panel alongside ChatPanel. */
+  withSecurityPanel?: boolean;
   /** Render the real app sidebar list next to the mounted route. */
   withAppList?: boolean;
   /** Render the real chat sidebar list next to the mounted route. */
@@ -633,10 +636,11 @@ export async function setupHybridChatHarness(
             <>
               <ChatPanel
                 chatId={search.id}
-                isPreviewOpen={!!opts.withPlanPanel}
+                isPreviewOpen={!!opts.withPlanPanel || !!opts.withSecurityPanel}
                 onTogglePreview={() => {}}
               />
               {opts.withPlanPanel && <PlanPanel />}
+              {opts.withSecurityPanel && <SecurityPanel />}
             </>
           );
         },


### PR DESCRIPTION
## Summary
- Improve security review actions
- Primary files: src/components/preview_panel/SecurityPanel.test.tsx, src/components/preview_panel/SecurityPanel.tsx, src/ipc/handlers/__tests__/security_review.integration.test.ts, src/testing/hybrid_chat_harness.tsx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-visible fix/review orchestration and chat streaming paths in an experimental feature; behavior is well covered by tests but mistakes could trigger wrong fix scope or duplicate streams.
> 
> **Overview**
> **Security Review** header and bulk-fix flows are reworked so review, fix-all, and existing fix chats are clearer and easier to use from the preview panel.
> 
> The sticky header is simplified: shorter copy (**Run review**, **Fix N issues** / **Fix all issues**), severity chips for counts, and tooltips for docs and **Edit rules**. When a bulk fix chat already exists, the UI shows **Show fix for …** with a **Re-run fix** overflow menu instead of a single re-run button. **Fix** with no checkboxes now targets **all** findings; fix controls stay disabled while a review is in flight.
> 
> Bulk fix handling always opens or reuses a fix chat via `openFixChat` and tracks scope with `selectedFixChat` for labels and re-run, rather than streaming immediately on reuse from the primary fix button.
> 
> Tests cover fix-all, stale-review disabling, subset re-run labels, and a hybrid integration path that drives **Fix all issues** through the real **SecurityPanel** (`withSecurityPanel` on the harness).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab2d9eff57d2de978d4d3610353dc3b2d6e65b91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## E2E deflake

Failing run: https://github.com/dyad-sh/dyad/actions/runs/29360670540

The merged Playwright report showed all three unexpected tests failing on the same shared page-object locator. The PR changed the visible control from "Run Security Review" to "Run review", but `SecurityReview.clickRunSecurityReview()` still searched for the old idle label and also waited for the old "Running Security Review..." label.

The fix updates both shared locator states to the current UI copy. This is the correct contract because the failure was deterministic locator drift across both affected specs, not a timing race requiring retries.

Verification:
- `npm run fmt && npm run lint && npm run ts`
- `npm run build`
- `PLAYWRIGHT_HTML_OPEN=never npm run e2e -- e2e-tests/security_review.spec.ts e2e-tests/local_agent_advanced.spec.ts` (5 passed)

