### PR TITLE
Require reviewer-useful PR descriptions in pr-push

### DIFF
--- a/.claude/skills/pr-push/SKILL.md
+++ b/.claude/skills/pr-push/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dyad:pr-push
-description: Fast script-driven workflow to commit uncommitted changes, run checks, push the branch, and create or update a GitHub PR.
+description: Publish local work by committing changes, running checks, pushing the branch, and creating or refreshing a GitHub PR with a reviewer-useful description.
 ---
 
 # PR Push
@@ -11,14 +11,27 @@ Use this skill to publish the current work to GitHub. It must complete autonomou
 
 1. Run `/remember-learnings` first. This captures session learnings before any push or PR creation, so any resulting `AGENTS.md` or `rules/` changes are included in the same publish flow.
 2. Decide whether to run unit tests locally before publishing. For broad or cross-cutting changes, run `npm test`. For targeted changes, run the narrowest relevant test command, such as `npm test -- path/to/file.test.ts`. For docs, agent-config, or other low-risk changes, it is acceptable to skip local unit tests because GitHub CI will run the full suite.
-3. Run the bundled script from the repository root. Set `PR_PUSH_COMMIT_MESSAGE` to a descriptive commit message for the work being published:
+3. Review the complete branch diff and commit range against the base branch. Write:
+   - A descriptive commit message for newly staged work.
+   - A concise PR title describing the user-visible outcome or engineering purpose.
+   - A reviewer-useful PR body with `## Summary` and `## Testing` sections.
+
+   The summary must contain 1-3 bullets that explain the motivation, the chosen approach or important design decisions, and meaningful behavior boundaries or trade-offs. Stay close to the user's original intent. Do not use changed filenames as a summary, merely restate commit subjects, or rely on an automated reviewer to explain the change later.
+
+   The testing section must list the commands run and their results. If local tests were intentionally skipped, state why.
+
+4. Save the PR body to an ignored file under `.claude/tmp/`, then run the bundled script from the repository root with all three publishing inputs:
 
    ```bash
-   PR_PUSH_COMMIT_MESSAGE="<descriptive commit message>" bash .agents/skills/pr-push/scripts/pr_push.sh
+   PR_PUSH_COMMIT_MESSAGE="<descriptive commit message>" \
+   PR_PUSH_PR_TITLE="<descriptive PR title>" \
+   PR_PUSH_PR_BODY_FILE=".claude/tmp/pr-body.md" \
+   bash .agents/skills/pr-push/scripts/pr_push.sh
    ```
 
-4. If the script reports a fixable failure, fix it and rerun the script. When fixing issues, do not run `git pull` from fork remotes; only pull from the upstream repo configured by `PR_PUSH_BASE_REPO` (default `dyad-sh/dyad`) if needed. Do not manually replay the full workflow unless the script itself is broken.
-5. Summarize the script's final output, including the branch, committed files, ignored files, checks, pushed remote, and PR URL or bot-account PR creation link. Also report the local unit-test decision and any test command that was run.
+5. If the script reports a fixable failure, fix it and rerun the script. When fixing issues, do not run `git pull` from fork remotes; only pull from the upstream repo configured by `PR_PUSH_BASE_REPO` (default `dyad-sh/dyad`) if needed. Do not manually replay the full workflow unless the script itself is broken.
+6. If the PR already existed, inspect its current title and body after the push. Refresh stale or generic agent-authored text to reflect the complete branch, while preserving human-written notes and sections added by review tools. Do not overwrite the entire body blindly.
+7. Summarize the script's final output, including the branch, committed files, ignored files, checks, pushed remote, and PR URL or bot-account PR creation link. Also report the local unit-test decision and any test command that was run.
 
 ## Script Behavior
 
@@ -31,14 +44,15 @@ The script handles the mechanical workflow:
 - Does not run unit tests. The agent decides whether to run `npm test` for broad changes or a targeted `npm test -- ...` command for narrow changes; GitHub CI runs the full suite.
 - Amends automated formatting/lint changes into the commit it created.
 - Pushes to the tracked upstream, an existing PR head remote, or `origin` with the documented fallback behavior.
-- Creates or updates the PR against `dyad-sh/dyad:main`, unless the active GitHub account is a bot.
+- Creates the PR against `dyad-sh/dyad:main`, unless the active GitHub account is a bot. Existing PR branches are pushed without blindly overwriting their descriptions.
 - Removes `needs-human:review-issue` when a PR exists.
 
 Optional environment overrides:
 
 - `PR_PUSH_COMMIT_MESSAGE`: commit message for newly staged work.
 - `PR_PUSH_PR_TITLE`: PR title.
-- `PR_PUSH_PR_BODY`: PR body.
+- `PR_PUSH_PR_BODY_FILE`: path to the prepared PR body; required when creating a PR.
+- `PR_PUSH_PR_BODY`: inline PR body override; useful when shell quoting is known to be safe.
 - `PR_PUSH_BASE_REPO`: default `dyad-sh/dyad`.
 - `PR_PUSH_BASE_BRANCH`: default `main`.
 - `PR_PUSH_REMOTE`: default fallback remote `origin`.

--- a/.claude/skills/pr-push/SKILL.md
+++ b/.claude/skills/pr-push/SKILL.md
@@ -14,11 +14,11 @@ Use this skill to publish the current work to GitHub. It must complete autonomou
 3. Review the complete branch diff and commit range against the base branch. Write:
    - A descriptive commit message for newly staged work.
    - A concise PR title describing the user-visible outcome or engineering purpose.
-   - A reviewer-useful PR body with `## Summary` and `## Testing` sections.
+   - A reviewer-useful PR body with a `## Summary` section.
 
-   The summary must contain 1-3 bullets that explain the motivation, the chosen approach or important design decisions, and meaningful behavior boundaries or trade-offs. Stay close to the user's original intent. Do not use changed filenames as a summary, merely restate commit subjects, or rely on an automated reviewer to explain the change later.
+   Start the summary with a 1-2 sentence overview of the purpose and outcome, then add bullets for the decisions that deserve reviewer attention. Focus those bullets on subjective choices, trade-offs, assumptions, intentional exclusions, behavior boundaries, and questions a reviewer should verify. Use as many bullets as the change needs; optimize for helping a reviewer decide whether the approach is right, not for terseness or narrating the diff.
 
-   The testing section must list the commands run and their results. If local tests were intentionally skipped, state why.
+   Do not add a routine `## Testing` section. Report verification commands and results in the final handoff instead. Stay close to the user's original intent, and do not use changed filenames as a summary, merely restate commit subjects, or rely on an automated reviewer to explain the change later.
 
 4. Save the PR body to an ignored file under `.claude/tmp/`, then run the bundled script from the repository root with all three publishing inputs:
 

--- a/.claude/skills/pr-push/scripts/pr_push.sh
+++ b/.claude/skills/pr-push/scripts/pr_push.sh
@@ -592,14 +592,22 @@ pr_body() {
     return
   fi
 
-  local base_ref files_line
-  base_ref="$(base_comparison_ref)"
-  files_line="$(git diff --name-only "$base_ref"...HEAD 2>/dev/null | awk 'NR <= 6 { printf "%s%s", sep, $0; sep=", " }' || true)"
+  if [[ -n "${PR_PUSH_PR_BODY_FILE:-}" ]]; then
+    [[ -f "$PR_PUSH_PR_BODY_FILE" ]] || die "PR body file does not exist: $PR_PUSH_PR_BODY_FILE"
+    cat "$PR_PUSH_PR_BODY_FILE"
+    return
+  fi
 
-  printf '## Summary\n'
-  printf -- '- %s\n' "$(git log -1 --pretty=%s)"
-  if [[ -n "$files_line" ]]; then
-    printf -- '- Primary files: %s\n' "$files_line"
+  die "PR body is required; set PR_PUSH_PR_BODY_FILE or PR_PUSH_PR_BODY after reviewing the complete branch diff"
+}
+
+validate_pr_body() {
+  local body="$1"
+
+  grep -qE '^## Summary[[:space:]]*$' <<<"$body" || die "PR body must contain a ## Summary section"
+  grep -qE '^## Testing[[:space:]]*$' <<<"$body" || die "PR body must contain a ## Testing section"
+  if grep -qE '^- Primary files:' <<<"$body"; then
+    die "PR body must explain the change instead of listing primary files"
   fi
 }
 
@@ -653,6 +661,7 @@ create_or_update_pr() {
 
     title="$(pr_title)"
     body="$(pr_body)"
+    validate_pr_body "$body"
     SUGGESTED_TITLE="$title"
     SUGGESTED_BODY="$body"
 

--- a/.claude/skills/pr-push/scripts/pr_push.sh
+++ b/.claude/skills/pr-push/scripts/pr_push.sh
@@ -605,7 +605,6 @@ validate_pr_body() {
   local body="$1"
 
   grep -qE '^## Summary[[:space:]]*$' <<<"$body" || die "PR body must contain a ## Summary section"
-  grep -qE '^## Testing[[:space:]]*$' <<<"$body" || die "PR body must contain a ## Testing section"
   if grep -qE '^- Primary files:' <<<"$body"; then
     die "PR body must explain the change instead of listing primary files"
   fi

--- a/rules/git-workflow.md
+++ b/rules/git-workflow.md
@@ -72,7 +72,7 @@ When passing a PR body inline via `gh pr create --body "..."`, unescaped backtic
 
 ## PR description quality
 
-Publishing helpers must transport an agent-written PR body based on the complete branch diff; a commit subject plus changed filenames is not an acceptable summary. Include reviewer-useful `Summary` and `Testing` sections, and preserve human or review-tool additions when refreshing an existing PR body.
+Publishing helpers must transport an agent-written PR body based on the complete branch diff; a commit subject plus changed filenames is not an acceptable summary. Start with a 1-2 sentence overview, then highlight subjective design decisions, trade-offs, boundaries, and questions reviewers should verify. Do not add a routine testing section, and preserve human or review-tool additions when refreshing an existing PR body.
 
 ## Formatter Touching Unrelated Skill Files
 

--- a/rules/git-workflow.md
+++ b/rules/git-workflow.md
@@ -70,6 +70,10 @@ gh pr create --repo dyad-sh/dyad --head <owner>:<branch> --no-maintainer-edit --
 
 When passing a PR body inline via `gh pr create --body "..."`, unescaped backticks are evaluated by `zsh` before `gh` runs. Avoid backticks in inline bodies, or use a body file / heredoc so literal code identifiers do not turn into `command not found` errors.
 
+## PR description quality
+
+Publishing helpers must transport an agent-written PR body based on the complete branch diff; a commit subject plus changed filenames is not an acceptable summary. Include reviewer-useful `Summary` and `Testing` sections, and preserve human or review-tool additions when refreshing an existing PR body.
+
 ## Formatter Touching Unrelated Skill Files
 
 `npm run fmt` may rewrite Markdown emphasis in `.claude/skills/*.md`. After


### PR DESCRIPTION
## Summary

This restores agent judgment to `pr-push` descriptions so reviewers receive the reasoning behind a change instead of a mechanical digest of its filenames. The publishing script remains deterministic about transport and minimum structure, while the agent owns the subjective explanation.

- **Description ownership:** Require the agent to review the complete branch and author the body. Reviewers should verify that this is the right boundary between deterministic automation and context-sensitive writing.
- **Summary shape:** Start with a 1-2 sentence overview, then use an unconstrained set of bullets for design choices, trade-offs, assumptions, exclusions, behavior boundaries, and open questions. The intent is to surface what is debatable or worth checking, not to narrate the diff.
- **Guardrails:** Accept safely quoted body files, require a Summary heading, and reject the known low-value Primary files fallback. The script deliberately does not attempt to judge prose quality beyond those mechanical checks.
- **Existing PRs:** Preserve human notes and automated-review sections when refreshing stale agent-authored text rather than blindly replacing the whole description.
- **Verification reporting:** Keep routine command results in the agent's final handoff instead of requiring a Testing section in every PR body.

#skip-bugbot

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Agent-config and shell-helper only; no app runtime or auth paths, with stricter validation that may fail PR creation until agents supply a proper body.
> 
> **Overview**
> **`pr-push` no longer auto-builds PR descriptions** from the latest commit subject and a short changed-file list. New PRs must supply a body via `PR_PUSH_PR_BODY_FILE` (preferred) or `PR_PUSH_PR_BODY`, and creation fails if neither is set.
> 
> The **`pr-push` skill** now has agents review the full branch diff first and write commit message, title, and a reviewer-focused `## Summary` (purpose, trade-offs, boundaries—not filename lists or routine testing sections). The shell script adds **`validate_pr_body`**, requiring a `## Summary` heading and rejecting the legacy `- Primary files:` pattern.
> 
> **`rules/git-workflow.md`** documents the same PR description expectations. Existing PRs are still pushed without the script blindly overwriting their bodies; the skill adds a step to refresh stale agent text while keeping human and review-tool sections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31b170a93efa4efab8d3acc440f71cbc7ab24a1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->