### PR TITLE
Remove experimental badge from Neon

### DIFF
--- a/src/components/chat/DyadAddIntegration.tsx
+++ b/src/components/chat/DyadAddIntegration.tsx
@@ -69,14 +69,12 @@ export const DyadAddIntegration: React.FC<DyadAddIntegrationProps> = ({
         "integrations.databaseSetup.providers.supabase.description",
       ),
       url: "https://supabase.com",
-      experimental: false,
     },
     {
       id: "neon" as const,
       name: t("integrations.databaseSetup.providers.neon.name"),
       description: t("integrations.databaseSetup.providers.neon.description"),
       url: "https://neon.tech",
-      experimental: true,
     },
   ];
 
@@ -349,11 +347,6 @@ export const DyadAddIntegration: React.FC<DyadAddIntegrationProps> = ({
                       <span className="text-sm font-semibold text-foreground">
                         {option.name}
                       </span>
-                      {option.experimental && (
-                        <DyadBadge color="amber">
-                          {t("integrations.databaseSetup.experimental")}
-                        </DyadBadge>
-                      )}
                       <span
                         onClick={(e) => {
                           e.stopPropagation();

--- a/src/i18n/locales/en/home.json
+++ b/src/i18n/locales/en/home.json
@@ -660,7 +660,6 @@
       "chooseProvider": "Choose a database provider",
       "configureInPanelTitle": "Finish setup in the Configure panel",
       "configureInPanelDescription": "Complete the {{provider}} setup in the panel on the right, then come back here.",
-      "experimental": "Experimental",
       "providers": {
         "supabase": {
           "name": "Supabase",

--- a/src/i18n/locales/es/home.json
+++ b/src/i18n/locales/es/home.json
@@ -629,7 +629,6 @@
       "chooseProvider": "Elige un proveedor de base de datos",
       "setUpProvider": "Configurar {{provider}}",
       "setUpDatabase": "Configurar base de datos",
-      "experimental": "Experimental",
       "providers": {
         "supabase": {
           "name": "Supabase",

--- a/src/i18n/locales/ko/home.json
+++ b/src/i18n/locales/ko/home.json
@@ -639,7 +639,6 @@
       "chooseProvider": "데이터베이스 공급자 선택",
       "configureInPanelTitle": "설정 패널에서 마무리하기",
       "configureInPanelDescription": "오른쪽 패널에서 {{provider}} 설정을 완료한 후 여기로 돌아오세요.",
-      "experimental": "실험적",
       "providers": {
         "supabase": {
           "name": "Supabase",

--- a/src/i18n/locales/pt-BR/home.json
+++ b/src/i18n/locales/pt-BR/home.json
@@ -629,7 +629,6 @@
       "chooseProvider": "Escolha um provedor de banco de dados",
       "configureInPanelTitle": "Conclua a configuração no painel Configurar",
       "configureInPanelDescription": "Conclua a configuração do {{provider}} no painel à direita e depois volte aqui.",
-      "experimental": "Experimental",
       "providers": {
         "supabase": {
           "name": "Supabase",

--- a/src/i18n/locales/zh-CN/home.json
+++ b/src/i18n/locales/zh-CN/home.json
@@ -629,7 +629,6 @@
       "chooseProvider": "选择数据库提供商",
       "configureInPanelTitle": "在配置面板中完成设置",
       "configureInPanelDescription": "在右侧面板中完成 {{provider}} 设置，然后返回此处。",
-      "experimental": "实验性",
       "providers": {
         "supabase": {
           "name": "Supabase",


### PR DESCRIPTION
## Summary

Remove the Experimental badge from Neon in the database provider selection card so Neon is presented as a standard integration.

- Leaves Neon availability, framework support checks, and setup behavior unchanged.
- Removes the now-unused badge translations from every supported locale.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

