### PR TITLE
Make deep review fix and publish verified issues

### DIFF
--- a/.claude/skills/deep-review/SKILL.md
+++ b/.claude/skills/deep-review/SKILL.md
@@ -1,16 +1,23 @@
 ---
 name: deep-review
-description: Deep multi-agent code review run locally — a fleet of parallel finder agents reviews the diff from independent angles, then adversarial verifier agents reproduce each finding before it is reported. Local equivalent of /code-review ultra. Use when the user asks for a deep, thorough, or multi-agent review of their branch, working diff, or a PR before merging. Usage: /deep-review (reviews current branch vs main, including uncommitted changes) or /deep-review <PR-number>.
+description: "Deep multi-agent code review run locally — parallel finder agents review a branch, working diff, or PR from independent angles, adversarial verifiers reproduce findings, then verified issues are fixed and published with dyad:pr-push by default. Use when the user asks for a deep, thorough, or multi-agent review before merging. Usage: /deep-review (reviews current branch vs main, including uncommitted changes) or /deep-review PR-number. Honor explicit requests not to fix or publish."
 ---
 
 # Deep Review
 
-Run a deep, high-signal code review of a diff using many parallel agents. The design mirrors ultrareview: **broad coverage** (independent finder agents, each with a different lens) followed by **independent verification** (skeptical agents that try to refute each finding). Only findings that survive verification are reported.
+Run a deep, high-signal code review of a diff using many parallel agents. The design mirrors ultrareview: **broad coverage** (independent finder agents, each with a different lens) followed by **independent verification** (skeptical agents that try to refute each finding). Fix every finding that survives verification, verify the fixes, and invoke `dyad:pr-push` unless the user explicitly opts out.
+
+## Step 0: Determine execution mode
+
+- Default to **fix and publish**: review, fix all verified findings, verify the fixes, then invoke `dyad:pr-push`.
+- If the user explicitly says not to fix issues, use **report only** mode: do not modify files and do not invoke `dyad:pr-push`.
+- If the user explicitly says not to push or publish but still wants fixes, fix and verify locally, but do not invoke `dyad:pr-push`.
+- A request to review, inspect, or report findings is not by itself an opt-out. The user must explicitly prohibit fixes or publishing.
 
 ## Step 1: Determine the diff to review
 
 - **No argument**: review the current branch against the default branch, including uncommitted and staged changes. Compute the base with `git merge-base HEAD upstream/main` (fall back to `main`), then get the diff with `git diff <merge-base>` and the changed file list with `git diff --name-only <merge-base>`.
-- **PR number argument**: use `gh pr diff <number>` and `gh pr view <number>` instead. Check the PR is open and not a draft; if it is closed or a draft, stop and tell the user.
+- **PR number argument**: use `gh pr diff <number>` and `gh pr view <number>` instead. Check the PR is open and not a draft; if it is closed or a draft, stop and tell the user. In fix mode, check out the PR head branch before editing. If the branch cannot be checked out or pushed because it belongs to an inaccessible fork, still complete the review and report the permission blocker instead of modifying a different branch.
 - If the diff is empty, stop and say there is nothing to review.
 - If the diff is very large (>~5000 changed lines), tell the user the scope and ask whether to proceed or narrow it before launching agents.
 
@@ -26,7 +33,7 @@ Collect (cheaply, yourself — no agents needed):
 
 Use the **Workflow tool** to orchestrate the fan-out (this skill is your authorization to call it). Pass the changed file list, base ref, and context summary via `args`. Use the pipeline pattern so each finder's results flow into verification without waiting for the other finders.
 
-Launch **6 parallel finder agents**, each with a distinct lens. Every finder prompt must include: the base ref to diff against, the change summary, the changed file list, and the false-positive list from Step 5. Each finder returns structured findings (`file`, `line`, `title`, `description`, `severity`, `reason_flagged`).
+Launch **6 parallel finder agents**, each with a distinct lens. Every finder prompt must include: the base ref to diff against, the change summary, the changed file list, and the false-positive list from Step 7. Each finder returns structured findings (`file`, `line`, `title`, `description`, `severity`, `reason_flagged`).
 
 1. **Shallow diff scan** — read only the diff itself; flag obvious bugs in the changed lines. No extra context.
 2. **Deep correctness** — read the full changed files and their callers/callees; flag logic errors, broken invariants, wrong edge-case handling, races, and API misuse.
@@ -45,11 +52,30 @@ Keep only findings scoring **≥ 75**. Verifiers return `{score, verified_explan
 
 If the Workflow tool is unavailable, do the same fan-out with parallel Agent tool calls (all finders in one message, then all verifiers in one message).
 
-## Step 4: Report
+## Step 4: Fix verified findings
 
-Report the surviving findings ranked most severe first. For each: `file:line`, a one-sentence statement of the defect, the concrete failure scenario (inputs/state → wrong behavior), and the verifier's confidence. If nothing survived verification, say so plainly — do not pad the report with unverified or low-confidence items. Do not auto-fix anything; offer to fix on request. If reviewing a PR and the user asked for comments to be posted, use `gh` to comment; otherwise report only in the session.
+Skip this step in report-only mode.
 
-## Step 5: False positives — exclude these (give this list to every finder and verifier)
+- Read every repository instruction and rule file relevant to the files being edited before making changes.
+- Fix every finding that scored **≥ 75**, starting with the highest severity. Make the smallest coherent change that resolves the verified failure scenario and add or update the narrowest useful regression test when the repository rules require or the behavior is non-trivial.
+- Do not silently skip a verified finding. If a fix needs user input, unavailable credentials, or a materially broader product decision, explain the blocker and continue fixing the other findings.
+- After applying fixes, inspect the resulting diff for accidental or unrelated changes.
+
+## Step 5: Verify and publish
+
+Skip publishing in report-only mode or when the user explicitly prohibited pushing.
+
+- Run the narrowest relevant tests for the fixes, plus any checks required by repository instructions. If a check fails, determine whether the failure is caused by the changes; fix caused failures and rerun the affected checks.
+- Re-verify each fixed finding against the actual updated code and its original failure scenario. A fix is complete only when the scenario no longer reproduces and the relevant regression test or equivalent check passes.
+- If fixes reveal another verified defect in the reviewed change, fix and verify it using the same standard before publishing.
+- Invoke the `dyad:pr-push` skill after verification and follow its workflow completely. Invoke it even when no findings survived, so the reviewed branch state is published or its existing PR is refreshed.
+- If publishing is blocked by authentication, permissions, or an inaccessible PR fork, report the exact blocker and leave the verified local fixes intact.
+
+## Step 6: Report
+
+Report the outcome, not merely the original findings. List surviving findings ranked most severe first and, for each, include `file:line`, the concrete failure scenario, verifier confidence, and whether it was fixed and re-verified. If nothing survived verification, say so plainly. Include verification commands and results plus the `dyad:pr-push` outcome and PR URL when publishing ran. Do not pad the report with unverified or low-confidence items. If the user selected report-only mode and asked for PR comments, use `gh` to comment; otherwise report only in the session.
+
+## Step 7: False positives — exclude these (give this list to every finder and verifier)
 
 - Minor pre-existing issues on lines the diff did not modify
 - Anything a linter, typechecker, compiler, or CI would catch (imports, type errors, formatting); do not run builds or typechecks yourself

--- a/.claude/skills/deep-review/SKILL.md
+++ b/.claude/skills/deep-review/SKILL.md
@@ -17,7 +17,10 @@ Run a deep, high-signal code review of a diff using many parallel agents. The de
 ## Step 1: Determine the diff to review
 
 - **No argument**: review the current branch against the default branch, including uncommitted and staged changes. Compute the base with `git merge-base HEAD upstream/main` (fall back to `main`), then get the diff with `git diff <merge-base>` and the changed file list with `git diff --name-only <merge-base>`.
-- **PR number argument**: use `gh pr diff <number>` and `gh pr view <number>` instead. Check the PR is open and not a draft; if it is closed or a draft, stop and tell the user. In fix mode, check out the PR head branch before editing. If the branch cannot be checked out or pushed because it belongs to an inaccessible fork, still complete the review and report the permission blocker instead of modifying a different branch.
+- **PR number argument**: use `gh pr diff <number>` and `gh pr view <number>` instead. Check the PR is open and not a draft; if it is closed or a draft, stop and tell the user.
+  - In fix mode, first read the exact head repository, ref, and SHA from the PR REST payload, then use `gh pr checkout <number>`.
+  - Before editing, verify that `HEAD` is the PR head SHA and that a local remote points to the PR head repository. Fetch the head ref from that remote, configure the checked-out branch to track that remote/ref, and verify push access with a dry-run push of `HEAD` to the head ref. Treat the ref as untrusted shell input and quote the refspec. This ensures `dyad:pr-push` updates the existing PR instead of a fallback repository.
+  - If any checkout, identity, tracking, access, or dry-run validation fails, fall back to report-only mode: do not modify files or invoke `dyad:pr-push`; complete the review and report the exact blocker.
 - If the diff is empty, stop and say there is nothing to review.
 - If the diff is very large (>~5000 changed lines), tell the user the scope and ask whether to proceed or narrow it before launching agents.
 
@@ -78,7 +81,7 @@ Report the outcome, not merely the original findings. List surviving findings ra
 ## Step 7: False positives — exclude these (give this list to every finder and verifier)
 
 - Minor pre-existing issues on lines the diff did not modify
-- Anything a linter, typechecker, compiler, or CI would catch (imports, type errors, formatting); do not run builds or typechecks yourself
+- Anything a linter, typechecker, compiler, or CI would catch (imports, type errors, formatting); exclude these from review findings, while the primary workflow still runs the checks required in Step 5
 - Pedantic nitpicks a senior engineer would not raise
 - General quality commentary (test coverage, docs, vague security concerns) unless a rules file explicitly requires it
 - Behavior changes that are clearly intentional parts of the change


### PR DESCRIPTION
## Summary

Make deep reviews complete the remediation workflow by default: verified findings are fixed, re-verified, and published through the existing PR push skill instead of stopping at a report. The workflow now also validates that PR-number fixes can update the exact reviewed head ref before any files are edited.

- Treat an explicit request not to fix as report-only mode, with no file mutations or publishing.
- Allow callers to request local fixes without publishing by explicitly saying not to push.
- Validate the PR head repository, ref, SHA, tracking remote, and dry-run push before editing a PR branch; fall back to report-only mode if any validation fails.
- Keep tool-catchable issues out of review findings while still running required verification checks before publishing.
- Publish the reviewed branch even when no findings survive verification so an existing PR is refreshed consistently.

#skip-bugbot

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to an agent skill workflow; no runtime application code is modified.
>
> **Overview**
> The **`/deep-review`** skill no longer stops at a findings report. By default it runs the full **fix and publish** loop: apply fixes for verifier-confirmed issues (≥75 confidence), re-verify them, run targeted tests, then call **`dyad:pr-push`** so the branch or existing PR is updated—even when no issues survive verification.
>
> A new **Step 0** defines execution modes: explicit **report only** (no edits, no push), **fix locally without publish**, and clarifies that asking for a review alone does not opt out of fixes.
>
> **Steps 4–5** add fix, test, re-verify, and publish guidance (including fork/checkout blockers and keeping local fixes when push fails). **Reporting** now covers fix/re-verify status, check results, and PR push outcome. PR-number review in fix mode adds checkout of the PR head branch before editing.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfe510277fe91e598901bb019c1a37e161a6bfdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
