### PR TITLE
Fix Supabase OAuth token propagation race

### DIFF
--- a/rules/electron-ipc.md
+++ b/rules/electron-ipc.md
@@ -71,6 +71,8 @@ writeSettings({
 
 **Electron readiness:** `readSettings()` and `writeSettings()` may decrypt/encrypt secrets through Electron `safeStorage`, which throws `safeStorage cannot be used before app is ready` before `app.whenReady()`. Queue pre-ready entry points like deep links (`open-url`, `second-instance`) until the app/window is ready before calling OAuth/settings handlers.
 
+**Custom-protocol debugging:** Before using `git bisect` on a `dyad://` flow, quit every dev and packaged Dyad instance and verify which build owns the protocol registration. macOS may route the link to a different running/registered build, producing a convincing but false good/bad result.
+
 ## Handler expectations
 
 - Handlers should `throw new Error("...")` on failure instead of returning `{ success: false }` style payloads.

--- a/src/supabase_admin/supabase_management_client.test.ts
+++ b/src/supabase_admin/supabase_management_client.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { listSupabaseOrganizations } from "./supabase_management_client";
+
+vi.mock("@/main/settings", () => ({
+  readSettings: vi.fn(() => ({})),
+  writeSettings: vi.fn(),
+}));
+
+describe("listSupabaseOrganizations", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("retries a transient 401 from a newly issued OAuth token", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(
+        new Response('{"message":"Unauthorized"}', {
+          status: 401,
+          statusText: "Unauthorized",
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([{ id: "org-1", slug: "example" }]), {
+          status: 200,
+        }),
+      );
+
+    const resultPromise = listSupabaseOrganizations("new-token");
+    await vi.runAllTimersAsync();
+
+    await expect(resultPromise).resolves.toEqual([
+      { id: "org-1", slug: "example" },
+    ]);
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry other authorization failures", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response('{"message":"Forbidden"}', {
+        status: 403,
+        statusText: "Forbidden",
+      }),
+    );
+
+    await expect(listSupabaseOrganizations("invalid-token")).rejects.toThrow(
+      "Failed to fetch organizations: Forbidden",
+    );
+    expect(fetch).toHaveBeenCalledOnce();
+  });
+});

--- a/src/supabase_admin/supabase_management_client.ts
+++ b/src/supabase_admin/supabase_management_client.ts
@@ -21,6 +21,10 @@ const fsPromises = fs.promises;
 
 const logger = log.scope("supabase_management_client");
 
+// Supabase can briefly reject a newly issued OAuth token while it propagates
+// to the Management API. Keep this retry window short and limited to 401s.
+const ORGANIZATION_AUTH_RETRY_DELAYS_MS = [250, 500, 1_000, 2_000] as const;
+
 // ─────────────────────────────────────────────────────────────────────
 // Interfaces for file collection and caching
 // ─────────────────────────────────────────────────────────────────────
@@ -378,19 +382,34 @@ export async function getSupabaseClientForOrganization(
 export async function listSupabaseOrganizations(
   accessToken: string,
 ): Promise<SupabaseOrganizationDetails[]> {
-  const response = await fetchWithRetry(
-    "https://api.supabase.com/v1/organizations",
-    {
-      method: "GET",
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
+  for (let attempt = 0; ; attempt++) {
+    const response = await fetchWithRetry(
+      "https://api.supabase.com/v1/organizations",
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
       },
-    },
-    "List Supabase organizations",
-  );
+      "List Supabase organizations",
+    );
 
-  if (response.status !== 200) {
+    if (response.status === 200) {
+      const organizations: SupabaseOrganizationDetails[] =
+        await response.json();
+      return organizations;
+    }
+
     const errorText = await response.text();
+    const retryDelay = ORGANIZATION_AUTH_RETRY_DELAYS_MS[attempt];
+    if (response.status === 401 && retryDelay !== undefined) {
+      logger.warn(
+        `Supabase organizations request was unauthorized; retrying in ${retryDelay}ms (attempt ${attempt + 2}/${ORGANIZATION_AUTH_RETRY_DELAYS_MS.length + 1})`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, retryDelay));
+      continue;
+    }
+
     logger.error(
       `Failed to fetch organizations (${response.status}): ${errorText}`,
     );
@@ -399,9 +418,6 @@ export async function listSupabaseOrganizations(
       response,
     );
   }
-
-  const organizations: SupabaseOrganizationDetails[] = await response.json();
-  return organizations;
 }
 
 export interface SupabaseOrganizationMember {


### PR DESCRIPTION
## Summary

Newly issued Supabase OAuth tokens can briefly return 401 from the Management API before token propagation completes, causing Dyad to miss organization-scoped credential setup. This gives the initial organization lookup a short retry window so the connection completes without requiring the user to reopen the deep link.

- Retry only 401 responses, using four bounded backoff delays totaling 3.75 seconds; existing 429 handling remains unchanged.
- Preserve immediate failure behavior for 403 and all other non-retryable responses. A genuinely invalid token may now take up to 3.75 seconds before the existing legacy fallback runs.
- Add unit coverage for transient-401 recovery and the non-401 boundary.
- Document the macOS custom-protocol ownership check that prevents false results while bisecting deep-link behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, bounded retry on one API helper plus docs and tests; invalid tokens may fail up to ~3.75s later before existing fallback.
> 
> **Overview**
> Fixes a race where **fresh Supabase OAuth tokens** can get **401** from the Management API during org lookup right after connect, which blocked organization-scoped credential setup.
> 
> **`listSupabaseOrganizations`** now retries **401 only** with four backoff delays (250ms–2s, ~3.75s total) before failing; **403** and other errors still fail immediately. Existing **429** behavior via `fetchWithRetry` is unchanged.
> 
> Adds **Vitest** coverage for transient-401 recovery vs non-retryable 403. **`rules/electron-ipc.md`** adds a note to verify **macOS `dyad://` protocol ownership** when bisecting deep-link flows so the wrong build does not fake good/bad results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2be7689218351faebd2b093325841d1bb0ca7753. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->