### PR TITLE
plans: clean-up state machines

### DIFF
--- a/plans/claude-cleanup-machines.md
+++ b/plans/claude-cleanup-machines.md
@@ -1,0 +1,839 @@
+# Projection Retirement: Machine-Written Jotai Atoms
+
+## Status
+
+Proposed follow-up to `plans/machine-followup.md` and the state-machine work
+landed through #4077–#4086. All 13 machines (app_run, chat_stream,
+github_ops, image_generation, preview_iframe, screenshot, version_preview,
+first_prompt, voice_to_text, plan_handoff, connection_flow, mcp_oauth,
+user_input) now run on SnapshotStore-based controllers that satisfy the
+`useSyncExternalStore` contract — yet most of them still project state into
+legacy Jotai atoms via `registerAtomWriter`/`projectToAtom`
+(`src/state_machines/projection.ts`) or manual `store.set` calls. This plan
+retires those projections.
+
+Relationship to `plans/codex-cleanup-state-machines.md`: that plan covers
+the same ground at domain level plus runtime consolidation
+(TransactionalDispatcher migrations, boundary tests, provider conventions).
+This plan is the atom-level execution companion for its projection-removal
+half: a verified per-atom inventory with reader-by-reader migration
+recipes. Where the two disagree on detail, this plan's file:line traces
+supersede — notably: `chatMessagesByIdAtom` is a primary store with a
+version_preview writer, not a simple chat_stream mirror; the
+package-manager warning channel has four producers including the
+entity-disposal path; and provider mount order constrains where the
+screenshot and chat-stream facades can be injected. Runtime migrations
+remain the other plan's scope; this plan is projection retirement only.
+
+Inputs: a full classification of the 116 atoms in `src/atoms/*`,
+`src/store/appAtoms.ts`, and the machine projection modules; per-atom
+reader/writer traces; and an adversarial verification pass over the traces
+(152 claims checked, 20 corrected). The corrections are folded in below.
+The load-bearing ones:
+
+- **Package-manager warning priority runs the opposite way from the trace's
+  claim**: release-age (2) outranks pnpm-migration (1) — higher number wins
+  (`src/atoms/previewRuntimeAtoms.ts:288-296`, test named "keeps release-age
+  warnings ahead of pnpm migration warnings" at
+  `previewRuntimeAtoms.test.ts:310`). Porting the rule as originally traced
+  would silently invert product behavior.
+- **Four missed preview-error writers** in `PreviewIframe.tsx` (`:415-426`
+  cloud-sandbox errors with source `dyad-app`, `:438-445` cloud sync errors,
+  `:449-451` sync-recovery clear, `:1501` dismiss-any). `dyad-app` errors
+  are therefore _not_ exclusively the app_run machine's, and
+  `useAppRunState` alone cannot replace the reader.
+- **Mount-order reality for facade injection**: `ChatStreamProvider` mounts
+  above the router (`renderer.tsx:141`); chat_stream's runtime deps are
+  registered late by `useChatStreamRuntime()` at `layout.tsx:133`, which
+  runs _under_ `AppRunProvider` (`layout.tsx:75`) but _above_
+  `ScreenshotProvider` (`layout.tsx:202`). The AppRunManager facade injects
+  cleanly; the screenshot facade needs wiring restructured or buffering.
+- **`subscribeStreamFinished` is already microtask-deferred**
+  (`chat_stream/manager.ts:235-249`) but is _not_ a drop-in for
+  watch-stream-idle: it does not fire on `disposeKey`, so a `watchIdle`
+  facade must also observe controller disposal.
+- **`syncChatFromDb` itself** guards its post-fetch write on
+  `isStreamingByIdAtom` at `src/lib/resyncChat.ts:59` — a third guard site
+  beyond ChatPanel's two.
+- `currentPreviewRunStateAtom` and `currentPreviewLoadingAtom` have **zero
+  production readers** (test-only); the run-state derived trio is cheaper
+  than traced.
+- `planStateAtom`'s machine read at `plan_handoff/commands.ts:114` is
+  **not** a cross-machine edge — the field it reads is written only by
+  non-machine hooks.
+
+Decision recorded here: **retire category-2 (machine-mirror) and category-3
+(cross-machine) atoms; keep category-1 (UI-only) atoms as Jotai.**
+Cross-machine communication moves to explicit facades or owned stores, with
+microtask-deferred delivery wherever a call would otherwise run inside
+another machine's dispatch. Every migration is behavior-preserving; known
+intentional deltas are enumerated per PR and flagged in PR descriptions.
+
+## The three atom populations
+
+Counts: 69 UI-only (keep), 32 machine-mirror, 12 cross-machine, 3
+mixed-ownership resolved by this plan. "Prod readers" counts production
+read/consume sites; test sites are enumerated in the recipes.
+
+### Population 1 — UI-only (69 atoms, keep)
+
+No machine owns this state; Jotai is the right tool. Grouped by family:
+
+| Atoms                                                                                                                                                                                                                                                                                                                                                                                          | Module                 | Writer                                                                  | Readers                                                          | Difficulty                                                                                  |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- | ----------------------------------------------------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| selectedAppIdAtom                                                                                                                                                                                                                                                                                                                                                                              | appAtoms               | UI hooks/pages                                                          | machines read it as input (version_preview sub, chat_stream get) | keep                                                                                        |
+| previewModeAtom, selectedChatIdAtom                                                                                                                                                                                                                                                                                                                                                            | appAtoms/chatAtoms     | UI navigation; plan_handoff writes each once as a navigate side effect  | UI                                                               | keep (documented machine write)                                                             |
+| appBlueprintStateAtom                                                                                                                                                                                                                                                                                                                                                                          | appBlueprintAtoms      | IPC event hook                                                          | UI                                                               | keep                                                                                        |
+| chatInputValuesById, chatInputValue, hasManuallySelectedChatMode, scrollToBottomRequestedChatIds, needsFreshPlanChat                                                                                                                                                                                                                                                                           | chatAtoms              | UI                                                                      | UI                                                               | keep                                                                                        |
+| homeChatInputValue, homeSelectedApp, attachments                                                                                                                                                                                                                                                                                                                                               | chatAtoms              | UI; first_prompt clears after submit                                    | UI                                                               | keep (documented machine write)                                                             |
+| Tab family (16): recentViewedChatIds, closedChatIds, sessionOpenedChatIds, chatTabSessionStorage, groupTabsByApp, closedTabHistory, hydrateChatTabSession, persistChatTabSession, popClosedTab, setRecentViewedChatIds, ensureRecentViewedChatId, pushRecentViewedChatId, removeRecentViewedChatId, pruneClosedChatIds, addSessionOpenedChatId, closeMultipleTabs, removeChatIdFromAllTracking | chatAtoms              | UI                                                                      | UI                                                               | keep                                                                                        |
+| agentTodosByChatIdAtom                                                                                                                                                                                                                                                                                                                                                                         | chatAtoms              | renderer IPC listeners                                                  | UI                                                               | keep                                                                                        |
+| helpDialogAtom, dropdownOpenAtom                                                                                                                                                                                                                                                                                                                                                               | helpDialogAtom/uiAtoms | UI                                                                      | UI                                                               | keep                                                                                        |
+| dismissedImageGenerationJobIdsAtom                                                                                                                                                                                                                                                                                                                                                             | imageGenerationAtoms   | UI                                                                      | UI                                                               | keep (composes with new machine hooks)                                                      |
+| integrationProviderSelection, pendingIntegration                                                                                                                                                                                                                                                                                                                                               | integrationAtoms       | UI                                                                      | UI                                                               | keep (former composes into new usePendingIntegrations hook)                                 |
+| planAcceptInNewChatByChatId, pendingQuestionnaire, planAnnotations                                                                                                                                                                                                                                                                                                                             | planAtoms              | UI                                                                      | plan_handoff reads planAcceptInNewChat at handoff time           | keep                                                                                        |
+| Visual-editing family: selectedComponentsPreview, visualEditingSelectedComponent, currentComponentCoordinates, previewIframeRef, annotatorMode, screenshotDataUrl, pendingVisualChanges                                                                                                                                                                                                        | previewAtoms           | UI                                                                      | preview_iframe reads selectedComponentsPreview as input          | keep                                                                                        |
+| dismissPackageManagerWarnings, dismissedPackageManagerWarningAppIds                                                                                                                                                                                                                                                                                                                            | previewRuntimeAtoms    | UI                                                                      | —                                                                | **exception: retires with the warning channel** (the dismissed-guard lives in the set path) |
+| lastLogTimestampAtom                                                                                                                                                                                                                                                                                                                                                                           | supabaseAtoms          | hook                                                                    | hook                                                             | keep                                                                                        |
+| terminalOpenByChatId, terminalFontSize                                                                                                                                                                                                                                                                                                                                                         | terminalAtoms          | UI                                                                      | UI                                                               | keep                                                                                        |
+| Test-runtime family (13): dismissedLegacyTestMigrationAppIds, testRunOutputByAppId, currentTestRunOutput, appendTestRunOutput, clearTestRunOutputForApp, testSpecsByAppId, testRunStateByAppId, currentTestSpecs, currentTestRunState, setTestSpecsForApp, setTestRunStateForApp, applyTestRunStarted, applyTestRunFinished, clearTestRuntimeForApp                                            | testRuntimeAtoms       | useTestRunEvents/TestsPanel                                             | UI                                                               | keep (no machine owns tests)                                                                |
+| isPreviewOpenAtom                                                                                                                                                                                                                                                                                                                                                                              | viewAtoms              | UI; chat_stream (:528) and first_prompt (:157) write as UI side effects | UI                                                               | keep (documented machine writes)                                                            |
+| isChatPanelHidden, selectedFile, stagedDiffFile, activeSettingsSection                                                                                                                                                                                                                                                                                                                         | viewAtoms              | UI                                                                      | UI                                                               | keep                                                                                        |
+
+### Population 2 — machine-mirror (32 atoms, retire)
+
+| Atom                                 | Writer                                                                                          | Prod readers              | Difficulty                              |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------- | ------------------------- | --------------------------------------- |
+| chatCompletionEventAtom              | chat_stream commands.ts:520                                                                     | 1                         | S                                       |
+| publishChatCompletionEventAtom       | chat_stream commands.ts:520 (sole caller)                                                       | 0                         | S                                       |
+| chatErrorByIdAtom                    | chat_stream (commands :226/:636, manager :150) + rogue `useStreamChat.setError`                 | 2                         | M                                       |
+| pendingToolConsentsAtom              | derived over userInputRequestsAtom                                                              | 1                         | S                                       |
+| streamingPreviewByChatIdAtom         | chat_stream commands.ts:215/:328                                                                | 2                         | M                                       |
+| imageGenerationJobsAtom              | image_generation provider projectToAtom                                                         | 6                         | M                                       |
+| setImageGenerationJobsProjectionAtom | provider (sole)                                                                                 | 0                         | S                                       |
+| pendingImageGenerationsCountAtom     | derived                                                                                         | 3                         | S                                       |
+| chatImageGenerationJobsAtom          | derived                                                                                         | 2                         | S                                       |
+| previewAppExitByAppIdAtom            | app_run commands :90/:155 clear; useRunApp :208 set (admission-gated)                           | 2                         | M                                       |
+| setPreviewAppExitForAppAtom          | same                                                                                            | 0                         | S                                       |
+| appUrlByAppIdAtom                    | app_run commands :65/:95/:159                                                                   | 4                         | M                                       |
+| setAppUrlForAppAtom                  | app_run (sole)                                                                                  | 0                         | S                                       |
+| consoleEntriesByAppIdAtom            | **reclassified: multi-producer log buffer** — app_run + useRunApp + useSupabase + PreviewIframe | 4                         | L                                       |
+| setConsoleEntriesForAppAtom          | app_run + Console clear                                                                         | 0                         | S                                       |
+| appendConsoleEntriesForAppAtom       | app_run + 3 legacy producers                                                                    | 0                         | L                                       |
+| currentPreviewRunStateAtom           | derived                                                                                         | 2 (sibling deriveds only) | S                                       |
+| currentPreviewLoadingAtom            | derived                                                                                         | 0 (test-only)             | S                                       |
+| currentPreviewRunStartedAtAtom       | derived                                                                                         | 1                         | S                                       |
+| currentPreviewErrorAtom              | derived                                                                                         | 1                         | L                                       |
+| currentPreviewAppExitAtom            | derived                                                                                         | 1                         | M                                       |
+| currentAppUrlAtom                    | derived                                                                                         | 3                         | M                                       |
+| currentPreviewReloadTokenAtom        | derived                                                                                         | 1                         | M                                       |
+| currentConsoleEntriesAtom            | derived                                                                                         | 3                         | L                                       |
+| currentPackageManagerWarningAtom     | derived                                                                                         | 1                         | L                                       |
+| clearPreviewRuntimeForAppAtom        | disposal action over 7 maps (renderer.tsx:153, harness:558)                                     | 2 callers                 | M (shrinks incrementally, deleted last) |
+| firstPromptSagaProjectionWriteAtom   | FirstPromptProvider :226/:285                                                                   | 1 (alias)                 | S                                       |
+| firstPromptSagaAtom                  | read-only alias                                                                                 | 4                         | S                                       |
+| userInputRequestsAtom                | user_input projection adapter (sole, enforced)                                                  | 5                         | M                                       |
+| respondingRequestIdsAtom             | same adapter                                                                                    | 3                         | S                                       |
+| activeCheckoutCounterAtom            | version_preview commands :34/:38                                                                | 1                         | S                                       |
+| isAnyCheckoutVersionInProgressAtom   | derived                                                                                         | 1                         | S                                       |
+
+### Population 3 — cross-machine (12 atoms + 3 mixed, retire; worst first-class problem)
+
+| Atom                                 | Writers                                                                                                                             | Prod readers | Difficulty |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- | ------------ | ---------- |
+| pendingScreenshotAppIdsAtom          | chat_stream commands.ts:532; useCommitChanges.ts:24 → consumed as mailbox by screenshot machine                                     | 2            | M          |
+| previewRunStateByAppIdAtom           | app_run manager.ts:146-149 → observed by preview_iframe provider                                                                    | 2            | M          |
+| setPreviewRunStateForAppAtom         | app_run (sole)                                                                                                                      | 0            | S          |
+| previewErrorByAppIdAtom              | app_run sets, preview_iframe clears, useRunApp + PreviewIframe (6 sites incl. the 4 missed ones)                                    | 2            | L          |
+| setPreviewErrorForAppAtom            | same channel                                                                                                                        | 0            | L          |
+| previewReloadTokenByAppIdAtom        | app_run ×3; chat_stream commands.ts:531                                                                                             | 2            | L          |
+| bumpPreviewReloadTokenForAppAtom     | same                                                                                                                                | 0            | M          |
+| packageManagerWarningByAppIdAtom     | chat_stream sets, app_run clears, useRunApp sets, disposal path deletes                                                             | 2            | M          |
+| setPackageManagerWarningForAppAtom   | chat_stream + useRunApp                                                                                                             | 0            | M          |
+| clearPackageManagerWarningForAppAtom | app_run + banner                                                                                                                    | 0            | M          |
+| chatMessagesByIdAtom                 | **reclassified from machine-mirror: primary renderer message store** — chat_stream ×4, version_preview :74, two component hydrators | 7            | L          |
+| isStreamingByIdAtom                  | chat_stream syncProjection → plan_handoff subscribes (the ORDERING INVARIANT case)                                                  | 10           | L          |
+| queuedMessagesByIdAtom               | mixed: chat_stream + useStreamChat + useQueuePersistence (primary storage, not a mirror)                                            | 2            | L          |
+| queuePausedByIdAtom                  | mixed, same trio; chat_stream also reads it in a command                                                                            | 2            | L          |
+| planStateAtom                        | mixed: plan_handoff writes acceptedChatIds; usePlanEvents/usePlan write plansByChatId (two states fused in one atom)                | 3            | L          |
+
+## What stays and why
+
+- **All 69 UI-only atoms stay as Jotai.** Selection, navigation, tabs,
+  drafts, dismissals, visual editing, test runtime, layout. Moving them
+  into machines would invert the ownership problem this plan fixes.
+- **Documented deliberate keeps — machine writes into UI-owned atoms.**
+  These are one-way fire-and-forget side effects into state the UI owns,
+  not projections, and no machine reads them back:
+  - plan_handoff → `previewModeAtom` (:106) and `selectedChatIdAtom` (:165)
+    as navigation side effects;
+  - first_prompt → clears `homeChatInputValueAtom`,
+    `homeSelectedAppAtom`, `attachmentsAtom` after successful submit;
+  - chat_stream (:528) and first_prompt (:157) → `isPreviewOpenAtom`.
+    Each keep gets a one-line comment at the write site naming this plan.
+- **Machine reads of UI atoms stay** (selectedAppIdAtom,
+  planAcceptInNewChatByChatIdAtom, selectedComponentsPreviewAtom): the
+  writer is the UI, so these are inputs, not projections. Out of scope.
+- **One exception in the UI-only bucket**: the package-manager dismiss pair
+  (`dismissPackageManagerWarningsAtom`,
+  `dismissedPackageManagerWarningAppIdsAtom`) retires _with_ the warning
+  channel — the dismissed-set guard is embedded in the channel's set path
+  and moves into the new store's `dismiss()`.
+- **The main-process user_input registry is untouched.** Only the renderer
+  projection adapter changes shape.
+
+## Retirement order
+
+Rule: cross-machine edges first (they are live coupling hazards), then
+machine-mirror atoms by ascending production reader count. Satellites
+(`set*`/`bump*`/`clear*` action atoms and `current*` selectors) ride with
+their base atom; families that share invariants retire as one unit.
+
+Cross-machine, ascending readers (ties broken by dependency order the
+traces establish):
+
+1. **pendingScreenshotAppIdsAtom** (2) — purest mailbox, no deferral
+   needed, best first target; establishes the producer-facade pattern.
+2. **previewRunStateByAppIdAtom** (2) — establishes the
+   app_run→preview_iframe _deferred_ facade pattern.
+3. **previewReloadTokenByAppIdAtom** (2) — chat_stream writer migrates to
+   the app_run `MANUAL_RELOAD` facade first (independently shippable).
+4. **packageManagerWarningByAppIdAtom** (2) — owned store; priority rule
+   must port un-inverted (release-age wins).
+5. **previewErrorByAppIdAtom** (2) — hardest channel; deliberately last in
+   the preview family so it reuses the facade and state-shape patterns
+   from 2 and from the app-exit template.
+6. **chatMessagesByIdAtom** (7) — new messages store +
+   `replaceChatMessages` facade for version_preview.
+7. **isStreamingByIdAtom** (10) — largest blast radius, last.
+   **Retiring it deletes the synchronous re-entrancy hazard itself: the
+   plan_handoff Jotai subscription firing inside chat_stream's
+   `setState`/`syncProjection` is the only known re-entry vector, and both
+   protective comments added in #4077 — the ORDERING INVARIANT block at
+   `src/chat_stream/controller.ts:181-192` and its companion warning at
+   the plan_handoff watch-stream-idle subscription — get deleted with it.**
+
+Mixed-ownership design decisions ride the same wave: queue pair with the
+chat_stream core work, planStateAtom split alongside plan_handoff's facade
+migration.
+
+Machine-mirror, ascending readers (family granularity):
+
+8. publish/chatCompletionEventAtom (0/1) · activeCheckoutCounter pair (1) ·
+   pendingToolConsentsAtom (1) · run-state derived trio (0–2, test-only
+   plus one component)
+9. previewAppExit family (2) — the template for the error channel ·
+   streamingPreviewByChatIdAtom (2) — establishes the sidecar-store pattern
+10. chatErrorByIdAtom (2) — ordered _with_ isStreamingByIdAtom despite low
+    count: same files (useStreamChat, ChatPanel, manager cleanup, harness)
+11. respondingRequestIdsAtom (3) + userInputRequestsAtom (5) — one unit,
+    same adapter, same snapshot
+12. image_generation family (2/3/6) — one unit
+13. appUrl family (3/4) · firstPromptSaga pair (4)
+14. console trio (4) — multi-producer, atomically
+15. **clearPreviewRuntimeForAppAtom strictly last** — it is the leak guard
+    for every previewRuntime map; shrink it map-by-map as each retires,
+    delete when empty.
+
+## Per-atom migration recipes
+
+Corrections from verification are already applied. "New" marks code that
+does not exist today.
+
+### chat_stream: completion event (S)
+
+- **Writers**: `commands.ts:520` (runEndSideEffects, `!wasCancelled`).
+- `useNotificationHandler.ts:326` → `useStreamFinished`
+  (`ChatStreamProvider.tsx:29`), filter `event.outcome === "completed"`
+  (exactly matches the `!wasCancelled` guard). New: thread `chatSummary`
+  through the finalizing StreamState (`state.ts:113`) into
+  `StreamFinishedEvent` (`manager.ts:38`) so `notifyStreamFinished`
+  (`manager.ts:206`) can emit it. Delivery is already microtask-deferred
+  (`manager.ts:238`) — the sequence-counter bookkeeping in `chatAtoms.ts:23`
+  disappears entirely.
+- `publishChatCompletionEventAtom` has zero readers; delete both atoms +
+  the `ChatCompletionEvent` type in the same PR.
+- Behavioral delta (flag): event fires after finalize-complete plus a
+  microtask instead of during runEndSideEffects — a few ms, irrelevant for
+  OS notifications.
+
+### chat_stream: isStreamingByIdAtom (L)
+
+- **Writer**: syncProjection (`commands.ts:715-727`) via AtomProjectionWriter
+  (`manager.ts:170-176`), invoked in lockstep from the controller
+  `setState` callback (`controller.ts:195-206`); cleanup write in
+  `disposeKey` (`manager.ts:153-155`).
+- Readers → replacements:
+  - `plan_handoff/commands.ts:188` → injected facade
+    `deps.chatStream.isIdle(chatId)` backed by
+    `!isStreamActive(manager.peek(chatId)?.getSnapshot() ?? {type:"idle"})`.
+  - `plan_handoff/commands.ts:193` (store.sub) → new facade
+    `watchIdle(chatId, cb)`. Build on `subscribeStreamFinished` — it
+    already defers via queueMicrotask (`manager.ts:235-249`), so no new
+    deferral code on that path — **but it only fires on finalizing→idle and
+    →errored; the facade must additionally observe `disposeKey`**, or a
+    watcher armed on a chat disposed mid-stream never fires (the atom
+    watcher fires today because disposeKey writes the projection). If built
+    on raw `controller.subscribe` instead, deferral must be added, since
+    SnapshotStore notifies synchronously.
+  - `ChatPanel.tsx:96` → `isStreamActive(useChatStreamState(chatId) ??
+{type:"idle"})` (hook returns `StreamState | undefined` — every
+    hook-based replacement below needs the same fallback).
+  - `ChatPanel.tsx:271/:274` → call-time
+    `isStreamActive(manager.peek(chatId)?.getSnapshot() ?? {type:"idle"})`
+    via `useChatStreamManager()`.
+  - `PromoMessage.tsx:155`, `DyadOutput.tsx:28`,
+    `DyadMarkdownParser.tsx:132` → same hook + fallback.
+  - `ChatTabs.tsx:245` (aggregate; per-tab lookups :607/:835) → new
+    manager-level `useStreamingChatIds` selector, or per-tab child
+    components with `useChatStreamState(chat.id)`.
+  - `useStreamChat.ts:45` → derive `isStreaming` from
+    `useChatStreamState`; this hook fans out to ~15 components — migrate it
+    first and most component readers come free.
+  - `resyncChat.ts:59` → inject `getIsStreaming(chatId)` from the
+    chat_stream command deps (its only callers are `commands.ts:467/:653`).
+  - Tests: `manager.test.ts:175/183/210/215`,
+    `queue_dispatch.test.ts:89`, `plan_handoff/commands.test.ts:34`
+    (fake chatStream facade), `DyadMarkdownParser.test.tsx:164`,
+    `explore_chat_history_streaming.integration.test.tsx:78/140`,
+    `hybrid_chat_harness.tsx:1053/1063` — drive the machine, not the atom.
+- Order: useStreamChat + components → plan_handoff facade (with disposal
+  observation) → resyncChat injection → tests/harness → delete atom,
+  syncProjection, writer plumbing, **and both #4077 protective comments**.
+
+### chat_stream: chatErrorByIdAtom (M)
+
+- **Writers**: machine (`commands.ts:636` set, `:226` clear on start,
+  `manager.ts:150` dispose) + rogue `useStreamChat.setError`
+  (`useStreamChat.ts:302-307`, called from ChatInput consent failure paths
+  `:709/:713/:742`).
+- `ChatPanel.tsx:65` and `useStreamChat.ts:46` → machine `errored` state
+  via `useChatStreamState`, **plus** a new `external-error`/`clear-error`
+  machine event so the ChatInput consent errors flow through the machine
+  (single owner) — or split consent errors into a legitimate UI-only atom.
+- Durability caveat: an errored controller self-releases when its last
+  subscriber unmounts (`manager.ts:252-262`); a lastError selector must pin
+  errored controllers or store last-error at manager level.
+- Bundle with isStreamingByIdAtom (same files). Tests:
+  `manager.test.ts:174/182`, `queue_dispatch.test.ts:255`, harness
+  `:1052/:1062`.
+
+### chat_stream: chatMessagesByIdAtom (L — reclassified primary store)
+
+- **Not a mirror**: StreamState carries zero message content; the atom IS
+  the canonical renderer message store. Retirement requires first
+  **building** a chat_stream-owned per-chat messages SnapshotStore + hooks
+  (`useChatMessages`, `useChatMessageCount`, `useLastChatMessage`).
+- Writers to funnel through the store: streaming
+  (`commands.ts:127/:335/:499/:577`), version_preview
+  (`version_preview/commands.ts:74`) via new facade
+  `chatStreamManager.replaceChatMessages(chatId, messages)`, and the two
+  component `fetchChatMessages` hydrators (`ChatPanel.tsx:275`,
+  `ChatInput.tsx:379`, invoked at `:723/:747`) via a machine hydrate
+  command.
+- The version_preview write already sits behind the `ipc.chat.getChat`
+  promise (`commands.ts:73`) — never synchronous inside a transition, so no
+  deferral; the real hazard is write-write conflict with an active stream
+  (nothing guards it today) — the facade must refuse/skip while a stream is
+  active for that chat.
+- Helper port: `applyStreamingPatch`, `mergeResyncMessages`,
+  `syncChatFromDb`, `triggerResync` are written against the
+  `Map<number, Message[]>` updater signature; **`syncChatFromDb` also
+  carries its own isStreaming guard at `resyncChat.ts:59` which must become
+  a machine-state check during the port** (in addition to ChatPanel's
+  `:271/:274` guards).
+- Readers: `ChatPanel.tsx:64` (+`:147/:196/:253`), `ChatInput.tsx:176`
+  (+`:276/:288/:336` → fine-grained selectors), `PromoMessage.tsx:154`
+  (count only), `ChatModeSelector.tsx:45` (count only). Tests:
+  `chat_stream/__tests__/commands.test.ts:142/:160`,
+  `version_preview/commands.test.ts:150/:197`.
+- Land the store behind the same write pattern first, flip readers second,
+  delete the atom last. Highest regression risk in the plan (streaming
+  render is the most E2E-covered surface).
+
+### chat_stream: queue pair (L — design decision, one PR)
+
+- `queuedMessagesByIdAtom` + `queuePausedByIdAtom` are primary storage with
+  three-way ownership (machine commands `commands.ts:425/:669/:512`,
+  useStreamChat mutators, useQueuePersistence hydration). Move both into
+  one chat_stream-owned QueueStore with a mutation facade — **same store**,
+  because `dispatchNextQueued` reads paused synchronously before the atomic
+  pop (`commands.ts:665/:669`); splitting would reintroduce read-skew.
+- Preserve: non-serializable per-item callbacks (memory-only), item object
+  identity (useQueuePersistence's WeakMap encode cache keys on it), atomic
+  dequeue, write-before-poke ordering (`useStreamChat.ts:143/:348`),
+  restore-as-paused hydration (`useQueuePersistence.ts:169-176`).
+- Readers/mutators: `useStreamChat.ts:48/:51` + mutators →
+  `useChatQueue(chatId)`/facade calls; `useQueuePersistence.ts:56/:140/
+:167/:172/:176/:193` → store subscribe + `hydrateMerge` (atomically marks
+  restored chats paused). Tests: `queue_dispatch.test.ts`,
+  `manager.test.ts:172-181`, `useStreamChat.test.tsx`, harness
+  `:1050/:1060`.
+
+### chat_stream: streamingPreviewByChatIdAtom (M — sidecar pattern)
+
+- **Writer**: `commands.ts:328` (applyPreviewChunk) and `:215` (clear on
+  transport cleanup). The `streamingPreviewSync.ts:17-18` comment claiming
+  plan_handoff also writes is stale — fix it.
+- New per-chat preview sidecar SnapshotStore (NOT a StreamState field —
+  that would re-notify all stream-state subscribers per chunk).
+- `DyadMarkdownParser.tsx:248` → `useChatStreamPreview(chatId)`;
+  `ChatMessage.tsx:131` → equality-gated `useChatStreamHasPreview(chatId)`
+  replicating the selectAtom boolean-transition optimization (and the
+  identity-stable no-op in applyPreviewChunk must carry over). Helpers are
+  setter-injected — swap the setter, done. Test:
+  `explore_chat_history_streaming.integration.test.tsx:82/:163/:186`.
+
+### user_input: pendingToolConsentsAtom (S) then requests/responding pair (M)
+
+- `pendingToolConsentsAtom`: sole reader `ChatInput.tsx:199` → new
+  user_input-owned `usePendingToolConsents(chatId)` hook (move the
+  descriptor mapping out of `chatAtoms.ts:565`, fold in the
+  respondingRequestIds filter from `:200-204`). Retires first and
+  independently; also fixes the inverted layering (atoms module importing a
+  machine projection — same wart in `planAtoms.ts:46` and
+  `integrationAtoms.ts:20`).
+- `userInputRequestsAtom` + `respondingRequestIdsAtom`: the renderer atom
+  IS the state (no SnapshotStore exists for user_input). Step 1: convert
+  the projection adapter's state to a SnapshotStore holding **both** the
+  requests map and the responding set in one snapshot (splitting them would
+  reintroduce torn reads the single Jotai commit avoids today).
+- Readers: `MessagesList.tsx:87` → `useUserInputRequests()` (or narrower
+  `selectQuestionnaireSettledAt`); `useNotificationHandler.ts:83` → full
+  snapshot hook; `planAtoms.ts:45-46` pendingQuestionnaireAtom →
+  `selectPendingQuestionnaires(requests, respondingIds)`;
+  `integrationAtoms.ts:20` → `usePendingIntegrations()` hook (composes the
+  kept UI atom `integrationProviderSelectionAtom`); `ChatInput.tsx:200` and
+  `useIntegrationContinue.ts:26` → responding selectors.
+- Preserve: revision-race handling vs hydrate, tombstone cap, questionnaire
+  cleanup timer, NotFound optimistic rollback. No cross-machine readers, no
+  deferral concerns. Main cost: `projection.test.ts` (~830 lines, ~19
+  assertion sites) ports behavior-preserving.
+
+### first_prompt: saga pair (S)
+
+- **Writer**: `FirstPromptProvider.tsx:285` subscribe effect (+ dispose
+  reset at `:226`).
+- New `useFirstPromptSaga()` = memoized
+  `projectFirstPromptState(useControllerSnapshot(useFirstPromptController()))`
+  — all building blocks exist; memoize on snapshot identity (projection
+  allocates per call). Keep the pure `projectFirstPromptState` and its
+  test.
+- Readers: `TitleBar.tsx:35`, `SetupBanner.tsx:42`,
+  `ProviderSettingsPage.tsx:132`, `home.tsx:45` — all under the provider.
+  Tests: `home.test.tsx:33` (mock the hook instead of the debugLabel atom
+  shim), `boundaries.test.ts:184` guard deleted. Dispose-reset semantics
+  come free from useControllerSnapshot.
+
+### version_preview: checkout counter pair (S)
+
+- **Writer**: `version_preview/commands.ts:34/:38` around
+  `ipc.version.checkoutVersion`.
+- `ChatHeader.tsx:64` → it already computes
+  `isMutatingState(versionPreviewState)` at `:79`; pass that to the
+  LoadingBar. Scope choice: per-selected-app (sensible for ChatHeader) vs
+  any-app parity (would need a small `useAnyVersionPreviewMutating` manager
+  selector) — default per-app, decide in review.
+- Delete the whole `src/store/appAtoms.ts` module; drop the assertion at
+  `version_preview/commands.test.ts:107`.
+- Behavioral delta (flag): loading bar spans post-effects and restores too
+  — arguably more correct.
+
+### plan_handoff: planStateAtom (L — split, not retire-as-unit)
+
+- Two states with different owners fused: plan_handoff writes
+  `acceptedChatIds` (`commands.ts:80` via `:50`); `plansByChatId` is
+  written by `usePlanEvents.ts:43` (IPC) and `usePlan.ts:39` (disk load).
+- The machine read at `commands.ts:114` is **not cross-machine**
+  (correction): plansByChatId has no machine writer. Still remove it —
+  inject `getPlanData(chatId)` into PlanHandoffDeps (`commands.ts:29`,
+  mirroring the chatStream facade); lazy pull, no deferral.
+- `PlanPanel.tsx:33` → split: acceptedChatIds (`:48`) → new retained
+  accepted-chats set on the plan_handoff projection +
+  `useIsPlanAccepted(chatId)` (must survive return-to-idle; HandoffState
+  has no terminal accepted state today); plansByChatId (`:44`) → renamed
+  `planDocumentsAtom` (category-1 keep) or React Query.
+- `usePlan.ts:18` → the split-out documents atom / query-cache presence.
+- Order: inject getPlanData → accepted-chats projection → migrate PlanPanel
+  → rename remainder, delete planStateAtom and the mark-plan-accepted
+  command (`state.ts:107`). The usePlan/usePlanEvents dual-source race
+  persists wherever plansByChatId lands — out of scope here, note in code.
+
+### screenshot: pendingScreenshotAppIdsAtom (M — first cross-machine target)
+
+- **Producers**: chat_stream `commands.ts:532` (async end-of-stream
+  command); `useCommitChanges.ts:24`.
+- Delete the mailbox consume loop
+  (`ScreenshotProvider.tsx:35-51`); producers call a
+  `requestCapture(appId, source)` facade →
+  `ScreenshotManager.send(appId, {type:"CAPTURE_REQUESTED", source})`
+  (exists, `manager.ts:31`).
+- **Wiring correction**: chat_stream's deps are registered by
+  `useChatStreamRuntime()` at `layout.tsx:133`, which runs _above_
+  `ScreenshotProvider` (`layout.tsx:202`) — `useScreenshotManager()` is not
+  in scope there. Options: hoist ScreenshotManager creation into layout
+  (createMachineProvider accepts an injected manager), register the facade
+  from a child below the provider, or buffer inside the facade. Late
+  binding is fine — deps are read lazily via `registerRuntimeDeps`
+  (`manager.ts:116`) and the facade fires only from the async end-of-stream
+  command. The commit producer needs nothing (its consumers render below
+  the provider).
+- No deferral: the write runs in the command drain loop after
+  setState/syncProjection complete, and screenshot never calls back into
+  chat_stream. Migrate both producers + delete the atom in one change (no
+  double-delivery window). Coalescing loss is benign (supersede/queue
+  policy lives in `screenshot/state.ts:10-17`); delete the mailbox doc
+  sentence in `state.ts:4-8` and the inbox comment at
+  `previewAtoms.ts:26-27`. Test: `ScreenshotProvider.test.tsx` rewritten to
+  drive `manager.send`.
+
+### app_run: previewRunStateByAppIdAtom + derived trio (M)
+
+- **Writer**: `AppRunManager.onStateChange → writeProjection`
+  (`manager.ts:47-54, 146-149`), shaped by `projectRunState`
+  (`transition.ts:402`); disposal delete via clearPreviewRuntimeForAppAtom.
+- `PreviewIframeProvider.tsx:23` (cross-machine) → new AppRunManager facade
+  (`onRunStateChanged` or edge-triggered `onRestartStarted`). **Delivery
+  MUST be microtask-deferred**: onStateChange fires inside AppRunController
+  setState; app_run buffers re-entry into itself
+  (`controller.ts:250-277`) but preview_iframe has no such buffer, and the
+  callback would run mid-notify on app_run's stack. The current React
+  effect path is already async, so deferral preserves semantics. Keep the
+  `handledRestartStartedAt` dedupe or make the facade edge-triggered.
+- Derived trio (correction: cheaper than traced —
+  currentPreviewRunStateAtom and currentPreviewLoadingAtom have **zero
+  production readers**): `PreviewLoadingScreen.tsx:162` →
+  `projectRunState(useAppRunState(selectedAppId))?.startedAt ?? null`
+  (selectedAppId already in scope at `:163`); delete all three deriveds.
+- Tests: `app_run/manager.test.ts:58-88` (dispose-blocks-late-writes
+  becomes a facade-listener test), `usePreviewIframe.test.tsx:58-63` (also
+  a direct writer — drive via facade), `useRunApp.test.tsx:337/342/362/
+649/711/738` (assert machine snapshots; useRunApp's own `loading` is
+  already machine-derived at `useRunApp.ts:315`),
+  `previewRuntimeAtoms.test.ts`. Also update stale comments at
+  `transition.ts:398` and `testRuntimeAtoms.ts:118`.
+- Disposal: AppRunProvider already registers
+  `useRegisterEntityDisposer("app", manager.disposeKey)` — drop this map
+  from clearPreviewRuntimeForAppAtom.
+
+### app_run: appUrl family (M)
+
+- **Writer**: `commands.ts:65` (applyUrl), `:95`/`:159` (clears). State
+  already lives on RunState (`url` on ready/reloading) — no new machine
+  state, just a convenience hook `useCurrentAppUrl`.
+- `PreviewIframe.tsx:219` → `useAppRunState(selectedAppId)`, url from
+  ready/reloading (identical `appUrl/originalUrl/mode` shape,
+  `state.ts:40`); `TestsPanel.tsx:477` and `RuntimeModeSelector.tsx:43` →
+  ready/reloading-with-url boolean. Semantics verified: machine drops the
+  URL on stop/errored where the atom retained it — all readers treat it as
+  a "dev server running" signal, strictly more correct; `pendingUrl` during
+  starting stays hidden. Tests: `useRunApp.test.tsx:355/650/658`,
+  `previewRuntimeAtoms.test.ts:186/212/223` deleted.
+- Coupling: the applyUrl executor also bumps the reload token
+  (`commands.ts:74`) — full deletion of that branch lands with the token
+  retirement; keep bump-after-url ordering.
+
+### app_run: previewAppExit family (M — template for the error channel)
+
+- **Writers**: app_run clears (`commands.ts:90/:155`); the value write at
+  `useRunApp.ts:208` is a hand-rolled projection already gated on the
+  machine admitting APP_EXIT (`:199-207`) — moving the projection into the
+  transition removes the dual writer entirely.
+- New: extend RunState `stopped` with `timestamp` (the APP_EXIT event
+  already carries it; transition currently drops it) + `selectAppExit`
+  selector — `didPreviewCommandFail` (`PreviewLoadingScreen.tsx:106-136`)
+  needs appId, exitCode, and timestamp.
+- `PreviewLoadingScreen.tsx:161` → `selectAppExit(useAppRunState(appId))`.
+  Clearing parity holds: START/RESTART replaces `stopped` exactly when the
+  executor clears the atom today; verify reload/HMR paths. Migrate the
+  component, delete the `useRunApp.ts:208` write, and update
+  `useRunApp.test.tsx:258/316` in one change (no window of disagreement).
+
+### app_run: reload token family (L)
+
+- **Writers**: app_run `commands.ts:74/:205/:208`; chat_stream
+  `commands.ts:531` — in **runEndSideEffects** (the `run-end-side-effects`
+  command; correction: not "handleStreamResponse", and gated on
+  `response.updatedFiles && targetAppId !== null`, not on wasCancelled).
+- Step 1 (independently shippable): migrate the chat_stream bump to
+  `appRunManager.send(targetAppId, {type:"MANUAL_RELOAD"})`. Injection:
+  add the manager (or a narrow `requestPreviewReload` callback) to
+  ChatStreamRuntimeDeps (`commands.ts:103-108` — currently store,
+  queryClient, getSettings, getPosthog). **Wiring works**: deps register
+  late via `useChatStreamRuntime()` at `layout.tsx:133`, under
+  AppRunProvider (`layout.tsx:75`), so `useAppRunManager()` is in scope —
+  despite ChatStreamProvider itself mounting above the router
+  (`renderer.tsx:141`). Mirror the wiring in `hybrid_chat_harness.tsx`
+  (`:572`, AppRunProvider `:990`). Deferral not strictly required (async
+  executor after snapshot commit; app_run never calls back) — add
+  queueMicrotask only if routing ever moves into a subscription.
+  Semantic delta (flag): MANUAL_RELOAD in `ready` passes through the
+  transient `reloading` state; outside `ready` it is the same unconditional
+  bump (`transition.ts:309-338`). Alternatively add a dedicated
+  BUMP_RELOAD_TOKEN event.
+- Step 2: machine-own the counter — per-app monotonic counter store on
+  AppRunManager/controller, bumped where the executor bumps today, reset in
+  `disposeKey` (parity with the disposal delete; PreviewPanel's key is
+  already composite `${selectedAppId}-${key}`, `PreviewPanel.tsx:230`).
+- Step 3: `PreviewPanel.tsx:89` → `usePreviewReloadToken(appId)`; re-mock
+  in `PreviewPanel.test.tsx:10-11/42/59`; retarget
+  `useRunApp.test.tsx:335/361/632/664`; delete the three atoms and their
+  clearPreviewRuntimeForAppAtom branch (also touched by
+  `previewRuntimeAtoms.test.ts:219`).
+
+### app_run/preview_iframe: previewError channel (L — do last in the preview family)
+
+- **No machine owns the full state**: three sources across six writer
+  sites. app_run `commands.ts:57-62` (`dyad-app`); preview_iframe
+  `commands.ts:45` clear (cross-machine, runs in beforeNotify —
+  synchronous facade calls forbidden); `useRunApp.ts:175-186/:191-195`
+  (`dyad-sync`, priority-merge updaters); PreviewIframe `setErrorMessage`
+  (`:223-231`) with call sites `:884/:901` (`preview-app`) **plus the four
+  the trace missed**: `:415-426` cloud-sandbox errors with source
+  `dyad-app` (so app_run state alone can never replace the reader),
+  `:438-445` cloud sync errors (`dyad-sync`, same clobber guard),
+  `:449-451` sync-recovery clear, `:1501` user dismiss (clears any source).
+  clearPreviewRuntimeForAppAtom and the harness also write the base atom
+  directly.
+- Owner decision: **preview_iframe** — it already issues both clears and
+  hosts the only reader. Extend PreviewIframeState with
+  `{message, source}`; new events for set/clear (IFRAME_ERROR, SYNC_ERROR,
+  SYNC_RECOVERED, DISMISS, plus a facade for app_run's setError/clearError
+  commands, **microtask-deferred** since those execute inside app_run's
+  command pipeline).
+- Encode in transitions: source-priority updater semantics (dyad-sync must
+  not clobber preview-app/dyad-app; only-clear-own-source on recovery),
+  dismiss-clears-any, and define the app_run-sets/preview_iframe-clears
+  race explicitly (Jotai serializes it today).
+- Reader `PreviewIframe.tsx:221` → `selectPreviewError(iframeState)` (it
+  already holds iframeState from usePreviewIframe); the source discriminant
+  is load-bearing (`:1515` hasStartupError only for `dyad-app`).
+- All writer sites land in one change or via temporary dual-write —
+  anything else silently desyncs banners. Tests:
+  `preview_iframe/commands.test.ts:167-176` (facade mock or own-state
+  assert), `useRunApp.test.tsx:174/207/739`,
+  `previewRuntimeAtoms.test.ts:255-273` (deleted), harness `:1071/:1081`
+  (seed via controller events).
+
+### app_run: console trio (L — reclassified multi-producer buffer)
+
+- **Producers (five)**: app_run executor (`commands.ts:99` clear, `:110`
+  start banner, `:163` clear), `useRunApp.ts:277/:303`,
+  `useSupabase.ts:204`, PreviewIframe client bridge
+  (`:624/:647/:681/:713/:897/:920`), Console clear button (`:73/:116`).
+- New keyed PreviewConsoleStore (append/clear facade on or beside
+  AppRunManager) preserving `createPreviewConsoleTail` ring-buffer
+  semantics (`src/lib/preview_console_buffer.ts`); disposal via
+  `disposeKey`.
+- Migrate all producers **atomically** (interleaved dual-write forks the
+  buffer), then readers: `Console.tsx:72` → `useConsoleEntries(appId)`;
+  `PreviewPanel.tsx:90` → narrower `useLatestConsoleEntry(appId)` (kills
+  re-render-per-log); `PreviewLoadingScreen.tsx:160` → entries hook. The
+  replacement hook takes appId from the caller (the old selector composed
+  selectedAppIdAtom).
+- Tests: `previewRuntimeAtoms.test.ts` buffer/tail cases → store unit
+  tests; `useRunApp.test.tsx:178/209/263/502/509/550`;
+  `PreviewPanel.test.tsx:45` re-mock.
+- Cheaper fallback if PR 4 runs hot: recategorize as a legitimate shared
+  UI log buffer and only remove app_run's machine writes through the
+  facade (S). Default is full retirement.
+
+### app_run/chat_stream: package-manager warning unit (M)
+
+- **Producers (four)**: chat_stream `commands.ts:196` (showWarningMessage,
+  called from runEndSideEffects `:552` and runErrorSideEffects `:633`;
+  settings gating stays in chat_stream); app_run clear `commands.ts:93`
+  (**keep the rebuild exception** — banner survives pnpm rebuild);
+  `useRunApp.ts:225` (a writer, not a reader; **pnpm-migration bypasses the
+  settings gate** — condition is `warningKind === "pnpm-migration" ||
+(hasSettings && showWarning)`, preserve the bypass); entity-disposal
+  path `renderer.tsx:153` / harness `:558` via
+  clearPreviewRuntimeForAppAtom `:363` (the producer the trace missed —
+  part of the same migration unit).
+- New standalone PackageManagerWarningStore (keyed SnapshotStore, **new
+  code**) with setWarning/clear/dismiss/clearAllForApp. Port the two
+  business rules verbatim: the dismissed-set guard
+  (`previewRuntimeAtoms.ts:284`), and the priority rule **with the correct
+  direction — release-age (2) beats pnpm-migration (1); existing warning
+  kept only when strictly higher; equal kind is last-write-wins**
+  (`:288-296`; characterization test `previewRuntimeAtoms.test.ts:310-341`
+  must be ported, not just deleted).
+- Reader: `PackageManagerWarningBanner.tsx:43` →
+  `usePackageManagerWarning(selectedAppId)`; its clear/dismiss (`:64-65`,
+  `:112`) → store methods.
+- No machine subscribes — synchronous React notification is safe; if a
+  machine ever subscribes, defer per the ORDERING INVARIANT discipline.
+- Retirement unit (all in one PR): base atom, set/clear action atoms,
+  dismiss pair, currentPackageManagerWarningAtom, banner, the four
+  producers, and the warning line in clearPreviewRuntimeForAppAtom. Tests:
+  `previewRuntimeAtoms.test.ts` warning cases,
+  `useRunApp.test.tsx:387-557`, `PackageManagerWarningBanner.test.tsx`;
+  `e2e-tests/package_manager.spec.ts` is behavioral and survives unchanged.
+
+### image_generation: projection family (M, one unit)
+
+- **Writer**: provider `projectToAtom` (`ImageGenerationProvider.tsx:37-46`),
+  sole-writer-enforced by `boundaries.test.ts:157-172`.
+- Prereq: move `ImageGenerationJob`/`ImageGenerationStatus` types from the
+  atom module into `src/image_generation/state.ts`.
+- New hooks: `useImageGenerationJobs()` (useSyncExternalStore over
+  `manager.subscribeProjection`/`getProjection` — names don't match
+  `useControllerSnapshot`'s contract, hence a bespoke hook);
+  `useChatImageGenerationJobs()` (**cached** filter keyed on
+  projection-array identity — a bare `.filter()` per getSnapshot would
+  loop); `useImageGenerationPendingCount()`.
+- Readers: `ImageGenerationProgressButton.tsx:12-13`,
+  `ImageGenerationProgressDialog.tsx:246`, `ChatInput.tsx:232`,
+  `ChatImageGenerationStrip.tsx:21` (both keep composing the kept UI atom
+  `dismissedImageGenerationJobIdsAtom`); `ImageGenerationToast.tsx:18` —
+  the one module-level `getDefaultStore().get()` escape hatch — inject a
+  `getPendingCount` callback from the provider's toast orchestration (the
+  manager is provider-owned, not module-global); provider self-read
+  (`:53`) → compute from the manager snapshot in scope.
+- Retire all four atoms together (jobs, set-projection, pending-count,
+  chat-jobs); delete/repoint the boundaries sole-writer guard. Tests:
+  `ImageGenerationProvider.test.tsx`, `imageGenerationAtoms.test.ts` →
+  plain selector unit tests, `ImageGenerationProgressDialog.test.tsx`.
+
+### clearPreviewRuntimeForAppAtom (retire last)
+
+- Fan-out disposal action over all seven previewRuntime maps
+  (`previewRuntimeAtoms.ts:330-367`), called from `renderer.tsx:153` and
+  harness `:558`. It is the only per-app leak guard until each map
+  retires. Shrink it map-by-map as PRs land (each replacement store
+  registers its own `disposeKey` cleanup on the existing entity-disposal
+  path, as AppRunProvider already does); delete the atom, the renderer
+  wiring, and `previewRuntimeAtoms.test.ts:219-226` when empty.
+
+## PR breakdown
+
+Rule for every PR: behavior-preserving under the existing test suites;
+any intentional delta is listed in the PR description (the known set:
+notification timing +1 microtask, checkout loading-bar span, MANUAL_RELOAD
+transient `reloading` state, machine URL dropping on stop). A PR that has
+to change a transition test to pass is out of scope by definition.
+
+### PR 1 — S-tier mirrors, no new stores
+
+Completion-event pair (with chatSummary plumbing), firstPromptSaga pair,
+checkout counter pair (delete `src/store/appAtoms.ts`),
+pendingToolConsentsAtom, run-state derived trio
+(currentPreviewLoading/RunState/RunStartedAt + PreviewLoadingScreen
+one-liner). Prereqs: none. Regression tests: `src/pages/home.test.tsx`,
+`src/state_machines/boundaries.test.ts` (first_prompt guard),
+`src/version_preview/commands.test.ts`, `src/hooks/useRunApp.test.tsx`
+(loading assertions → machine snapshots), `src/atoms/previewRuntimeAtoms.test.ts`,
+notification smoke via `src/hooks/useNotificationHandler` coverage.
+
+### PR 2 — single-machine store conversions
+
+image_generation family (types move + 3 hooks + toast callback), user_input
+family (adapter → SnapshotStore; userInputRequests + respondingRequestIds +
+the planAtoms/integrationAtoms deriveds), streamingPreviewByChatIdAtom
+sidecar store (establishes the sidecar pattern), previewAppExit family
+(timestamp on `stopped` + selectAppExit — the template for PR 4's error
+work). Prereqs: none (parallel with PR 1). Regression tests:
+`ImageGenerationProvider.test.tsx`, `imageGenerationAtoms.test.ts` (ported
+to selector tests), `ImageGenerationProgressDialog.test.tsx`,
+`src/user_input/projection.test.ts` (full port),
+`explore_chat_history_streaming.integration.test.tsx`,
+`useRunApp.test.tsx:258/316`.
+
+### PR 3 — cross-machine signal edges into app_run and screenshot
+
+pendingScreenshotAppIds facade (both producers + wiring restructure in one
+change), previewRunStateByAppId + setter (preview_iframe deferred facade),
+reload-token family (chat_stream → MANUAL_RELOAD facade, then
+manager-owned counter), appUrl family. Prereqs: PR 1 (derived trio gone).
+Regression tests: `ScreenshotProvider.test.tsx` (rewritten),
+`src/preview_iframe/usePreviewIframe.test.tsx`,
+`src/app_run/manager.test.ts`, `useRunApp.test.tsx`
+(url/token/run-state assertions), `PreviewPanel.test.tsx` (re-mock),
+harness wiring check for the AppRunManager dep.
+
+### PR 4 — multi-producer channels get owned stores
+
+previewError channel (preview_iframe owner; all six writer sites including
+the four missed PreviewIframe ones, deferred app_run facade), console trio
+(PreviewConsoleStore, five producers atomically), package-manager warning
+unit (store with **release-age-wins** priority, dismiss pair folded in,
+all four producers). clearPreviewRuntimeForAppAtom reaches empty and is
+deleted here along with `src/atoms/previewRuntimeAtoms.ts`. Prereqs: PR 3
+(facade pattern, applyUrl/token coupling resolved, app-exit template).
+Regression tests: `preview_iframe/commands.test.ts`,
+`useRunApp.test.tsx:174/207/739` and `:178-550` console cases and
+`:387-557` warning cases, `PackageManagerWarningBanner.test.tsx`
+(including the ported priority-direction test),
+`e2e-tests/package_manager.spec.ts` (behavioral, unchanged).
+
+### PR 5 — chat_stream / plan_handoff core (internally stacked series)
+
+Lands as an ordered stack behind one umbrella: (a) isStreamingByIdAtom —
+useStreamChat + component readers, ChatTabs aggregate selector,
+plan_handoff isIdle/watchIdle facade **with disposal observation**,
+resyncChat injection, delete atom + syncProjection + **both #4077
+protective comments**; bundle chatErrorByIdAtom (external-error event,
+lastError durability) in the same stack; (b) queue pair → QueueStore, one
+PR; (c) chatMessagesByIdAtom — messages store landed behind existing write
+pattern, version_preview `replaceChatMessages` facade (stream-active
+guard), hydrate command, readers flipped, atom deleted last; (d)
+planStateAtom split (getPlanData dep → accepted-chats projection →
+planDocumentsAtom rename). Prereqs: PRs 1–2 (completion event and sidecar
+patterns; shared files with useStreamChat settled). Regression tests:
+`chat_stream/__tests__/{manager,queue_dispatch,commands}.test.ts`,
+`plan_handoff/commands.test.ts` (fake facade),
+`useStreamChat.test.tsx`, `DyadMarkdownParser.test.tsx`,
+`explore_chat_history_streaming.integration.test.tsx`,
+`src/testing/hybrid_chat_harness.tsx` seed/assert helpers,
+`version_preview/commands.test.ts:150/:197` — plus the full E2E streaming
+suite, since streaming render is the most E2E-covered surface in the app.
+
+## Non-goals
+
+- **Moving UI-only atoms into machines.** Category 1 stays Jotai; this
+  plan removes machine-owned state from Jotai, not UI state from Jotai.
+- **Rewriting consumers' UX or component structure.** Readers swap their
+  subscription source; render output is unchanged. Known micro-deltas are
+  flagged, not designed around.
+- No XState or generic pub/sub bus; facades are narrow, typed,
+  per-edge methods on existing managers.
+- The main-process user_input registry, connection_flow, github_ops,
+  voice_to_text, and mcp_oauth are untouched (they project nothing).
+- Not redesigning reload-as-remount (the preview_iframe `iframeEpoch`
+  alternative changes remount semantics — out of scope).
+- Not fixing the usePlan/usePlanEvents dual-source write race for plan
+  documents; it moves intact and gets a comment.
+- Not retiring machine _reads_ of UI-owned atoms (selectedAppIdAtom etc.);
+  input-dependency cleanup is a separate discussion.
+
+## Success criteria
+
+- **Zero machine-written Jotai atoms** except the documented deliberate
+  keeps (plan_handoff navigation writes to previewModeAtom /
+  selectedChatIdAtom; first_prompt's post-submit clears of
+  homeChatInputValue / homeSelectedApp / attachments; chat_stream and
+  first_prompt writes to isPreviewOpenAtom), each carrying a comment
+  naming this plan. `registerAtomWriter`/`projectToAtom` have no remaining
+  production callers and are deleted from `src/state_machines/projection.ts`.
+- **Cross-machine communication happens only through facades or owned
+  stores**, with microtask-deferred delivery on every edge that would
+  otherwise run inside another machine's dispatch (app_run→preview_iframe
+  run-state and error edges; plan_handoff watchIdle inherits deferral from
+  subscribeStreamFinished and additionally observes disposal). No machine
+  `store.get`/`store.sub`s an atom written by another machine.
+- **The #4077 protective comments are deleted** — the ORDERING INVARIANT
+  block at `src/chat_stream/controller.ts:181-192` and its companion at the
+  plan_handoff watch-stream-idle site — because the re-entrancy vector they
+  guard no longer exists, not because they were suppressed.
+- `src/atoms/previewRuntimeAtoms.ts`, `src/store/appAtoms.ts`,
+  `src/first_prompt/projection.ts`'s atoms, and the projection atoms in
+  `src/user_input/projection.ts` are gone;
+  `clearPreviewRuntimeForAppAtom` and its renderer/harness wiring are gone;
+  per-app/per-chat cleanup rides `useRegisterEntityDisposer` +
+  `disposeKey` everywhere.
+- Behavior parity: all listed unit/integration suites pass ported (not
+  weakened); `e2e-tests/package_manager.spec.ts` and the streaming E2E
+  suite pass unchanged; the priority-direction characterization test
+  (release-age over pnpm-migration) exists against the new store.
+- The boundaries tests that enforced sole-writer atom discipline are
+  deleted or inverted to assert the atoms no longer exist.

--- a/plans/cleanup-state-machines.md
+++ b/plans/cleanup-state-machines.md
@@ -1,0 +1,378 @@
+# Cleanup of the State-Machine Layer
+
+## Status
+
+Proposal. This is the unified successor to two overlapping plans and the
+committed cleanup trajectory:
+
+- `plans/codex-cleanup-state-machines.md` — ownership model, target renderer
+  APIs, boundary enforcement, runtime consolidation. Its architecture and
+  rules are adopted here; its rollout is superseded by this plan's.
+- `plans/claude-cleanup-machines.md` — the verified atom-level inventory
+  (116 atoms classified; 152 trace claims adversarially checked, 20
+  corrected) and per-atom migration recipes. It remains the **execution
+  appendix** for this plan: every atom retirement below is specified
+  reader-by-reader there, and its file:line traces are authoritative where
+  the two source plans disagreed.
+- `plans/distrbuted-machines.md` — the actor-runtime alternative. Not
+  adopted now, **deliberately kept open**. This plan sequences the cleanup
+  so that nothing done here is discarded if the distributed runtime is
+  pursued, and names the hold-points where work would be.
+
+Follows `plans/state-machines-hardening.md` (all nine PRs landed). The
+hardening work made the layer safe; this plan makes it small and truthful:
+one authoritative owner per lifecycle fact, typed cross-machine edges, and
+no second Jotai representation of machine state.
+
+## Target architecture
+
+```text
+producer event
+    |
+    v
+typed machine facade            (carries operation identity;
+    |                            delivers post-commit, deferred
+    v                            when crossing into another machine)
+dispatch -> committed immutable snapshot -> pure selectors
+    |                                          |
+    v                                          v
+command adapter                        React domain hook
+    |                                          |
+    v                                          v
+IPC / Query / UI-only runtime stores        component
+```
+
+The central rule:
+
+> A lifecycle fact represented in a machine snapshot is not also stored in
+> Jotai.
+
+Jotai remains correct for client-only state no machine owns: edit buffers,
+navigation, tabs, dismissals, visual-editor selections, high-frequency
+console/stream content, independent diagnostics. React Query remains
+authoritative for IPC-backed entities. Main-process machines may expose
+renderer read models across IPC — a process boundary is not a second
+same-process authority.
+
+Every cross-machine facade introduced by this plan follows two rules taken
+from the distributed proposal, so the facades are shaped like the actor
+references that might replace them:
+
+1. **Events carry operation identity** (invocation refs), never inferred
+   from timestamps or map edges.
+2. **Delivery is post-commit**, and microtask-deferred on any edge that
+   would otherwise run inside another machine's dispatch.
+
+## The inventory (verified)
+
+Full tables, per-atom traces, and corrections live in
+`plans/claude-cleanup-machines.md`. Summary:
+
+- **116 atoms** across `src/atoms/*`, `src/store/appAtoms.ts`, and machine
+  projection modules.
+- **69 UI-only — keep as Jotai.** Includes documented deliberate keeps
+  (machine writes into UI-owned atoms: plan_handoff navigation writes,
+  first_prompt post-submit clears, isPreviewOpenAtom) and machine _reads_
+  of UI atoms (inputs, not projections — out of scope).
+- **32 machine-mirror — retire.** Machine is the writer; the atom
+  duplicates snapshot state (isStreaming-adjacent flags, saga projections,
+  image-gen job copies, app_run's preview-runtime family, user_input's
+  renderer adapter atoms).
+- **12 cross-machine + 3 mixed-ownership — retire; worst class.** Atoms as
+  mailboxes or status buses between machines: `pendingScreenshotAppIdsAtom`
+  (producer mailbox), `previewRunStateByAppIdAtom` (preview_iframe infers
+  app_run restarts), `isStreamingByIdAtom` (plan_handoff subscribes — the
+  #4077 ORDERING INVARIANT re-entrancy hazard), plus mixed-owner primary
+  stores that need owned stores and facades (`chatMessagesByIdAtom` — which
+  version_preview also writes; the queue pair; `planStateAtom` split).
+
+Load-bearing verification corrections (already folded into the appendix
+recipes; repeated here because getting them wrong inverts behavior):
+release-age outranks pnpm-migration in the warning priority rule; six (not
+two) preview-error writer sites, four of them in `PreviewIframe.tsx`
+including `dyad-app`-sourced cloud-sandbox errors; `subscribeStreamFinished`
+is microtask-deferred but does not fire on `disposeKey`, so the plan_handoff
+`watchIdle` facade must also observe disposal; provider mount order
+(`ChatStreamProvider` above the router, deps registered under
+`AppRunProvider` but above `ScreenshotProvider`) constrains facade wiring.
+
+## Ownership model
+
+Adopted verbatim from the codex plan; classification is mandatory before
+code changes:
+
+- **Machine-owned lifecycle state** — stored only in the snapshot; read via
+  domain hooks/facades; derived with pure selectors; never mirrored into a
+  writable atom; never reconstructed by watching command side effects.
+- **External entity data** — React Query / main persistence; adapters
+  invalidate; copied into machine state only when a stable operation
+  snapshot is required for correctness.
+- **UI/runtime state** — Jotai (shared/surviving unmounts) or local React
+  state; never promoted into a machine solely to reduce atom count.
+- **Cross-process projections** — named read models with one adapter owning
+  hydration/ordering/writes; read-only public APIs; may stay Jotai-backed
+  where composition is materially useful (`user_input` is the allowlisted
+  case).
+- **Derived indexes** — read-only external-store selectors over
+  authoritative keyed snapshots; exposed only for real cross-key consumers;
+  never independently mutated.
+
+## Shared infrastructure
+
+1. **Selector-aware external-store bindings** in `src/state_machines/react.ts`:
+   `useMachineSelector`, `useKeyedMachineSelector`, `useProjectionSource` —
+   no resubscription on selector-closure change, reference-stable snapshots,
+   optional equality, StrictMode/unrelated-key tests, no Jotai dependency.
+2. **Standard manager facade** (`getSnapshot(key)` / `subscribeKey` /
+   `send` / `disposeKey` / `dispose`) — a naming/shape convention over
+   `KeyedControllerHost`; domain extensions stay domain-owned.
+3. **Projection-free provider convention** — providers own managers and
+   lifecycle only; they do not copy snapshots to atoms. Domain hooks live
+   beside the provider.
+4. **Composition-root wiring** for the typed edges this plan creates:
+   `app_run → preview_iframe`, `chat_stream → plan_handoff`,
+   producers `→ screenshot`, `user_input → chat_stream` (existing
+   direction preserved). Dependency graph recorded in module headers and an
+   architecture test; must remain acyclic. Respect the verified mount-order
+   constraints when choosing injection sites.
+5. **Ownership boundary test** (extends `boundaries.test.ts`):
+   `state.ts`/`transition.ts` cannot import `@/atoms`, Jotai, React, IPC, or
+   another machine; machine directories cannot import another machine's
+   owners; lifecycle projection modules cannot export writable atoms;
+   cross-process projections are allowlisted with reasons; new
+   `registerAtomWriter`/`projectToAtom` uses outside the allowlist fail.
+   Temporary exceptions carry an owner and a deletion PR number.
+
+## Rollout
+
+Two phases. Phase A is **no-regrets**: valuable in every future, including
+the distributed one (its deletions are prerequisites for a host move, not
+casualties of it). Phase B is **hold-point-gated**: runtime consolidation
+that a main-hosting decision could discard, done opportunistically or after
+the gate.
+
+Rules for every PR (merged from both source plans):
+
+- Consumer migration precedes projection deletion **in the same PR**; no
+  indefinite dual consumption; a compatibility projection has exactly one
+  writer until deletion.
+- Behavior-preserving under existing suites; intentional deltas enumerated
+  in the PR description (known set: notification timing +1 microtask,
+  checkout loading-bar span, MANUAL_RELOAD transient `reloading`, machine
+  URL dropping on stop). A PR that must change a transition test is out of
+  scope by definition.
+- When replacing an atom edge with a subscription, close the
+  read-before-subscribe race: check before and immediately after
+  subscribing.
+- One-shot events run only after the authoritative snapshot commit and
+  preserve operation identity.
+- Every removed keyed atom has an explicit entity-deletion/provider
+  disposal replacement (`clearPreviewRuntimeForAppAtom` shrinks map-by-map
+  and is deleted last).
+- Do not mix controller-runtime migration with ownership/behavior changes.
+
+### Phase A — ownership cleanup (no-regrets)
+
+Per-atom recipes for A2–A6 are in `plans/claude-cleanup-machines.md`
+(sections named per atom); each PR below names its scope and what it
+subsumes from the codex rollout.
+
+**PR A1 — Boundary enforcement and bindings** _(codex PR 1)_
+Ownership table into repo docs; boundary-test rules with allowlisted
+current violations mapped to their deletion PRs (A2–A6); selector-aware
+React bindings + tests. No production behavior change.
+
+**PR A2 — S-tier mirrors, no new stores** _(claude PR 1; subsumes codex
+PRs 2 and 9)_
+Completion-event pair (via `useStreamFinished` + chatSummary threading),
+firstPromptSaga pair, version_preview checkout-counter pair (delete
+`src/store/appAtoms.ts`), pendingToolConsentsAtom, app_run run-state
+derived trio (two of three have zero production readers).
+
+**PR A3 — Single-machine store conversions** _(claude PR 2; subsumes codex
+PR 3)_
+image_generation projection family (manager snapshot exposed directly;
+dismissal atom stays UI); user_input renderer adapter → one SnapshotStore
+holding requests + responding set (stays the allowlisted cross-process
+read model — renamed and documented as such, per codex §J);
+streamingPreviewByChatIdAtom → per-chat sidecar store (high-frequency
+content stays out of StreamState); previewAppExit family (timestamp onto
+`stopped`, the template for A5's error work).
+
+**PR A4 — Cross-machine signal edges** _(claude PR 3; subsumes codex PR 4
+and the facade half of PR 5)_
+`pendingScreenshotAppIdsAtom` → `ScreenshotRequestFacade.requestCapture(appId, source)`,
+both producers migrated in one change, coalescing policy explicit in the
+machine; `previewRunStateByAppIdAtom` → app_run lifecycle facade to
+preview_iframe (**microtask-deferred**; edge-triggered or
+invocation-identified, never `startedAt`-deduped); reload-token family
+(chat_stream bump → `MANUAL_RELOAD` facade, then a manager-owned counter);
+appUrl family (URL read from RunState).
+
+**PR A5 — Multi-producer channels get owned stores** _(claude PR 4;
+completes codex PR 5's atom deletions)_
+previewError channel → preview_iframe-owned state with all six writer
+sites landing together (app_run's set/clear crosses via a deferred facade;
+source-priority and dismiss semantics encoded in transitions); console
+trio → keyed PreviewConsoleStore, five producers atomically;
+package-manager warning unit → standalone store porting the dismissed-set
+guard and the **release-age-wins** priority rule with its characterization
+test. `previewRuntimeAtoms.ts` and `clearPreviewRuntimeForAppAtom` reach
+empty and are deleted.
+
+**PR A6 — chat_stream / plan_handoff core** _(claude PR 5; subsumes codex
+PR 7 and the facade half of PR 8)_
+Ordered stack: (a) `isStreamingByIdAtom` — useStreamChat first (~15
+components come free), ChatTabs aggregate selector, plan_handoff
+`isIdle`/`watchIdle` facade **with disposal observation**, resyncChat
+injection, then delete the atom, syncProjection, and **both #4077
+protective comments** — retiring this atom deletes the re-entrancy hazard
+itself; (b) chatErrorByIdAtom bundled (same files; external-error machine
+event; lastError durability); (c) chatMessagesByIdAtom — chat_stream-owned
+messages store landed behind the existing write pattern, version_preview
+`replaceChatMessages` facade with a stream-active guard, hydrate command,
+readers flipped, atom deleted last (highest regression risk; full
+streaming E2E suite required); (d) queue pair → one QueueStore (atomic
+dequeue, pause read-before-pop, restore-as-paused hydration, item identity
+preserved); (e) planStateAtom split (acceptedChatIds → plan_handoff
+projection; plansByChatId → renamed UI-owned documents atom).
+
+**PR A7 — Compatibility infrastructure removal** _(codex PR 12)_
+Delete or narrow `registerAtomWriter`/`projectToAtom` (only the
+allowlisted cross-process projection may retain a renamed private copy);
+remove boundary-test allowlist entries; update `rules/state-machines.md`,
+`rules/jotai-state.md`, `docs/why-state-machines.md`; add the test
+asserting no lifecycle atom names from this plan return.
+
+Dependencies: A1 first; A2/A3 parallel; A4 after A2 (derived trio gone);
+A5 after A4 (facade + app-exit template); A6 after A2/A3 (patterns
+settled); A7 last.
+
+### Phase B — runtime consolidation (hold-point-gated)
+
+The remaining custom controller loops (app_run, chat_stream, first_prompt,
+github_ops, plan_handoff, preview_iframe, version_preview) and main
+registries still predate `TransactionalDispatcher`. Uniformity is worth
+having — but the distributed proposal's candidate-placement table marks
+app_run, github_ops, version_preview, chat_stream, and plan_handoff as
+possible main-hosted machines, and a host move deletes the renderer
+controller wholesale. Mechanically migrating those five ahead of the
+placement decision is potential throwaway work (this is exactly the
+distributed plan's "superseded by this plan" list).
+
+Policy:
+
+- **Migrate freely, opportunistically** (when the machine is touched for
+  other reasons): `preview_iframe`, `screenshot`-adjacent leftovers,
+  `first_prompt`, `voice_to_text`-style renderer-forever domains. Each
+  migration = trace comparison + controller conformance suite, one
+  high-blast-radius controller per PR.
+- **Hold** bulk dispatcher migration of `app_run`, `github_ops`,
+  `version_preview`, `chat_stream`, `plan_handoff` renderer controllers,
+  and any new bespoke per-domain IPC read models, until the Phase C gate
+  is decided. (Dispatcher adoption _inside main registries_ —
+  connection_flow, mcp_oauth — is distributed-compatible, since the actor
+  host composes the dispatcher; migrate those opportunistically with the
+  codex §J constraints: resource ownership stays in the registry,
+  synchronous claim contracts documented if they block direct use.)
+
+### Phase C — the distributed decision gate
+
+Not scheduled; a recorded decision procedure for when (if) to open
+`plans/distrbuted-machines.md`:
+
+1. **Forcing function: `app_run`.** After Phase A, app_run's remaining
+   pain is structural — the renderer owns the lifecycle of a main-owned
+   process; producer correlation, IPC settlement, and reload-teardown all
+   compensate for that split. If that pain justifies action, the first
+   step is **not** the generic runtime: it is a one-off main-hosted
+   app_run machine built on existing primitives (dispatcher,
+   InvocationRef, leases) with hand-written typed contracts, the way
+   user_input already is — using the distributed plan's Pilot 1 section
+   (event model, safe remote projection, acceptance scenarios 1–12) as
+   its design doc. Phase A's facade shapes (post-commit, identity-carrying)
+   mean preview_iframe and other consumers only swap event sources.
+2. **Rule of three for the runtime.** Extract
+   `src/distributed_machines/` only when a third main-hosted machine is
+   hand-rolling mechanically identical transport/read-model plumbing
+   (user_input and a main-hosted app_run would be two). At that point the
+   distributed plan's Phases 0–3 (ADR, deletion budget, kernel, transport)
+   run as written — extraction from proven copies, not speculation. This
+   is the same method that produced the micro-kernel
+   (`plans/machine-followup.md`) and it is the house rule.
+3. **If the gate never triggers**, Phase B's holds convert to ordinary
+   opportunistic migrations and the codex plan's end-state stands as the
+   final architecture.
+
+## Verification strategy
+
+From the codex plan, with the appendix's concrete test lists per atom:
+
+- **Pure transition tests** unchanged (reachability, inventories,
+  ignored-reference identity, capability consistency, stale invocations).
+  Projection removal requiring a transition change means the projection
+  exposed a missing domain fact — isolate and review it as behavior.
+- **Controller conformance** (`runControllerConformanceSuite`) for every
+  migrated runtime.
+- **Renderer tests** per deleted atom: replacement hook under a test-owned
+  manager; unrelated-entity transitions do not rerender keyed consumers;
+  StrictMode replay; provider replacement; deletion cleanup. Tests and the
+  hybrid harness drive the machine boundary — never write a lifecycle atom
+  to simulate machine state after migration.
+- **Integration scenarios** (codex list): run/restart/stop from one
+  committed snapshot path; stale proxy/exit after controller replacement;
+  double-submit queues; cancel around registration; stream completion
+  wakes plan handoff without an atom edge; screenshot from completion and
+  commit; concurrent image jobs; concurrent version mutations; first-prompt
+  resume without projection atoms.
+- **Performance checks**: keyed subscribers notified only for their
+  entity; stream chunks do not rerender lifecycle consumers; console
+  appends do not rerender run controls; aggregates reference-stable;
+  controller retention bounded. If per-tab subscriptions measure too hot,
+  add a manager-owned read-only index — never a writable atom.
+
+## Non-goals
+
+- XState or any statechart framework; a generic pub/sub bus.
+- Moving UI-only atoms into machines, or console logs / streamed chunks /
+  form buffers into snapshots.
+- Replacing React Query.
+- Adopting the distributed runtime in this plan (Phase C is a gate, not a
+  commitment); building transport/actor infrastructure ahead of the rule
+  of three.
+- Rewriting stable transitions to normalize names; changing visible
+  product behavior as part of mechanical cleanup.
+- Fixing the usePlan/usePlanEvents dual-source write race (moves intact,
+  commented); retiring machine _reads_ of UI-owned atoms.
+
+## Success criteria
+
+Phase A is complete when:
+
+- Zero same-process machine-written Jotai atoms remain except the
+  documented deliberate keeps (each commented at the write site);
+  `registerAtomWriter`/`projectToAtom` have no production callers outside
+  the cross-process allowlist.
+- Cross-machine communication uses typed facades or owned stores only —
+  post-commit, identity-carrying, deferred where crossing into another
+  machine's dispatch. No machine reads or subscribes to an atom written by
+  another machine.
+- The #4077 protective comments are deleted because the re-entrancy vector
+  no longer exists.
+- `previewRuntimeAtoms.ts`, `store/appAtoms.ts`, the first_prompt and
+  user_input projection atoms, and `clearPreviewRuntimeForAppAtom` are
+  gone; cleanup rides `useRegisterEntityDisposer` + `disposeKey`.
+- Boundary tests prevent reintroduction; all listed suites pass ported,
+  not weakened; the streaming E2E suite and
+  `e2e-tests/package_manager.spec.ts` pass unchanged; the
+  priority-direction characterization test exists against the new store.
+- A contributor can answer — where a lifecycle fact is stored, which
+  transition changes it, which selector exposes it, which command performs
+  its effects, which typed facade connects another machine — without
+  finding a second atom, counter, ref, or effect that must agree.
+
+Phase B/C add: migrated controllers pass conformance with trace parity;
+every remaining custom runtime has a documented reason (resource
+ownership, synchronous contract, or a pending Phase C hold); and if the
+gate triggers, the distributed pilots are judged by that plan's own
+acceptance criteria and deletion budget.

--- a/plans/codex-cleanup-state-machines.md
+++ b/plans/codex-cleanup-state-machines.md
@@ -1,0 +1,1028 @@
+# Cleanup and Consolidation of the State-Machine Layer
+
+## Status
+
+Proposal.
+
+This plan follows `plans/state-machines-hardening.md`. The hardening work made
+the state-machine layer substantially safer: transition results are
+discriminated, operation identity is explicit, lifecycle cleanup is shared,
+selected controllers use transactional dispatch, and transition traces are
+more useful. It did not attempt to make the resulting architecture small or
+uniform.
+
+The next problem is comprehensibility. Several workflows now have an
+authoritative state-machine snapshot and a second Jotai representation of the
+same lifecycle. Some machines use `TransactionalDispatcher`; others still
+implement their own dispatch loop. Some cross-machine signals travel through
+typed facades, while others travel through atoms that act as mailboxes or
+observable flags. Providers and managers repeat similar ownership plumbing.
+
+This plan removes those transitional structures without weakening the race,
+identity, disposal, persistence, or observability guarantees established by
+the hardening work.
+
+## Executive summary
+
+The target architecture is:
+
+```text
+producer event
+    |
+    v
+typed machine facade
+    |
+    v
+TransactionalDispatcher -> committed immutable snapshot -> pure selectors
+    |                                                       |
+    v                                                       v
+command adapter                                      React domain hook
+    |                                                       |
+    v                                                       v
+IPC / Query / UI-only runtime stores                      component
+```
+
+The central rule is:
+
+> A lifecycle fact represented in a machine snapshot is not also stored in
+> Jotai.
+
+Jotai remains appropriate for client-only state that is not owned by a
+machine: edit buffers, navigation preferences, high-frequency console and
+stream content, transient selections, and independently sourced diagnostics.
+React Query remains authoritative for IPC-backed entities. Main-process
+machines may expose renderer read models across IPC, because that is a process
+boundary rather than a second same-process authority.
+
+The cleanup is incremental. Each domain migrates its consumers first, deletes
+its compatibility projection in the same PR, and retains focused regression
+tests. There is no repository-wide flag day and no period in which two
+independent writers are accepted as a steady state.
+
+## Problem statement
+
+### 1. Same lifecycle, multiple representations
+
+The largest example is `app_run`.
+
+`RunState` already contains:
+
+- the lifecycle (`idle`, `starting`, `ready`, `reloading`, `stopping`,
+  `stopped`, or `errored`);
+- the operation and `startedAt`;
+- the current invocation identity;
+- the current URL;
+- the exit code;
+- the operation error.
+
+The renderer also stores related values in:
+
+- `previewRunStateByAppIdAtom`;
+- `appUrlByAppIdAtom`;
+- `previewAppExitByAppIdAtom`;
+- `previewErrorByAppIdAtom`;
+- `previewReloadTokenByAppIdAtom`.
+
+Some of these are exact projections, some combine independent sources, and
+some are imperative UI epochs. Keeping them together in
+`previewRuntimeAtoms.ts` obscures ownership and makes one output event update
+the machine and atoms in separate commits.
+
+`chat_stream`, `first_prompt`, and `image_generation` also publish
+same-process machine projections into Jotai:
+
+- `isStreamingByIdAtom`;
+- `firstPromptSagaAtom`;
+- `imageGenerationJobsAtom` and its derived atoms.
+
+Single-writer enforcement prevents the worst races, but it does not remove the
+second representation, projection lifecycle, cleanup ordering, or reviewer
+burden.
+
+### 2. Atoms used as cross-machine protocols
+
+Three current dependencies use Jotai as an event or status bus:
+
+- `preview_iframe` watches `previewRunStateByAppIdAtom` to infer that
+  `app_run` restarted;
+- `plan_handoff` watches `isStreamingByIdAtom` to infer that `chat_stream`
+  became idle;
+- screenshot producers write `pendingScreenshotAppIdsAtom`, which the
+  screenshot provider consumes as a mailbox.
+
+These dependencies are difficult to discover from the machine types. They
+also lose domain information: a boolean edge or map mutation is weaker than a
+typed event carrying the relevant operation identity.
+
+### 3. Controller mechanics remain inconsistent
+
+There are thirteen machine domains:
+
+- renderer workflows: `app_run`, `chat_stream`, `first_prompt`,
+  `github_ops`, `image_generation`, `plan_handoff`, `preview_iframe`,
+  `screenshot`, `version_preview`, and `voice_to_text`;
+- main-process workflows: `connection_flow`, `mcp_oauth`, and `user_input`.
+
+Only `image_generation`, `screenshot`, and `voice_to_text` currently use
+`TransactionalDispatcher`. The remaining runtimes use combinations of
+`SnapshotStore`, hand-written re-entrancy queues, direct observer calls,
+registry maps, timers, and domain-specific command drains.
+
+Some deviations are legitimate, especially main-process registries owning
+external resources. The current code does not make the distinction obvious:
+custom mechanics and necessary domain policy are interleaved.
+
+### 4. Aggregate UI state is sometimes stored instead of selected
+
+Examples:
+
+- `activeCheckoutCounterAtom` mirrors whether any `version_preview` controller
+  is mutating;
+- `isStreamingByIdAtom` is an aggregate index over per-chat snapshots;
+- image-generation job arrays are copied from a manager projection store into
+  Jotai and then selected again.
+
+Aggregate views are useful, but they should be read-only external-store
+selectors over authoritative snapshots. They should not require another
+general-purpose state container.
+
+### 5. Domain adapters know too much about Jotai
+
+Machine command adapters legitimately perform UI effects, but several also
+read lifecycle flags or write lifecycle projections. This makes a pure machine
+look authoritative while its effective behavior still depends on atom state.
+
+For example, `plan_handoff` reads streaming status from Jotai, and
+`app_run` commands separately write URL and error atoms. These should be
+explicit dependencies or machine events, not implicit access to a shared
+store.
+
+## Goals
+
+1. Give each lifecycle fact exactly one authoritative owner.
+2. Make renderer components read machine snapshots through domain hooks and
+   pure selectors.
+3. Remove same-process machine-to-Jotai lifecycle projections.
+4. Replace atom mailboxes and cross-machine flag watching with typed facades
+   or typed events wired at composition roots.
+5. Migrate custom controller transaction mechanics to
+   `TransactionalDispatcher` unless a documented resource-owning registry
+   genuinely requires a different runtime.
+6. Reduce provider, manager, and selector boilerplate without introducing a
+   framework that owns domain policy.
+7. Keep high-frequency and orthogonal UI state out of machine snapshots.
+8. Preserve all operation-correlation, stale-event, disposal, hydration,
+   queue-ownership, and cross-process guarantees from the hardening work.
+9. Make ownership mechanically auditable in tests and repository boundaries.
+
+## Non-goals
+
+- Replacing the pure TypeScript machines with XState or another statechart
+  framework.
+- Moving all renderer state into machines.
+- Moving console logs, partial streamed text, form buffers, modal visibility,
+  selected files, or other high-frequency/ephemeral UI state into machine
+  snapshots.
+- Replacing React Query with machine or Jotai caches.
+- Rewriting stable domain transitions merely to normalize state names.
+- Combining independent machines into one application-wide machine.
+- Removing cross-process renderer read models when the authority lives in the
+  main process.
+- Changing visible product behavior as part of a mechanical cleanup.
+
+## Ownership model
+
+Every stateful value touched by a machine migration must be classified before
+code changes begin.
+
+### Machine-owned lifecycle state
+
+Examples:
+
+- current phase;
+- active operation identity;
+- retry/cancellation status;
+- machine-owned URL or selected version;
+- machine-owned error and recovery state;
+- capability flags derived from the snapshot.
+
+Rules:
+
+- stored only in the machine snapshot;
+- read through a domain hook/facade;
+- derived with pure selectors;
+- never mirrored into a writable atom;
+- never reconstructed by watching command side effects.
+
+### External entity data
+
+Examples:
+
+- apps, chats, versions, settings, files, reports, persisted plans.
+
+Rules:
+
+- owned by React Query or the main-process persistence layer;
+- invalidated or refreshed by command adapters;
+- not copied into machine state unless a stable operation snapshot is required
+  for correctness.
+
+### UI/runtime state
+
+Examples:
+
+- chat edit buffers;
+- partial streamed message text;
+- console output buffers;
+- terminal panel visibility;
+- dismissed banners;
+- visual-editor selections;
+- local dialog/form state.
+
+Rules:
+
+- Jotai when it must survive unmounts or be shared across distant components;
+- local React state when confined to one subtree;
+- keyed by entity where applicable;
+- not promoted into a machine solely to reduce atom count.
+
+### Cross-process projections
+
+Examples:
+
+- renderer-visible pending user-input requests whose authority is the
+  main-process `user_input` registry.
+
+Rules:
+
+- explicitly named as read models or projections;
+- one adapter owns hydration, ordering, and writes;
+- public APIs are read-only;
+- not described as duplicate renderer machine state;
+- may remain Jotai-backed when Jotai composition is materially useful.
+
+### Derived indexes
+
+Examples:
+
+- “any version checkout in progress”;
+- “which chats are currently streaming”;
+- image-generation job lists.
+
+Rules:
+
+- computed from authoritative keyed snapshots;
+- exposed by a manager as a reference-stable external-store snapshot only
+  when a real cross-key consumer exists;
+- never independently mutated;
+- prefer per-key subscriptions so unrelated entities do not rerender;
+- document retention and cleanup if the index includes terminal snapshots.
+
+## Current-state audit and intended disposition
+
+| Domain             | Runtime today                                          | Duplicate/implicit state                                                       | Disposition                                                                                     |
+| ------------------ | ------------------------------------------------------ | ------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
+| `app_run`          | Custom `SnapshotStore`, FIFO, command queue            | Loading, URL, operation error, exit overlap in preview atoms                   | Migrate runtime; remove lifecycle projections; split independent diagnostics                    |
+| `chat_stream`      | Custom `SnapshotStore` and command orchestration       | `isStreamingByIdAtom`; queue/status dependencies through Jotai                 | Migrate runtime; direct per-chat selectors; typed status facade                                 |
+| `first_prompt`     | Custom controller                                      | `firstPromptSagaAtom` mirrors snapshot projection                              | Expose snapshot/projection in provider context; delete atoms                                    |
+| `github_ops`       | Custom controller                                      | No lifecycle atom projection                                                   | Preserve hook shape; migrate transaction mechanics                                              |
+| `image_generation` | `TransactionalDispatcher` per job                      | Manager projection copied into Jotai                                           | Expose manager projection directly through hooks; keep dismissal UI atom                        |
+| `plan_handoff`     | Custom controller                                      | Reads stream-idle through `isStreamingByIdAtom`                                | Inject chat-stream status facade; migrate runtime                                               |
+| `preview_iframe`   | Custom controller                                      | Restart inferred through app-run atom; error command writes mixed preview atom | Wire typed app-run event; split iframe diagnostics; migrate runtime                             |
+| `screenshot`       | `TransactionalDispatcher`                              | `pendingScreenshotAppIdsAtom` is a producer mailbox                            | Replace mailbox with injected screenshot request facade                                         |
+| `version_preview`  | Custom controller                                      | Global `activeCheckoutCounterAtom` mirrors mutations                           | Expose aggregate mutation selector from manager; migrate runtime                                |
+| `voice_to_text`    | `TransactionalDispatcher`                              | None identified                                                                | Use as the minimal direct-binding reference implementation                                      |
+| `connection_flow`  | Custom main registry with derived effects              | No Jotai duplication                                                           | Adopt shared dispatch/lease mechanics where compatible; document remaining deviation            |
+| `mcp_oauth`        | Custom main registry owning listeners, waiters, timers | No Jotai duplication                                                           | Separate pure transaction mechanics from resource registry; retain explicit resource policy     |
+| `user_input`       | Main registry plus renderer IPC projection             | Legitimate cross-process projection                                            | Keep boundary; audit naming and optionally replace atom backend only if it simplifies consumers |
+
+## Target renderer APIs
+
+### Keyed machine hook
+
+Each keyed renderer machine exposes one domain hook:
+
+```ts
+interface AppRunView {
+  state: RunState;
+  projection: AppRunProjection;
+  send(event: AppRunInput): void;
+}
+
+function useAppRun(appId: number | null): AppRunView;
+```
+
+The projection is a reference-stable, pure function of the snapshot:
+
+```ts
+function projectAppRun(state: RunState): AppRunProjection;
+```
+
+It can expose convenient values such as `isLoading`, `url`, `operationError`,
+and capabilities, but it does not store them elsewhere.
+
+### Imperative facade
+
+Non-React consumers and other machines receive a narrow facade:
+
+```ts
+interface ChatStreamStatusFacade {
+  getState(chatId: number): StreamState;
+  subscribe(chatId: number, listener: () => void): () => void;
+}
+```
+
+The facade is injected at a composition root. A machine does not import
+another machine's manager, controller, provider, or atom.
+
+### Aggregate external-store selector
+
+Cross-key UI uses an aggregate manager snapshot only when per-key component
+subscriptions are impractical:
+
+```ts
+interface ImageGenerationProjectionSource {
+  getSnapshot(): readonly ImageGenerationJobView[];
+  subscribe(listener: () => void): () => void;
+}
+```
+
+The manager owns reference stability and retention. React consumes it with
+`useSyncExternalStore`; it is not copied into Jotai.
+
+### One-shot domain events
+
+Events such as stream completion or app-run restart remain subscriptions, not
+state:
+
+```ts
+interface AppRunLifecycleEvent {
+  appId: number;
+  invocationRef: AppRunInvocationRef;
+  type: "restart-started" | "stopped";
+}
+```
+
+Callbacks run after the committed snapshot is visible. Event APIs document
+whether they are lossless, replayable, or live-only.
+
+## Shared infrastructure changes
+
+### 1. Selector-aware external-store bindings
+
+Add small React helpers under `src/state_machines/react.ts`:
+
+- `useMachineSelector(controller, selector, isEqual?)`;
+- `useKeyedMachineSelector(manager, key, selector, isEqual?)`;
+- `useProjectionSource(source)`.
+
+Requirements:
+
+- no resubscription when only the selector closure changes;
+- reference-stable server snapshot behavior;
+- optional equality for small scalar/object projections;
+- tests for unrelated-key updates and StrictMode replay;
+- no dependency on Jotai.
+
+Prefer React's supported selector shim if already available transitively;
+otherwise keep the helper small and tested rather than implementing a broad
+state library.
+
+### 2. Standard manager facade
+
+Keep `KeyedControllerHost`, but standardize the common renderer manager
+surface:
+
+```ts
+interface KeyedMachineManager<Key, State, Input> {
+  getSnapshot(key: Key): State;
+  subscribeKey(key: Key, listener: () => void): () => void;
+  send(key: Key, input: Input): void;
+  disposeKey(key: Key): void;
+  dispose(): void;
+}
+```
+
+Do not force promise-returning dispatch, recovery indexes, or specialized
+registrations into this base interface. Those remain domain extensions.
+
+### 3. Projection-free provider convention
+
+Providers own managers and lifecycle only. They do not copy snapshots to
+atoms.
+
+The standard provider shape is:
+
+1. construct the manager without external subscriptions;
+2. start subscriptions after commit;
+3. register entity disposal;
+4. expose the manager through context;
+5. stop synchronously and dispose with the existing StrictMode-safe lifecycle.
+
+Domain hooks live beside the provider and return state/projection/actions.
+
+### 4. Composition-root wiring
+
+Create typed adapters at the nearest common owner for:
+
+- `app_run -> preview_iframe`;
+- `chat_stream -> plan_handoff`;
+- producers `-> screenshot`;
+- `user_input -> chat_stream` (preserve the existing facade direction).
+
+Record the final dependency graph in module headers and in a focused
+architecture test. It must remain acyclic.
+
+### 5. Ownership boundary test
+
+Extend `src/state_machines/boundaries.test.ts` with enforceable rules:
+
+- `state.ts` and `transition.ts` cannot import `@/atoms`, Jotai, React, IPC, or
+  another machine;
+- a machine directory cannot import another machine's controller, registry,
+  manager, or provider;
+- machine lifecycle projection modules cannot export writable Jotai atoms;
+- approved cross-process projection modules are allowlisted with a reason;
+- approved UI/runtime atom imports in command adapters are inventoried;
+- new uses of `registerAtomWriter` or `projectToAtom` outside the cross-process
+  allowlist fail the test.
+
+This is intentionally stricter for new code than for the initial migration.
+Temporary exceptions carry an owner and deletion PR.
+
+## Domain cleanup details
+
+### A. `app_run`
+
+This is the first and most important cleanup because it has the most confused
+ownership and feeds `preview_iframe`.
+
+#### State and projection
+
+Add `app_run/projection.ts` with a pure, cached `projectAppRun` selector.
+Expose:
+
+- lifecycle state;
+- `isLoading`;
+- active operation and `startedAt`;
+- current `RunUrl | null`;
+- operation error;
+- stopped/ready status;
+- capabilities such as `canStart`, `canRestart`, `canStop`, and
+  `canReload`.
+
+Do not expose invocation identity to ordinary UI consumers unless required for
+diagnostics.
+
+#### Split `previewRuntimeAtoms`
+
+Delete machine-owned storage:
+
+- `previewRunStateByAppIdAtom`;
+- `currentPreviewRunStateAtom`;
+- `currentPreviewLoadingAtom`;
+- `currentPreviewRunStartedAtAtom`;
+- `appUrlByAppIdAtom`;
+- `currentAppUrlAtom`;
+- the `dyad-app` portion of `previewErrorByAppIdAtom`.
+
+Audit before deciding the fate of:
+
+- `previewAppExitByAppIdAtom`: if the UI needs the last output event timestamp
+  independently of current machine state, rename it to
+  `lastPreviewExitEventByAppIdAtom` and document it as diagnostics history;
+  otherwise derive exit information from `RunState`;
+- `previewReloadTokenByAppIdAtom`: move iframe identity changes into
+  `PreviewIframeState.iframeEpoch` and delete the token;
+- `previewErrorByAppIdAtom`: split independent iframe/client/sync diagnostics
+  into explicitly named keyed stores, then compose display priority in a pure
+  preview selector;
+- console entries and package-manager warnings: retain as runtime/UI state.
+
+#### Commands and producer output
+
+- `applyUrl` changes machine state; it must not separately write a URL atom.
+- Operation failure changes machine state; it must not separately write a
+  lifecycle error atom.
+- `APP_EXIT` must have one authoritative admission/commit path. Independent
+  diagnostic history, if retained, is written only after the machine admits
+  the correlated event.
+- HMR/manual reload emits a typed iframe reload/restart event through the
+  composition adapter rather than incrementing an atom token.
+- Console logging and warnings remain adapter effects.
+
+#### Runtime
+
+Migrate `AppRunController` to `TransactionalDispatcher`.
+
+Preserve:
+
+- non-blocking run/stop IPC settlement;
+- per-app command scheduling policy;
+- invocation registration and claims;
+- dispatch waiter settlement;
+- legacy ref-less producer compatibility;
+- external agent lifecycle operations;
+- disposal of pending waiters and late settlements.
+
+Delete:
+
+- the hand-written `processing` flag;
+- the `pendingEvents` FIFO;
+- duplicate snapshot/observer ordering code;
+- projection-writer lifecycle from `AppRunManager`.
+
+### B. `chat_stream`
+
+#### Remove the streaming atom
+
+Delete `isStreamingByIdAtom` after migrating all consumers.
+
+Provide pure selectors:
+
+- `selectIsStreamActive(state)`;
+- `selectCanSubmitImmediately(state)`;
+- `selectCanCancel(state)`;
+- `selectStreamError(state)`.
+
+React components that render one chat use a keyed machine selector. Tab-list
+rows subscribe per chat rather than reading a global map. If measurement shows
+that this creates unacceptable subscription overhead, add a manager-owned
+read-only active-chat index; do not restore a writable atom.
+
+#### Migrate imperative consumers
+
+- `resyncChat` receives a `ChatStreamStatusFacade`;
+- `plan_handoff` receives the same facade and subscribes to the target chat;
+- queue dispatch consults the controller snapshot, not the streaming atom;
+- tests and hybrid harnesses drive the manager/controller rather than writing
+  `isStreamingByIdAtom` directly.
+
+#### Clarify retained Jotai state
+
+Retain, with documented ownership:
+
+- `chatMessagesByIdAtom` for optimistic/streaming renderer messages;
+- `streamingPreviewByChatIdAtom` for high-frequency partial content;
+- editable/persisted queued message data if the queue remains a user-editable
+  renderer model;
+- `queuePausedByIdAtom` only if pause is intentionally queue policy outside
+  the stream lifecycle;
+- `chatErrorByIdAtom` only for errors not represented by `StreamState`.
+
+For each retained value, add a short ownership comment explaining why it is
+not derivable from `StreamState`. Split mixed error state if necessary.
+
+#### Runtime
+
+Migrate the controller transaction loop to `TransactionalDispatcher`, while
+retaining the command scheduler that allows long-lived stream work without
+blocking event admission.
+
+Preserve:
+
+- globally unique invocation refs;
+- registration/cancel races;
+- finalize side effects;
+- queue ownership and durable follow-up acknowledgement;
+- quiescent controller release;
+- post-commit `streamFinished` delivery;
+- late transport cleanup.
+
+### C. `first_prompt`
+
+- Expand the provider context to expose a reference-stable snapshot source.
+- Add `useFirstPrompt()` returning `{ state, projection, send/resume }`.
+- Move `projectFirstPromptState` to a pure cached selector without Jotai.
+- Migrate `home.tsx`, `TitleBar`, `SetupBanner`, and
+  `ProviderSettingsPage` to the hook.
+- Delete `firstPromptSagaProjectionWriteAtom`,
+  `firstPromptSagaAtom`, its manual subscription, and disposal reset.
+- Keep home input, attachments, selected app, and setup-dialog visibility in
+  their existing UI owners.
+- Migrate controller transaction mechanics after projection removal so any
+  behavior regression is bisectable.
+
+### D. `image_generation`
+
+- Keep the manager-owned aggregate `SnapshotStore` because it provides a real
+  retained cross-job read model.
+- Rename `getProjection`/`subscribeProjection` to
+  `getJobsSnapshot`/`subscribeJobs` for clarity.
+- Add hooks for all jobs, pending count, and chat-visible jobs using external
+  store selectors.
+- Migrate the progress dialog, progress button, chat strip/input, and toast
+  orchestration to those hooks or direct manager subscriptions.
+- Delete `_imageGenerationJobsAtom`, `imageGenerationJobsAtom`,
+  `setImageGenerationJobsProjectionAtom`,
+  `pendingImageGenerationsCountAtom`, and
+  `chatImageGenerationJobsAtom`.
+- Retain `dismissedImageGenerationJobIdsAtom` as independent UI state.
+- Keep terminal retention policy in the manager and test its reference
+  stability.
+
+### E. `version_preview`
+
+- Add an aggregate manager selector for active mutations, derived from keyed
+  snapshots.
+- Migrate `ChatHeader` from
+  `isAnyCheckoutVersionInProgressAtom` to the selector.
+- Delete `activeCheckoutCounterAtom` and
+  `isAnyCheckoutVersionInProgressAtom`.
+- Remove counter increment/decrement from the command adapter.
+- Ensure the aggregate includes every mutation phase that previously held the
+  counter, including recovery/return flows where appropriate.
+- Migrate the custom controller to `TransactionalDispatcher` in a separate PR
+  with trace comparison and recovery tests.
+
+### F. `preview_iframe`
+
+- Stop watching `previewRunStateByAppIdAtom`.
+- Wire an app-run lifecycle facade at the provider composition root.
+- Send `RUNTIME_RESTARTED` with sufficient identity to reject duplicate or
+  stale notifications; do not deduplicate only by `startedAt`.
+- Route URL changes from committed app-run snapshots/events.
+- Make `PreviewIframeState.iframeEpoch` the only iframe replacement/reload
+  identity.
+- Split preview iframe errors from app-run and sync errors; compose them only
+  at the display selector.
+- Migrate the controller to `TransactionalDispatcher`.
+
+### G. `plan_handoff`
+
+- Replace `watch-stream-idle`'s Jotai subscription with the injected
+  `ChatStreamStatusFacade`.
+- The watcher reads the current committed chat snapshot before subscribing,
+  subscribes by chat key, and rechecks after subscription to close the
+  check/subscribe race.
+- Preserve task-scope cleanup when leaving the waiting state.
+- Keep plan content in its existing renderer owner; the handoff snapshot
+  retains only operation facts required for correctness.
+- Migrate the controller to `TransactionalDispatcher` and timer leases.
+
+### H. `screenshot`
+
+- Define a narrow `ScreenshotRequestFacade` with
+  `requestCapture(appId, source)`.
+- Inject it into `useCommitChanges`, chat-stream command dependencies, and
+  other producers.
+- Delete `pendingScreenshotAppIdsAtom` and the provider consumer effect.
+- Decide request coalescing explicitly in `ScreenshotManager`: replacement,
+  queueing, or ignore-by-state must be a transition policy, not an incidental
+  `Map` overwrite.
+- Preserve app-key disposal and selector-settle watchdog behavior.
+
+### I. `github_ops`
+
+- Preserve `useGithubOps` and `projectGithubOps` as the reference
+  projection-free public API.
+- Migrate the controller to `TransactionalDispatcher`.
+- Remove its hand-written event queue.
+- Retain domain-specific command concurrency and conflict-resolution runner
+  registration.
+- Run capability consistency and branch-inventory integration tests unchanged.
+
+### J. Main-process registries
+
+#### `connection_flow`
+
+- Use `TransactionalDispatcher` for state commit, observers, and timer lease
+  cancellation if the commandless derived-effect model can be expressed
+  without changing public synchronous claim semantics.
+- Represent timeout installation/cancellation with `TimerLeaseScope`.
+- Keep provider-specific timeout policy in the registry.
+- If synchronous `start`/`claimReturn` results prevent direct dispatcher use,
+  extract a small dispatcher-backed core and document the facade boundary.
+
+#### `mcp_oauth`
+
+- Separate state transaction mechanics from resource ownership:
+  listener handles, authorization callbacks, waiters, port-close barriers,
+  and provider aborts remain in the registry.
+- Route state changes through `TransactionalDispatcher`.
+- Use task/timer scopes for listeners and timeouts.
+- Preserve the port/flow identity registry and late listener-close barriers.
+- Add disposal and stale-callback conformance tests before changing structure.
+
+#### `user_input`
+
+The main registry remains authoritative and the renderer remains a
+cross-process read model.
+
+In the first cleanup pass:
+
+- rename projection types and comments consistently as a renderer read model;
+- retain the single-writer hydration/revision logic;
+- retain Jotai if its derived composition materially simplifies consumers;
+- exclude it explicitly from the no-projection boundary rule.
+
+In an optional later pass, compare a service-owned `SnapshotStore` plus domain
+hooks against the current atoms. Migrate only if it reduces total adapters and
+consumer complexity. Atom count alone is not sufficient justification.
+
+## Rollout
+
+Each PR must be independently reviewable and must delete the compatibility
+path it replaces. Do not land new hooks while leaving indefinite dual
+consumption.
+
+### PR 1 — Ownership inventory and boundary enforcement
+
+- Add the ownership table to repository documentation.
+- Add boundary-test rules for new machine lifecycle atoms, atom mailboxes, and
+  machine-to-machine imports.
+- Allowlist current violations with explicit deletion PR numbers/order.
+- Add selector-aware React binding tests.
+- No production behavior changes.
+
+### PR 2 — First-prompt projection removal
+
+This is the smallest proof that direct machine hooks can replace a global atom.
+
+- Add `useFirstPrompt`.
+- Migrate four consumers.
+- Delete both projection atoms and manual synchronization.
+- Add provider/hook tests, including StrictMode and disposal.
+
+### PR 3 — Image-generation projection removal
+
+- Add manager projection hooks/selectors.
+- Migrate consumers and toast orchestration.
+- Delete machine projection atoms.
+- Retain and test independent dismissal state.
+
+### PR 4 — Screenshot typed ingress
+
+- Add `ScreenshotRequestFacade`.
+- Migrate all producers.
+- Delete the mailbox atom and consumer effect.
+- Test simultaneous per-app requests and same-app coalescing.
+
+### PR 5 — App-run ownership split
+
+- Add `projectAppRun` and direct hook consumers.
+- Split runtime diagnostics from lifecycle state.
+- Remove loading, URL, lifecycle error, exit overlap, and reload-token
+  projections as resolved by the audit.
+- Wire typed app-run events to `preview_iframe`.
+- Keep the existing controller runtime for this PR to isolate ownership
+  changes.
+
+### PR 6 — App-run transactional migration
+
+- Move `AppRunController` to `TransactionalDispatcher`.
+- Remove custom FIFO/commit plumbing and projection writer.
+- Run controller conformance plus stale-output, external lifecycle, and
+  disposal tests.
+
+### PR 7 — Chat-stream direct status API
+
+- Add per-chat selectors/facade.
+- Migrate React and imperative consumers.
+- Delete `isStreamingByIdAtom`.
+- Update hybrid fixtures to drive the real manager boundary.
+- Preserve the existing controller runtime for bisection.
+
+### PR 8 — Plan-handoff and chat-stream transactional migrations
+
+- Replace stream-idle atom watching with the facade.
+- Migrate both custom controller loops.
+- Preserve durable follow-up acknowledgement and post-commit completion
+  notification.
+- Run co-simulation and integration suites for submit/cancel/queue/handoff
+  races.
+
+### PR 9 — Version-preview aggregate cleanup
+
+- Replace the global checkout counter with a manager selector.
+- Delete the atoms and adapter counter writes.
+- Test concurrent per-app mutations and controller disposal.
+
+### PR 10 — Remaining renderer controller migrations
+
+Use separate commits, and split into multiple PRs if review size grows:
+
+1. `github_ops`;
+2. `preview_iframe`;
+3. `version_preview`.
+
+Each migration requires before/after trace comparison and controller
+conformance.
+
+### PR 11 — Main-process registry consolidation
+
+Prefer separate PRs per registry:
+
+1. `connection_flow`;
+2. `mcp_oauth`;
+3. `user_input` runtime mechanics only if the dispatcher fits its synchronous
+   registry contract.
+
+Resource ownership and cross-process protocols receive focused tests rather
+than a mechanical bulk conversion.
+
+### PR 12 — Remove compatibility infrastructure
+
+After all same-process writers are gone:
+
+- delete unused `registerAtomWriter`/`projectToAtom` code if only the
+  allowlisted cross-process projection no longer needs it;
+- otherwise move the helpers next to the cross-process projection and narrow
+  their names;
+- remove all temporary boundary-test allowlist entries;
+- update `rules/state-machines.md`, `rules/jotai-state.md`, and
+  `docs/why-state-machines.md`;
+- add a repository test asserting that no lifecycle atom names from this plan
+  return.
+
+## Verification strategy
+
+### Pure transition tests
+
+Every domain continues to run:
+
+- reachable state/event exploration;
+- state and command inventory checks;
+- ignored-event reference identity checks;
+- capability/transition consistency where interactive actions exist;
+- stale invocation tests.
+
+Projection removal must not require transition changes unless the old
+projection exposed a missing domain fact. Such a change is isolated and
+reviewed as behavior, not folded into a mechanical consumer migration.
+
+### Controller conformance
+
+Every migrated controller runs `runControllerConformanceSuite`, covering:
+
+- observer/subscriber/command re-entrancy;
+- commit-before-notify ordering;
+- synchronous throws and async rejections;
+- disposal during commands;
+- late emissions after disposal;
+- recreate-after-dispose with stale callbacks;
+- final cleanup and idempotent disposal.
+
+### Renderer tests
+
+For each deleted atom:
+
+- test the replacement hook under a test-owned manager;
+- assert unrelated entity transitions do not rerender keyed consumers;
+- assert selectors update synchronously after committed transitions;
+- test provider replacement and StrictMode replay;
+- test deletion cleanup.
+
+Do not mock Jotai to simulate machine lifecycle after the migration.
+
+### Integration tests
+
+Required scenarios:
+
+- app run/restart/stop updates toolbar, iframe, URL, errors, and exit display
+  from one committed snapshot path;
+- proxy URL before/after IPC settlement;
+- stale proxy/exit output after controller replacement;
+- chat double-submit queues rather than drops;
+- cancel before and after stream registration;
+- stream completion wakes plan handoff without an atom edge;
+- screenshot requests from chat completion and explicit commit;
+- simultaneous image-generation jobs and terminal retention;
+- simultaneous version mutations across apps;
+- provider setup resumes first prompt without projection atoms.
+
+Use the renderer+IPC integration harness where possible. Use Playwright only
+for behavior requiring the real iframe, Electron output subscription, or
+browser interaction. Rebuild before E2E runs.
+
+### Performance checks
+
+Projection removal must not replace one global atom rerender with broad
+provider rerenders.
+
+Measure or assert:
+
+- keyed subscribers are notified only for their entity;
+- high-frequency stream chunks do not rerender lifecycle-only consumers;
+- console appends do not rerender app-run controls;
+- aggregate indexes reuse their reference when their selected value is
+  unchanged;
+- controller retention remains bounded.
+
+## Migration rules
+
+1. Consumer migration precedes projection deletion within the same PR.
+2. A compatibility projection has exactly one writer until deletion.
+3. Do not add new writes to a projection scheduled for removal.
+4. Do not make a formerly read-only projection writable to ease migration.
+5. Cross-machine adapters are injected; machine modules never import each
+   other's owners.
+6. When replacing an atom edge with a subscription, close the
+   read-before-subscribe race by checking before and immediately after
+   subscription.
+7. One-shot events run only after the authoritative snapshot commit.
+8. Preserve operation identity through new facade events.
+9. UI forms clear or close only on authoritative settlement.
+10. Every removed keyed atom has an explicit entity-deletion and provider
+    disposal replacement.
+11. Do not mix controller-runtime migration with domain behavior changes
+    unless the old mechanics make separation impossible.
+12. Any retained lifecycle-like atom must be justified in the ownership table
+    and boundary allowlist.
+
+## Risks and mitigations
+
+### Broader React subscriptions
+
+Direct external-store subscriptions could rerender more components than
+fine-grained atoms.
+
+Mitigation: selector-aware keyed hooks, scalar selectors, equality tests, and
+keeping high-frequency content outside lifecycle snapshots.
+
+### Lost aggregate visibility
+
+Deleting global maps can make “any entity active?” queries harder.
+
+Mitigation: add manager-owned, read-only aggregate indexes only for actual
+consumers. Test reference stability and cleanup.
+
+### Cross-machine timing changes
+
+Replacing atom observation with direct events can change callback ordering.
+
+Mitigation: specify post-commit delivery, carry invocation identity, and test
+re-entrant sends. Do not emit lifecycle events from command side effects when
+the transition itself is authoritative.
+
+### Mixed error sources
+
+Splitting `previewErrorByAppIdAtom` may change precedence between app-run,
+iframe, client, and sync errors.
+
+Mitigation: inventory current precedence and encode it in one pure display
+selector with table-driven tests before storage changes.
+
+### Controller migration regressions
+
+Custom runtimes may contain undocumented scheduling behavior.
+
+Mitigation: capture before/after traces, characterize scheduler concurrency,
+run conformance, and migrate one high-blast-radius controller per PR.
+
+### Test harness dependence on writable atoms
+
+Several tests currently set lifecycle atoms directly.
+
+Mitigation: introduce small test manager drivers and event fixtures. Tests
+should exercise the same authority boundary as production.
+
+## Success criteria
+
+The cleanup is complete when:
+
+- no same-process machine lifecycle is mirrored into Jotai;
+- `app_run` UI URL/loading/error state comes from its committed snapshot;
+- `isStreamingByIdAtom`, the first-prompt projection atoms, image-generation
+  projection atoms, screenshot mailbox atom, and version checkout counter are
+  deleted;
+- cross-machine coordination uses typed injected facades/events;
+- every renderer controller uses `TransactionalDispatcher`;
+- every remaining custom main-process registry has a documented resource or
+  synchronous-contract reason and uses shared transaction/lease primitives
+  where possible;
+- providers own lifecycle but do not synchronize machine snapshots into
+  atoms;
+- aggregate views are read-only manager projections with bounded retention;
+- boundary tests prevent reintroduction of lifecycle atoms and atom
+  mailboxes;
+- no UI regression occurs in run/restart, chat queue/cancel, plan handoff,
+  image generation, screenshot capture, version preview, OAuth, or user-input
+  flows;
+- `rules/state-machines.md`, `rules/jotai-state.md`, and
+  `docs/why-state-machines.md` describe the implemented architecture rather
+  than the transitional one.
+
+## Expected outcome
+
+The number of pure transitions and domain states will not necessarily shrink;
+they encode real workflow complexity. The surrounding code should shrink
+materially:
+
+- fewer writable atoms and setters;
+- no projection-writer lifecycle in renderer managers;
+- fewer manual subscriptions and edge-detection effects;
+- fewer hand-written controller queues;
+- clearer domain hooks;
+- explicit cross-machine dependencies;
+- one place to answer each lifecycle question.
+
+The desired review experience is that a contributor can determine:
+
+1. where a lifecycle fact is stored;
+2. which transition changes it;
+3. which selector exposes it;
+4. which command performs its effects;
+5. which typed facade connects another machine;
+
+without searching for a second atom, counter, ref, or effect that must agree.

--- a/plans/distrbuted-machines.md
+++ b/plans/distrbuted-machines.md
@@ -1,0 +1,1727 @@
+# Distributed Machine Runtime
+
+## Status
+
+Alternative architecture proposal.
+
+This plan is an alternative to completing the full rollout in
+`plans/codex-cleanup-state-machines.md`. It keeps the no-regrets ownership,
+selector, and simple projection-removal work from that plan, but replaces the
+later controller-by-controller cleanup with a shared actor runtime capable of
+hosting authoritative state machines in either Electron's main process or the
+renderer.
+
+The filename intentionally matches the requested
+`plans/distrbuted-machines.md`. The architecture and code should use the
+correct term “distributed.”
+
+## Summary
+
+Dyad currently has several related but distinct state-machine architectures:
+
+- renderer-owned controllers and managers;
+- main-process registries;
+- Jotai projections of renderer machine state;
+- IPC projections of main machine state;
+- typed facades for some cross-machine calls;
+- atoms used as status buses or mailboxes for other cross-machine calls;
+- domain-specific hydration, subscriptions, operation registries, and
+  disposal.
+
+The proposed runtime unifies these under one actor model:
+
+```text
+                          one authoritative actor
+                                     |
+              +----------------------+----------------------+
+              |                                             |
+       local typed ActorRef                         remote typed ActorRef
+              |                                             |
+              v                                             v
+    TransactionalDispatcher                      validated IPC transport
+              |                                             |
+              +----------------------+----------------------+
+                                     |
+                         committed immutable snapshot
+                                     |
+                          pure selectors / events
+                                     |
+                     React hooks or another actor facade
+```
+
+Every actor has exactly one authoritative host. “Distributed” means that the
+typed reference, snapshot subscription, tracing, and protocol contracts work
+across process boundaries. It does not mean shared memory, multi-primary
+replication, or transparent synchronous calls across IPC.
+
+The first remote pilot is `app_run`, hosted in the main process because the
+main process owns the child process, stdout producer, and teardown. The first
+local pilot is `voice_to_text`, hosted in the renderer because it owns browser
+media resources. Together they must prove that host location is an adapter
+rather than a second controller architecture.
+
+## Why pursue this instead of only cleaning up the existing layer?
+
+The incremental cleanup plan would improve the current design, but it would
+retain a structural distinction between:
+
+- main registries and renderer controllers;
+- local hooks and remote IPC projections;
+- process-owned resources and renderer-owned lifecycle;
+- ordinary machine messages and cross-machine handoffs.
+
+That distinction causes much of the current boilerplate. `app_run` is the
+clearest example: the renderer owns lifecycle state while the main process
+owns the process whose lifecycle is being modeled. Producer correlation,
+renderer disposal, projection atoms, and IPC settlement all compensate for
+that separation.
+
+A distributed runtime can move authority next to the resource while exposing
+the same read/send API to React. If successful, it removes entire classes of
+code instead of only standardizing them.
+
+This is worthwhile only if the framework replaces existing infrastructure.
+Adding it underneath the current controllers, managers, projections, and IPC
+adapters without deleting them would make the architecture worse.
+
+## Design principles
+
+### 1. One authoritative host
+
+Every actor instance is authoritative in exactly one process:
+
+- `main`: privileged work, durable workflows, child processes, filesystem,
+  git, OAuth listeners, or workflows that should survive renderer reload;
+- `renderer`: DOM, iframe, browser media, and presentation workflows tied to
+  one renderer lifetime.
+
+There is no bidirectional writable replication.
+
+### 2. Pure domain logic remains portable
+
+The existing shape remains:
+
+- `state.ts`: TypeScript domain types;
+- `transition.ts`: pure total transition;
+- `commands.ts`: command data and adapters;
+- `machine.ts` or `definition.ts`: runtime definition and placement metadata;
+- `transport.ts`: Zod wire codecs for remotely visible keys, events,
+  snapshots, and receipts;
+- `hooks.ts`: renderer bindings.
+
+`state.ts` and `transition.ts` do not import Electron, React, Jotai, IPC,
+Zod, timers, `Date`, or another machine.
+
+### 3. Location is explicit
+
+Remote calls must not masquerade as synchronous local calls.
+
+```ts
+const actor = useDistributedMachine(appRunMachine, appId);
+
+const receipt = await actor.dispatch({
+  type: "RESTART_REQUESTED",
+  options,
+});
+```
+
+The API and types distinguish local synchronous enqueue from remote committed
+dispatch. A caller can always determine whether failure means:
+
+- transport rejected;
+- event rejected before transition;
+- event deliberately ignored;
+- state committed;
+- command failed later;
+- durable receiver acceptance failed.
+
+### 4. Commit is not completion
+
+The generic transport acknowledges only event admission and state commit.
+Long-running command completion remains domain state/events.
+
+The runtime does not offer a misleading generic `dispatchAndWaitForEffects`.
+A domain may provide a typed waiter facade correlated to an invocation when
+the workflow genuinely requires it.
+
+### 5. Security is part of the machine definition
+
+A generic machine channel is not permission to dispatch arbitrary events.
+
+The main host:
+
+- registers only a static allowlist of remote machine definitions;
+- validates the machine ID, entity key, event, and expected actor identity;
+- uses the existing trusted-main-frame IPC handler boundary;
+- checks entity ownership/authorization before dispatch;
+- never accepts serialized commands from the renderer;
+- never dynamically imports a machine named by renderer input.
+
+### 6. Distributed failures are modeled, not hidden
+
+Renderer reload, window destruction, main shutdown, hydration races, duplicate
+messages, stale snapshots, and version mismatch are first-class contracts.
+
+### 7. Presentation stays responsive
+
+High-volume content such as console logs and LLM chunks does not travel as
+whole machine snapshots. Existing batched or streaming IPC channels remain
+appropriate. Machines own lifecycle and correlation, not every byte of
+runtime output.
+
+### 8. The framework stays small
+
+The runtime standardizes:
+
+- actor identity and keyed hosting;
+- event transaction mechanics;
+- local/remote references;
+- validated transport;
+- snapshot revisioning and subscriptions;
+- lifecycle, hydration, and tracing;
+- optional persistence and durable protocols.
+
+It does not standardize:
+
+- domain state shapes;
+- concurrency policy;
+- stale-event policy;
+- command semantics;
+- UI composition;
+- database schemas;
+- provider/backend behavior.
+
+## Terminology
+
+### Machine definition
+
+Pure transition plus runtime metadata, codecs, command scheduler factory, and
+host placement.
+
+### Actor
+
+One live keyed instance of a machine definition.
+
+### Actor key
+
+Stable domain key such as `appId`, `chatId`, provider, or OAuth port.
+
+### Actor instance ID
+
+Globally unique identity for one actor lifetime. Recreating the same machine
+and key produces a new actor instance ID.
+
+### Actor reference
+
+Typed capability for reading and sending to one actor. It may be local or
+remote.
+
+### Snapshot revision
+
+Monotonically increasing revision within one actor instance when the committed
+snapshot reference changes. It orders remote snapshot delivery but is not a
+globally unique operation identity.
+
+### Transaction sequence
+
+Monotonically increasing sequence for every processed event, including
+command-only applied events and ignored events. It orders receipts and traces
+without forcing a value-equal snapshot publication.
+
+### Invocation reference
+
+Identity for one domain operation within or across actor lifetimes. It remains
+separate from actor identity and message identity.
+
+### Message ID
+
+Transport identity used to deduplicate one remote dispatch.
+
+### Idempotency key
+
+Durable domain identity used when a receiver must deduplicate acceptance
+across retries or process restarts. A message ID is not automatically an
+idempotency key.
+
+## Proposed module structure
+
+```text
+src/distributed_machines/
+  definition.ts
+  actor_host.ts
+  actor_ref.ts
+  local_actor_ref.ts
+  remote_actor_ref.ts
+  registry.ts
+  transport_types.ts
+  remote_snapshot_store.ts
+  persistence.ts
+  protocol.ts
+  tracing.ts
+  react.ts
+  testing/
+    fake_transport.ts
+    host_conformance.ts
+    remote_conformance.ts
+    crash_harness.ts
+
+src/ipc/types/distributed_machines.ts
+src/ipc/handlers/distributed_machine_handlers.ts
+src/ipc/services/distributed_machine_host.ts
+```
+
+The existing primitives under `src/state_machines/` remain the pure/runtime
+kernel. The distributed layer composes them; it does not duplicate
+`TransactionalDispatcher`, `SnapshotStore`, `TaskScope`, timer leases,
+invocation references, trace buffers, or transition test utilities.
+
+If the pilots show that “distributed machines” are the normal form, the
+folders may later be consolidated. Do not move existing files during the
+pilot merely for naming symmetry.
+
+## Machine definition API
+
+The exact API should be proven by pilots, but it should express the following
+contracts:
+
+```ts
+interface DistributedMachineDefinition<
+  Id extends string,
+  Key,
+  State,
+  Event,
+  Command,
+  Reason extends string,
+> {
+  readonly id: Id;
+  readonly host: "main" | "renderer";
+  readonly initialState: (key: Key) => State;
+  readonly transition: (
+    state: State,
+    event: Event,
+  ) => TransitionResult<State, Command, Reason>;
+  readonly createScheduler: (key: Key) => CommandScheduler<Command>;
+  readonly createCommandRunner: (
+    context: MachineHostContext<Key, State, Event>,
+  ) => CommandRunner<Command, Event>;
+  readonly lifecycle: ActorLifecyclePolicy<Key, State>;
+  readonly persistence?: MachinePersistencePolicy<Key, State>;
+  readonly remote?: RemoteMachineContract<Key, State, Event>;
+}
+```
+
+Important constraints:
+
+- host placement is static for a shipped application version;
+- command runners are constructed only in the host process;
+- remote contracts are required only when another process needs access;
+- state/event wire codecs live outside pure domain files;
+- a renderer-hosted actor can use the same local reference API without
+  defining remote codecs;
+- definitions are registered explicitly at a composition root.
+
+Avoid elaborate type-level inference in the first implementation. Clear
+generic annotations and useful compiler errors are more valuable than a
+clever DSL.
+
+## Actor host
+
+`ActorHost` owns keyed actors for one process:
+
+```ts
+interface ActorHost {
+  register(definition: DistributedMachineDefinition<...>): void;
+  ensure(machineId: string, key: unknown): HostedActor;
+  peek(machineId: string, key: unknown): HostedActor | undefined;
+  disposeKey(machineId: string, key: unknown): void;
+  disposeMachine(machineId: string): void;
+  dispose(): Promise<void>;
+}
+```
+
+Each hosted actor owns:
+
+- actor instance ID;
+- snapshot revision;
+- transaction sequence;
+- `TransactionalDispatcher`;
+- command scheduler/runner;
+- task and timer scopes;
+- invocation registry where required;
+- subscriber set;
+- optional persistence adapter;
+- bounded traces;
+- final disposal barrier.
+
+### Event transaction
+
+For one admitted event:
+
+1. validate the event at the transport boundary if remote;
+2. deduplicate the message envelope;
+3. append to the actor FIFO;
+4. run the pure transition exactly once;
+5. validate the result;
+6. reserve the command batch;
+7. cancel exiting state-owned leases;
+8. commit the snapshot;
+9. increment the snapshot revision only if the snapshot reference changed;
+10. notify local snapshot subscribers only if the snapshot changed;
+11. publish a remote snapshot envelope only if the snapshot changed;
+12. notify trace/transition observers;
+13. start the reserved command batch;
+14. resolve the remote dispatch receipt;
+15. process re-entrant events afterward.
+
+The receipt resolves after commit and publication has been scheduled, not
+after commands finish.
+
+Ignored events:
+
+- retain the exact snapshot reference and revision;
+- receive a transaction sequence for receipts/traces;
+- run no commands;
+- emit ignored-event traces;
+- return an ignored receipt with the stable domain reason.
+
+Applied command-only transitions also retain the snapshot revision and publish
+no snapshot. Their receipt records the new transaction sequence and current
+snapshot revision.
+
+### Dispatch tickets
+
+The existing `TransactionalDispatcher.send()` returns `void`. Remote dispatch
+requires an outcome for the exact queued event, including an event enqueued
+re-entrantly while another transaction is processing.
+
+Extend the dispatcher with a ticketed API:
+
+```ts
+interface DispatchTicket<State, Reason> {
+  readonly settled: Promise<
+    | {
+        kind: "applied";
+        state: State;
+      }
+    | {
+        kind: "ignored";
+        state: State;
+        reason: Reason;
+      }
+    | {
+        kind: "failed";
+        stage: "transition" | "validation" | "before-admission";
+        error: unknown;
+      }
+    | {
+        kind: "disposed";
+      }
+  >;
+}
+
+dispatcher.enqueue(event): DispatchTicket<State, Reason>;
+```
+
+Requirements:
+
+- the pending FIFO stores event/ticket entries, not domain wrapper events;
+- a re-entrant enqueue returns immediately and settles after its own FIFO turn;
+- ordinary `send(event)` remains a compatibility wrapper that intentionally
+  discards the ticket;
+- transition/validation failure settles the corresponding ticket and does not
+  wedge later entries;
+- disposal settles every unprocessed ticket as disposed;
+- scheduler or command failure after commit does not rewrite the settled
+  applied ticket;
+- ticket settlement happens after observer notification and scheduler handoff,
+  matching the dispatcher transaction contract.
+
+The actor host converts the dispatcher ticket into a transport receipt. Do not
+infer outcomes by comparing snapshots or listening to global observers.
+
+### Scheduler policy
+
+The host delegates scheduling to the definition. Supported reusable
+schedulers may include:
+
+- serial batch scheduler;
+- concurrent batch scheduler;
+- detached command scheduler;
+- keyed/operation-scoped scheduler.
+
+The runtime does not select one based on command shape.
+
+### Lifecycle policy
+
+Definitions state:
+
+- whether subscription creates an actor;
+- whether dispatch creates an actor;
+- idle eviction policy;
+- terminal retention;
+- entity-deletion behavior;
+- renderer/window ownership;
+- shutdown flush requirements;
+- whether the actor survives renderer reload;
+- whether state survives application restart.
+
+Actor disposal:
+
+1. stops event admission;
+2. settles or rejects domain waiters;
+3. publishes any declared terminal projection;
+4. cancels tasks/timers/resources;
+5. flushes persistence where required;
+6. removes subscriptions;
+7. disposes the dispatcher.
+
+## Local actor references
+
+A local reference is a thin typed facade over the host:
+
+```ts
+interface LocalActorRef<State, Event> {
+  readonly kind: "local";
+  getSnapshot(): State;
+  subscribe(listener: () => void): () => void;
+  send(event: Event): void;
+}
+```
+
+Local sends preserve the synchronous enqueue behavior of
+`TransactionalDispatcher`. Domain APIs may wrap `send` with waiters where
+needed.
+
+Renderer hooks use `useSyncExternalStore` and pure selectors. They do not copy
+snapshots into Jotai.
+
+## Remote actor transport
+
+### Contract integration
+
+Add contracts through the existing IPC architecture:
+
+- `defineContract` for subscribe/bootstrap, dispatch, and unsubscribe;
+- `defineEvent` for snapshot and actor-disposed broadcasts;
+- `createTypedHandler` for all main handlers;
+- preload allowlisting derived from the contracts.
+
+Do not call `ipcMain.handle` directly.
+
+The generic envelope is validated twice:
+
+1. the outer IPC Zod contract validates the protocol envelope;
+2. the registered machine's codecs validate its key, event, and snapshot.
+
+This preserves a static channel surface without treating inner payloads as
+trusted `unknown`.
+
+### Static manifest
+
+Remote definitions are assembled into a main-owned manifest:
+
+```ts
+const remoteMachineManifest = createRemoteMachineManifest([
+  appRunMachine,
+  githubOpsMachine,
+]);
+```
+
+The manifest:
+
+- rejects duplicate machine IDs;
+- contains key/event/snapshot codecs;
+- contains authorization policy;
+- maps IDs to already-constructed host definitions;
+- is the only router target.
+
+The renderer receives generated/inferred typed clients by importing the shared
+definition contract. It cannot register new main-hosted machines.
+
+### Dispatch envelope
+
+```ts
+interface MachineDispatchEnvelope {
+  protocolVersion: number;
+  machineId: string;
+  encodedKey: unknown;
+  expectedActorInstanceId?: string;
+  messageId: string;
+  causationId?: string;
+  correlationId?: string;
+  expectedRevision?: number;
+  encodedEvent: unknown;
+}
+```
+
+Semantics:
+
+- `expectedActorInstanceId` prevents a stale renderer from addressing a
+  replacement actor;
+- `expectedRevision` is optional optimistic concurrency, not required for
+  ordinary events;
+- `messageId` deduplicates retry of one transport send within the configured
+  retention window;
+- `correlationId` connects traces and domain waiters;
+- `causationId` reconstructs event chains;
+- domain invocation refs remain inside typed events where correctness needs
+  them.
+
+### Dispatch receipt
+
+```ts
+type MachineDispatchReceipt<Reason> =
+  | {
+      kind: "applied";
+      actorInstanceId: string;
+      revision: number;
+      transactionSequence: number;
+      messageId: string;
+    }
+  | {
+      kind: "ignored";
+      actorInstanceId: string;
+      revision: number;
+      transactionSequence: number;
+      messageId: string;
+      reason: Reason;
+    }
+  | {
+      kind: "rejected";
+      messageId: string;
+      reason:
+        | "unknown-machine"
+        | "invalid-key"
+        | "invalid-event"
+        | "unauthorized"
+        | "stale-actor"
+        | "revision-conflict"
+        | "host-disposing"
+        | "protocol-version";
+    };
+```
+
+Expected user/environment failures crossing the main boundary use
+`DyadError`/`DyadErrorKind` where the existing IPC error path is more
+appropriate. Domain-level ignored events remain successful receipts, not
+exceptions.
+
+Unexpected transition, validation, scheduler, or command failures are reported
+as programming errors. A command failure does not retroactively change an
+already-applied receipt.
+
+## Remote snapshot protocol
+
+### Snapshot envelope
+
+```ts
+interface MachineSnapshotEnvelope {
+  protocolVersion: number;
+  machineId: string;
+  encodedKey: unknown;
+  actorInstanceId: string;
+  revision: number;
+  encodedState: unknown;
+}
+```
+
+Snapshots are immutable, schema-versioned, and validated on both sides.
+`revision` changes only when the snapshot changes; transaction-only sequencing
+is carried by receipts and traces rather than snapshot envelopes.
+
+### Atomic subscribe/bootstrap
+
+The main handler must:
+
+1. validate and authorize the subscription;
+2. synchronously register the `webContents` subscriber;
+3. obtain the current actor snapshot and revision;
+4. return the bootstrap envelope.
+
+There must be no `await` between subscriber registration and snapshot capture.
+
+Broadcasts can arrive before the invoke promise resolves. The renderer remote
+store buffers them and applies envelopes monotonically after bootstrap:
+
+- a newer actor instance replaces an explicitly superseded instance;
+- within one actor instance, only increasing revisions apply;
+- duplicate revisions are ignored;
+- a revision gap triggers resynchronization rather than speculative merge;
+- an envelope for an old actor instance is ignored;
+- buffered entries are bounded.
+
+### Unsubscribe and window cleanup
+
+- Renderer unmount unsubscribes through the transport.
+- Main automatically removes every subscription on `webContents.destroyed`.
+- Unsubscribe is idempotent.
+- Lost unsubscribe messages cannot retain a destroyed window.
+- Subscription ownership is per `webContents`, machine, and encoded key.
+- Multiple components in one renderer are reference-counted by the renderer
+  remote store so they do not create duplicate IPC subscriptions.
+
+### Actor disposal notification
+
+Main publishes a typed disposed envelope containing the actor instance ID and
+final revision. The remote store transitions to the definition's unavailable
+or initial view and must not accept a late snapshot from the disposed actor.
+
+## Remote snapshot store and React API
+
+One renderer-owned `RemoteMachineClient` manages remote stores:
+
+```ts
+interface RemoteActorRef<State, Event, Reason> {
+  readonly kind: "remote";
+  getStatus(): "connecting" | "ready" | "disconnected" | "incompatible";
+  getSnapshot(): State;
+  subscribe(listener: () => void): () => void;
+  dispatch(event: Event): Promise<MachineDispatchReceipt<Reason>>;
+  resync(): Promise<void>;
+}
+```
+
+The React hook exposes transport status explicitly:
+
+```ts
+const { state, projection, connection, dispatch } = useDistributedMachine(
+  appRunMachine,
+  appId,
+);
+```
+
+Rules:
+
+- `state` is never silently fabricated as current authoritative state while
+  disconnected;
+- definitions choose an initial/unavailable view;
+- UI capabilities account for connection status;
+- selectors are pure and reference-stable;
+- remote snapshots are not copied into Jotai;
+- transport errors are distinct from domain operation errors;
+- reconnect automatically resubscribes and bootstraps;
+- pending dispatch promises reject or resolve with a transport-specific result
+  when the renderer is destroyed.
+
+## Serialization and wire compatibility
+
+Moving an existing renderer machine to main requires a serializability audit.
+
+Snapshots/events may not contain:
+
+- callbacks;
+- React objects;
+- DOM nodes;
+- Jotai stores;
+- query clients;
+- `AbortController` or resource handles;
+- unencoded `Map`, `Set`, `Error`, class instances, or platform objects.
+
+Wire codecs may deliberately encode supported domain values, but JSON
+stringification is not the implicit contract.
+
+### Versioning
+
+Each remote machine contract has:
+
+- protocol version;
+- state schema version;
+- event schema version;
+- optional migration for persisted state;
+- compatibility policy during an app update.
+
+The main and renderer normally ship together, but in-flight renderer reloads
+and update transitions can briefly cross versions. On incompatibility:
+
+- reject dispatch before transition;
+- stop applying snapshots;
+- report a clear recoverable renderer status;
+- request a full renderer reload when appropriate;
+- never coerce unknown events or states.
+
+### Legacy update compatibility
+
+Existing domains sometimes accept missing invocation refs so work crossing an
+application update can finish. Each pilot documents whether to retain this
+compatibility, structurally claim the producer, or deliberately terminate the
+old operation.
+
+The framework must not invent a universal “accept missing identity” rule.
+
+## Commands and execution location
+
+Commands execute beside the authoritative actor by default.
+
+For main-hosted actors:
+
+- filesystem, git, process, database, and privileged IPC work runs in main;
+- command adapters call services directly instead of invoking main through
+  renderer IPC;
+- renderer presentation observes snapshots or typed presentation events.
+
+For renderer-hosted actors:
+
+- DOM, media, and iframe effects run in renderer;
+- privileged operations use ordinary contract-driven IPC through the command
+  adapter.
+
+The first version does not support arbitrary commands marked
+`execution: "main" | "renderer"`. Split-location command routing would create
+a second distributed workflow with its own failure and acknowledgement
+semantics. Add it only after a real pilot proves snapshots/events cannot model
+the need.
+
+### Presentation events
+
+Toasts, navigation, focus, and other one-shot UI effects cannot always be
+derived safely from retained state. Main-hosted actors may publish typed,
+correlated presentation events after commit.
+
+Requirements:
+
+- events are live-only unless explicitly persisted;
+- duplicate suppression uses event identity;
+- events identify the actor instance and causative revision;
+- missing a presentation event never corrupts domain state;
+- critical user decisions are protocols, not presentation events.
+
+## Actor-to-actor communication
+
+### Ordinary messages
+
+An actor receives a typed facade/reference through its command adapter or
+composition root. It never imports another actor's host, manager, or registry.
+
+If both actors are in the same process, the facade dispatches locally. If they
+are in different processes, it uses the same validated transport.
+
+The dependency graph remains explicit and acyclic for ordinary command
+dependencies.
+
+### Durable protocol actors
+
+Cross-machine work requiring acknowledgement is not an ordinary message.
+
+Examples:
+
+- `user_input -> chat_stream` follow-up;
+- plan handoff into a new implementation turn;
+- any workflow that must survive renderer or application restart.
+
+Use a protocol actor with states such as:
+
+```text
+created
+  -> awaiting-receiver-acceptance
+  -> durably-accepted
+  -> executing
+  -> acknowledged
+  -> settled
+
+created/awaiting/executing
+  -> cancelling
+  -> rejected or settled
+```
+
+The protocol definition names:
+
+- durable owner;
+- record schema and version;
+- idempotency key;
+- acceptance transaction;
+- retry schedule;
+- cancellation semantics before/after acceptance;
+- receiver deduplication;
+- acknowledgement point;
+- crash/reload recovery;
+- retention and pruning.
+
+The actor transport provides message delivery; it does not claim exactly-once
+execution.
+
+## Persistence and recovery
+
+Persistence is optional per definition.
+
+```ts
+interface MachinePersistencePolicy<Key, State> {
+  load(key: Key): Promise<PersistedSnapshot<State> | undefined>;
+  save(key: Key, snapshot: PersistedSnapshot<State>): Promise<void>;
+  delete(key: Key): Promise<void>;
+  flushOnShutdown: boolean;
+}
+```
+
+### Hydration state
+
+The host does not accept domain events against an unhydrated persisted actor
+unless the definition explicitly defines buffering/merge semantics.
+
+The runtime tracks:
+
+- absent;
+- hydrating;
+- ready;
+- hydration-failed;
+- disposing.
+
+This runtime status is not silently inserted into the domain state union.
+Definitions may model a domain-visible recovery state when the UI needs it.
+
+Events arriving during hydration are:
+
+- buffered FIFO with a strict bound;
+- rejected; or
+- handled by a domain-defined merge policy.
+
+The definition must choose.
+
+### Save semantics
+
+- Commit remains the in-memory linearization point for ephemeral actors.
+- Durable protocols define a database acceptance transaction as their
+  authoritative linearization point.
+- Debounced snapshot persistence is never described as durable acceptance.
+- Shutdown flush has a hard timeout and reports failures.
+- Main shutdown follows Electron's `before-quit` re-entry rules.
+
+### Crash behavior
+
+The plan must document separately:
+
+- renderer reload;
+- renderer crash/window destruction;
+- main process/application crash;
+- operating-system termination;
+- application update between versions.
+
+Main-hosted ephemeral actors survive renderer reload but not main crash.
+Persisted actors recover only to the last committed durable snapshot/protocol
+record.
+
+## Security model
+
+### Trusted sender
+
+All invoke handlers use the existing trusted-main-frame enforcement. Machine
+transport does not accept messages from arbitrary frames or webviews.
+
+### Definition allowlist
+
+Only definitions registered in the main manifest are remotely addressable.
+Machine IDs are constants, not paths or module names.
+
+### Event allowlist
+
+Each definition's Zod event codec is the event allowlist. Avoid a schema such
+as `{ type: string, payload: unknown }`.
+
+### Entity authorization
+
+Definitions provide an authorization function where the key or event scopes
+access:
+
+```ts
+authorizeDispatch({
+  sender,
+  key,
+  event,
+  currentState,
+}): void | Promise<void>;
+```
+
+Authorization occurs before transition and before actor creation where
+possible. A renderer-supplied app ID never grants access by itself.
+
+### Commands are never transported from renderer
+
+The main derives commands only from its registered pure transition. The
+renderer cannot submit serialized commands, scheduler choices, state, or
+transition functions.
+
+### Snapshot projection
+
+Remote codecs explicitly project renderer-visible state. Main-only secrets,
+tokens, resource handles, paths, or large internal payloads are not exposed
+merely because they exist in the host snapshot.
+
+When remote state is a safe subset, distinguish:
+
+- authoritative host state;
+- remote snapshot/read-model state.
+
+The read model remains revisioned and single-writer, but it need not serialize
+the complete host state.
+
+### Resource limits
+
+Bound:
+
+- dispatch envelope size;
+- pending messages per actor;
+- deduplication retention;
+- remote snapshot size;
+- buffered pre-bootstrap snapshots;
+- subscriptions per window;
+- actors created only by subscriptions;
+- trace payloads and per-key metadata.
+
+## Observability
+
+Every transition trace includes:
+
+- process/host;
+- machine ID;
+- encoded safe entity key;
+- actor instance ID;
+- actor revision;
+- message ID;
+- correlation and causation IDs;
+- event description;
+- applied/ignored classification;
+- command descriptions;
+- transport latency for remote dispatch;
+- command errors;
+- persistence status when relevant.
+
+### Cross-process ordering
+
+A single wall-clock timestamp is not a causal order. Use:
+
+- per-host monotonic trace sequence;
+- actor revision;
+- causation/correlation IDs;
+- message send/receive trace pairs.
+
+Debug tooling reconstructs causal chains without pretending to create a total
+order across independent actors.
+
+### Redaction
+
+Machine definitions provide safe event/state descriptions. Raw untagged
+objects are never retained in production traces. Replay traces remain
+dev/test-only and use explicit serializers/redactors.
+
+### Debug surface
+
+Extend the dev-only machine inspector to show:
+
+- actor host process;
+- actor instance and revision;
+- connection/hydration status;
+- subscribers;
+- pending command batches;
+- task/timer resources;
+- last transport receipt;
+- trace chain.
+
+Do not expose this surface in production.
+
+## Testing architecture
+
+### Definition tests
+
+Existing transition requirements remain:
+
+- total state/event handling;
+- reference-stable ignored transitions;
+- reachable-state and producible-command inventories;
+- capability consistency;
+- deterministic fake clocks and IDs;
+- co-simulation for interacting workflows.
+
+### Local host conformance
+
+For every actor host:
+
+- re-entrant subscriber, observer, and command emissions;
+- scheduler throws/rejections;
+- actor disposal during command execution;
+- late event after disposal;
+- key disposal/recreation;
+- stale actor instance rejection;
+- timer/resource cleanup;
+- bounded idle eviction.
+
+### Transport conformance
+
+Use an in-memory fake duplex transport to test:
+
+- duplicate dispatch delivery;
+- dropped receipt after committed dispatch and retry;
+- snapshots arriving before bootstrap;
+- duplicate/out-of-order snapshots;
+- revision gaps and resync;
+- stale actor instance snapshots;
+- disconnect during dispatch;
+- reconnect and resubscribe;
+- renderer destruction without unsubscribe;
+- protocol version mismatch;
+- malformed keys/events/snapshots;
+- unauthorized dispatch;
+- command failure after applied receipt.
+
+### Process crash harness
+
+Provide deterministic harnesses that can:
+
+- destroy/recreate a remote client while preserving the main host;
+- dispose/recreate a host while preserving queued fake transport messages;
+- hydrate persisted actors;
+- deliver stale messages from the previous actor lifetime;
+- assert pending promise settlement.
+
+### IPC integration tests
+
+Use real contract registration and the handler test harness to verify:
+
+- trusted sender enforcement;
+- outer and per-machine Zod validation;
+- manifest routing;
+- webContents subscription cleanup;
+- `DyadError` preservation;
+- snapshot projection excludes main-only fields.
+
+### Renderer integration tests
+
+Use test hosts/references rather than writable lifecycle atoms. Verify:
+
+- loading and reconnect UI;
+- committed snapshots update selectors;
+- unrelated keys do not rerender;
+- dispatch receipt versus command completion;
+- StrictMode subscription replay;
+- provider replacement;
+- actor disposal.
+
+### E2E
+
+The app-run pilot requires packaged Electron tests for:
+
+- app continues running through renderer reload;
+- renderer rehydrates the current URL/state;
+- restart and stop;
+- stale stdout/exit from a previous invocation;
+- application update compatibility where supported;
+- window close/application quit cleanup.
+
+Build before every E2E run that changes runtime code.
+
+## Pilot 1: main-hosted `app_run`
+
+`app_run` is the proving ground because it currently spans both processes and
+contains the most compensating architecture.
+
+### Current ownership problems
+
+- Renderer owns `RunState`.
+- Main owns the spawned app process.
+- Main emits output carrying partial/legacy invocation identity.
+- Renderer commands invoke main and await settlement.
+- URL, loading, exit, errors, and reload epochs overlap with Jotai state.
+- Renderer disposal tries to reason about main-owned process lifetime.
+- `preview_iframe` infers restart through an atom projection.
+
+### Target ownership
+
+Main owns the keyed `app_run` actor and:
+
+- starts/restarts/rebuilds/stops processes;
+- binds process output to the actor invocation at producer creation;
+- owns active invocation/resource handles;
+- applies correlated proxy-ready and exit events directly;
+- survives renderer reload;
+- disposes on app deletion or application shutdown;
+- publishes a safe remote snapshot.
+
+Renderer owns:
+
+- remote actor reference/store;
+- pure `AppRunProjection`;
+- console output buffer;
+- independent UI warnings/diagnostics;
+- local `preview_iframe` actor.
+
+### Domain changes
+
+Refine events into intent and producer events:
+
+```ts
+type AppRunEvent =
+  | { type: "START_REQUESTED"; operationId: string; startedAt: number }
+  | {
+      type: "RESTART_REQUESTED";
+      operationId: string;
+      startedAt: number;
+      options: RestartOptions;
+    }
+  | { type: "STOP_REQUESTED"; operationId: string; startedAt: number }
+  | { type: "PROCESS_SPAWNED"; invocationRef: AppRunInvocationRef }
+  | { type: "PROCESS_FAILED"; invocationRef: AppRunInvocationRef; error: ... }
+  | { type: "PROXY_READY"; invocationRef: AppRunInvocationRef; url: RunUrl }
+  | { type: "PROCESS_EXITED"; invocationRef: AppRunInvocationRef; ... };
+```
+
+The exact transition preserves existing behavior, including proxy-ready before
+spawn settlement when that ordering is real.
+
+Callbacks and renderer stores do not enter remote state/events.
+
+### Main command adapter
+
+Move app lifecycle orchestration behind a main service consumed directly by
+the actor:
+
+- process start/restart/stop;
+- sandbox recreation;
+- log clearing;
+- producer callback registration;
+- external agent lifecycle claims;
+- cleanup and cancellation tombstones.
+
+Existing IPC app-run handlers become temporary adapters that dispatch the
+actor for legacy callers. The new renderer uses the machine transport.
+
+### Remote read model
+
+Publish only renderer-safe lifecycle fields:
+
+- phase;
+- operation;
+- started time;
+- current URL/mode;
+- operation error;
+- exit details needed by UI;
+- capabilities;
+- actor/invocation diagnostic identity where necessary.
+
+Do not include process handles, internal paths, or command runtime data.
+
+### Output channels
+
+Console stdout/stderr continues through the existing batched app-output
+channel. Lifecycle-significant producer events enter the main actor before
+output broadcasting. Renderer display buffers cannot drive lifecycle.
+
+### `preview_iframe` composition
+
+The renderer composition layer observes committed app-run remote snapshots or
+typed post-commit lifecycle events and sends:
+
+- `APP_URL_CHANGED`;
+- `RUNTIME_RESTARTED`;
+- `RUNTIME_STOPPED` if required.
+
+Carry actor/invocation identity. Do not deduplicate by timestamps or atom map
+edges.
+
+### Deletions required for pilot success
+
+The pilot is not complete until it deletes or makes obsolete:
+
+- renderer `AppRunController`;
+- renderer `AppRunManager`;
+- app-run projection writer;
+- machine-owned loading/URL/error Jotai projections;
+- renderer-to-main lifecycle command adapter;
+- restart inference through `previewRunStateByAppIdAtom`;
+- hand-written renderer invocation registry for app-run producer routing.
+
+Retain only independently justified console, warning, and UI state.
+
+### Acceptance scenarios
+
+1. Start an app and receive URL.
+2. Proxy URL arrives before process-start settlement.
+3. Restart with each options combination.
+4. Rebuild through external agent lifecycle.
+5. Stop before start settles.
+6. Old proxy/exit output arrives after restart.
+7. Delete app while start is pending.
+8. Reload renderer while app remains ready.
+9. Reload renderer while start/restart is pending.
+10. Close window while app remains main-owned according to product policy.
+11. Quit app and clean up child process with bounded shutdown.
+12. Incompatible renderer/main protocol requests reload rather than applying
+    malformed state.
+
+## Pilot 2: local renderer-hosted `voice_to_text`
+
+This pilot proves the same definition/actor-reference/React API works without
+IPC.
+
+Renderer remains authoritative because it owns:
+
+- `getUserMedia`;
+- recorder callbacks;
+- media tracks;
+- transcription presentation lifecycle.
+
+Requirements:
+
+- use the shared `ActorHost` and local actor reference;
+- keep resource handles out of snapshots;
+- keep `TransactionalDispatcher`;
+- expose the same selector-aware React hook shape as remote actors;
+- prove local dispatch stays synchronous where required;
+- preserve media cleanup on unmount/disposal;
+- add no wire codecs unless another process genuinely needs access.
+
+The pilot should delete domain-specific wrapper boilerplate where the shared
+host replaces it. It should not force local events through IPC for symmetry.
+
+## Candidate placement after pilots
+
+This is a hypothesis to validate, not an automatic migration list.
+
+| Domain             | Likely host                        | Reason                                                    |
+| ------------------ | ---------------------------------- | --------------------------------------------------------- |
+| `app_run`          | Main                               | Owns child processes and producer identity                |
+| `connection_flow`  | Main                               | Owns OAuth flow, timeouts, deep-link claims               |
+| `mcp_oauth`        | Main                               | Owns loopback listeners and provider exchange             |
+| `user_input`       | Main                               | Must survive renderer lifecycle and owns waiters          |
+| `github_ops`       | Main                               | Owns privileged git mutation/recovery                     |
+| `version_preview`  | Main                               | Owns checkout, branch recovery, filesystem effects        |
+| `chat_stream`      | Main, pending study                | Main already owns stream admission and durable acceptance |
+| `plan_handoff`     | Main/durable, pending study        | Cross-chat workflow should survive renderer reload        |
+| `first_prompt`     | Renderer initially                 | Presentation-heavy; persistence value unclear             |
+| `image_generation` | Main if reload survival is desired | Long-running job with IPC-backed execution                |
+| `screenshot`       | Renderer                           | Owns iframe capture/DOM readiness                         |
+| `preview_iframe`   | Renderer                           | Owns DOM and iframe identity                              |
+| `voice_to_text`    | Renderer                           | Owns browser media resources                              |
+
+Before moving any machine:
+
+1. inventory resource ownership;
+2. inventory callbacks/nonserializable state;
+3. decide renderer-reload and app-restart behavior;
+4. specify remote read model;
+5. specify high-volume data path;
+6. measure deletion value;
+7. identify cross-machine dependency changes.
+
+## Chat-stream feasibility study
+
+Do not move `chat_stream` to main merely for consistency. First resolve:
+
+- optimistic renderer messages versus durable accepted messages;
+- high-frequency chunk transport;
+- editable queued messages;
+- renderer callbacks currently embedded in `StreamRequest`;
+- main admission barrier and stream controller ownership;
+- React Query/Jotai refresh effects;
+- user-input durable handoff;
+- cancellation and finalization UI;
+- renderer reload during an active stream.
+
+A main-hosted chat lifecycle is attractive because main already owns stream
+admission and can survive renderer reload, but callbacks and presentation state
+must be replaced with IDs, receipts, and read models. Produce a dedicated
+design before implementation.
+
+## Relationship to `codex-cleanup-state-machines.md`
+
+### Complete first
+
+These are no-regrets prerequisites:
+
+- ownership inventory and boundary enforcement;
+- selector-aware external-store React bindings;
+- simple removal of `first_prompt` Jotai projection;
+- direct image-generation manager projection, if it does not conflict with a
+  decision to move jobs to main;
+- classification of UI/runtime versus lifecycle atoms.
+
+### Superseded by this plan
+
+Do not complete these cleanup items before the pilots:
+
+- migrating `app_run` to another renderer controller shape;
+- building a final renderer-only app-run hook/projection architecture;
+- migrating every custom controller mechanically before host placement is
+  decided;
+- finalizing bespoke cross-machine facades that actor refs/protocols would
+  replace;
+- consolidating all main registries around the current registry API.
+
+### Still applicable
+
+The cleanup plan's desired outcomes remain:
+
+- no same-process lifecycle duplication in Jotai;
+- typed dependencies;
+- pure selectors;
+- direct hooks;
+- fewer manual subscriptions;
+- deletion of atom mailboxes;
+- boundary enforcement.
+
+This plan changes how those outcomes are reached.
+
+## Rollout plan
+
+### Phase 0 — Architecture decision and deletion budget
+
+Write an ADR recording:
+
+- one-authority actor model;
+- explicit local versus remote semantics;
+- no multi-primary replication;
+- commit-versus-completion contract;
+- generic transport security model;
+- persistence boundaries;
+- why an actor runtime is preferred over incremental controller cleanup.
+
+For each pilot, list the files/types expected to be deleted. The pilot fails
+architecturally if it adds more permanent layers than it removes.
+
+No production code.
+
+### Phase 1 — Definition and local host kernel
+
+Implement:
+
+- minimal machine definition;
+- actor instance identity/revision;
+- `ActorHost`;
+- local actor reference;
+- lifecycle policies;
+- integration with `TransactionalDispatcher`;
+- host conformance suite;
+- selector-aware React hooks.
+
+Exercise with synthetic machines only. Do not migrate a production domain in
+the kernel PR.
+
+### Phase 2 — Contract-driven remote transport
+
+Implement:
+
+- distributed machine IPC contracts;
+- static remote manifest;
+- trusted typed handlers;
+- outer and per-definition validation;
+- dispatch receipts;
+- subscribe/bootstrap;
+- snapshot/disposed events;
+- webContents cleanup;
+- fake transport and transport conformance suite;
+- bounded deduplication.
+
+Use a test-only machine registered in handler integration tests. Do not expose
+arbitrary production machine dispatch yet.
+
+### Phase 3 — Remote client, hydration, and React
+
+Implement:
+
+- `RemoteMachineClient`;
+- revisioned remote snapshot stores;
+- pre-bootstrap buffering;
+- resync on gaps;
+- reconnect/disconnect status;
+- reference-counted subscriptions;
+- remote actor refs;
+- selector-aware hooks;
+- renderer StrictMode tests.
+
+Prove against fake transport and the test-only IPC machine.
+
+### Phase 4 — App-run main-hosted pilot
+
+Land in reviewable steps while keeping one authority:
+
+1. extract/reuse main app-runtime service boundaries;
+2. define app-run wire codecs and safe remote projection;
+3. construct the main actor and route producer events;
+4. add renderer remote hook behind the application composition boundary;
+5. migrate consumers;
+6. wire preview iframe from committed remote state/events;
+7. remove renderer authority and lifecycle projections;
+8. delete temporary legacy adapters.
+
+Avoid running old and new command side effects in parallel. A pure shadow
+transition may consume copied events for trace comparison, but it must run no
+commands and publish no application state.
+
+### Phase 5 — Voice-to-text local pilot
+
+- adopt the shared definition/host/ref/hook API;
+- preserve renderer resource ownership;
+- delete redundant local wrapper mechanics;
+- compare ergonomics and bundle impact with the remote pilot.
+
+Gate further adoption on a written pilot review.
+
+### Phase 6 — Pilot review and go/no-go
+
+Evaluate:
+
+- net lines/modules deleted;
+- reduction in atom projections and IPC glue;
+- runtime and type complexity;
+- trace/debug quality;
+- renderer reload correctness;
+- security review findings;
+- test runtime;
+- contributor comprehensibility;
+- bundle size and preload compatibility;
+- performance under output load.
+
+Possible decisions:
+
+- proceed unchanged;
+- narrow the framework to main-hosted resource actors;
+- retain local machines on the existing lightweight controller API;
+- stop and revert the framework, keeping only no-regrets cleanup.
+
+### Phase 7 — Resource-owner migrations
+
+If approved, migrate one domain per PR:
+
+1. `connection_flow`;
+2. `mcp_oauth`;
+3. `github_ops`;
+4. `version_preview`.
+
+Each PR:
+
+- selects the authoritative host;
+- defines remote projection if required;
+- deletes its previous registry/controller boundary;
+- retains domain transition tests;
+- adds crash/reload tests appropriate to placement.
+
+### Phase 8 — Protocol and long-running workflow migrations
+
+Design separately before implementation:
+
+1. durable protocol actor primitive;
+2. `user_input -> chat_stream` proof;
+3. plan handoff;
+4. chat-stream feasibility decision;
+5. image-generation reload-survival decision.
+
+Do not generalize durable protocols beyond needs demonstrated by the pilot.
+
+### Phase 9 — Renderer-local consolidation
+
+Consider `first_prompt`, `preview_iframe`, `screenshot`, and other local
+machines. Migrate only where the shared local host reduces code. A stable,
+small local controller need not move merely for numerical consistency.
+
+### Phase 10 — Delete transitional infrastructure
+
+After migrations:
+
+- remove unused domain controllers/managers/registries;
+- remove lifecycle projection atoms and writer helpers;
+- remove atom mailboxes;
+- narrow or remove legacy IPC channels;
+- remove transport compatibility branches after the supported update window;
+- update state-machine, Jotai, IPC, and error rules;
+- update architecture and “why state machines” documentation;
+- add boundaries preventing reintroduction.
+
+## Review and PR constraints
+
+- Kernel, transport, and each production pilot are separate revert points.
+- No PR combines generic transport with app-run behavior changes.
+- No production actor migration is a repository-wide mechanical rewrite.
+- Every remote definition receives security review.
+- Every host move receives crash/reload behavior review.
+- High-blast-radius pilots receive deep multi-agent review when executed.
+- Documentation must describe guarantees actually implemented in that PR.
+- Temporary compatibility layers include an explicit deletion phase and test.
+
+## Risks
+
+### Framework overreach
+
+The runtime could become a second application framework with excessive
+generics and indirection.
+
+Mitigation:
+
+- two pilots before broad migration;
+- deletion budget;
+- small explicit interfaces;
+- no actor hierarchy, supervision trees, dynamic placement, or remote command
+  execution initially;
+- preserve ordinary services and React Query.
+
+### False location transparency
+
+Callers may assume a remote actor behaves like a local object.
+
+Mitigation:
+
+- distinct `send` and async `dispatch`;
+- explicit connection status;
+- typed receipts;
+- no generic effect-completion promise;
+- documentation and tests for disconnect/retry.
+
+### Generic IPC security hole
+
+A router accepting arbitrary machine/event payloads could widen renderer
+privilege.
+
+Mitigation:
+
+- trusted typed handler;
+- static manifest;
+- nested machine-specific validation;
+- per-definition authorization;
+- commands never cross from renderer;
+- bounds and audit logs.
+
+### Snapshot volume
+
+Large or frequent snapshots could saturate IPC and rerender the UI.
+
+Mitigation:
+
+- lifecycle-only snapshots;
+- safe remote projections;
+- existing batched/stream channels for high-volume data;
+- selector-aware subscriptions;
+- measure app-run and chat before migration.
+
+### Renderer/main version mismatch
+
+An update or reload could briefly pair incompatible contracts.
+
+Mitigation:
+
+- explicit protocol/schema versions;
+- reject rather than coerce;
+- resync/reload path;
+- compatibility tests.
+
+### Duplicate dispatch after lost receipt
+
+Main may commit an event while the renderer loses the receipt and retries.
+
+Mitigation:
+
+- message ID deduplication;
+- bounded receipt cache;
+- domain idempotency key for durable acceptance;
+- tests for commit-plus-dropped-receipt.
+
+### Actor retention leaks
+
+Remote subscriptions or one-shot keys could retain actors indefinitely.
+
+Mitigation:
+
+- explicit lifecycle policy;
+- webContents destruction cleanup;
+- bounded idle eviction;
+- per-definition retention tests and inspector visibility.
+
+### Main-process load
+
+Moving more orchestration to main could increase CPU/memory pressure or block
+Electron.
+
+Mitigation:
+
+- state transitions stay small and synchronous;
+- heavy work remains async services/workers;
+- respect electron-worker guidance for computation;
+- profile actor counts, snapshot sizes, and command scheduling;
+- never await long work inside the event drain.
+
+### Migration creates two authorities
+
+Compatibility could leave old renderer and new main actors both active.
+
+Mitigation:
+
+- one command authority at every rollout step;
+- shadow mode is pure and effect-free;
+- consumer cutover and old-authority deletion occur in the pilot PR sequence;
+- tests assert only one process issues lifecycle commands.
+
+### Durable protocol complexity
+
+An actor transport can tempt contributors to treat remote delivery as exactly
+once.
+
+Mitigation:
+
+- separate protocol API;
+- durable idempotency records;
+- explicit acceptance/acknowledgement semantics;
+- do not advertise exactly-once execution.
+
+## Non-goals
+
+- General distributed computing outside the Electron main/renderer boundary.
+- Multiple main processes or networked Dyad instances.
+- Hot-moving a live actor between processes.
+- Multi-primary state, CRDTs, or conflict resolution between writable replicas.
+- Serializing closures or resource handles.
+- Replacing all IPC with machine messages.
+- Sending console logs or LLM chunks as snapshots.
+- Making React Query data machine-owned.
+- Replacing domain services with commands embedded in one mega runtime.
+- Persisting every actor.
+- Guaranteeing exactly-once command execution.
+- Building Erlang/OTP, Akka, or XState inside Dyad.
+
+## Success criteria
+
+The architecture is accepted only if both pilots demonstrate:
+
+- one authoritative actor per key;
+- the same definition/host/reference concepts work locally and remotely;
+- remote dispatch is validated, authorized, deduplicated, and explicitly
+  acknowledged at commit;
+- snapshots bootstrap without lost-update races;
+- stale actor instances and revisions cannot overwrite current state;
+- renderer reload recovers main-hosted state;
+- local actors incur no IPC or artificial async behavior;
+- React reads snapshots without Jotai lifecycle projections;
+- traces connect transport messages and transitions across processes;
+- disposal cleans subscriptions, tasks, timers, waiters, and resources;
+- existing domain race regressions remain covered;
+- app-run removes more permanent architecture than the framework adds to that
+  domain;
+- contributors can explain sent, committed, completed, and durably accepted
+  as distinct states.
+
+Broader rollout succeeds when:
+
+- privileged/resource-owning workflows are hosted beside their resources;
+- main registries and renderer controllers use the same transaction/lifecycle
+  kernel;
+- same-process lifecycle projection atoms and atom mailboxes are gone;
+- cross-process read models are generated/hosted by the remote actor client
+  rather than hand-written per domain;
+- durable cross-machine handoffs use explicit protocol actors;
+- remaining custom runtimes have narrow documented reasons;
+- `rules/state-machines.md`, `rules/electron-ipc.md`,
+  `rules/jotai-state.md`, and architecture documentation match production.
+
+## Expected outcome
+
+The desired end state is not “everything is remote.” It is:
+
+- authority lives beside the resource it controls;
+- every workflow uses the same pure transition and transaction mechanics;
+- local and remote access share a recognizable typed API;
+- process boundaries remain explicit where their semantics matter;
+- renderer reload is a supported lifecycle event rather than accidental
+  teardown;
+- Jotai stores UI/runtime state, not machine lifecycle copies;
+- IPC transports validated intent and snapshots, not ad hoc controller glue;
+- cross-machine durability is a named protocol rather than an optimistic
+  callback chain.
+
+If the app-run and voice-to-text pilots cannot achieve this while deleting
+their old infrastructure, stop after the no-regrets cleanup. The goal is a
+smaller and more truthful architecture, not adoption of an ambitious
+framework for its own sake.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only; no production code, IPC, or state behavior changes.
> 
> **Overview**
> Introduces **four new `plans/` documents** (no runtime code) that chart post-hardening cleanup of the SnapshotStore-based state machines.
> 
> **`plans/cleanup-state-machines.md`** is the **unified successor**: one lifecycle fact per owner, typed cross-machine facades (post-commit, microtask-deferred), Phase A ownership cleanup (PRs A1–A7), Phase B `TransactionalDispatcher` work gated on a future distributed decision, and Phase C as the go/no-go for the actor runtime.
> 
> **`plans/claude-cleanup-machines.md`** is the **execution appendix**—116 atoms classified (69 keep, 32 mirror retire, 12+3 cross-machine/mixed retire), verification corrections (warning priority, six preview-error writers, mount order, `watchIdle` + disposal), per-atom migration recipes, and a five-PR rollout ending with `isStreamingByIdAtom` and deletion of the #4077 re-entrancy comments.
> 
> **`plans/codex-cleanup-state-machines.md`** is the **domain-level** companion: ownership model, target renderer APIs, shared React bindings, twelve-PR rollout, and verification strategy.
> 
> **`plans/distrbuted-machines.md`** records an **alternative**—main/renderer actor hosts with validated IPC—piloting main-hosted `app_run` and local `voice_to_text`, with explicit overlap and supersession vs the codex/claude cleanup tracks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89aef35f25aa99ce689cf37ca749cd91eb4a5813. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

