### PR TITLE
Make stopping a stream non-destructive for queued prompts

### DIFF
--- a/src/chat_stream/transition.ts
+++ b/src/chat_stream/transition.ts
@@ -41,6 +41,14 @@ export function selectCanCancel(state: StreamState): boolean {
   return state.type === "starting" || state.type === "streaming";
 }
 
+/** True while a requested cancellation still needs to preserve parked queue work. */
+export function selectIsCancellationSettling(state: StreamState): boolean {
+  return (
+    state.type === "cancelling" ||
+    (state.type === "finalizing" && state.wasCancelled)
+  );
+}
+
 /** The terminal stream error rendered by chat surfaces. */
 export function selectStreamError(state: StreamState): string | null {
   return state.type === "errored" ? state.error : null;

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -150,6 +150,7 @@ export function ChatInput({ chatId }: { chatId?: number }) {
     streamMessage,
     cancelStream,
     isStreaming,
+    isCancellationSettling,
     error,
     setError,
     queuedMessages,
@@ -429,13 +430,27 @@ export function ChatInput({ chatId }: { chatId?: number }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Auto-clear pause state when queue becomes empty (Users expect that deleting all queued messages returns them to normal send mode)
+  // Auto-clear pause state when queue becomes empty (Users expect that deleting
+  // all queued messages returns them to normal send mode). Keep the Stop latch
+  // until cancellation settles so a late submission admitted by the stream
+  // machine cannot land in an unpaused queue.
 
   useEffect(() => {
-    if (chatId && isPaused && queuedMessages.length === 0) {
+    if (
+      chatId &&
+      isPaused &&
+      queuedMessages.length === 0 &&
+      !isCancellationSettling
+    ) {
       clearPauseOnly();
     }
-  }, [chatId, isPaused, queuedMessages.length, clearPauseOnly]);
+  }, [
+    chatId,
+    isPaused,
+    queuedMessages.length,
+    isCancellationSettling,
+    clearPauseOnly,
+  ]);
 
   // Queue management handlers
   const handleEditQueuedMessage = useCallback(
@@ -641,19 +656,22 @@ export function ChatInput({ chatId }: { chatId?: number }) {
     // queue after it. Skipping the latch on a stale empty snapshot would let
     // finalization dispatch that item, so Stop would start a new generation.
     // A latch with a genuinely empty queue is harmless — the empty-queue effect
-    // above clears it.
-    if (!isPaused) {
-      pauseQueue();
-    }
+    // above clears it after cancellation settles.
     // Always reset editing state when cancelling, regardless of pause state
     if (editingQueuedMessageId) {
       resetEditingState();
     }
-    // Do NOT reset pause state here; queued messages should remain paused after stopping
+    // Enter the authoritative cancelling state before publishing the pause
+    // latch. This prevents the empty-queue effect from observing the latch
+    // without also observing that cancellation is settling.
     if (chatId) {
       // The stream machine reconciles the cancel with the real terminal
       // event (including cancels fired before main registered the stream).
       cancelStream();
+    }
+    // Do NOT reset pause state here; queued messages should remain paused after stopping
+    if (!isPaused) {
+      pauseQueue();
     }
   };
 

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -157,7 +157,6 @@ export function ChatInput({ chatId }: { chatId?: number }) {
     updateQueuedMessage,
     removeQueuedMessage,
     reorderQueuedMessages,
-    clearAllQueuedMessages,
     isPaused,
     pauseQueue,
     clearPauseOnly,
@@ -631,9 +630,13 @@ export function ChatInput({ chatId }: { chatId?: number }) {
   };
 
   const handleCancel = () => {
-    // Only clear the queue if NOT paused
-    if (!isPaused) {
-      clearAllQueuedMessages();
+    // Stopping is non-destructive: queued prompts are parked, never deleted.
+    // `isPaused` is a transient latch (resuming, an emptied queue, or a
+    // step-limit continue all clear it), so it can be false while the user
+    // still has prompts they care about queued — deleting them here silently
+    // lost work, including the queue restored (paused) after a restart.
+    if (!isPaused && queuedMessages.length > 0) {
+      pauseQueue();
     }
     // Always reset editing state when cancelling, regardless of pause state
     if (editingQueuedMessageId) {

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -635,7 +635,14 @@ export function ChatInput({ chatId }: { chatId?: number }) {
     // step-limit continue all clear it), so it can be false while the user
     // still has prompts they care about queued — deleting them here silently
     // lost work, including the queue restored (paused) after a restart.
-    if (!isPaused && queuedMessages.length > 0) {
+    //
+    // Latch unconditionally rather than gating on `queuedMessages`: that is a
+    // render-time snapshot, and the machine can admit a follow-up into the live
+    // queue after it. Skipping the latch on a stale empty snapshot would let
+    // finalization dispatch that item, so Stop would start a new generation.
+    // A latch with a genuinely empty queue is harmless — the empty-queue effect
+    // above clears it.
+    if (!isPaused) {
       pauseQueue();
     }
     // Always reset editing state when cancelling, regardless of pause state

--- a/src/hooks/useStreamChat.ts
+++ b/src/hooks/useStreamChat.ts
@@ -12,6 +12,7 @@ import type { StreamSettledResult } from "@/chat_stream/state";
 import {
   isStreamActive,
   selectCanCancel,
+  selectIsCancellationSettling,
   selectStreamError,
 } from "@/chat_stream/transition";
 import { useChatStreamState } from "@/hooks/useChatStream";
@@ -294,6 +295,10 @@ export function useStreamChat({
     cancelStream,
     isStreaming:
       hasChatId && chatId !== undefined ? isStreamActive(streamState) : false,
+    isCancellationSettling:
+      hasChatId && chatId !== undefined
+        ? selectIsCancellationSettling(streamState)
+        : false,
     error:
       hasChatId && chatId !== undefined ? selectStreamError(streamState) : null,
     setError: (value: string | null) => {

--- a/src/ipc/handlers/__tests__/pause_queue.integration.test.tsx
+++ b/src/ipc/handlers/__tests__/pause_queue.integration.test.tsx
@@ -44,6 +44,23 @@ async function queueMessages(
 describe("pause queue (integration)", () => {
   let harness: HybridChatHarness;
 
+  /**
+   * Cancellation is only observable once the stop button is gone (the machine
+   * reached a terminal state) and the cancel IPC round-trip has settled.
+   * Asserting before that can pass on a mid-flight queue and leaves the
+   * cancellation running into test cleanup.
+   */
+  async function waitForStreamTermination() {
+    await waitFor(
+      () =>
+        expect(
+          screen.queryByRole("button", { name: /cancel generation/i }),
+        ).toBeNull(),
+      { timeout: 20_000 },
+    );
+    await harness.bridge.settleInFlight();
+  }
+
   beforeAll(async () => {
     harness = await setupHybridChatHarness({
       electronMock: h,
@@ -135,10 +152,12 @@ describe("pause queue (integration)", () => {
     // No pause click: stopping used to delete the whole queue here.
     fireEvent.click(screen.getByRole("button", { name: /cancel generation/i }));
 
+    // The "Paused" label lands synchronously, so gate the queue assertions on
+    // cancellation actually completing: stream terminated, IPC settled.
     await screen.findByText("Paused");
-    await waitFor(() =>
-      expect(queueHeader.textContent).toMatch(queuedCountText(3)),
-    );
+    await waitForStreamTermination();
+
+    expect(queueHeader.textContent).toMatch(queuedCountText(3));
     // Scoped to the queue: the last prompt typed also lingers in the composer.
     for (const message of ["unpaused 1", "unpaused 2", "unpaused 3"]) {
       expect(within(queueHeader).getByText(message)).toBeTruthy();
@@ -164,13 +183,7 @@ describe("pause queue (integration)", () => {
     await screen.findByText("Paused");
 
     fireEvent.click(screen.getByRole("button", { name: /cancel generation/i }));
-    await waitFor(
-      () =>
-        expect(
-          screen.queryByRole("button", { name: /cancel generation/i }),
-        ).toBeNull(),
-      { timeout: 20_000 },
-    );
+    await waitForStreamTermination();
     expect(queueHeader.textContent).toMatch(queuedCountText(3));
 
     // Resuming clears the pause latch but dispatches only the first item, so
@@ -185,9 +198,9 @@ describe("pause queue (integration)", () => {
       await screen.findByRole("button", { name: /cancel generation/i }),
     );
     await screen.findByText("Paused");
-    await waitFor(() =>
-      expect(queueHeader.textContent).toMatch(queuedCountText(2)),
-    );
+    await waitForStreamTermination();
+
+    expect(queueHeader.textContent).toMatch(queuedCountText(2));
     for (const message of ["resumed 2", "resumed 3"]) {
       expect(within(queueHeader).getByText(message)).toBeTruthy();
     }

--- a/src/ipc/handlers/__tests__/pause_queue.integration.test.tsx
+++ b/src/ipc/handlers/__tests__/pause_queue.integration.test.tsx
@@ -1,4 +1,12 @@
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 
 import {
   cleanup,
@@ -13,6 +21,7 @@ import {
   type HybridChatHarness,
 } from "@/testing/hybrid_chat_harness";
 import { h } from "@/testing/hybrid.setup";
+import { ipc } from "@/ipc/types";
 
 function queuedCountText(count: number) {
   return new RegExp(`^${count}\\s+Queued`, "i");
@@ -162,6 +171,39 @@ describe("pause queue (integration)", () => {
     for (const message of ["unpaused 1", "unpaused 2", "unpaused 3"]) {
       expect(within(queueHeader).getByText(message)).toBeTruthy();
     }
+  }, 60_000);
+
+  it("parks a submission admitted while an empty queue is cancelling", async () => {
+    const chatId = await harness.createChat();
+    harness.mount({ chatId });
+
+    await startMediumStream(harness, chatId);
+
+    // Hold the cancel IPC open so the renderer remains deterministically in
+    // `cancelling` while the follow-up is submitted.
+    const cancelSpy = vi
+      .spyOn(ipc.chat, "cancelStream")
+      .mockReturnValue(new Promise(() => {}));
+
+    fireEvent.click(screen.getByRole("button", { name: /cancel generation/i }));
+    await harness.pressEnterInChat("late while cancelling", { chatId });
+
+    const queueHeader = screen.getByTestId("queue-header");
+    expect(queueHeader.textContent).toMatch(queuedCountText(1));
+    expect(screen.getByText("Paused")).toBeTruthy();
+
+    // Let the real main-process cancellation settle. The late prompt must
+    // remain parked rather than dispatching after the next normal stream.
+    cancelSpy.mockRestore();
+    await ipc.chat.cancelStream(chatId);
+    await waitForStreamTermination();
+
+    await harness.pressEnterInChat("next explicit stream", { chatId });
+    await harness.waitForStreamEnd(chatId);
+
+    expect(queueHeader.textContent).toMatch(queuedCountText(1));
+    expect(within(queueHeader).getByText("late while cancelling")).toBeTruthy();
+    expect(screen.getByText("Paused")).toBeTruthy();
   }, 60_000);
 
   it("keeps the rest of the queue when stopped right after resuming", async () => {

--- a/src/ipc/handlers/__tests__/pause_queue.integration.test.tsx
+++ b/src/ipc/handlers/__tests__/pause_queue.integration.test.tsx
@@ -1,6 +1,12 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 
-import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 
 import {
   setupHybridChatHarness,
@@ -111,6 +117,80 @@ describe("pause queue (integration)", () => {
       },
       { timeout: 20_000 },
     );
+  }, 60_000);
+
+  it("keeps an unpaused queue when stopped and parks it in the paused state", async () => {
+    const chatId = await harness.createChat();
+    harness.mount({ chatId });
+
+    await startMediumStream(harness, chatId);
+    await queueMessages(
+      harness,
+      chatId,
+      Array.from({ length: 3 }, (_, index) => `unpaused ${index + 1}`),
+    );
+
+    const queueHeader = screen.getByTestId("queue-header");
+
+    // No pause click: stopping used to delete the whole queue here.
+    fireEvent.click(screen.getByRole("button", { name: /cancel generation/i }));
+
+    await screen.findByText("Paused");
+    await waitFor(() =>
+      expect(queueHeader.textContent).toMatch(queuedCountText(3)),
+    );
+    // Scoped to the queue: the last prompt typed also lingers in the composer.
+    for (const message of ["unpaused 1", "unpaused 2", "unpaused 3"]) {
+      expect(within(queueHeader).getByText(message)).toBeTruthy();
+    }
+  }, 60_000);
+
+  it("keeps the rest of the queue when stopped right after resuming", async () => {
+    const chatId = await harness.createChat();
+    harness.mount({ chatId });
+
+    await startMediumStream(harness, chatId);
+    // The first queued prompt sleeps as well, so the window between "resume
+    // dispatched item 1" and the stop click stays wide open.
+    await queueMessages(harness, chatId, [
+      "tc=1 [sleep=medium] resumed 1",
+      "resumed 2",
+      "resumed 3",
+    ]);
+
+    const queueHeader = screen.getByTestId("queue-header");
+
+    fireEvent.click(screen.getByRole("button", { name: /pause queue/i }));
+    await screen.findByText("Paused");
+
+    fireEvent.click(screen.getByRole("button", { name: /cancel generation/i }));
+    await waitFor(
+      () =>
+        expect(
+          screen.queryByRole("button", { name: /cancel generation/i }),
+        ).toBeNull(),
+      { timeout: 20_000 },
+    );
+    expect(queueHeader.textContent).toMatch(queuedCountText(3));
+
+    // Resuming clears the pause latch but dispatches only the first item, so
+    // the remaining prompts are unprotected until the next stop re-parks them.
+    fireEvent.click(screen.getByRole("button", { name: /resume queue/i }));
+    await waitFor(
+      () => expect(queueHeader.textContent).toMatch(queuedCountText(2)),
+      { timeout: 20_000 },
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /cancel generation/i }),
+    );
+    await screen.findByText("Paused");
+    await waitFor(() =>
+      expect(queueHeader.textContent).toMatch(queuedCountText(2)),
+    );
+    for (const message of ["resumed 2", "resumed 3"]) {
+      expect(within(queueHeader).getByText(message)).toBeTruthy();
+    }
   }, 60_000);
 
   it("sends immediately while stopped with a paused queue", async () => {


### PR DESCRIPTION
closes #4111

Clicking Stop deleted every queued prompt in the chat unless the queue happened to be paused at that moment. Pause is a transient latch -- resuming, an emptied queue, or a step-limit continue all clear it -- so prompts were routinely lost, most visibly when a queue restored (paused) after a restart was resumed and then stopped: resume dispatches only the first item, leaving the rest unprotected. The deletion was mirrored to the persisted queue file, so relaunching could not bring them back.

Stop now parks the queue in the paused state instead of clearing it. The stream machine already suppresses queue dispatch for a cancelled stream, so nothing auto-resumes; the user reviews the parked prompts and resumes from the queue header, and individual prompts can still be deleted from the queue list.

Cancellation and cancelled finalization also protect the pause latch from the empty-queue cleanup. A follow-up admitted while Stop is settling therefore remains parked instead of auto-dispatching after a later user-started stream.

Adds integration coverage for stopping an unpaused queue, the resume-then-stop sequence that dropped the tail of the queue, and an initially empty queue receiving a follow-up while cancellation is settling.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
