### PR TITLE
format plan

### DIFF
--- a/plans/claude-correct-state-machines.md
+++ b/plans/claude-correct-state-machines.md
@@ -147,7 +147,7 @@ Every item is a real review comment or fix iteration from this wave.
 #4108, #4119 (5+ findings), #4123:
 
 - Observer-only windows never called `start()` on the client — one
-  bootstrap snapshot, then silence (HIGH, found in chat_stream _and_
+  bootstrap snapshot, then silence (HIGH, found in chat*stream \_and*
   plan_handoff managers).
 - Dispatch overtaking subscribe on first submit → `stale-actor` (P1);
   fixed by awaiting bootstrap before dispatch, per machine.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Plan markdown formatting only; no runtime, tests, or configuration changes.
> 
> **Overview**
> **Documentation-only** tweak in `plans/claude-correct-state-machines.md` under the E5 remote subscribe/bootstrap/release section.
> 
> The bullet about observer-only windows and `chat_stream` / `plan_handoff` managers updates inline emphasis from underscore-style to escaped asterisk markdown (`chat*stream \_and*`), with no change to technical content or rollout proposals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50b08f16e333bad6708dedfa406a7af84900bd80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->