### PR TITLE
Redesign settings page with a flat, modern layout

### DIFF
--- a/src/components/DefaultChatModeSelector.tsx
+++ b/src/components/DefaultChatModeSelector.tsx
@@ -83,7 +83,11 @@ export function DefaultChatModeSelector() {
         value={effectiveDefault}
         onValueChange={(v) => v && handleDefaultChatModeChange(v)}
       >
-        <SelectTrigger className="w-full sm:w-[240px]" id="default-chat-mode">
+        <SelectTrigger
+          className="w-full sm:w-[240px]"
+          id="default-chat-mode"
+          aria-describedby="default-chat-mode-description"
+        >
           <SelectValue>{getModeDisplayName(effectiveDefault)}</SelectValue>
         </SelectTrigger>
         <SelectContent>

--- a/src/components/DefaultChatModeSelector.tsx
+++ b/src/components/DefaultChatModeSelector.tsx
@@ -1,5 +1,6 @@
 import { useSettings } from "@/hooks/useSettings";
 import { useFreeAgentQuota } from "@/hooks/useFreeAgentQuota";
+import { SettingField } from "@/components/settings/SettingField";
 import {
   Select,
   SelectContent,
@@ -73,52 +74,45 @@ export function DefaultChatModeSelector() {
   };
 
   return (
-    <div className="space-y-1">
-      <div className="flex items-center space-x-2">
-        <label
-          htmlFor="default-chat-mode"
-          className="text-sm font-medium text-gray-700 dark:text-gray-300"
-        >
-          {t("workflow.defaultChatMode")}
-        </label>
-        <Select
-          value={effectiveDefault}
-          onValueChange={(v) => v && handleDefaultChatModeChange(v)}
-        >
-          <SelectTrigger className="w-40" id="default-chat-mode">
-            <SelectValue>{getModeDisplayName(effectiveDefault)}</SelectValue>
-          </SelectTrigger>
-          <SelectContent>
-            {showBasicAgentOption && (
-              <SelectItem value="local-agent">
-                <div className="flex flex-col items-start">
-                  <span className="font-medium">
-                    {isProEnabled ? "Agent" : "Basic Agent"}
-                  </span>
-                  <span className="text-xs text-muted-foreground">
-                    {isProEnabled
-                      ? "Better at bigger tasks"
-                      : "Free tier (10 messages/day)"}
-                  </span>
-                </div>
-              </SelectItem>
-            )}
-            <SelectItem value="build" disabled={isDyadFreeSelected}>
+    <SettingField
+      htmlFor="default-chat-mode"
+      label={t("workflow.defaultChatMode")}
+      description={t("workflow.defaultChatModeDescription")}
+    >
+      <Select
+        value={effectiveDefault}
+        onValueChange={(v) => v && handleDefaultChatModeChange(v)}
+      >
+        <SelectTrigger className="w-full sm:w-[240px]" id="default-chat-mode">
+          <SelectValue>{getModeDisplayName(effectiveDefault)}</SelectValue>
+        </SelectTrigger>
+        <SelectContent>
+          {showBasicAgentOption && (
+            <SelectItem value="local-agent">
               <div className="flex flex-col items-start">
-                <span className="font-medium">Build</span>
+                <span className="font-medium">
+                  {isProEnabled ? "Agent" : "Basic Agent"}
+                </span>
                 <span className="text-xs text-muted-foreground">
-                  {isDyadFreeSelected
-                    ? "Use Agent with Dyad Free"
-                    : "Generate and edit code"}
+                  {isProEnabled
+                    ? "Better at bigger tasks"
+                    : "Free tier (10 messages/day)"}
                 </span>
               </div>
             </SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
-      <div className="text-sm text-gray-500 dark:text-gray-400">
-        {t("workflow.defaultChatModeDescription")}
-      </div>
-    </div>
+          )}
+          <SelectItem value="build" disabled={isDyadFreeSelected}>
+            <div className="flex flex-col items-start">
+              <span className="font-medium">Build</span>
+              <span className="text-xs text-muted-foreground">
+                {isDyadFreeSelected
+                  ? "Use Agent with Dyad Free"
+                  : "Generate and edit code"}
+              </span>
+            </div>
+          </SelectItem>
+        </SelectContent>
+      </Select>
+    </SettingField>
   );
 }

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useSettings } from "@/hooks/useSettings";
 import { Language, LanguageSchema } from "@/lib/schemas";
-import { Label } from "@/components/ui/label";
+import { SettingField } from "@/components/settings/SettingField";
 import {
   Select,
   SelectContent,
@@ -52,15 +52,13 @@ export function LanguageSelector() {
   };
 
   return (
-    <div className="space-y-2">
-      <div className="flex flex-col gap-1">
-        <Label htmlFor="language">{t("general.language")}</Label>
-        <p className="text-sm text-muted-foreground">
-          {t("general.languageDescription")}
-        </p>
-      </div>
+    <SettingField
+      htmlFor="language"
+      label={t("general.language")}
+      description={t("general.languageDescription")}
+    >
       <Select value={currentLanguage} onValueChange={handleChange}>
-        <SelectTrigger id="language" className="w-[220px]">
+        <SelectTrigger id="language" className="w-full sm:w-[240px]">
           <SelectValue placeholder="Select language" />
         </SelectTrigger>
         <SelectContent>
@@ -71,6 +69,6 @@ export function LanguageSelector() {
           ))}
         </SelectContent>
       </Select>
-    </div>
+    </SettingField>
   );
 }

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -58,7 +58,11 @@ export function LanguageSelector() {
       description={t("general.languageDescription")}
     >
       <Select value={currentLanguage} onValueChange={handleChange}>
-        <SelectTrigger id="language" className="w-full sm:w-[240px]">
+        <SelectTrigger
+          id="language"
+          className="w-full sm:w-[240px]"
+          aria-describedby="language-description"
+        >
           <SelectValue placeholder="Select language" />
         </SelectTrigger>
         <SelectContent>

--- a/src/components/MaxChatTurnsSelector.tsx
+++ b/src/components/MaxChatTurnsSelector.tsx
@@ -80,7 +80,11 @@ export const MaxChatTurnsSelector: React.FC = () => {
         value={currentValue}
         onValueChange={(v) => v && handleValueChange(v)}
       >
-        <SelectTrigger className="w-full sm:w-[240px]" id="max-chat-turns">
+        <SelectTrigger
+          className="w-full sm:w-[240px]"
+          id="max-chat-turns"
+          aria-describedby="max-chat-turns-description"
+        >
           <SelectValue placeholder={t("ai.selectMaxChatTurns")} />
         </SelectTrigger>
         <SelectContent>

--- a/src/components/MaxChatTurnsSelector.tsx
+++ b/src/components/MaxChatTurnsSelector.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useSettings } from "@/hooks/useSettings";
+import { SettingField } from "@/components/settings/SettingField";
 import {
   Select,
   SelectContent,
@@ -70,33 +71,26 @@ export const MaxChatTurnsSelector: React.FC = () => {
     options.find((opt) => opt.value === currentValue) || options[1];
 
   return (
-    <div className="space-y-1">
-      <div className="flex items-center gap-4">
-        <label
-          htmlFor="max-chat-turns"
-          className="text-sm font-medium text-gray-700 dark:text-gray-300"
-        >
-          {t("ai.maxChatTurns")}
-        </label>
-        <Select
-          value={currentValue}
-          onValueChange={(v) => v && handleValueChange(v)}
-        >
-          <SelectTrigger className="w-[180px]" id="max-chat-turns">
-            <SelectValue placeholder={t("ai.selectMaxChatTurns")} />
-          </SelectTrigger>
-          <SelectContent>
-            {options.map((option) => (
-              <SelectItem key={option.value} value={option.value}>
-                {option.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
-      <div className="text-sm text-gray-500 dark:text-gray-400">
-        {currentOption.description}
-      </div>
-    </div>
+    <SettingField
+      htmlFor="max-chat-turns"
+      label={t("ai.maxChatTurns")}
+      description={currentOption.description}
+    >
+      <Select
+        value={currentValue}
+        onValueChange={(v) => v && handleValueChange(v)}
+      >
+        <SelectTrigger className="w-full sm:w-[240px]" id="max-chat-turns">
+          <SelectValue placeholder={t("ai.selectMaxChatTurns")} />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map((option) => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </SettingField>
   );
 };

--- a/src/components/MaxToolCallStepsSelector.tsx
+++ b/src/components/MaxToolCallStepsSelector.tsx
@@ -80,7 +80,11 @@ export const MaxToolCallStepsSelector: React.FC = () => {
         value={currentValue}
         onValueChange={(v) => v && handleValueChange(v)}
       >
-        <SelectTrigger className="w-full sm:w-[240px]" id="max-tool-call-steps">
+        <SelectTrigger
+          className="w-full sm:w-[240px]"
+          id="max-tool-call-steps"
+          aria-describedby="max-tool-call-steps-description"
+        >
           <SelectValue placeholder={t("ai.selectMaxToolCallSteps")} />
         </SelectTrigger>
         <SelectContent>

--- a/src/components/MaxToolCallStepsSelector.tsx
+++ b/src/components/MaxToolCallStepsSelector.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useSettings } from "@/hooks/useSettings";
+import { SettingField } from "@/components/settings/SettingField";
 import {
   Select,
   SelectContent,
@@ -70,33 +71,26 @@ export const MaxToolCallStepsSelector: React.FC = () => {
     options[0];
 
   return (
-    <div className="space-y-1">
-      <div className="flex items-center gap-4">
-        <label
-          htmlFor="max-tool-call-steps"
-          className="text-sm font-medium text-gray-700 dark:text-gray-300"
-        >
-          {t("ai.maxToolCallSteps")}
-        </label>
-        <Select
-          value={currentValue}
-          onValueChange={(v) => v && handleValueChange(v)}
-        >
-          <SelectTrigger className="w-[180px]" id="max-tool-call-steps">
-            <SelectValue placeholder={t("ai.selectMaxToolCallSteps")} />
-          </SelectTrigger>
-          <SelectContent>
-            {options.map((option) => (
-              <SelectItem key={option.value} value={option.value}>
-                {option.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
-      <div className="text-sm text-gray-500 dark:text-gray-400">
-        {currentOption.description}
-      </div>
-    </div>
+    <SettingField
+      htmlFor="max-tool-call-steps"
+      label={t("ai.maxToolCallSteps")}
+      description={currentOption.description}
+    >
+      <Select
+        value={currentValue}
+        onValueChange={(v) => v && handleValueChange(v)}
+      >
+        <SelectTrigger className="w-full sm:w-[240px]" id="max-tool-call-steps">
+          <SelectValue placeholder={t("ai.selectMaxToolCallSteps")} />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map((option) => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </SettingField>
   );
 };

--- a/src/components/ProviderSettings.tsx
+++ b/src/components/ProviderSettings.tsx
@@ -76,30 +76,22 @@ export function ProviderSettingsGrid() {
 
   if (isLoading) {
     return (
-      <div className="p-6">
-        <h2 className="text-lg font-medium mb-6">
-          {t("settings:ai.providers")}
-        </h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-          {[1, 2, 3, 4, 5].map((i) => (
-            <Card key={i} className="border-border">
-              <CardHeader className="p-4">
-                <Skeleton className="h-6 w-3/4 mb-2" />
-                <Skeleton className="h-4 w-1/2" />
-              </CardHeader>
-            </Card>
-          ))}
-        </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {[1, 2, 3, 4, 5].map((i) => (
+          <Card key={i} className="border-border shadow-none">
+            <CardHeader className="p-4">
+              <Skeleton className="h-6 w-3/4 mb-2" />
+              <Skeleton className="h-4 w-1/2" />
+            </CardHeader>
+          </Card>
+        ))}
       </div>
     );
   }
 
   if (error) {
     return (
-      <div className="p-6">
-        <h2 className="text-lg font-medium mb-6">
-          {t("settings:ai.providers")}
-        </h2>
+      <div>
         <Alert variant="destructive">
           <AlertTriangle className="h-4 w-4" />
           <AlertTitle>{t("common:error")}</AlertTitle>
@@ -112,8 +104,7 @@ export function ProviderSettingsGrid() {
   }
 
   return (
-    <div className="p-6">
-      <h2 className="text-lg font-medium mb-6">{t("settings:ai.providers")}</h2>
+    <div>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         {providers
           ?.filter((p) => p.type !== "local")
@@ -123,7 +114,7 @@ export function ProviderSettingsGrid() {
             return (
               <Card
                 key={provider.id}
-                className="relative transition-all hover:shadow-md border-border"
+                className="relative border-border shadow-none transition-colors hover:border-primary/40 hover:bg-muted/30"
               >
                 <CardHeader
                   className="p-4 cursor-pointer"
@@ -175,19 +166,20 @@ export function ProviderSettingsGrid() {
                   <CardTitle className="text-lg font-medium mb-2">
                     {provider.name}
                     {isProviderSetup(provider.id) ? (
-                      <span className="ml-3 text-sm font-medium text-green-500 bg-green-50 dark:bg-green-900/30 border border-green-500/50 dark:border-green-500/50 px-2 py-1 rounded-full">
+                      <span className="ml-2 inline-flex items-center gap-1 rounded-full border border-emerald-500/20 bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:text-emerald-400">
+                        <span className="size-1.5 rounded-full bg-emerald-500" />
                         {t("common:ready")}
                       </span>
                     ) : (
-                      <span className="text-sm text-gray-500 bg-gray-50 dark:bg-gray-900 dark:text-gray-300 px-2 py-1 rounded-full">
+                      <span className="ml-2 rounded-full border border-border/70 bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
                         {t("common:needsSetup")}
                       </span>
                     )}
                   </CardTitle>
                   <CardDescription>
                     {provider.hasFreeTier && (
-                      <span className="text-blue-600 mt-2 dark:text-blue-400 text-sm font-medium bg-blue-100 dark:bg-blue-900/30 px-2 py-1 rounded-full inline-flex items-center">
-                        <GiftIcon className="w-4 h-4 mr-1" />
+                      <span className="mt-2 inline-flex items-center rounded-full border border-blue-500/20 bg-blue-500/10 px-2 py-0.5 text-xs font-medium text-blue-700 dark:text-blue-400">
+                        <GiftIcon className="mr-1 h-3.5 w-3.5" />
                         {t("settings:ai.freeTierAvailable")}
                       </span>
                     )}
@@ -199,7 +191,7 @@ export function ProviderSettingsGrid() {
 
         {/* Add custom provider button */}
         <Card
-          className="cursor-pointer transition-all hover:shadow-md border-border border-dashed hover:border-primary/70"
+          className="cursor-pointer border-border border-dashed shadow-none transition-colors hover:border-primary/70 hover:bg-muted/30"
           onClick={() => setIsDialogOpen(true)}
         >
           <CardHeader className="p-4 flex flex-col items-center justify-center h-full">

--- a/src/components/ReleaseChannelSelector.tsx
+++ b/src/components/ReleaseChannelSelector.tsx
@@ -58,7 +58,11 @@ export function ReleaseChannelSelector() {
         value={settings.releaseChannel}
         onValueChange={(v) => v && handleReleaseChannelChange(v)}
       >
-        <SelectTrigger className="w-full sm:w-[240px]" id="release-channel">
+        <SelectTrigger
+          className="w-full sm:w-[240px]"
+          id="release-channel"
+          aria-describedby="release-channel-description"
+        >
           <SelectValue />
         </SelectTrigger>
         <SelectContent>

--- a/src/components/ReleaseChannelSelector.tsx
+++ b/src/components/ReleaseChannelSelector.tsx
@@ -1,5 +1,6 @@
 import { useSettings } from "@/hooks/useSettings";
 
+import { SettingField } from "@/components/settings/SettingField";
 import {
   Select,
   SelectContent,
@@ -48,30 +49,23 @@ export function ReleaseChannelSelector() {
   };
 
   return (
-    <div className="space-y-1">
-      <div className="flex items-center space-x-2">
-        <label
-          htmlFor="release-channel"
-          className="text-sm font-medium text-gray-700 dark:text-gray-300"
-        >
-          {t("general.releaseChannel")}
-        </label>
-        <Select
-          value={settings.releaseChannel}
-          onValueChange={(v) => v && handleReleaseChannelChange(v)}
-        >
-          <SelectTrigger className="w-32" id="release-channel">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="stable">{t("general.stable")}</SelectItem>
-            <SelectItem value="beta">{t("general.beta")}</SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
-      <div className="text-sm text-gray-500 dark:text-gray-400">
-        <p>{t("general.releaseChannelDescription")}</p>
-      </div>
-    </div>
+    <SettingField
+      htmlFor="release-channel"
+      label={t("general.releaseChannel")}
+      description={t("general.releaseChannelDescription")}
+    >
+      <Select
+        value={settings.releaseChannel}
+        onValueChange={(v) => v && handleReleaseChannelChange(v)}
+      >
+        <SelectTrigger className="w-full sm:w-[240px]" id="release-channel">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="stable">{t("general.stable")}</SelectItem>
+          <SelectItem value="beta">{t("general.beta")}</SelectItem>
+        </SelectContent>
+      </Select>
+    </SettingField>
   );
 }

--- a/src/components/RuntimeModeSelector.tsx
+++ b/src/components/RuntimeModeSelector.tsx
@@ -93,7 +93,11 @@ export function RuntimeModeSelector() {
           value={settings.runtimeMode2 ?? "host"}
           onValueChange={(v) => v && handleRuntimeModeChange(v)}
         >
-          <SelectTrigger className="w-full sm:w-[240px]" id="runtime-mode">
+          <SelectTrigger
+            className="w-full sm:w-[240px]"
+            id="runtime-mode"
+            aria-describedby="runtime-mode-description"
+          >
             <SelectValue />
           </SelectTrigger>
           <SelectContent>

--- a/src/components/RuntimeModeSelector.tsx
+++ b/src/components/RuntimeModeSelector.tsx
@@ -1,4 +1,4 @@
-import { Label } from "@/components/ui/label";
+import { SettingField } from "@/components/settings/SettingField";
 import {
   Select,
   SelectContent,
@@ -83,34 +83,30 @@ export function RuntimeModeSelector() {
   };
 
   return (
-    <div className="space-y-2">
-      <div className="space-y-1">
-        <div className="flex items-center space-x-2">
-          <Label className="text-sm font-medium" htmlFor="runtime-mode">
-            {t("general.runtimeMode")}
-          </Label>
-          <Select
-            value={settings.runtimeMode2 ?? "host"}
-            onValueChange={(v) => v && handleRuntimeModeChange(v)}
-          >
-            <SelectTrigger className="w-48" id="runtime-mode">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="host">Local (default)</SelectItem>
-              <SelectItem value="docker">Docker (experimental)</SelectItem>
-              {showCloudSandboxOption && (
-                <SelectItem disabled={!hasCloudSandboxAccess} value="cloud">
-                  Cloud Sandbox (Pro)
-                </SelectItem>
-              )}
-            </SelectContent>
-          </Select>
-        </div>
-        <div className="text-sm text-gray-500 dark:text-gray-400">
-          {t("general.runtimeModeDescription")}
-        </div>
-      </div>
+    <div className="space-y-3">
+      <SettingField
+        htmlFor="runtime-mode"
+        label={t("general.runtimeMode")}
+        description={t("general.runtimeModeDescription")}
+      >
+        <Select
+          value={settings.runtimeMode2 ?? "host"}
+          onValueChange={(v) => v && handleRuntimeModeChange(v)}
+        >
+          <SelectTrigger className="w-full sm:w-[240px]" id="runtime-mode">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="host">Local (default)</SelectItem>
+            <SelectItem value="docker">Docker (experimental)</SelectItem>
+            {showCloudSandboxOption && (
+              <SelectItem disabled={!hasCloudSandboxAccess} value="cloud">
+                Cloud Sandbox (Pro)
+              </SelectItem>
+            )}
+          </SelectContent>
+        </Select>
+      </SettingField>
       {showCloudSandboxOption && !hasCloudSandboxAccess && (
         <div className="text-sm text-muted-foreground bg-muted/40 p-2 rounded">
           Cloud sandboxes are a Dyad Pro feature.{" "}

--- a/src/components/ThinkingBudgetSelector.tsx
+++ b/src/components/ThinkingBudgetSelector.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useSettings } from "@/hooks/useSettings";
+import { SettingField } from "@/components/settings/SettingField";
 import {
   Select,
   SelectContent,
@@ -30,35 +31,28 @@ export const ThinkingBudgetSelector: React.FC = () => {
   const currentOption = getThinkingEffortOption(currentValue);
 
   return (
-    <div className="space-y-1">
-      <div className="flex items-center gap-4">
-        <label
-          htmlFor="thinking-budget"
-          className="text-sm font-medium text-gray-700 dark:text-gray-300"
-        >
-          {t("ai.thinkingBudget")}
-        </label>
-        <Select
-          value={currentValue}
-          onValueChange={(v) => v && handleValueChange(v)}
-        >
-          <SelectTrigger className="w-[180px]" id="thinking-budget">
-            <SelectValue placeholder={t("ai.selectThinkingBudget")} />
-          </SelectTrigger>
-          <SelectContent>
-            {THINKING_EFFORT_OPTIONS.map((option) => (
-              <SelectItem key={option.value} value={option.value}>
-                {option.value === THINKING_EFFORT_DEFAULT
-                  ? `${option.label} (default)`
-                  : option.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
-      <div className="text-sm text-gray-500 dark:text-gray-400">
-        {currentOption.description}
-      </div>
-    </div>
+    <SettingField
+      htmlFor="thinking-budget"
+      label={t("ai.thinkingBudget")}
+      description={currentOption.description}
+    >
+      <Select
+        value={currentValue}
+        onValueChange={(v) => v && handleValueChange(v)}
+      >
+        <SelectTrigger className="w-full sm:w-[240px]" id="thinking-budget">
+          <SelectValue placeholder={t("ai.selectThinkingBudget")} />
+        </SelectTrigger>
+        <SelectContent>
+          {THINKING_EFFORT_OPTIONS.map((option) => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.value === THINKING_EFFORT_DEFAULT
+                ? `${option.label} (default)`
+                : option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </SettingField>
   );
 };

--- a/src/components/ThinkingBudgetSelector.tsx
+++ b/src/components/ThinkingBudgetSelector.tsx
@@ -40,7 +40,11 @@ export const ThinkingBudgetSelector: React.FC = () => {
         value={currentValue}
         onValueChange={(v) => v && handleValueChange(v)}
       >
-        <SelectTrigger className="w-full sm:w-[240px]" id="thinking-budget">
+        <SelectTrigger
+          className="w-full sm:w-[240px]"
+          id="thinking-budget"
+          aria-describedby="thinking-budget-description"
+        >
           <SelectValue placeholder={t("ai.selectThinkingBudget")} />
         </SelectTrigger>
         <SelectContent>

--- a/src/components/ZoomSelector.tsx
+++ b/src/components/ZoomSelector.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { useSettings } from "@/hooks/useSettings";
 import { ZoomLevel, ZoomLevelSchema, DEFAULT_ZOOM_LEVEL } from "@/lib/schemas";
-import { Label } from "@/components/ui/label";
+import { SettingField } from "@/components/settings/SettingField";
 import {
   Select,
   SelectContent,
@@ -38,20 +38,18 @@ export function ZoomSelector() {
   }, [settings?.zoomLevel]);
 
   return (
-    <div className="space-y-2">
-      <div className="flex flex-col gap-1">
-        <Label htmlFor="zoom-level">{t("general.zoom")}</Label>
-        <p className="text-sm text-muted-foreground">
-          {t("general.zoomDescription")}
-        </p>
-      </div>
+    <SettingField
+      htmlFor="zoom-level"
+      label={t("general.zoom")}
+      description={t("general.zoomDescription")}
+    >
       <Select
         value={currentZoomLevel}
         onValueChange={(value) =>
           updateSettings({ zoomLevel: value as ZoomLevel })
         }
       >
-        <SelectTrigger id="zoom-level" className="w-[220px]">
+        <SelectTrigger id="zoom-level" className="w-full sm:w-[240px]">
           <SelectValue placeholder={t("general.selectZoom")} />
         </SelectTrigger>
         <SelectContent>
@@ -67,6 +65,6 @@ export function ZoomSelector() {
           ))}
         </SelectContent>
       </Select>
-    </div>
+    </SettingField>
   );
 }

--- a/src/components/ZoomSelector.tsx
+++ b/src/components/ZoomSelector.tsx
@@ -49,7 +49,11 @@ export function ZoomSelector() {
           updateSettings({ zoomLevel: value as ZoomLevel })
         }
       >
-        <SelectTrigger id="zoom-level" className="w-full sm:w-[240px]">
+        <SelectTrigger
+          id="zoom-level"
+          className="w-full sm:w-[240px]"
+          aria-describedby="zoom-level-description"
+        >
           <SelectValue placeholder={t("general.selectZoom")} />
         </SelectTrigger>
         <SelectContent>

--- a/src/components/settings/SettingField.tsx
+++ b/src/components/settings/SettingField.tsx
@@ -31,7 +31,10 @@ export function SettingField({
           {label}
         </Label>
         {description && (
-          <p className="text-[13px] leading-relaxed text-muted-foreground">
+          <p
+            id={htmlFor ? `${htmlFor}-description` : undefined}
+            className="text-[13px] leading-relaxed text-muted-foreground"
+          >
             {description}
           </p>
         )}

--- a/src/components/settings/SettingField.tsx
+++ b/src/components/settings/SettingField.tsx
@@ -1,0 +1,42 @@
+import type { ReactNode } from "react";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+
+/**
+ * A consistent settings field: a label + optional description stacked above the
+ * control. Used to give every selector on the Settings page the same rhythm,
+ * typography, and control width. Keep controls at `w-full sm:w-[240px]` so they
+ * align down the column on desktop and go full-width on narrow viewports.
+ */
+export function SettingField({
+  htmlFor,
+  label,
+  description,
+  children,
+  className,
+}: {
+  htmlFor?: string;
+  label: ReactNode;
+  description?: ReactNode;
+  children?: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cn("space-y-2.5", className)}>
+      <div className="space-y-1">
+        <Label
+          htmlFor={htmlFor}
+          className="text-sm font-medium text-foreground"
+        >
+          {label}
+        </Label>
+        {description && (
+          <p className="text-[13px] leading-relaxed text-muted-foreground">
+            {description}
+          </p>
+        )}
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -39,7 +39,7 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground hover:bg-muted/50 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-lg border bg-transparent px-3 py-2 text-sm whitespace-nowrap transition-[color,background-color,box-shadow] duration-150 outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -67,7 +67,7 @@ function MiniSelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-7 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground hover:bg-muted/50 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-lg border bg-transparent px-3 py-2 text-sm whitespace-nowrap transition-[color,background-color,box-shadow] duration-150 outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-7 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -102,7 +102,7 @@ function SelectContent({
         <SelectPrimitive.Popup
           data-slot="select-content"
           className={cn(
-            "bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--available-height) min-w-[8rem] origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+            "bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--available-height) min-w-[8rem] origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-xl border shadow-lg",
             className,
           )}
           {...props}

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -7,14 +7,14 @@ function Switch({ className, ...props }: SwitchPrimitive.Root.Props) {
     <SwitchPrimitive.Root
       data-slot="switch"
       className={cn(
-        "data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-unchecked:bg-input/80 shrink-0 rounded-full border border-transparent shadow-xs focus-visible:ring-[3px] h-[1.15rem] w-8 peer group/switch relative inline-flex items-center transition-all outline-none data-disabled:cursor-not-allowed data-disabled:opacity-50",
+        "data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-unchecked:bg-input/80 shrink-0 rounded-full border border-transparent focus-visible:ring-[3px] h-5 w-9 peer group/switch relative inline-flex items-center transition-colors duration-200 ease-out outline-none data-disabled:cursor-not-allowed data-disabled:opacity-50",
         className,
       )}
       {...props}
     >
       <SwitchPrimitive.Thumb
         data-slot="switch-thumb"
-        className="bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full size-4 data-checked:translate-x-[calc(100%-2px)] data-unchecked:translate-x-0 pointer-events-none block ring-0 transition-transform"
+        className="bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full size-4 data-checked:translate-x-[calc(100%+2px)] data-unchecked:translate-x-0 pointer-events-none block ring-0 transition-transform duration-200 ease-out"
       />
     </SwitchPrimitive.Root>
   );

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -7,14 +7,14 @@ function Switch({ className, ...props }: SwitchPrimitive.Root.Props) {
     <SwitchPrimitive.Root
       data-slot="switch"
       className={cn(
-        "data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-unchecked:bg-input/80 shrink-0 rounded-full border border-transparent focus-visible:ring-[3px] h-5 w-9 peer group/switch relative inline-flex items-center transition-colors duration-200 ease-out outline-none data-disabled:cursor-not-allowed data-disabled:opacity-50",
+        "data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-unchecked:bg-input/80 shrink-0 rounded-full border border-transparent focus-visible:ring-[3px] h-5 w-9 p-0.5 peer group/switch relative inline-flex items-center transition-colors duration-200 ease-out outline-none data-disabled:cursor-not-allowed data-disabled:opacity-50",
         className,
       )}
       {...props}
     >
       <SwitchPrimitive.Thumb
         data-slot="switch-thumb"
-        className="bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full size-4 data-checked:translate-x-[calc(100%+2px)] data-unchecked:translate-x-0 pointer-events-none block ring-0 transition-transform duration-200 ease-out"
+        className="bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full size-4 data-checked:translate-x-full data-unchecked:translate-x-0 pointer-events-none block ring-0 transition-transform duration-200 ease-out"
       />
     </SwitchPrimitive.Root>
   );

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -412,7 +412,7 @@ export function GeneralSettings({ appVersion }: { appVersion: string | null }) {
               className={cn(
                 "rounded-md px-4 py-1.5 text-sm font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
                 theme === option
-                  ? "border border-border/70 bg-background-lightest text-foreground"
+                  ? "border border-border/70 bg-(--background-lightest) text-foreground"
                   : "border border-transparent text-muted-foreground hover:text-foreground",
               )}
             >

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -81,9 +81,7 @@ function SettingsSection({
         >
           {title}
         </h2>
-        {description && (
-          <p className={cn("mt-1.5", hint)}>{description}</p>
-        )}
+        {description && <p className={cn("mt-1.5", hint)}>{description}</p>}
       </div>
       <div className="min-w-0 space-y-6">{children}</div>
     </section>

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { useTheme } from "../contexts/ThemeContext";
 import { ProviderSettingsGrid } from "@/components/ProviderSettings";
 import ConfirmationDialog from "@/components/ConfirmationDialog";
@@ -18,6 +18,8 @@ import { SupabaseIntegration } from "@/components/SupabaseIntegration";
 import { CustomAppsFolderSelector } from "@/components/CustomAppsFolderSelector";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import { AppBlueprintSwitch } from "@/components/AppBlueprintSwitch";
 import { TestingForNewAppsSwitch } from "@/components/TestingForNewAppsSwitch";
 import { AutoExpandPreviewSwitch } from "@/components/AutoExpandPreviewSwitch";
@@ -40,6 +42,53 @@ import { AutoApproveMcpSwitch } from "@/components/AutoApproveMcpSwitch";
 import { useSetAtom } from "jotai";
 import { activeSettingsSectionAtom } from "@/atoms/viewAtoms";
 import { SECTION_IDS, SETTING_IDS } from "@/lib/settingsSearchIndex";
+
+const hint = "text-[13px] leading-relaxed text-muted-foreground";
+
+/**
+ * A single settings group: a sticky label + description in the left rail and its
+ * controls in the right column. Sections are separated by a hairline rule rather
+ * than boxed cards, so the surface stays flat — no elevation shadows.
+ */
+function SettingsSection({
+  id,
+  title,
+  description,
+  tone = "default",
+  children,
+}: {
+  id: string;
+  title: string;
+  description?: ReactNode;
+  tone?: "default" | "danger";
+  children: ReactNode;
+}) {
+  return (
+    <section
+      id={id}
+      className={cn(
+        "grid grid-cols-1 gap-x-12 gap-y-5 border-t py-8 first:border-t-0 first:pt-0 md:grid-cols-[minmax(150px,190px)_1fr]",
+        "scroll-mt-20",
+        tone === "danger" ? "border-destructive/20" : "border-border/60",
+      )}
+    >
+      <div className="self-start md:sticky md:top-6">
+        <h2
+          className={cn(
+            "text-[15px] font-semibold tracking-tight",
+            tone === "danger" ? "text-destructive" : "text-foreground",
+          )}
+        >
+          {title}
+        </h2>
+        {description && (
+          <p className={cn("mt-1.5", hint)}>{description}</p>
+        )}
+      </div>
+      <div className="min-w-0 space-y-6">{children}</div>
+    </section>
+  );
+}
 
 export default function SettingsPage() {
   const [isResetDialogOpen, setIsResetDialogOpen] = useState(false);
@@ -69,307 +118,265 @@ export default function SettingsPage() {
   };
 
   return (
-    <div className="min-h-screen px-8 py-4">
-      <div className="max-w-5xl mx-auto">
+    <div className="min-h-screen bg-background">
+      <div className="mx-auto max-w-5xl px-6 py-8 md:px-10">
         <BackButton />
-        <div className="flex justify-between mb-4">
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+
+        <header className="mt-1 mb-9">
+          <h1 className="text-2xl font-semibold tracking-tight text-foreground">
             Settings
           </h1>
-        </div>
+          <p className={cn("mt-1", hint)}>
+            Manage your preferences, providers, and integrations.
+          </p>
+        </header>
 
-        <div className="space-y-6">
+        <div>
           <GeneralSettings appVersion={appVersion} />
           <WorkflowSettings />
           <AISettings />
 
-          <div
+          <SettingsSection
             id={SECTION_IDS.providers}
-            className="bg-white dark:bg-gray-800 rounded-xl shadow-sm"
+            title="Model Providers"
+            description="Connect the AI providers Dyad uses to build and run your apps."
           >
             <ProviderSettingsGrid />
-          </div>
+          </SettingsSection>
 
-          <div className="space-y-6">
-            <div
-              id={SECTION_IDS.telemetry}
-              className="bg-white dark:bg-gray-800 rounded-xl shadow-sm p-6"
-            >
-              <h2 className="text-lg font-medium text-gray-900 dark:text-white mb-4">
-                Telemetry
-              </h2>
-              <div id={SETTING_IDS.telemetry} className="space-y-2">
-                <TelemetrySwitch />
-                <div className="text-sm text-gray-500 dark:text-gray-400">
-                  This records anonymous usage data to improve the product.
-                </div>
-              </div>
-
-              <div className="mt-2 flex items-center text-sm text-gray-500 dark:text-gray-400">
-                <span className="mr-2 font-medium">Telemetry ID:</span>
-                <span className="bg-gray-100 dark:bg-gray-700 px-2 py-0.5 rounded text-gray-800 dark:text-gray-200 font-mono">
-                  {settings ? settings.telemetryUserId : "n/a"}
-                </span>
-              </div>
+          <SettingsSection
+            id={SECTION_IDS.telemetry}
+            title="Telemetry"
+            description="Anonymous usage data that helps improve Dyad."
+          >
+            <div id={SETTING_IDS.telemetry} className="space-y-1.5">
+              <TelemetrySwitch />
+              <p className={hint}>
+                This records anonymous usage data to improve the product.
+              </p>
             </div>
-          </div>
 
-          {/* Integrations Section */}
-          <div
+            <div className="flex items-center gap-2 text-[13px] text-muted-foreground">
+              <span className="font-medium">Telemetry ID</span>
+              <span className="rounded-md border border-border/60 bg-muted/50 px-2 py-0.5 font-mono text-foreground">
+                {settings ? settings.telemetryUserId : "n/a"}
+              </span>
+            </div>
+          </SettingsSection>
+
+          <SettingsSection
             id={SECTION_IDS.integrations}
-            className="bg-white dark:bg-gray-800 rounded-xl shadow-sm p-6"
+            title="Integrations"
+            description="Link Dyad to the services you deploy and store data with."
           >
-            <h2 className="text-lg font-medium text-gray-900 dark:text-white mb-4">
-              Integrations
-            </h2>
-            <div className="space-y-4">
-              <div id={SETTING_IDS.github}>
-                <GitHubIntegration />
-              </div>
-              <div id={SETTING_IDS.vercel}>
-                <VercelIntegration />
-              </div>
-              <div id={SETTING_IDS.supabase}>
-                <SupabaseIntegration />
-              </div>
-              <div id={SETTING_IDS.neon}>
-                <NeonIntegration />
-              </div>
+            <div id={SETTING_IDS.github}>
+              <GitHubIntegration />
             </div>
-          </div>
+            <div id={SETTING_IDS.vercel}>
+              <VercelIntegration />
+            </div>
+            <div id={SETTING_IDS.supabase}>
+              <SupabaseIntegration />
+            </div>
+            <div id={SETTING_IDS.neon}>
+              <NeonIntegration />
+            </div>
+          </SettingsSection>
 
-          {/* Agent v2 Permissions */}
-
-          <div
+          <SettingsSection
             id={SECTION_IDS.agentPermissions}
-            className="bg-white dark:bg-gray-800 rounded-xl shadow-sm p-6"
+            title="Agent Permissions"
+            description="Control what the agent can do on your behalf. Requires Pro."
           >
-            <h2 className="text-lg font-medium text-gray-900 dark:text-white mb-4">
-              Agent Permissions (Pro)
-            </h2>
             <AgentToolsSettings />
-          </div>
+          </SettingsSection>
 
-          {/* Advanced Section */}
-          <div
+          <SettingsSection
             id={SECTION_IDS.advanced}
-            className="bg-white dark:bg-gray-800 rounded-xl shadow-sm p-6"
+            title="Advanced"
+            description="We recommend keeping the defaults unless something isn't working."
           >
-            <div className="mb-6">
-              <h2 className="text-lg font-medium text-gray-900 dark:text-white">
-                Advanced
-              </h2>
-              <p className="text-sm text-gray-500 dark:text-gray-400 mt-1 mb-2">
-                We recommend keeping the default settings unless something is
-                not working
+            <div
+              id={SETTING_IDS.enableSandboxScriptExecution}
+              className="space-y-1.5"
+            >
+              <div className="flex items-center gap-2">
+                <Switch
+                  id="enable-sandbox-script-execution"
+                  aria-label="Enable sandbox script execution"
+                  checked={!!settings?.enableSandboxScriptExecution}
+                  onCheckedChange={(checked) => {
+                    updateSettings({
+                      enableSandboxScriptExecution: checked,
+                    });
+                  }}
+                />
+                <Label htmlFor="enable-sandbox-script-execution">
+                  Enable sandbox script execution
+                </Label>
+              </div>
+              <p className={hint}>
+                Allow local-agent attachment scripts to inspect files with
+                execute_sandbox_script.
               </p>
             </div>
-            <div className="space-y-4">
-              <div
-                id={SETTING_IDS.enableSandboxScriptExecution}
-                className="space-y-1 mt-4"
-              >
-                <div className="flex items-center space-x-2">
-                  <Switch
-                    id="enable-sandbox-script-execution"
-                    aria-label="Enable sandbox script execution"
-                    checked={!!settings?.enableSandboxScriptExecution}
-                    onCheckedChange={(checked) => {
-                      updateSettings({
-                        enableSandboxScriptExecution: checked,
-                      });
-                    }}
-                  />
-                  <Label htmlFor="enable-sandbox-script-execution">
-                    Enable sandbox script execution
-                  </Label>
-                </div>
-                <div className="text-sm text-gray-500 dark:text-gray-400">
-                  Allow local-agent attachment scripts to inspect files with
-                  execute_sandbox_script.
-                </div>
-              </div>
-              <div
-                id={SETTING_IDS.blockUnsafeNpmPackages}
-                className="space-y-1 mt-4"
-              >
-                <BlockUnsafeNpmPackagesSwitch />
-              </div>
-              <div
-                id={SETTING_IDS.autoApproveNonSchemaSql}
-                className="space-y-1 mt-4"
-              >
-                <AutoApproveSqlSwitch />
-              </div>
-            </div>
-          </div>
 
-          {/* Experiments Section */}
-          <div
+            <div id={SETTING_IDS.blockUnsafeNpmPackages}>
+              <BlockUnsafeNpmPackagesSwitch />
+            </div>
+
+            <div id={SETTING_IDS.autoApproveNonSchemaSql}>
+              <AutoApproveSqlSwitch />
+            </div>
+          </SettingsSection>
+
+          <SettingsSection
             id={SECTION_IDS.experiments}
-            className="bg-white dark:bg-gray-800 rounded-xl shadow-sm p-6"
+            title="Experiments"
+            description="Early features that may not be stable yet. Enable at your own risk."
           >
-            <div className="mb-6">
-              <h2 className="text-lg font-medium text-gray-900 dark:text-white">
-                Experiments
-              </h2>
-              <p className="text-sm text-gray-500 dark:text-gray-400 mt-1 mb-2">
-                We do not recommend enabling experiments as these features may
-                not be stable
+            <div id={SETTING_IDS.enableCloudSandbox}>
+              <CloudSandboxExperimentSwitch />
+            </div>
+
+            <div id={SETTING_IDS.autoApproveSafeMcpTools}>
+              <AutoApproveMcpSwitch />
+            </div>
+
+            <div id={SETTING_IDS.enableMcpToolSearch} className="space-y-1.5">
+              <div className="flex items-center gap-2">
+                <Switch
+                  id="enable-mcp-tool-search"
+                  aria-label="Enable MCP tool search"
+                  disabled={!settings?.enableSandboxScriptExecution}
+                  checked={
+                    !!settings?.enableMcpToolSearch &&
+                    !!settings?.enableSandboxScriptExecution
+                  }
+                  onCheckedChange={(checked) => {
+                    updateSettings({
+                      enableMcpToolSearch: checked,
+                    });
+                  }}
+                />
+                <Label htmlFor="enable-mcp-tool-search">
+                  Enable MCP tool search
+                </Label>
+              </div>
+              <p className={hint}>
+                When many MCP tools are enabled, let the agent search for the
+                tools on demand instead of listing every tool in its context.
+                Requires sandbox script execution.
+              </p>
+              {!settings?.enableSandboxScriptExecution && (
+                <p className="text-xs text-amber-700 dark:text-amber-500">
+                  Cannot be enabled unless sandbox script execution is on.
+                </p>
+              )}
+            </div>
+
+            <div
+              id={SETTING_IDS.enablePnpmMinimumReleaseAgeWarning}
+              className="space-y-1.5"
+            >
+              <div className="flex items-center gap-2">
+                <Switch
+                  id="enable-pnpm-minimum-release-age-warning"
+                  aria-label="Enable pnpm upgrade warning"
+                  checked={!!settings?.enablePnpmMinimumReleaseAgeWarning}
+                  onCheckedChange={(checked) => {
+                    updateSettings({
+                      enablePnpmMinimumReleaseAgeWarning: checked,
+                    });
+                  }}
+                />
+                <Label htmlFor="enable-pnpm-minimum-release-age-warning">
+                  Enable pnpm upgrade warning
+                </Label>
+              </div>
+              <p className={hint}>
+                Show the pnpm release-age warning toast and one-click pnpm
+                upgrade action.
               </p>
             </div>
-            <div className="space-y-4">
-              <div id={SETTING_IDS.enableCloudSandbox} className="space-y-1">
-                <CloudSandboxExperimentSwitch />
-              </div>
-              <div
-                id={SETTING_IDS.autoApproveSafeMcpTools}
-                className="space-y-1 mt-4"
-              >
-                <AutoApproveMcpSwitch />
-              </div>
-              <div
-                id={SETTING_IDS.enableMcpToolSearch}
-                className="space-y-1 mt-4"
-              >
-                <div className="flex items-center space-x-2">
-                  <Switch
-                    id="enable-mcp-tool-search"
-                    aria-label="Enable MCP tool search"
-                    disabled={!settings?.enableSandboxScriptExecution}
-                    checked={
-                      !!settings?.enableMcpToolSearch &&
-                      !!settings?.enableSandboxScriptExecution
-                    }
-                    onCheckedChange={(checked) => {
-                      updateSettings({
-                        enableMcpToolSearch: checked,
-                      });
-                    }}
-                  />
-                  <Label htmlFor="enable-mcp-tool-search">
-                    Enable MCP tool search
-                  </Label>
-                </div>
-                <div className="text-sm text-gray-500 dark:text-gray-400">
-                  When many MCP tools are enabled, let the agent search for the
-                  tools on demand instead of listing every tool in its context.
-                  Requires sandbox script execution.
-                </div>
-                {!settings?.enableSandboxScriptExecution && (
-                  <div className="text-xs text-amber-500">
-                    Cannot be enabled unless sandbox script execution is on.
-                  </div>
-                )}
-              </div>
-              <div
-                id={SETTING_IDS.enablePnpmMinimumReleaseAgeWarning}
-                className="space-y-1 mt-4"
-              >
-                <div className="flex items-center space-x-2">
-                  <Switch
-                    id="enable-pnpm-minimum-release-age-warning"
-                    aria-label="Enable pnpm upgrade warning"
-                    checked={!!settings?.enablePnpmMinimumReleaseAgeWarning}
-                    onCheckedChange={(checked) => {
-                      updateSettings({
-                        enablePnpmMinimumReleaseAgeWarning: checked,
-                      });
-                    }}
-                  />
-                  <Label htmlFor="enable-pnpm-minimum-release-age-warning">
-                    Enable pnpm upgrade warning
-                  </Label>
-                </div>
-                <div className="text-sm text-gray-500 dark:text-gray-400">
-                  Show the pnpm release-age warning toast and one-click pnpm
-                  upgrade action.
-                </div>
-              </div>
-              <div
-                id={SETTING_IDS.enableSelectAppFromHomeChatInput}
-                className="space-y-1 mt-4"
-              >
-                <div className="flex items-center space-x-2">
-                  <Switch
-                    id="enable-select-app-from-home-chat-input"
-                    aria-label="Enable Select App from Home Chat Input"
-                    checked={!!settings?.enableSelectAppFromHomeChatInput}
-                    onCheckedChange={(checked) => {
-                      updateSettings({
-                        enableSelectAppFromHomeChatInput: checked,
-                      });
-                    }}
-                  />
-                  <Label htmlFor="enable-select-app-from-home-chat-input">
-                    Enable Select App from Home Chat Input
-                  </Label>
-                </div>
-                <div className="text-sm text-gray-500 dark:text-gray-400">
-                  Show an app selector in the home chat input to start a chat
-                  referencing an existing app.
-                </div>
-              </div>
-              <div
-                id={SETTING_IDS.enableCodeExplorer}
-                className="space-y-1 mt-4"
-              >
-                <div className="flex items-center space-x-2">
-                  <Switch
-                    id="enable-code-explorer"
-                    aria-label="Enable code explorer (Pro)"
-                    checked={!!settings?.enableCodeExplorer}
-                    onCheckedChange={(checked) => {
-                      updateSettings({
-                        enableCodeExplorer: checked,
-                      });
-                    }}
-                  />
-                  <Label htmlFor="enable-code-explorer">
-                    Enable code explorer (Pro)
-                  </Label>
-                </div>
-                <div className="text-sm text-gray-500 dark:text-gray-400">
-                  Let the local agent explore configured TypeScript projects
-                  with a compiler-backed code graph.
-                </div>
-              </div>
-            </div>
-          </div>
 
-          {/* Danger Zone */}
-          <div
+            <div
+              id={SETTING_IDS.enableSelectAppFromHomeChatInput}
+              className="space-y-1.5"
+            >
+              <div className="flex items-center gap-2">
+                <Switch
+                  id="enable-select-app-from-home-chat-input"
+                  aria-label="Enable Select App from Home Chat Input"
+                  checked={!!settings?.enableSelectAppFromHomeChatInput}
+                  onCheckedChange={(checked) => {
+                    updateSettings({
+                      enableSelectAppFromHomeChatInput: checked,
+                    });
+                  }}
+                />
+                <Label htmlFor="enable-select-app-from-home-chat-input">
+                  Enable Select App from Home Chat Input
+                </Label>
+              </div>
+              <p className={hint}>
+                Show an app selector in the home chat input to start a chat
+                referencing an existing app.
+              </p>
+            </div>
+
+            <div id={SETTING_IDS.enableCodeExplorer} className="space-y-1.5">
+              <div className="flex items-center gap-2">
+                <Switch
+                  id="enable-code-explorer"
+                  aria-label="Enable code explorer (Pro)"
+                  checked={!!settings?.enableCodeExplorer}
+                  onCheckedChange={(checked) => {
+                    updateSettings({
+                      enableCodeExplorer: checked,
+                    });
+                  }}
+                />
+                <Label htmlFor="enable-code-explorer">
+                  Enable code explorer (Pro)
+                </Label>
+              </div>
+              <p className={hint}>
+                Let the local agent explore configured TypeScript projects with
+                a compiler-backed code graph.
+              </p>
+            </div>
+          </SettingsSection>
+
+          <SettingsSection
             id={SECTION_IDS.dangerZone}
-            className="bg-white dark:bg-gray-800 rounded-xl shadow-sm p-6 border border-red-200 dark:border-red-800"
+            title="Danger Zone"
+            description="Irreversible actions. Proceed with care."
+            tone="danger"
           >
-            <h2 className="text-lg font-medium text-red-600 dark:text-red-400 mb-4">
-              Danger Zone
-            </h2>
-
-            <div className="space-y-4">
-              <div
-                id={SETTING_IDS.reset}
-                className="flex items-start justify-between flex-col sm:flex-row sm:items-center gap-4"
-              >
-                <div>
-                  <h3 className="text-sm font-medium text-gray-900 dark:text-white">
-                    Reset Everything
-                  </h3>
-                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                    This will delete all your apps, chats, and settings. This
-                    action cannot be undone.
-                  </p>
-                </div>
-                <button
-                  onClick={() => setIsResetDialogOpen(true)}
-                  disabled={isResetting}
-                  className="rounded-md border border-transparent bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  {isResetting ? "Resetting..." : "Reset Everything"}
-                </button>
+            <div
+              id={SETTING_IDS.reset}
+              className="flex flex-col gap-4 rounded-xl border border-destructive/25 bg-destructive/[0.035] p-4 sm:flex-row sm:items-center sm:justify-between dark:bg-destructive/[0.08]"
+            >
+              <div>
+                <h3 className="text-sm font-medium text-foreground">
+                  Reset Everything
+                </h3>
+                <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                  This will delete all your apps, chats, and settings. This
+                  action cannot be undone.
+                </p>
               </div>
+              <Button
+                variant="destructive"
+                onClick={() => setIsResetDialogOpen(true)}
+                disabled={isResetting}
+                className="shrink-0"
+              >
+                {isResetting ? "Resetting..." : "Reset Everything"}
+              </Button>
             </div>
-          </div>
+          </SettingsSection>
         </div>
       </div>
 
@@ -391,174 +398,157 @@ export function GeneralSettings({ appVersion }: { appVersion: string | null }) {
   const { theme, setTheme } = useTheme();
 
   return (
-    <div
+    <SettingsSection
       id={SECTION_IDS.general}
-      className="bg-white dark:bg-gray-800 rounded-xl shadow-sm p-6"
+      title="General"
+      description="Appearance, language, and how Dyad runs on your machine."
     >
-      <h2 className="text-lg font-medium text-gray-900 dark:text-white mb-4">
-        General Settings
-      </h2>
+      <div id={SETTING_IDS.theme} className="flex items-center gap-4">
+        <label className="text-sm font-medium text-foreground">Theme</label>
 
-      <div className="space-y-4 mb-4">
-        <div id={SETTING_IDS.theme} className="flex items-center gap-4">
-          <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
-            Theme
-          </label>
-
-          <div className="relative bg-gray-100 dark:bg-gray-700 rounded-lg p-1 flex">
-            {(["system", "light", "dark"] as const).map((option) => (
-              <button
-                key={option}
-                onClick={() => setTheme(option)}
-                className={`
-                px-4 py-1.5 text-sm font-medium rounded-md
-                transition-all duration-200
-                ${
-                  theme === option
-                    ? "bg-white dark:bg-gray-600 text-gray-900 dark:text-white shadow-sm"
-                    : "text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white"
-                }
-              `}
-              >
-                {option.charAt(0).toUpperCase() + option.slice(1)}
-              </button>
-            ))}
-          </div>
+        <div className="inline-flex rounded-lg border border-border/50 bg-muted/60 p-1">
+          {(["system", "light", "dark"] as const).map((option) => (
+            <button
+              key={option}
+              onClick={() => setTheme(option)}
+              className={cn(
+                "rounded-md px-4 py-1.5 text-sm font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+                theme === option
+                  ? "border border-border/70 bg-background-lightest text-foreground"
+                  : "border border-transparent text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {option.charAt(0).toUpperCase() + option.slice(1)}
+            </button>
+          ))}
         </div>
       </div>
 
-      <div className="mt-4">
-        <LanguageSelector />
-      </div>
+      <LanguageSelector />
 
-      <div id={SETTING_IDS.zoom} className="mt-4">
+      <div id={SETTING_IDS.zoom}>
         <ZoomSelector />
       </div>
 
-      <div id={SETTING_IDS.autoUpdate} className="space-y-1 mt-4">
+      <div id={SETTING_IDS.autoUpdate} className="space-y-1.5">
         <AutoUpdateSwitch />
-        <div className="text-sm text-gray-500 dark:text-gray-400">
+        <p className={hint}>
           This will automatically update the app when new versions are
           available.
-        </div>
+        </p>
       </div>
 
-      <div id={SETTING_IDS.releaseChannel} className="mt-4">
+      <div id={SETTING_IDS.releaseChannel}>
         <ReleaseChannelSelector />
       </div>
 
-      <div id={SETTING_IDS.runtimeMode} className="mt-4">
+      <div id={SETTING_IDS.runtimeMode}>
         <RuntimeModeSelector />
       </div>
-      <div id={SETTING_IDS.nodePath} className="mt-4">
+      <div id={SETTING_IDS.nodePath}>
         <NodePathSelector />
       </div>
-      <div id={SETTING_IDS.customAppsFolder} className="mt-4">
+      <div id={SETTING_IDS.customAppsFolder}>
         <CustomAppsFolderSelector />
       </div>
 
-      <div className="flex items-center text-sm text-gray-500 dark:text-gray-400 mt-4">
-        <span className="mr-2 font-medium">App Version:</span>
-        <span className="bg-gray-100 dark:bg-gray-700 px-2 py-0.5 rounded text-gray-800 dark:text-gray-200 font-mono">
+      <div className="flex items-center gap-2 text-[13px] text-muted-foreground">
+        <span className="font-medium">App Version</span>
+        <span className="rounded-md border border-border/60 bg-muted/50 px-2 py-0.5 font-mono text-foreground">
           {appVersion ? appVersion : "-"}
         </span>
       </div>
-    </div>
+    </SettingsSection>
   );
 }
 
 export function WorkflowSettings() {
   return (
-    <div
+    <SettingsSection
       id={SECTION_IDS.workflow}
-      className="bg-white dark:bg-gray-800 rounded-xl shadow-sm p-6"
+      title="Workflow"
+      description="How Dyad handles code changes, previews, and notifications."
     >
-      <h2 className="text-lg font-medium text-gray-900 dark:text-white mb-4">
-        Workflow Settings
-      </h2>
-
-      <div id={SETTING_IDS.defaultChatMode} className="mt-4">
+      <div id={SETTING_IDS.defaultChatMode}>
         <DefaultChatModeSelector />
       </div>
 
-      <div id={SETTING_IDS.autoApprove} className="space-y-1 mt-4">
+      <div id={SETTING_IDS.autoApprove} className="space-y-1.5">
         <AutoApproveSwitch showToast={false} />
-        <div className="text-sm text-gray-500 dark:text-gray-400">
+        <p className={hint}>
           This will automatically approve code changes and run them.
-        </div>
+        </p>
       </div>
 
-      <div id={SETTING_IDS.appBlueprint} className="space-y-1 mt-4">
+      <div id={SETTING_IDS.appBlueprint} className="space-y-1.5">
         <AppBlueprintSwitch />
-        <div className="text-sm text-gray-500 dark:text-gray-400">
+        <p className={hint}>
           When creating a new app, generate a lightweight app blueprint (name,
           design, color, template) before building.
-        </div>
+        </p>
       </div>
 
-      <div id={SETTING_IDS.testingForNewApps} className="space-y-1 mt-4">
+      <div id={SETTING_IDS.testingForNewApps} className="space-y-1.5">
         <TestingForNewAppsSwitch />
-        <div className="text-sm text-gray-500 dark:text-gray-400">
+        <p className={hint}>
           When creating a new app, opt it into AI E2E testing by default. This
           only affects apps created while this setting is on; existing apps are
           unchanged.
-        </div>
+        </p>
       </div>
 
-      <div id={SETTING_IDS.autoExpandPreview} className="space-y-1 mt-4">
+      <div id={SETTING_IDS.autoExpandPreview} className="space-y-1.5">
         <AutoExpandPreviewSwitch />
-        <div className="text-sm text-gray-500 dark:text-gray-400">
+        <p className={hint}>
           Automatically expand the preview panel when code changes are made.
-        </div>
+        </p>
       </div>
 
-      <div id={SETTING_IDS.keepPreviewsRunning} className="space-y-1 mt-4">
+      <div id={SETTING_IDS.keepPreviewsRunning} className="space-y-1.5">
         <KeepPreviewsRunningSwitch />
-        <div className="text-sm text-gray-500 dark:text-gray-400">
+        <p className={hint}>
           Note: this may take more memory but allows faster preview loads when
           switching apps.
-        </div>
+        </p>
       </div>
 
-      <div id={SETTING_IDS.chatEventNotification} className="space-y-1 mt-4">
+      <div id={SETTING_IDS.chatEventNotification} className="space-y-1.5">
         <ChatEventNotificationSwitch />
-        <div className="text-sm text-gray-500 dark:text-gray-400">
+        <p className={hint}>
           Show native notifications when a chat response completes or a
           questionnaire needs your input while the app is not focused.
-        </div>
+        </p>
       </div>
-    </div>
+    </SettingsSection>
   );
 }
+
 export function AISettings() {
   return (
-    <div
+    <SettingsSection
       id={SECTION_IDS.ai}
-      className="bg-white dark:bg-gray-800 rounded-xl shadow-sm p-6"
+      title="AI"
+      description="Tune how the model reasons, and how long conversations run."
     >
-      <h2 className="text-lg font-medium text-gray-900 dark:text-white mb-4">
-        AI Settings
-      </h2>
-
-      <div id={SETTING_IDS.thinkingBudget} className="mt-4">
+      <div id={SETTING_IDS.thinkingBudget}>
         <ThinkingBudgetSelector />
       </div>
 
-      <div id={SETTING_IDS.maxChatTurns} className="mt-4">
+      <div id={SETTING_IDS.maxChatTurns}>
         <MaxChatTurnsSelector />
       </div>
 
-      <div id={SETTING_IDS.maxToolCallSteps} className="mt-4">
+      <div id={SETTING_IDS.maxToolCallSteps}>
         <MaxToolCallStepsSelector />
       </div>
 
-      <div id={SETTING_IDS.contextCompaction} className="space-y-1 mt-4">
+      <div id={SETTING_IDS.contextCompaction} className="space-y-1.5">
         <ContextCompactionSwitch />
-        <div className="text-sm text-gray-500 dark:text-gray-400">
+        <p className={hint}>
           Automatically compact long conversations to stay within context
           limits. Original messages are preserved in the app data directory.
-        </div>
+        </p>
       </div>
-    </div>
+    </SettingsSection>
   );
 }


### PR DESCRIPTION
## Summary

Redesign the Settings page as a flatter, calmer two-column layout while preserving the existing settings behavior. Shared controls and provider configuration now follow the same spacing, typography, and token-based styling so the page reads as one system instead of a stack of unrelated cards.

- Use a reusable section rail for labels and descriptions, with hairline dividers instead of elevated card containers; the layout collapses to one column at narrower widths.
- Consolidate repeated selector label/help/control markup into `SettingField`, keeping control widths and accessible label associations consistent.
- Modernize the shared Select and Switch presentation with theme tokens, hover states, and restrained motion without changing their public behavior.
- Flatten provider cards and remove the duplicate provider heading while retaining the existing setup and status flows.
- Keep destructive actions visually separated in a tinted Danger Zone rather than restoring card elevation elsewhere.

<img width="1779" height="1123" alt="Redesigned settings page" src="https://github.com/user-attachments/assets/de2068f3-9966-4c6b-924e-22eb98eeddf9" />

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
