### PR TITLE
Require build provenance for release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@
 # Need to write to repo contents to upload the app to GitHub Release
 # See: https://www.electronforge.io/config/publishers/github#authentication
 permissions:
-  contents: write
+  contents: read
 
 name: Release app
 on:
@@ -17,6 +17,8 @@ jobs:
   prepare-release:
     name: Prepare Release Tag
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       tag: ${{ steps.prepare.outputs.tag }}
       version: ${{ steps.prepare.outputs.version }}
@@ -38,6 +40,10 @@ jobs:
   build:
     needs: prepare-release
     environment: release
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
     strategy:
       # Continue building other platforms even if one fails
       fail-fast: false
@@ -153,6 +159,17 @@ jobs:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           WINDOWS_SIGN: ${{ contains(matrix.os.name, 'windows') && 'true' || '' }}
 
+      - name: Generate release provenance manifest
+        env:
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
+          RELEASE_VERSION: ${{ needs.prepare-release.outputs.version }}
+        run: node scripts/generate-release-provenance.js "out/release-provenance-${{ matrix.os.name }}.json" "${{ matrix.os.name }}" out/make
+
+      - name: Attest release provenance manifest
+        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4.2.0
+        with:
+          subject-path: out/release-provenance-${{ matrix.os.name }}.json
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
@@ -162,8 +179,10 @@ jobs:
 
   publish:
     name: Publish Release
-    needs: build
+    needs: [prepare-release, build]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Github checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -193,6 +212,12 @@ jobs:
         env:
           DEBUG: "@electron/*,electron-forge:*"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload provenance manifests to draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
+        run: gh release upload "$RELEASE_TAG" out/release-provenance-*.json --clobber
 
   verify-assets:
     name: Verify Release Assets

--- a/rules/auto-update.md
+++ b/rules/auto-update.md
@@ -7,3 +7,9 @@ Debugging update failures reported by users, or changing updater/debug-report co
 - The full .NET inner-exception chain persists across restarts in Squirrel's own log next to `Update.exe`: `%LocalAppData%\dyad\SquirrelSetup.log`. Debug bundles capture its tail via `readUpdaterLogs()` in `src/ipc/handlers/debug_handlers.ts` (`updaterLogs` field).
 - Bug-report bodies travel in the GitHub issue-creation URL (`openGitHubIssue` in `HelpDialog.tsx`), so any new log section added there must be tightly size-capped (~1-2k chars) to avoid overlong URLs. When capping updater logs, reserve space for the `Last updater error (this session)` block; blindly taking the tail can keep only Squirrel stack tails and drop the root cause. Do not split updater log sections on arbitrary blank lines because .NET exception text can contain internal blank lines; use known section headers such as `Squirrel*.log (tail):`.
 - Session upload bundles are POSTed and can carry larger updater log tails, but every new uploaded debug field must also be rendered in the `HelpDialog` review screen so users can inspect it before submitting.
+
+## Trusted releases
+
+- Auto-update clients must only receive releases accepted by the provenance verifier in `dyad-cloud/apps/api/src/app/v1/update/release_trust.ts`; a GitHub release and its asset digests are not sufficient trust signals by themselves.
+- The verifier allowlists the exact SHA-256 of `.github/workflows/release.yml`. Any intentional workflow edit must be coordinated with that allowlist or new releases will fail closed and disappear from update/landing feeds.
+- Generate platform provenance from Electron Forge's publishable artifacts under `out/make`, not all of `out`; the latter also contains unpackaged application files that are not release assets.

--- a/scripts/generate-release-provenance.js
+++ b/scripts/generate-release-provenance.js
@@ -32,7 +32,24 @@ function listFilesRecursively(directory) {
 
 function hashFile(filePath) {
   const hash = crypto.createHash("sha256");
-  hash.update(fs.readFileSync(filePath));
+  const fileDescriptor = fs.openSync(filePath, "r");
+  const buffer = Buffer.alloc(1024 * 1024);
+  try {
+    let bytesRead;
+    while (
+      (bytesRead = fs.readSync(
+        fileDescriptor,
+        buffer,
+        0,
+        buffer.length,
+        null,
+      )) > 0
+    ) {
+      hash.update(buffer.subarray(0, bytesRead));
+    }
+  } finally {
+    fs.closeSync(fileDescriptor);
+  }
   return hash.digest("hex");
 }
 
@@ -44,7 +61,7 @@ function collectReleaseArtifacts(outputDirectory) {
       sha256: hashFile(filePath),
       size: fs.statSync(filePath).size,
     }))
-    .sort((a, b) => a.name.localeCompare(b.name));
+    .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
 
   const duplicateNames = artifacts
     .filter((artifact, index) =>
@@ -112,7 +129,8 @@ function createReleaseProvenance({
 }
 
 function main() {
-  const [outputPath, platform, outputDirectory = "out"] = process.argv.slice(2);
+  const [outputPath, platform, outputDirectory = "out/make"] =
+    process.argv.slice(2);
   if (!outputPath || !platform) {
     throw new Error(
       "Usage: generate-release-provenance.js <output-path> <platform> [artifact-directory]",

--- a/scripts/generate-release-provenance.js
+++ b/scripts/generate-release-provenance.js
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+
+const crypto = require("crypto");
+const fs = require("fs");
+const path = require("path");
+
+const PROVENANCE_SCHEMA_VERSION = 1;
+const RELEASE_WORKFLOW = ".github/workflows/release.yml";
+const RELEASE_ARTIFACT_EXTENSIONS = new Set([
+  ".AppImage",
+  ".deb",
+  ".exe",
+  ".nupkg",
+  ".rpm",
+  ".zip",
+]);
+
+function isReleaseArtifact(filePath) {
+  const basename = path.basename(filePath);
+  return (
+    basename === "RELEASES" ||
+    RELEASE_ARTIFACT_EXTENSIONS.has(path.extname(basename))
+  );
+}
+
+function listFilesRecursively(directory) {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(directory, entry.name);
+    return entry.isDirectory() ? listFilesRecursively(entryPath) : [entryPath];
+  });
+}
+
+function hashFile(filePath) {
+  const hash = crypto.createHash("sha256");
+  hash.update(fs.readFileSync(filePath));
+  return hash.digest("hex");
+}
+
+function collectReleaseArtifacts(outputDirectory) {
+  const artifacts = listFilesRecursively(outputDirectory)
+    .filter(isReleaseArtifact)
+    .map((filePath) => ({
+      name: path.basename(filePath),
+      sha256: hashFile(filePath),
+      size: fs.statSync(filePath).size,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const duplicateNames = artifacts
+    .filter((artifact, index) =>
+      artifacts.some(
+        (candidate, candidateIndex) =>
+          candidateIndex !== index && candidate.name === artifact.name,
+      ),
+    )
+    .map((artifact) => artifact.name);
+
+  if (duplicateNames.length > 0) {
+    throw new Error(
+      `Release artifacts must have unique basenames: ${[...new Set(duplicateNames)].join(", ")}`,
+    );
+  }
+  if (artifacts.length === 0) {
+    throw new Error(`No release artifacts found under ${outputDirectory}`);
+  }
+
+  return artifacts;
+}
+
+function requireEnvironment(name, environment = process.env) {
+  const value = environment[name];
+  if (!value) {
+    throw new Error(`${name} environment variable is required`);
+  }
+  return value;
+}
+
+function createReleaseProvenance({
+  environment = process.env,
+  outputDirectory,
+  platform,
+}) {
+  const repository = requireEnvironment("GITHUB_REPOSITORY", environment);
+  const [owner, name] = repository.split("/");
+  if (!owner || !name) {
+    throw new Error(`Invalid GITHUB_REPOSITORY value: ${repository}`);
+  }
+
+  const version = requireEnvironment("RELEASE_VERSION", environment);
+  const tag = requireEnvironment("RELEASE_TAG", environment);
+  if (tag !== `v${version}`) {
+    throw new Error(`Release tag ${tag} does not match version ${version}`);
+  }
+
+  return {
+    schemaVersion: PROVENANCE_SCHEMA_VERSION,
+    repository: {
+      id: requireEnvironment("GITHUB_REPOSITORY_ID", environment),
+      name,
+      owner,
+    },
+    source: {
+      commit: requireEnvironment("GITHUB_SHA", environment),
+      ref: requireEnvironment("GITHUB_REF", environment),
+      runAttempt: requireEnvironment("GITHUB_RUN_ATTEMPT", environment),
+      runId: requireEnvironment("GITHUB_RUN_ID", environment),
+      workflow: RELEASE_WORKFLOW,
+    },
+    release: { platform, tag, version },
+    artifacts: collectReleaseArtifacts(outputDirectory),
+  };
+}
+
+function main() {
+  const [outputPath, platform, outputDirectory = "out"] = process.argv.slice(2);
+  if (!outputPath || !platform) {
+    throw new Error(
+      "Usage: generate-release-provenance.js <output-path> <platform> [artifact-directory]",
+    );
+  }
+
+  const provenance = createReleaseProvenance({ outputDirectory, platform });
+  fs.writeFileSync(outputPath, `${JSON.stringify(provenance, null, 2)}\n`);
+  console.log(
+    `Wrote ${outputPath} for ${provenance.artifacts.length} ${platform} release artifacts.`,
+  );
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error("Failed to generate release provenance:", error.message);
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  collectReleaseArtifacts,
+  createReleaseProvenance,
+  isReleaseArtifact,
+};

--- a/scripts/verify-release-assets.js
+++ b/scripts/verify-release-assets.js
@@ -130,15 +130,21 @@ async function verifyReleaseAssets() {
       process.exit(1);
     }
 
-    // Check for unexpected assets (optional warning)
+    // Extra assets are not covered by provenance and would make downstream
+    // trusted-release verification reject the release.
     const unexpectedAssets = actualAssets.filter(
       (actual) => !expectedAssets.includes(actual),
     );
 
     if (unexpectedAssets.length > 0) {
-      console.warn("⚠️  Unexpected assets found:");
-      unexpectedAssets.forEach((asset) => console.warn(`  - ${asset}`));
-      console.warn("");
+      console.error("❌ VERIFICATION FAILED!");
+      console.error("📦 Unexpected assets:");
+      unexpectedAssets.forEach((asset) => console.error(`  - ${asset}`));
+      console.error("");
+      console.error(
+        "Remove stale assets from the draft and rerun the release.",
+      );
+      process.exit(1);
     }
 
     console.log("✅ VERIFICATION PASSED!");

--- a/scripts/verify-release-assets.js
+++ b/scripts/verify-release-assets.js
@@ -97,6 +97,10 @@ async function verifyReleaseAssets() {
       `dyad_${normalizeVersionForPlatform(version, "deb")}_amd64.deb`,
       `dyad_${version}_x86_64.AppImage`,
       "RELEASES",
+      "release-provenance-linux.json",
+      "release-provenance-macos-intel.json",
+      "release-provenance-macos.json",
+      "release-provenance-windows.json",
     ];
 
     console.log("📋 Expected assets:");

--- a/src/__tests__/generate_release_provenance_script.test.ts
+++ b/src/__tests__/generate_release_provenance_script.test.ts
@@ -38,16 +38,16 @@ describe("release provenance generator", () => {
 
     expect(collectReleaseArtifacts(directory)).toEqual([
       {
-        name: "dyad.zip",
-        sha256:
-          "4a70fe9aa6436e02c2dea340fbd1e352e4ef2d8ce6ca52ad25d4b95471fc8bf2",
-        size: 3,
-      },
-      {
         name: "RELEASES",
         sha256:
           "05b3abf2579a5eb66403cd78be557fd860633a1fe2103c7642030defe32c657f",
         size: 8,
+      },
+      {
+        name: "dyad.zip",
+        sha256:
+          "4a70fe9aa6436e02c2dea340fbd1e352e4ef2d8ce6ca52ad25d4b95471fc8bf2",
+        size: 3,
       },
     ]);
   });

--- a/src/__tests__/generate_release_provenance_script.test.ts
+++ b/src/__tests__/generate_release_provenance_script.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment node
+
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { createRequire } from "module";
+import { afterEach, describe, expect, it } from "vitest";
+
+const require = createRequire(import.meta.url);
+const {
+  collectReleaseArtifacts,
+  createReleaseProvenance,
+} = require("../../scripts/generate-release-provenance.js");
+
+const temporaryDirectories: string[] = [];
+
+function createTemporaryDirectory() {
+  const directory = fs.mkdtempSync(
+    path.join(os.tmpdir(), "dyad-release-provenance-"),
+  );
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("release provenance generator", () => {
+  it("hashes and sorts only published release artifact types", () => {
+    const directory = createTemporaryDirectory();
+    fs.mkdirSync(path.join(directory, "nested"));
+    fs.writeFileSync(path.join(directory, "nested", "dyad.zip"), "zip");
+    fs.writeFileSync(path.join(directory, "RELEASES"), "manifest");
+    fs.writeFileSync(path.join(directory, "ignored.json"), "{}");
+
+    expect(collectReleaseArtifacts(directory)).toEqual([
+      {
+        name: "dyad.zip",
+        sha256:
+          "4a70fe9aa6436e02c2dea340fbd1e352e4ef2d8ce6ca52ad25d4b95471fc8bf2",
+        size: 3,
+      },
+      {
+        name: "RELEASES",
+        sha256:
+          "05b3abf2579a5eb66403cd78be557fd860633a1fe2103c7642030defe32c657f",
+        size: 8,
+      },
+    ]);
+  });
+
+  it("binds artifacts to the repository, workflow, ref, and commit", () => {
+    const directory = createTemporaryDirectory();
+    fs.writeFileSync(path.join(directory, "dyad.exe"), "binary");
+
+    const provenance = createReleaseProvenance({
+      outputDirectory: directory,
+      platform: "windows",
+      environment: {
+        GITHUB_REF: "refs/heads/main",
+        GITHUB_REPOSITORY: "dyad-sh/dyad",
+        GITHUB_REPOSITORY_ID: "964395174",
+        GITHUB_RUN_ATTEMPT: "1",
+        GITHUB_RUN_ID: "12345",
+        GITHUB_SHA: "0123456789abcdef0123456789abcdef01234567",
+        RELEASE_TAG: "v1.8.0",
+        RELEASE_VERSION: "1.8.0",
+      },
+    });
+
+    expect(provenance).toMatchObject({
+      schemaVersion: 1,
+      repository: { id: "964395174", name: "dyad", owner: "dyad-sh" },
+      source: {
+        commit: "0123456789abcdef0123456789abcdef01234567",
+        ref: "refs/heads/main",
+        runAttempt: "1",
+        runId: "12345",
+        workflow: ".github/workflows/release.yml",
+      },
+      release: { platform: "windows", tag: "v1.8.0", version: "1.8.0" },
+    });
+  });
+
+  it("rejects a tag that does not match the package version", () => {
+    const directory = createTemporaryDirectory();
+    fs.writeFileSync(path.join(directory, "dyad.exe"), "binary");
+
+    expect(() =>
+      createReleaseProvenance({
+        outputDirectory: directory,
+        platform: "windows",
+        environment: {
+          GITHUB_REF: "refs/heads/main",
+          GITHUB_REPOSITORY: "dyad-sh/dyad",
+          GITHUB_REPOSITORY_ID: "964395174",
+          GITHUB_RUN_ATTEMPT: "1",
+          GITHUB_RUN_ID: "12345",
+          GITHUB_SHA: "0123456789abcdef0123456789abcdef01234567",
+          RELEASE_TAG: "v9.9.9",
+          RELEASE_VERSION: "1.8.0",
+        },
+      }),
+    ).toThrow("does not match version");
+  });
+});


### PR DESCRIPTION
## Summary

Make release artifacts cryptographically attributable to the reviewed, environment-protected release workflow so downstream services can reject releases created directly through GitHub.

Companion verifier and landing changes: https://github.com/dyad-sh/dyad-cloud/pull/375

- Generate one manifest per build platform from Forge's publishable `out/make` artifacts, binding every asset hash and size to the exact repository ID, workflow, source ref, commit, run, tag, and version.
- Use GitHub artifact attestations with OIDC in the existing `release` environment-gated build job; the attestation action is pinned by commit.
- Upload the four manifests with the draft release and require them in release asset verification.
- Narrow workflow permissions so only tag preparation and publishing receive `contents: write`; build receives only the read/OIDC/attestation permissions it needs.
- This is intentionally fail-closed and coordinated with dyad-cloud: changing `release.yml` requires approving its new SHA-256 in the API verifier before the next release.
- A separate external KMS authorization signature is not included here; the existing GitHub environment reviewer approval remains the independent human authorization boundary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the release pipeline and trust model for shipping binaries; misconfiguration or uncoordinated `release.yml` edits can fail closed and block updates.
> 
> **Overview**
> Release builds now emit **attested provenance manifests** so downstream auto-update can trust artifacts only from the reviewed `release` workflow, not arbitrary GitHub uploads.
> 
> Each matrix build runs `generate-release-provenance.js` over Forge publishable files in `out/make` (hashes, sizes, repo/run/commit/tag/version, workflow path), then **GitHub artifact attestation** via OIDC in the `release` environment. The publish job uploads the four `release-provenance-*.json` files to the draft release; `verify-release-assets.js` requires them and **fails** on any extra release asset (no longer a warning).
> 
> Workflow **permissions are tightened**: default `contents: read`; only prepare/publish jobs get `contents: write`; build gets read + attestation/OIDC only. `rules/auto-update.md` documents coordination with the dyad-cloud verifier allowlist for `release.yml` SHA-256.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 789dffed29b09f26b07aac5a3cc8d915bfbf2dbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->