### PR TITLE
Ensure Ctrl+C stops all Electron dev processes

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "bump": "node scripts/bump-version.mjs",
     "clean": "rimraf out scaffold/node_modules",
-    "start": "electron-forge start",
+    "start": "node scripts/start-supervisor.mjs",
     "start:onboarding": "node scripts/start-onboarding.mjs",
     "dev": "cross-env NODE_ENV=development npm start",
     "dev:engine": "cross-env DYAD_ENGINE_URL=http://localhost:8080/v1 npm start",

--- a/rules/electron-workers.md
+++ b/rules/electron-workers.md
@@ -29,3 +29,9 @@ Read this when spawning `worker_threads` or `utilityProcess` children, moving he
 - Logged main-process RSS **includes** all worker_threads — they are threads, not processes. Renderer/GPU/utility processes are separate; enumerate them with `app.getAppMetrics()`.
 - On macOS, `os.totalmem() - os.freemem()` is misleading: `os.freemem()` counts only truly-free pages, so reclaimable file cache reads as "used" (a healthy 16 GB Mac can show ~85% "used" by this formula while `memory_pressure` reports the system 86% free). For real pressure signals use `vm_stat` (pageouts, compressed pages), `sysctl vm.swapusage`, and `memory_pressure`.
 - Two V8 string facts that change memory math: ASCII text is stored at 1 byte/char (not 2), and string concatenation builds lazy cons strings — a `` `${prefix} ${hugeString}` `` template is nearly free until something flattens it (e.g. `JSON.stringify`). Corollary: never re-materialize codebase-scale strings just to measure them — sum `content.length` values instead of `join(...)` followed by `.length`.
+
+## Development launcher cleanup
+
+- Treat Ctrl+C cleanup for `npm start` as development tooling; do not add signal-only shutdown behavior to packaged runtime paths. A POSIX supervisor should launch Electron Forge as a process-group leader and signal the negative group PID so Forge, Electron, renderer helpers, and preview servers are terminated together.
+- Keep SIGINT/SIGTERM/SIGHUP handlers installed until forced cleanup finishes. npm and the controlling PTY can deliver repeated signals; a one-shot handler lets a later signal terminate the supervisor before its fallback timer kills children that ignored SIGTERM.
+- Electron's macOS Crashpad handler leaves the Forge process group, and a killed Electron process can remain registered with LaunchServices. Clean up the checkout-specific Crashpad PID separately and notify `lsappinfo` of the Electron PID's exit so no helper or Dock entry remains.

--- a/scripts/start-supervisor.mjs
+++ b/scripts/start-supervisor.mjs
@@ -1,0 +1,199 @@
+import { spawn, spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const forgeCli = path.join(
+  repoRoot,
+  "node_modules/@electron-forge/cli/dist/electron-forge.js",
+);
+const electronExecutable = path.join(
+  repoRoot,
+  "node_modules/electron/dist/Electron.app/Contents/MacOS/Electron",
+);
+const crashpadExecutable = path.join(
+  repoRoot,
+  "node_modules/electron/dist/Electron.app/Contents/Frameworks/Electron Framework.framework/Helpers/chrome_crashpad_handler",
+);
+
+function readProcessTable(runSync) {
+  const result = runSync("ps", ["-axo", "pid=,pgid=,command="], {
+    encoding: "utf8",
+  });
+
+  return String(result.stdout ?? "")
+    .split("\n")
+    .map((line) => line.match(/^\s*(\d+)\s+(\d+)\s+(.+)$/))
+    .filter(Boolean);
+}
+
+export function findMacElectronPids({ processGroupId, runSync = spawnSync }) {
+  return readProcessTable(runSync)
+    .filter(
+      (match) =>
+        Number(match[2]) === processGroupId &&
+        match[3].startsWith(`${electronExecutable} `),
+    )
+    .map((match) => Number(match[1]));
+}
+
+export function findMacCrashpadPids({ runSync = spawnSync } = {}) {
+  return readProcessTable(runSync)
+    .filter((match) => match[3].startsWith(`${crashpadExecutable} `))
+    .map((match) => Number(match[1]));
+}
+
+export function signalDetachedProcesses({
+  pids,
+  signal,
+  kill = process.kill.bind(process),
+}) {
+  for (const pid of pids) {
+    try {
+      kill(pid, signal);
+    } catch (error) {
+      if (error?.code !== "ESRCH") throw error;
+    }
+  }
+}
+
+export function unregisterMacElectronApps({
+  pids,
+  exitStatus,
+  spawnProcess = spawn,
+}) {
+  for (const pid of pids) {
+    const cleanup = spawnProcess(
+      "lsappinfo",
+      ["quit", "-asn", `#${pid}`, "-exitstatus", String(exitStatus)],
+      {
+        detached: true,
+        stdio: "ignore",
+      },
+    );
+    cleanup.once("error", () => {});
+    cleanup.unref();
+  }
+}
+
+export function signalDevelopmentTree({
+  pid,
+  signal,
+  platform = process.platform,
+  kill = process.kill.bind(process),
+  runSync = spawnSync,
+}) {
+  if (platform === "win32") {
+    runSync("taskkill", ["/pid", String(pid), "/T", "/F"], {
+      stdio: "ignore",
+    });
+    return;
+  }
+
+  try {
+    // The Forge child is a process-group leader on POSIX. A negative PID
+    // signals Forge, Electron, Electron helpers, and spawned app servers.
+    kill(-pid, signal);
+  } catch (error) {
+    if (error?.code !== "ESRCH") throw error;
+  }
+}
+
+export function startDevelopmentSupervisor({
+  args = process.argv.slice(2),
+  platform = process.platform,
+  parentProcess = process,
+  spawnProcess = spawn,
+  spawnCleanupProcess = spawn,
+  runSync = spawnSync,
+  forceKillAfterMs = 1_000,
+} = {}) {
+  const child = spawnProcess(
+    parentProcess.execPath,
+    [forgeCli, "start", ...args],
+    {
+      cwd: repoRoot,
+      detached: platform !== "win32",
+      env: parentProcess.env,
+      stdio: "inherit",
+    },
+  );
+
+  let shutdownSignal;
+  let forceKillTimer;
+
+  const shutdown = (signal) => {
+    if (shutdownSignal || !child.pid) return;
+    shutdownSignal = signal;
+    const exitStatus = signal === "SIGINT" ? 130 : 143;
+    let detachedPids = [];
+
+    if (platform === "darwin") {
+      const electronPids = findMacElectronPids({
+        processGroupId: child.pid,
+        runSync,
+      });
+      detachedPids = findMacCrashpadPids({ runSync });
+      unregisterMacElectronApps({
+        pids: electronPids,
+        exitStatus,
+        spawnProcess: spawnCleanupProcess,
+      });
+    }
+
+    signalDevelopmentTree({ pid: child.pid, signal: "SIGTERM", platform });
+    signalDetachedProcesses({ pids: detachedPids, signal: "SIGTERM" });
+    forceKillTimer = setTimeout(() => {
+      signalDevelopmentTree({ pid: child.pid, signal: "SIGKILL", platform });
+      signalDetachedProcesses({ pids: detachedPids, signal: "SIGKILL" });
+      parentProcess.exitCode = exitStatus;
+    }, forceKillAfterMs);
+  };
+
+  const handleSigint = () => shutdown("SIGINT");
+  const handleSigterm = () => shutdown("SIGTERM");
+  const handleSighup = () => shutdown("SIGHUP");
+  parentProcess.on("SIGINT", handleSigint);
+  parentProcess.on("SIGTERM", handleSigterm);
+  if (platform !== "win32") parentProcess.on("SIGHUP", handleSighup);
+
+  child.once("error", (error) => {
+    clearTimeout(forceKillTimer);
+    console.error("Failed to start Electron Forge:", error);
+    parentProcess.exitCode = 1;
+  });
+
+  child.once("exit", (code, signal) => {
+    parentProcess.removeListener("SIGINT", handleSigint);
+    parentProcess.removeListener("SIGTERM", handleSigterm);
+    parentProcess.removeListener("SIGHUP", handleSighup);
+
+    if (shutdownSignal) {
+      // Forge exits promptly on SIGTERM, but Electron and app servers may not.
+      // Keep the force-kill timer alive to finish the whole process group.
+      return;
+    }
+
+    clearTimeout(forceKillTimer);
+    if (typeof code === "number") {
+      parentProcess.exitCode = code;
+    } else {
+      console.error(
+        `Electron Forge exited with ${signal ?? "an unknown signal"}`,
+      );
+      parentProcess.exitCode = 1;
+    }
+  });
+
+  return child;
+}
+
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  startDevelopmentSupervisor();
+}

--- a/scripts/start-supervisor.test.mjs
+++ b/scripts/start-supervisor.test.mjs
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  findMacCrashpadPids,
+  findMacElectronPids,
+  signalDetachedProcesses,
+  signalDevelopmentTree,
+  startDevelopmentSupervisor,
+  unregisterMacElectronApps,
+} from "./start-supervisor.mjs";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const electronExecutable = path.join(
+  repoRoot,
+  "node_modules/electron/dist/Electron.app/Contents/MacOS/Electron",
+);
+const crashpadExecutable = path.join(
+  repoRoot,
+  "node_modules/electron/dist/Electron.app/Contents/Frameworks/Electron Framework.framework/Helpers/chrome_crashpad_handler",
+);
+
+test("signals the full POSIX development process group", () => {
+  const calls = [];
+
+  signalDevelopmentTree({
+    pid: 1234,
+    signal: "SIGTERM",
+    platform: "darwin",
+    kill: (...args) => calls.push(args),
+  });
+
+  assert.deepEqual(calls, [[-1234, "SIGTERM"]]);
+});
+
+test("finds Electron main processes in the development process group", () => {
+  const stdout = `
+  100  50 /repo/node
+  200  50 ${electronExecutable} .
+  201  50 ${repoRoot}/node_modules/electron/dist/Electron.app/Contents/Frameworks/Electron Helper
+  300  99 ${electronExecutable} .
+`;
+
+  assert.deepEqual(
+    findMacElectronPids({
+      processGroupId: 50,
+      runSync: () => ({ stdout }),
+    }),
+    [200],
+  );
+});
+
+test("finds detached Crashpad processes for this checkout", () => {
+  const stdout = `
+  200  50 ${crashpadExecutable} --database=dyad
+  300  99 ${repoRoot}-zero/node_modules/electron/dist/Electron.app/Contents/Frameworks/Electron Framework.framework/Helpers/chrome_crashpad_handler --database=dyad-zero
+`;
+
+  assert.deepEqual(findMacCrashpadPids({ runSync: () => ({ stdout }) }), [200]);
+});
+
+test("signals detached development processes individually", () => {
+  const calls = [];
+
+  signalDetachedProcesses({
+    pids: [200, 201],
+    signal: "SIGKILL",
+    kill: (...args) => calls.push(args),
+  });
+
+  assert.deepEqual(calls, [
+    [200, "SIGKILL"],
+    [201, "SIGKILL"],
+  ]);
+});
+
+test("unregisters Electron apps from macOS LaunchServices", () => {
+  const calls = [];
+  const cleanup = new EventEmitter();
+  cleanup.unref = () => calls.push(["unref"]);
+
+  unregisterMacElectronApps({
+    pids: [200],
+    exitStatus: 130,
+    spawnProcess: (...args) => {
+      calls.push(args);
+      return cleanup;
+    },
+  });
+
+  assert.deepEqual(calls, [
+    [
+      "lsappinfo",
+      ["quit", "-asn", "#200", "-exitstatus", "130"],
+      { detached: true, stdio: "ignore" },
+    ],
+    ["unref"],
+  ]);
+});
+
+test("repeated terminal signals cannot interrupt forced cleanup", async () => {
+  const parentProcess = new EventEmitter();
+  parentProcess.execPath = process.execPath;
+  parentProcess.env = {};
+  parentProcess.exitCode = undefined;
+  const child = new EventEmitter();
+  child.pid = 4321;
+  const spawnCalls = [];
+  const originalKill = process.kill;
+  const killCalls = [];
+  process.kill = (...args) => {
+    killCalls.push(args);
+    return true;
+  };
+
+  try {
+    startDevelopmentSupervisor({
+      parentProcess,
+      platform: "linux",
+      forceKillAfterMs: 1,
+      spawnProcess: (...args) => {
+        spawnCalls.push(args);
+        return child;
+      },
+    });
+
+    parentProcess.emit("SIGINT");
+    parentProcess.emit("SIGINT");
+    parentProcess.emit("SIGHUP");
+    child.emit("exit", null, "SIGTERM");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    assert.equal(spawnCalls[0][2].detached, true);
+    assert.deepEqual(killCalls, [
+      [-4321, "SIGTERM"],
+      [-4321, "SIGKILL"],
+    ]);
+    assert.equal(parentProcess.exitCode, 130);
+  } finally {
+    process.kill = originalKill;
+  }
+});


### PR DESCRIPTION
## Summary

Make Ctrl+C from `npm start` reliably stop the complete Electron development session, including preview servers and macOS helpers that previously survived after Electron Forge returned control to the shell. The solution is intentionally confined to the development launcher and does not change packaged application shutdown behavior.

- Run Electron Forge under a small supervisor with its own child process group, allowing one signal to reach Forge, Electron, renderer helpers, and app preview servers; follow SIGTERM with SIGKILL after one second because Forge may exit before all descendants do.
- Keep terminal signal handlers active through forced cleanup so repeated SIGINT/SIGHUP delivery from npm and the PTY cannot terminate the supervisor midway through shutdown.
- On macOS, separately target checkout-specific Crashpad helpers because they detach from Forge's process group, and notify LaunchServices so a dead Electron process does not leave a stale Dock entry.
- Preserve cross-platform behavior by using `taskkill /T /F` for the supervised tree on Windows while retaining POSIX process-group signaling elsewhere.
- Keep the scope limited to `npm start`; production Electron lifecycle code and packaged runtime paths are intentionally unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the development `npm start` launcher and documentation; packaged Electron lifecycle is untouched.
> 
> **Overview**
> **`npm start` now runs through a development supervisor** instead of invoking Electron Forge directly, so Ctrl+C can tear down the whole dev session—not just Forge.
> 
> The supervisor spawns Forge as a **POSIX process-group leader** (detached on non-Windows) and on SIGINT/SIGTERM/SIGHUP sends **SIGTERM to the entire group**, then **SIGKILL after one second** if anything is still alive. Signal handlers stay registered through that forced cleanup so repeated signals from npm or the PTY cannot exit the supervisor early.
> 
> On **macOS**, it additionally kills checkout-specific **Crashpad** helpers that leave Forge’s group and uses **`lsappinfo quit`** so Electron does not leave a stale Dock entry. **Windows** uses `taskkill /T /F` for the supervised tree.
> 
> **`rules/electron-workers.md`** documents that this behavior is dev-only and must not be wired into packaged shutdown. **`scripts/start-supervisor.test.mjs`** covers process-group signaling, macOS PID discovery, LaunchServices cleanup, and repeated-signal behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4bf1803a80b2c40ec0a8c9ff6c2022a7de622f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

