### PR TITLE
feat: add stdio support to the MCP plugin catalog

### DIFF
--- a/e2e-tests/helpers/page-objects/components/Catalog.ts
+++ b/e2e-tests/helpers/page-objects/components/Catalog.ts
@@ -20,6 +20,15 @@ export class Catalog {
     await card.getByRole("button", { name: "Add" }).click();
   }
 
+  // stdio entries open a run-locally consent dialog before the add
+  // proceeds; confirm it.
+  async confirmStdioConsent() {
+    await this.page
+      .getByRole("alertdialog")
+      .getByRole("button", { name: "Add plugin" })
+      .click();
+  }
+
   async expectAdded(name: string) {
     await expect(this.card(name).getByText("Added")).toBeVisible({
       timeout: Timeout.MEDIUM,

--- a/e2e-tests/mcp_catalog.spec.ts
+++ b/e2e-tests/mcp_catalog.spec.ts
@@ -55,16 +55,49 @@ testSkipIfWindows(
     await po.setUp();
     await po.navigation.goToPluginsTab();
 
-    // 5 entries served; the stdio and malformed ones must be dropped.
-    await expect(po.page.getByTestId("catalog-card")).toHaveCount(3, {
+    // 7 entries served; the policy-violating stdio ones (non-npx
+    // command, unpinned version) and the malformed one must be dropped.
+    await expect(po.page.getByTestId("catalog-card")).toHaveCount(4, {
       timeout: 15_000,
     });
-    await expect(po.page.getByText("E2E Stdio Server")).toHaveCount(0);
+    await expect(po.page.getByText("E2E Stdio Node Server")).toHaveCount(0);
+    await expect(po.page.getByText("E2E Stdio Unpinned Server")).toHaveCount(0);
+
+    // The valid stdio entry renders with its pinned package and a
+    // "Local" tag instead of a hostname.
+    const stdioCard = po.catalog.card("E2E Stdio Server");
+    await expect(stdioCard).toBeVisible();
+    await expect(stdioCard.getByText("Local", { exact: true })).toBeVisible();
+    await expect(
+      stdioCard.getByText("@dyad-sh/e2e-nonexistent-mcp@1.0.0"),
+    ).toBeVisible();
 
     await po.catalog.search("OAuth");
     await expect(po.page.getByTestId("catalog-card")).toHaveCount(1);
     await po.catalog.search("");
-    await expect(po.page.getByTestId("catalog-card")).toHaveCount(3);
+    await expect(po.page.getByTestId("catalog-card")).toHaveCount(4);
+  },
+);
+
+testSkipIfWindows(
+  "catalog - one-click add of a stdio entry creates a local plugin",
+  async ({ po }) => {
+    await po.setUp();
+    await po.navigation.goToPluginsTab();
+
+    // Only the add flow is covered here: the entry's package
+    // deliberately doesn't exist, so a spawn can't succeed. Stdio
+    // connection itself is covered by mcp.spec.ts with a real local
+    // server.
+    await po.catalog.addFromCatalog("E2E Stdio Server");
+    // The consent dialog shows the full command for inspection.
+    await expect(
+      po.page
+        .getByRole("alertdialog")
+        .getByText("npx -y @dyad-sh/e2e-nonexistent-mcp@1.0.0"),
+    ).toBeVisible();
+    await po.catalog.confirmStdioConsent();
+    await po.catalog.expectAdded("E2E Stdio Server");
   },
 );
 

--- a/e2e-tests/mcp_catalog.spec.ts
+++ b/e2e-tests/mcp_catalog.spec.ts
@@ -55,16 +55,15 @@ testSkipIfWindows(
     await po.setUp();
     await po.navigation.goToPluginsTab();
 
-    // 7 entries served; the policy-violating stdio ones (non-npx
-    // command, unpinned version) and the malformed one must be dropped.
+    // 6 entries served; the non-npx stdio entry and the malformed one
+    // must be dropped.
     await expect(po.page.getByTestId("catalog-card")).toHaveCount(4, {
       timeout: 15_000,
     });
     await expect(po.page.getByText("E2E Stdio Node Server")).toHaveCount(0);
-    await expect(po.page.getByText("E2E Stdio Unpinned Server")).toHaveCount(0);
 
-    // The valid stdio entry renders with its pinned package and a
-    // "Local" tag instead of a hostname.
+    // The valid stdio entry renders with its package and a "Local" tag
+    // instead of a hostname.
     const stdioCard = po.catalog.card("E2E Stdio Server");
     await expect(stdioCard).toBeVisible();
     await expect(stdioCard.getByText("Local", { exact: true })).toBeVisible();

--- a/src/components/plugins/catalog/CatalogCard.tsx
+++ b/src/components/plugins/catalog/CatalogCard.tsx
@@ -1,7 +1,10 @@
 import { Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardHeader, CardTitle } from "@/components/ui/card";
-import type { McpCatalogEntry } from "@/ipc/types/mcp_catalog";
+import {
+  isPinnedPackageSpec,
+  type McpCatalogEntry,
+} from "@/ipc/types/mcp_catalog";
 
 // The schema already validates url, but parse defensively so one bad
 // entry can't throw during render and take down the whole section.
@@ -11,6 +14,16 @@ function hostnameOf(url: string): string {
   } catch {
     return url;
   }
+}
+
+// What the entry connects to: the hostname for http entries, the
+// pinned package for stdio ones. The schema guarantees a pinned spec
+// exists; fall back to the command just in case.
+function sourceOf(entry: McpCatalogEntry): string {
+  if (entry.transport === "stdio") {
+    return entry.args.find(isPinnedPackageSpec) ?? entry.command;
+  }
+  return hostnameOf(entry.url);
 }
 
 export function CatalogCard({
@@ -29,9 +42,14 @@ export function CatalogCard({
       <CardHeader className="p-4">
         <CardTitle className="text-base font-medium mb-1 flex items-center gap-2 min-w-0">
           <span className="truncate">{entry.name}</span>
-          {entry.oauth != null && (
+          {entry.transport === "http" && entry.oauth != null && (
             <span className="text-xs font-normal text-muted-foreground shrink-0">
               OAuth
+            </span>
+          )}
+          {entry.transport === "stdio" && (
+            <span className="text-xs font-normal text-muted-foreground shrink-0">
+              Local
             </span>
           )}
         </CardTitle>
@@ -42,7 +60,7 @@ export function CatalogCard({
         )}
         <div className="mt-3 flex items-center justify-between gap-2">
           <span className="text-xs text-muted-foreground truncate">
-            {hostnameOf(entry.url)}
+            {sourceOf(entry)}
           </span>
           {isAdded ? (
             <span className="flex items-center gap-1 text-xs font-medium text-green-600 dark:text-green-400 shrink-0">

--- a/src/components/plugins/catalog/CatalogCard.tsx
+++ b/src/components/plugins/catalog/CatalogCard.tsx
@@ -2,7 +2,7 @@ import { Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardHeader, CardTitle } from "@/components/ui/card";
 import {
-  isPinnedPackageSpec,
+  looksLikePackageSpec,
   type McpCatalogEntry,
 } from "@/ipc/types/mcp_catalog";
 
@@ -16,12 +16,11 @@ function hostnameOf(url: string): string {
   }
 }
 
-// What the entry connects to: the hostname for http entries, the
-// pinned package for stdio ones. The schema guarantees a pinned spec
-// exists; fall back to the command just in case.
+// What the entry connects to: the hostname for http entries, the package
+// for stdio ones, falling back to the command if no arg looks like one.
 function sourceOf(entry: McpCatalogEntry): string {
   if (entry.transport === "stdio") {
-    return entry.args.find(isPinnedPackageSpec) ?? entry.command;
+    return entry.args.find(looksLikePackageSpec) ?? entry.command;
   }
   return hostnameOf(entry.url);
 }

--- a/src/components/plugins/catalog/CatalogSection.tsx
+++ b/src/components/plugins/catalog/CatalogSection.tsx
@@ -5,11 +5,18 @@ import { Input } from "@/components/ui/input";
 import { ipc } from "@/ipc/types";
 import { queryKeys } from "@/lib/queryKeys";
 import { CatalogCard } from "./CatalogCard";
+import { StdioCatalogConsentDialog } from "./StdioCatalogConsentDialog";
 import { useAddFromCatalog } from "./useAddFromCatalog";
 
 export function CatalogSection() {
   const [search, setSearch] = useState("");
-  const { addFromCatalog, addingSlug } = useAddFromCatalog();
+  const {
+    addFromCatalog,
+    addingSlug,
+    pendingStdioEntry,
+    confirmPendingStdio,
+    cancelPendingStdio,
+  } = useAddFromCatalog();
 
   const catalogQuery = useQuery({
     queryKey: queryKeys.mcp.catalog,
@@ -64,6 +71,11 @@ export function CatalogSection() {
 
   return (
     <div className="mt-10" data-testid="catalog-section">
+      <StdioCatalogConsentDialog
+        entry={pendingStdioEntry}
+        onConfirm={confirmPendingStdio}
+        onCancel={cancelPendingStdio}
+      />
       <div className="mb-4 flex items-center justify-between gap-4">
         <div>
           <h2 className="text-xl font-semibold text-gray-900 dark:text-white">

--- a/src/components/plugins/catalog/StdioCatalogConsentDialog.tsx
+++ b/src/components/plugins/catalog/StdioCatalogConsentDialog.tsx
@@ -10,6 +10,10 @@ import {
 } from "@/components/ui/alert-dialog";
 import type { McpCatalogEntry } from "@/ipc/types/mcp_catalog";
 
+function quoteIfSpaced(token: string): string {
+  return /\s/.test(token) ? `'${token}'` : token;
+}
+
 /**
  * Consent gate for adding a local (stdio) catalog plugin. A stdio plugin
  * runs an npm package on the user's machine, so adding one asks for
@@ -28,10 +32,16 @@ export function StdioCatalogConsentDialog({
 }) {
   if (!entry || entry.transport !== "stdio") return null;
   // Show any entry env vars as a prefix, e.g. `SOME_VAR=1 npx -y pkg@1.2.3`.
+  // Quote values/args that contain whitespace so token boundaries stay
+  // visible; this is for reading, not shell-safe copy-paste.
   const envPrefix = Object.entries(entry.env ?? {})
-    .map(([key, value]) => `${key}=${value}`)
+    .map(([key, value]) => `${key}=${quoteIfSpaced(value)}`)
     .join(" ");
-  const fullCommand = [envPrefix, entry.command, ...entry.args]
+  const fullCommand = [
+    envPrefix,
+    entry.command,
+    ...entry.args.map(quoteIfSpaced),
+  ]
     .filter(Boolean)
     .join(" ");
 

--- a/src/components/plugins/catalog/StdioCatalogConsentDialog.tsx
+++ b/src/components/plugins/catalog/StdioCatalogConsentDialog.tsx
@@ -1,0 +1,68 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import type { McpCatalogEntry } from "@/ipc/types/mcp_catalog";
+
+/**
+ * Consent gate for adding a local (stdio) catalog plugin. A stdio plugin
+ * runs an npm package on the user's machine, so adding one asks for
+ * confirmation and shows the command that will run.
+ */
+export function StdioCatalogConsentDialog({
+  entry,
+  onConfirm,
+  onCancel,
+}: {
+  // Null (or a non-stdio entry) keeps the dialog closed; the parent
+  // sets it to the pending stdio entry to open.
+  entry: McpCatalogEntry | null;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  if (!entry || entry.transport !== "stdio") return null;
+  // Show any entry env vars as a prefix, e.g. `SOME_VAR=1 npx -y pkg@1.2.3`.
+  const envPrefix = Object.entries(entry.env ?? {})
+    .map(([key, value]) => `${key}=${value}`)
+    .join(" ");
+  const fullCommand = [envPrefix, entry.command, ...entry.args]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <AlertDialog open onOpenChange={(open) => !open && onCancel()}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Run this plugin on your computer?</AlertDialogTitle>
+          <AlertDialogDescription className="space-y-3">
+            <span className="block">
+              <span className="text-foreground font-medium">{entry.name}</span>{" "}
+              runs locally by downloading and executing an npm package on your
+              computer, with the same access as any program you run.
+            </span>
+            <span className="block">
+              Dyad curates this catalog, but the package is maintained by a
+              third party and runs without a sandbox.
+            </span>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <div className="min-w-0 space-y-1">
+          <p className="text-muted-foreground text-xs">This will run:</p>
+          <pre className="text-foreground bg-muted overflow-x-auto rounded-md p-3 text-xs">
+            <code>{fullCommand}</code>
+          </pre>
+        </div>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={onCancel}>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm}>Add plugin</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/plugins/catalog/useAddFromCatalog.ts
+++ b/src/components/plugins/catalog/useAddFromCatalog.ts
@@ -9,6 +9,10 @@ import { usePluginConnect } from "../usePluginConnect";
 export function useAddFromCatalog() {
   const queryClient = useQueryClient();
   const [addingSlug, setAddingSlug] = useState<string | null>(null);
+  // A stdio entry awaiting the user's run-locally consent. Null when no
+  // consent is pending.
+  const [pendingStdioEntry, setPendingStdioEntry] =
+    useState<McpCatalogEntry | null>(null);
   const { onServerCreated } = usePluginConnect();
 
   const mutation = useMutation({
@@ -28,7 +32,7 @@ export function useAddFromCatalog() {
     meta: { showErrorToast: true },
   });
 
-  const addFromCatalog = async (entry: McpCatalogEntry) => {
+  const performAdd = async (entry: McpCatalogEntry) => {
     if (addingSlug) return;
     setAddingSlug(entry.slug);
     let created: Awaited<ReturnType<typeof ipc.mcp.addFromCatalog>> | null =
@@ -50,10 +54,35 @@ export function useAddFromCatalog() {
     // runs through the shared flow so it holds the connect slot (no
     // competing flow) and reuses the probed callback port; it is not
     // awaited so an abandoned browser step can't wedge the add.
-    if (entry.oauth?.required) {
+    if (entry.transport === "http" && entry.oauth?.required) {
       void onServerCreated(created, { wantsOAuth: true });
     }
   };
 
-  return { addFromCatalog, addingSlug } as const;
+  const addFromCatalog = async (entry: McpCatalogEntry) => {
+    // Adding an stdio entry enables it, which runs its npm package
+    // locally, so confirm before adding. http entries only open a
+    // network connection and add directly.
+    if (entry.transport === "stdio") {
+      setPendingStdioEntry(entry);
+      return;
+    }
+    await performAdd(entry);
+  };
+
+  const confirmPendingStdio = async () => {
+    const entry = pendingStdioEntry;
+    setPendingStdioEntry(null);
+    if (entry) await performAdd(entry);
+  };
+
+  const cancelPendingStdio = () => setPendingStdioEntry(null);
+
+  return {
+    addFromCatalog,
+    addingSlug,
+    pendingStdioEntry,
+    confirmPendingStdio,
+    cancelPendingStdio,
+  } as const;
 }

--- a/src/components/plugins/catalog/useAddFromCatalog.ts
+++ b/src/components/plugins/catalog/useAddFromCatalog.ts
@@ -17,7 +17,19 @@ export function useAddFromCatalog() {
 
   const mutation = useMutation({
     mutationFn: async (entry: McpCatalogEntry) => {
-      const created = await ipc.mcp.addFromCatalog({ slug: entry.slug });
+      // Send the reviewed command so the handler can abort if the catalog
+      // changed since the consent prompt.
+      const created = await ipc.mcp.addFromCatalog({
+        slug: entry.slug,
+        expectedStdioConfig:
+          entry.transport === "stdio"
+            ? {
+                command: entry.command,
+                args: entry.args,
+                env: entry.env ?? null,
+              }
+            : undefined,
+      });
       return { entry, created };
     },
     onSuccess: async () => {

--- a/src/ipc/handlers/__tests__/mcp_catalog.integration.test.tsx
+++ b/src/ipc/handlers/__tests__/mcp_catalog.integration.test.tsx
@@ -22,6 +22,9 @@ describe("Plugins catalog (integration)", () => {
   let catalogServer: http.Server;
   let mcpServerProcess: ChildProcess;
   let mcpPort: number;
+  // The payload the catalog endpoint serves. Mutable so a test can swap
+  // in a different set of entries; reset it in a finally.
+  let catalogPayload: unknown;
 
   beforeAll(async () => {
     // A real fake MCP server for the catalog entry to point at.
@@ -49,22 +52,21 @@ describe("Plugins catalog (integration)", () => {
       mcpServerProcess.once("error", reject);
     });
 
-    // A local catalog endpoint serving one addable entry.
+    // A local catalog endpoint serving one addable entry by default.
+    catalogPayload = {
+      servers: [
+        {
+          slug: "integration-open",
+          name: "Integration Open Server",
+          category: "Testing",
+          transport: "http",
+          url: `http://localhost:${mcpPort}/mcp`,
+        },
+      ],
+    };
     catalogServer = http.createServer((_req, res) => {
       res.setHeader("content-type", "application/json");
-      res.end(
-        JSON.stringify({
-          servers: [
-            {
-              slug: "integration-open",
-              name: "Integration Open Server",
-              category: "Testing",
-              transport: "http",
-              url: `http://localhost:${mcpPort}/mcp`,
-            },
-          ],
-        }),
-      );
+      res.end(JSON.stringify(catalogPayload));
     });
     await new Promise<void>((resolve) =>
       catalogServer.listen(0, "127.0.0.1", resolve),
@@ -212,6 +214,50 @@ describe("Plugins catalog (integration)", () => {
     } finally {
       process.env.DYAD_MCP_CATALOG_URL = previousUrl;
       featuredServer.close();
+      clearMcpCatalogCacheForTests();
+    }
+  }, 40_000);
+
+  it("aborts an stdio add when the catalog no longer matches the consent", async () => {
+    const previousPayload = catalogPayload;
+    catalogPayload = {
+      servers: [
+        {
+          slug: "integration-stdio",
+          name: "Integration Stdio Server",
+          category: "Testing",
+          transport: "stdio",
+          command: "npx",
+          args: ["-y", "@dyad-sh/e2e-nonexistent-mcp@1.0.0"],
+        },
+      ],
+    };
+    clearMcpCatalogCacheForTests();
+    try {
+      // A config that differs from the served entry (as if the catalog
+      // changed after the consent prompt) is rejected and adds nothing.
+      await expect(
+        ipc.mcp.addFromCatalog({
+          slug: "integration-stdio",
+          expectedStdioConfig: {
+            command: "npx",
+            args: ["-y", "@dyad-sh/e2e-nonexistent-mcp@2.0.0"],
+          },
+        }),
+      ).rejects.toThrow(/changed/i);
+      expect(await ipc.mcp.listServers()).toHaveLength(0);
+
+      // The matching config adds the row.
+      const created = await ipc.mcp.addFromCatalog({
+        slug: "integration-stdio",
+        expectedStdioConfig: {
+          command: "npx",
+          args: ["-y", "@dyad-sh/e2e-nonexistent-mcp@1.0.0"],
+        },
+      });
+      expect(created.catalogSlug).toBe("integration-stdio");
+    } finally {
+      catalogPayload = previousPayload;
       clearMcpCatalogCacheForTests();
     }
   }, 40_000);

--- a/src/ipc/handlers/__tests__/mcp_catalog.integration.test.tsx
+++ b/src/ipc/handlers/__tests__/mcp_catalog.integration.test.tsx
@@ -234,6 +234,13 @@ describe("Plugins catalog (integration)", () => {
     };
     clearMcpCatalogCacheForTests();
     try {
+      // A stdio add with no reviewed config never went through consent, so
+      // it is rejected.
+      await expect(
+        ipc.mcp.addFromCatalog({ slug: "integration-stdio" }),
+      ).rejects.toThrow(/changed/i);
+      expect(await ipc.mcp.listServers()).toHaveLength(0);
+
       // A config that differs from the served entry (as if the catalog
       // changed after the consent prompt) is rejected and adds nothing.
       await expect(

--- a/src/ipc/handlers/mcp_handlers.ts
+++ b/src/ipc/handlers/mcp_handlers.ts
@@ -52,6 +52,16 @@ async function isPortFreeOnBothLoopbacks(port: number): Promise<boolean> {
   return v4 === "free" || v6 === "free";
 }
 
+function envsEqual(
+  a: Record<string, string>,
+  b: Record<string, string>,
+): boolean {
+  const keys = Object.keys(a);
+  return (
+    keys.length === Object.keys(b).length && keys.every((k) => a[k] === b[k])
+  );
+}
+
 // Parse a JSON string from the renderer and surface a clear error
 // instead of letting the main process see a raw SyntaxError. Returns
 // `null` if the input is falsy.
@@ -151,29 +161,26 @@ export function registerMcpHandlers() {
         return toMcpServer(existing[0]);
       }
 
-      // The catalog can refresh between the consent prompt and this add.
-      // Abort if the fetched command no longer matches what the user
-      // reviewed.
-      if (entry.transport === "stdio" && expectedStdioConfig) {
-        const argsMatch =
-          entry.args.length === expectedStdioConfig.args.length &&
-          entry.args.every((arg, i) => arg === expectedStdioConfig.args[i]);
-        const entryEnv = entry.env ?? {};
-        const expectedEnv = expectedStdioConfig.env ?? {};
-        const envKeys = Object.keys(entryEnv);
-        const envMatch =
-          envKeys.length === Object.keys(expectedEnv).length &&
-          envKeys.every((key) => entryEnv[key] === expectedEnv[key]);
-        if (
-          entry.command !== expectedStdioConfig.command ||
-          !argsMatch ||
-          !envMatch
-        ) {
-          throw new DyadError(
-            "The plugin catalog changed since you reviewed this plugin. Please try adding it again.",
-            DyadErrorKind.Precondition,
-          );
-        }
+      // A stdio add must run exactly the command the consent prompt showed.
+      // Abort if the fetched entry wasn't reviewed, no longer matches, or
+      // the slug changed transport since the prompt.
+      const stdioMatchesReview =
+        entry.transport === "stdio" &&
+        expectedStdioConfig != null &&
+        entry.command === expectedStdioConfig.command &&
+        entry.args.length === expectedStdioConfig.args.length &&
+        entry.args.every((arg, i) => arg === expectedStdioConfig.args[i]) &&
+        envsEqual(entry.env ?? {}, expectedStdioConfig.env ?? {});
+      const transportMismatch =
+        (entry.transport === "stdio") !== (expectedStdioConfig != null);
+      if (
+        (entry.transport === "stdio" && !stdioMatchesReview) ||
+        transportMismatch
+      ) {
+        throw new DyadError(
+          "The plugin catalog changed since you reviewed this plugin. Please try adding it again.",
+          DyadErrorKind.Precondition,
+        );
       }
 
       const values =

--- a/src/ipc/handlers/mcp_handlers.ts
+++ b/src/ipc/handlers/mcp_handlers.ts
@@ -118,78 +118,106 @@ export function registerMcpHandlers() {
     return { entries, addedSlugs };
   });
 
-  createTypedHandler(mcpContracts.addFromCatalog, async (_, { slug }) => {
-    const entries = await getRemoteMcpCatalog();
-    // The user reached this from a populated catalog, so an empty list
-    // here means the fetch failed rather than the slug being unknown.
-    // Surface that as a connectivity problem instead of a not-found.
-    if (entries.length === 0) {
-      throw new DyadError(
-        "Could not reach the plugin catalog. Please check your connection and try again.",
-        DyadErrorKind.Precondition,
-      );
-    }
-    const entry = entries.find((e) => e.slug === slug);
-    if (!entry) {
-      throw new DyadError(
-        `Unknown catalog entry: ${slug}`,
-        DyadErrorKind.NotFound,
-      );
-    }
-
-    // Adding the same entry twice returns the existing server. The
-    // unique index on catalog_slug makes this safe against concurrent
-    // adds: onConflictDoNothing skips the duplicate insert, and we read
-    // the winning row back.
-    const existing = await db
-      .select()
-      .from(mcpServers)
-      .where(eq(mcpServers.catalogSlug, slug));
-    if (existing.length > 0) {
-      return toMcpServer(existing[0]);
-    }
-
-    const values =
-      entry.transport === "stdio"
-        ? {
-            name: entry.name,
-            transport: "stdio" as const,
-            command: entry.command,
-            args: entry.args,
-            envJson: entry.env ?? null,
-            enabled: true,
-            catalogSlug: entry.slug,
-          }
-        : {
-            name: entry.name,
-            transport: "http" as const,
-            url: entry.url,
-            headersJson: entry.headers ?? null,
-            enabled: true,
-            oauthEnabled: entry.oauth != null,
-            oauthScope: entry.oauth?.scope ?? null,
-            catalogSlug: entry.slug,
-          };
-    const [created] = await db
-      .insert(mcpServers)
-      .values(values)
-      .onConflictDoNothing({ target: mcpServers.catalogSlug })
-      .returning();
-    if (!created) {
-      const [row] = await db
-        .select()
-        .from(mcpServers)
-        .where(eq(mcpServers.catalogSlug, slug));
-      if (!row) {
+  createTypedHandler(
+    mcpContracts.addFromCatalog,
+    async (_, { slug, expectedStdioConfig }) => {
+      const entries = await getRemoteMcpCatalog();
+      // The user reached this from a populated catalog, so an empty list
+      // here means the fetch failed rather than the slug being unknown.
+      // Surface that as a connectivity problem instead of a not-found.
+      if (entries.length === 0) {
+        throw new DyadError(
+          "Could not reach the plugin catalog. Please check your connection and try again.",
+          DyadErrorKind.Precondition,
+        );
+      }
+      const entry = entries.find((e) => e.slug === slug);
+      if (!entry) {
         throw new DyadError(
           `Unknown catalog entry: ${slug}`,
           DyadErrorKind.NotFound,
         );
       }
-      return toMcpServer(row);
-    }
-    return toMcpServer(created);
-  });
+
+      // Adding the same entry twice returns the existing server. The
+      // unique index on catalog_slug makes this safe against concurrent
+      // adds: onConflictDoNothing skips the duplicate insert, and we read
+      // the winning row back.
+      const existing = await db
+        .select()
+        .from(mcpServers)
+        .where(eq(mcpServers.catalogSlug, slug));
+      if (existing.length > 0) {
+        return toMcpServer(existing[0]);
+      }
+
+      // The catalog can refresh between the consent prompt and this add.
+      // Abort if the fetched command no longer matches what the user
+      // reviewed.
+      if (entry.transport === "stdio" && expectedStdioConfig) {
+        const argsMatch =
+          entry.args.length === expectedStdioConfig.args.length &&
+          entry.args.every((arg, i) => arg === expectedStdioConfig.args[i]);
+        const entryEnv = entry.env ?? {};
+        const expectedEnv = expectedStdioConfig.env ?? {};
+        const envKeys = Object.keys(entryEnv);
+        const envMatch =
+          envKeys.length === Object.keys(expectedEnv).length &&
+          envKeys.every((key) => entryEnv[key] === expectedEnv[key]);
+        if (
+          entry.command !== expectedStdioConfig.command ||
+          !argsMatch ||
+          !envMatch
+        ) {
+          throw new DyadError(
+            "The plugin catalog changed since you reviewed this plugin. Please try adding it again.",
+            DyadErrorKind.Precondition,
+          );
+        }
+      }
+
+      const values =
+        entry.transport === "stdio"
+          ? {
+              name: entry.name,
+              transport: "stdio" as const,
+              command: entry.command,
+              args: entry.args,
+              envJson: entry.env ?? null,
+              enabled: true,
+              catalogSlug: entry.slug,
+            }
+          : {
+              name: entry.name,
+              transport: "http" as const,
+              url: entry.url,
+              headersJson: entry.headers ?? null,
+              enabled: true,
+              oauthEnabled: entry.oauth != null,
+              oauthScope: entry.oauth?.scope ?? null,
+              catalogSlug: entry.slug,
+            };
+      const [created] = await db
+        .insert(mcpServers)
+        .values(values)
+        .onConflictDoNothing({ target: mcpServers.catalogSlug })
+        .returning();
+      if (!created) {
+        const [row] = await db
+          .select()
+          .from(mcpServers)
+          .where(eq(mcpServers.catalogSlug, slug));
+        if (!row) {
+          throw new DyadError(
+            `Unknown catalog entry: ${slug}`,
+            DyadErrorKind.NotFound,
+          );
+        }
+        return toMcpServer(row);
+      }
+      return toMcpServer(created);
+    },
+  );
 
   createTypedHandler(mcpContracts.createServer, async (_, params) => {
     const {

--- a/src/ipc/handlers/mcp_handlers.ts
+++ b/src/ipc/handlers/mcp_handlers.ts
@@ -149,18 +149,30 @@ export function registerMcpHandlers() {
       return toMcpServer(existing[0]);
     }
 
+    const values =
+      entry.transport === "stdio"
+        ? {
+            name: entry.name,
+            transport: "stdio" as const,
+            command: entry.command,
+            args: entry.args,
+            envJson: entry.env ?? null,
+            enabled: true,
+            catalogSlug: entry.slug,
+          }
+        : {
+            name: entry.name,
+            transport: "http" as const,
+            url: entry.url,
+            headersJson: entry.headers ?? null,
+            enabled: true,
+            oauthEnabled: entry.oauth != null,
+            oauthScope: entry.oauth?.scope ?? null,
+            catalogSlug: entry.slug,
+          };
     const [created] = await db
       .insert(mcpServers)
-      .values({
-        name: entry.name,
-        transport: "http",
-        url: entry.url,
-        headersJson: entry.headers ?? null,
-        enabled: true,
-        oauthEnabled: entry.oauth != null,
-        oauthScope: entry.oauth?.scope ?? null,
-        catalogSlug: entry.slug,
-      })
+      .values(values)
       .onConflictDoNothing({ target: mcpServers.catalogSlug })
       .returning();
     if (!created) {

--- a/src/ipc/shared/remote_mcp_catalog.test.ts
+++ b/src/ipc/shared/remote_mcp_catalog.test.ts
@@ -95,52 +95,30 @@ describe("remote_mcp_catalog", () => {
     }
   });
 
-  it("drops stdio entries whose command is not npx", async () => {
+  it("drops stdio entries with a non-npx command or no args", async () => {
     mockCatalogResponse([
       { ...VALID_STDIO_ENTRY, command: "node" },
       { ...VALID_STDIO_ENTRY, slug: "bash-server", command: "bash" },
+      { ...VALID_STDIO_ENTRY, slug: "no-args", args: [] },
       VALID_ENTRY,
     ]);
     const entries = await getRemoteMcpCatalog();
     expect(entries.map((e) => e.slug)).toEqual(["figma"]);
   });
 
-  it("drops stdio entries without an exact-version-pinned package", async () => {
-    // A flag-shaped token like `--package@1.0.0` must not count as a spec,
-    // and malformed versions like leading-zero `01.2.3` are not pinned.
+  it("keeps unpinned stdio entries (pinning is enforced upstream)", async () => {
+    // The desktop only checks the shape; cloud CI pins the catalog data
+    // and the consent prompt shows the exact command.
     mockCatalogResponse([
       { ...VALID_STDIO_ENTRY, args: ["-y", "mongodb-mcp-server@latest"] },
-      { ...VALID_STDIO_ENTRY, args: ["-y", "mongodb-mcp-server"] },
-      { ...VALID_STDIO_ENTRY, args: ["-y", "mongodb-mcp-server@^1.13.0"] },
-      { ...VALID_STDIO_ENTRY, args: ["-y", "mongodb-mcp-server@1.x"] },
-      { ...VALID_STDIO_ENTRY, args: ["-y", "mongodb-mcp-server@01.2.3"] },
-      { ...VALID_STDIO_ENTRY, args: ["-y", "mongodb-mcp-server@1.02.3"] },
-      { ...VALID_STDIO_ENTRY, args: ["--package@1.0.0"] },
-      { ...VALID_STDIO_ENTRY, args: ["-y@1.0.0"] },
-      { ...VALID_STDIO_ENTRY, args: [] },
-      VALID_STDIO_ENTRY,
-    ]);
-    const entries = await getRemoteMcpCatalog();
-    expect(entries.map((e) => e.slug)).toEqual(["mongodb"]);
-  });
-
-  it("drops stdio entries that leave a second package unpinned", async () => {
-    // A pinned positional does not excuse a repeated `--package` that
-    // floats another package's version.
-    mockCatalogResponse([
       {
         ...VALID_STDIO_ENTRY,
-        args: [
-          "-y",
-          "--package",
-          "other-mcp@latest",
-          "mongodb-mcp-server@1.13.0",
-        ],
+        slug: "eq-package",
+        args: ["-y", "--package=other@latest", "mongodb-mcp-server@1.13.0"],
       },
-      VALID_STDIO_ENTRY,
     ]);
     const entries = await getRemoteMcpCatalog();
-    expect(entries.map((e) => e.slug)).toEqual(["mongodb"]);
+    expect(entries.map((e) => e.slug)).toEqual(["mongodb", "eq-package"]);
   });
 
   it("accepts scoped and prerelease pinned packages", async () => {

--- a/src/ipc/shared/remote_mcp_catalog.test.ts
+++ b/src/ipc/shared/remote_mcp_catalog.test.ts
@@ -12,6 +12,14 @@ const VALID_ENTRY = {
   oauth: { required: true },
 };
 
+const VALID_STDIO_ENTRY = {
+  slug: "mongodb",
+  name: "MongoDB",
+  transport: "stdio",
+  command: "npx",
+  args: ["-y", "mongodb-mcp-server@1.13.0"],
+};
+
 function mockCatalogResponse(servers: unknown[], extra?: object) {
   vi.stubGlobal(
     "fetch",
@@ -57,20 +65,115 @@ describe("remote_mcp_catalog", () => {
   });
 
   it("drops entries with transports this client does not support", async () => {
-    // Forward compatibility: a newer catalog may serve stdio entries.
+    // Forward compatibility: a newer catalog may serve entry kinds this
+    // client doesn't know about yet.
+    mockCatalogResponse([{ ...VALID_ENTRY, transport: "sse" }, VALID_ENTRY]);
+    const entries = await getRemoteMcpCatalog();
+    expect(entries.map((e) => e.slug)).toEqual(["figma"]);
+  });
+
+  it("keeps stdio entries alongside http ones", async () => {
     mockCatalogResponse([
+      VALID_STDIO_ENTRY,
+      VALID_ENTRY,
       {
-        slug: "mongodb",
-        name: "MongoDB",
-        transport: "stdio",
-        command: "npx",
-        args: ["-y", "mongodb-mcp-server@1.13.0"],
+        ...VALID_STDIO_ENTRY,
+        slug: "mongodb-env",
+        env: { MDB_MCP_READ_ONLY: "true" },
       },
-      { ...VALID_ENTRY, transport: "sse" },
+    ]);
+    const entries = await getRemoteMcpCatalog();
+    expect(entries.map((e) => e.slug)).toEqual([
+      "mongodb",
+      "figma",
+      "mongodb-env",
+    ]);
+    const withEnv = entries[2];
+    expect(withEnv.transport).toBe("stdio");
+    if (withEnv.transport === "stdio") {
+      expect(withEnv.env).toEqual({ MDB_MCP_READ_ONLY: "true" });
+    }
+  });
+
+  it("drops stdio entries whose command is not npx", async () => {
+    mockCatalogResponse([
+      { ...VALID_STDIO_ENTRY, command: "node" },
+      { ...VALID_STDIO_ENTRY, slug: "bash-server", command: "bash" },
       VALID_ENTRY,
     ]);
     const entries = await getRemoteMcpCatalog();
     expect(entries.map((e) => e.slug)).toEqual(["figma"]);
+  });
+
+  it("drops stdio entries without an exact-version-pinned package", async () => {
+    // A flag-shaped token like `--package@1.0.0` must not count as a spec.
+    mockCatalogResponse([
+      { ...VALID_STDIO_ENTRY, args: ["-y", "mongodb-mcp-server@latest"] },
+      { ...VALID_STDIO_ENTRY, args: ["-y", "mongodb-mcp-server"] },
+      { ...VALID_STDIO_ENTRY, args: ["-y", "mongodb-mcp-server@^1.13.0"] },
+      { ...VALID_STDIO_ENTRY, args: ["-y", "mongodb-mcp-server@1.x"] },
+      { ...VALID_STDIO_ENTRY, args: ["--package@1.0.0"] },
+      { ...VALID_STDIO_ENTRY, args: ["-y@1.0.0"] },
+      { ...VALID_STDIO_ENTRY, args: [] },
+      VALID_STDIO_ENTRY,
+    ]);
+    const entries = await getRemoteMcpCatalog();
+    expect(entries.map((e) => e.slug)).toEqual(["mongodb"]);
+  });
+
+  it("accepts scoped and prerelease pinned packages", async () => {
+    mockCatalogResponse([
+      {
+        ...VALID_STDIO_ENTRY,
+        slug: "scoped",
+        args: ["-y", "@azure/mcp@0.9.3"],
+      },
+      {
+        ...VALID_STDIO_ENTRY,
+        slug: "prerelease",
+        args: ["-y", "snyk-mcp@2.0.0-beta.1"],
+      },
+    ]);
+    const entries = await getRemoteMcpCatalog();
+    expect(entries.map((e) => e.slug)).toEqual(["scoped", "prerelease"]);
+  });
+
+  it("accepts npx flags and server-CLI args around the spec", async () => {
+    // Real catalog shapes: leading npx flags and trailing subcommands.
+    mockCatalogResponse([
+      {
+        ...VALID_STDIO_ENTRY,
+        slug: "azure",
+        args: ["-y", "@azure/mcp@3.0.0-beta.23", "server", "start"],
+      },
+      {
+        ...VALID_STDIO_ENTRY,
+        slug: "snyk",
+        args: ["-y", "snyk@1.1305.2", "mcp", "-t", "stdio"],
+      },
+      {
+        ...VALID_STDIO_ENTRY,
+        slug: "meta-quest",
+        args: ["-y", "--ignore-scripts", "@meta-quest/metavr@1.3.2", "mcp"],
+      },
+    ]);
+    const entries = await getRemoteMcpCatalog();
+    expect(entries.map((e) => e.slug)).toEqual(["azure", "snyk", "meta-quest"]);
+  });
+
+  it("passes through stdio env vars", async () => {
+    mockCatalogResponse([
+      {
+        ...VALID_STDIO_ENTRY,
+        env: { MDB_MCP_READ_ONLY: "true", LOG_LEVEL: "debug" },
+      },
+    ]);
+    const entries = await getRemoteMcpCatalog();
+    const entry = entries[0];
+    expect(entry.transport).toBe("stdio");
+    if (entry.transport === "stdio") {
+      expect(entry.env).toEqual({ MDB_MCP_READ_ONLY: "true", LOG_LEVEL: "debug" });
+    }
   });
 
   it("drops duplicate slugs, keeping the first", async () => {

--- a/src/ipc/shared/remote_mcp_catalog.test.ts
+++ b/src/ipc/shared/remote_mcp_catalog.test.ts
@@ -106,15 +106,37 @@ describe("remote_mcp_catalog", () => {
   });
 
   it("drops stdio entries without an exact-version-pinned package", async () => {
-    // A flag-shaped token like `--package@1.0.0` must not count as a spec.
+    // A flag-shaped token like `--package@1.0.0` must not count as a spec,
+    // and malformed versions like leading-zero `01.2.3` are not pinned.
     mockCatalogResponse([
       { ...VALID_STDIO_ENTRY, args: ["-y", "mongodb-mcp-server@latest"] },
       { ...VALID_STDIO_ENTRY, args: ["-y", "mongodb-mcp-server"] },
       { ...VALID_STDIO_ENTRY, args: ["-y", "mongodb-mcp-server@^1.13.0"] },
       { ...VALID_STDIO_ENTRY, args: ["-y", "mongodb-mcp-server@1.x"] },
+      { ...VALID_STDIO_ENTRY, args: ["-y", "mongodb-mcp-server@01.2.3"] },
+      { ...VALID_STDIO_ENTRY, args: ["-y", "mongodb-mcp-server@1.02.3"] },
       { ...VALID_STDIO_ENTRY, args: ["--package@1.0.0"] },
       { ...VALID_STDIO_ENTRY, args: ["-y@1.0.0"] },
       { ...VALID_STDIO_ENTRY, args: [] },
+      VALID_STDIO_ENTRY,
+    ]);
+    const entries = await getRemoteMcpCatalog();
+    expect(entries.map((e) => e.slug)).toEqual(["mongodb"]);
+  });
+
+  it("drops stdio entries that leave a second package unpinned", async () => {
+    // A pinned positional does not excuse a repeated `--package` that
+    // floats another package's version.
+    mockCatalogResponse([
+      {
+        ...VALID_STDIO_ENTRY,
+        args: [
+          "-y",
+          "--package",
+          "other-mcp@latest",
+          "mongodb-mcp-server@1.13.0",
+        ],
+      },
       VALID_STDIO_ENTRY,
     ]);
     const entries = await getRemoteMcpCatalog();
@@ -172,7 +194,10 @@ describe("remote_mcp_catalog", () => {
     const entry = entries[0];
     expect(entry.transport).toBe("stdio");
     if (entry.transport === "stdio") {
-      expect(entry.env).toEqual({ MDB_MCP_READ_ONLY: "true", LOG_LEVEL: "debug" });
+      expect(entry.env).toEqual({
+        MDB_MCP_READ_ONLY: "true",
+        LOG_LEVEL: "debug",
+      });
     }
   });
 

--- a/src/ipc/types/mcp.ts
+++ b/src/ipc/types/mcp.ts
@@ -221,10 +221,19 @@ export const mcpContracts = {
 
   addFromCatalog: defineContract({
     channel: "mcp:add-from-catalog",
-    // Slug only: the main process resolves it against the fetched
-    // catalog, so the renderer can't inject arbitrary server configs
-    // through this channel.
-    input: z.object({ slug: z.string().min(1) }),
+    // expectedStdioConfig is the command the consent prompt showed. The
+    // handler aborts if the catalog it re-fetches no longer matches, so a
+    // stale dialog can't add something the user didn't review.
+    input: z.object({
+      slug: z.string().min(1),
+      expectedStdioConfig: z
+        .object({
+          command: z.string(),
+          args: z.array(z.string()),
+          env: z.record(z.string(), z.string()).nullable().optional(),
+        })
+        .optional(),
+    }),
     output: McpServerSchema,
   }),
 

--- a/src/ipc/types/mcp_catalog.ts
+++ b/src/ipc/types/mcp_catalog.ts
@@ -40,43 +40,21 @@ export const HttpCatalogEntrySchema = z.object({
   headers: z.record(z.string(), z.string()).optional(),
 });
 
-// A package spec pinned to an exact version (`name@1.2.3` or
-// `@scope/name@1.2.3`). Version grammar is the official semver.org regex
-// (https://semver.org); the name can't start with `-` so flags aren't specs.
-const PINNED_PACKAGE_SPEC_REGEX =
-  /^(@[a-z0-9~._][a-z0-9~._-]*\/)?[a-z0-9~._][a-z0-9~._-]*@(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/i;
+// Matches a `name@version` arg (optionally scoped) so the UI can show the
+// package name. Display-only, so a loose shape is enough.
+const PACKAGE_SPEC_REGEX = /^(@[a-z0-9~._-]+\/)?[a-z0-9~._-]+@\d/i;
 
-export function isPinnedPackageSpec(arg: string): boolean {
-  return PINNED_PACKAGE_SPEC_REGEX.test(arg);
+export function looksLikePackageSpec(arg: string): boolean {
+  return PACKAGE_SPEC_REGEX.test(arg);
 }
 
-// An arg shaped like `name@version` (optionally scoped), used to spot
-// specs that aren't pinned, e.g. `pkg@latest`.
-const VERSIONED_SPEC_REGEX = /^(@[a-z0-9~._-]+\/)?[a-z0-9~._-]+@/i;
-
-// Requires every package-spec-shaped arg to be pinned, so a repeated
-// `--package foo@latest` can't float a version. Returns false instead of
-// throwing so one bad entry doesn't abort the batch.
-function argsPinPackages(args: string[]): boolean {
-  return (
-    args.some(isPinnedPackageSpec) &&
-    args.every(
-      (arg) => !VERSIONED_SPEC_REGEX.test(arg) || isPinnedPackageSpec(arg),
-    )
-  );
-}
-
+// Version pinning is enforced by cloud CI on the catalog data and shown to
+// the user by the consent prompt, so the desktop only checks the shape.
 export const StdioCatalogEntrySchema = z.object({
   ...baseEntry,
   transport: z.literal("stdio"),
   command: z.literal("npx"),
-  args: z
-    .array(z.string())
-    .min(1)
-    .refine(
-      argsPinPackages,
-      "every package arg must be pinned to an exact version",
-    ),
+  args: z.array(z.string()).min(1),
   env: z.record(z.string(), z.string()).optional(),
 });
 

--- a/src/ipc/types/mcp_catalog.ts
+++ b/src/ipc/types/mcp_catalog.ts
@@ -1,13 +1,15 @@
 import { z } from "zod";
 
-// Only http entries are supported. The transport literal makes any
-// other transport fail per-entry validation and drop out, so the
-// catalog can serve entry kinds this client doesn't know about yet.
+// Http and stdio entries are supported. The transport discriminator
+// makes any other entry kind fail per-entry validation and drop out,
+// so the catalog can serve entry kinds this client doesn't know about
+// yet.
 //
 // Kept dependency-free (zod only) so the contract in mcp.ts can import
 // it without pulling the main-process catalog client into the renderer
 // bundle.
-export const McpCatalogEntrySchema = z.object({
+
+const baseEntry = {
   slug: z
     .string()
     .min(1)
@@ -17,6 +19,10 @@ export const McpCatalogEntrySchema = z.object({
   category: z.string().optional(),
   // Surfaced in a Featured section as well as its category.
   featured: z.boolean().optional(),
+} as const;
+
+export const HttpCatalogEntrySchema = z.object({
+  ...baseEntry,
   transport: z.literal("http"),
   url: z
     .string()
@@ -34,4 +40,40 @@ export const McpCatalogEntrySchema = z.object({
   headers: z.record(z.string(), z.string()).optional(),
 });
 
+// Exact-version package spec: `name@1.2.3` or `@scope/name@1.2.3` with an
+// optional prerelease/build suffix. Rejects tags and ranges. The name
+// can't start with `-`, so a flag-shaped token isn't read as a spec. Also
+// used by the UI to show an entry's package name.
+const PINNED_PACKAGE_SPEC_REGEX =
+  /^(@[a-z0-9~._][a-z0-9~._-]*\/)?[a-z0-9~._][a-z0-9~._-]*@\d+\.\d+\.\d+(-[0-9a-z.-]+)?(\+[0-9a-z.-]+)?$/i;
+
+export function isPinnedPackageSpec(arg: string): boolean {
+  return PINNED_PACKAGE_SPEC_REGEX.test(arg);
+}
+
+// Enforces our npx and exact-version convention, dropping a malformed
+// entry like an @latest slip. Real protection against a bad package comes
+// from curation, cloud CI, and the consent prompt. Refine returns false
+// instead of throwing so one bad entry does not abort the batch.
+export const StdioCatalogEntrySchema = z.object({
+  ...baseEntry,
+  transport: z.literal("stdio"),
+  command: z.literal("npx"),
+  args: z
+    .array(z.string())
+    .min(1)
+    .refine(
+      (args) => args.some(isPinnedPackageSpec),
+      "args must include an exact-version-pinned package spec",
+    ),
+  env: z.record(z.string(), z.string()).optional(),
+});
+
+export const McpCatalogEntrySchema = z.discriminatedUnion("transport", [
+  HttpCatalogEntrySchema,
+  StdioCatalogEntrySchema,
+]);
+
 export type McpCatalogEntry = z.infer<typeof McpCatalogEntrySchema>;
+export type HttpCatalogEntry = z.infer<typeof HttpCatalogEntrySchema>;
+export type StdioCatalogEntry = z.infer<typeof StdioCatalogEntrySchema>;

--- a/src/ipc/types/mcp_catalog.ts
+++ b/src/ipc/types/mcp_catalog.ts
@@ -40,21 +40,32 @@ export const HttpCatalogEntrySchema = z.object({
   headers: z.record(z.string(), z.string()).optional(),
 });
 
-// Exact-version package spec: `name@1.2.3` or `@scope/name@1.2.3` with an
-// optional prerelease/build suffix. Rejects tags and ranges. The name
-// can't start with `-`, so a flag-shaped token isn't read as a spec. Also
-// used by the UI to show an entry's package name.
+// A package spec pinned to an exact version (`name@1.2.3` or
+// `@scope/name@1.2.3`). Version grammar is the official semver.org regex
+// (https://semver.org); the name can't start with `-` so flags aren't specs.
 const PINNED_PACKAGE_SPEC_REGEX =
-  /^(@[a-z0-9~._][a-z0-9~._-]*\/)?[a-z0-9~._][a-z0-9~._-]*@\d+\.\d+\.\d+(-[0-9a-z.-]+)?(\+[0-9a-z.-]+)?$/i;
+  /^(@[a-z0-9~._][a-z0-9~._-]*\/)?[a-z0-9~._][a-z0-9~._-]*@(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/i;
 
 export function isPinnedPackageSpec(arg: string): boolean {
   return PINNED_PACKAGE_SPEC_REGEX.test(arg);
 }
 
-// Enforces our npx and exact-version convention, dropping a malformed
-// entry like an @latest slip. Real protection against a bad package comes
-// from curation, cloud CI, and the consent prompt. Refine returns false
-// instead of throwing so one bad entry does not abort the batch.
+// An arg shaped like `name@version` (optionally scoped), used to spot
+// specs that aren't pinned, e.g. `pkg@latest`.
+const VERSIONED_SPEC_REGEX = /^(@[a-z0-9~._-]+\/)?[a-z0-9~._-]+@/i;
+
+// Requires every package-spec-shaped arg to be pinned, so a repeated
+// `--package foo@latest` can't float a version. Returns false instead of
+// throwing so one bad entry doesn't abort the batch.
+function argsPinPackages(args: string[]): boolean {
+  return (
+    args.some(isPinnedPackageSpec) &&
+    args.every(
+      (arg) => !VERSIONED_SPEC_REGEX.test(arg) || isPinnedPackageSpec(arg),
+    )
+  );
+}
+
 export const StdioCatalogEntrySchema = z.object({
   ...baseEntry,
   transport: z.literal("stdio"),
@@ -63,8 +74,8 @@ export const StdioCatalogEntrySchema = z.object({
     .array(z.string())
     .min(1)
     .refine(
-      (args) => args.some(isPinnedPackageSpec),
-      "args must include an exact-version-pinned package spec",
+      argsPinPackages,
+      "every package arg must be pinned to an exact version",
     ),
   env: z.record(z.string(), z.string()).optional(),
 });

--- a/testing/fake-llm-server/index.ts
+++ b/testing/fake-llm-server/index.ts
@@ -308,22 +308,14 @@ export function createFakeLlmApp(getPort: () => number) {
           command: "npx",
           args: ["-y", "@dyad-sh/e2e-nonexistent-mcp@1.0.0"],
         },
-        // The desktop client must drop these three: a stdio entry that
-        // violates the npx policy, one without an exact version pin, and
-        // a malformed one.
+        // The desktop client must drop these: a stdio entry whose command
+        // isn't npx, and a malformed one.
         {
           slug: "e2e-stdio-node",
           name: "E2E Stdio Node Server",
           transport: "stdio",
           command: "node",
           args: ["server.mjs"],
-        },
-        {
-          slug: "e2e-stdio-unpinned",
-          name: "E2E Stdio Unpinned Server",
-          transport: "stdio",
-          command: "npx",
-          args: ["-y", "fake-mcp@latest"],
         },
         { slug: "e2e-broken" },
       ],

--- a/testing/fake-llm-server/index.ts
+++ b/testing/fake-llm-server/index.ts
@@ -295,14 +295,35 @@ export function createFakeLlmApp(getPort: () => number) {
           url: "http://localhost:3002/mcp",
           headers: { "X-Test-Header": "dyad-e2e" },
         },
-        // The desktop client must drop these two: an entry kind it
-        // doesn't support yet and a malformed one.
+        // Valid stdio entry. The package is scoped under @dyad-sh so it
+        // can never resolve against the real npm registry: the spec only
+        // exercises the add flow, and an actual `npx` spawn in CI must
+        // fail with a 404 instead of executing someone's package.
         {
           slug: "e2e-stdio",
           name: "E2E Stdio Server",
+          description: "Fake local stdio MCP server",
+          category: "Testing",
           transport: "stdio",
           command: "npx",
-          args: ["-y", "fake-mcp@1.0.0"],
+          args: ["-y", "@dyad-sh/e2e-nonexistent-mcp@1.0.0"],
+        },
+        // The desktop client must drop these three: a stdio entry that
+        // violates the npx policy, one without an exact version pin, and
+        // a malformed one.
+        {
+          slug: "e2e-stdio-node",
+          name: "E2E Stdio Node Server",
+          transport: "stdio",
+          command: "node",
+          args: ["server.mjs"],
+        },
+        {
+          slug: "e2e-stdio-unpinned",
+          name: "E2E Stdio Unpinned Server",
+          transport: "stdio",
+          command: "npx",
+          args: ["-y", "fake-mcp@latest"],
         },
         { slug: "e2e-broken" },
       ],


### PR DESCRIPTION
*This description was written by Claude but is human-reviewed.*

The catalog previously registered only http MCP servers. This adds the stdio transport, so the local npx-based servers that already ship in the catalog data are no longer dropped and can be added in one click.

Catalog entries are now validated as a discriminated union on transport. The stdio shape is a light shape check: the command must be npx and the args must include an exact-version-pinned package. This is not a trust boundary against a hostile catalog, which picks the package name regardless; the real controls are curation, cloud CI, TLS, and the consent step below.

Because adding a stdio plugin runs an npm package locally, the add flow first shows a consent dialog that names the plugin, warns it runs an unsandboxed third-party package, and shows the full command (including any env vars) for inspection. http adds are unchanged. The catalog card shows the pinned package and a "Local" tag instead of a hostname.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

