### PR TITLE
Use provider defaults for unspecified model temperature

### DIFF
--- a/src/ipc/utils/token_utils.test.ts
+++ b/src/ipc/utils/token_utils.test.ts
@@ -18,20 +18,7 @@ vi.mock("@/ipc/utils/findLanguageModel", () => ({
 const mockFindLanguageModel = vi.mocked(findLanguageModel);
 
 describe("getTemperature", () => {
-  it("does not set a default temperature for custom models", async () => {
-    mockFindLanguageModel.mockResolvedValueOnce({
-      id: 1,
-      apiName: "custom-model",
-      displayName: "Custom Model",
-      type: "custom",
-    });
-
-    await expect(
-      getTemperature({ provider: "custom::provider", name: "custom-model" }),
-    ).resolves.toBeUndefined();
-  });
-
-  it("keeps the fallback temperature for non-custom models without metadata", async () => {
+  it("does not set a default temperature for models without metadata", async () => {
     mockFindLanguageModel.mockResolvedValueOnce({
       apiName: "cloud-model",
       displayName: "Cloud Model",
@@ -40,7 +27,20 @@ describe("getTemperature", () => {
 
     await expect(
       getTemperature({ provider: "provider", name: "cloud-model" }),
-    ).resolves.toBe(0);
+    ).resolves.toBeUndefined();
+  });
+
+  it("uses configured model temperature metadata", async () => {
+    mockFindLanguageModel.mockResolvedValueOnce({
+      apiName: "cloud-model",
+      displayName: "Cloud Model",
+      type: "cloud",
+      temperature: 0.7,
+    });
+
+    await expect(
+      getTemperature({ provider: "provider", name: "cloud-model" }),
+    ).resolves.toBe(0.7);
   });
 });
 

--- a/src/ipc/utils/token_utils.ts
+++ b/src/ipc/utils/token_utils.ts
@@ -35,10 +35,7 @@ export async function getTemperature(
   model: LargeLanguageModel,
 ): Promise<number | undefined> {
   const modelOption = await findLanguageModel(model);
-  if (modelOption?.type === "custom") {
-    return modelOption.temperature;
-  }
-  return modelOption?.temperature ?? 0;
+  return modelOption?.temperature;
 }
 
 /**

--- a/src/ipc/utils/token_utils.ts
+++ b/src/ipc/utils/token_utils.ts
@@ -35,7 +35,7 @@ export async function getTemperature(
   model: LargeLanguageModel,
 ): Promise<number | undefined> {
   const modelOption = await findLanguageModel(model);
-  return modelOption?.temperature;
+  return modelOption?.temperature ?? undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary

Let model providers apply their own default sampling behavior when Dyad has no explicit temperature metadata, making built-in and custom models consistent.

- Explicit temperatures in the model catalog are still forwarded unchanged.
- Models without temperature metadata now omit the option instead of Dyad imposing a temperature of `0`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default LLM sampling for models without temperature metadata (previously always 0), which can alter response variability but is limited to the temperature resolution path.
> 
> **Overview**
> **`getTemperature`** no longer forces **`0`** for non-custom models or treats custom models differently. It now returns only catalog **`temperature`** when set, otherwise **`undefined`**.
> 
> Chat **`streamText`** calls therefore skip the temperature option when Dyad has no explicit value, so built-in and custom models alike use the provider’s default sampling instead of deterministic **`0`**.
> 
> Tests were updated to assert **`undefined`** without metadata and **`0.7`** when metadata is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e89ae69e76c8c6709420ad4a9aa9ae9608e49953. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->