### PR TITLE
feat: open a plugin's page after adding it

### DIFF
--- a/e2e-tests/helpers/page-objects/components/Plugins.ts
+++ b/e2e-tests/helpers/page-objects/components/Plugins.ts
@@ -28,18 +28,23 @@ export class Plugins {
   // by itself, so callers can ask for it either way.
   async openPluginDetail(serverName: string) {
     const detail = this.page.getByTestId("plugin-detail");
-    const card = this.page
-      .getByTestId("plugin-card")
-      .filter({ has: this.page.getByText(serverName, { exact: true }) });
+    const named = this.page.getByText(serverName, { exact: true });
+    // Scoped to this server: a detail page for a different one still
+    // needs the card clicked.
+    const detailForServer = detail.filter({ has: named });
+    const card = this.page.getByTestId("plugin-card").filter({ has: named });
     // Adding navigates here on its own, so wait for whichever of the two
     // settles first. Checking the detail page alone would read false
     // while a navigation is still in flight, then look for a card that
     // has already left the DOM.
-    await expect(detail.or(card).first()).toBeVisible({
+    await expect(detailForServer.or(card).first()).toBeVisible({
       timeout: Timeout.MEDIUM,
     });
-    if (!(await detail.isVisible())) {
-      await card.click();
+    if (!(await detailForServer.isVisible())) {
+      // A navigation landing between that check and this click removes
+      // the card, which is a success rather than a failure. The
+      // assertions below decide either way.
+      await card.click().catch(() => {});
     }
     await expect(detail).toBeVisible({ timeout: Timeout.MEDIUM });
     await expect(detail.getByText(serverName, { exact: true })).toBeVisible({

--- a/e2e-tests/helpers/page-objects/components/Plugins.ts
+++ b/e2e-tests/helpers/page-objects/components/Plugins.ts
@@ -43,8 +43,11 @@ export class Plugins {
     if (!(await detailForServer.isVisible())) {
       // A navigation landing between that check and this click removes
       // the card, which is a success rather than a failure. The
-      // assertions below decide either way.
-      await card.click().catch(() => {});
+      // assertions below decide either way; log so a real click problem
+      // isn't just an opaque timeout further down.
+      await card.click().catch((error) => {
+        console.log(`openPluginDetail: card click did not land: ${error}`);
+      });
     }
     await expect(detail).toBeVisible({ timeout: Timeout.MEDIUM });
     await expect(detail.getByText(serverName, { exact: true })).toBeVisible({

--- a/e2e-tests/helpers/page-objects/components/Plugins.ts
+++ b/e2e-tests/helpers/page-objects/components/Plugins.ts
@@ -23,14 +23,26 @@ export class Plugins {
     await expect(dialog).not.toBeVisible({ timeout: Timeout.MEDIUM });
   }
 
-  // Click the named summary card and wait for its detail page.
+  // Ensure the named server's detail page is open, clicking its summary
+  // card only if it isn't already. Adding a server lands on this page
+  // by itself, so callers can ask for it either way.
   async openPluginDetail(serverName: string) {
+    const detail = this.page.getByTestId("plugin-detail");
     const card = this.page
       .getByTestId("plugin-card")
       .filter({ has: this.page.getByText(serverName, { exact: true }) });
-    await expect(card).toBeVisible({ timeout: Timeout.MEDIUM });
-    await card.click();
-    await expect(this.page.getByTestId("plugin-detail")).toBeVisible({
+    // Adding navigates here on its own, so wait for whichever of the two
+    // settles first. Checking the detail page alone would read false
+    // while a navigation is still in flight, then look for a card that
+    // has already left the DOM.
+    await expect(detail.or(card).first()).toBeVisible({
+      timeout: Timeout.MEDIUM,
+    });
+    if (!(await detail.isVisible())) {
+      await card.click();
+    }
+    await expect(detail).toBeVisible({ timeout: Timeout.MEDIUM });
+    await expect(detail.getByText(serverName, { exact: true })).toBeVisible({
       timeout: Timeout.MEDIUM,
     });
   }

--- a/e2e-tests/mcp.spec.ts
+++ b/e2e-tests/mcp.spec.ts
@@ -38,6 +38,11 @@ testSkipIfWindows("mcp - call calculator", async ({ po }) => {
     .fill(testMcpServerPath);
   await po.plugins.submitAddPluginDialog();
 
+  // Adding lands on the new server's page, which is where env vars are
+  // entered. Asserted before openPluginDetail below, which tolerates
+  // either starting point.
+  await expect(po.page.getByTestId("plugin-detail")).toBeVisible();
+
   // Environment variables are edited on the plugin's detail page.
   await po.plugins.openPluginDetail("testing-mcp-server");
   const detail = po.page.getByTestId("plugin-detail");

--- a/e2e-tests/mcp_catalog.spec.ts
+++ b/e2e-tests/mcp_catalog.spec.ts
@@ -148,10 +148,16 @@ testSkipIfWindows(
       await po.navigation.goToPluginsTab();
 
       await po.catalog.addFromCatalog("E2E OAuth Server");
-      await po.catalog.expectAdded("E2E OAuth Server");
+      // Adding an OAuth entry lands on the new server's page, so the
+      // connect reports progress where the user is already looking.
+      await expect(po.page.getByTestId("plugin-detail")).toBeVisible();
       await expect(po.page.getByText("OAuth: connected")).toBeVisible({
         timeout: 15_000,
       });
+
+      // Back on the catalog the entry reads as added, not as pending.
+      await po.navigation.goToPluginsTab();
+      await po.catalog.expectAdded("E2E OAuth Server");
     } finally {
       await stop(oauthServer);
     }

--- a/src/components/plugins/AddPluginDialog.tsx
+++ b/src/components/plugins/AddPluginDialog.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -74,6 +75,7 @@ export function AddPluginDialog({
     opts: { wantsOAuth: boolean },
   ) => Promise<void>;
 }) {
+  const navigate = useNavigate();
   const { createServer } = useMcp();
   const [name, setName] = useState("");
   const [transport, setTransport] = useState<Transport>("stdio");
@@ -185,10 +187,22 @@ export function AddPluginDialog({
     setOauthScope("");
     onOpenChange(false);
 
-    if (transport === "http" && created) {
-      await onServerCreated(created, { wantsOAuth });
-    } else if (created) {
-      // http servers get feedback from the OAuth/probe flow above.
+    if (!created) return;
+
+    // Land on the new server's page: a stdio server usually still
+    // needs env vars, an http one headers, and an OAuth connect shows
+    // its progress there. The form gives no way to tell which of those
+    // apply, so go there either way.
+    navigate({ to: "/plugins/$serverId", params: { serverId: created.id } });
+
+    if (transport === "http") {
+      // Not awaited: the connect runs while the user is already on the
+      // detail page, which reports its own progress. Connect state
+      // lives in shared atoms, so navigating can't lose it.
+      void onServerCreated(created, { wantsOAuth });
+    } else {
+      // Only stdio needs a toast; an http server reports itself
+      // through the connect flow above.
       showSuccess(`Added "${created.name}"`);
     }
   };

--- a/src/components/plugins/catalog/CatalogCard.test.tsx
+++ b/src/components/plugins/catalog/CatalogCard.test.tsx
@@ -10,10 +10,16 @@ const entry: McpCatalogEntry = {
   url: "https://mcp.example.com/mcp",
 };
 
-function renderCard(status: CatalogCardStatus, isAdding = false) {
+const oauthEntry: McpCatalogEntry = { ...entry, oauth: { required: true } };
+
+function renderCard(
+  status: CatalogCardStatus,
+  isAdding = false,
+  cardEntry: McpCatalogEntry = entry,
+) {
   return render(
     <CatalogCard
-      entry={entry}
+      entry={cardEntry}
       status={status}
       isAdding={isAdding}
       onAdd={vi.fn()}
@@ -58,15 +64,23 @@ describe("CatalogCard status", () => {
   // The label changes as a connect progresses, so it has to sit in a
   // region assistive tech watches.
   it.each(["connecting", "needs-connect", "added"] as const)(
-    "announces the %s state through a status role",
+    "announces the %s state of a connectable entry through a status role",
     (status) => {
-      renderCard(status);
+      renderCard(status, false, oauthEntry);
       expect(screen.getByRole("status")).toBeTruthy();
     },
   );
 
+  // An entry that never connects settles on "added" and stays there, so
+  // a live region on it would only add noise.
+  it("does not make a settled entry a live region", () => {
+    renderCard("added");
+    expect(screen.getByText("Added")).toBeTruthy();
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
   it("keeps the decorative icon out of the announced text", () => {
-    renderCard("connecting");
+    renderCard("connecting", false, oauthEntry);
     expect(screen.getByRole("status").textContent).toBe("Connecting…");
   });
 });

--- a/src/components/plugins/catalog/CatalogCard.test.tsx
+++ b/src/components/plugins/catalog/CatalogCard.test.tsx
@@ -54,4 +54,19 @@ describe("CatalogCard status", () => {
     expect(screen.getByText("Added")).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Add" })).toBeNull();
   });
+
+  // The label changes as a connect progresses, so it has to sit in a
+  // region assistive tech watches.
+  it.each(["connecting", "needs-connect", "added"] as const)(
+    "announces the %s state through a status role",
+    (status) => {
+      renderCard(status);
+      expect(screen.getByRole("status")).toBeTruthy();
+    },
+  );
+
+  it("keeps the decorative icon out of the announced text", () => {
+    renderCard("connecting");
+    expect(screen.getByRole("status").textContent).toBe("Connecting…");
+  });
 });

--- a/src/components/plugins/catalog/CatalogCard.test.tsx
+++ b/src/components/plugins/catalog/CatalogCard.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { McpCatalogEntry } from "@/ipc/types/mcp_catalog";
+import { CatalogCard, type CatalogCardStatus } from "./CatalogCard";
+
+const entry: McpCatalogEntry = {
+  slug: "example",
+  name: "Example",
+  transport: "http",
+  url: "https://mcp.example.com/mcp",
+};
+
+function renderCard(status: CatalogCardStatus, isAdding = false) {
+  return render(
+    <CatalogCard
+      entry={entry}
+      status={status}
+      isAdding={isAdding}
+      onAdd={vi.fn()}
+    />,
+  );
+}
+
+describe("CatalogCard status", () => {
+  it("offers Add when the entry isn't added yet", () => {
+    renderCard("not-added");
+    expect(screen.getByRole("button", { name: "Add" })).toBeTruthy();
+    expect(screen.queryByText("Added")).toBeNull();
+  });
+
+  it("shows progress while adding", () => {
+    renderCard("not-added", true);
+    const button = screen.getByRole<HTMLButtonElement>("button", {
+      name: "Adding…",
+    });
+    expect(button.disabled).toBe(true);
+  });
+
+  it("reports a connect in flight rather than claiming it's done", () => {
+    renderCard("connecting");
+    expect(screen.getByText("Connecting…")).toBeTruthy();
+    expect(screen.queryByText("Added")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Add" })).toBeNull();
+  });
+
+  it("reports an added server that still isn't connected", () => {
+    renderCard("needs-connect");
+    expect(screen.getByText("Not connected")).toBeTruthy();
+    expect(screen.queryByText("Added")).toBeNull();
+  });
+
+  it("shows Added once there's nothing left to do", () => {
+    renderCard("added");
+    expect(screen.getByText("Added")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Add" })).toBeNull();
+  });
+});

--- a/src/components/plugins/catalog/CatalogCard.tsx
+++ b/src/components/plugins/catalog/CatalogCard.tsx
@@ -1,4 +1,4 @@
-import { Check } from "lucide-react";
+import { Check, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -25,14 +25,23 @@ function sourceOf(entry: McpCatalogEntry): string {
   return hostnameOf(entry.url);
 }
 
+// What an already-added entry is doing. "Added" on its own says only
+// that a row exists, which reads as finished while an OAuth connect is
+// still running or has failed.
+export type CatalogCardStatus =
+  | "not-added"
+  | "added"
+  | "connecting"
+  | "needs-connect";
+
 export function CatalogCard({
   entry,
-  isAdded,
+  status,
   isAdding,
   onAdd,
 }: {
   entry: McpCatalogEntry;
-  isAdded: boolean;
+  status: CatalogCardStatus;
   isAdding: boolean;
   onAdd: (entry: McpCatalogEntry) => void;
 }) {
@@ -61,7 +70,16 @@ export function CatalogCard({
           <span className="text-xs text-muted-foreground truncate">
             {sourceOf(entry)}
           </span>
-          {isAdded ? (
+          {status === "connecting" ? (
+            <span className="flex items-center gap-1 text-xs font-medium text-muted-foreground shrink-0">
+              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+              Connecting…
+            </span>
+          ) : status === "needs-connect" ? (
+            <span className="text-xs font-medium text-amber-600 dark:text-amber-400 shrink-0">
+              Not connected
+            </span>
+          ) : status === "added" ? (
             <span className="flex items-center gap-1 text-xs font-medium text-green-600 dark:text-green-400 shrink-0">
               <Check className="w-3.5 h-3.5" />
               Added

--- a/src/components/plugins/catalog/CatalogCard.tsx
+++ b/src/components/plugins/catalog/CatalogCard.tsx
@@ -5,6 +5,7 @@ import {
   looksLikePackageSpec,
   type McpCatalogEntry,
 } from "@/ipc/types/mcp_catalog";
+import { catalogEntryCanConnect } from "./catalogCardStatus";
 
 // The schema already validates url, but parse defensively so one bad
 // entry can't throw during render and take down the whole section.
@@ -75,11 +76,11 @@ export function CatalogCard({
               {isAdding ? "Adding…" : "Add"}
             </Button>
           ) : (
-            // One region for every state, so a change from Connecting…
-            // to Added or Not connected is announced. The icons repeat
-            // the label, so they stay out of the accessible name.
+            // A live region only where the label can still change, so a
+            // catalog of settled entries isn't a wall of them. The icons
+            // repeat the label, so they stay out of the accessible name.
             <span
-              role="status"
+              role={catalogEntryCanConnect(entry) ? "status" : undefined}
               className={`flex items-center gap-1 text-xs font-medium shrink-0 ${
                 status === "connecting"
                   ? "text-muted-foreground"

--- a/src/components/plugins/catalog/CatalogCard.tsx
+++ b/src/components/plugins/catalog/CatalogCard.tsx
@@ -70,24 +70,36 @@ export function CatalogCard({
           <span className="text-xs text-muted-foreground truncate">
             {sourceOf(entry)}
           </span>
-          {status === "connecting" ? (
-            <span className="flex items-center gap-1 text-xs font-medium text-muted-foreground shrink-0">
-              <Loader2 className="w-3.5 h-3.5 animate-spin" />
-              Connecting…
-            </span>
-          ) : status === "needs-connect" ? (
-            <span className="text-xs font-medium text-amber-600 dark:text-amber-400 shrink-0">
-              Not connected
-            </span>
-          ) : status === "added" ? (
-            <span className="flex items-center gap-1 text-xs font-medium text-green-600 dark:text-green-400 shrink-0">
-              <Check className="w-3.5 h-3.5" />
-              Added
-            </span>
-          ) : (
+          {status === "not-added" ? (
             <Button size="sm" onClick={() => onAdd(entry)} disabled={isAdding}>
               {isAdding ? "Adding…" : "Add"}
             </Button>
+          ) : (
+            // One region for every state, so a change from Connecting…
+            // to Added or Not connected is announced. The icons repeat
+            // the label, so they stay out of the accessible name.
+            <span
+              role="status"
+              className={`flex items-center gap-1 text-xs font-medium shrink-0 ${
+                status === "connecting"
+                  ? "text-muted-foreground"
+                  : status === "needs-connect"
+                    ? "text-amber-600 dark:text-amber-400"
+                    : "text-green-600 dark:text-green-400"
+              }`}
+            >
+              {status === "connecting" && (
+                <Loader2 className="w-3.5 h-3.5 animate-spin" aria-hidden />
+              )}
+              {status === "added" && (
+                <Check className="w-3.5 h-3.5" aria-hidden />
+              )}
+              {status === "connecting"
+                ? "Connecting…"
+                : status === "needs-connect"
+                  ? "Not connected"
+                  : "Added"}
+            </span>
           )}
         </div>
       </CardHeader>

--- a/src/components/plugins/catalog/CatalogSection.tsx
+++ b/src/components/plugins/catalog/CatalogSection.tsx
@@ -3,7 +3,6 @@ import { Star } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { useMcp } from "@/hooks/useMcp";
 import { useMcpCatalog } from "@/hooks/useMcpCatalog";
-import { usePluginConnect } from "../usePluginConnect";
 import { CatalogCard } from "./CatalogCard";
 import { catalogCardStatus } from "./catalogCardStatus";
 import { StdioCatalogConsentDialog } from "./StdioCatalogConsentDialog";
@@ -14,6 +13,7 @@ export function CatalogSection() {
   const {
     addFromCatalog,
     addingSlug,
+    connectingServerId,
     pendingStdioEntry,
     confirmPendingStdio,
     cancelPendingStdio,
@@ -22,7 +22,6 @@ export function CatalogSection() {
   const catalogQuery = useMcpCatalog();
 
   const { servers } = useMcp();
-  const { connectingServerId } = usePluginConnect();
 
   const entries = catalogQuery.data?.entries ?? [];
   const addedSlugs = useMemo(

--- a/src/components/plugins/catalog/CatalogSection.tsx
+++ b/src/components/plugins/catalog/CatalogSection.tsx
@@ -1,8 +1,11 @@
 import { useMemo, useState } from "react";
 import { Star } from "lucide-react";
 import { Input } from "@/components/ui/input";
+import { useMcp } from "@/hooks/useMcp";
 import { useMcpCatalog } from "@/hooks/useMcpCatalog";
+import { usePluginConnect } from "../usePluginConnect";
 import { CatalogCard } from "./CatalogCard";
+import { catalogCardStatus } from "./catalogCardStatus";
 import { StdioCatalogConsentDialog } from "./StdioCatalogConsentDialog";
 import { useAddFromCatalog } from "./useAddFromCatalog";
 
@@ -18,11 +21,22 @@ export function CatalogSection() {
 
   const catalogQuery = useMcpCatalog();
 
+  const { servers } = useMcp();
+  const { connectingServerId } = usePluginConnect();
+
   const entries = catalogQuery.data?.entries ?? [];
   const addedSlugs = useMemo(
     () => new Set(catalogQuery.data?.addedSlugs ?? []),
     [catalogQuery.data?.addedSlugs],
   );
+
+  const serverBySlug = useMemo(() => {
+    const map = new Map<string, (typeof servers)[number]>();
+    for (const server of servers) {
+      if (server.catalogSlug) map.set(server.catalogSlug, server);
+    }
+    return map;
+  }, [servers]);
 
   const filtered = useMemo(() => {
     const needle = search.trim().toLowerCase();
@@ -98,7 +112,12 @@ export function CatalogSection() {
               <CatalogCard
                 key={entry.slug}
                 entry={entry}
-                isAdded={addedSlugs.has(entry.slug)}
+                status={catalogCardStatus({
+                  entry,
+                  addedSlugs,
+                  serverBySlug,
+                  connectingServerId,
+                })}
                 isAdding={addingSlug === entry.slug}
                 onAdd={addFromCatalog}
               />
@@ -116,7 +135,12 @@ export function CatalogSection() {
               <CatalogCard
                 key={entry.slug}
                 entry={entry}
-                isAdded={addedSlugs.has(entry.slug)}
+                status={catalogCardStatus({
+                  entry,
+                  addedSlugs,
+                  serverBySlug,
+                  connectingServerId,
+                })}
                 isAdding={addingSlug === entry.slug}
                 onAdd={addFromCatalog}
               />

--- a/src/components/plugins/catalog/catalogCardStatus.test.ts
+++ b/src/components/plugins/catalog/catalogCardStatus.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import type { McpServer } from "@/ipc/types";
+import type { McpCatalogEntry } from "@/ipc/types/mcp_catalog";
+import { catalogCardStatus } from "./catalogCardStatus";
+
+function entryOf(overrides: Partial<McpCatalogEntry> = {}): McpCatalogEntry {
+  return {
+    slug: "example",
+    name: "Example",
+    transport: "http",
+    url: "https://mcp.example.com/mcp",
+    ...overrides,
+  } as McpCatalogEntry;
+}
+
+function serverOf(overrides: Partial<McpServer> = {}): McpServer {
+  return {
+    id: 1,
+    name: "Example",
+    transport: "http",
+    command: null,
+    args: null,
+    envJson: null,
+    headersJson: null,
+    url: "https://mcp.example.com/mcp",
+    enabled: true,
+    oauthEnabled: false,
+    oauthConnected: false,
+    oauthCallbackPort: null,
+    oauthClientId: null,
+    envUnreadable: false,
+    headersUnreadable: false,
+    catalogSlug: "example",
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    ...overrides,
+  };
+}
+
+function statusFor({
+  entry = entryOf(),
+  server,
+  added = true,
+  connectingServerId = null,
+}: {
+  entry?: McpCatalogEntry;
+  server?: McpServer;
+  added?: boolean;
+  connectingServerId?: number | null;
+} = {}) {
+  return catalogCardStatus({
+    entry,
+    addedSlugs: new Set(added ? [entry.slug] : []),
+    serverBySlug: new Map(server ? [[entry.slug, server]] : []),
+    connectingServerId,
+  });
+}
+
+describe("catalogCardStatus", () => {
+  it("offers Add for an entry that isn't added", () => {
+    expect(statusFor({ added: false })).toBe("not-added");
+  });
+
+  it("reports added while the server row hasn't arrived yet", () => {
+    expect(statusFor({ server: undefined })).toBe("added");
+  });
+
+  it("reports a connect in flight", () => {
+    expect(
+      statusFor({
+        entry: entryOf({ oauth: { required: true } }),
+        server: serverOf({ oauthEnabled: true }),
+        connectingServerId: 1,
+      }),
+    ).toBe("connecting");
+  });
+
+  it("reports a required-OAuth server that hasn't connected", () => {
+    expect(
+      statusFor({
+        entry: entryOf({ oauth: { required: true } }),
+        server: serverOf({ oauthEnabled: true, oauthConnected: false }),
+      }),
+    ).toBe("needs-connect");
+  });
+
+  it("reports a required-OAuth server that has connected", () => {
+    expect(
+      statusFor({
+        entry: entryOf({ oauth: { required: true } }),
+        server: serverOf({ oauthEnabled: true, oauthConnected: true }),
+      }),
+    ).toBe("added");
+  });
+
+  // Optional OAuth is enabled on the row but never auto-connected, so
+  // it would otherwise look permanently broken despite working.
+  it("does not flag optional OAuth as not connected", () => {
+    expect(
+      statusFor({
+        entry: entryOf({ oauth: { required: false } }),
+        server: serverOf({ oauthEnabled: true, oauthConnected: false }),
+      }),
+    ).toBe("added");
+  });
+
+  it("does not flag a plain http entry as not connected", () => {
+    expect(statusFor({ server: serverOf() })).toBe("added");
+  });
+
+  it("does not flag an stdio entry as not connected", () => {
+    expect(
+      statusFor({
+        entry: entryOf({
+          transport: "stdio",
+          command: "npx",
+          args: ["-y", "pkg"],
+        }),
+        server: serverOf({ transport: "stdio", oauthEnabled: true }),
+      }),
+    ).toBe("added");
+  });
+});

--- a/src/components/plugins/catalog/catalogCardStatus.ts
+++ b/src/components/plugins/catalog/catalogCardStatus.ts
@@ -1,0 +1,35 @@
+import type { McpServer } from "@/ipc/types";
+import type { McpCatalogEntry } from "@/ipc/types/mcp_catalog";
+import type { CatalogCardStatus } from "./CatalogCard";
+
+/**
+ * What an entry's card should report.
+ *
+ * `addedSlugs` and the server rows come from separate queries that
+ * settle independently, so a slug can be added before its row arrives.
+ * That reports a plain "added" rather than guessing at a connection
+ * state.
+ *
+ * Only a required-OAuth entry can be "not connected". An optional one
+ * works anonymously and offers Connect on its own card, so reporting it
+ * here would call a working plugin broken.
+ */
+export function catalogCardStatus({
+  entry,
+  addedSlugs,
+  serverBySlug,
+  connectingServerId,
+}: {
+  entry: McpCatalogEntry;
+  addedSlugs: ReadonlySet<string>;
+  serverBySlug: ReadonlyMap<string, McpServer>;
+  connectingServerId: number | null;
+}): CatalogCardStatus {
+  if (!addedSlugs.has(entry.slug)) return "not-added";
+  const server = serverBySlug.get(entry.slug);
+  if (!server) return "added";
+  if (connectingServerId === server.id) return "connecting";
+  const requiresOauth = entry.transport === "http" && entry.oauth?.required;
+  if (requiresOauth && !server.oauthConnected) return "needs-connect";
+  return "added";
+}

--- a/src/components/plugins/catalog/catalogCardStatus.ts
+++ b/src/components/plugins/catalog/catalogCardStatus.ts
@@ -3,6 +3,15 @@ import type { McpCatalogEntry } from "@/ipc/types/mcp_catalog";
 import type { CatalogCardStatus } from "./CatalogCard";
 
 /**
+ * Whether an entry's card can still change status. Only a required-OAuth
+ * entry connects on add, so every other card settles on "added" and
+ * stays there.
+ */
+export function catalogEntryCanConnect(entry: McpCatalogEntry): boolean {
+  return entry.transport === "http" && entry.oauth?.required === true;
+}
+
+/**
  * What an entry's card should report.
  *
  * `addedSlugs` and the server rows come from separate queries that
@@ -29,7 +38,8 @@ export function catalogCardStatus({
   const server = serverBySlug.get(entry.slug);
   if (!server) return "added";
   if (connectingServerId === server.id) return "connecting";
-  const requiresOauth = entry.transport === "http" && entry.oauth?.required;
-  if (requiresOauth && !server.oauthConnected) return "needs-connect";
+  if (catalogEntryCanConnect(entry) && !server.oauthConnected) {
+    return "needs-connect";
+  }
   return "added";
 }

--- a/src/components/plugins/catalog/useAddFromCatalog.ts
+++ b/src/components/plugins/catalog/useAddFromCatalog.ts
@@ -15,7 +15,7 @@ export function useAddFromCatalog() {
   // consent is pending.
   const [pendingStdioEntry, setPendingStdioEntry] =
     useState<McpCatalogEntry | null>(null);
-  const { onServerCreated } = usePluginConnect();
+  const { onServerCreated, connectingServerId } = usePluginConnect();
 
   const mutation = useMutation({
     mutationFn: async (entry: McpCatalogEntry) => {
@@ -114,6 +114,9 @@ export function useAddFromCatalog() {
   return {
     addFromCatalog,
     addingSlug,
+    // Passed through so the catalog can show connect progress without
+    // mounting the connect hook a second time.
+    connectingServerId,
     pendingStdioEntry,
     confirmPendingStdio,
     cancelPendingStdio,

--- a/src/components/plugins/catalog/useAddFromCatalog.ts
+++ b/src/components/plugins/catalog/useAddFromCatalog.ts
@@ -80,6 +80,14 @@ export function useAddFromCatalog() {
     // competing flow) and reuses the probed callback port; it is not
     // awaited so an abandoned browser step can't wedge the add.
     if (entry.transport === "http" && entry.oauth?.required) {
+      // Go to the server's page first, so the connect reports progress
+      // somewhere the user is looking. An entry with nothing to
+      // configure and no connect to watch stays on the catalog, which
+      // keeps adding several in a row workable.
+      navigate({
+        to: "/plugins/$serverId",
+        params: { serverId: created.id },
+      });
       void onServerCreated(created, { wantsOAuth: true });
     }
   };

--- a/src/ipc/handlers/__tests__/plugins_page.integration.test.tsx
+++ b/src/ipc/handlers/__tests__/plugins_page.integration.test.tsx
@@ -54,17 +54,22 @@ describe("Plugins page (integration)", () => {
     );
     fireEvent.click(within(dialog).getByRole("button", { name: "Add Plugin" }));
 
+    // Adding opens the new plugin's page, which is where env vars are
+    // entered.
+    const detail = await screen.findByTestId("plugin-detail");
+    expect(detail.textContent).toContain("testing-mcp-server");
+
+    // Tools appear once the stdio server finishes its handshake.
+    await within(detail).findByText("calculator_add", undefined, {
+      timeout: 20_000,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "All Plugins" }));
     const card = await screen.findByTestId("plugin-card");
     expect(card.textContent).toContain("testing-mcp-server");
-
-    // The tool count fills in once the stdio server finishes its
-    // handshake; the stats row aggregates it.
-    await waitFor(
-      () => {
-        expect(card.textContent).toMatch(/\d+ tools/);
-      },
-      { timeout: 20_000 },
-    );
+    await waitFor(() => {
+      expect(card.textContent).toMatch(/\d+ tools/);
+    });
     await waitFor(() => {
       expect(screen.getByTestId("plugins-stats").textContent).toMatch(
         /1 plugin · \d+ tools enabled/,


### PR DESCRIPTION
*This description was written by Claude but is human-reviewed.*

Adding a plugin left you on the list with a toast, which is a dead end for a stdio server that still needs env vars or an http one that needs headers. Adding from the dialog now opens the new plugin's page, and the OAuth connect is no longer awaited first, so it runs while you are already watching the page that reports it.

Catalog adds do the same when there is something to see: an entry declaring inputs already went to its setup page, and one that requires OAuth now does too. An entry with nothing to configure and no connect to run stays on the catalog, so adding several in a row still works.

- The catalog card showed a green Added tick as soon as the row existed, which read as finished while a connect was still running or had failed. It now shows Connecting… or Not connected instead. Only required OAuth counts as not connected; an optional one works anonymously, so flagging it would call a working plugin broken.
- The badge derivation lives in its own function so its cases can be tested without rendering the catalog.
- openPluginDetail in the e2e page object no longer assumes it starts on the list, and waits for whichever of the two views settles rather than reading visibility mid-navigation.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

