### PR TITLE
Add comments for safety

### DIFF
--- a/src/chat_stream/controller.ts
+++ b/src/chat_stream/controller.ts
@@ -103,6 +103,17 @@ export function createChatStreamController(
 
     const result = transition(previous, event);
     observeTransition(observer, previous, event, result);
+    // ORDERING INVARIANT — send() can be re-entered synchronously while
+    // setState below is still on the stack: syncProjection writes
+    // isStreamingByIdAtom, plan_handoff's watch-stream-idle Jotai sub fires
+    // synchronously on that write, and its start-implementation command
+    // calls chatStream.submit(...) -> send() on this same controller
+    // (plan-accept -> implement flow). That re-entry is only safe because
+    // (a) commands are pushed to commandQueue BEFORE setState, so the inner
+    // event's commands cannot overtake this event's, and (b) SnapshotStore
+    // commits the snapshot BEFORE running this callback, so the inner
+    // transition sees committed state. Do not reorder these lines without
+    // adding a re-entrancy buffer (processing flag + pending-event FIFO).
     commandQueue.push(...result.commands);
     store.setState(result.state, () => {
       // Keep the legacy isStreaming projection in lockstep with the machine

--- a/src/preview_iframe/commands.ts
+++ b/src/preview_iframe/commands.ts
@@ -64,6 +64,10 @@ export function createPreviewIframeCommandAdapter(
                   },
               "*",
             );
+            // This emit re-enters the controller's send() synchronously
+            // while the outer send() is still inside setState (commands run
+            // in beforeNotify). Safe only because the SELECTION_RESTORED
+            // transition is command-free — see the note in transition.ts.
             emit({ type: "SELECTION_RESTORED" });
           }
           return;

--- a/src/preview_iframe/transition.ts
+++ b/src/preview_iframe/transition.ts
@@ -234,6 +234,12 @@ export function transition(
       );
     case "SELECTION_RESTORED":
       if (!state.restoreQueued) return ignore(state, "restore-not-queued");
+      // MUST stay command-free: the restore-overlays command emits this
+      // event synchronously while the controller is still mid-setState for
+      // the outer event, and the controller has no re-entrancy buffer.
+      // Returning commands here would execute them against a half-notified
+      // store. Add a processing-flag + pending-event FIFO to the controller
+      // before attaching commands to this transition.
       return applied({ ...state, restoreQueued: false });
     default:
       return assertNever(event);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Comment-only change with no runtime or API impact; it records existing safety constraints for future refactors.
> 
> **Overview**
> Adds **inline documentation only** (no behavior changes) explaining when `send()` can be called re-entrantly while a prior `setState` is still on the stack.
> 
> In **`chat_stream/controller.ts`**, documents the **ordering invariant**: enqueue commands before `setState`, and rely on `SnapshotStore` committing state before the projection callback—so nested events (e.g. plan accept → implement via Jotai `isStreaming` + `chatStream.submit`) stay safe unless those lines are reordered without a re-entrancy buffer.
> 
> In **`preview_iframe`**, documents that `restore-overlays` **synchronously emits** `SELECTION_RESTORED` during command execution inside `setState`, and that the **`SELECTION_RESTORED` transition must remain command-free** until the controller gains a processing flag + pending-event FIFO.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54effbad2e42d14c2c899736930e5732409c4581. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

