### PR TITLE
feat: collect user-supplied setup fields for catalog MCP servers

### DIFF
--- a/src/components/plugins/PluginDetailPage.tsx
+++ b/src/components/plugins/PluginDetailPage.tsx
@@ -14,9 +14,12 @@ import {
 import { DeleteConfirmationDialog } from "@/components/DeleteConfirmationDialog";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useMcp } from "@/hooks/useMcp";
+import { useMcpCatalog } from "@/hooks/useMcpCatalog";
 import type { McpToolConsent } from "@/ipc/types";
 import { CatalogBadge } from "./CatalogBadge";
 import { KeyValueEditor, arrayToJsonObject } from "./KeyValueEditor";
+import { PluginSetupSection } from "./PluginSetupSection";
+import { serverNeedsSetup } from "./pluginSetup";
 import { usePluginConnect, type ConnectFeedback } from "./usePluginConnect";
 
 // Keyed on the full kind union so adding a feedback kind forces a
@@ -24,6 +27,7 @@ import { usePluginConnect, type ConnectFeedback } from "./usePluginConnect";
 const FEEDBACK_TITLES: Record<ConnectFeedback["kind"], string> = {
   unauthorized: "Server requires authentication",
   discovery_failed: "Server doesn't support OAuth",
+  credentials: "Authentication failed",
 };
 
 export function PluginDetailPage({ serverId }: { serverId: number }) {
@@ -49,6 +53,10 @@ export function PluginDetailPage({ serverId }: { serverId: number }) {
     onEnableOAuthAndRetry,
     onDisableOAuthAndRetry,
   } = usePluginConnect();
+
+  // The server's catalog entry supplies the declared setup fields. It's a
+  // cached read that returns nothing for manually-added servers.
+  const catalogQuery = useMcpCatalog();
 
   const s = servers.find((srv) => srv.id === serverId);
 
@@ -85,6 +93,13 @@ export function PluginDetailPage({ serverId }: { serverId: number }) {
   const discoveredTools = toolsByServer[s.id];
   const tools = discoveredTools ?? [];
   const feedback = feedbackFor(s);
+
+  const catalogEntry = s.catalogSlug
+    ? catalogQuery.data?.entries.find((e) => e.slug === s.catalogSlug)
+    : undefined;
+  const setupInputs = catalogEntry?.inputs ?? [];
+  // Show the guided setup until every declared field has a saved value.
+  const needsSetup = serverNeedsSetup(s, setupInputs);
 
   const onSetToolConsent = async (
     toolName: string,
@@ -139,7 +154,7 @@ export function PluginDetailPage({ serverId }: { serverId: number }) {
               </div>
             </div>
             <div className="flex items-center gap-2 shrink-0">
-              {s.oauthEnabled && !s.oauthConnected && (
+              {s.oauthEnabled && !s.oauthConnected && !needsSetup && (
                 // Only one OAuth flow can run at a time (shared
                 // connect slot), so Connect is blocked while any
                 // server is connecting; the label only spins for this
@@ -152,7 +167,7 @@ export function PluginDetailPage({ serverId }: { serverId: number }) {
                   {connectingServerId === s.id ? "Connecting…" : "Connect"}
                 </Button>
               )}
-              {s.oauthEnabled && s.oauthConnected && (
+              {s.oauthEnabled && s.oauthConnected && !needsSetup && (
                 <Button
                   variant="outline"
                   onClick={() => onDisconnect(s.id)}
@@ -181,7 +196,7 @@ export function PluginDetailPage({ serverId }: { serverId: number }) {
             </div>
           </div>
 
-          {feedback && (
+          {feedback && !needsSetup && (
             <div className="mt-4">
               <Alert variant="destructive">
                 <AlertTitle>{FEEDBACK_TITLES[feedback.kind]}</AlertTitle>
@@ -210,7 +225,22 @@ export function PluginDetailPage({ serverId }: { serverId: number }) {
             </div>
           )}
 
-          {s.transport === "stdio" && (
+          {needsSetup && (
+            <PluginSetupSection
+              server={s}
+              inputs={setupInputs}
+              isSaving={isUpdatingServer}
+              onSave={async (update) => {
+                await updateServer(update);
+                // An OAuth server goes straight into its connect flow
+                // after setup, like the one-click add; key-based servers
+                // just enable and discover.
+                if (s.oauthEnabled) void onConnect(s.id);
+              }}
+            />
+          )}
+
+          {!needsSetup && s.transport === "stdio" && (
             <div className="mt-6">
               <div className="text-sm font-medium mb-2">
                 Environment Variables
@@ -229,7 +259,7 @@ export function PluginDetailPage({ serverId }: { serverId: number }) {
               />
             </div>
           )}
-          {s.transport === "http" && (
+          {!needsSetup && s.transport === "http" && (
             <div className="mt-6">
               <div className="text-sm font-medium mb-2">Headers</div>
               <KeyValueEditor

--- a/src/components/plugins/PluginDetailPage.tsx
+++ b/src/components/plugins/PluginDetailPage.tsx
@@ -100,9 +100,11 @@ export function PluginDetailPage({ serverId }: { serverId: number }) {
   const setupInputs = catalogEntry?.inputs ?? [];
   // Show the guided setup until every declared field has a saved value.
   const needsSetup = serverNeedsSetup(s, setupInputs);
-  // A disabled catalog server whose entry hasn't loaded yet might still
-  // need setup, so keep its controls locked until the catalog resolves.
-  const setupPending = !!s.catalogSlug && !catalogQuery.data && !s.enabled;
+  // A disabled catalog server might still need setup while its catalog is
+  // loading, so keep its controls locked until the fetch settles. Once it
+  // settles (even on error) the toggle works again, so a slow or failing
+  // catalog can't strand an already-configured server.
+  const setupPending = !!s.catalogSlug && catalogQuery.isLoading && !s.enabled;
   const setupIncomplete = needsSetup || setupPending;
 
   const onSetToolConsent = async (
@@ -247,9 +249,7 @@ export function PluginDetailPage({ serverId }: { serverId: number }) {
 
           {setupPending && (
             <div className="mt-4 text-sm text-muted-foreground">
-              {catalogQuery.isError
-                ? "Couldn't load setup details."
-                : "Loading setup…"}
+              Loading setup…
             </div>
           )}
 

--- a/src/components/plugins/PluginDetailPage.tsx
+++ b/src/components/plugins/PluginDetailPage.tsx
@@ -100,6 +100,10 @@ export function PluginDetailPage({ serverId }: { serverId: number }) {
   const setupInputs = catalogEntry?.inputs ?? [];
   // Show the guided setup until every declared field has a saved value.
   const needsSetup = serverNeedsSetup(s, setupInputs);
+  // A disabled catalog server whose entry hasn't loaded yet might still
+  // need setup, so keep its controls locked until the catalog resolves.
+  const setupPending = !!s.catalogSlug && !catalogQuery.data && !s.enabled;
+  const setupIncomplete = needsSetup || setupPending;
 
   const onSetToolConsent = async (
     toolName: string,
@@ -154,7 +158,7 @@ export function PluginDetailPage({ serverId }: { serverId: number }) {
               </div>
             </div>
             <div className="flex items-center gap-2 shrink-0">
-              {s.oauthEnabled && !s.oauthConnected && !needsSetup && (
+              {s.oauthEnabled && !s.oauthConnected && !setupIncomplete && (
                 // Only one OAuth flow can run at a time (shared
                 // connect slot), so Connect is blocked while any
                 // server is connecting; the label only spins for this
@@ -167,7 +171,7 @@ export function PluginDetailPage({ serverId }: { serverId: number }) {
                   {connectingServerId === s.id ? "Connecting…" : "Connect"}
                 </Button>
               )}
-              {s.oauthEnabled && s.oauthConnected && !needsSetup && (
+              {s.oauthEnabled && s.oauthConnected && !setupIncomplete && (
                 <Button
                   variant="outline"
                   onClick={() => onDisconnect(s.id)}
@@ -181,6 +185,7 @@ export function PluginDetailPage({ serverId }: { serverId: number }) {
               <Switch
                 aria-label={`Enabled toggle for ${s.name}`}
                 checked={!!s.enabled}
+                disabled={setupIncomplete}
                 onCheckedChange={() => toggleEnabled(s.id, !!s.enabled)}
               />
               <DeleteConfirmationDialog
@@ -196,7 +201,7 @@ export function PluginDetailPage({ serverId }: { serverId: number }) {
             </div>
           </div>
 
-          {feedback && !needsSetup && (
+          {feedback && !setupIncomplete && (
             <div className="mt-4">
               <Alert variant="destructive">
                 <AlertTitle>{FEEDBACK_TITLES[feedback.kind]}</AlertTitle>
@@ -240,7 +245,15 @@ export function PluginDetailPage({ serverId }: { serverId: number }) {
             />
           )}
 
-          {!needsSetup && s.transport === "stdio" && (
+          {setupPending && (
+            <div className="mt-4 text-sm text-muted-foreground">
+              {catalogQuery.isError
+                ? "Couldn't load setup details."
+                : "Loading setup…"}
+            </div>
+          )}
+
+          {!setupIncomplete && s.transport === "stdio" && (
             <div className="mt-6">
               <div className="text-sm font-medium mb-2">
                 Environment Variables
@@ -259,7 +272,7 @@ export function PluginDetailPage({ serverId }: { serverId: number }) {
               />
             </div>
           )}
-          {!needsSetup && s.transport === "http" && (
+          {!setupIncomplete && s.transport === "http" && (
             <div className="mt-6">
               <div className="text-sm font-medium mb-2">Headers</div>
               <KeyValueEditor

--- a/src/components/plugins/PluginDetailPage.tsx
+++ b/src/components/plugins/PluginDetailPage.tsx
@@ -233,7 +233,11 @@ export function PluginDetailPage({ serverId }: { serverId: number }) {
           )}
 
           {needsSetup && (
+            // Keyed by server so switching between two setup-needing
+            // servers starts each from its own blank fields, never
+            // carrying one server's typed credentials into another.
             <PluginSetupSection
+              key={s.id}
               server={s}
               inputs={setupInputs}
               isSaving={isUpdatingServer}

--- a/src/components/plugins/PluginSetupSection.test.tsx
+++ b/src/components/plugins/PluginSetupSection.test.tsx
@@ -1,0 +1,164 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { McpServer } from "@/ipc/types";
+import type { CatalogInput } from "@/ipc/types/mcp_catalog";
+import { PluginSetupSection } from "./PluginSetupSection";
+
+vi.mock("./AddPluginDialog", () => ({
+  useOauthCallbackPort: () => 53682,
+}));
+
+function makeServer(overrides: Partial<McpServer> = {}): McpServer {
+  return {
+    id: 1,
+    name: "Test Server",
+    transport: "http",
+    command: null,
+    args: null,
+    envJson: null,
+    headersJson: null,
+    url: "https://example.com/mcp",
+    enabled: false,
+    oauthEnabled: false,
+    oauthConnected: false,
+    oauthCallbackPort: null,
+    oauthClientId: null,
+    catalogSlug: "test",
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    ...overrides,
+  };
+}
+
+// Fills inputs in render order; labels aren't tied to the inputs here,
+// so address them positionally.
+function fillInputs(values: string[]) {
+  const all = Array.from(document.querySelectorAll<HTMLInputElement>("input"));
+  all.forEach((input, i) => {
+    if (values[i] !== undefined) {
+      fireEvent.change(input, { target: { value: values[i] } });
+    }
+  });
+}
+
+describe("PluginSetupSection", () => {
+  it("writes a header input to headersJson with its prefix and keeps existing headers", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const inputs: CatalogInput[] = [
+      {
+        kind: "header",
+        name: "Authorization",
+        prefix: "Bearer ",
+        label: "Key",
+      },
+    ];
+    render(
+      <PluginSetupSection
+        server={makeServer({ headersJson: { "X-Existing": "1" } })}
+        inputs={inputs}
+        isSaving={false}
+        onSave={onSave}
+      />,
+    );
+
+    fillInputs(["secret-key"]);
+    fireEvent.click(screen.getByRole("button", { name: "Save & enable" }));
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 1,
+        enabled: true,
+        headersJson: { "X-Existing": "1", Authorization: "Bearer secret-key" },
+      }),
+    );
+    // Header setups don't show the OAuth redirect hint.
+    expect(screen.queryByText(/redirect URI/i)).toBeNull();
+  });
+
+  it("writes an env input to envJson", () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const inputs: CatalogInput[] = [
+      { kind: "env", name: "API_TOKEN", label: "Token" },
+    ];
+    render(
+      <PluginSetupSection
+        server={makeServer({ transport: "stdio", url: null })}
+        inputs={inputs}
+        isSaving={false}
+        onSave={onSave}
+      />,
+    );
+
+    fillInputs(["tok-123"]);
+    fireEvent.click(screen.getByRole("button", { name: "Save & enable" }));
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: true,
+        envJson: { API_TOKEN: "tok-123" },
+      }),
+    );
+  });
+
+  it("writes oauth client id/secret and shows the redirect-URI hint with the callback port", () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const inputs: CatalogInput[] = [
+      { kind: "oauthClientId" },
+      { kind: "oauthClientSecret" },
+    ];
+    render(
+      <PluginSetupSection
+        server={makeServer()}
+        inputs={inputs}
+        isSaving={false}
+        onSave={onSave}
+      />,
+    );
+
+    // The client id renders as text, the secret as a password field.
+    expect(screen.getByText(/localhost:53682\/callback/)).toBeTruthy();
+
+    fillInputs(["client-abc", "secret-xyz"]);
+    fireEvent.click(screen.getByRole("button", { name: "Save & enable" }));
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: true,
+        oauthClientId: "client-abc",
+        oauthClientSecret: "secret-xyz",
+      }),
+    );
+  });
+
+  it("keeps Save disabled until every input is filled", () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const inputs: CatalogInput[] = [
+      { kind: "oauthClientId" },
+      { kind: "oauthClientSecret" },
+    ];
+    render(
+      <PluginSetupSection
+        server={makeServer()}
+        inputs={inputs}
+        isSaving={false}
+        onSave={onSave}
+      />,
+    );
+
+    const button = screen.getByRole<HTMLButtonElement>("button", {
+      name: "Save & enable",
+    });
+    expect(button.disabled).toBe(true);
+
+    // Only the first field filled: still incomplete.
+    const allInputs = Array.from(
+      document.querySelectorAll<HTMLInputElement>("input"),
+    );
+    fireEvent.change(allInputs[0], { target: { value: "client-abc" } });
+    expect(button.disabled).toBe(true);
+
+    fireEvent.change(allInputs[1], { target: { value: "secret-xyz" } });
+    expect(button.disabled).toBe(false);
+  });
+});

--- a/src/components/plugins/PluginSetupSection.tsx
+++ b/src/components/plugins/PluginSetupSection.tsx
@@ -1,0 +1,114 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { CatalogInput } from "@/ipc/types/mcp_catalog";
+import type { McpServer } from "@/ipc/types";
+import type { McpServerUpdate } from "@/ipc/types/mcp";
+import { useOauthCallbackPort } from "./AddPluginDialog";
+
+// A stable key per input, and where its value is stored, both derive from
+// `kind` (plus `name` for the ones that address a specific header/var).
+function keyOf(input: CatalogInput): string {
+  if (input.kind === "header") return `header:${input.name}`;
+  if (input.kind === "env") return `env:${input.name}`;
+  return input.kind;
+}
+
+function labelOf(input: CatalogInput): string {
+  if (input.kind === "oauthClientId") return "Client ID";
+  if (input.kind === "oauthClientSecret") return "Client secret";
+  return input.label;
+}
+
+// The client ID is a public identifier; keys and secrets are masked.
+function isSecret(input: CatalogInput): boolean {
+  return input.kind !== "oauthClientId";
+}
+
+/**
+ * Collects the values a catalog entry declares it needs, writes each to
+ * its column, and enables the server. Shown while a field-requiring
+ * server is still disabled.
+ */
+export function PluginSetupSection({
+  server,
+  inputs,
+  isSaving,
+  onSave,
+}: {
+  server: McpServer;
+  inputs: CatalogInput[];
+  isSaving: boolean;
+  onSave: (update: McpServerUpdate) => Promise<void>;
+}) {
+  const [values, setValues] = useState<Record<string, string>>({});
+  const allFilled = inputs.every((input) =>
+    (values[keyOf(input)] ?? "").trim(),
+  );
+  // Only OAuth-client setups need a redirect URI registered at the
+  // provider; the port matches the one the connect flow will bind.
+  const callbackPort = useOauthCallbackPort();
+  const needsCallbackUrl = inputs.some(
+    (input) => input.kind === "oauthClientId",
+  );
+
+  const save = async () => {
+    const headers: Record<string, string> = { ...server.headersJson };
+    const env: Record<string, string> = { ...server.envJson };
+    const update: McpServerUpdate = {
+      id: server.id,
+      enabled: true,
+      headersJson: headers,
+      envJson: env,
+    };
+    for (const input of inputs) {
+      const value = (values[keyOf(input)] ?? "").trim();
+      if (!value) continue;
+      if (input.kind === "oauthClientId") update.oauthClientId = value;
+      else if (input.kind === "oauthClientSecret")
+        update.oauthClientSecret = value;
+      else if (input.kind === "header")
+        headers[input.name] = (input.prefix ?? "") + value;
+      else if (input.kind === "env") env[input.name] = value;
+    }
+    await onSave(update);
+  };
+
+  return (
+    <div
+      className="mt-4 rounded-lg border border-amber-500/40 bg-amber-50/50 p-4 dark:bg-amber-900/10"
+      data-testid="plugin-setup"
+    >
+      <div className="text-sm font-medium">Finish setup</div>
+      <div className="mt-3 space-y-3">
+        {inputs.map((input) => {
+          const key = keyOf(input);
+          return (
+            <div key={key} className="space-y-1">
+              <Label>{labelOf(input)}</Label>
+              <Input
+                type={isSecret(input) ? "password" : "text"}
+                value={values[key] ?? ""}
+                onChange={(e) =>
+                  setValues((prev) => ({ ...prev, [key]: e.target.value }))
+                }
+              />
+            </div>
+          );
+        })}
+      </div>
+      {needsCallbackUrl && (
+        <p className="text-muted-foreground mt-3 text-sm">
+          Register this as the app's redirect URI at the provider:{" "}
+          <code className="text-foreground bg-muted rounded px-1 py-0.5">
+            http://localhost:{callbackPort ?? "…"}/callback
+          </code>
+        </p>
+      )}
+      <Button className="mt-3" onClick={save} disabled={!allFilled || isSaving}>
+        {isSaving ? "Saving…" : "Save & enable"}
+      </Button>
+    </div>
+  );
+}

--- a/src/components/plugins/PluginSetupSection.tsx
+++ b/src/components/plugins/PluginSetupSection.tsx
@@ -26,6 +26,34 @@ function isSecret(input: CatalogInput): boolean {
   return input.kind !== "oauthClientId";
 }
 
+// Pre-fill values the renderer already has for a partially-configured
+// server (a stored header/env value or the client id) so re-entering
+// setup doesn't force re-typing them. The client secret never reaches
+// the renderer, so it stays blank.
+function seedValues(
+  server: McpServer,
+  inputs: CatalogInput[],
+): Record<string, string> {
+  const seed: Record<string, string> = {};
+  for (const input of inputs) {
+    if (input.kind === "header") {
+      const stored = server.headersJson?.[input.name];
+      if (stored != null) {
+        seed[keyOf(input)] =
+          input.prefix && stored.startsWith(input.prefix)
+            ? stored.slice(input.prefix.length)
+            : stored;
+      }
+    } else if (input.kind === "env") {
+      const stored = server.envJson?.[input.name];
+      if (stored != null) seed[keyOf(input)] = stored;
+    } else if (input.kind === "oauthClientId" && server.oauthClientId) {
+      seed[keyOf(input)] = server.oauthClientId;
+    }
+  }
+  return seed;
+}
+
 /**
  * Collects the values a catalog entry declares it needs, writes each to
  * its column, and enables the server. Shown while a field-requiring
@@ -42,7 +70,9 @@ export function PluginSetupSection({
   isSaving: boolean;
   onSave: (update: McpServerUpdate) => Promise<void>;
 }) {
-  const [values, setValues] = useState<Record<string, string>>({});
+  const [values, setValues] = useState<Record<string, string>>(() =>
+    seedValues(server, inputs),
+  );
   const allFilled = inputs.every((input) =>
     (values[keyOf(input)] ?? "").trim(),
   );

--- a/src/components/plugins/PluginSetupSection.tsx
+++ b/src/components/plugins/PluginSetupSection.tsx
@@ -54,24 +54,28 @@ export function PluginSetupSection({
   );
 
   const save = async () => {
+    const update: McpServerUpdate = { id: server.id, enabled: true };
     const headers: Record<string, string> = { ...server.headersJson };
     const env: Record<string, string> = { ...server.envJson };
-    const update: McpServerUpdate = {
-      id: server.id,
-      enabled: true,
-      headersJson: headers,
-      envJson: env,
-    };
+    let wroteHeader = false;
+    let wroteEnv = false;
     for (const input of inputs) {
       const value = (values[keyOf(input)] ?? "").trim();
       if (!value) continue;
       if (input.kind === "oauthClientId") update.oauthClientId = value;
       else if (input.kind === "oauthClientSecret")
         update.oauthClientSecret = value;
-      else if (input.kind === "header")
+      else if (input.kind === "header") {
         headers[input.name] = (input.prefix ?? "") + value;
-      else if (input.kind === "env") env[input.name] = value;
+        wroteHeader = true;
+      } else if (input.kind === "env") {
+        env[input.name] = value;
+        wroteEnv = true;
+      }
     }
+    // Only touch the columns the entry actually declares inputs for.
+    if (wroteHeader) update.headersJson = headers;
+    if (wroteEnv) update.envJson = env;
     await onSave(update);
   };
 
@@ -86,8 +90,9 @@ export function PluginSetupSection({
           const key = keyOf(input);
           return (
             <div key={key} className="space-y-1">
-              <Label>{labelOf(input)}</Label>
+              <Label htmlFor={key}>{labelOf(input)}</Label>
               <Input
+                id={key}
                 type={isSecret(input) ? "password" : "text"}
                 value={values[key] ?? ""}
                 onChange={(e) =>
@@ -106,7 +111,11 @@ export function PluginSetupSection({
           </code>
         </p>
       )}
-      <Button className="mt-3" onClick={save} disabled={!allFilled || isSaving}>
+      <Button
+        className="mt-3"
+        onClick={() => void save().catch(() => {})}
+        disabled={!allFilled || isSaving}
+      >
         {isSaving ? "Saving…" : "Save & enable"}
       </Button>
     </div>

--- a/src/components/plugins/PluginSetupSection.tsx
+++ b/src/components/plugins/PluginSetupSection.tsx
@@ -118,12 +118,17 @@ export function PluginSetupSection({
       <div className="mt-3 space-y-3">
         {inputs.map((input) => {
           const key = keyOf(input);
+          // Namespace the DOM id by server so two setups on screen can't
+          // share an id.
+          const fieldId = `setup-${server.id}-${key}`;
           return (
             <div key={key} className="space-y-1">
-              <Label htmlFor={key}>{labelOf(input)}</Label>
+              <Label htmlFor={fieldId}>{labelOf(input)}</Label>
               <Input
-                id={key}
+                id={fieldId}
                 type={isSecret(input) ? "password" : "text"}
+                autoComplete="off"
+                spellCheck={false}
                 value={values[key] ?? ""}
                 onChange={(e) =>
                   setValues((prev) => ({ ...prev, [key]: e.target.value }))

--- a/src/components/plugins/PluginSetupSection.tsx
+++ b/src/components/plugins/PluginSetupSection.tsx
@@ -26,34 +26,6 @@ function isSecret(input: CatalogInput): boolean {
   return input.kind !== "oauthClientId";
 }
 
-// Pre-fill values the renderer already has for a partially-configured
-// server (a stored header/env value or the client id) so re-entering
-// setup doesn't force re-typing them. The client secret never reaches
-// the renderer, so it stays blank.
-function seedValues(
-  server: McpServer,
-  inputs: CatalogInput[],
-): Record<string, string> {
-  const seed: Record<string, string> = {};
-  for (const input of inputs) {
-    if (input.kind === "header") {
-      const stored = server.headersJson?.[input.name];
-      if (stored != null) {
-        seed[keyOf(input)] =
-          input.prefix && stored.startsWith(input.prefix)
-            ? stored.slice(input.prefix.length)
-            : stored;
-      }
-    } else if (input.kind === "env") {
-      const stored = server.envJson?.[input.name];
-      if (stored != null) seed[keyOf(input)] = stored;
-    } else if (input.kind === "oauthClientId" && server.oauthClientId) {
-      seed[keyOf(input)] = server.oauthClientId;
-    }
-  }
-  return seed;
-}
-
 /**
  * Collects the values a catalog entry declares it needs, writes each to
  * its column, and enables the server. Shown while a field-requiring
@@ -70,9 +42,7 @@ export function PluginSetupSection({
   isSaving: boolean;
   onSave: (update: McpServerUpdate) => Promise<void>;
 }) {
-  const [values, setValues] = useState<Record<string, string>>(() =>
-    seedValues(server, inputs),
-  );
+  const [values, setValues] = useState<Record<string, string>>({});
   const allFilled = inputs.every((input) =>
     (values[keyOf(input)] ?? "").trim(),
   );

--- a/src/components/plugins/PluginSummaryCard.tsx
+++ b/src/components/plugins/PluginSummaryCard.tsx
@@ -9,6 +9,7 @@ import type { ConnectFeedback } from "./usePluginConnect";
 
 export function PluginSummaryCard({
   server: s,
+  needsSetup,
   toolCount,
   enabledToolCount,
   discoveryFailed,
@@ -20,6 +21,8 @@ export function PluginSummaryCard({
   onOpen,
 }: {
   server: McpServer;
+  /** A catalog server with declared setup fields still unfilled. */
+  needsSetup: boolean;
   toolCount: number | null;
   enabledToolCount: number | null;
   /** Discovery settled without a tool list (unreachable or unauthorized). */
@@ -53,9 +56,14 @@ export function PluginSummaryCard({
         <CardTitle className="text-lg font-medium mb-1 flex items-center gap-2 min-w-0">
           <span className="truncate">{s.name}</span>
           {s.catalogSlug && <CatalogBadge />}
-          {feedback ? (
+          {needsSetup ? (
+            <span className="text-xs font-medium px-2 py-1 rounded-full shrink-0 text-amber-600 bg-amber-50 dark:bg-amber-900/30 dark:text-amber-300 border border-amber-500/50">
+              Needs setup
+            </span>
+          ) : feedback ? (
             <span className="text-xs font-medium px-2 py-1 rounded-full text-red-600 bg-red-50 border border-red-500/50 dark:bg-red-900/30 dark:text-red-300 shrink-0">
-              {feedback.kind === "unauthorized"
+              {feedback.kind === "unauthorized" ||
+              feedback.kind === "credentials"
                 ? "Needs auth"
                 : "Connection error"}
             </span>

--- a/src/components/plugins/PluginSummaryCard.tsx
+++ b/src/components/plugins/PluginSummaryCard.tsx
@@ -10,6 +10,7 @@ import type { ConnectFeedback } from "./usePluginConnect";
 export function PluginSummaryCard({
   server: s,
   needsSetup,
+  setupLocked,
   toolCount,
   enabledToolCount,
   discoveryFailed,
@@ -23,6 +24,8 @@ export function PluginSummaryCard({
   server: McpServer;
   /** A catalog server with declared setup fields still unfilled. */
   needsSetup: boolean;
+  /** Setup is unfinished or its catalog entry hasn't resolved; lock controls. */
+  setupLocked: boolean;
   toolCount: number | null;
   enabledToolCount: number | null;
   /** Discovery settled without a tool list (unreachable or unauthorized). */
@@ -96,7 +99,7 @@ export function PluginSummaryCard({
           </span>
           <div className="flex items-center gap-2">
             <div className="relative z-10 flex items-center gap-2">
-              {s.oauthEnabled && !s.oauthConnected && (
+              {s.oauthEnabled && !s.oauthConnected && !setupLocked && (
                 <Button
                   size="sm"
                   onClick={() => onConnect(s.id)}
@@ -115,6 +118,7 @@ export function PluginSummaryCard({
                 id={`plugin-enabled-${s.id}`}
                 aria-label={`Enabled toggle for ${s.name}`}
                 checked={!!s.enabled}
+                disabled={setupLocked}
                 onCheckedChange={() => onToggleEnabled(s.id, !!s.enabled)}
               />
             </div>

--- a/src/components/plugins/PluginsList.tsx
+++ b/src/components/plugins/PluginsList.tsx
@@ -3,10 +3,13 @@ import { useNavigate } from "@tanstack/react-router";
 import { Card, CardHeader } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useMcp } from "@/hooks/useMcp";
+import { useMcpCatalog } from "@/hooks/useMcpCatalog";
+import type { CatalogInput } from "@/ipc/types/mcp_catalog";
 import { AddPluginDialog, useOauthStorageEncrypted } from "./AddPluginDialog";
 import { OauthPlaintextStorageAlert } from "./OauthPlaintextStorageAlert";
 import { PluginSummaryCard } from "./PluginSummaryCard";
 import { PluginsStats } from "./PluginsStats";
+import { serverNeedsSetup } from "./pluginSetup";
 import { usePluginConnect } from "./usePluginConnect";
 
 export function PluginsList({
@@ -31,6 +34,17 @@ export function PluginsList({
     usePluginConnect();
 
   const oauthStorageEncrypted = useOauthStorageEncrypted();
+
+  const catalogQuery = useMcpCatalog();
+  // Declared setup fields per catalog slug, so a card can tell whether
+  // its server still has any unfilled.
+  const inputsBySlug = useMemo(() => {
+    const map = new Map<string, CatalogInput[]>();
+    for (const e of catalogQuery.data?.entries ?? []) {
+      if (e.inputs?.length) map.set(e.slug, e.inputs);
+    }
+    return map;
+  }, [catalogQuery.data]);
 
   const hasOauthServer = useMemo(
     () => (servers || []).some((s) => s.transport === "http" && s.oauthEnabled),
@@ -82,6 +96,10 @@ export function PluginsList({
             <PluginSummaryCard
               key={s.id}
               server={s}
+              needsSetup={
+                !!s.catalogSlug &&
+                serverNeedsSetup(s, inputsBySlug.get(s.catalogSlug) ?? [])
+              }
               toolCount={toolCountFor(s.id)}
               enabledToolCount={enabledToolCountFor(s.id)}
               discoveryFailed={discoveryFailedFor(s.id)}

--- a/src/components/plugins/PluginsList.tsx
+++ b/src/components/plugins/PluginsList.tsx
@@ -96,12 +96,12 @@ export function PluginsList({
             const needsSetup =
               !!s.catalogSlug &&
               serverNeedsSetup(s, inputsBySlug.get(s.catalogSlug) ?? []);
-            // A disabled catalog server whose entry hasn't loaded yet
-            // might still need setup, so lock its controls until the
-            // catalog resolves.
+            // A disabled catalog server might still need setup while its
+            // catalog is loading, so lock its controls until the fetch
+            // settles rather than for as long as data is missing.
             const setupLocked =
               needsSetup ||
-              (!!s.catalogSlug && !catalogQuery.data && !s.enabled);
+              (!!s.catalogSlug && catalogQuery.isLoading && !s.enabled);
             return (
               <PluginSummaryCard
                 key={s.id}

--- a/src/components/plugins/PluginsList.tsx
+++ b/src/components/plugins/PluginsList.tsx
@@ -92,30 +92,39 @@ export function PluginsList({
         </div>
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-          {servers.map((s) => (
-            <PluginSummaryCard
-              key={s.id}
-              server={s}
-              needsSetup={
-                !!s.catalogSlug &&
-                serverNeedsSetup(s, inputsBySlug.get(s.catalogSlug) ?? [])
-              }
-              toolCount={toolCountFor(s.id)}
-              enabledToolCount={enabledToolCountFor(s.id)}
-              discoveryFailed={discoveryFailedFor(s.id)}
-              feedback={feedbackFor(s)}
-              isConnecting={connectingServerId === s.id}
-              connectDisabled={connectingServerId !== null}
-              onConnect={onConnect}
-              onToggleEnabled={toggleEnabled}
-              onOpen={(serverId) =>
-                navigate({
-                  to: "/plugins/$serverId",
-                  params: { serverId },
-                })
-              }
-            />
-          ))}
+          {servers.map((s) => {
+            const needsSetup =
+              !!s.catalogSlug &&
+              serverNeedsSetup(s, inputsBySlug.get(s.catalogSlug) ?? []);
+            // A disabled catalog server whose entry hasn't loaded yet
+            // might still need setup, so lock its controls until the
+            // catalog resolves.
+            const setupLocked =
+              needsSetup ||
+              (!!s.catalogSlug && !catalogQuery.data && !s.enabled);
+            return (
+              <PluginSummaryCard
+                key={s.id}
+                server={s}
+                needsSetup={needsSetup}
+                setupLocked={setupLocked}
+                toolCount={toolCountFor(s.id)}
+                enabledToolCount={enabledToolCountFor(s.id)}
+                discoveryFailed={discoveryFailedFor(s.id)}
+                feedback={feedbackFor(s)}
+                isConnecting={connectingServerId === s.id}
+                connectDisabled={connectingServerId !== null}
+                onConnect={onConnect}
+                onToggleEnabled={toggleEnabled}
+                onOpen={(serverId) =>
+                  navigate({
+                    to: "/plugins/$serverId",
+                    params: { serverId },
+                  })
+                }
+              />
+            );
+          })}
           {servers.length === 0 && (
             <div className="col-span-full text-sm text-muted-foreground">
               No plugins added yet.

--- a/src/components/plugins/catalog/CatalogSection.tsx
+++ b/src/components/plugins/catalog/CatalogSection.tsx
@@ -1,9 +1,7 @@
 import { useMemo, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
 import { Star } from "lucide-react";
 import { Input } from "@/components/ui/input";
-import { ipc } from "@/ipc/types";
-import { queryKeys } from "@/lib/queryKeys";
+import { useMcpCatalog } from "@/hooks/useMcpCatalog";
 import { CatalogCard } from "./CatalogCard";
 import { StdioCatalogConsentDialog } from "./StdioCatalogConsentDialog";
 import { useAddFromCatalog } from "./useAddFromCatalog";
@@ -18,16 +16,7 @@ export function CatalogSection() {
     cancelPendingStdio,
   } = useAddFromCatalog();
 
-  const catalogQuery = useQuery({
-    queryKey: queryKeys.mcp.catalog,
-    queryFn: () => ipc.mcp.listCatalog(),
-    // Cache a populated catalog for an hour, but expire an empty result
-    // quickly so a transient fetch failure doesn't hide the section
-    // until the next remount.
-    staleTime: (query) =>
-      query.state.data?.entries.length ? 60 * 60 * 1000 : 30 * 1000,
-    refetchOnWindowFocus: false,
-  });
+  const catalogQuery = useMcpCatalog();
 
   const entries = catalogQuery.data?.entries ?? [];
   const addedSlugs = useMemo(

--- a/src/components/plugins/catalog/useAddFromCatalog.ts
+++ b/src/components/plugins/catalog/useAddFromCatalog.ts
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { McpCatalogEntry } from "@/ipc/types/mcp_catalog";
 import { ipc } from "@/ipc/types";
@@ -8,6 +9,7 @@ import { usePluginConnect } from "../usePluginConnect";
 
 export function useAddFromCatalog() {
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
   const [addingSlug, setAddingSlug] = useState<string | null>(null);
   // A stdio entry awaiting the user's run-locally consent. Null when no
   // consent is pending.
@@ -60,6 +62,17 @@ export function useAddFromCatalog() {
     }
     if (!created) return;
     showSuccess(`Added "${created.name}"`);
+
+    // A server that declares inputs was added disabled and needs the user
+    // to fill them in, so send them to its setup page instead of
+    // connecting.
+    if ((entry.inputs?.length ?? 0) > 0) {
+      navigate({
+        to: "/plugins/$serverId",
+        params: { serverId: String(created.id) },
+      });
+      return;
+    }
 
     // Only required-OAuth servers connect automatically. Optional ones
     // work anonymously and offer Connect on their card. The connect

--- a/src/components/plugins/catalog/useAddFromCatalog.ts
+++ b/src/components/plugins/catalog/useAddFromCatalog.ts
@@ -69,7 +69,7 @@ export function useAddFromCatalog() {
     if ((entry.inputs?.length ?? 0) > 0) {
       navigate({
         to: "/plugins/$serverId",
-        params: { serverId: String(created.id) },
+        params: { serverId: created.id },
       });
       return;
     }

--- a/src/components/plugins/pluginSetup.ts
+++ b/src/components/plugins/pluginSetup.ts
@@ -1,0 +1,27 @@
+import type { McpServer } from "@/ipc/types";
+import type { CatalogInput } from "@/ipc/types/mcp_catalog";
+
+// Whether a declared setup input already has a stored value. The client
+// secret never reaches the renderer, so a saved client id stands in for
+// the id/secret pair it was saved alongside.
+function isInputSatisfied(server: McpServer, input: CatalogInput): boolean {
+  switch (input.kind) {
+    case "header":
+      return !!server.headersJson?.[input.name];
+    case "env":
+      return !!server.envJson?.[input.name];
+    case "oauthClientId":
+    case "oauthClientSecret":
+      return !!server.oauthClientId;
+  }
+}
+
+// A catalog server needs setup while any input it declares is still
+// unfilled, independent of enabled state: disabling a configured server
+// must not send it back through setup.
+export function serverNeedsSetup(
+  server: McpServer,
+  inputs: CatalogInput[],
+): boolean {
+  return inputs.some((input) => !isInputSatisfied(server, input));
+}

--- a/src/components/plugins/usePluginConnect.ts
+++ b/src/components/plugins/usePluginConnect.ts
@@ -1,5 +1,7 @@
+import { useMemo } from "react";
 import { atom, useAtom } from "jotai";
 import { useMcp } from "@/hooks/useMcp";
+import { useMcpCatalog } from "@/hooks/useMcpCatalog";
 import type { McpServer } from "@/ipc/types";
 import { ipc } from "@/ipc/types";
 import { showError, showInfo, showSuccess } from "@/lib/toast";
@@ -9,7 +11,7 @@ import { useOauthCallbackPort } from "./AddPluginDialog";
 // render it as a badge or alert.
 export type ConnectFeedback = {
   serverId: number;
-  kind: "discovery_failed" | "unauthorized";
+  kind: "discovery_failed" | "unauthorized" | "credentials";
   message: string;
 };
 
@@ -34,6 +36,24 @@ export function usePluginConnect() {
   const [connectFeedback, setConnectFeedback] = useAtom(connectFeedbackAtom);
 
   const callbackPort = useOauthCallbackPort();
+
+  const catalogQuery = useMcpCatalog();
+  // Catalog slugs whose entries authenticate via a user-supplied key, so
+  // a 401 means "check the key", not "enable OAuth" -- even before the
+  // key has been entered.
+  const slugsNeedingKey = useMemo(
+    () =>
+      new Set(
+        (catalogQuery.data?.entries ?? [])
+          .filter((e) =>
+            (e.inputs ?? []).some(
+              (i) => i.kind === "header" || i.kind === "env",
+            ),
+          )
+          .map((e) => e.slug),
+      ),
+    [catalogQuery.data],
+  );
 
   // Sole owner of the shared connect slot: claims it for the duration
   // of `fn`. Buttons that start a connect flow disable while the slot
@@ -199,6 +219,22 @@ export function usePluginConnect() {
       return connectFeedback;
     }
     if (!server.oauthEnabled && statusByServer[server.id] === "unauthorized") {
+      // If the catalog says this server needs an API key, treat a 401 as
+      // a bad key rather than a sign that OAuth is required. Manual
+      // servers have no entry, so infer that from any headers/env they set.
+      const wantsKey =
+        server.catalogSlug != null
+          ? slugsNeedingKey.has(server.catalogSlug)
+          : Object.keys(server.headersJson ?? {}).length > 0 ||
+            Object.keys(server.envJson ?? {}).length > 0;
+      if (wantsKey) {
+        return {
+          serverId: server.id,
+          kind: "credentials",
+          message:
+            "This server rejected the provided credentials. Check that your API key or token is correct.",
+        };
+      }
       return {
         serverId: server.id,
         kind: "unauthorized",

--- a/src/components/plugins/usePluginConnect.ts
+++ b/src/components/plugins/usePluginConnect.ts
@@ -220,13 +220,9 @@ export function usePluginConnect() {
     }
     if (!server.oauthEnabled && statusByServer[server.id] === "unauthorized") {
       // If the catalog says this server needs an API key, treat a 401 as
-      // a bad key rather than a sign that OAuth is required. Manual
-      // servers have no entry, so infer that from any headers/env they set.
+      // a bad key rather than a sign that OAuth is required.
       const wantsKey =
-        server.catalogSlug != null
-          ? slugsNeedingKey.has(server.catalogSlug)
-          : Object.keys(server.headersJson ?? {}).length > 0 ||
-            Object.keys(server.envJson ?? {}).length > 0;
+        server.catalogSlug != null && slugsNeedingKey.has(server.catalogSlug);
       if (wantsKey) {
         return {
           serverId: server.id,

--- a/src/hooks/useMcp.ts
+++ b/src/hooks/useMcp.ts
@@ -123,7 +123,20 @@ export function useMcp() {
     mutationFn: async (params: McpServerUpdate) => {
       return ipc.mcp.updateServer(params);
     },
-    onSuccess: async () => {
+    onSuccess: async (_result, params) => {
+      // Drop this server's cached probe result before re-discovering, so a
+      // status from before the change (e.g. a 401 from before its key was
+      // saved) can't briefly show as a failure. The batched query keeps
+      // previous data through a refetch, which would otherwise retain it.
+      queryClient.setQueriesData<Record<number, McpListToolsResult>>(
+        { queryKey: queryKeys.mcp.toolsByServer.all },
+        (old) => {
+          if (!old || !(params.id in old)) return old;
+          const next = { ...old };
+          delete next[params.id];
+          return next;
+        },
+      );
       await queryClient.invalidateQueries({ queryKey: queryKeys.mcp.servers });
       await queryClient.invalidateQueries({
         queryKey: queryKeys.mcp.toolsByServer.all,

--- a/src/hooks/useMcpCatalog.ts
+++ b/src/hooks/useMcpCatalog.ts
@@ -1,0 +1,17 @@
+import { useQuery } from "@tanstack/react-query";
+import { ipc } from "@/ipc/types";
+import { queryKeys } from "@/lib/queryKeys";
+
+// Shared read of the curated MCP catalog. Every caller uses the same
+// query key, so TanStack dedups them into one fetch and one cache entry.
+// Cache a populated catalog for an hour, but expire an empty result
+// quickly so a transient fetch failure doesn't hide it until remount.
+export function useMcpCatalog() {
+  return useQuery({
+    queryKey: queryKeys.mcp.catalog,
+    queryFn: () => ipc.mcp.listCatalog(),
+    staleTime: (query) =>
+      query.state.data?.entries.length ? 60 * 60 * 1000 : 30 * 1000,
+    refetchOnWindowFocus: false,
+  });
+}

--- a/src/hooks/useMcpCatalog.ts
+++ b/src/hooks/useMcpCatalog.ts
@@ -12,6 +12,10 @@ export function useMcpCatalog() {
     queryFn: () => ipc.mcp.listCatalog(),
     staleTime: (query) =>
       query.state.data?.entries.length ? 60 * 60 * 1000 : 30 * 1000,
+    // Staleness alone doesn't refetch, so poll while the catalog is empty
+    // (e.g. after a transient fetch failure) until it fills.
+    refetchInterval: (query) =>
+      query.state.data?.entries.length ? false : 30 * 1000,
     refetchOnWindowFocus: false,
   });
 }

--- a/src/ipc/handlers/__tests__/mcp_catalog.integration.test.tsx
+++ b/src/ipc/handlers/__tests__/mcp_catalog.integration.test.tsx
@@ -268,4 +268,51 @@ describe("Plugins catalog (integration)", () => {
       clearMcpCatalogCacheForTests();
     }
   }, 40_000);
+
+  it("adds a field-requiring entry disabled, then setup enables it", async () => {
+    const previousPayload = catalogPayload;
+    catalogPayload = {
+      servers: [
+        {
+          slug: "integration-apikey",
+          name: "Integration API-key Server",
+          category: "Testing",
+          transport: "http",
+          url: `http://localhost:${mcpPort}/mcp`,
+          inputs: [
+            {
+              kind: "header",
+              name: "Authorization",
+              prefix: "Bearer ",
+              label: "API key",
+            },
+          ],
+        },
+      ],
+    };
+    clearMcpCatalogCacheForTests();
+    try {
+      // A declared-input entry is added disabled so it can't connect
+      // before the user fills in the key.
+      const created = await ipc.mcp.addFromCatalog({
+        slug: "integration-apikey",
+      });
+      expect(created.enabled).toBe(false);
+      expect(created.catalogSlug).toBe("integration-apikey");
+
+      // Saving the setup fields writes the header and enables the server.
+      const updated = await ipc.mcp.updateServer({
+        id: created.id,
+        enabled: true,
+        headersJson: { Authorization: "Bearer secret-key" },
+      });
+      expect(updated.enabled).toBe(true);
+      expect(updated.headersJson).toEqual({
+        Authorization: "Bearer secret-key",
+      });
+    } finally {
+      catalogPayload = previousPayload;
+      clearMcpCatalogCacheForTests();
+    }
+  }, 40_000);
 });

--- a/src/ipc/handlers/__tests__/mcp_catalog.integration.test.tsx
+++ b/src/ipc/handlers/__tests__/mcp_catalog.integration.test.tsx
@@ -16,6 +16,10 @@ import {
   type HybridChatHarness,
 } from "@/testing/hybrid_chat_harness";
 import { h } from "@/testing/hybrid.setup";
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { mcpServers } from "@/db/schema";
+import { decryptFromString } from "@/ipc/utils/mcp_oauth_provider";
 
 describe("Plugins catalog (integration)", () => {
   let harness: HybridChatHarness;
@@ -310,6 +314,96 @@ describe("Plugins catalog (integration)", () => {
       expect(updated.headersJson).toEqual({
         Authorization: "Bearer secret-key",
       });
+    } finally {
+      catalogPayload = previousPayload;
+      clearMcpCatalogCacheForTests();
+    }
+  }, 40_000);
+
+  it("adds a field-requiring stdio entry disabled, then setup writes its env var", async () => {
+    const previousPayload = catalogPayload;
+    catalogPayload = {
+      servers: [
+        {
+          slug: "integration-env",
+          name: "Integration Env Server",
+          category: "Testing",
+          transport: "stdio",
+          command: "npx",
+          args: ["-y", "@dyad-sh/e2e-nonexistent-mcp@1.0.0"],
+          inputs: [{ kind: "env", name: "API_TOKEN", label: "Token" }],
+        },
+      ],
+    };
+    clearMcpCatalogCacheForTests();
+    try {
+      // A stdio entry with inputs is added disabled too, so its package
+      // never spawns before the env var is filled in.
+      const created = await ipc.mcp.addFromCatalog({
+        slug: "integration-env",
+        expectedStdioConfig: {
+          command: "npx",
+          args: ["-y", "@dyad-sh/e2e-nonexistent-mcp@1.0.0"],
+        },
+      });
+      expect(created.enabled).toBe(false);
+      expect(created.transport).toBe("stdio");
+
+      const updated = await ipc.mcp.updateServer({
+        id: created.id,
+        enabled: true,
+        envJson: { API_TOKEN: "tok-123" },
+      });
+      expect(updated.enabled).toBe(true);
+      expect(updated.envJson).toEqual({ API_TOKEN: "tok-123" });
+    } finally {
+      catalogPayload = previousPayload;
+      clearMcpCatalogCacheForTests();
+    }
+  }, 40_000);
+
+  it("adds an oauth entry disabled, then setup stores encrypted client credentials", async () => {
+    const previousPayload = catalogPayload;
+    catalogPayload = {
+      servers: [
+        {
+          slug: "integration-oauth",
+          name: "Integration OAuth Server",
+          category: "Testing",
+          transport: "http",
+          url: `http://localhost:${mcpPort}/mcp`,
+          oauth: { required: true },
+          inputs: [{ kind: "oauthClientId" }, { kind: "oauthClientSecret" }],
+        },
+      ],
+    };
+    clearMcpCatalogCacheForTests();
+    try {
+      const created = await ipc.mcp.addFromCatalog({
+        slug: "integration-oauth",
+      });
+      expect(created.enabled).toBe(false);
+      expect(created.oauthEnabled).toBe(true);
+      expect(created.oauthClientId).toBeNull();
+
+      const updated = await ipc.mcp.updateServer({
+        id: created.id,
+        enabled: true,
+        oauthClientId: "client-abc",
+        oauthClientSecret: "secret-xyz",
+      });
+      expect(updated.enabled).toBe(true);
+      expect(updated.oauthClientId).toBe("client-abc");
+      // The client secret is encrypted at rest and never sent to the
+      // renderer: it isn't on the returned server, and the stored value
+      // is not the plaintext but decrypts back to it.
+      expect(updated).not.toHaveProperty("oauthClientSecret");
+      const [row] = await db
+        .select()
+        .from(mcpServers)
+        .where(eq(mcpServers.id, created.id));
+      expect(row.oauthClientSecret).not.toBe("secret-xyz");
+      expect(decryptFromString(row.oauthClientSecret!)).toBe("secret-xyz");
     } finally {
       catalogPayload = previousPayload;
       clearMcpCatalogCacheForTests();

--- a/src/ipc/handlers/mcp_handlers.ts
+++ b/src/ipc/handlers/mcp_handlers.ts
@@ -99,6 +99,7 @@ function toMcpServer(dbServer: typeof mcpServers.$inferSelect): McpServer {
     // `oauthStateHasTokens` checks for a real access token.
     oauthConnected: oauthStateHasTokens(dbServer.oauthState),
     oauthCallbackPort: dbServer.oauthCallbackPort,
+    oauthClientId: dbServer.oauthClientId,
     catalogSlug: dbServer.catalogSlug,
     createdAt: dbServer.createdAt,
     updatedAt: dbServer.updatedAt,
@@ -182,6 +183,10 @@ export function registerMcpHandlers() {
         );
       }
 
+      // An entry that declares inputs needs the user to fill them on the
+      // setup page first, so it's added disabled and doesn't connect or
+      // spawn until configured.
+      const needsSetup = (entry.inputs?.length ?? 0) > 0;
       const values =
         entry.transport === "stdio"
           ? {
@@ -190,7 +195,7 @@ export function registerMcpHandlers() {
               command: entry.command,
               args: entry.args,
               envJson: entry.env ?? null,
-              enabled: true,
+              enabled: !needsSetup,
               catalogSlug: entry.slug,
             }
           : {
@@ -198,7 +203,7 @@ export function registerMcpHandlers() {
               transport: "http" as const,
               url: entry.url,
               headersJson: entry.headers ?? null,
-              enabled: true,
+              enabled: !needsSetup,
               oauthEnabled: entry.oauth != null,
               oauthScope: entry.oauth?.scope ?? null,
               catalogSlug: entry.slug,
@@ -322,6 +327,22 @@ export function registerMcpHandlers() {
         update.oauthCallbackPort = null;
       }
     }
+    // New client credentials must take effect: clear any persisted
+    // client-registration blob so the provider re-seeds from these
+    // columns instead of a stale registered client shadowing them.
+    if (
+      params.oauthClientId !== undefined ||
+      params.oauthClientSecret !== undefined
+    ) {
+      update.oauthState = null;
+    }
+    if (params.oauthClientId !== undefined)
+      update.oauthClientId = params.oauthClientId;
+    if (params.oauthClientSecret !== undefined)
+      update.oauthClientSecret = params.oauthClientSecret
+        ? encryptToString(params.oauthClientSecret)
+        : null;
+    if (params.oauthScope !== undefined) update.oauthScope = params.oauthScope;
 
     const result = await db
       .update(mcpServers)

--- a/src/ipc/shared/remote_mcp_catalog.test.ts
+++ b/src/ipc/shared/remote_mcp_catalog.test.ts
@@ -72,6 +72,49 @@ describe("remote_mcp_catalog", () => {
     expect(entries.map((e) => e.slug)).toEqual(["figma"]);
   });
 
+  it("keeps entries that declare setup inputs and carries them through", async () => {
+    mockCatalogResponse([
+      {
+        ...VALID_ENTRY,
+        slug: "asana",
+        inputs: [{ kind: "oauthClientId" }, { kind: "oauthClientSecret" }],
+      },
+      {
+        ...VALID_ENTRY,
+        slug: "render",
+        oauth: undefined,
+        inputs: [
+          {
+            kind: "header",
+            name: "Authorization",
+            prefix: "Bearer ",
+            label: "API key",
+          },
+        ],
+      },
+    ]);
+    const entries = await getRemoteMcpCatalog();
+    expect(entries.map((e) => e.slug)).toEqual(["asana", "render"]);
+    const asana = entries[0];
+    if (asana.transport === "http") {
+      expect(asana.inputs).toEqual([
+        { kind: "oauthClientId" },
+        { kind: "oauthClientSecret" },
+      ]);
+    }
+  });
+
+  it("drops an entry whose input kind this client doesn't know", async () => {
+    // A whole entry drops if any input kind is unrecognized, so a newer
+    // field type can't cause a half-configured add on this client.
+    mockCatalogResponse([
+      { ...VALID_ENTRY, slug: "future", inputs: [{ kind: "instanceUrl" }] },
+      VALID_ENTRY,
+    ]);
+    const entries = await getRemoteMcpCatalog();
+    expect(entries.map((e) => e.slug)).toEqual(["figma"]);
+  });
+
   it("keeps stdio entries alongside http ones", async () => {
     mockCatalogResponse([
       VALID_STDIO_ENTRY,

--- a/src/ipc/shared/remote_mcp_catalog.test.ts
+++ b/src/ipc/shared/remote_mcp_catalog.test.ts
@@ -102,6 +102,17 @@ describe("remote_mcp_catalog", () => {
         { kind: "oauthClientSecret" },
       ]);
     }
+    const render = entries[1];
+    if (render.transport === "http") {
+      expect(render.inputs).toEqual([
+        {
+          kind: "header",
+          name: "Authorization",
+          prefix: "Bearer ",
+          label: "API key",
+        },
+      ]);
+    }
   });
 
   it("drops an entry whose input kind this client doesn't know", async () => {

--- a/src/ipc/types/mcp.ts
+++ b/src/ipc/types/mcp.ts
@@ -35,6 +35,10 @@ export const McpServerSchema = z.object({
   oauthConnected: z.boolean(),
   // Null falls back to DEFAULT_OAUTH_CALLBACK_PORT.
   oauthCallbackPort: z.number().nullable(),
+  // Public OAuth client id (not a secret). Surfaced so the UI can tell
+  // whether a pre-registered client has been configured; the secret is
+  // never sent to the renderer.
+  oauthClientId: z.string().nullable(),
   // Set when the server was added from the curated catalog.
   catalogSlug: z.string().nullable(),
   createdAt: z.date(),
@@ -103,6 +107,11 @@ export const McpServerUpdateSchema = z.object({
   url: z.string().optional(),
   enabled: z.boolean().optional(),
   oauthEnabled: z.boolean().optional(),
+  oauthClientId: z.string().nullable().optional(),
+  // Plaintext on update; the handler encrypts it before storing and never
+  // returns it via `McpServerSchema`.
+  oauthClientSecret: z.string().nullable().optional(),
+  oauthScope: z.string().nullable().optional(),
 });
 
 export type McpServerUpdate = z.infer<typeof McpServerUpdateSchema>;

--- a/src/ipc/types/mcp.ts
+++ b/src/ipc/types/mcp.ts
@@ -47,6 +47,19 @@ export const McpServerSchema = z.object({
 
 export type McpServer = z.infer<typeof McpServerSchema>;
 
+// OAuth scope tokens use only printable ASCII (no space, quote, or
+// backslash), separated by single spaces. Catches typos like
+// leading/trailing spaces, control chars, or quotes at validation time so
+// they don't surface as opaque OAuth provider errors later. Empty string
+// means "use the server's default scope".
+const oauthScopeSchema = z
+  .string()
+  .regex(/^(?:[\x21\x23-\x5b\x5d-\x7e]+(?: [\x21\x23-\x5b\x5d-\x7e]+)*)?$/, {
+    message: "OAuth scope contains invalid characters",
+  })
+  .nullable()
+  .optional();
+
 export const CreateMcpServerSchema = z.object({
   name: z.string(),
   transport: McpTransportEnum.default("stdio"),
@@ -70,18 +83,7 @@ export const CreateMcpServerSchema = z.object({
   // Plaintext OAuth client_secret on create. The handler encrypts it
   // before storing and never returns it via `McpServerSchema`.
   oauthClientSecret: z.string().nullable().optional(),
-  // OAuth scope tokens use only printable ASCII (no space, quote, or
-  // backslash), separated by single spaces. Catches typos like
-  // leading/trailing spaces, control chars, or quotes at validation
-  // time so they don't surface as opaque OAuth provider errors later.
-  // Empty string means "use the server's default scope".
-  oauthScope: z
-    .string()
-    .regex(/^(?:[\x21\x23-\x5b\x5d-\x7e]+(?: [\x21\x23-\x5b\x5d-\x7e]+)*)?$/, {
-      message: "OAuth scope contains invalid characters",
-    })
-    .nullable()
-    .optional(),
+  oauthScope: oauthScopeSchema,
   // Null falls back to DEFAULT_OAUTH_CALLBACK_PORT.
   oauthCallbackPort: z
     .number()
@@ -111,7 +113,7 @@ export const McpServerUpdateSchema = z.object({
   // Plaintext on update; the handler encrypts it before storing and never
   // returns it via `McpServerSchema`.
   oauthClientSecret: z.string().nullable().optional(),
-  oauthScope: z.string().nullable().optional(),
+  oauthScope: oauthScopeSchema,
 });
 
 export type McpServerUpdate = z.infer<typeof McpServerUpdateSchema>;

--- a/src/ipc/types/mcp_catalog.ts
+++ b/src/ipc/types/mcp_catalog.ts
@@ -9,6 +9,28 @@ import { z } from "zod";
 // it without pulling the main-process catalog client into the renderer
 // bundle.
 
+// A value the user must supply during setup. `kind` selects the input to
+// render and where the value is stored. Discriminated union: an unknown
+// kind fails validation and drops the whole entry, so newer field kinds
+// don't break this client.
+export const CatalogInputSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("oauthClientId") }),
+  z.object({ kind: z.literal("oauthClientSecret") }),
+  z.object({
+    kind: z.literal("header"),
+    name: z.string().min(1),
+    prefix: z.string().optional(),
+    label: z.string().min(1),
+  }),
+  z.object({
+    kind: z.literal("env"),
+    name: z.string().min(1),
+    label: z.string().min(1),
+  }),
+]);
+
+export type CatalogInput = z.infer<typeof CatalogInputSchema>;
+
 const baseEntry = {
   slug: z
     .string()
@@ -19,6 +41,8 @@ const baseEntry = {
   category: z.string().optional(),
   // Surfaced in a Featured section as well as its category.
   featured: z.boolean().optional(),
+  // Values the user must supply on the plugin's setup page.
+  inputs: z.array(CatalogInputSchema).optional(),
 } as const;
 
 export const HttpCatalogEntrySchema = z.object({


### PR DESCRIPTION
*This description was written by Claude but is human-reviewed.*

Some catalog servers need credentials the user must supply: an OAuth client id/secret for a pre-registered app, or an API key sent as a header or environment variable. Entries now declare these as typed `inputs`. A server that declares them is added disabled, opens a guided setup on its plugin page, writes each value where it belongs (a header, an env var, or the OAuth columns), and enables itself once saved.

Follow-ups:
1. Per-server setup instructions telling the user where to find each credential.
2. A free-text `url` input for servers whose instance or region is part of the URL.
3. Adding more catalog servers.
4. Per-server icons in the catalog.
5. An `add_mcp_server` agent tool so the assistant can add a plugin on request.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

