### PR TITLE
Route Linux dev deep links back into the running instance

### DIFF
--- a/src/ipc/handlers/shell_handler.ts
+++ b/src/ipc/handlers/shell_handler.ts
@@ -1,13 +1,25 @@
-import { shell } from "electron";
+import { app, shell } from "electron";
 import log from "electron-log";
 import path from "node:path";
 import { createLoggedHandler } from "./safe_handle";
 import { IS_TEST_BUILD } from "../utils/test_utils";
 import { isFileWithinAnyDyadMediaDir } from "../utils/media_path_utils";
 import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
+import { registerDyadProtocolLinux } from "../../main/linux_protocol_registration";
 
 const logger = log.scope("shell_handlers");
 const handle = createLoggedHandler(logger);
+
+// Hosts whose OAuth flows redirect back into the app via a dyad:// deep link
+// (Neon, Supabase, and Dyad Pro all live under *.dyad.sh).
+function isDyadOAuthUrl(url: string): boolean {
+  try {
+    const host = new URL(url).hostname;
+    return host === "dyad.sh" || host.endsWith(".dyad.sh");
+  } catch {
+    return false;
+  }
+}
 
 // Only allow opening files with known safe media extensions via shell.openPath.
 // This prevents execution of arbitrary executables even if they reside under a
@@ -46,6 +58,18 @@ export function registerShellHandlers() {
     if (IS_TEST_BUILD) {
       logger.debug("E2E test mode: skipped opening external URL:", url);
       return;
+    }
+    // On Linux, dev and packaged builds share the single dyad:// scheme and it's
+    // "last registration wins", so launching the packaged app steals the handler
+    // and OAuth callbacks (dyad://neon-oauth-return, etc.) open packaged instead
+    // of this dev instance. Reclaim the handler just before the browser opens so
+    // the callback routes back here. Best-effort; the helper self-guards platform.
+    if (
+      !app.isPackaged &&
+      process.platform === "linux" &&
+      isDyadOAuthUrl(url)
+    ) {
+      await registerDyadProtocolLinux(app.getPath("userData"));
     }
     await shell.openExternal(url);
     logger.debug("Opened external URL:", url);

--- a/src/main.ts
+++ b/src/main.ts
@@ -325,8 +325,9 @@ if (process.defaultApp) {
 
 export async function onReady() {
   // Linux: claim the dyad:// scheme for this build (best-effort, see module).
-  // setAsDefaultProtocolClient above is unreliable on Linux.
-  void registerDyadProtocolLinux();
+  // setAsDefaultProtocolClient above is unreliable on Linux. Pass this instance's
+  // userData so a browser-launched deep link forwards here, not a second window.
+  void registerDyadProtocolLinux(app.getPath("userData"));
 
   // React DevTools extension loading is intentionally disabled. In Electron it
   // can spam startup logs with:

--- a/src/main/linux_protocol_registration.test.ts
+++ b/src/main/linux_protocol_registration.test.ts
@@ -6,7 +6,7 @@ import {
 } from "@/main/linux_protocol_registration";
 
 describe("computeExecCommand", () => {
-  it("uses the electron binary plus entry script in dev", () => {
+  it("pins NODE_ENV and the absolute userData for the dev relaunch", () => {
     const command = computeExecCommand({
       defaultApp: true,
       execPath: "/usr/lib/electron/electron",
@@ -15,6 +15,51 @@ describe("computeExecCommand", () => {
         "/home/user/code/dyad/.vite/main.js",
       ],
       appImagePath: undefined,
+      nodeEnv: "development",
+      devUserDataDir: "/home/user/code/dyad/userData",
+    });
+
+    const script = path.resolve("/home/user/code/dyad/.vite/main.js");
+    const escapedScript = script.replace(/(["`$\\])/g, "\\$1");
+    // The env prefix keeps the relaunched deep-link handler on the dev userData
+    // (independent of the launcher's CWD) so it forwards into the running dev
+    // instance instead of opening a second window (see computeExecCommand).
+    expect(command.exec).toBe(
+      `env -u ELECTRON_RUN_AS_NODE NODE_ENV=development ` +
+        `"DYAD_DEV_USER_DATA_DIR=/home/user/code/dyad/userData" ` +
+        `"/usr/lib/electron/electron" "${escapedScript}" %u`,
+    );
+    expect(command.tryExec).toBe("/usr/lib/electron/electron");
+  });
+
+  it("omits DYAD_DEV_USER_DATA_DIR when the userData dir is unknown", () => {
+    const command = computeExecCommand({
+      defaultApp: true,
+      execPath: "/usr/lib/electron/electron",
+      argv: [
+        "/usr/lib/electron/electron",
+        "/home/user/code/dyad/.vite/main.js",
+      ],
+      appImagePath: undefined,
+      nodeEnv: "development",
+      devUserDataDir: undefined,
+    });
+
+    expect(command.exec).toContain("NODE_ENV=development");
+    expect(command.exec).not.toContain("DYAD_DEV_USER_DATA_DIR");
+  });
+
+  it("omits the env prefix when NODE_ENV is not development", () => {
+    const command = computeExecCommand({
+      defaultApp: true,
+      execPath: "/usr/lib/electron/electron",
+      argv: [
+        "/usr/lib/electron/electron",
+        "/home/user/code/dyad/.vite/main.js",
+      ],
+      appImagePath: undefined,
+      nodeEnv: undefined,
+      devUserDataDir: "/home/user/code/dyad/userData",
     });
 
     const script = path.resolve("/home/user/code/dyad/.vite/main.js");
@@ -22,7 +67,7 @@ describe("computeExecCommand", () => {
     expect(command.exec).toBe(
       `"/usr/lib/electron/electron" "${escapedScript}" %u`,
     );
-    expect(command.tryExec).toBe("/usr/lib/electron/electron");
+    expect(command.exec).not.toContain("env ");
   });
 
   it("uses the stable APPIMAGE path, never the /tmp mount", () => {
@@ -31,6 +76,8 @@ describe("computeExecCommand", () => {
       execPath: "/tmp/.mount_dyadXXXX/usr/lib/dyad/dyad",
       argv: ["/tmp/.mount_dyadXXXX/usr/lib/dyad/dyad"],
       appImagePath: "/home/user/AppImages/dyad.AppImage",
+      nodeEnv: undefined,
+      devUserDataDir: undefined,
     });
 
     expect(command.exec).toBe(`"/home/user/AppImages/dyad.AppImage" %u`);
@@ -44,6 +91,8 @@ describe("computeExecCommand", () => {
       execPath: "/opt/dyad/dyad",
       argv: ["/opt/dyad/dyad"],
       appImagePath: undefined,
+      nodeEnv: undefined,
+      devUserDataDir: undefined,
     });
 
     expect(command.exec).toBe(`"/opt/dyad/dyad" %u`);
@@ -56,6 +105,8 @@ describe("computeExecCommand", () => {
       execPath: "/opt/dyad/dyad",
       argv: [],
       appImagePath: `/home/u$er/My "Apps"/dyad \`v1\`.AppImage`,
+      nodeEnv: undefined,
+      devUserDataDir: undefined,
     });
 
     expect(command.exec).toBe(

--- a/src/main/linux_protocol_registration.ts
+++ b/src/main/linux_protocol_registration.ts
@@ -22,6 +22,18 @@ interface ExecInputs {
   argv: string[];
   // process.env.APPIMAGE: stable path to the .AppImage, set by the runtime.
   appImagePath: string | undefined;
+  // process.env.NODE_ENV: "development" for `npm start`. The dev instance keys
+  // its userData (and thus its single-instance lock) off this, so a relaunched
+  // handler must carry the same value to reach the running dev instance rather
+  // than the default userData a packaged install uses. See computeExecCommand.
+  nodeEnv: string | undefined;
+  // Absolute userData dir the running dev instance is using (app.getPath).
+  // In dev, getUserDataPath() falls back to path.resolve("./userData"), i.e.
+  // relative to the CWD. The OS launches the deep-link handler from a different
+  // CWD than `npm start` did, so without pinning this the relaunch computes a
+  // different userData, grabs a different single-instance lock, and opens a
+  // second dev window instead of forwarding. Baked in via DYAD_DEV_USER_DATA_DIR.
+  devUserDataDir: string | undefined;
 }
 
 interface ExecCommand {
@@ -41,7 +53,8 @@ function quote(value: string): string {
 // The Exec target differs per packaging format. Pure so it can be unit-tested
 // without touching the real environment.
 export function computeExecCommand(inputs: ExecInputs): ExecCommand {
-  const { defaultApp, execPath, argv, appImagePath } = inputs;
+  const { defaultApp, execPath, argv, appImagePath, nodeEnv, devUserDataDir } =
+    inputs;
 
   // AppImage: process.execPath points at the ephemeral /tmp/.mount_* extract
   // that changes every launch, so it must not be used. appImagePath (from
@@ -56,8 +69,39 @@ export function computeExecCommand(inputs: ExecInputs): ExecCommand {
   // Dev / unpackaged: electron binary plus the app entry script.
   if (defaultApp && argv.length >= 2) {
     const script = path.resolve(argv[1]);
+    // When the OS opens a dyad:// link it launches this Exec line as a fresh
+    // process. To forward the deep link into the *running* dev instance it must
+    // land on the same single-instance lock, which is keyed off the dev
+    // userData. main.ts only selects that userData when NODE_ENV ===
+    // "development", and getUserDataPath() then resolves "./userData" relative
+    // to the CWD. A bare `electron .` launch (a) omits NODE_ENV, defaulting to
+    // ~/.config/dyad — the userData a packaged install uses — and (b) runs from
+    // the launcher's CWD, not the project root, so even with NODE_ENV set the
+    // relative path points elsewhere. Either way it grabs a different lock and
+    // opens a second window instead of forwarding. Pin both: NODE_ENV via `env`,
+    // and the exact absolute userData via DYAD_DEV_USER_DATA_DIR. `-u
+    // ELECTRON_RUN_AS_NODE` guards the rare case where the launching environment
+    // has it set, which would run electron as plain node.
+    const envAssignments =
+      nodeEnv === "development"
+        ? [
+            "env",
+            "-u",
+            "ELECTRON_RUN_AS_NODE",
+            `NODE_ENV=${nodeEnv}`,
+            // Quote the whole VAR=value token, not just the value: the Desktop
+            // Entry spec only recognizes an argument as quoted when it *begins*
+            // with `"`, so a mid-argument quote (VAR="/a b") can be mis-split by
+            // a strict parser. env(1) receives VAR=value as one argv element.
+            ...(devUserDataDir
+              ? [quote(`DYAD_DEV_USER_DATA_DIR=${devUserDataDir}`)]
+              : []),
+          ]
+        : [];
+    const envPrefix =
+      envAssignments.length > 0 ? `${envAssignments.join(" ")} ` : "";
     return {
-      exec: `${quote(execPath)} ${quote(script)} %u`,
+      exec: `${envPrefix}${quote(execPath)} ${quote(script)} %u`,
       tryExec: execPath,
     };
   }
@@ -93,7 +137,13 @@ export function buildDesktopFile(command: ExecCommand): string {
 // every startup so the handler always points at the build the user launched last.
 // The file goes under ~/.local/share (this user only), so it won't clash with
 // a deb/rpm system install.
-export async function registerDyadProtocolLinux(): Promise<void> {
+// `devUserDataDir` should be the running instance's app.getPath("userData"); it
+// is baked into the dev handler so a browser-launched deep link forwards into
+// this instance regardless of the launcher's working directory. Callers in the
+// main process pass it; it's ignored outside dev.
+export async function registerDyadProtocolLinux(
+  devUserDataDir?: string,
+): Promise<void> {
   if (process.platform !== "linux") {
     return;
   }
@@ -108,6 +158,8 @@ export async function registerDyadProtocolLinux(): Promise<void> {
       execPath: process.execPath,
       argv: process.argv,
       appImagePath: process.env.APPIMAGE,
+      nodeEnv: process.env.NODE_ENV,
+      devUserDataDir,
     });
 
     // Honor XDG_DATA_HOME so the file lands where the desktop environment


### PR DESCRIPTION
On Linux, dev and packaged builds share the single dyad:// scheme ("last registration wins"), so OAuth callbacks could open a second window or the packaged app instead of the running dev instance.

Pin the dev relaunch environment (NODE_ENV + absolute DYAD_DEV_USER_DATA_DIR) into the .desktop Exec line so the handler lands on the same single-instance lock, and reclaim the handler just before opening a *.dyad.sh OAuth URL from an unpackaged build. Quote the whole VAR=value token so paths with spaces stay spec-compliant.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

