### PR TITLE
Show inline warnings for Fable model refusals

### DIFF
--- a/rules/electron-ipc.md
+++ b/rules/electron-ipc.md
@@ -137,7 +137,7 @@ When modifying `ChatResponseChunkSchema` or adding new `safeSend("chat:response:
 
 **Renderer-visible fields must be in the output schema:** `createTypedHandler` validates handler output through the contract's Zod schema. If the handler returns extra fields that are not declared in the output schema, renderer code cannot type-safely consume them and they may be stripped by parsing. Add any consumed fields (for example `appId` on `ChatSchema`) to the IPC output schema when relying on them in renderer code.
 
-**Model refusals are stream completions, not errors:** AI SDK providers can normalize a successful safety refusal to `finishReason: "content-filter"` while preserving a provider-specific value such as `rawFinishReason: "refusal"`. Handle these terminal parts in both `chat_stream_handlers.ts` and `local_agent_handler.ts`, discard incomplete output from the refused attempt, and persist a renderer-visible warning instead of relying on `onError` or matching generated text.
+**Model refusals are stream completions, not errors:** AI SDK providers can normalize a successful safety refusal to `finishReason: "content-filter"` while preserving a provider-specific value such as `rawFinishReason: "refusal"`. Route every stream-consumption path (including continuation/fix streams) through the shared refusal handling, treat refusal as terminal for follow-up generation, discard incomplete output from the refused attempt, and persist a renderer-visible warning in both renderer content and AI history instead of relying on `onError` or matching generated text.
 
 ## End-of-turn warnings
 

--- a/rules/electron-ipc.md
+++ b/rules/electron-ipc.md
@@ -137,6 +137,8 @@ When modifying `ChatResponseChunkSchema` or adding new `safeSend("chat:response:
 
 **Renderer-visible fields must be in the output schema:** `createTypedHandler` validates handler output through the contract's Zod schema. If the handler returns extra fields that are not declared in the output schema, renderer code cannot type-safely consume them and they may be stripped by parsing. Add any consumed fields (for example `appId` on `ChatSchema`) to the IPC output schema when relying on them in renderer code.
 
+**Model refusals are stream completions, not errors:** AI SDK providers can normalize a successful safety refusal to `finishReason: "content-filter"` while preserving a provider-specific value such as `rawFinishReason: "refusal"`. Handle these terminal parts in both `chat_stream_handlers.ts` and `local_agent_handler.ts`, discard incomplete output from the refused attempt, and persist a renderer-visible warning instead of relying on `onError` or matching generated text.
+
 ## End-of-turn warnings
 
 When a main-process workflow needs to show a user-facing warning toast after a turn completes, thread it through every completion path, not just `chat:response:end`. Build-mode auto-approve and local-agent flows use `ChatResponseEndSchema`, while manual proposal approval uses `ApproveProposalResultSchema`; surface the warning in both `useStreamChat` and `ChatInput` so the behavior stays consistent.

--- a/src/ipc/handlers/chat_stream_handlers.test.ts
+++ b/src/ipc/handlers/chat_stream_handlers.test.ts
@@ -135,6 +135,11 @@ describe("processStreamChunks", () => {
           totalTokens: 15,
         },
       };
+      yield {
+        type: "text-delta",
+        id: "text-after-finish",
+        text: "Spurious output after finish",
+      };
     }
 
     const updates: string[] = [];
@@ -152,11 +157,13 @@ describe("processStreamChunks", () => {
     });
 
     expect(result.fullResponse).not.toContain("Partial response");
+    expect(result.fullResponse).not.toContain("Spurious output");
     expect(result.fullResponse).toContain("Existing response.");
     expect(result.fullResponse).toContain(
       '<dyad-output type="warning" message="Request declined by the model">',
     );
     expect(result.incrementalResponse).toContain("<dyad-output");
+    expect(result.modelRefused).toBe(true);
     expect(updates.at(-1)).toBe(result.fullResponse);
   });
 
@@ -195,6 +202,7 @@ describe("processStreamChunks", () => {
 
     expect(result.fullResponse).toBe("Existing response.");
     expect(result.incrementalResponse).toBe("");
+    expect(result.modelRefused).toBe(false);
   });
 });
 

--- a/src/ipc/handlers/chat_stream_handlers.test.ts
+++ b/src/ipc/handlers/chat_stream_handlers.test.ts
@@ -160,7 +160,7 @@ describe("processStreamChunks", () => {
     expect(result.fullResponse).not.toContain("Spurious output");
     expect(result.fullResponse).toContain("Existing response.");
     expect(result.fullResponse).toContain(
-      '<dyad-output type="warning" message="Request declined by the model">',
+      '<dyad-output type="warning" message="Model refused to respond for safety reasons">',
     );
     expect(result.incrementalResponse).toContain("<dyad-output");
     expect(result.modelRefused).toBe(true);

--- a/src/ipc/handlers/chat_stream_handlers.test.ts
+++ b/src/ipc/handlers/chat_stream_handlers.test.ts
@@ -11,7 +11,9 @@ import { processFullResponseActions } from "@/ipc/processors/response_processor"
 import {
   removeDyadTags,
   hasUnclosedDyadWrite,
+  processStreamChunks,
 } from "@/ipc/handlers/chat_stream_handlers";
+import type { AsyncIterableStream, TextStreamPart, ToolSet } from "ai";
 import fs from "node:fs";
 import path from "node:path";
 import { db } from "@/db";
@@ -105,6 +107,96 @@ vi.mock("@/db", () => ({
     })),
   },
 }));
+
+describe("processStreamChunks", () => {
+  it("replaces partial output with an inline warning for Fable refusals", async () => {
+    async function* refusalParts(): AsyncGenerator<TextStreamPart<ToolSet>> {
+      yield {
+        type: "text-delta",
+        id: "text-1",
+        text: "Partial response that must not be shown",
+      };
+      yield {
+        type: "finish",
+        finishReason: "content-filter",
+        rawFinishReason: "refusal",
+        totalUsage: {
+          inputTokens: 10,
+          inputTokenDetails: {
+            noCacheTokens: 10,
+            cacheReadTokens: 0,
+            cacheWriteTokens: 0,
+          },
+          outputTokens: 5,
+          outputTokenDetails: {
+            textTokens: 5,
+            reasoningTokens: 0,
+          },
+          totalTokens: 15,
+        },
+      };
+    }
+
+    const updates: string[] = [];
+    const result = await processStreamChunks({
+      fullStream: refusalParts() as unknown as AsyncIterableStream<
+        TextStreamPart<ToolSet>
+      >,
+      fullResponse: "Existing response.\n",
+      abortController: new AbortController(),
+      chatId: 1,
+      processResponseChunkUpdate: async ({ fullResponse }) => {
+        updates.push(fullResponse);
+        return fullResponse;
+      },
+    });
+
+    expect(result.fullResponse).not.toContain("Partial response");
+    expect(result.fullResponse).toContain("Existing response.");
+    expect(result.fullResponse).toContain(
+      '<dyad-output type="warning" message="Request declined by the model">',
+    );
+    expect(result.incrementalResponse).toContain("<dyad-output");
+    expect(updates.at(-1)).toBe(result.fullResponse);
+  });
+
+  it("does not label other content filters as Fable refusals", async () => {
+    async function* filteredParts(): AsyncGenerator<TextStreamPart<ToolSet>> {
+      yield {
+        type: "finish",
+        finishReason: "content-filter",
+        rawFinishReason: "content_filter",
+        totalUsage: {
+          inputTokens: 10,
+          inputTokenDetails: {
+            noCacheTokens: 10,
+            cacheReadTokens: 0,
+            cacheWriteTokens: 0,
+          },
+          outputTokens: 0,
+          outputTokenDetails: {
+            textTokens: 0,
+            reasoningTokens: 0,
+          },
+          totalTokens: 10,
+        },
+      };
+    }
+
+    const result = await processStreamChunks({
+      fullStream: filteredParts() as unknown as AsyncIterableStream<
+        TextStreamPart<ToolSet>
+      >,
+      fullResponse: "Existing response.",
+      abortController: new AbortController(),
+      chatId: 1,
+      processResponseChunkUpdate: async ({ fullResponse }) => fullResponse,
+    });
+
+    expect(result.fullResponse).toBe("Existing response.");
+    expect(result.incrementalResponse).toBe("");
+  });
+});
 
 describe("getDyadAddDependencyTags", () => {
   it("should return an empty array when no dyad-add-dependency tags are found", () => {

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -167,6 +167,14 @@ import { toRendererMessage } from "../utils/renderer_chat_message";
 
 type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
 
+function createEmptyTextStream(): AsyncIterableStream<TextStreamPart<ToolSet>> {
+  return new ReadableStream<TextStreamPart<ToolSet>>({
+    start(controller) {
+      controller.close();
+    },
+  }) as AsyncIterableStream<TextStreamPart<ToolSet>>;
+}
+
 const logger = log.scope("chat_stream_handlers");
 
 // Track active streams for cancellation
@@ -207,6 +215,7 @@ export async function processStreamChunks({
   abortController,
   chatId,
   processResponseChunkUpdate,
+  includeReasoning = true,
 }: {
   fullStream: AsyncIterableStream<TextStreamPart<ToolSet>>;
   fullResponse: string;
@@ -215,10 +224,16 @@ export async function processStreamChunks({
   processResponseChunkUpdate: (params: {
     fullResponse: string;
   }) => Promise<string>;
-}): Promise<{ fullResponse: string; incrementalResponse: string }> {
+  includeReasoning?: boolean;
+}): Promise<{
+  fullResponse: string;
+  incrementalResponse: string;
+  modelRefused: boolean;
+}> {
   const responseBeforeStream = fullResponse;
   let incrementalResponse = "";
   let inThinkingBlock = false;
+  let modelRefused = false;
 
   for await (const part of fullStream) {
     let chunk = "";
@@ -238,9 +253,10 @@ export async function processStreamChunks({
       fullResponse = responseBeforeStream;
       incrementalResponse = "";
       chunk = MODEL_REFUSAL_WARNING;
+      modelRefused = true;
     } else if (part.type === "text-delta") {
       chunk += part.text;
-    } else if (part.type === "reasoning-delta") {
+    } else if (part.type === "reasoning-delta" && includeReasoning) {
       if (!inThinkingBlock) {
         chunk = "<think>";
         inThinkingBlock = true;
@@ -283,9 +299,13 @@ export async function processStreamChunks({
       logger.log(`Stream for chat ${chatId} was aborted`);
       break;
     }
+
+    if (modelRefused) {
+      break;
+    }
   }
 
-  return { fullResponse, incrementalResponse };
+  return { fullResponse, incrementalResponse, modelRefused };
 }
 
 export function registerChatStreamHandlers() {
@@ -1542,6 +1562,8 @@ This conversation includes one or more image attachments. When the user uploads 
           return;
         }
 
+        let modelRefused = false;
+
         // Use MCP agent code path if:
         // 1. The enableMcpServersForBuildMode experiment is on AND
         // 2. Mode is "build" AND there are enabled MCP servers
@@ -1589,23 +1611,31 @@ This conversation includes one or more image attachments. When the user uploads 
               processResponseChunkUpdate,
             });
             fullResponse = result.fullResponse;
-            chatMessages.push({
-              role: "assistant",
-              content: fullResponse,
-            });
-            chatMessages.push({
-              role: "user",
-              content: "OK.",
-            });
+            if (result.modelRefused) {
+              modelRefused = true;
+            } else {
+              chatMessages.push({
+                role: "assistant",
+                content: fullResponse,
+              });
+              chatMessages.push({
+                role: "user",
+                content: "OK.",
+              });
+            }
           }
         }
 
         // When calling streamText, the messages need to be properly formatted for mixed content
-        const { fullStream } = await simpleStreamText({
-          chatMessages,
-          modelClient,
-          files: files,
-        });
+        const fullStream = modelRefused
+          ? createEmptyTextStream()
+          : (
+              await simpleStreamText({
+                chatMessages,
+                modelClient,
+                files: files,
+              })
+            ).fullStream;
 
         // Process the stream as before
         try {
@@ -1617,8 +1647,11 @@ This conversation includes one or more image attachments. When the user uploads 
             processResponseChunkUpdate,
           });
           fullResponse = result.fullResponse;
+          if (result.modelRefused) {
+            modelRefused = true;
+          }
 
-          if (isTurboEditsV2Enabled(settings)) {
+          if (!modelRefused && isTurboEditsV2Enabled(settings)) {
             let issues = await dryRunSearchReplace({
               fullResponse,
               appPath: getDyadAppPath(updatedChat.app.path),
@@ -1666,9 +1699,7 @@ This conversation includes one or more image attachments. When the user uploads 
               searchReplaceFixAttempts++;
               const userPrompt = {
                 role: "user",
-                content: `${fixSearchReplacePrompt}
-                
-${formattedSearchReplaceIssues}`,
+                content: `${fixSearchReplacePrompt}\n\n${formattedSearchReplaceIssues}`,
               } as const;
 
               const { fullStream: fixSearchReplaceStream } =
@@ -1692,6 +1723,10 @@ ${formattedSearchReplaceIssues}`,
                 processResponseChunkUpdate,
               });
               fullResponse = result.fullResponse;
+              if (result.modelRefused) {
+                modelRefused = true;
+                break;
+              }
               previousAttempts.push({
                 role: "assistant",
                 content: removeNonEssentialTags(result.incrementalResponse),
@@ -1716,6 +1751,7 @@ ${formattedSearchReplaceIssues}`,
           }
 
           if (
+            !modelRefused &&
             !abortController.signal.aborted &&
             hasUnclosedDyadWrite(fullResponse)
           ) {
@@ -1747,23 +1783,24 @@ ${formattedSearchReplaceIssues}`,
                 modelClient,
                 files: files,
               });
-              for await (const part of contStream) {
-                // If the stream was aborted, exit early
-                if (abortController.signal.aborted) {
-                  logger.log(`Stream for chat ${req.chatId} was aborted`);
-                  break;
-                }
-                if (part.type !== "text-delta") continue; // ignore reasoning for continuation
-                fullResponse += part.text;
-                fullResponse = cleanFullResponse(fullResponse);
-                fullResponse = await processResponseChunkUpdate({
-                  fullResponse,
-                });
+              const result = await processStreamChunks({
+                fullStream: contStream,
+                fullResponse,
+                abortController,
+                chatId: req.chatId,
+                processResponseChunkUpdate,
+                includeReasoning: false,
+              });
+              fullResponse = result.fullResponse;
+              if (result.modelRefused) {
+                modelRefused = true;
+                break;
               }
             }
           }
           const addDependencies = getDyadAddDependencyTags(fullResponse);
           if (
+            !modelRefused &&
             !abortController.signal.aborted &&
             // If there are dependencies, we don't want to auto-fix problems
             // because there's going to be type errors since the packages aren't
@@ -1866,6 +1903,10 @@ ${problemReport.problems
                   processResponseChunkUpdate,
                 });
                 fullResponse = result.fullResponse;
+                if (result.modelRefused) {
+                  modelRefused = true;
+                  break;
+                }
                 previousAttempts.push({
                   role: "assistant",
                   content: removeNonEssentialTags(result.incrementalResponse),

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -99,6 +99,10 @@ import { fileExists } from "../utils/file_utils";
 import { isCodeExplorerReady } from "../processors/code_explorer";
 import { appendCancelledResponseNotice } from "@/shared/chatCancellation";
 import {
+  isModelRefusal,
+  MODEL_REFUSAL_WARNING,
+} from "@/ipc/utils/model_refusal";
+import {
   extractMentionedAppsCodebasesFromPrompt,
   extractMentionedAppsReferencesFromPrompt,
   type MentionedAppCodebaseEntry,
@@ -197,7 +201,7 @@ function parseMcpToolKey(toolKey: string): {
 }
 
 // Helper function to process stream chunks
-async function processStreamChunks({
+export async function processStreamChunks({
   fullStream,
   fullResponse,
   abortController,
@@ -212,6 +216,7 @@ async function processStreamChunks({
     fullResponse: string;
   }) => Promise<string>;
 }): Promise<{ fullResponse: string; incrementalResponse: string }> {
+  const responseBeforeStream = fullResponse;
   let incrementalResponse = "";
   let inThinkingBlock = false;
 
@@ -226,7 +231,14 @@ async function processStreamChunks({
       chunk = "</think>";
       inThinkingBlock = false;
     }
-    if (part.type === "text-delta") {
+    if (isModelRefusal(part)) {
+      // Anthropic returns Fable classifier refusals as successful responses.
+      // A refusal can arrive after partial output, which Anthropic documents as
+      // incomplete, so replace this stream's output with a persisted warning.
+      fullResponse = responseBeforeStream;
+      incrementalResponse = "";
+      chunk = MODEL_REFUSAL_WARNING;
+    } else if (part.type === "text-delta") {
       chunk += part.text;
     } else if (part.type === "reasoning-delta") {
       if (!inThinkingBlock) {

--- a/src/ipc/utils/model_refusal.ts
+++ b/src/ipc/utils/model_refusal.ts
@@ -1,7 +1,7 @@
 import type { TextStreamPart, ToolSet } from "ai";
 
 export const MODEL_REFUSAL_WARNING =
-  '<dyad-output type="warning" message="Request declined by the model">The model\'s safety system declined this request. Try rephrasing with more context about your goal, or switch to a different model.</dyad-output>';
+  '<dyad-output type="warning" message="Model refused to respond for safety reasons">The model’s safety system rejected this request. Try switching to a different model.</dyad-output>';
 
 export function isModelRefusal(part: TextStreamPart<ToolSet>): boolean {
   return (

--- a/src/ipc/utils/model_refusal.ts
+++ b/src/ipc/utils/model_refusal.ts
@@ -1,0 +1,12 @@
+import type { TextStreamPart, ToolSet } from "ai";
+
+export const MODEL_REFUSAL_WARNING =
+  '<dyad-output type="warning" message="Request declined by the model">The model\'s safety system declined this request. For legitimate cybersecurity work, explain the authorized, defensive goal and environment, or try another model.</dyad-output>';
+
+export function isModelRefusal(part: TextStreamPart<ToolSet>): boolean {
+  return (
+    part.type === "finish" &&
+    part.finishReason === "content-filter" &&
+    part.rawFinishReason === "refusal"
+  );
+}

--- a/src/ipc/utils/model_refusal.ts
+++ b/src/ipc/utils/model_refusal.ts
@@ -1,7 +1,7 @@
 import type { TextStreamPart, ToolSet } from "ai";
 
 export const MODEL_REFUSAL_WARNING =
-  '<dyad-output type="warning" message="Request declined by the model">The model\'s safety system declined this request. For legitimate cybersecurity work, explain the authorized, defensive goal and environment, or try another model.</dyad-output>';
+  '<dyad-output type="warning" message="Request declined by the model">The model\'s safety system declined this request. Try rephrasing with more context about your goal, or switch to a different model.</dyad-output>';
 
 export function isModelRefusal(part: TextStreamPart<ToolSet>): boolean {
   return (

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.test.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.test.ts
@@ -525,7 +525,7 @@ describe("handleLocalAgentStream", () => {
 
   describe("Warning propagation", () => {
     it("replaces partial output with an inline warning for Fable refusals", async () => {
-      const { event } = createFakeEvent();
+      const { event, getMessagesByChannel } = createFakeEvent();
       mockSettings = buildTestSettings({ enableDyadPro: true });
       mockChatData = buildTestChat();
       mockStreamResult = createFakeStream([
@@ -556,6 +556,17 @@ describe("handleLocalAgentStream", () => {
       expect(finalContent).toContain(
         '<dyad-output type="warning" message="Request declined by the model">',
       );
+      const aiMessagesUpdate = dbOperations.updates.find(
+        (update) => update.data.aiMessagesJson !== undefined,
+      );
+      expect(JSON.stringify(aiMessagesUpdate?.data.aiMessagesJson)).toContain(
+        "Request declined by the model",
+      );
+      expect(
+        getMessagesByChannel("chat:response:end")[0].args[0],
+      ).toMatchObject({
+        updatedFiles: false,
+      });
     });
 
     it("includes warning messages in the error payload when a tool fails after warning", async () => {

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.test.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.test.ts
@@ -554,13 +554,13 @@ describe("handleLocalAgentStream", () => {
       const finalContent = contentUpdates.at(-1)?.data.content as string;
       expect(finalContent).not.toContain("Incomplete output");
       expect(finalContent).toContain(
-        '<dyad-output type="warning" message="Request declined by the model">',
+        '<dyad-output type="warning" message="Model refused to respond for safety reasons">',
       );
       const aiMessagesUpdate = dbOperations.updates.find(
         (update) => update.data.aiMessagesJson !== undefined,
       );
       expect(JSON.stringify(aiMessagesUpdate?.data.aiMessagesJson)).toContain(
-        "Request declined by the model",
+        "Model refused to respond for safety reasons",
       );
       expect(
         getMessagesByChannel("chat:response:end")[0].args[0],

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.test.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.test.ts
@@ -524,6 +524,40 @@ describe("handleLocalAgentStream", () => {
   });
 
   describe("Warning propagation", () => {
+    it("replaces partial output with an inline warning for Fable refusals", async () => {
+      const { event } = createFakeEvent();
+      mockSettings = buildTestSettings({ enableDyadPro: true });
+      mockChatData = buildTestChat();
+      mockStreamResult = createFakeStream([
+        { type: "text-delta", id: "text-1", text: "Incomplete output" },
+        {
+          type: "finish",
+          finishReason: "content-filter",
+          rawFinishReason: "refusal",
+        },
+      ]);
+
+      await handleLocalAgentStream(
+        event,
+        { chatId: 1, prompt: "test" },
+        new AbortController(),
+        {
+          placeholderMessageId: 10,
+          systemPrompt: "You are helpful",
+          dyadRequestId,
+        },
+      );
+
+      const contentUpdates = dbOperations.updates.filter(
+        (update) => update.data.content !== undefined,
+      );
+      const finalContent = contentUpdates.at(-1)?.data.content as string;
+      expect(finalContent).not.toContain("Incomplete output");
+      expect(finalContent).toContain(
+        '<dyad-output type="warning" message="Request declined by the model">',
+      );
+    });
+
     it("includes warning messages in the error payload when a tool fails after warning", async () => {
       const { event, getMessagesByChannel } = createFakeEvent();
       mockSettings = buildTestSettings({ enableDyadPro: true });

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -112,6 +112,10 @@ import { exitPlanTool } from "./tools/exit_plan";
 import { writeAppBlueprintTool } from "./tools/write_app_blueprint";
 import { appendCancelledResponseNotice } from "@/shared/chatCancellation";
 import {
+  isModelRefusal,
+  MODEL_REFUSAL_WARNING,
+} from "@/ipc/utils/model_refusal";
+import {
   isChatPendingCompaction,
   performCompaction,
   checkAndMarkForCompaction,
@@ -864,6 +868,7 @@ export async function handleLocalAgentStream(
     // Track total steps across all passes to detect step limit
     let totalStepsExecuted = 0;
     let hitStepLimit = false;
+    let modelRefused = false;
 
     // If there are persisted todos from a previous turn, inject a synthetic
     // user message so the LLM is aware of them. Inserted BEFORE the user's
@@ -948,6 +953,7 @@ export async function handleLocalAgentStream(
           }
           attemptToolInputIds.clear();
         };
+        const responseBeforeAttempt = fullResponse;
 
         try {
           const streamResult = streamText({
@@ -1240,6 +1246,18 @@ export async function handleLocalAgentStream(
               }
 
               switch (part.type) {
+                case "finish":
+                  if (isModelRefusal(part)) {
+                    // Refusals are successful responses and may arrive after
+                    // incomplete output, so replace this attempt with a warning.
+                    fullResponse = responseBeforeAttempt;
+                    passProducedChatText = false;
+                    inThinkingBlock = false;
+                    chunk = MODEL_REFUSAL_WARNING;
+                    modelRefused = true;
+                  }
+                  break;
+
                 case "text-delta":
                   passProducedChatText = true;
                   chunk += part.text;
@@ -1340,6 +1358,10 @@ export async function handleLocalAgentStream(
                 await updateResponseInDb(placeholderMessageId, fullResponse);
                 sendChunk(fullResponse);
               }
+
+              if (modelRefused) {
+                break;
+              }
             }
           } catch (error) {
             if (!abortController.signal.aborted) {
@@ -1361,6 +1383,12 @@ export async function handleLocalAgentStream(
           activeRetryReplayEvents = null;
 
           if (abortController.signal.aborted) {
+            break;
+          }
+
+          if (modelRefused) {
+            responseMessages = [];
+            steps = [];
             break;
           }
 
@@ -1471,6 +1499,10 @@ export async function handleLocalAgentStream(
       }
 
       if (abortController.signal.aborted) {
+        break;
+      }
+
+      if (modelRefused) {
         break;
       }
 
@@ -1607,7 +1639,11 @@ export async function handleLocalAgentStream(
       });
     }
 
-    if (shouldWarnIfAttachmentUnread && !usedAttachmentAccessTool) {
+    if (
+      !modelRefused &&
+      shouldWarnIfAttachmentUnread &&
+      !usedAttachmentAccessTool
+    ) {
       const unreadAttachmentWarning =
         "Your model did not reference the attached file. If this was unintended, try a larger model or paste the contents inline.";
       const warningMessage = `\n\n<dyad-output type="warning" message="${escapeXmlAttr(unreadAttachmentWarning)}">${escapeXmlContent(unreadAttachmentWarning)}</dyad-output>`;

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -1586,6 +1586,13 @@ export async function handleLocalAgentStream(
       return false; // Cancelled - don't consume quota
     }
 
+    if (modelRefused) {
+      accumulatedAiMessages.push({
+        role: "assistant",
+        content: [{ type: "text", text: MODEL_REFUSAL_WARNING }],
+      });
+    }
+
     // Collect XML produced by post-turn side-effects (step-limit notice,
     // Supabase deploy results) so we can persist them into aiMessagesJson.
     // parseAiMessagesJson reads from aiMessagesJson when present and ignores
@@ -1716,7 +1723,8 @@ export async function handleLocalAgentStream(
     // Send completion
     safeSend(event.sender, "chat:response:end", {
       chatId: req.chatId,
-      updatedFiles: !readOnly,
+      updatedFiles:
+        !readOnly && (!modelRefused || Object.keys(fileEditTracker).length > 0),
       chatSummary: ctx.chatSummary,
       warningMessages:
         warningMessages.length > 0 ? [...new Set(warningMessages)] : undefined,


### PR DESCRIPTION
## Summary

Surface Claude Fable 5 classifier refusals as a persistent inline chat warning instead of leaving users with an empty or incomplete response.

- Detect the AI SDK's normalized `content-filter` finish only when the provider's raw finish reason is `refusal`, avoiding false labels for unrelated content filters.
- Apply the behavior to both the default chat stream and the separate local-agent stream used by ask, plan, and agent modes.
- Replace partial output from the refused attempt because Anthropic documents mid-stream refusal output as incomplete; content from earlier completed attempts is retained.
- Keep the message category-neutral because the AI SDK exposes the refusal stop reason but not Fable's `stop_details.category` metadata.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core LLM stream consumption in build chat and local agent (continuation, turbo-edits, auto-fix gating), but refusal is narrowly detected and covered by tests; misclassification would mainly affect warning display and whether follow-up streams run.
> 
> **Overview**
> Adds shared detection for **Fable/Anthropic safety refusals** when the AI SDK reports `finishReason: "content-filter"` with `rawFinishReason: "refusal"`, and surfaces a persistent `<dyad-output type="warning">` instead of leaving partial or empty assistant text.
> 
> **Build-mode chat streaming** routes refusal handling through `processStreamChunks` (now exported): on refusal it rolls back that stream’s partial output, appends the warning, stops the chunk loop, and sets `modelRefused` so follow-up work is skipped—no second `simpleStreamText` call, no turbo-edits fix loops, unclosed-write continuation, or auto-fix passes. Continuation streams now use `processStreamChunks` with `includeReasoning: false` instead of a hand-rolled text-delta loop.
> 
> **Local agent** applies the same finish-part check inline, aborts the current pass and outer tool loop on refusal, writes the warning into `aiMessagesJson`, and avoids post-turn side effects like the unread-attachment warning; `chat:response:end` `updatedFiles` stays false unless file edits already happened.
> 
> IPC docs note that refusals are successful stream completions, not errors. Unit tests cover refusal vs other content filters for both paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc2084e251c675a316643b2115751e496f8328e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

