### PR TITLE
Upgrade GitHub workflows to Claude Opus 5

### DIFF
--- a/.github/workflows/claude-deflake-e2e.yml
+++ b/.github/workflows/claude-deflake-e2e.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
-          claude_args: --model claude-opus-4-8
+          claude_args: --model claude-opus-5
           display_report: true
           prompt: |
             /dyad:deflake-e2e-recent-commits ${{ inputs.commit_count || '10' }}

--- a/.github/workflows/claude-deflake-e2e.yml
+++ b/.github/workflows/claude-deflake-e2e.yml
@@ -69,7 +69,7 @@ jobs:
         run: cd testing/fake-llm-server && npm install && npm run build
 
       - name: Deflake E2E tests
-        uses: anthropics/claude-code-action@b76a0776ae74036e77cd11018083743453d7ad35 # v1.0.179
+        uses: anthropics/claude-code-action@80c86e6b3cc02993f6c493655003f711315c83d7 # v1.0.182
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           CLAUDE_CODE_MAX_OUTPUT_TOKENS: 48000

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -77,7 +77,7 @@ jobs:
         run: node scripts/issue-agent/render-template.mjs
 
       - name: PR Review
-        uses: anthropics/claude-code-action@b76a0776ae74036e77cd11018083743453d7ad35 # v1.0.179
+        uses: anthropics/claude-code-action@80c86e6b3cc02993f6c493655003f711315c83d7 # v1.0.182
         env:
           # Default is 32,000 which Claude willl sometimes hit.
           # https://code.claude.com/docs/en/settings

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -98,7 +98,7 @@ jobs:
           prompt: ${{ steps.render-prompt.outputs.prompt }}
 
           claude_args: |
-            --model claude-opus-4-8
+            --model claude-opus-5
             --setting-sources user
             --allowedTools "Agent,Read,Glob,Grep,Edit(tmp/pr-review/**)"
 

--- a/.github/workflows/claude-rules-review.yml
+++ b/.github/workflows/claude-rules-review.yml
@@ -42,7 +42,7 @@ jobs:
         run: rm -f .claude/settings.json .claude/settings.local.json
 
       - name: Review AGENTS.md and rules/
-        uses: anthropics/claude-code-action@b76a0776ae74036e77cd11018083743453d7ad35 # v1.0.179
+        uses: anthropics/claude-code-action@80c86e6b3cc02993f6c493655003f711315c83d7 # v1.0.182
         env:
           CLAUDE_CODE_MAX_OUTPUT_TOKENS: 48000
         with:

--- a/.github/workflows/claude-rules-review.yml
+++ b/.github/workflows/claude-rules-review.yml
@@ -51,7 +51,7 @@ jobs:
           display_report: true
           direct: true
           allowed_tools: "Read,Glob,Grep,Bash(git log:*),Bash(gh issue create:*),Bash(gh issue list:*),Bash(gh issue close:*),Bash(gh label:*)"
-          claude_args: --model claude-opus-4-8
+          claude_args: --model claude-opus-5
           prompt: |
             # Rules Documentation Review Agent
 

--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          model: claude-opus-4-8
+          model: claude-opus-5
           allowed_tools: "Bash(echo:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Write"
           prompt: ${{ steps.render-prompt.outputs.prompt }}
 

--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -48,7 +48,7 @@ jobs:
         run: node scripts/issue-agent/render-template.mjs
 
       - name: Triage issue
-        uses: anthropics/claude-code-base-action@e8132bc5e637a42c27763fc757faa37e1ee43b34 # v0.0.63
+        uses: anthropics/claude-code-base-action@30234c90700acf18e36ad3d509af11032df842ff # Claude Code 2.1.219
         env:
           GITHUB_TOKEN: ${{ github.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}

--- a/e2e-tests/local_agent_add_integration.spec.ts
+++ b/e2e-tests/local_agent_add_integration.spec.ts
@@ -61,7 +61,9 @@ testSkipIfWindows(
     // The regression: the armed follow-up is dispatched as a real turn, so the
     // conversation keeps going instead of stopping after Continue.
     await expect(
-      messages.getByText("Continue. I have completed the supabase integration."),
+      messages.getByText(
+        "Continue. I have completed the supabase integration.",
+      ),
     ).toBeVisible({ timeout: Timeout.LONG });
 
     // The request settled: the card drops its pending controls and switches to

--- a/e2e-tests/local_agent_add_integration.spec.ts
+++ b/e2e-tests/local_agent_add_integration.spec.ts
@@ -61,9 +61,7 @@ testSkipIfWindows(
     // The regression: the armed follow-up is dispatched as a real turn, so the
     // conversation keeps going instead of stopping after Continue.
     await expect(
-      messages.getByText(
-        "Continue. I have completed the supabase integration.",
-      ),
+      messages.getByText("Continue. I have completed the supabase integration."),
     ).toBeVisible({ timeout: Timeout.LONG });
 
     // The request settled: the card drops its pending controls and switches to

--- a/rules/claude-github-workflows.md
+++ b/rules/claude-github-workflows.md
@@ -24,6 +24,8 @@ When a headless Claude job must write local handoff artifacts, exclude project/l
 
 Both `claude-code-action` and `claude-code-base-action` read `.claude/settings.json` from the workspace after `actions/checkout`, and the project's file is committed (tracked in git). **`permissions.allow` arrays merge across scopes — they do not replace each other.** From the Claude Code docs: _"Array settings merge across scopes. When the same array-valued setting (such as `permissions.allow`) appears in multiple scopes, the arrays are concatenated and deduplicated, not replaced."_ ([source](https://code.claude.com/docs/en/settings)).
 
+When upgrading the standalone `claude-code-base-action`, do not infer its bundled Claude Code version from the latest release tag: the repository can continue receiving immutable sync commits after tagged releases stop. Inspect `action.yml` at the exact commit, pin that SHA, and annotate the bundled CLI version so model compatibility is reviewable.
+
 This has two consequences that bite in CI:
 
 1. **The `allowed_tools` action input is additive, not authoritative.** A workflow that sets `allowed_tools: "Read,Glob,Grep,Bash(git log:*)"` still inherits every entry in the project's `.claude/settings.json` — `Bash(git:*)`, `Bash(gh pr create:*)`, `Bash(npm run:*)`, `Bash(rm -f ...)`, etc. The narrow list looks tight but isn't.


### PR DESCRIPTION
## Summary

Upgrade the Claude-powered GitHub Actions workflows to Opus 5 while ensuring every affected action installs a compatible Claude Code CLI.

- Pins `claude-code-action` v1.0.182 for deflaking, PR review, and rules review; this immutable release installs the minimum compatible Claude Code 2.1.219.
- Pins the triage workflow's standalone base action to its matching immutable 2.1.219 sync commit because that repository has no corresponding release tag.
- Documents how to verify standalone base-action CLI compatibility when release tags lag its sync commits.
- Leaves prompts, permissions, triggers, and non-Opus-5 workflows unchanged.

#skip-bugbot

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only CI workflow pins and agent documentation; no application runtime, auth, or data paths are modified. Main operational risk is higher Opus 5 usage cost and possible model/action compatibility if pins are wrong.
> 
> **Overview**
> Moves **Claude-powered GitHub Actions** from **`claude-opus-4-8`** to **`claude-opus-5`** for E2E deflaking, PR review, rules review, and issue triage.
> 
> **`claude-code-action`** is pinned from **v1.0.179** to **v1.0.182** in the three workflows that use it. **Issue triage** also bumps **`claude-code-base-action`** to a new commit annotated as **Claude Code 2.1.219**, with **`model: claude-opus-5`**.
> 
> **`rules/claude-github-workflows.md`** adds guidance that **`claude-code-base-action`** upgrades should be verified via **`action.yml` at the pinned SHA** (not release tags alone), with the bundled CLI version noted in the workflow comment for model compatibility review.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d97970aa3602aee062bcac3ab20d7287f7a41b12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
