### PR TITLE
Resolve TypeScript CLI from package metadata

### DIFF
--- a/src/ipc/processors/tsc.test.ts
+++ b/src/ipc/processors/tsc.test.ts
@@ -222,6 +222,20 @@ describe("isMissingPathError", () => {
 
 describe("runTypeScriptCheck", () => {
   let appPath: string;
+  const typeScriptBinPath = path.join("bin", "tsc");
+
+  async function writeTypeScriptPackage(packagePath: string) {
+    await fs.mkdir(path.join(packagePath, "bin"), { recursive: true });
+    await fs.writeFile(
+      path.join(packagePath, "package.json"),
+      JSON.stringify({
+        name: "typescript",
+        version: "7.0.0",
+        bin: { tsc: "./bin/tsc" },
+      }),
+    );
+    await fs.writeFile(path.join(packagePath, typeScriptBinPath), "");
+  }
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -231,16 +245,8 @@ describe("runTypeScriptCheck", () => {
     appPath = await fs.realpath(
       await fs.mkdtemp(path.join(os.tmpdir(), "dyad-tsc-cli-")),
     );
-    await fs.mkdir(path.join(appPath, "node_modules", "typescript", "lib"), {
-      recursive: true,
-    });
-    await fs.writeFile(
-      path.join(appPath, "node_modules", "typescript", "package.json"),
-      JSON.stringify({ name: "typescript", version: "7.0.0" }),
-    );
-    await fs.writeFile(
-      path.join(appPath, "node_modules", "typescript", "lib", "tsc.js"),
-      "",
+    await writeTypeScriptPackage(
+      path.join(appPath, "node_modules", "typescript"),
     );
     await fs.writeFile(path.join(appPath, "tsconfig.app.json"), "{}");
     await fs.mkdir(path.join(appPath, "src"));
@@ -290,7 +296,7 @@ describe("runTypeScriptCheck", () => {
       expect.objectContaining({
         command: "node",
         args: expect.arrayContaining([
-          path.join(appPath, "node_modules", "typescript", "lib", "tsc.js"),
+          path.join(appPath, "node_modules", "typescript", typeScriptBinPath),
           "--pretty",
           "false",
           "--diagnostics",
@@ -317,7 +323,7 @@ describe("runTypeScriptCheck", () => {
     );
     const args = runBufferedProcessMock.mock.calls[1][0].args as string[];
     expect(args[0]).toBe(
-      path.join(appPath, "node_modules", "typescript", "lib", "tsc.js"),
+      path.join(appPath, "node_modules", "typescript", typeScriptBinPath),
     );
     const tsBuildInfoPath = args[args.indexOf("--tsBuildInfoFile") + 1];
     expect(path.dirname(tsBuildInfoPath)).toBe(
@@ -335,17 +341,8 @@ describe("runTypeScriptCheck", () => {
     try {
       const packagePath = path.join(workspaceRoot, "packages", "web");
       await fs.mkdir(packagePath, { recursive: true });
-      await fs.mkdir(
-        path.join(workspaceRoot, "node_modules", "typescript", "lib"),
-        { recursive: true },
-      );
-      await fs.writeFile(
-        path.join(workspaceRoot, "node_modules", "typescript", "package.json"),
-        JSON.stringify({ name: "typescript", version: "7.0.0" }),
-      );
-      await fs.writeFile(
-        path.join(workspaceRoot, "node_modules", "typescript", "lib", "tsc.js"),
-        "",
+      await writeTypeScriptPackage(
+        path.join(workspaceRoot, "node_modules", "typescript"),
       );
       await fs.writeFile(path.join(packagePath, "tsconfig.json"), "{}");
 
@@ -357,7 +354,12 @@ describe("runTypeScriptCheck", () => {
       ).resolves.toEqual({ problems: [], outcome: "passed" });
       const args = runBufferedProcessMock.mock.calls[1][0].args as string[];
       expect(args[0]).toBe(
-        path.join(workspaceRoot, "node_modules", "typescript", "lib", "tsc.js"),
+        path.join(
+          workspaceRoot,
+          "node_modules",
+          "typescript",
+          typeScriptBinPath,
+        ),
       );
     } finally {
       await fs.rm(workspaceRoot, { recursive: true, force: true });
@@ -379,12 +381,16 @@ describe("runTypeScriptCheck", () => {
         "node_modules",
         "typescript",
       );
-      await fs.mkdir(path.join(packagePath, "lib"), { recursive: true });
+      await fs.mkdir(path.join(packagePath, "bin"), { recursive: true });
       await fs.writeFile(
         path.join(packagePath, "package.json"),
-        JSON.stringify({ name: "typescript", version }),
+        JSON.stringify({
+          name: "typescript",
+          version,
+          bin: { tsc: "./bin/tsc" },
+        }),
       );
-      await fs.writeFile(path.join(packagePath, "lib", "tsc.js"), "");
+      await fs.writeFile(path.join(packagePath, typeScriptBinPath), "");
       const linkTarget =
         process.platform === "win32"
           ? packagePath
@@ -416,9 +422,35 @@ describe("runTypeScriptCheck", () => {
     expect(runBufferedProcessMock).toHaveBeenLastCalledWith(
       expect.objectContaining({
         args: expect.arrayContaining([
-          path.join(nodeModulesPath, "typescript", "lib", "tsc.js"),
+          path.join(nodeModulesPath, "typescript", typeScriptBinPath),
         ]),
       }),
+    );
+  });
+
+  it("uses the CLI path declared by the TypeScript package", async () => {
+    const packagePath = path.join(appPath, "node_modules", "typescript");
+    const customBinPath = path.join("cli", "typescript.js");
+    await fs.mkdir(path.join(packagePath, "cli"));
+    await fs.writeFile(
+      path.join(packagePath, "package.json"),
+      JSON.stringify({
+        name: "typescript",
+        version: "7.0.0",
+        bin: { tsc: "./cli/typescript.js" },
+      }),
+    );
+    await fs.writeFile(path.join(packagePath, customBinPath), "");
+
+    mockVersion();
+    runBufferedProcessMock.mockResolvedValueOnce(processResult());
+
+    await expect(runTypeScriptCheck({ appPath })).resolves.toEqual({
+      problems: [],
+      outcome: "passed",
+    });
+    expect(runBufferedProcessMock.mock.calls[1][0].args[0]).toBe(
+      path.join(packagePath, customBinPath),
     );
   });
 
@@ -490,7 +522,7 @@ describe("runTypeScriptCheck", () => {
 
   it("reports a missing local CLI entry as an install precondition", async () => {
     await fs.rm(
-      path.join(appPath, "node_modules", "typescript", "lib", "tsc.js"),
+      path.join(appPath, "node_modules", "typescript", typeScriptBinPath),
     );
 
     await expect(runTypeScriptCheck({ appPath })).rejects.toMatchObject({

--- a/src/ipc/processors/tsc.ts
+++ b/src/ipc/processors/tsc.ts
@@ -13,7 +13,6 @@ import {
   type BufferedProcessResult,
 } from "@/ipc/utils/buffered_process";
 import {
-  getTypeScriptCliPath,
   isMissingPathError,
   resolveTypeScriptPackageJsonPath,
 } from "../../../shared/node_module_resolution";
@@ -157,6 +156,10 @@ interface ParsedDiagnostics {
 
 interface TypeScriptCli {
   entryPath: string;
+}
+
+interface TypeScriptPackageJson {
+  bin?: Record<string, unknown>;
 }
 
 function normalizePath(filePath: string): string {
@@ -367,7 +370,36 @@ async function resolveTypeScriptCli(appPath: string): Promise<TypeScriptCli> {
     );
   }
 
-  const entryPath = getTypeScriptCliPath(packageJsonPath);
+  const packagePath = path.dirname(packageJsonPath);
+  let binPath: unknown;
+  try {
+    const packageJson = JSON.parse(
+      await fs.readFile(packageJsonPath, "utf8"),
+    ) as TypeScriptPackageJson;
+    binPath = packageJson.bin?.tsc;
+  } catch (error) {
+    throw new TypeCheckPreconditionError(
+      "typescript-not-found",
+      `Failed to read TypeScript package metadata at ${packageJsonPath}`,
+      { cause: error },
+    );
+  }
+
+  if (typeof binPath !== "string") {
+    throw new TypeCheckPreconditionError(
+      "typescript-not-found",
+      `No local TypeScript CLI declared in ${packageJsonPath}`,
+    );
+  }
+
+  const entryPath = path.resolve(packagePath, binPath);
+  if (!isPathInside(packagePath, entryPath)) {
+    throw new TypeCheckPreconditionError(
+      "typescript-not-found",
+      `Local TypeScript CLI path escapes its package: ${binPath}`,
+    );
+  }
+
   try {
     await fs.access(entryPath);
   } catch (error) {

--- a/src/ipc/processors/tsc.ts
+++ b/src/ipc/processors/tsc.ts
@@ -393,13 +393,6 @@ async function resolveTypeScriptCli(appPath: string): Promise<TypeScriptCli> {
   }
 
   const entryPath = path.resolve(packagePath, binPath);
-  if (!isPathInside(packagePath, entryPath)) {
-    throw new TypeCheckPreconditionError(
-      "typescript-not-found",
-      `Local TypeScript CLI path escapes its package: ${binPath}`,
-    );
-  }
-
   try {
     await fs.access(entryPath);
   } catch (error) {

--- a/src/ipc/processors/typescript_utility_process_integration.test.ts
+++ b/src/ipc/processors/typescript_utility_process_integration.test.ts
@@ -88,15 +88,15 @@ describe("TypeScript utility process exclusion", () => {
     const appPath = await fs.mkdtemp(
       path.join(os.tmpdir(), "dyad-ts-scheduler-"),
     );
-    await fs.mkdir(path.join(appPath, "node_modules", "typescript", "lib"), {
+    await fs.mkdir(path.join(appPath, "node_modules", "typescript", "bin"), {
       recursive: true,
     });
     await fs.writeFile(
       path.join(appPath, "node_modules", "typescript", "package.json"),
-      "{}",
+      JSON.stringify({ bin: { tsc: "./bin/tsc" } }),
     );
     await fs.writeFile(
-      path.join(appPath, "node_modules", "typescript", "lib", "tsc.js"),
+      path.join(appPath, "node_modules", "typescript", "bin", "tsc"),
       "",
     );
     await fs.writeFile(path.join(appPath, "tsconfig.json"), "{}");


### PR DESCRIPTION
## Summary

Resolve the app-local TypeScript compiler through the package's declared `bin.tsc` entry instead of relying on the internal `lib/tsc.js` layout. This keeps shell-free execution with Dyad's selected Node runtime while following the npm package contract used by TypeScript 5, 6, and 7.

- Continue bypassing generated `.bin` shims so Windows does not require `cmd.exe` and paths containing spaces remain safe.
- Report missing or invalid CLI declarations as TypeScript installation preconditions while allowing linked targets.
- Cover custom declared CLI paths and hoisted TypeScript installations in the focused processor tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the local TypeScript compiler is located for every type check; mis-resolution would break checks or run the wrong entry, though validation and tests narrow that risk.
> 
> **Overview**
> Type checking no longer assumes the compiler lives at **`lib/tsc.js`**. **`resolveTypeScriptCli`** in `tsc.ts` reads the installed package’s **`package.json`**, resolves **`bin.tsc`** relative to the package root, and still launches that entry with **`node`** (not **`.bin`** shims).
> 
> Invalid or unsafe setups are treated as **`typescript-not-found`** preconditions: unreadable metadata, missing **`bin.tsc`**, paths that escape the package directory, or a CLI file that isn’t on disk.
> 
> Processor and utility-process tests now stub TypeScript with **`bin/tsc`** layouts (including hoisted pnpm installs) and add coverage for a **custom** declared CLI path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f73c39e292e319e22a109c3c8ed15c09355067d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/3988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

