### PR TITLE
feat: report an OOM verdict in crash telemetry

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -73,6 +73,7 @@ import {
   crashAnnotationEventFields,
   crashPerformanceEventFields,
 } from "./utils/crash_telemetry_fields";
+import { classifyOom } from "./utils/oom_classifier";
 import {
   stopAllAppsSync,
   stopAppGarbageCollection,
@@ -704,6 +705,11 @@ const createWindow = () => {
         pendingNativeBrowserCrash?.attribution ?? null;
       pendingNativeBrowserCrash = null;
 
+      const oom = classifyOom({
+        nativeCrash,
+        performance: pendingForceCloseData,
+      });
+
       sendTelemetryEvent("app:crash_detected", {
         // Mark as error so renderer PostHog before_send sampling does not
         // drop 90% of events for non-Pro users (see src/renderer.tsx).
@@ -735,6 +741,9 @@ const createWindow = () => {
         }),
         ...(nativeCrash?.annotations &&
           crashAnnotationEventFields(nativeCrash.annotations)),
+        // The OOM verdict and the signals behind it (see classifyOom).
+        oom_verdict: oom.verdict,
+        ...(oom.signals.length > 0 && { oom_signals: oom.signals }),
       });
 
       pendingForceCloseData = null;

--- a/src/main.ts
+++ b/src/main.ts
@@ -742,8 +742,9 @@ const createWindow = () => {
         ...(nativeCrash?.annotations &&
           crashAnnotationEventFields(nativeCrash.annotations)),
         // The OOM verdict and the signals behind it (see classifyOom).
+        // Comma-joined: crash event properties stay scalar for PostHog.
         oom_verdict: oom.verdict,
-        ...(oom.signals.length > 0 && { oom_signals: oom.signals }),
+        ...(oom.signals.length > 0 && { oom_signals: oom.signals.join(",") }),
       });
 
       pendingForceCloseData = null;

--- a/src/utils/crash_telemetry_fields.ts
+++ b/src/utils/crash_telemetry_fields.ts
@@ -1,7 +1,9 @@
 import type { UserSettings } from "../lib/schemas";
 import type { ActivitySnapshot } from "./memory_activity";
 
-type PerformanceSnapshot = NonNullable<UserSettings["lastKnownPerformance"]>;
+export type PerformanceSnapshot = NonNullable<
+  UserSettings["lastKnownPerformance"]
+>;
 
 // Known Electron process types get their own telemetry field; anything else
 // is summed into "other" so the set of PostHog columns stays stable.

--- a/src/utils/oom_classifier.test.ts
+++ b/src/utils/oom_classifier.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import { classifyOom } from "@/utils/oom_classifier";
+import type { MinidumpSummary } from "@/utils/minidump_summary";
+
+const baseDump: MinidumpSummary = { exceptionCode: 0xc0000005 };
+
+describe("classifyOom", () => {
+  it("returns none when there is nothing to classify", () => {
+    expect(classifyOom({ nativeCrash: null, performance: null })).toEqual({
+      verdict: "none",
+      signals: [],
+    });
+  });
+
+  it("declares native_oom for the Windows OOM exception code", () => {
+    const result = classifyOom({
+      nativeCrash: { exceptionCode: 0xe0000008, crashReason: "OUT_OF_MEMORY" },
+      performance: null,
+    });
+    expect(result.verdict).toBe("native_oom");
+    expect(result.signals).toContain("oom_exception_code");
+  });
+
+  it("declares native_oom for a recorded allocation size", () => {
+    const result = classifyOom({
+      nativeCrash: { ...baseDump, oomAllocationSizeBytes: 4096 },
+      performance: null,
+    });
+    expect(result.verdict).toBe("native_oom");
+    expect(result.signals).toContain("oom_allocation_size");
+  });
+
+  it("declares native_oom for V8's heap OOM crash key", () => {
+    const result = classifyOom({
+      nativeCrash: {
+        exceptionCode: 5,
+        crashReason: "SIGTRAP",
+        annotations: { "electron.v8-oom.is_heap_oom": "1" },
+      },
+      performance: null,
+    });
+    expect(result.verdict).toBe("native_oom");
+    expect(result.signals).toEqual(["v8_heap_oom_annotation"]);
+  });
+
+  it("declares native_oom for other v8-oom crash keys", () => {
+    const result = classifyOom({
+      nativeCrash: {
+        exceptionCode: 5,
+        annotations: { "electron.v8-oom.location": "CodeRange setup" },
+      },
+      performance: null,
+    });
+    expect(result.verdict).toBe("native_oom");
+    expect(result.signals).toEqual(["v8_oom_annotation"]);
+  });
+
+  it("suspects OOM from a peak heap near the limit when no dump exists", () => {
+    const result = classifyOom({
+      nativeCrash: null,
+      performance: { timestamp: 0, memoryUsageMB: 100, peakHeapPct: 97 },
+    });
+    expect(result.verdict).toBe("suspected_oom");
+    expect(result.signals).toEqual(["peak_heap_near_limit"]);
+  });
+
+  it("suspects OOM from exhausted system memory when no dump exists", () => {
+    const result = classifyOom({
+      nativeCrash: null,
+      performance: {
+        timestamp: 0,
+        memoryUsageMB: 100,
+        systemMemoryUsageMB: 15600,
+        systemMemoryTotalMB: 16000,
+      },
+    });
+    expect(result.verdict).toBe("suspected_oom");
+    expect(result.signals).toEqual(["system_memory_near_limit"]);
+  });
+
+  it("keeps pressure signals without changing the verdict when a non-OOM dump exists", () => {
+    const result = classifyOom({
+      nativeCrash: { ...baseDump, crashReason: "ACCESS_VIOLATION" },
+      performance: { timestamp: 0, memoryUsageMB: 100, peakHeapPct: 97 },
+    });
+    expect(result.verdict).toBe("none");
+    expect(result.signals).toEqual(["peak_heap_near_limit"]);
+  });
+
+  it("fires the heap signal at the threshold and not below it", () => {
+    const at = classifyOom({
+      nativeCrash: null,
+      performance: { timestamp: 0, memoryUsageMB: 100, peakHeapPct: 95 },
+    });
+    expect(at.verdict).toBe("suspected_oom");
+
+    const below = classifyOom({
+      nativeCrash: null,
+      performance: { timestamp: 0, memoryUsageMB: 100, peakHeapPct: 94.9 },
+    });
+    expect(below).toEqual({ verdict: "none", signals: [] });
+  });
+
+  it("combines dump and pressure signals under a native_oom verdict", () => {
+    const result = classifyOom({
+      nativeCrash: { exceptionCode: 0xe0000008, crashReason: "OUT_OF_MEMORY" },
+      performance: { timestamp: 0, memoryUsageMB: 100, peakHeapPct: 99 },
+    });
+    expect(result.verdict).toBe("native_oom");
+    expect(result.signals).toEqual([
+      "oom_exception_code",
+      "peak_heap_near_limit",
+    ]);
+  });
+});

--- a/src/utils/oom_classifier.test.ts
+++ b/src/utils/oom_classifier.test.ts
@@ -13,8 +13,9 @@ describe("classifyOom", () => {
   });
 
   it("declares native_oom for the Windows OOM exception code", () => {
+    // Matched on the raw code, so no crashReason is needed.
     const result = classifyOom({
-      nativeCrash: { exceptionCode: 0xe0000008, crashReason: "OUT_OF_MEMORY" },
+      nativeCrash: { exceptionCode: 0xe0000008 },
       performance: null,
     });
     expect(result.verdict).toBe("native_oom");
@@ -28,6 +29,24 @@ describe("classifyOom", () => {
     });
     expect(result.verdict).toBe("native_oom");
     expect(result.signals).toContain("oom_allocation_size");
+  });
+
+  it("treats a zero-byte allocation failure as an OOM", () => {
+    const result = classifyOom({
+      nativeCrash: { ...baseDump, oomAllocationSizeBytes: 0 },
+      performance: null,
+    });
+    expect(result.verdict).toBe("native_oom");
+    expect(result.signals).toContain("oom_allocation_size");
+  });
+
+  it("declares native_oom for the oom-size crash key", () => {
+    const result = classifyOom({
+      nativeCrash: { ...baseDump, annotations: { "oom-size": "4096" } },
+      performance: null,
+    });
+    expect(result.verdict).toBe("native_oom");
+    expect(result.signals).toEqual(["oom_size_annotation"]);
   });
 
   it("declares native_oom for V8's heap OOM crash key", () => {
@@ -73,9 +92,60 @@ describe("classifyOom", () => {
         systemMemoryUsageMB: 15600,
         systemMemoryTotalMB: 16000,
       },
+      platform: "win32",
     });
     expect(result.verdict).toBe("suspected_oom");
     expect(result.signals).toEqual(["system_memory_near_limit"]);
+  });
+
+  it("ignores system memory on macOS, where free memory reads low", () => {
+    const result = classifyOom({
+      nativeCrash: null,
+      performance: {
+        timestamp: 0,
+        memoryUsageMB: 100,
+        systemMemoryUsageMB: 15600,
+        systemMemoryTotalMB: 16000,
+      },
+      platform: "darwin",
+    });
+    expect(result).toEqual({ verdict: "none", signals: [] });
+  });
+
+  it("fires the system memory signal at the ratio and not below it", () => {
+    const perf = (usedMB: number) => ({
+      timestamp: 0,
+      memoryUsageMB: 100,
+      systemMemoryUsageMB: usedMB,
+      systemMemoryTotalMB: 1000,
+    });
+    const at = classifyOom({
+      nativeCrash: null,
+      performance: perf(950),
+      platform: "win32",
+    });
+    expect(at.verdict).toBe("suspected_oom");
+
+    const below = classifyOom({
+      nativeCrash: null,
+      performance: perf(949),
+      platform: "win32",
+    });
+    expect(below).toEqual({ verdict: "none", signals: [] });
+  });
+
+  it("ignores system memory when the recorded total is zero", () => {
+    const result = classifyOom({
+      nativeCrash: null,
+      performance: {
+        timestamp: 0,
+        memoryUsageMB: 100,
+        systemMemoryUsageMB: 100,
+        systemMemoryTotalMB: 0,
+      },
+      platform: "win32",
+    });
+    expect(result).toEqual({ verdict: "none", signals: [] });
   });
 
   it("keeps pressure signals without changing the verdict when a non-OOM dump exists", () => {

--- a/src/utils/oom_classifier.test.ts
+++ b/src/utils/oom_classifier.test.ts
@@ -74,13 +74,42 @@ describe("classifyOom", () => {
     expect(result.signals).toEqual(["v8_oom_annotation"]);
   });
 
-  it("suspects OOM from a peak heap near the limit when no dump exists", () => {
+  it("suspects OOM from a heap near its limit at the last heartbeat", () => {
     const result = classifyOom({
       nativeCrash: null,
-      performance: { timestamp: 0, memoryUsageMB: 100, peakHeapPct: 97 },
+      performance: {
+        timestamp: 0,
+        memoryUsageMB: 100,
+        heapUsedMB: 4000,
+        heapLimitMB: 4144,
+      },
     });
     expect(result.verdict).toBe("suspected_oom");
-    expect(result.signals).toEqual(["peak_heap_near_limit"]);
+    expect(result.signals).toEqual(["heap_near_limit"]);
+  });
+
+  it("ignores a session heap peak that had recovered by the last heartbeat", () => {
+    // The peak can be a long-recovered spike from earlier in the
+    // session, so it never counts on its own.
+    const result = classifyOom({
+      nativeCrash: null,
+      performance: {
+        timestamp: 0,
+        memoryUsageMB: 100,
+        heapUsedMB: 500,
+        heapLimitMB: 4144,
+        peakHeapPct: 99,
+      },
+    });
+    expect(result).toEqual({ verdict: "none", signals: [] });
+  });
+
+  it("ignores the heap when no limit was recorded", () => {
+    const result = classifyOom({
+      nativeCrash: null,
+      performance: { timestamp: 0, memoryUsageMB: 100, heapUsedMB: 4000 },
+    });
+    expect(result).toEqual({ verdict: "none", signals: [] });
   });
 
   it("suspects OOM from exhausted system memory when no dump exists", () => {
@@ -98,18 +127,21 @@ describe("classifyOom", () => {
     expect(result.signals).toEqual(["system_memory_near_limit"]);
   });
 
-  it("ignores system memory on macOS, where free memory reads low", () => {
-    const result = classifyOom({
-      nativeCrash: null,
-      performance: {
-        timestamp: 0,
-        memoryUsageMB: 100,
-        systemMemoryUsageMB: 15600,
-        systemMemoryTotalMB: 16000,
-      },
-      platform: "darwin",
-    });
-    expect(result).toEqual({ verdict: "none", signals: [] });
+  it("ignores system memory off Windows, where free memory reads low", () => {
+    const exhausted = {
+      timestamp: 0,
+      memoryUsageMB: 100,
+      systemMemoryUsageMB: 15600,
+      systemMemoryTotalMB: 16000,
+    };
+    for (const platform of ["darwin", "linux"] as const) {
+      const result = classifyOom({
+        nativeCrash: null,
+        performance: exhausted,
+        platform,
+      });
+      expect(result).toEqual({ verdict: "none", signals: [] });
+    }
   });
 
   it("fires the system memory signal at the ratio and not below it", () => {
@@ -151,35 +183,42 @@ describe("classifyOom", () => {
   it("keeps pressure signals without changing the verdict when a non-OOM dump exists", () => {
     const result = classifyOom({
       nativeCrash: { ...baseDump, crashReason: "ACCESS_VIOLATION" },
-      performance: { timestamp: 0, memoryUsageMB: 100, peakHeapPct: 97 },
+      performance: {
+        timestamp: 0,
+        memoryUsageMB: 100,
+        heapUsedMB: 4000,
+        heapLimitMB: 4144,
+      },
     });
     expect(result.verdict).toBe("none");
-    expect(result.signals).toEqual(["peak_heap_near_limit"]);
+    expect(result.signals).toEqual(["heap_near_limit"]);
   });
 
   it("fires the heap signal at the threshold and not below it", () => {
-    const at = classifyOom({
-      nativeCrash: null,
-      performance: { timestamp: 0, memoryUsageMB: 100, peakHeapPct: 95 },
+    const perf = (heapUsedMB: number) => ({
+      timestamp: 0,
+      memoryUsageMB: 100,
+      heapUsedMB,
+      heapLimitMB: 1000,
     });
+    const at = classifyOom({ nativeCrash: null, performance: perf(950) });
     expect(at.verdict).toBe("suspected_oom");
 
-    const below = classifyOom({
-      nativeCrash: null,
-      performance: { timestamp: 0, memoryUsageMB: 100, peakHeapPct: 94.9 },
-    });
+    const below = classifyOom({ nativeCrash: null, performance: perf(949) });
     expect(below).toEqual({ verdict: "none", signals: [] });
   });
 
   it("combines dump and pressure signals under a native_oom verdict", () => {
     const result = classifyOom({
-      nativeCrash: { exceptionCode: 0xe0000008, crashReason: "OUT_OF_MEMORY" },
-      performance: { timestamp: 0, memoryUsageMB: 100, peakHeapPct: 99 },
+      nativeCrash: { exceptionCode: 0xe0000008 },
+      performance: {
+        timestamp: 0,
+        memoryUsageMB: 100,
+        heapUsedMB: 4000,
+        heapLimitMB: 4144,
+      },
     });
     expect(result.verdict).toBe("native_oom");
-    expect(result.signals).toEqual([
-      "oom_exception_code",
-      "peak_heap_near_limit",
-    ]);
+    expect(result.signals).toEqual(["oom_exception_code", "heap_near_limit"]);
   });
 });

--- a/src/utils/oom_classifier.ts
+++ b/src/utils/oom_classifier.ts
@@ -25,7 +25,7 @@ export type OomSignal =
   | "oom_size_annotation"
   | "v8_heap_oom_annotation"
   | "v8_oom_annotation"
-  | "peak_heap_near_limit"
+  | "heap_near_limit"
   | "system_memory_near_limit";
 
 export interface OomClassification {
@@ -37,9 +37,8 @@ export interface OomClassification {
 // on the raw code so the verdict does not depend on the name table.
 const CHROMIUM_OOM_EXCEPTION_CODE = 0xe0000008;
 
-// A session peak this close to the V8 heap limit means allocations were
-// at risk of failing. Conservative enough to survive sampling jitter in
-// the 30 second heartbeat.
+// A heap this close to its limit at the last heartbeat means
+// allocations were at risk of failing.
 const HEAP_NEAR_LIMIT_PCT = 95;
 // Same idea for whole-system memory at the last heartbeat.
 const SYSTEM_MEMORY_NEAR_LIMIT_RATIO = 0.95;
@@ -75,15 +74,24 @@ export function classifyOom(input: {
   const dumpSignals = signals.length;
 
   if (performance) {
-    if ((performance.peakHeapPct ?? 0) >= HEAP_NEAR_LIMIT_PCT) {
-      signals.push("peak_heap_near_limit");
+    // The heap ratio at the last heartbeat, not the session peak: a
+    // peak can be a long-recovered spike from earlier in the session,
+    // while the last heartbeat is at most one interval before death.
+    const heapUsedMB = performance.heapUsedMB ?? 0;
+    const heapLimitMB = performance.heapLimitMB ?? 0;
+    if (
+      heapLimitMB > 0 &&
+      (heapUsedMB / heapLimitMB) * 100 >= HEAP_NEAR_LIMIT_PCT
+    ) {
+      signals.push("heap_near_limit");
     }
-    // Skipped on macOS, where os.freemem() excludes reclaimable file
-    // cache and a healthy system can look nearly full.
+    // Windows only: os.freemem() there reports available memory, cache
+    // included. On Linux and macOS it reports truly free pages, so a
+    // healthy system with a warm file cache can look nearly full.
     const totalMB = performance.systemMemoryTotalMB ?? 0;
     const usedMB = performance.systemMemoryUsageMB ?? 0;
     if (
-      platform !== "darwin" &&
+      platform === "win32" &&
       totalMB > 0 &&
       usedMB / totalMB >= SYSTEM_MEMORY_NEAR_LIMIT_RATIO
     ) {

--- a/src/utils/oom_classifier.ts
+++ b/src/utils/oom_classifier.ts
@@ -1,0 +1,84 @@
+import type { UserSettings } from "../lib/schemas";
+import type { MinidumpSummary } from "./minidump_summary";
+
+type PerformanceSnapshot = NonNullable<UserSettings["lastKnownPerformance"]>;
+
+// Whether a crash was memory exhaustion, decided from what the crash
+// left behind. The verdict is the decision; the signals are the
+// individual checks that matched, reported alongside it so the
+// reasoning stays visible in telemetry.
+//
+// "native_oom": the dump itself declares the OOM, through the exception
+// code, the failed allocation size, or V8's own crash keys.
+//
+// "suspected_oom": no dump exists, but the last heartbeat before the
+// crash showed memory near exhaustion. Covers deaths that leave no
+// dump, like the OS killing the process under memory pressure.
+//
+// "none": no sign of OOM. Memory pressure signals can still be present
+// when a dump attributes the crash to something else; they stay in the
+// signals list but do not change the verdict, since the dump already
+// explained the crash.
+export type OomVerdict = "native_oom" | "suspected_oom" | "none";
+
+export interface OomClassification {
+  verdict: OomVerdict;
+  signals: string[];
+}
+
+// A session peak this close to the V8 heap limit means allocations were
+// at risk of failing. Conservative enough to survive sampling jitter in
+// the 30 second heartbeat.
+const HEAP_NEAR_LIMIT_PCT = 95;
+// Same idea for whole-system memory at the last heartbeat.
+const SYSTEM_MEMORY_NEAR_LIMIT_RATIO = 0.95;
+
+export function classifyOom(input: {
+  nativeCrash: MinidumpSummary | null;
+  performance: PerformanceSnapshot | null;
+}): OomClassification {
+  const { nativeCrash, performance } = input;
+  const signals: string[] = [];
+
+  if (nativeCrash) {
+    if (nativeCrash.crashReason === "OUT_OF_MEMORY") {
+      signals.push("oom_exception_code");
+    }
+    if (nativeCrash.oomAllocationSizeBytes !== undefined) {
+      signals.push("oom_allocation_size");
+    }
+    if (nativeCrash.annotations?.["electron.v8-oom.is_heap_oom"] === "1") {
+      signals.push("v8_heap_oom_annotation");
+    } else if (hasV8OomAnnotation(nativeCrash.annotations)) {
+      signals.push("v8_oom_annotation");
+    }
+  }
+  const dumpSignals = signals.length;
+
+  if (performance) {
+    if ((performance.peakHeapPct ?? 0) >= HEAP_NEAR_LIMIT_PCT) {
+      signals.push("peak_heap_near_limit");
+    }
+    const totalMB = performance.systemMemoryTotalMB ?? 0;
+    const usedMB = performance.systemMemoryUsageMB ?? 0;
+    if (totalMB > 0 && usedMB / totalMB >= SYSTEM_MEMORY_NEAR_LIMIT_RATIO) {
+      signals.push("system_memory_near_limit");
+    }
+  }
+
+  if (dumpSignals > 0) {
+    return { verdict: "native_oom", signals };
+  }
+  if (!nativeCrash && signals.length > 0) {
+    return { verdict: "suspected_oom", signals };
+  }
+  return { verdict: "none", signals };
+}
+
+function hasV8OomAnnotation(
+  annotations: Record<string, string> | undefined,
+): boolean {
+  return Object.keys(annotations ?? {}).some((key) =>
+    key.startsWith("electron.v8-oom."),
+  );
+}

--- a/src/utils/oom_classifier.ts
+++ b/src/utils/oom_classifier.ts
@@ -1,7 +1,5 @@
-import type { UserSettings } from "../lib/schemas";
+import type { PerformanceSnapshot } from "./crash_telemetry_fields";
 import type { MinidumpSummary } from "./minidump_summary";
-
-type PerformanceSnapshot = NonNullable<UserSettings["lastKnownPerformance"]>;
 
 // Whether a crash was memory exhaustion, decided from what the crash
 // left behind. The verdict is the decision; the signals are the
@@ -21,10 +19,23 @@ type PerformanceSnapshot = NonNullable<UserSettings["lastKnownPerformance"]>;
 // explained the crash.
 export type OomVerdict = "native_oom" | "suspected_oom" | "none";
 
+export type OomSignal =
+  | "oom_exception_code"
+  | "oom_allocation_size"
+  | "oom_size_annotation"
+  | "v8_heap_oom_annotation"
+  | "v8_oom_annotation"
+  | "peak_heap_near_limit"
+  | "system_memory_near_limit";
+
 export interface OomClassification {
   verdict: OomVerdict;
-  signals: string[];
+  signals: OomSignal[];
 }
+
+// Chromium's kOomExceptionCode, raised for Windows OOM crashes. Matched
+// on the raw code so the verdict does not depend on the name table.
+const CHROMIUM_OOM_EXCEPTION_CODE = 0xe0000008;
 
 // A session peak this close to the V8 heap limit means allocations were
 // at risk of failing. Conservative enough to survive sampling jitter in
@@ -36,17 +47,25 @@ const SYSTEM_MEMORY_NEAR_LIMIT_RATIO = 0.95;
 export function classifyOom(input: {
   nativeCrash: MinidumpSummary | null;
   performance: PerformanceSnapshot | null;
+  platform?: NodeJS.Platform;
 }): OomClassification {
-  const { nativeCrash, performance } = input;
-  const signals: string[] = [];
+  const { nativeCrash, performance, platform = process.platform } = input;
+  const signals: OomSignal[] = [];
 
   if (nativeCrash) {
-    if (nativeCrash.crashReason === "OUT_OF_MEMORY") {
+    if (nativeCrash.exceptionCode === CHROMIUM_OOM_EXCEPTION_CODE) {
       signals.push("oom_exception_code");
     }
     if (nativeCrash.oomAllocationSizeBytes !== undefined) {
       signals.push("oom_allocation_size");
     }
+    // Chromium's allocation size crash key, for dumps that declare the
+    // OOM through annotations instead of exception parameters.
+    if (nativeCrash.annotations?.["oom-size"]) {
+      signals.push("oom_size_annotation");
+    }
+    // The specific heap OOM key subsumes the general v8-oom family, so
+    // the two signals never appear together.
     if (nativeCrash.annotations?.["electron.v8-oom.is_heap_oom"] === "1") {
       signals.push("v8_heap_oom_annotation");
     } else if (hasV8OomAnnotation(nativeCrash.annotations)) {
@@ -59,9 +78,15 @@ export function classifyOom(input: {
     if ((performance.peakHeapPct ?? 0) >= HEAP_NEAR_LIMIT_PCT) {
       signals.push("peak_heap_near_limit");
     }
+    // Skipped on macOS, where os.freemem() excludes reclaimable file
+    // cache and a healthy system can look nearly full.
     const totalMB = performance.systemMemoryTotalMB ?? 0;
     const usedMB = performance.systemMemoryUsageMB ?? 0;
-    if (totalMB > 0 && usedMB / totalMB >= SYSTEM_MEMORY_NEAR_LIMIT_RATIO) {
+    if (
+      platform !== "darwin" &&
+      totalMB > 0 &&
+      usedMB / totalMB >= SYSTEM_MEMORY_NEAR_LIMIT_RATIO
+    ) {
       signals.push("system_memory_near_limit");
     }
   }


### PR DESCRIPTION
*This description was written by Claude but is human-reviewed*

The crash telemetry now records plenty of memory data, but reading an OOM out of it still means manually cross-checking exception codes, crash keys, and heartbeat stats per event. This adds the conclusion as two fields on app:crash_detected.

oom_verdict is "native_oom" when the dump itself declares the OOM (the Windows OOM exception code, a recorded failed allocation size, or V8's v8-oom crash keys), "suspected_oom" (when no dump exists but the last heartbeat before the crash showed the V8 heap at 95 percent of its limit, or, on Windows, system memory at 95 percent of total), and "none" otherwise. oom_signals lists exactly which checks matched, so the reasoning stays visible instead of collapsing into a score. Pressure signals never change the verdict when a dump attributes the crash to something else.

The classifier is a pure function over data already gathered at the relaunch, so no new collection is added.

Verified live with a main-process V8 heap OOM: the crash event reported native_oom with the v8_heap_oom_annotation signal.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

