### PR TITLE
Fix Claude PR review artifact generation

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -99,6 +99,7 @@ jobs:
 
           claude_args: |
             --model claude-opus-4-8
+            --setting-sources user
             --allowedTools "Agent,Read,Glob,Grep,Edit(tmp/pr-review/**)"
 
       - name: Verify Claude review outputs

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -99,6 +99,18 @@ jobs:
 
           claude_args: |
             --model claude-opus-4-8
+            --allowedTools "Agent,Read,Glob,Grep,Edit(tmp/pr-review/**)"
+
+      - name: Verify Claude review outputs
+        run: |
+          if [[ ! -s "$REVIEW_OUTPUT_PATH" ]]; then
+            echo "::error::Claude did not write $REVIEW_OUTPUT_PATH"
+            exit 1
+          fi
+          if [[ ! -s "$REVIEW_FINDINGS_PATH" ]]; then
+            echo "::error::Claude did not write $REVIEW_FINDINGS_PATH"
+            exit 1
+          fi
 
       - name: Upload Claude review artifact
         uses: actions/upload-artifact@v6

--- a/rules/claude-github-workflows.md
+++ b/rules/claude-github-workflows.md
@@ -18,7 +18,7 @@ If a workflow's behavior depends on a deterministic check (identity comparisons,
 
 When a Claude workflow needs write credentials, prefer a two-job shape: the Claude job runs with read-only permissions and uploads a constrained JSON/Markdown artifact, then a separate `needs:` job downloads the artifact, checks out trusted helper scripts from `github.sha`, validates the artifact, creates the GitHub App token, and performs deterministic GitHub mutations.
 
-When a headless Claude job must write local handoff artifacts, explicitly pre-approve its inspection tools and scope `Edit(...)` to the output directory via `claude_args --allowedTools`. After the action, verify every mandatory file with `test -s` before upload: `actions/upload-artifact`'s `if-no-files-found: error` still succeeds when only one of several listed paths exists, and Claude Code can report a successful session after denied tool calls.
+When a headless Claude job must write local handoff artifacts, exclude project/local settings with `claude_args --setting-sources user`, explicitly pre-approve its inspection tools, and scope `Edit(...)` to the output directory via `--allowedTools`. Without the setting-source restriction, the repository's broad project allowlist merges with the scoped rule and defeats the intended boundary. After the action, verify every mandatory file with `test -s` before upload: `actions/upload-artifact`'s `if-no-files-found: error` still succeeds when only one of several listed paths exists, and Claude Code can report a successful session after denied tool calls.
 
 ## Harden the agent's permissions — `.claude/settings.json` merges into CI
 
@@ -34,7 +34,7 @@ This has two consequences that bite in CI:
 **How to apply** (layered defenses, pick what fits the job):
 
 1. **Skip `actions/checkout` entirely** when the agent doesn't need repo contents (classification, summarization, structured-output jobs). Without checkout, `.claude/settings.json` is never in the workspace.
-2. **Strip the file after checkout** when the job does need the repo: add a step `run: rm -f .claude/settings.json .claude/settings.local.json` immediately after `actions/checkout`, before invoking the action. This is the right move for fork checkouts where the file is attacker-controlled.
+2. **Disable project/local setting sources** when the job needs the repo but not its Claude configuration: pass `--setting-sources user` in `claude_args`. This is more reliable than deleting `.claude/settings*.json` before `claude-code-action`, because newer action versions restore sensitive configuration paths from the trusted base ref before launching Claude. For `claude-code-base-action`, which does not restore project configuration, stripping the files after checkout remains an option.
 3. **Pass an inline `settings:` input** with an explicit `deny` list. This merges too, but `deny` beats `allow`, so it's an additional belt-and-suspenders layer. The action's `settings` input accepts a JSON string or a file path. Example for a tool-less classifier:
    ```yaml
    settings: |

--- a/rules/claude-github-workflows.md
+++ b/rules/claude-github-workflows.md
@@ -18,6 +18,8 @@ If a workflow's behavior depends on a deterministic check (identity comparisons,
 
 When a Claude workflow needs write credentials, prefer a two-job shape: the Claude job runs with read-only permissions and uploads a constrained JSON/Markdown artifact, then a separate `needs:` job downloads the artifact, checks out trusted helper scripts from `github.sha`, validates the artifact, creates the GitHub App token, and performs deterministic GitHub mutations.
 
+When a headless Claude job must write local handoff artifacts, explicitly pre-approve its inspection tools and scope `Edit(...)` to the output directory via `claude_args --allowedTools`. After the action, verify every mandatory file with `test -s` before upload: `actions/upload-artifact`'s `if-no-files-found: error` still succeeds when only one of several listed paths exists, and Claude Code can report a successful session after denied tool calls.
+
 ## Harden the agent's permissions — `.claude/settings.json` merges into CI
 
 Both `claude-code-action` and `claude-code-base-action` read `.claude/settings.json` from the workspace after `actions/checkout`, and the project's file is committed (tracked in git). **`permissions.allow` arrays merge across scopes — they do not replace each other.** From the Claude Code docs: _"Array settings merge across scopes. When the same array-valued setting (such as `permissions.allow`) appears in multiple scopes, the arrays are concatenated and deduplicated, not replaced."_ ([source](https://code.claude.com/docs/en/settings)).


### PR DESCRIPTION
## Summary

Restore Claude PR review artifact generation after the v1.0.179 action upgrade caused headless review sessions to finish with denied tool calls and omit their mandatory output files. The producing job now owns output validation, and its local write permission is isolated from the repository's broad project-level Claude settings.

- Load only action-created user settings so `.claude/settings.json` cannot widen the scoped tool approvals through additive permission merging.
- Explicitly pre-approve the one review sub-agent plus repository read/search tools required by the review prompt.
- Scope file modification permission to `tmp/pr-review/**`, keeping application source and workflow files outside the effective write boundary.
- Require both the Markdown summary and findings JSON to be non-empty before artifact upload, since `if-no-files-found: error` accepts a partial multi-path upload.
- Record the permission-merging, action configuration restoration, and partial-artifact behavior in the Claude workflow rules.

Failing run: https://github.com/dyad-sh/dyad/actions/runs/29886655069/job/88819030105?pr=4013

Because this workflow uses `pull_request_target`, PR runs execute the workflow definition from `main`; the new permission arguments can only be exercised by a subsequent PR after this change lands.

#skip-bugbot

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only changes to Claude review permissions and output checks; no application runtime or auth logic affected.
>
> **Overview**
> Fixes **Claude PR review** failing to produce handoff files after the `claude-code-action` v1.0.179 upgrade, where sessions could end “successfully” while **tool calls were denied** and mandatory outputs were never written.
>
> The review job now passes **`--allowedTools`** with the sub-agent plus read/search tools and **`Edit(tmp/pr-review/**)`** so writes stay limited to the review output directory. A new **Verify Claude review outputs** step fails the job if the Markdown summary or findings JSON is missing or empty, so bad runs surface in the producing job instead of breaking the downstream poster.
>
> Workflow guidance in **`rules/claude-github-workflows.md`** documents this pattern: scope headless `Edit`, and don’t rely on **`upload-artifact` `if-no-files-found: error`** alone when multiple paths are listed—partial uploads can still pass.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5471b12e6cf7897c9aa7989d294227fdb4043353. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
