### PR TITLE
Fix nightly runner reboot workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -56,7 +56,7 @@ flowchart TD
 | `draft-stale-prs.yml`        | `Draft stale PRs`              | Converts inactive open PRs to draft after 7 days without meaningful activity.                                   | Daily cron (`0 0 * * *`) or `workflow_dispatch`.                                                                     | None.                                                                                                                                                                                               |
 | `label-rebase-prs.yml`       | `Label PRs needing rebase`     | Finds conflicting open PRs from allowed authors and flags them for rebase.                                      | `push` to `main`.                                                                                                    | Adds `cc:rebase` when eligible PR is conflicted (`mergeable_state == dirty`) and not already in rebase states.                                                                                      |
 | `merge-pr.yml`               | `Merge PR when ready`          | Auto-merges eligible PRs after successful CI when all checks pass.                                              | `workflow_run` for `CI` on `completed` (successful PR-triggered CI only).                                            | None (reads `merge-when-ready`, does not set labels).                                                                                                                                               |
-| `nightly-runner-cleanup.yml` | `Nightly Runner Cleanup`       | Safely frees disk space on self-hosted macOS runners ci1-ci4 (caches, npm, runner \_work).                      | Daily cron (4 AM PST); or `workflow_dispatch`.                                                                       | None.                                                                                                                                                                                               |
+| `nightly-runner-cleanup.yml` | `Nightly Runner Cleanup`       | Safely frees disk space on self-hosted macOS runners ci1-ci4 (caches, npm, runner \_work), then reboots them.   | Daily cron (`0 12 * * *`, 4 AM PST / 5 AM PDT); or `workflow_dispatch`.                                              | None.                                                                                                                                                                                               |
 | `playwright-comment.yml`     | `Playwright Report Comment`    | Posts a Playwright summary comment on the PR tied to a completed CI run.                                        | `workflow_run` for `CI` on `completed`.                                                                              | None.                                                                                                                                                                                               |
 | `pr-review-responder.yml`    | `PR Review Responder`          | Runs Claude fix loops for trusted PRs, retriggers checks/reviews, and advances request-state labels.            | `pull_request_target` on `labeled` (only `cc:request:now`); `workflow_run` for `CI` on `completed`.                  | `cc:request`/`cc:request:N` -> `cc:pending`; then `cc:request:N+1` on pushed commits, `cc:done` on clean finish, `cc:failed` on failure; may add `needs-human:review-issue` when retries exhausted. |
 | `pr-status-labeler.yml`      | `PR Status Labeler`            | Applies human-attention labels based on CI outcome and review freshness/verdict.                                | `workflow_run` for `CI` on `completed`.                                                                              | Swaps between `needs-human:final-check` (clean + passing) and `needs-human:review-issue` (failing/stale/missing/issueful review).                                                                   |
@@ -64,13 +64,25 @@ flowchart TD
 
 ## Nightly Runner Cleanup
 
-The `nightly-runner-cleanup.yml` workflow runs at 4:00 AM PST on self-hosted macOS runners `ci1` through `ci4` to reclaim disk space.
+The `nightly-runner-cleanup.yml` workflow runs at 12:00 UTC (4:00 AM PST / 5:00 AM PDT) on self-hosted macOS runners `ci1` through `ci4` to reclaim disk space and reboot each machine.
+
+Each runner account must be allowed to schedule the workflow's exact reboot command without a password. Configure this with `visudo` in a file under `/etc/sudoers.d/`:
+
+```sudoers
+# ci1, ci2, and ci3
+ci ALL=(root) NOPASSWD: /sbin/shutdown -r +1
+
+# ci4
+ci4 ALL=(root) NOPASSWD: /sbin/shutdown -r +1
+```
+
+The Actions runner service must also start without an interactive login after reboot. The workflow waits three minutes before dispatching verification jobs and fails verification if a machine's uptime is greater than 15 minutes.
 
 **Validation (manual run):**
 
 1. Go to Actions → Nightly Runner Cleanup → Run workflow.
 2. Confirm the run completes successfully and logs show cleanup running on each runner.
-3. Check logs for "Disk before" and "Disk after" to verify space reclaimed.
-4. Confirm each runner re-registers and the verify job prints post-reboot disk space.
+3. Check logs for "Disk before" and "Disk after" to verify space reclaimed from `/System/Volumes/Data`.
+4. Confirm each runner re-registers and verification reports an uptime under 15 minutes.
 
-**Expected behavior:** Deletes only allowlisted paths (npm cache, Playwright browsers, runner \_work dirs older than 2 days, Library/Caches subdirs). Never removes runner binaries, config, or user data outside caches.
+**Expected behavior:** Deletes only allowlisted paths (npm cache, Playwright browsers, inactive runner repository workspaces older than 2 days, Library/Caches subdirs). It preserves the active workspace and runner-owned `_work` directories such as `_temp` and `_PipelineMapping`, and never removes runner binaries, config, or user data outside caches.

--- a/.github/workflows/nightly-runner-cleanup.yml
+++ b/.github/workflows/nightly-runner-cleanup.yml
@@ -1,5 +1,5 @@
 # Nightly disk cleanup for self-hosted macOS CI runners.
-# Runs at 4:00 AM PST to prevent disk exhaustion from CI workloads.
+# Runs at 12:00 UTC (4:00 AM PST / 5:00 AM PDT) to prevent disk exhaustion.
 # After cleanup, reboots runners, then a verification job checks disk space.
 # Safe to run manually via workflow_dispatch for testing.
 #
@@ -12,7 +12,7 @@ name: Nightly Runner Cleanup
 
 on:
   schedule:
-    # 4:00 AM PST = 12:00 UTC (PST is UTC-8)
+    # GitHub cron is UTC and does not adjust for daylight saving time.
     - cron: "0 12 * * *"
   workflow_dispatch:
 
@@ -32,13 +32,22 @@ jobs:
           CI_NIGHTLY_CLEANUP: "1"
         run: bash scripts/ci-cleanup-macos.sh
 
-      - name: Reboot runner
-        run: sudo reboot
+      # Delay the reboot so this job and actions/checkout's post-job hook can
+      # finish cleanly before the runner goes offline.
+      - name: Schedule reboot
+        run: sudo -n /sbin/shutdown -r +1
+
+  wait-for-reboot:
+    needs: cleanup
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Allow runners to reboot
+        run: sleep 180
 
   verify:
-    needs: cleanup
-    # Run even if cleanup "fails" (reboot kills the runner mid-job), but still
-    # respect manual workflow cancellation.
+    needs: wait-for-reboot
     if: ${{ !cancelled() }}
     timeout-minutes: 15
     strategy:
@@ -47,9 +56,20 @@ jobs:
         runner: [ci1, ci2, ci3, ci4]
     runs-on: ${{ matrix.runner }}
     steps:
+      - name: Verify recent reboot
+        run: |
+          boot_epoch=$(sysctl -n kern.boottime | sed -E 's/^\{ sec = ([0-9]+),.*/\1/')
+          now_epoch=$(date +%s)
+          uptime_seconds=$((now_epoch - boot_epoch))
+          echo "Runner uptime: ${uptime_seconds} seconds"
+          if [ "$uptime_seconds" -gt 900 ]; then
+            echo "::error::Runner did not reboot in the last 15 minutes"
+            exit 1
+          fi
+
       - name: Print available disk space
         run: |
           echo "=== Post-Reboot Disk Space ==="
-          df -h /
+          df -h /System/Volumes/Data
           echo ""
-          echo "Available space: $(df -h / | tail -1 | awk '{print $4}')"
+          echo "Available space: $(df -h /System/Volumes/Data | tail -1 | awk '{print $4}')"

--- a/scripts/ci-cleanup-macos.sh
+++ b/scripts/ci-cleanup-macos.sh
@@ -18,15 +18,22 @@
 
 set -euo pipefail
 
+DISK_VOLUME="/System/Volumes/Data"
+if [ ! -d "$DISK_VOLUME" ]; then
+  # Keep the script testable on non-macOS hosts while targeting the writable
+  # Data volume on APFS-based macOS runners.
+  DISK_VOLUME="/"
+fi
+
 echo "=== CI Cleanup (macOS self-hosted) ==="
 if [ "${CI_NIGHTLY_CLEANUP:-0}" = "1" ]; then
   echo "Mode: nightly (host-level + workspace)"
 else
   echo "Mode: per-job (workspace only)"
 fi
-df -h / | tail -1 | awk '{print "Disk before cleanup: "$4" available ("$5" used)"}'
+df -h "$DISK_VOLUME" | tail -1 | awk '{print "Disk before cleanup: "$4" available ("$5" used)"}'
 
-bytes_before=$(df -k / | tail -1 | awk '{print $4}')
+bytes_before=$(df -k "$DISK_VOLUME" | tail -1 | awk '{print $4}')
 
 # ---------------------------------------------------------------------------
 # 1. Build outputs in the workspace
@@ -148,22 +155,34 @@ if [ "${CI_NIGHTLY_CLEANUP:-0}" = "1" ]; then
     rm -rf "$d"
   done
 
-  # Runner _work: remove stale job workspaces older than 2 days
+  # Runner _work: remove stale repository workspaces older than 2 days.
+  # Never remove runner-owned directories (for example _temp or
+  # _PipelineMapping), or the top-level directory containing the currently
+  # executing GITHUB_WORKSPACE.
   if [ -d "$RUNNER_DIR/_work" ]; then
-    stale=$(find "$RUNNER_DIR/_work" -mindepth 1 -maxdepth 1 -type d -mtime +2 2>/dev/null || true)
-    if [ -n "$stale" ]; then
-      echo "Removing stale _work dirs (older than 2 days):"
-      echo "$stale"
-      echo "$stale" | while IFS= read -r dir; do rm -rf "$dir"; done
+    active_workspace="${GITHUB_WORKSPACE:-$PWD}"
+    find "$RUNNER_DIR/_work" -mindepth 1 -maxdepth 1 -type d -mtime +2 -print0 2>/dev/null |
+      while IFS= read -r -d '' dir; do
+        dir_name=$(basename "$dir")
+        if [[ "$dir_name" == _* ]]; then
+          echo "Keeping runner-owned _work dir: $dir"
+          continue
+        fi
+        if [[ "$active_workspace" == "$dir" || "$active_workspace" == "$dir/"* ]]; then
+          echo "Keeping active _work dir: $dir"
+          continue
+        fi
 
-    fi
+        echo "Removing stale _work dir: $dir"
+        rm -rf "$dir"
+      done
   fi
 fi
 
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
-bytes_after=$(df -k / | tail -1 | awk '{print $4}')
+bytes_after=$(df -k "$DISK_VOLUME" | tail -1 | awk '{print $4}')
 freed_kb=$((bytes_after - bytes_before))
 if [ "$freed_kb" -gt 1024 ]; then
   freed_mb=$((freed_kb / 1024))
@@ -172,5 +191,5 @@ else
   echo "Freed ~${freed_kb} KB"
 fi
 
-df -h / | tail -1 | awk '{print "Disk after cleanup:  "$4" available ("$5" used)"}'
+df -h "$DISK_VOLUME" | tail -1 | awk '{print "Disk after cleanup:  "$4" available ("$5" used)"}'
 echo "=== Cleanup complete ==="

--- a/scripts/ci-cleanup-macos.test.sh
+++ b/scripts/ci-cleanup-macos.test.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+export HOME="$TEST_ROOT/home"
+export RUNNER_DIR="$HOME/actions-runner"
+export GITHUB_WORKSPACE="$RUNNER_DIR/_work/dyad/dyad"
+export CI_NIGHTLY_CLEANUP=1
+
+mkdir -p \
+  "$GITHUB_WORKSPACE" \
+  "$RUNNER_DIR/_work/stale-repo/stale-repo" \
+  "$RUNNER_DIR/_work/_PipelineMapping" \
+  "$HOME/Library/Caches"
+
+# A top-level repository directory can retain an old mtime even while files in
+# its active workspace are changing.
+touch -t 202001010000 "$RUNNER_DIR/_work/dyad"
+touch -t 202001010000 "$RUNNER_DIR/_work/stale-repo"
+touch -t 202001010000 "$RUNNER_DIR/_work/_PipelineMapping"
+
+cd "$GITHUB_WORKSPACE"
+bash "$SCRIPT_DIR/ci-cleanup-macos.sh" >"$TEST_ROOT/output.log"
+
+test -d "$GITHUB_WORKSPACE"
+test -d "$RUNNER_DIR/_work/_PipelineMapping"
+test ! -e "$RUNNER_DIR/_work/stale-repo"
+grep -q "Keeping active _work dir: $RUNNER_DIR/_work/dyad" "$TEST_ROOT/output.log"
+grep -q "Keeping runner-owned _work dir: $RUNNER_DIR/_work/_PipelineMapping" "$TEST_ROOT/output.log"
+grep -q "Removing stale _work dir: $RUNNER_DIR/_work/stale-repo" "$TEST_ROOT/output.log"
+
+echo "ci-cleanup-macos tests passed"


### PR DESCRIPTION
The nightly self-hosted runner workflow can fail before rebooting because its cleanup removes the active Actions workspace, while runners without passwordless sudo reject the reboot command. This change protects live runner state and makes reboot completion observable instead of treating an abrupt runner disconnect as the intended control flow.

Key decisions and boundaries:

- Preserve the active `GITHUB_WORKSPACE` ancestor and all runner-owned `_work` directories whose names begin with `_`, while continuing to delete inactive repository workspaces older than two days.
- Schedule `/sbin/shutdown -r +1` non-interactively so checkout post-job cleanup can finish before the machine disappears.
- Insert a three-minute GitHub-hosted grace period before verification, then fail verification unless runner uptime is under 15 minutes.
- Report the writable APFS Data volume rather than the sealed system volume.
- Document the exact narrowly scoped sudoers entries required by the runner accounts; machine provisioning remains outside this repository change.
- Add a shell regression test covering active, runner-owned, and stale workspace directories.

Reviewer note: please verify that three minutes is sufficient for the slowest runner to reboot and re-register under its LaunchDaemon configuration.

#skip-bugbot


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect production self-hosted CI hosts (scheduled reboots and nightly disk cleanup); misconfigured sudo or the 3-minute grace window could leave runners offline or skip reboot verification.
> 
> **Overview**
> Fixes the **Nightly Runner Cleanup** workflow so cleanup can finish and reboots are reliable and verifiable on self-hosted macOS runners.
> 
> **Reboot flow:** Replaces immediate `sudo reboot` with passwordless `sudo -n /sbin/shutdown -r +1`, adds a GitHub-hosted **3-minute wait** before verification, and fails verify if runner uptime exceeds **15 minutes**. Disk checks target **`/System/Volumes/Data`** instead of `/`.
> 
> **Cleanup script:** Nightly `_work` pruning now **skips** runner-owned dirs (`_*`) and the tree containing **`GITHUB_WORKSPACE`**, while still removing stale repo workspaces older than two days. Disk reporting uses the same Data volume with a `/` fallback for non-macOS tests.
> 
> **Docs & tests:** Workflow README documents cron/UTC, required **sudoers** entries, and manual validation steps. Adds **`scripts/ci-cleanup-macos.test.sh`** for active vs stale vs runner-owned `_work` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b93d4a23059ea9094df5334fecb54f2c81089d90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->