### PR TITLE
Update internal workload model routing

### DIFF
--- a/src/ipc/handlers/image_generation_handlers.ts
+++ b/src/ipc/handlers/image_generation_handlers.ts
@@ -81,7 +81,7 @@ export function registerImageGenerationHandlers() {
           },
           body: JSON.stringify({
             prompt: fullPrompt,
-            model: "gpt-image-1.5",
+            model: "dyad/image-gen",
           }),
           signal: controller.signal,
         });

--- a/src/ipc/utils/llm_engine_provider.test.ts
+++ b/src/ipc/utils/llm_engine_provider.test.ts
@@ -6,7 +6,10 @@ import type {
 } from "@ai-sdk/provider";
 
 import type { UserSettings } from "../../lib/schemas";
-import { createDyadEngine } from "./llm_engine_provider";
+import {
+  createDyadEngine,
+  transcribeWithDyadEngine,
+} from "./llm_engine_provider";
 
 describe("createDyadEngine", () => {
   test("uses Anthropic messages API for Anthropic engine models", async () => {
@@ -212,5 +215,34 @@ describe("createDyadEngine", () => {
       "X-Dyad-Request-Id": "visible-turn-1:attempt-1",
       "X-Dyad-Free-Quota-Key": "visible-turn-1",
     });
+  });
+});
+
+describe("transcribeWithDyadEngine", () => {
+  test("uses the Dyad transcription model alias", async () => {
+    let request: { input: RequestInfo | URL; init?: RequestInit } | undefined;
+
+    const text = await transcribeWithDyadEngine(
+      Buffer.from("audio"),
+      "recording.webm",
+      "request-1",
+      {
+        apiKey: "dyad-pro-key",
+        baseURL: "https://engine.example.test/v1",
+        dyadOptions: {},
+        settings: {} as UserSettings,
+        fetch: async (input, init) => {
+          request = { input, init };
+          return Response.json({ text: "transcribed" });
+        },
+      },
+    );
+
+    expect(text).toBe("transcribed");
+    expect(String(request?.input)).toBe(
+      "https://engine.example.test/v1/audio/transcriptions",
+    );
+    const formData = request?.init?.body as FormData;
+    expect(formData.get("model")).toBe("dyad/transcribe");
   });
 });

--- a/src/ipc/utils/llm_engine_provider.ts
+++ b/src/ipc/utils/llm_engine_provider.ts
@@ -381,7 +381,7 @@ export async function transcribeWithDyadEngine(
   );
   const blob = new Blob([audioBytes], { type: mimeType });
   formData.append("file", blob, filename);
-  formData.append("model", "gpt-4o-mini-transcribe");
+  formData.append("model", "dyad/transcribe");
 
   const fetchFn = options.fetch || getTestFetchOption().fetch || fetch;
   const response = await fetchFn(`${baseURL}/audio/transcriptions`, {

--- a/src/pro/main/ipc/handlers/local_agent/mcp_auto_consent.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/mcp_auto_consent.spec.ts
@@ -42,7 +42,7 @@ describe("classifyMcpToolConsent", () => {
     expect(d.decision).toBe("allow");
     expect(d.reason).toBe("safe read");
     expect(mocks.getModelClient).toHaveBeenCalledWith(
-      { name: "dyad/auto-approver", provider: "openai" },
+      { name: "gpt-5.4-mini", provider: "openai" },
       baseInput.settings,
     );
   });

--- a/src/pro/main/ipc/handlers/local_agent/mcp_auto_consent.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/mcp_auto_consent.spec.ts
@@ -41,6 +41,10 @@ describe("classifyMcpToolConsent", () => {
     const d = await classifyMcpToolConsent(baseInput);
     expect(d.decision).toBe("allow");
     expect(d.reason).toBe("safe read");
+    expect(mocks.getModelClient).toHaveBeenCalledWith(
+      { name: "dyad/auto-approver", provider: "openai" },
+      baseInput.settings,
+    );
   });
 
   it("parses a decision wrapped in prose/code fences", async () => {

--- a/src/pro/main/ipc/handlers/local_agent/mcp_auto_consent.ts
+++ b/src/pro/main/ipc/handlers/local_agent/mcp_auto_consent.ts
@@ -14,11 +14,9 @@ import {
 
 const logger = log.scope("mcp-auto-consent");
 
-// Fixed, cheap classifier model routed through the Dyad Pro engine gateway.
-// Mirrors SUBAGENT_MODEL in explore_code_subagent.ts (same subsystem). Swap here
-// only; a mid-size model is deliberate for a security judgment, not the smallest.
+// Fixed classifier model routed through the Dyad Pro engine gateway.
 const MCP_CONSENT_MODEL: LargeLanguageModel = {
-  name: "gpt-5.4-mini",
+  name: "dyad/auto-approver",
   provider: "openai",
 };
 

--- a/src/pro/main/ipc/handlers/local_agent/mcp_auto_consent.ts
+++ b/src/pro/main/ipc/handlers/local_agent/mcp_auto_consent.ts
@@ -16,7 +16,7 @@ const logger = log.scope("mcp-auto-consent");
 
 // Fixed classifier model routed through the Dyad Pro engine gateway.
 const MCP_CONSENT_MODEL: LargeLanguageModel = {
-  name: "dyad/auto-approver",
+  name: "gpt-5.4-mini",
   provider: "openai",
 };
 

--- a/src/pro/main/ipc/handlers/local_agent/tools/explore_code_subagent.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/explore_code_subagent.spec.ts
@@ -153,7 +153,7 @@ describe("runExploreCodeSubagent", () => {
     });
 
     expect(mocks.getModelClient).toHaveBeenCalledWith(
-      { provider: "openai", name: "dyad/explorer" },
+      { provider: "openai", name: "gpt-5.6-luna" },
       mocks.readSettings.mock.results[0].value,
     );
     const options = vi.mocked(streamText).mock.calls[0][0] as any;

--- a/src/pro/main/ipc/handlers/local_agent/tools/explore_code_subagent.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/explore_code_subagent.spec.ts
@@ -152,6 +152,10 @@ describe("runExploreCodeSubagent", () => {
       ctx: createMockContext(),
     });
 
+    expect(mocks.getModelClient).toHaveBeenCalledWith(
+      { provider: "openai", name: "dyad/explorer" },
+      mocks.readSettings.mock.results[0].value,
+    );
     const options = vi.mocked(streamText).mock.calls[0][0] as any;
     expect(Object.keys(options.tools).sort()).toEqual([
       "explore_code",

--- a/src/pro/main/ipc/handlers/local_agent/tools/explore_code_subagent.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/explore_code_subagent.ts
@@ -60,7 +60,7 @@ import { formatExploreProgressLog } from "./explore_code_subagent_progress";
 
 const logger = log.scope("explore_code_subagent");
 
-const SUBAGENT_MODEL = { provider: "openai", name: "dyad/explorer" } as const;
+const SUBAGENT_MODEL = { provider: "openai", name: "gpt-5.6-luna" } as const;
 // Max model turns in the agent loop. Each step may issue several parallel tool
 // calls, so this is distinct from the read-only tool-call budget below.
 const SUBAGENT_MAX_STEPS = 12;

--- a/src/pro/main/ipc/handlers/local_agent/tools/explore_code_subagent.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/explore_code_subagent.ts
@@ -60,7 +60,7 @@ import { formatExploreProgressLog } from "./explore_code_subagent_progress";
 
 const logger = log.scope("explore_code_subagent");
 
-const SUBAGENT_MODEL = { provider: "openai", name: "gpt-5.4-mini" } as const;
+const SUBAGENT_MODEL = { provider: "openai", name: "dyad/explorer" } as const;
 // Max model turns in the agent loop. Each step may issue several parallel tool
 // calls, so this is distinct from the read-only tool-call budget below.
 const SUBAGENT_MAX_STEPS = 12;

--- a/src/pro/main/ipc/handlers/local_agent/tools/generate_image.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/generate_image.ts
@@ -55,7 +55,7 @@ async function callGenerateImage(
     method: "POST",
     body: JSON.stringify({
       prompt,
-      model: "gpt-image-1.5",
+      model: "dyad/image-gen",
     }),
   });
 


### PR DESCRIPTION
## Summary

Update the desktop app's internal workload routing so media services use stable gateway aliases while agent reasoning workloads continue to select explicit models. This keeps image and transcription backend selection flexible without changing the intended explorer and MCP approval behavior.

- Route the code explorer directly to `gpt-5.6-luna` while keeping the MCP consent classifier on `gpt-5.4-mini`.
- Route audio transcription through `dyad/transcribe` instead of pinning the underlying transcription model.
- Route both renderer-driven and agent-driven image generation through `dyad/image-gen` so those paths cannot drift.
- Add focused routing assertions for explorer, auto-approver, and transcription. The existing image-generation integration flow continues to cover the renderer request and saved-media behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior depends on the engine honoring new aliases and the explorer model swap; wrong gateway mapping would break media or degrade exploration without compile-time checks.
> 
> **Overview**
> **Internal workload routing** now separates stable Dyad engine aliases for media from explicit chat models for agent reasoning.
> 
> Image generation in both the **renderer IPC handler** and the **local agent `generate_image` tool** sends `model: "dyad/image-gen"` instead of pinning `gpt-image-1.5`. **Audio transcription** via `transcribeWithDyadEngine` uses `dyad/transcribe` instead of `gpt-4o-mini-transcribe`.
> 
> The **code explorer sub-agent** moves from `gpt-5.4-mini` to **`gpt-5.6-luna`**. The **MCP auto-consent classifier** stays on **`gpt-5.4-mini`** (comment cleanup only).
> 
> Tests now assert the routed models for transcription, explorer, and MCP consent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af829e26d5a1a03e9304059cc3a9917b0f540e66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->