### PR TITLE
fix: attribute annotation-stripped minidumps to the main process

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -201,8 +201,10 @@ const logger = log.scope("main");
 // recent ones for examination/export.
 const MAX_RETAINED_DUMPS = 5;
 let nativeCrashDumpsProcessed = false;
-let pendingNativeBrowserCrash: MinidumpSummary | null = null;
-let pendingNativeBrowserCrashAttribution: "ptype" | "sentinel" | null = null;
+let pendingNativeBrowserCrash: {
+  summary: MinidumpSummary;
+  attribution: "ptype" | "sentinel";
+} | null = null;
 
 // Summarize each new minidump (signal, faulting module + offset, process type —
 // no memory). A main-process crash is the app crash, so its summary is stashed
@@ -251,10 +253,9 @@ function processNativeCrashDumps(): void {
       // is also in the scan.
       const outranks =
         attribution === "ptype" &&
-        pendingNativeBrowserCrashAttribution === "sentinel";
+        pendingNativeBrowserCrash?.attribution === "sentinel";
       if (attribution && (!pendingNativeBrowserCrash || outranks)) {
-        pendingNativeBrowserCrash = summary;
-        pendingNativeBrowserCrashAttribution = attribution;
+        pendingNativeBrowserCrash = { summary, attribution };
         // A browser-process dump is direct evidence of a main-process crash,
         // so report it even if the crash sentinel wasn't written (e.g. a
         // crash during early startup).
@@ -698,10 +699,10 @@ const createWindow = () => {
         });
       }
 
-      const nativeCrash = pendingNativeBrowserCrash;
-      const nativeCrashAttribution = pendingNativeBrowserCrashAttribution;
+      const nativeCrash = pendingNativeBrowserCrash?.summary ?? null;
+      const nativeCrashAttribution =
+        pendingNativeBrowserCrash?.attribution ?? null;
       pendingNativeBrowserCrash = null;
-      pendingNativeBrowserCrashAttribution = null;
 
       sendTelemetryEvent("app:crash_detected", {
         // Mark as error so renderer PostHog before_send sampling does not
@@ -716,7 +717,9 @@ const createWindow = () => {
         ...(nativeCrash && {
           // "ptype" when the dump named the browser process itself; "sentinel"
           // when an annotation-stripped dump was correlated with the crash
-          // sentinel instead (see browserCrashAttribution).
+          // sentinel instead (see browserCrashAttribution). Sentinel
+          // attribution is weaker: the dump could belong to a child process
+          // that also lost its labels.
           crash_attribution: nativeCrashAttribution,
           crash_reason: nativeCrash.crashReason,
           exception_code: nativeCrash.exceptionCode,

--- a/src/main.ts
+++ b/src/main.ts
@@ -60,6 +60,7 @@ import {
   stopPerformanceMonitoring,
 } from "./utils/performance_monitor";
 import {
+  browserCrashAttribution,
   parseMinidumpSummary,
   type MinidumpSummary,
 } from "./utils/minidump_summary";
@@ -201,6 +202,7 @@ const logger = log.scope("main");
 const MAX_RETAINED_DUMPS = 5;
 let nativeCrashDumpsProcessed = false;
 let pendingNativeBrowserCrash: MinidumpSummary | null = null;
+let pendingNativeBrowserCrashAttribution: "ptype" | "sentinel" | null = null;
 
 // Summarize each new minidump (signal, faulting module + offset, process type —
 // no memory). A main-process crash is the app crash, so its summary is stashed
@@ -237,11 +239,25 @@ function processNativeCrashDumps(): void {
         summary.faultingModule,
         summary.faultingOffset,
       );
-      if (summary.ptype === "browser" && !pendingNativeBrowserCrash) {
+      // The sentinel check in onReady runs before the window exists, so
+      // pendingCrashDetected already reflects it by the time this runs
+      // from did-finish-load.
+      const attribution = browserCrashAttribution(
+        summary,
+        pendingCrashDetected,
+      );
+      // A ptype dump outranks a sentinel-attributed one, so a stripped
+      // child dump cannot claim the crash when the labeled browser dump
+      // is also in the scan.
+      const outranks =
+        attribution === "ptype" &&
+        pendingNativeBrowserCrashAttribution === "sentinel";
+      if (attribution && (!pendingNativeBrowserCrash || outranks)) {
         pendingNativeBrowserCrash = summary;
-        // A browser-process dump is direct evidence of a main-process crash, so
-        // report it even if the crash sentinel wasn't written (e.g. a crash
-        // during early startup).
+        pendingNativeBrowserCrashAttribution = attribution;
+        // A browser-process dump is direct evidence of a main-process crash,
+        // so report it even if the crash sentinel wasn't written (e.g. a
+        // crash during early startup).
         pendingCrashDetected = true;
       }
     }
@@ -683,7 +699,9 @@ const createWindow = () => {
       }
 
       const nativeCrash = pendingNativeBrowserCrash;
+      const nativeCrashAttribution = pendingNativeBrowserCrashAttribution;
       pendingNativeBrowserCrash = null;
+      pendingNativeBrowserCrashAttribution = null;
 
       sendTelemetryEvent("app:crash_detected", {
         // Mark as error so renderer PostHog before_send sampling does not
@@ -692,10 +710,14 @@ const createWindow = () => {
         has_performance_data: !!pendingForceCloseData,
         ...(pendingForceCloseData &&
           crashPerformanceEventFields(pendingForceCloseData)),
-        // "native" when a main-process minidump was captured for this crash,
-        // else "unknown" (no dump: force-kill / OOM-kill / power loss / missed).
+        // "native" when a minidump was attributed to this crash, else
+        // "unknown" (no dump: force-kill / OOM-kill / power loss / missed).
         crash_cause: nativeCrash ? "native" : "unknown",
         ...(nativeCrash && {
+          // "ptype" when the dump named the browser process itself; "sentinel"
+          // when an annotation-stripped dump was correlated with the crash
+          // sentinel instead (see browserCrashAttribution).
+          crash_attribution: nativeCrashAttribution,
           crash_reason: nativeCrash.crashReason,
           exception_code: nativeCrash.exceptionCode,
           fault_address: nativeCrash.faultAddress,

--- a/src/utils/minidump_summary.test.ts
+++ b/src/utils/minidump_summary.test.ts
@@ -887,4 +887,23 @@ describe("browserCrashAttribution", () => {
     expect(browserCrashAttribution(summary("gpu-process"), true)).toBeNull();
     expect(browserCrashAttribution(summary("utility"), false)).toBeNull();
   });
+
+  it("reads Electron's process_type key when ptype is stripped", () => {
+    const withProcessType = (value: string): MinidumpSummary => ({
+      exceptionCode: 0xe0000008,
+      annotations: { process_type: value },
+    });
+    expect(browserCrashAttribution(withProcessType("browser"), false)).toBe(
+      "ptype",
+    );
+    // A surviving child label blocks the sentinel fallback.
+    expect(
+      browserCrashAttribution(withProcessType("renderer"), true),
+    ).toBeNull();
+  });
+
+  it("treats an empty ptype as absent", () => {
+    expect(browserCrashAttribution(summary(""), true)).toBe("sentinel");
+    expect(browserCrashAttribution(summary(""), false)).toBeNull();
+  });
 });

--- a/src/utils/minidump_summary.test.ts
+++ b/src/utils/minidump_summary.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { parseMinidumpBuffer } from "@/utils/minidump_summary";
+import {
+  browserCrashAttribution,
+  parseMinidumpBuffer,
+  type MinidumpSummary,
+} from "@/utils/minidump_summary";
 
 // Build a minimal but valid minidump containing only the streams the parser
 // reads (module list + exception, and optionally a CrashpadInfo stream with a
@@ -857,5 +861,30 @@ describe("parseMinidumpBuffer", () => {
 
   it("rejects a truncated buffer", () => {
     expect(parseMinidumpBuffer(Buffer.alloc(8), "linux", "x64")).toBeNull();
+  });
+});
+
+describe("browserCrashAttribution", () => {
+  const summary = (ptype?: string): MinidumpSummary => ({
+    exceptionCode: 0xe0000008,
+    ptype,
+  });
+
+  it("attributes a browser-ptype dump regardless of the sentinel", () => {
+    expect(browserCrashAttribution(summary("browser"), false)).toBe("ptype");
+    expect(browserCrashAttribution(summary("browser"), true)).toBe("ptype");
+  });
+
+  it("attributes a ptype-less dump only when the sentinel detected a crash", () => {
+    // Annotation-stripped dump (e.g. a Windows main-process OOM): the
+    // sentinel is the only remaining evidence of whose crash this was.
+    expect(browserCrashAttribution(summary(undefined), true)).toBe("sentinel");
+    expect(browserCrashAttribution(summary(undefined), false)).toBeNull();
+  });
+
+  it("never attributes a child-process dump, even with the sentinel", () => {
+    expect(browserCrashAttribution(summary("renderer"), true)).toBeNull();
+    expect(browserCrashAttribution(summary("gpu-process"), true)).toBeNull();
+    expect(browserCrashAttribution(summary("utility"), false)).toBeNull();
   });
 });

--- a/src/utils/minidump_summary.ts
+++ b/src/utils/minidump_summary.ts
@@ -232,28 +232,31 @@ export function parseMinidumpSummary(
 
 // How a dump attributes to the main (browser) process, or null if it doesn't.
 //
-// "ptype": the dump's ptype annotation names the browser process. Direct
-// evidence, regardless of how the previous session ended.
+// "ptype": a process label in the dump names the browser process. Direct
+// evidence, regardless of how the previous session ended. Electron writes
+// two labels, Crashpad's ptype and its own process_type crash key, and
+// either counts; an empty value counts as absent.
 //
-// "sentinel": the dump has no ptype annotation, but the crash sentinel
-// says the app died without a clean quit. Crashpad's handler walks the
+// "sentinel": the dump has no process label, but the crash sentinel says
+// the app died without a clean quit. Crashpad's handler walks the
 // annotation list newest-first and stops at the first entry it cannot
 // read back from the crashed process, so a dump written under memory
 // exhaustion (a main-process V8 OOM) keeps only the crash-time
-// annotations and loses the earlier ones, ptype included. The sentinel
-// stands in as the evidence that the dump is the app's death and not a
-// survived child crash.
+// annotations and loses the earlier ones, the labels included. The
+// sentinel stands in as the evidence that the dump is the app's death
+// and not a survived child crash.
 //
-// A dump with a non-browser ptype is never attributed: renderer and
+// A dump with a non-browser label is never attributed: renderer and
 // utility crashes have their own reporting paths.
 export function browserCrashAttribution(
   summary: MinidumpSummary,
   appCrashDetected: boolean,
 ): "ptype" | "sentinel" | null {
-  if (summary.ptype === "browser") {
+  const label = summary.ptype || summary.annotations?.process_type;
+  if (label === "browser") {
     return "ptype";
   }
-  if (summary.ptype === undefined && appCrashDetected) {
+  if (!label && appCrashDetected) {
     return "sentinel";
   }
   return null;

--- a/src/utils/minidump_summary.ts
+++ b/src/utils/minidump_summary.ts
@@ -230,6 +230,35 @@ export function parseMinidumpSummary(
   return parseMinidumpBuffer(buf, platform, arch);
 }
 
+// How a dump attributes to the main (browser) process, or null if it doesn't.
+//
+// "ptype": the dump's ptype annotation names the browser process. Direct
+// evidence, regardless of how the previous session ended.
+//
+// "sentinel": the dump has no ptype annotation, but the crash sentinel
+// says the app died without a clean quit. Crashpad's handler walks the
+// annotation list newest-first and stops at the first entry it cannot
+// read back from the crashed process, so a dump written under memory
+// exhaustion (a main-process V8 OOM) keeps only the crash-time
+// annotations and loses the earlier ones, ptype included. The sentinel
+// stands in as the evidence that the dump is the app's death and not a
+// survived child crash.
+//
+// A dump with a non-browser ptype is never attributed: renderer and
+// utility crashes have their own reporting paths.
+export function browserCrashAttribution(
+  summary: MinidumpSummary,
+  appCrashDetected: boolean,
+): "ptype" | "sentinel" | null {
+  if (summary.ptype === "browser") {
+    return "ptype";
+  }
+  if (summary.ptype === undefined && appCrashDetected) {
+    return "sentinel";
+  }
+  return null;
+}
+
 // Parse an in-memory minidump into a MinidumpSummary. Finds the streams it needs
 // via the directory, decodes the crash reason from the exception code, resolves
 // the faulting instruction pointer to a module + offset, and reads the process


### PR DESCRIPTION
*This description was written by Claude but is human-reviewed.*

This fixes a bug introduced in #3614 and exposed by the Windows OOM tracking in #3909.

Windows main-process V8 OOM dumps lose their early-registered Crashpad annotations: the handler walks the annotation list newest-first and stops at the first entry it cannot read back from the crashed process, which under memory exhaustion strips everything registered before the crash-time keys - ptype included. app:crash_detected then fell through to crash_cause "unknown" and dropped the parsed OUT_OF_MEMORY details even though the dump carried them.

Attribute a ptype-less dump to the main process when the crash sentinel independently says the app died, and record how the dump was attributed in a new crash_attribution event field ("ptype" | "sentinel"). Dumps with a non-browser ptype are still never attributed, and a ptype dump outranks a sentinel-attributed one when both appear in the same scan.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

