### PR TITLE
feat: extract all Crashpad annotations from crash minidumps

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -67,7 +67,10 @@ import {
   moveDump,
   pruneDumps,
 } from "./utils/crash_dumps";
-import { crashPerformanceEventFields } from "./utils/crash_telemetry_fields";
+import {
+  crashAnnotationEventFields,
+  crashPerformanceEventFields,
+} from "./utils/crash_telemetry_fields";
 import {
   stopAllAppsSync,
   stopAppGarbageCollection,
@@ -239,19 +242,6 @@ function processNativeCrashDumps(): void {
     moveDump(file, path.join(retainDir, crashReportName(file)));
   }
   pruneDumps(retainDir, MAX_RETAINED_DUMPS);
-}
-
-// Crash annotations as flat telemetry fields, one property per key, because
-// PostHog cannot easily filter nested JSON. Keys are sanitized to snake case.
-function crashAnnotationEventFields(
-  annotations: Record<string, string>,
-): Record<string, string> {
-  const fields: Record<string, string> = {};
-  for (const [key, value] of Object.entries(annotations)) {
-    const name = key.toLowerCase().replace(/[^a-z0-9]+/g, "_");
-    fields[`crash_annotation_${name}`] = value;
-  }
-  return fields;
 }
 
 // A readable, sortable dump name from the crash time (the dump's mtime), with a

--- a/src/main.ts
+++ b/src/main.ts
@@ -241,6 +241,19 @@ function processNativeCrashDumps(): void {
   pruneDumps(retainDir, MAX_RETAINED_DUMPS);
 }
 
+// Crash annotations as flat telemetry fields, one property per key, because
+// PostHog cannot easily filter nested JSON. Keys are sanitized to snake case.
+function crashAnnotationEventFields(
+  annotations: Record<string, string>,
+): Record<string, string> {
+  const fields: Record<string, string> = {};
+  for (const [key, value] of Object.entries(annotations)) {
+    const name = key.toLowerCase().replace(/[^a-z0-9]+/g, "_");
+    fields[`crash_annotation_${name}`] = value;
+  }
+  return fields;
+}
+
 // A readable, sortable dump name from the crash time (the dump's mtime), with a
 // short id suffix to avoid collisions: crash-2026-06-07T20-41-55-123Z-9ac4d4e8.dmp
 function crashReportName(dumpPath: string): string {
@@ -652,6 +665,8 @@ const createWindow = () => {
           faulting_debug_file: nativeCrash.faultingDebugFile,
           faulting_debug_id: nativeCrash.faultingDebugId,
         }),
+        ...(nativeCrash?.annotations &&
+          crashAnnotationEventFields(nativeCrash.annotations)),
       });
 
       pendingForceCloseData = null;

--- a/src/utils/crash_telemetry_fields.test.ts
+++ b/src/utils/crash_telemetry_fields.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { crashPerformanceEventFields } from "@/utils/crash_telemetry_fields";
+import {
+  crashAnnotationEventFields,
+  crashPerformanceEventFields,
+} from "@/utils/crash_telemetry_fields";
 
 describe("crashPerformanceEventFields", () => {
   it("flattens working sets and activity into scalar fields", () => {
@@ -58,5 +61,41 @@ describe("crashPerformanceEventFields", () => {
     expect(fields.last_known_working_set_browser_mb).toBeUndefined();
     expect(fields.last_known_active_streams).toBeUndefined();
     expect(fields.peak_active_streams).toBeUndefined();
+  });
+});
+
+describe("crashAnnotationEventFields", () => {
+  it("prefixes and snake-cases annotation keys", () => {
+    expect(
+      crashAnnotationEventFields({
+        "electron.v8-oom.is_heap_oom": "1",
+        "lsb-release": "Linux Mint 22.3",
+        ptype: "utility",
+      }),
+    ).toEqual({
+      crash_annotation_electron_v8_oom_is_heap_oom: "1",
+      crash_annotation_lsb_release: "Linux Mint 22.3",
+      crash_annotation_ptype: "utility",
+    });
+  });
+
+  it("keeps the leading underscore of Electron's internal keys", () => {
+    // _productName and friends come from Electron's crashReporter; the
+    // double underscore marks them apart from same-named plain keys.
+    expect(crashAnnotationEventFields({ _productName: "dyad" })).toEqual({
+      crash_annotation__productname: "dyad",
+    });
+  });
+
+  it("lowercases and collapses runs of special characters", () => {
+    expect(crashAnnotationEventFields({ "GPU  Status?!": "ok" })).toEqual({
+      crash_annotation_gpu_status_: "ok",
+    });
+  });
+
+  it("lets the last key win when sanitized names collide", () => {
+    expect(
+      crashAnnotationEventFields({ "oom-size": "1", oom_size: "2" }),
+    ).toEqual({ crash_annotation_oom_size: "2" });
   });
 });

--- a/src/utils/crash_telemetry_fields.test.ts
+++ b/src/utils/crash_telemetry_fields.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  ALLOWED_ANNOTATION_KEYS,
   crashAnnotationEventFields,
   crashPerformanceEventFields,
 } from "@/utils/crash_telemetry_fields";
@@ -106,11 +107,21 @@ describe("crashAnnotationEventFields", () => {
     });
   });
 
+  it("normalizes every allowlisted key to a distinct field name", () => {
+    // Distinct field names are what lets the flattener assign without a
+    // collision check; this guards additions to the allowlist.
+    const fields = crashAnnotationEventFields(
+      Object.fromEntries([...ALLOWED_ANNOTATION_KEYS].map((k) => [k, "v"])),
+    );
+    expect(Object.keys(fields)).toHaveLength(ALLOWED_ANNOTATION_KEYS.size);
+  });
+
   it("passes the V8 heap keys through by exact name", () => {
     expect(
       crashAnnotationEventFields({
         "electron.v8-oom.heap.limit": "4144",
-        "electron.v8-fatal.message": "MarkCompactCollector: young object promotion failed",
+        "electron.v8-fatal.message":
+          "MarkCompactCollector: young object promotion failed",
       }),
     ).toEqual({
       crash_annotation_electron_v8_oom_heap_limit: "4144",

--- a/src/utils/crash_telemetry_fields.test.ts
+++ b/src/utils/crash_telemetry_fields.test.ts
@@ -93,9 +93,9 @@ describe("crashAnnotationEventFields", () => {
     });
   });
 
-  it("lets the last key win when sanitized names collide", () => {
+  it("lets the first key win when sanitized names collide", () => {
     expect(
       crashAnnotationEventFields({ "oom-size": "1", oom_size: "2" }),
-    ).toEqual({ crash_annotation_oom_size: "2" });
+    ).toEqual({ crash_annotation_oom_size: "1" });
   });
 });

--- a/src/utils/crash_telemetry_fields.test.ts
+++ b/src/utils/crash_telemetry_fields.test.ts
@@ -87,15 +87,28 @@ describe("crashAnnotationEventFields", () => {
     });
   });
 
-  it("lowercases and collapses runs of special characters", () => {
-    expect(crashAnnotationEventFields({ "GPU  Status?!": "ok" })).toEqual({
-      crash_annotation_gpu_status_: "ok",
+  it("drops keys outside the allowlist and reports only their count", () => {
+    expect(
+      crashAnnotationEventFields({
+        "url-chunk": "https://example.com/secret",
+        "switch-1": "--user-data-dir=/home/user",
+        "oom-size": "4096",
+      }),
+    ).toEqual({
+      crash_annotation_oom_size: "4096",
+      crash_annotations_dropped: 2,
+    });
+  });
+
+  it("omits the dropped count when nothing is dropped", () => {
+    expect(crashAnnotationEventFields({ ptype: "browser" })).toEqual({
+      crash_annotation_ptype: "browser",
     });
   });
 
   it("lets the first key win when sanitized names collide", () => {
     expect(
-      crashAnnotationEventFields({ "oom-size": "1", oom_size: "2" }),
-    ).toEqual({ crash_annotation_oom_size: "1" });
+      crashAnnotationEventFields({ "gpu-webgl": "1", gpu_webgl: "2" }),
+    ).toEqual({ crash_annotation_gpu_webgl: "1" });
   });
 });

--- a/src/utils/crash_telemetry_fields.test.ts
+++ b/src/utils/crash_telemetry_fields.test.ts
@@ -106,9 +106,16 @@ describe("crashAnnotationEventFields", () => {
     });
   });
 
-  it("lets the first key win when sanitized names collide", () => {
+  it("passes the V8 heap keys through by exact name", () => {
     expect(
-      crashAnnotationEventFields({ "gpu-webgl": "1", gpu_webgl: "2" }),
-    ).toEqual({ crash_annotation_gpu_webgl: "1" });
+      crashAnnotationEventFields({
+        "electron.v8-oom.heap.limit": "4144",
+        "electron.v8-fatal.message": "MarkCompactCollector: young object promotion failed",
+      }),
+    ).toEqual({
+      crash_annotation_electron_v8_oom_heap_limit: "4144",
+      crash_annotation_electron_v8_fatal_message:
+        "MarkCompactCollector: young object promotion failed",
+    });
   });
 });

--- a/src/utils/crash_telemetry_fields.ts
+++ b/src/utils/crash_telemetry_fields.ts
@@ -37,18 +37,72 @@ export function crashPerformanceEventFields(
   };
 }
 
-// Crash annotations as flat telemetry fields, one property per key, because
-// PostHog cannot easily filter nested JSON. Keys are sanitized to snake case.
+// Only annotation keys known to hold diagnostic, non-sensitive values are
+// exported to telemetry. Chromium can add new crash keys in future Electron
+// versions, so unknown keys are dropped and only counted.
+const ALLOWED_ANNOTATION_KEYS = new Set([
+  // Our crashReporter globalExtra parameters.
+  "app_version",
+  "electron_version",
+  "chrome_version",
+  "os",
+  "arch",
+  // Electron's own crashReporter parameters.
+  "_productName",
+  "_companyName",
+  "_version",
+  // Crashpad and Electron process context.
+  "ptype",
+  "process_type",
+  "platform",
+  "plat",
+  "prod",
+  "ver",
+  "pid",
+  "osarch",
+  "lsb-release",
+  "service-name",
+  "chrome-trace-id",
+  "num-experiments",
+]);
+
+// Families of diagnostic keys: memory and GPU state.
+const ALLOWED_ANNOTATION_PREFIXES = [
+  "electron.", // e.g. electron.v8-oom.is_heap_oom
+  "gpu", // gpu_webgl, gpu_compositing
+  "oom-", // oom-size
+  "total-", // total-discardable-memory-allocated
+  "v8", // v8-oom variants outside the electron. namespace
+];
+
+function isAllowedAnnotation(key: string): boolean {
+  return (
+    ALLOWED_ANNOTATION_KEYS.has(key) ||
+    ALLOWED_ANNOTATION_PREFIXES.some((prefix) => key.startsWith(prefix))
+  );
+}
+
+// Allowlisted crash annotations as flat telemetry fields, one property per
+// key, because PostHog cannot easily filter nested JSON. Keys are sanitized
+// to snake case. Dropped keys are reported only as a count.
 export function crashAnnotationEventFields(
   annotations: Record<string, string>,
-): Record<string, string> {
-  const fields: Record<string, string> = {};
+): Record<string, string | number> {
+  const fields: Record<string, string | number> = {};
+  let dropped = 0;
   for (const [key, value] of Object.entries(annotations)) {
+    if (!isAllowedAnnotation(key)) {
+      dropped++;
+      continue;
+    }
     const name = `crash_annotation_${key.toLowerCase().replace(/[^a-z0-9]+/g, "_")}`;
     // First writer wins on sanitized-name collisions, matching the
     // parser's precedence of the sources.
     if (Object.hasOwn(fields, name)) continue;
     fields[name] = value;
+  }
+  if (dropped > 0) {
+    fields.crash_annotations_dropped = dropped;
   }
   return fields;
 }

--- a/src/utils/crash_telemetry_fields.ts
+++ b/src/utils/crash_telemetry_fields.ts
@@ -40,7 +40,8 @@ export function crashPerformanceEventFields(
 // Only annotation keys known to hold diagnostic, non-sensitive values are
 // exported to telemetry, each by its exact name. Unknown keys, including
 // ones future Electron versions may add, are dropped and only counted.
-const ALLOWED_ANNOTATION_KEYS = new Set([
+// The minidump parser also exempts these keys from its annotation cap.
+export const ALLOWED_ANNOTATION_KEYS = new Set([
   // Our crashReporter globalExtra parameters.
   "app_version",
   "electron_version",

--- a/src/utils/crash_telemetry_fields.ts
+++ b/src/utils/crash_telemetry_fields.ts
@@ -38,8 +38,8 @@ export function crashPerformanceEventFields(
 }
 
 // Only annotation keys known to hold diagnostic, non-sensitive values are
-// exported to telemetry. Chromium can add new crash keys in future Electron
-// versions, so unknown keys are dropped and only counted.
+// exported to telemetry, each by its exact name. Unknown keys, including
+// ones future Electron versions may add, are dropped and only counted.
 const ALLOWED_ANNOTATION_KEYS = new Set([
   // Our crashReporter globalExtra parameters.
   "app_version",
@@ -64,23 +64,22 @@ const ALLOWED_ANNOTATION_KEYS = new Set([
   "service-name",
   "chrome-trace-id",
   "num-experiments",
+  // Memory and GPU state.
+  "oom-size",
+  "total-discardable-memory-allocated",
+  "gpu_webgl",
+  "gpu_compositing",
+  // V8 OOM and fatal error keys, from Electron's node_bindings.cc.
+  "electron.v8-oom.is_heap_oom",
+  "electron.v8-oom.location",
+  "electron.v8-oom.detail",
+  "electron.v8-oom.heap.used",
+  "electron.v8-oom.heap.total",
+  "electron.v8-oom.heap.limit",
+  "electron.v8-oom.heap.total_available",
+  "electron.v8-fatal.message",
+  "electron.v8-fatal.location",
 ]);
-
-// Families of diagnostic keys: memory and GPU state.
-const ALLOWED_ANNOTATION_PREFIXES = [
-  "electron.", // e.g. electron.v8-oom.is_heap_oom
-  "gpu", // gpu_webgl, gpu_compositing
-  "oom-", // oom-size
-  "total-", // total-discardable-memory-allocated
-  "v8", // v8-oom variants outside the electron. namespace
-];
-
-function isAllowedAnnotation(key: string): boolean {
-  return (
-    ALLOWED_ANNOTATION_KEYS.has(key) ||
-    ALLOWED_ANNOTATION_PREFIXES.some((prefix) => key.startsWith(prefix))
-  );
-}
 
 // Allowlisted crash annotations as flat telemetry fields, one property per
 // key, because PostHog cannot easily filter nested JSON. Keys are sanitized
@@ -91,15 +90,12 @@ export function crashAnnotationEventFields(
   const fields: Record<string, string | number> = {};
   let dropped = 0;
   for (const [key, value] of Object.entries(annotations)) {
-    if (!isAllowedAnnotation(key)) {
+    if (!ALLOWED_ANNOTATION_KEYS.has(key)) {
       dropped++;
       continue;
     }
-    const name = `crash_annotation_${key.toLowerCase().replace(/[^a-z0-9]+/g, "_")}`;
-    // First writer wins on sanitized-name collisions, matching the
-    // parser's precedence of the sources.
-    if (Object.hasOwn(fields, name)) continue;
-    fields[name] = value;
+    const name = key.toLowerCase().replace(/[^a-z0-9]+/g, "_");
+    fields[`crash_annotation_${name}`] = value;
   }
   if (dropped > 0) {
     fields.crash_annotations_dropped = dropped;

--- a/src/utils/crash_telemetry_fields.ts
+++ b/src/utils/crash_telemetry_fields.ts
@@ -37,6 +37,19 @@ export function crashPerformanceEventFields(
   };
 }
 
+// Crash annotations as flat telemetry fields, one property per key, because
+// PostHog cannot easily filter nested JSON. Keys are sanitized to snake case.
+export function crashAnnotationEventFields(
+  annotations: Record<string, string>,
+): Record<string, string> {
+  const fields: Record<string, string> = {};
+  for (const [key, value] of Object.entries(annotations)) {
+    const name = key.toLowerCase().replace(/[^a-z0-9]+/g, "_");
+    fields[`crash_annotation_${name}`] = value;
+  }
+  return fields;
+}
+
 function workingSetFields(
   prefix: string,
   sets: Record<string, number> | undefined,

--- a/src/utils/crash_telemetry_fields.ts
+++ b/src/utils/crash_telemetry_fields.ts
@@ -44,8 +44,11 @@ export function crashAnnotationEventFields(
 ): Record<string, string> {
   const fields: Record<string, string> = {};
   for (const [key, value] of Object.entries(annotations)) {
-    const name = key.toLowerCase().replace(/[^a-z0-9]+/g, "_");
-    fields[`crash_annotation_${name}`] = value;
+    const name = `crash_annotation_${key.toLowerCase().replace(/[^a-z0-9]+/g, "_")}`;
+    // First writer wins on sanitized-name collisions, matching the
+    // parser's precedence of the sources.
+    if (Object.hasOwn(fields, name)) continue;
+    fields[name] = value;
   }
   return fields;
 }

--- a/src/utils/minidump_summary.test.ts
+++ b/src/utils/minidump_summary.test.ts
@@ -34,6 +34,7 @@ function buildMinidump(opts: {
   annotations?: Record<string, string>; // module annotation objects beyond ptype
   annotationType?: number; // type written on annotation objects, default 1 (string)
   simpleAnnotations?: Record<string, string>; // process-level dictionary
+  moduleSimpleAnnotations?: Record<string, string>; // module-level dictionary
 }): Buffer {
   const buf = Buffer.alloc(16384);
   const dv = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
@@ -49,6 +50,7 @@ function buildMinidump(opts: {
   const hasCrashpadInfo =
     objectAnnotations.length > 0 ||
     opts.simpleAnnotations !== undefined ||
+    opts.moduleSimpleAnnotations !== undefined ||
     opts.addressMask !== undefined;
   const streamCount = hasCrashpadInfo ? 3 : 2;
   let cursor = 32 + streamCount * 12;
@@ -176,8 +178,26 @@ function buildMinidump(opts: {
       cursor = annObjectsRva + 4 + entries.length * 12;
     }
 
-    // ModuleCrashpadInfo: annotation_objects RVA @ +24.
+    // Module-level simple annotations dictionary: same layout as the
+    // process-level one below.
+    let moduleSimpleRva = 0;
+    if (opts.moduleSimpleAnnotations) {
+      const entries = Object.entries(opts.moduleSimpleAnnotations).map(
+        ([key, value]) => [writeUtf8(key), writeUtf8(value)] as const,
+      );
+      moduleSimpleRva = cursor;
+      dv.setUint32(moduleSimpleRva, entries.length, true);
+      entries.forEach(([keyRva, valueRva], i) => {
+        dv.setUint32(moduleSimpleRva + 4 + i * 8, keyRva, true);
+        dv.setUint32(moduleSimpleRva + 8 + i * 8, valueRva, true);
+      });
+      cursor = moduleSimpleRva + 4 + entries.length * 8;
+    }
+
+    // ModuleCrashpadInfo: simple_annotations RVA @ +16,
+    // annotation_objects RVA @ +24.
     const moduleInfoRva = cursor;
+    dv.setUint32(moduleInfoRva + 16, moduleSimpleRva, true);
     dv.setUint32(moduleInfoRva + 24, annObjectsRva, true);
     cursor = moduleInfoRva + 28;
 
@@ -742,6 +762,53 @@ describe("parseMinidumpBuffer", () => {
     const summary = parseMinidumpBuffer(dump, "linux", "x64")!;
     expect(summary.ptype).toBe("browser");
     expect(Object.keys(summary.annotations!)).toHaveLength(32);
+  });
+
+  it("keeps a ptype that sits past the cap in the module annotations", () => {
+    // ptype is exempt from the cap, so it survives even as the last of
+    // 33 module annotation objects.
+    const many: Record<string, string> = {};
+    for (let i = 0; i < 32; i++) {
+      many[`key${i}`] = "v";
+    }
+    many.ptype = "browser";
+    const dump = buildMinidump({
+      modules: oneModule,
+      exceptionCode: 11,
+      ip: 0x10010n,
+      ipOffset: 248,
+      annotations: many,
+    });
+    const summary = parseMinidumpBuffer(dump, "linux", "x64")!;
+    expect(summary.ptype).toBe("browser");
+  });
+
+  it("collects a module's simple annotations dictionary", () => {
+    const dump = buildMinidump({
+      modules: oneModule,
+      exceptionCode: 11,
+      ip: 0x10010n,
+      ipOffset: 248,
+      ptype: "renderer",
+      moduleSimpleAnnotations: { "module-key": "module-value" },
+      simpleAnnotations: { "process-key": "process-value" },
+    });
+    const annotations = parseMinidumpBuffer(dump, "linux", "x64")!.annotations!;
+    expect(annotations["module-key"]).toBe("module-value");
+    expect(annotations["process-key"]).toBe("process-value");
+    expect(annotations.ptype).toBe("renderer");
+  });
+
+  it("keeps the module annotation when a simple annotation repeats the key", () => {
+    const dump = buildMinidump({
+      modules: oneModule,
+      exceptionCode: 11,
+      ip: 0x10010n,
+      ipOffset: 248,
+      ptype: "browser",
+      simpleAnnotations: { ptype: "impostor" },
+    });
+    expect(parseMinidumpBuffer(dump, "linux", "x64")!.ptype).toBe("browser");
   });
 
   it("leaves ptype undefined when there is no CrashpadInfo stream", () => {

--- a/src/utils/minidump_summary.test.ts
+++ b/src/utils/minidump_summary.test.ts
@@ -783,6 +783,23 @@ describe("parseMinidumpBuffer", () => {
     expect(summary.ptype).toBe("browser");
   });
 
+  it("keeps allowlisted keys behind a cap's worth of unknown keys", () => {
+    const many: Record<string, string> = {};
+    for (let i = 0; i < 32; i++) {
+      many[`key${i}`] = "v";
+    }
+    many["electron.v8-oom.is_heap_oom"] = "1";
+    const dump = buildMinidump({
+      modules: oneModule,
+      exceptionCode: 11,
+      ip: 0x10010n,
+      ipOffset: 248,
+      annotations: many,
+    });
+    const summary = parseMinidumpBuffer(dump, "linux", "x64")!;
+    expect(summary.annotations!["electron.v8-oom.is_heap_oom"]).toBe("1");
+  });
+
   it("collects a module's simple annotations dictionary", () => {
     const dump = buildMinidump({
       modules: oneModule,

--- a/src/utils/minidump_summary.test.ts
+++ b/src/utils/minidump_summary.test.ts
@@ -31,13 +31,26 @@ function buildMinidump(opts: {
   ipOffset: number; // where the IP sits in the CPU context: 248 (x64) / 264 (arm64)
   ptype?: string;
   addressMask?: bigint; // Crashpad address_mask, written into the CrashpadInfo stream
+  annotations?: Record<string, string>; // module annotation objects beyond ptype
+  annotationType?: number; // type written on annotation objects, default 1 (string)
+  simpleAnnotations?: Record<string, string>; // process-level dictionary
 }): Buffer {
   const buf = Buffer.alloc(16384);
   const dv = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
   // 2 streams (module list + exception), or 3 when a CrashpadInfo stream is
   // included. Payloads start after the 32-byte header + the directory (one
   // 12-byte entry per stream).
-  const streamCount = opts.ptype !== undefined ? 3 : 2;
+  const objectAnnotations: [string, string][] = [
+    ...(opts.ptype !== undefined
+      ? ([["ptype", opts.ptype]] as [string, string][])
+      : []),
+    ...Object.entries(opts.annotations ?? {}),
+  ];
+  const hasCrashpadInfo =
+    objectAnnotations.length > 0 ||
+    opts.simpleAnnotations !== undefined ||
+    opts.addressMask !== undefined;
+  const streamCount = hasCrashpadInfo ? 3 : 2;
   let cursor = 32 + streamCount * 12;
 
   // Writes a length-prefixed UTF-8 string (u32 byte-length + bytes) at the
@@ -137,23 +150,31 @@ function buildMinidump(opts: {
   const exceptionSize = 168;
   cursor = (exceptionRva + exceptionSize + 3) & ~3;
 
-  // --- Optional CrashpadInfo stream carrying one "ptype" annotation ---
-  // Mirrors the nested chain the parser walks to find ptype, built bottom-up so
-  // each level can reference the RVA of the one below it:
-  //   annotation (name + value) -> annotation_objects list -> module_info ->
-  //   module_list -> CrashpadInfo.
+  // --- Optional CrashpadInfo stream carrying annotations ---
+  // Mirrors the nested chain the parser walks, built bottom-up so each level
+  // can reference the RVA of the one below it:
+  //   annotation (name + type + value) -> annotation_objects list ->
+  //   module_info -> module_list -> CrashpadInfo, plus an optional
+  //   process-level simple annotations dictionary.
   let crashpadInfoRva = 0;
-  if (opts.ptype !== undefined) {
-    const nameRva = writeUtf8("ptype");
-    const valueRva = writeUtf8(opts.ptype);
-
-    // annotation_objects: u32 count, then one 12-byte annotation
-    // (name RVA @ +0, value RVA @ +8 within the annotation).
-    const annObjectsRva = cursor;
-    dv.setUint32(annObjectsRva, 1, true);
-    dv.setUint32(annObjectsRva + 4, nameRva, true);
-    dv.setUint32(annObjectsRva + 12, valueRva, true);
-    cursor = annObjectsRva + 16;
+  if (hasCrashpadInfo) {
+    // annotation_objects: u32 count, then 12-byte annotations
+    // (name RVA @ +0, u16 type @ +4, value RVA @ +8).
+    let annObjectsRva = 0;
+    if (objectAnnotations.length > 0) {
+      const entries = objectAnnotations.map(
+        ([name, value]) => [writeUtf8(name), writeUtf8(value)] as const,
+      );
+      annObjectsRva = cursor;
+      dv.setUint32(annObjectsRva, entries.length, true);
+      entries.forEach(([nameRva, valueRva], i) => {
+        const obj = annObjectsRva + 4 + i * 12;
+        dv.setUint32(obj, nameRva, true);
+        dv.setUint16(obj + 4, opts.annotationType ?? 1, true);
+        dv.setUint32(obj + 8, valueRva, true);
+      });
+      cursor = annObjectsRva + 4 + entries.length * 12;
+    }
 
     // ModuleCrashpadInfo: annotation_objects RVA @ +24.
     const moduleInfoRva = cursor;
@@ -166,8 +187,26 @@ function buildMinidump(opts: {
     dv.setUint32(cpModListRva + 12, moduleInfoRva, true);
     cursor = cpModListRva + 16;
 
-    // CrashpadInfo: module_list RVA @ +48, optional address_mask u64 @ +56.
+    // Simple annotations dictionary: u32 count, then 8-byte entries of
+    // (key RVA @ +0, value RVA @ +4).
+    let simpleRva = 0;
+    if (opts.simpleAnnotations) {
+      const entries = Object.entries(opts.simpleAnnotations).map(
+        ([key, value]) => [writeUtf8(key), writeUtf8(value)] as const,
+      );
+      simpleRva = cursor;
+      dv.setUint32(simpleRva, entries.length, true);
+      entries.forEach(([keyRva, valueRva], i) => {
+        dv.setUint32(simpleRva + 4 + i * 8, keyRva, true);
+        dv.setUint32(simpleRva + 8 + i * 8, valueRva, true);
+      });
+      cursor = simpleRva + 4 + entries.length * 8;
+    }
+
+    // CrashpadInfo: simple_annotations RVA @ +40, module_list RVA @ +48,
+    // optional address_mask u64 @ +56.
     crashpadInfoRva = cursor;
+    dv.setUint32(crashpadInfoRva + 40, simpleRva, true);
     dv.setUint32(crashpadInfoRva + 48, cpModListRva, true);
     if (opts.addressMask !== undefined) {
       dv.setBigUint64(crashpadInfoRva + 56, opts.addressMask, true);
@@ -191,7 +230,7 @@ function buildMinidump(opts: {
   dv.setUint32(44, 6, true);
   dv.setUint32(48, exceptionSize, true);
   dv.setUint32(52, exceptionRva, true);
-  if (opts.ptype !== undefined) {
+  if (hasCrashpadInfo) {
     dv.setUint32(56, 0x43500001, true);
     dv.setUint32(60, opts.addressMask !== undefined ? 64 : 52, true);
     dv.setUint32(64, crashpadInfoRva, true);
@@ -621,6 +660,68 @@ describe("parseMinidumpBuffer", () => {
       ptype: "browser",
     });
     expect(parseMinidumpBuffer(dump, "linux", "x64")!.ptype).toBe("browser");
+  });
+
+  it("collects all module annotation objects, not just ptype", () => {
+    const dump = buildMinidump({
+      modules: oneModule,
+      exceptionCode: 11,
+      ip: 0x10010n,
+      ipOffset: 248,
+      ptype: "browser",
+      annotations: { "oom-size": "2048", "gpu-status": "enabled" },
+    });
+    const s = parseMinidumpBuffer(dump, "linux", "x64");
+    expect(s!.ptype).toBe("browser");
+    expect(s!.annotations).toEqual({
+      ptype: "browser",
+      "oom-size": "2048",
+      "gpu-status": "enabled",
+    });
+  });
+
+  it("collects the process-level simple annotations dictionary", () => {
+    const dump = buildMinidump({
+      modules: oneModule,
+      exceptionCode: 11,
+      ip: 0x10010n,
+      ipOffset: 248,
+      simpleAnnotations: { app_version: "1.2.3", os: "linux" },
+    });
+    const s = parseMinidumpBuffer(dump, "linux", "x64");
+    expect(s!.annotations).toEqual({ app_version: "1.2.3", os: "linux" });
+    expect(s!.ptype).toBeUndefined();
+  });
+
+  it("skips annotation objects that are not string typed", () => {
+    const dump = buildMinidump({
+      modules: oneModule,
+      exceptionCode: 11,
+      ip: 0x10010n,
+      ipOffset: 248,
+      annotations: { blob: "binary-bytes" },
+      annotationType: 3,
+    });
+    expect(parseMinidumpBuffer(dump, "linux", "x64")!.annotations).toBe(
+      undefined,
+    );
+  });
+
+  it("caps annotation count and value length", () => {
+    const many: Record<string, string> = { long: "x".repeat(600) };
+    for (let i = 0; i < 40; i++) {
+      many[`key${i}`] = "v";
+    }
+    const dump = buildMinidump({
+      modules: oneModule,
+      exceptionCode: 11,
+      ip: 0x10010n,
+      ipOffset: 248,
+      simpleAnnotations: many,
+    });
+    const annotations = parseMinidumpBuffer(dump, "linux", "x64")!.annotations;
+    expect(Object.keys(annotations!)).toHaveLength(32);
+    expect(annotations!.long).toHaveLength(512);
   });
 
   it("leaves ptype undefined when there is no CrashpadInfo stream", () => {

--- a/src/utils/minidump_summary.test.ts
+++ b/src/utils/minidump_summary.test.ts
@@ -724,6 +724,26 @@ describe("parseMinidumpBuffer", () => {
     expect(annotations!.long).toHaveLength(512);
   });
 
+  it("keeps ptype when the cap fills across both annotation sources", () => {
+    // ptype is a module annotation object and the summary depends on it,
+    // so it must win over a cap's worth of simple annotations.
+    const many: Record<string, string> = {};
+    for (let i = 0; i < 40; i++) {
+      many[`key${i}`] = "v";
+    }
+    const dump = buildMinidump({
+      modules: oneModule,
+      exceptionCode: 11,
+      ip: 0x10010n,
+      ipOffset: 248,
+      ptype: "browser",
+      simpleAnnotations: many,
+    });
+    const summary = parseMinidumpBuffer(dump, "linux", "x64")!;
+    expect(summary.ptype).toBe("browser");
+    expect(Object.keys(summary.annotations!)).toHaveLength(32);
+  });
+
   it("leaves ptype undefined when there is no CrashpadInfo stream", () => {
     const dump = buildMinidump({
       modules: oneModule,

--- a/src/utils/minidump_summary.ts
+++ b/src/utils/minidump_summary.ts
@@ -18,6 +18,9 @@ export interface MinidumpSummary {
   faultingDebugFile?: string; // name keying the module's symbol file, e.g. "electron.exe.pdb"
   faultingDebugId?: string; // build fingerprint keying the module's symbol file
   ptype?: string; // crashing process type: "browser" (main) / "renderer" / "gpu-process" / …
+  // All Crashpad annotations: our crashReporter extra parameters and
+  // Chromium's own crash keys. Counts and lengths are capped.
+  annotations?: Record<string, string>;
 }
 
 // These values are fixed by the minidump file format. The signature and stream
@@ -113,8 +116,17 @@ const CV_SIG_ELF_BUILD_ID = 0x4270454c; // Crashpad's ELF build id record
 // (16) @20 | LOCATION_DESCRIPTOR simple_annotations (8) @36 | LOCATION_DESCRIPTOR
 // module_list (8) @44 | u32 reserved @52 | u64 address_mask @56.
 const CRASHPAD_MODULE_LIST_RVA_OFF = 48; // rva field of module_list (@44 + 4)
+const CRASHPAD_SIMPLE_ANNOTATIONS_RVA_OFF = 40; // rva field of simple_annotations (@36 + 4)
 const CRASHPAD_ADDRESS_MASK_OFF = 56;
 const CRASHPAD_INFO_MIN_SIZE_FOR_MASK = 64; // through the end of address_mask
+
+// Crashpad annotation object type for plain string values.
+const ANNOTATION_TYPE_STRING = 1;
+
+// Caps so a corrupt dump cannot balloon the summary.
+const MAX_ANNOTATIONS = 32;
+const MAX_ANNOTATION_KEY_LEN = 64;
+const MAX_ANNOTATION_VALUE_LEN = 512;
 
 // On Linux, Crashpad stores the POSIX signal number in ExceptionCode.
 const SIGNAL_NAMES: Record<number, string> = {
@@ -321,6 +333,10 @@ export function parseMinidumpBuffer(
       }
     }
 
+    const annotations = crashpadInfoRva
+      ? parseAnnotations(view, buf, crashpadInfoRva)
+      : undefined;
+
     return {
       crashReason,
       exceptionCode,
@@ -329,9 +345,8 @@ export function parseMinidumpBuffer(
       faultingOffset,
       faultingDebugFile,
       faultingDebugId,
-      ptype: crashpadInfoRva
-        ? parsePtype(view, buf, crashpadInfoRva)
-        : undefined,
+      ptype: annotations?.ptype,
+      annotations,
     };
   } catch {
     return null;
@@ -443,57 +458,6 @@ function redactFaultAddress(
 ): `0x${string}` | "non-null" {
   const masked = applyAddressMask(address, mask);
   return masked <= NULL_PAGE_LIMIT ? toHex(masked) : "non-null";
-}
-
-// Read the "ptype" Crashpad annotation (the crashing process type) from the
-// MinidumpCrashpadInfo stream. Nested structs we walk, with the byte offset of
-// the field we read from each:
-//
-//   MinidumpCrashpadInfo        ->  module_list rva          @ +48
-//   module_list                 ->  count, then 12-byte links
-//     link                      ->  module_info rva          @ +8
-//   MinidumpModuleCrashpadInfo  ->  annotation_objects rva   @ +24
-//   annotation_objects          ->  count, then 12-byte annotations
-//     annotation                ->  name rva @ +0, value rva @ +8
-//
-// name and value are length-prefixed UTF-8; return the value named "ptype".
-function parsePtype(
-  view: DataView,
-  buf: Buffer,
-  infoRva: number,
-): string | undefined {
-  try {
-    if (infoRva + CRASHPAD_MODULE_LIST_RVA_OFF + 4 > buf.length) {
-      return undefined;
-    }
-    const modListRva = view.getUint32(
-      infoRva + CRASHPAD_MODULE_LIST_RVA_OFF,
-      true,
-    );
-    if (modListRva === 0 || modListRva + 4 > buf.length) return undefined;
-    const moduleCount = view.getUint32(modListRva, true);
-    for (let i = 0; i < moduleCount; i++) {
-      const link = modListRva + 4 + i * 12;
-      if (link + 12 > buf.length) break;
-      const moduleInfoRva = view.getUint32(link + 8, true);
-      if (moduleInfoRva + 28 > buf.length) continue;
-      const objectsRva = view.getUint32(moduleInfoRva + 24, true);
-      if (objectsRva === 0 || objectsRva + 4 > buf.length) continue;
-      const objectCount = view.getUint32(objectsRva, true);
-      for (let j = 0; j < objectCount; j++) {
-        const obj = objectsRva + 4 + j * 12;
-        if (obj + 12 > buf.length) break;
-        if (
-          readLengthPrefixed(view, buf, view.getUint32(obj, true)) === "ptype"
-        ) {
-          return readLengthPrefixed(view, buf, view.getUint32(obj + 8, true));
-        }
-      }
-    }
-  } catch {
-    // best effort — ptype is optional context
-  }
-  return undefined;
 }
 
 // Read the address_mask from the MinidumpCrashpadInfo stream, used to strip
@@ -658,4 +622,105 @@ function readMinidumpString(view: DataView, buf: Buffer, rva: number): string {
 function basename(p: string): string {
   const i = Math.max(p.lastIndexOf("/"), p.lastIndexOf("\\"));
   return i >= 0 ? p.slice(i + 1) : p;
+}
+
+// All Crashpad annotations in the dump: the process-level simple annotations
+// dictionary plus each module's string annotation objects. This is where our
+// crashReporter extra parameters and Chromium's crash keys live. Returns
+// undefined when the dump has none.
+function parseAnnotations(
+  view: DataView,
+  buf: Buffer,
+  infoRva: number,
+): Record<string, string> | undefined {
+  const annotations: Record<string, string> = {};
+  try {
+    readSimpleAnnotations(view, buf, infoRva, annotations);
+    readModuleAnnotationObjects(view, buf, infoRva, annotations);
+  } catch {
+    // best effort: keep whatever was collected
+  }
+  return Object.keys(annotations).length > 0 ? annotations : undefined;
+}
+
+// MinidumpSimpleStringDictionary: u32 count, then 8-byte entries of
+// { key rva @ +0, value rva @ +4 }, both length-prefixed UTF-8.
+function readSimpleAnnotations(
+  view: DataView,
+  buf: Buffer,
+  infoRva: number,
+  out: Record<string, string>,
+): void {
+  if (infoRva + CRASHPAD_SIMPLE_ANNOTATIONS_RVA_OFF + 4 > buf.length) return;
+  const dictRva = view.getUint32(
+    infoRva + CRASHPAD_SIMPLE_ANNOTATIONS_RVA_OFF,
+    true,
+  );
+  if (dictRva === 0 || dictRva + 4 > buf.length) return;
+  const count = view.getUint32(dictRva, true);
+  for (let i = 0; i < count; i++) {
+    const entry = dictRva + 4 + i * 8;
+    if (entry + 8 > buf.length) break;
+    addAnnotation(
+      out,
+      readLengthPrefixed(view, buf, view.getUint32(entry, true)),
+      readLengthPrefixed(view, buf, view.getUint32(entry + 4, true)),
+    );
+  }
+}
+
+// Nested structs we walk, with the byte offset of the field we read from each:
+//
+//   MinidumpCrashpadInfo        ->  module_list rva          @ +48
+//   module_list                 ->  count, then 12-byte links
+//     link                      ->  module_info rva          @ +8
+//   MinidumpModuleCrashpadInfo  ->  annotation_objects rva   @ +24
+//   annotation_objects          ->  count, then 12-byte annotations
+//     annotation                ->  name rva @ +0, u16 type @ +4, value rva @ +8
+//
+// Only string-typed annotations are collected; other types hold binary data.
+function readModuleAnnotationObjects(
+  view: DataView,
+  buf: Buffer,
+  infoRva: number,
+  out: Record<string, string>,
+): void {
+  if (infoRva + CRASHPAD_MODULE_LIST_RVA_OFF + 4 > buf.length) return;
+  const modListRva = view.getUint32(
+    infoRva + CRASHPAD_MODULE_LIST_RVA_OFF,
+    true,
+  );
+  if (modListRva === 0 || modListRva + 4 > buf.length) return;
+  const moduleCount = view.getUint32(modListRva, true);
+  for (let i = 0; i < moduleCount; i++) {
+    const link = modListRva + 4 + i * 12;
+    if (link + 12 > buf.length) break;
+    const moduleInfoRva = view.getUint32(link + 8, true);
+    if (moduleInfoRva + 28 > buf.length) continue;
+    const objectsRva = view.getUint32(moduleInfoRva + 24, true);
+    if (objectsRva === 0 || objectsRva + 4 > buf.length) continue;
+    const objectCount = view.getUint32(objectsRva, true);
+    for (let j = 0; j < objectCount; j++) {
+      const obj = objectsRva + 4 + j * 12;
+      if (obj + 12 > buf.length) break;
+      if (view.getUint16(obj + 4, true) !== ANNOTATION_TYPE_STRING) continue;
+      addAnnotation(
+        out,
+        readLengthPrefixed(view, buf, view.getUint32(obj, true)),
+        readLengthPrefixed(view, buf, view.getUint32(obj + 8, true)),
+      );
+    }
+  }
+}
+
+function addAnnotation(
+  out: Record<string, string>,
+  key: string,
+  value: string,
+): void {
+  if (!key || Object.keys(out).length >= MAX_ANNOTATIONS) return;
+  out[key.slice(0, MAX_ANNOTATION_KEY_LEN)] = value.slice(
+    0,
+    MAX_ANNOTATION_VALUE_LEN,
+  );
 }

--- a/src/utils/minidump_summary.ts
+++ b/src/utils/minidump_summary.ts
@@ -635,8 +635,11 @@ function parseAnnotations(
 ): Record<string, string> | undefined {
   const annotations: Record<string, string> = {};
   try {
-    readSimpleAnnotations(view, buf, infoRva, annotations);
+    // Module annotation objects first: they hold ptype, which the summary
+    // needs to attribute the crash, so once the cap fills it can only
+    // drop simple annotations.
     readModuleAnnotationObjects(view, buf, infoRva, annotations);
+    readSimpleAnnotations(view, buf, infoRva, annotations);
   } catch {
     // best effort: keep whatever was collected
   }
@@ -659,6 +662,9 @@ function readSimpleAnnotations(
   if (dictRva === 0 || dictRva + 4 > buf.length) return;
   const count = view.getUint32(dictRva, true);
   for (let i = 0; i < count; i++) {
+    // Also bounds a corrupt count, which could otherwise run the loop
+    // to the end of the file.
+    if (annotationsFull(out)) break;
     const entry = dictRva + 4 + i * 8;
     if (entry + 8 > buf.length) break;
     addAnnotation(
@@ -693,6 +699,7 @@ function readModuleAnnotationObjects(
   if (modListRva === 0 || modListRva + 4 > buf.length) return;
   const moduleCount = view.getUint32(modListRva, true);
   for (let i = 0; i < moduleCount; i++) {
+    if (annotationsFull(out)) break;
     const link = modListRva + 4 + i * 12;
     if (link + 12 > buf.length) break;
     const moduleInfoRva = view.getUint32(link + 8, true);
@@ -701,6 +708,9 @@ function readModuleAnnotationObjects(
     if (objectsRva === 0 || objectsRva + 4 > buf.length) continue;
     const objectCount = view.getUint32(objectsRva, true);
     for (let j = 0; j < objectCount; j++) {
+      // Also bounds a corrupt count, which could otherwise run the loop
+      // to the end of the file.
+      if (annotationsFull(out)) break;
       const obj = objectsRva + 4 + j * 12;
       if (obj + 12 > buf.length) break;
       if (view.getUint16(obj + 4, true) !== ANNOTATION_TYPE_STRING) continue;
@@ -713,14 +723,19 @@ function readModuleAnnotationObjects(
   }
 }
 
+function annotationsFull(out: Record<string, string>): boolean {
+  return Object.keys(out).length >= MAX_ANNOTATIONS;
+}
+
 function addAnnotation(
   out: Record<string, string>,
   key: string,
   value: string,
 ): void {
-  if (!key || Object.keys(out).length >= MAX_ANNOTATIONS) return;
-  out[key.slice(0, MAX_ANNOTATION_KEY_LEN)] = value.slice(
-    0,
-    MAX_ANNOTATION_VALUE_LEN,
-  );
+  // Truncate before the checks so lookup and storage use the same key.
+  const k = key.slice(0, MAX_ANNOTATION_KEY_LEN);
+  if (!k) return;
+  // The cap only blocks new keys; overwriting an existing key is fine.
+  if (!Object.hasOwn(out, k) && annotationsFull(out)) return;
+  out[k] = value.slice(0, MAX_ANNOTATION_VALUE_LEN);
 }

--- a/src/utils/minidump_summary.ts
+++ b/src/utils/minidump_summary.ts
@@ -117,6 +117,12 @@ const CV_SIG_ELF_BUILD_ID = 0x4270454c; // Crashpad's ELF build id record
 // module_list (8) @44 | u32 reserved @52 | u64 address_mask @56.
 const CRASHPAD_MODULE_LIST_RVA_OFF = 48; // rva field of module_list (@44 + 4)
 const CRASHPAD_SIMPLE_ANNOTATIONS_RVA_OFF = 40; // rva field of simple_annotations (@36 + 4)
+
+// MinidumpModuleCrashpadInfo: u32 version @0 | LOCATION_DESCRIPTOR
+// list_annotations (8) @4 | LOCATION_DESCRIPTOR simple_annotations (8) @12
+// | LOCATION_DESCRIPTOR annotation_objects (8) @20.
+const MODULE_INFO_SIMPLE_RVA_OFF = 16; // rva field of simple_annotations (@12 + 4)
+const MODULE_INFO_OBJECTS_RVA_OFF = 24; // rva field of annotation_objects (@20 + 4)
 const CRASHPAD_ADDRESS_MASK_OFF = 56;
 const CRASHPAD_INFO_MIN_SIZE_FOR_MASK = 64; // through the end of address_mask
 
@@ -127,6 +133,9 @@ const ANNOTATION_TYPE_STRING = 1;
 const MAX_ANNOTATIONS = 32;
 const MAX_ANNOTATION_KEY_LEN = 64;
 const MAX_ANNOTATION_VALUE_LEN = 512;
+// Bound on counts read from the dump, so a corrupt count cannot spin the
+// scan loops. Generous next to real dumps, which hold about 20 entries.
+const MAX_ANNOTATION_SCAN = 64;
 
 // On Linux, Crashpad stores the POSIX signal number in ExceptionCode.
 const SIGNAL_NAMES: Record<number, string> = {
@@ -493,7 +502,10 @@ function readLengthPrefixed(view: DataView, buf: Buffer, rva: number): string {
   const len = view.getUint32(rva, true);
   const start = rva + 4;
   if (len <= 0 || start + len > buf.length) return "";
-  return buf.toString("utf8", start, start + len);
+  // Decode no more than the caps can keep (4 bytes per UTF-8 character at
+  // worst), so a corrupt length cannot decode megabytes just to be sliced.
+  const capped = Math.min(len, MAX_ANNOTATION_VALUE_LEN * 4);
+  return buf.toString("utf8", start, start + capped);
 }
 
 // Parse the module list stream into the base address, size, and name of each
@@ -635,10 +647,10 @@ function parseAnnotations(
 ): Record<string, string> | undefined {
   const annotations: Record<string, string> = {};
   try {
-    // Module annotation objects first: they hold ptype, which the summary
-    // needs to attribute the crash, so once the cap fills it can only
-    // drop simple annotations.
-    readModuleAnnotationObjects(view, buf, infoRva, annotations);
+    // Module annotations first: they hold ptype, which the summary needs
+    // to attribute the crash. First writer wins in addAnnotation, so the
+    // process-level dictionary cannot overwrite them.
+    readModuleAnnotations(view, buf, infoRva, annotations);
     readSimpleAnnotations(view, buf, infoRva, annotations);
   } catch {
     // best effort: keep whatever was collected
@@ -647,24 +659,17 @@ function parseAnnotations(
 }
 
 // MinidumpSimpleStringDictionary: u32 count, then 8-byte entries of
-// { key rva @ +0, value rva @ +4 }, both length-prefixed UTF-8.
-function readSimpleAnnotations(
+// { key rva @ +0, value rva @ +4 }, both length-prefixed UTF-8. Used for
+// the process-level dictionary and each module's simple annotations.
+function readSimpleDictionary(
   view: DataView,
   buf: Buffer,
-  infoRva: number,
+  dictRva: number,
   out: Record<string, string>,
 ): void {
-  if (infoRva + CRASHPAD_SIMPLE_ANNOTATIONS_RVA_OFF + 4 > buf.length) return;
-  const dictRva = view.getUint32(
-    infoRva + CRASHPAD_SIMPLE_ANNOTATIONS_RVA_OFF,
-    true,
-  );
   if (dictRva === 0 || dictRva + 4 > buf.length) return;
-  const count = view.getUint32(dictRva, true);
+  const count = Math.min(view.getUint32(dictRva, true), MAX_ANNOTATION_SCAN);
   for (let i = 0; i < count; i++) {
-    // Also bounds a corrupt count, which could otherwise run the loop
-    // to the end of the file.
-    if (annotationsFull(out)) break;
     const entry = dictRva + 4 + i * 8;
     if (entry + 8 > buf.length) break;
     addAnnotation(
@@ -675,17 +680,36 @@ function readSimpleAnnotations(
   }
 }
 
+function readSimpleAnnotations(
+  view: DataView,
+  buf: Buffer,
+  infoRva: number,
+  out: Record<string, string>,
+): void {
+  if (infoRva + CRASHPAD_SIMPLE_ANNOTATIONS_RVA_OFF + 4 > buf.length) return;
+  readSimpleDictionary(
+    view,
+    buf,
+    view.getUint32(infoRva + CRASHPAD_SIMPLE_ANNOTATIONS_RVA_OFF, true),
+    out,
+  );
+}
+
 // Nested structs we walk, with the byte offset of the field we read from each:
 //
 //   MinidumpCrashpadInfo        ->  module_list rva          @ +48
 //   module_list                 ->  count, then 12-byte links
 //     link                      ->  module_info rva          @ +8
-//   MinidumpModuleCrashpadInfo  ->  annotation_objects rva   @ +24
+//   MinidumpModuleCrashpadInfo  ->  simple_annotations rva   @ +16
+//                                   annotation_objects rva   @ +24
 //   annotation_objects          ->  count, then 12-byte annotations
 //     annotation                ->  name rva @ +0, u16 type @ +4, value rva @ +8
 //
-// Only string-typed annotations are collected; other types hold binary data.
-function readModuleAnnotationObjects(
+// Each module carries a simple annotations dictionary and typed annotation
+// objects; both are read. Only string-typed objects are collected; other
+// types hold binary data. The loops run to their bounded counts instead of
+// stopping at the cap, so a late ptype object is still found.
+function readModuleAnnotations(
   view: DataView,
   buf: Buffer,
   infoRva: number,
@@ -697,20 +721,31 @@ function readModuleAnnotationObjects(
     true,
   );
   if (modListRva === 0 || modListRva + 4 > buf.length) return;
-  const moduleCount = view.getUint32(modListRva, true);
+  const moduleCount = Math.min(
+    view.getUint32(modListRva, true),
+    MAX_ANNOTATION_SCAN,
+  );
   for (let i = 0; i < moduleCount; i++) {
-    if (annotationsFull(out)) break;
     const link = modListRva + 4 + i * 12;
     if (link + 12 > buf.length) break;
     const moduleInfoRva = view.getUint32(link + 8, true);
     if (moduleInfoRva + 28 > buf.length) continue;
-    const objectsRva = view.getUint32(moduleInfoRva + 24, true);
+    readSimpleDictionary(
+      view,
+      buf,
+      view.getUint32(moduleInfoRva + MODULE_INFO_SIMPLE_RVA_OFF, true),
+      out,
+    );
+    const objectsRva = view.getUint32(
+      moduleInfoRva + MODULE_INFO_OBJECTS_RVA_OFF,
+      true,
+    );
     if (objectsRva === 0 || objectsRva + 4 > buf.length) continue;
-    const objectCount = view.getUint32(objectsRva, true);
+    const objectCount = Math.min(
+      view.getUint32(objectsRva, true),
+      MAX_ANNOTATION_SCAN,
+    );
     for (let j = 0; j < objectCount; j++) {
-      // Also bounds a corrupt count, which could otherwise run the loop
-      // to the end of the file.
-      if (annotationsFull(out)) break;
       const obj = objectsRva + 4 + j * 12;
       if (obj + 12 > buf.length) break;
       if (view.getUint16(obj + 4, true) !== ANNOTATION_TYPE_STRING) continue;
@@ -734,8 +769,10 @@ function addAnnotation(
 ): void {
   // Truncate before the checks so lookup and storage use the same key.
   const k = key.slice(0, MAX_ANNOTATION_KEY_LEN);
-  if (!k) return;
-  // The cap only blocks new keys; overwriting an existing key is fine.
-  if (!Object.hasOwn(out, k) && annotationsFull(out)) return;
+  // First writer wins, so the trusted source (module annotations, read
+  // first) cannot be overwritten by a later dictionary.
+  if (!k || Object.hasOwn(out, k)) return;
+  // ptype drives crash attribution, so the cap never drops it.
+  if (annotationsFull(out) && k !== "ptype") return;
   out[k] = value.slice(0, MAX_ANNOTATION_VALUE_LEN);
 }

--- a/src/utils/minidump_summary.ts
+++ b/src/utils/minidump_summary.ts
@@ -129,7 +129,8 @@ const CRASHPAD_INFO_MIN_SIZE_FOR_MASK = 64; // through the end of address_mask
 // Crashpad annotation object type for plain string values.
 const ANNOTATION_TYPE_STRING = 1;
 
-// Caps so a corrupt dump cannot balloon the summary.
+// Caps so a corrupt dump cannot balloon the summary. Not a strict bound:
+// ptype is exempt, so one entry more is possible.
 const MAX_ANNOTATIONS = 32;
 const MAX_ANNOTATION_KEY_LEN = 64;
 const MAX_ANNOTATION_VALUE_LEN = 512;

--- a/src/utils/minidump_summary.ts
+++ b/src/utils/minidump_summary.ts
@@ -647,14 +647,20 @@ function parseAnnotations(
   infoRva: number,
 ): Record<string, string> | undefined {
   const annotations: Record<string, string> = {};
+  // Each source is best effort on its own: a throw in one still keeps
+  // whatever the other collects.
   try {
     // Module annotations first: they hold ptype, which the summary needs
     // to attribute the crash. First writer wins in addAnnotation, so the
     // process-level dictionary cannot overwrite them.
     readModuleAnnotations(view, buf, infoRva, annotations);
+  } catch {
+    // keep whatever was collected
+  }
+  try {
     readSimpleAnnotations(view, buf, infoRva, annotations);
   } catch {
-    // best effort: keep whatever was collected
+    // keep whatever was collected
   }
   return Object.keys(annotations).length > 0 ? annotations : undefined;
 }

--- a/src/utils/minidump_summary.ts
+++ b/src/utils/minidump_summary.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { ALLOWED_ANNOTATION_KEYS } from "./crash_telemetry_fields";
 
 // A small, symbol-free summary extracted from a minidump: enough to attribute a
 // native crash (which signal, which module faulted) without any memory contents,
@@ -129,8 +130,9 @@ const CRASHPAD_INFO_MIN_SIZE_FOR_MASK = 64; // through the end of address_mask
 // Crashpad annotation object type for plain string values.
 const ANNOTATION_TYPE_STRING = 1;
 
-// Caps so a corrupt dump cannot balloon the summary. Not a strict bound:
-// ptype is exempt, so one entry more is possible.
+// Caps so a corrupt dump cannot balloon the summary. Allowlisted keys are
+// exempt, so unknown keys cannot crowd them out; the true bound is the cap
+// plus the allowlist size.
 const MAX_ANNOTATIONS = 32;
 const MAX_ANNOTATION_KEY_LEN = 64;
 const MAX_ANNOTATION_VALUE_LEN = 512;
@@ -498,7 +500,11 @@ function applyAddressMask(pointer: bigint, mask: bigint): bigint {
 }
 
 // A u32 byte-length followed by UTF-8 bytes (MinidumpUTF8String / ByteArray).
-function readLengthPrefixed(view: DataView, buf: Buffer, rva: number): string {
+function readAnnotationString(
+  view: DataView,
+  buf: Buffer,
+  rva: number,
+): string {
   if (rva === 0 || rva + 4 > buf.length) return "";
   const len = view.getUint32(rva, true);
   const start = rva + 4;
@@ -681,8 +687,8 @@ function readSimpleDictionary(
     if (entry + 8 > buf.length) break;
     addAnnotation(
       out,
-      readLengthPrefixed(view, buf, view.getUint32(entry, true)),
-      readLengthPrefixed(view, buf, view.getUint32(entry + 4, true)),
+      readAnnotationString(view, buf, view.getUint32(entry, true)),
+      readAnnotationString(view, buf, view.getUint32(entry + 4, true)),
     );
   }
 }
@@ -758,8 +764,8 @@ function readModuleAnnotations(
       if (view.getUint16(obj + 4, true) !== ANNOTATION_TYPE_STRING) continue;
       addAnnotation(
         out,
-        readLengthPrefixed(view, buf, view.getUint32(obj, true)),
-        readLengthPrefixed(view, buf, view.getUint32(obj + 8, true)),
+        readAnnotationString(view, buf, view.getUint32(obj, true)),
+        readAnnotationString(view, buf, view.getUint32(obj + 8, true)),
       );
     }
   }
@@ -779,7 +785,7 @@ function addAnnotation(
   // First writer wins, so the trusted source (module annotations, read
   // first) cannot be overwritten by a later dictionary.
   if (!k || Object.hasOwn(out, k)) return;
-  // ptype drives crash attribution, so the cap never drops it.
-  if (annotationsFull(out) && k !== "ptype") return;
+  // Keys telemetry keeps (ptype among them) are never dropped by the cap.
+  if (annotationsFull(out) && !ALLOWED_ANNOTATION_KEYS.has(k)) return;
   out[k] = value.slice(0, MAX_ANNOTATION_VALUE_LEN);
 }


### PR DESCRIPTION
*This description was written by Claude but is human-reviewed*

Crash dumps carry a key-value dictionary the crashing app wrote before dying: our crashReporter extra parameters (app version, platform, GPU status) and Electron's and Chromium's own crash keys, including the heap statistics Electron records when it dies of OOM. The parser walked this structure but extracted a single key, ptype.

It now collects the whole dictionary, from both storage formats: the process-level simple annotations dictionary, which the parser never read, and the per-module string annotation objects. Entry count and value length are capped so a corrupt dump cannot balloon the summary. The bespoke ptype walk is gone; ptype now comes from the collected dictionary.

The annotations are attached to app:crash_detected as one flat crash_annotation_<key> property per entry, since PostHog cannot easily filter nested JSON.

Verified against real retained dumps, which yield around 20 keys (app_version, electron_version, lsb-release, service-name, and so on) with ptype resolving identically to before. A real production OOM dump surfaces electron.v8-oom.is_heap_oom=1 and the heap-limit location, which is the evidence the planned OOM classifier needs.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

