### PR TITLE
fix: resume the chat after the database integration Continue

### DIFF
--- a/e2e-tests/fixtures/engine/local-agent/add-integration.ts
+++ b/e2e-tests/fixtures/engine/local-agent/add-integration.ts
@@ -1,0 +1,19 @@
+import type { LocalAgentFixture } from "../../../../testing/fake-llm-server/localAgentTypes";
+
+export const fixture: LocalAgentFixture = {
+  description: "Prompt the user to set up a database integration",
+  turns: [
+    {
+      text: "Let's connect a database first.",
+      toolCalls: [
+        {
+          name: "add_integration",
+          args: {},
+        },
+      ],
+    },
+    {
+      text: "The database integration is connected.",
+    },
+  ],
+};

--- a/e2e-tests/local_agent_add_integration.spec.ts
+++ b/e2e-tests/local_agent_add_integration.spec.ts
@@ -1,0 +1,74 @@
+import { expect } from "@playwright/test";
+import { Timeout, testSkipIfWindows } from "./helpers/test_helper";
+
+/**
+ * End-to-end guard for the `add_integration` round trip.
+ *
+ * The local-agent tool parks the turn on a user-input request: the user picks a
+ * provider in the chat card, finishes the connector in the Configure panel, and
+ * clicks Continue. Main must arm the follow-up turn and dispatch it, so the
+ * conversation resumes instead of stopping dead after Continue.
+ *
+ * The agent-mode branches of the chat stream handler return early, so they have
+ * to report natural completion themselves. When they don't, the handler's
+ * `finally` sweeps the armed request instead of dispatching its follow-up.
+ */
+testSkipIfWindows(
+  "local-agent - finishing the database integration resumes the chat",
+  async ({ po }) => {
+    await po.setUpDyadPro({ localAgent: true });
+    await po.importApp("minimal");
+    await po.chatActions.selectLocalAgentMode();
+
+    // The tool parks the turn on a user-input request rather than finishing the
+    // conversation, so wait for the card it renders instead of chat completion.
+    await po.sendPrompt("tc=local-agent/add-integration", {
+      skipWaitForCompletion: true,
+    });
+
+    const messages = po.page.getByTestId("messages-list");
+    await expect(
+      messages.getByText("Let's connect a database first."),
+    ).toBeVisible({ timeout: Timeout.LONG });
+
+    // Pick a provider in the chat card, which hands off to the Configure panel.
+    const supabaseRadio = messages.getByRole("radio", { name: /Supabase/ });
+    await supabaseRadio.click();
+    await expect(supabaseRadio).toHaveAttribute("aria-checked", "true");
+    await messages.getByRole("button", { name: "Next" }).click();
+
+    // Both Continue buttons — the Configure panel's and the chat card's mirror —
+    // stay disabled until the connector actually links a project.
+    const chatContinue = po.page.getByTestId(
+      "integration-chat-continue-button",
+    );
+    const panelContinue = po.page.getByTestId(
+      "integration-setup-continue-button",
+    );
+    await expect(panelContinue).toBeVisible({ timeout: Timeout.MEDIUM });
+    await expect(panelContinue).toBeDisabled();
+    await expect(chatContinue).toBeDisabled();
+
+    // Finish the connector where the card sent the user.
+    await po.appManagement.clickConnectSupabaseButton();
+    await expect(po.page.getByText("Fake Supabase Project")).toBeVisible({
+      timeout: Timeout.MEDIUM,
+    });
+
+    await expect(panelContinue).toBeEnabled({ timeout: Timeout.MEDIUM });
+    await panelContinue.click();
+
+    // The regression: the armed follow-up is dispatched as a real turn, so the
+    // conversation keeps going instead of stopping after Continue.
+    await expect(
+      messages.getByText("Continue. I have completed the supabase integration."),
+    ).toBeVisible({ timeout: Timeout.LONG });
+
+    // The request settled: the card drops its pending controls and switches to
+    // the completed state.
+    await expect(chatContinue).toBeHidden();
+    await expect(
+      messages.getByText("Supabase integration complete"),
+    ).toBeVisible({ timeout: Timeout.MEDIUM });
+  },
+);

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -853,6 +853,10 @@ export function registerChatStreamHandlers() {
     let attachmentPaths: string[] = [];
     const abortController = new AbortController();
     let trackedStream: TrackedStream | undefined;
+    // Set on every successful terminal path — including the agent-mode branches
+    // that return early below. The `finally` block only arms a user-input
+    // follow-up (`streamFinished`) when this is true, so leaving it false on a
+    // turn that actually completed sweeps the armed request instead.
     let finishedNaturally = false;
     let replayedAcceptedFollowUp = false;
     let mutatedPersistedChat = false;
@@ -2173,6 +2177,7 @@ This conversation includes one or more image attachments. When the user uploads 
               "Ask mode local agent stream did not complete successfully",
             );
           }
+          finishedNaturally = streamSuccess;
           return;
         }
 
@@ -2188,17 +2193,22 @@ This conversation includes one or more image attachments. When the user uploads 
             freeModelMode,
           });
 
-          await handleLocalAgentStream(event, req, abortController, {
-            placeholderMessageId: placeholderAssistantMessage.id,
-            systemPrompt: planModeSystemPrompt,
-            dyadRequestId: dyadRequestId ?? "[no-request-id]",
-            planModeOnly: true,
-            messageOverride: isSummarizeIntent ? chatMessages : undefined,
-            settingsOverride: settings,
-            freeModelMode,
-            referencedApps: referencedAppsForAgent,
-            currentTurnHasOnDiskAttachment: false,
-          });
+          finishedNaturally = await handleLocalAgentStream(
+            event,
+            req,
+            abortController,
+            {
+              placeholderMessageId: placeholderAssistantMessage.id,
+              systemPrompt: planModeSystemPrompt,
+              dyadRequestId: dyadRequestId ?? "[no-request-id]",
+              planModeOnly: true,
+              messageOverride: isSummarizeIntent ? chatMessages : undefined,
+              settingsOverride: settings,
+              freeModelMode,
+              referencedApps: referencedAppsForAgent,
+              currentTurnHasOnDiskAttachment: false,
+            },
+          );
           return;
         }
 
@@ -2259,6 +2269,7 @@ This conversation includes one or more image attachments. When the user uploads 
             }
           }
 
+          finishedNaturally = streamSuccess;
           return;
         }
 


### PR DESCRIPTION
`add_integration` parks the local-agent turn on a user-input request. When the user finishes the connector and clicks Continue, the registry arms a follow-up and the chat stream handler is supposed to promote it to `due` on natural completion (`userInputRegistry.streamFinished`), which dispatches "Continue. I have completed the <provider> integration." as the next turn.

The handler gates that on `finishedNaturally`, but the flag was only set on the fall-through return at the end of the try block. The ask, plan and local-agent branches all return early, so the flag stayed false for every agent-mode turn and the `finally` took the `sweepChat` branch instead. The armed request settled as `swept`, no `follow-up-due` was broadcast, and the conversation stopped right after Continue.

Set `finishedNaturally` from `handleLocalAgentStream`'s success result on all three early-return branches. Cancellations and errors still return false, so they keep sweeping as before.

Adds an E2E regression test that drives the whole journey through the packaged app: the agent parks on the request, the user picks a provider in the chat card, finishes the connector in the Configure panel and clicks Continue. It asserts the armed follow-up turn is dispatched into the chat and the card settles into its completed state.

It connects Supabase rather than Neon because `neon:set-app-project` runs `ensureNitroIfVite()`, which installs a Nitro layer into the Vite fixture app; every existing Neon E2E uses the Next.js template for that reason. The regression is provider-independent.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

