### PR TITLE
fix(chat): support spaces in app mentions

### DIFF
--- a/src/components/chat/LexicalChatInput.test.tsx
+++ b/src/components/chat/LexicalChatInput.test.tsx
@@ -117,4 +117,59 @@ describe("LexicalChatInput", () => {
       1,
     );
   });
+
+  it("does not emit changes while restoring an external app mention", async () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <LexicalChatInput
+        value="Compare @app:This Is My App."
+        onChange={onChange}
+        onSubmit={vi.fn()}
+        messageHistory={[]}
+        excludeCurrentApp={false}
+        disableSendButton={false}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        container.querySelector("[data-beautiful-mention]"),
+      ).not.toBeNull();
+    });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("preserves an unknown app mention when known apps finish loading", async () => {
+    const props = {
+      value: "Compare @app:MissingApp.",
+      onChange: vi.fn(),
+      onSubmit: vi.fn(),
+      messageHistory: [],
+      excludeCurrentApp: false,
+      disableSendButton: false,
+    };
+    const { container, rerender } = render(<LexicalChatInput {...props} />);
+
+    await waitFor(() => {
+      expect(
+        container
+          .querySelector("[data-beautiful-mention]")
+          ?.getAttribute("data-beautiful-mention"),
+      ).toBe("@MissingApp");
+    });
+
+    mocks.apps = [{ id: 1, name: "Another App" }];
+    rerender(<LexicalChatInput {...props} />);
+
+    await waitFor(() => {
+      expect(
+        container
+          .querySelector("[data-beautiful-mention]")
+          ?.getAttribute("data-beautiful-mention"),
+      ).toBe("@MissingApp");
+    });
+    expect(
+      container.querySelector('[contenteditable="true"]')?.textContent,
+    ).toBe("Compare @MissingApp.");
+  });
 });

--- a/src/components/chat/LexicalChatInput.test.tsx
+++ b/src/components/chat/LexicalChatInput.test.tsx
@@ -84,6 +84,48 @@ describe("LexicalChatInput", () => {
     ).toBe("Compare @This Is My App.");
   });
 
+  it("does not rebuild a non-ASCII app mention on parent rerender", async () => {
+    mocks.apps = [{ id: 1, name: "猫" }];
+    const props = {
+      value: "Compare @app:猫.",
+      onChange: vi.fn(),
+      onSubmit: vi.fn(),
+      messageHistory: [],
+      excludeCurrentApp: false,
+      disableSendButton: false,
+    };
+    const { container, rerender } = render(<LexicalChatInput {...props} />);
+
+    await waitFor(() => {
+      const mention = container.querySelector("[data-beautiful-mention]");
+      expect(mention?.getAttribute("data-beautiful-mention")).toBe("@猫");
+    });
+
+    const editor = container.querySelector('[contenteditable="true"]');
+    if (!editor) {
+      throw new Error("Expected editor");
+    }
+    const textWalker = document.createTreeWalker(editor, NodeFilter.SHOW_TEXT);
+    const leadingText = textWalker.nextNode();
+    if (!leadingText) {
+      throw new Error("Expected leading editor text");
+    }
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.setStart(leadingText, 2);
+    range.collapse(true);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    mocks.apps = [{ id: 1, name: "猫" }];
+    rerender(<LexicalChatInput {...props} />);
+
+    await waitFor(() => {
+      expect(selection?.anchorNode).toBe(leadingText);
+      expect(selection?.anchorOffset).toBe(2);
+    });
+  });
+
   it("rebuilds a spaced app mention when app names finish loading", async () => {
     const props = {
       value: "Compare @app:This Is My App.",

--- a/src/components/chat/LexicalChatInput.test.tsx
+++ b/src/components/chat/LexicalChatInput.test.tsx
@@ -2,8 +2,12 @@ import { render, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { LexicalChatInput } from "./LexicalChatInput";
 
+const mocks = vi.hoisted(() => ({
+  apps: [] as Array<{ id: number; name: string }>,
+}));
+
 vi.mock("@/hooks/useLoadApps", () => ({
-  useLoadApps: () => ({ apps: [] }),
+  useLoadApps: () => ({ apps: mocks.apps }),
 }));
 vi.mock("@/hooks/usePrompts", () => ({
   usePrompts: () => ({ prompts: [] }),
@@ -22,6 +26,7 @@ vi.mock("jotai", async (importOriginal) => ({
 describe("LexicalChatInput", () => {
   beforeEach(() => {
     document.body.innerHTML = "";
+    mocks.apps = [];
   });
 
   it("reactively updates editor editability when disabled changes", async () => {
@@ -47,5 +52,35 @@ describe("LexicalChatInput", () => {
         container.querySelector('[contenteditable="false"]'),
       ).not.toBeNull();
     });
+  });
+
+  it("restores an app mention containing spaces as one mention node", async () => {
+    mocks.apps = [{ id: 1, name: "This Is My App" }];
+
+    const { container } = render(
+      <LexicalChatInput
+        value="Compare @app:This Is My App."
+        onChange={vi.fn()}
+        onSubmit={vi.fn()}
+        messageHistory={[]}
+        excludeCurrentApp={false}
+        disableSendButton={false}
+      />,
+    );
+
+    await waitFor(() => {
+      const mention = container.querySelector("[data-beautiful-mention]");
+      expect(mention).not.toBeNull();
+      expect(mention?.getAttribute("data-beautiful-mention")).toBe(
+        "@This Is My App",
+      );
+    });
+
+    expect(container.querySelectorAll("[data-beautiful-mention]")).toHaveLength(
+      1,
+    );
+    expect(
+      container.querySelector('[contenteditable="true"]')?.textContent,
+    ).toBe("Compare @This Is My App.");
   });
 });

--- a/src/components/chat/LexicalChatInput.test.tsx
+++ b/src/components/chat/LexicalChatInput.test.tsx
@@ -83,4 +83,38 @@ describe("LexicalChatInput", () => {
       container.querySelector('[contenteditable="true"]')?.textContent,
     ).toBe("Compare @This Is My App.");
   });
+
+  it("rebuilds a spaced app mention when app names finish loading", async () => {
+    const props = {
+      value: "Compare @app:This Is My App.",
+      onChange: vi.fn(),
+      onSubmit: vi.fn(),
+      messageHistory: [],
+      excludeCurrentApp: false,
+      disableSendButton: false,
+    };
+    const { container, rerender } = render(<LexicalChatInput {...props} />);
+
+    await waitFor(() => {
+      expect(
+        container
+          .querySelector("[data-beautiful-mention]")
+          ?.getAttribute("data-beautiful-mention"),
+      ).toBe("@This");
+    });
+
+    mocks.apps = [{ id: 1, name: "This Is My App" }];
+    rerender(<LexicalChatInput {...props} />);
+
+    await waitFor(() => {
+      expect(
+        container
+          .querySelector("[data-beautiful-mention]")
+          ?.getAttribute("data-beautiful-mention"),
+      ).toBe("@This Is My App");
+    });
+    expect(container.querySelectorAll("[data-beautiful-mention]")).toHaveLength(
+      1,
+    );
+  });
 });

--- a/src/components/chat/LexicalChatInput.tsx
+++ b/src/components/chat/LexicalChatInput.tsx
@@ -194,6 +194,7 @@ function ExternalValueSyncPlugin({
   promptsById: Record<number, string>;
 }) {
   const [editor] = useLexicalComposerContext();
+  const lastAppMentionSignatureRef = useRef<string | null>(null);
 
   useEffect(() => {
     // Derive the display text that should appear in the editor (@Name) from the
@@ -213,13 +214,37 @@ function ExternalValueSyncPlugin({
       }
     });
 
+    const appMentionMatches =
+      appNames.length > 0
+        ? findKnownAppMentionMatches(value, appNames)
+        : Array.from(
+            value.matchAll(new RegExp(MENTION_REGEX.source, "g")),
+          ).flatMap((match) => {
+            const { appName } = splitAppMentionTrailingDots(match[1]);
+            if (!appName) {
+              return [];
+            }
+            return [
+              {
+                appName,
+                start: match.index,
+                end: match.index + "@app:".length + appName.length,
+              },
+            ];
+          });
+    const appMentionSignature = JSON.stringify(appMentionMatches);
+    const appMentionStructureChanged =
+      lastAppMentionSignatureRef.current !== null &&
+      lastAppMentionSignatureRef.current !== appMentionSignature;
+    lastAppMentionSignatureRef.current = appMentionSignature;
+
     const currentText = editor.getEditorState().read(() => {
       const root = $getRoot();
       return root.getTextContent();
     });
 
     // If the editor already reflects the same display text, do nothing to avoid loops
-    if (currentText === displayText) return;
+    if (currentText === displayText && !appMentionStructureChanged) return;
     editor.update(() => {
       const root = $getRoot();
       root.clear();
@@ -228,24 +253,6 @@ function ExternalValueSyncPlugin({
 
       // Build nodes from internal value, turning app, prompt, file, and media
       // references into mention nodes.
-      const appMentionMatches =
-        appNames.length > 0
-          ? findKnownAppMentionMatches(value, appNames)
-          : Array.from(
-              value.matchAll(new RegExp(MENTION_REGEX.source, "g")),
-            ).flatMap((match) => {
-              const { appName } = splitAppMentionTrailingDots(match[1]);
-              if (!appName) {
-                return [];
-              }
-              return [
-                {
-                  appName,
-                  start: match.index,
-                  end: match.index + "@app:".length + appName.length,
-                },
-              ];
-            });
       const mentionMatches: Array<{
         start: number;
         end: number;

--- a/src/components/chat/LexicalChatInput.tsx
+++ b/src/components/chat/LexicalChatInput.tsx
@@ -27,10 +27,10 @@ import { forwardRef } from "react";
 import { useAtomValue } from "jotai";
 import { selectedAppIdAtom } from "@/atoms/appAtoms";
 import {
-  APP_MENTION_NAME_PATTERN,
+  findKnownAppMentionMatches,
   formatKnownAppMentionsForPrompt,
   MENTION_REGEX,
-  parseAppMentions,
+  parseKnownAppMentions,
   splitAppMentionTrailingDots,
 } from "@/shared/parse_mention_apps";
 import { useLoadApp } from "@/hooks/useLoadApp";
@@ -186,9 +186,11 @@ function EditableStatePlugin({ editable }: { editable: boolean }) {
 // Plugin to sync external value prop into the editor
 function ExternalValueSyncPlugin({
   value,
+  appNames,
   promptsById,
 }: {
   value: string;
+  appNames: string[];
   promptsById: Record<number, string>;
 }) {
   const [editor] = useLexicalComposerContext();
@@ -224,45 +226,79 @@ function ExternalValueSyncPlugin({
 
       const paragraph = $createParagraphNode();
 
-      // Build nodes from internal value, turning @app:Name, @prompt:<id>, @file:<path>, and @media:<ref> into mention nodes
+      // Build nodes from internal value, turning app, prompt, file, and media
+      // references into mention nodes.
+      const appMentionMatches =
+        appNames.length > 0
+          ? findKnownAppMentionMatches(value, appNames)
+          : Array.from(
+              value.matchAll(new RegExp(MENTION_REGEX.source, "g")),
+            ).flatMap((match) => {
+              const { appName } = splitAppMentionTrailingDots(match[1]);
+              if (!appName) {
+                return [];
+              }
+              return [
+                {
+                  appName,
+                  start: match.index,
+                  end: match.index + "@app:".length + appName.length,
+                },
+              ];
+            });
+      const mentionMatches: Array<{
+        start: number;
+        end: number;
+        type: "app" | "prompt" | "file" | "media";
+        value: string;
+      }> = appMentionMatches.map((match) => ({
+        start: match.start,
+        end: match.end,
+        type: "app",
+        value: match.appName,
+      }));
+
+      const nonAppMentionRegex =
+        /@prompt:(\d+)|@file:([^\s]+)|@media:([^\s]+)/g;
+      let nonAppMatch: RegExpExecArray | null;
+      while ((nonAppMatch = nonAppMentionRegex.exec(value)) !== null) {
+        mentionMatches.push({
+          start: nonAppMatch.index,
+          end: nonAppMatch.index + nonAppMatch[0].length,
+          type: nonAppMatch[1] ? "prompt" : nonAppMatch[2] ? "file" : "media",
+          value: nonAppMatch[1] ?? nonAppMatch[2] ?? nonAppMatch[3],
+        });
+      }
+      mentionMatches.sort((a, b) => a.start - b.start);
+
       let lastIndex = 0;
-      let match: RegExpExecArray | null;
-      const combined = new RegExp(
-        `@app:(${APP_MENTION_NAME_PATTERN})|@prompt:(\\d+)|@file:([^\\s]+)|@media:([^\\s]+)`,
-        "g",
-      );
-      while ((match = combined.exec(value)) !== null) {
-        const start = match.index;
-        const full = match[0];
+      for (const match of mentionMatches) {
+        const start = match.start;
+        if (start < lastIndex) {
+          continue;
+        }
         if (start > lastIndex) {
           const textBefore = value.slice(lastIndex, start);
           if (textBefore) paragraph.append($createTextNode(textBefore));
         }
-        if (match[1]) {
-          const { appName, trailingDots } = splitAppMentionTrailingDots(
-            match[1],
-          );
-          paragraph.append($createBeautifulMentionNode("@", appName));
-          if (trailingDots) {
-            paragraph.append($createTextNode(trailingDots));
-          }
-        } else if (match[2]) {
-          const id = Number(match[2]);
+        if (match.type === "app") {
+          paragraph.append($createBeautifulMentionNode("@", match.value));
+        } else if (match.type === "prompt") {
+          const id = Number(match.value);
           const title = promptsById[id] || `prompt:${id}`;
           paragraph.append($createBeautifulMentionNode("@", title));
-        } else if (match[3]) {
-          const filePath = match[3];
-          paragraph.append($createBeautifulMentionNode("@", filePath));
-        } else if (match[4]) {
+        } else if (match.type === "file") {
+          paragraph.append($createBeautifulMentionNode("@", match.value));
+        } else {
           let mediaRef: string;
           try {
-            mediaRef = decodeURIComponent(match[4]);
+            mediaRef = decodeURIComponent(match.value);
           } catch {
-            mediaRef = match[4];
+            mediaRef = match.value;
           }
           paragraph.append($createBeautifulMentionNode("@", mediaRef));
         }
-        lastIndex = start + full.length;
+        lastIndex = match.end;
       }
       if (lastIndex < value.length) {
         const trailing = value.slice(lastIndex);
@@ -276,7 +312,7 @@ function ExternalValueSyncPlugin({
       root.append(paragraph);
       paragraph.selectEnd();
     });
-  }, [editor, value, promptsById]);
+  }, [appNames, editor, value, promptsById]);
 
   return null;
 }
@@ -315,6 +351,10 @@ export function LexicalChatInput({
   const selectedAppId = useAtomValue(selectedAppIdAtom);
   const { app } = useLoadApp(selectedAppId);
   const appFiles = app?.files;
+  const appNames = React.useMemo(
+    () => (apps ?? []).map((candidate) => candidate.name),
+    [apps],
+  );
 
   // Prepare mention items - convert apps to mention format
   const mentionItems = React.useMemo(() => {
@@ -352,7 +392,7 @@ export function LexicalChatInput({
     const currentAppName = currentApp?.name;
 
     // Parse already mentioned apps from current input value
-    const alreadyMentioned = parseAppMentions(value);
+    const alreadyMentioned = parseKnownAppMentions(value, appNames);
 
     // Filter out current app and already mentioned apps
     const filteredApps = apps.filter((app) => {
@@ -399,6 +439,7 @@ export function LexicalChatInput({
     return result;
   }, [
     apps,
+    appNames,
     selectedAppId,
     value,
     excludeCurrentApp,
@@ -528,6 +569,7 @@ export function LexicalChatInput({
         />
         <ExternalValueSyncPlugin
           value={value}
+          appNames={appNames}
           promptsById={Object.fromEntries(
             (prompts || []).map((p) => [p.id, p.title]),
           )}

--- a/src/components/chat/LexicalChatInput.tsx
+++ b/src/components/chat/LexicalChatInput.tsx
@@ -30,6 +30,7 @@ import { useAtomValue } from "jotai";
 import { selectedAppIdAtom } from "@/atoms/appAtoms";
 import {
   findKnownAppMentionMatches,
+  formatKnownAppMentionsForDisplay,
   formatKnownAppMentionsForPrompt,
   MENTION_REGEX,
   parseKnownAppMentions,
@@ -203,7 +204,10 @@ function ExternalValueSyncPlugin({
   useEffect(() => {
     // Derive the display text that should appear in the editor (@Name) from the
     // internal value representation (@app:Name)
-    let displayText = (value || "").replace(MENTION_REGEX, "@$1");
+    let displayText = formatKnownAppMentionsForDisplay(
+      value || "",
+      appNames,
+    ).replace(MENTION_REGEX, "@$1");
     displayText = displayText.replace(/@prompt:(\d+)/g, (_m, idStr) => {
       const id = Number(idStr);
       const title = promptsById[id];

--- a/src/components/chat/LexicalChatInput.tsx
+++ b/src/components/chat/LexicalChatInput.tsx
@@ -1,9 +1,11 @@
 import React, { useCallback, useEffect, useRef } from "react";
 import {
+  $addUpdateTag,
   $getRoot,
   $createParagraphNode,
   $createTextNode,
   EditorState,
+  type LexicalEditor,
 } from "lexical";
 import { LexicalComposer } from "@lexical/react/LexicalComposer";
 import { PlainTextPlugin } from "@lexical/react/LexicalPlainTextPlugin";
@@ -44,6 +46,8 @@ const beautifulMentionsTheme: BeautifulMentionsTheme = {
   "/": "px-2 py-0.5 mx-0.5 bg-accent text-accent-foreground rounded-md",
   "/Focused": "outline-none ring-2 ring-ring",
 };
+
+const EXTERNAL_VALUE_SYNC_TAG = "external-value-sync";
 
 // Custom menu item component
 const CustomMenuItem = forwardRef<
@@ -214,24 +218,31 @@ function ExternalValueSyncPlugin({
       }
     });
 
-    const appMentionMatches =
-      appNames.length > 0
-        ? findKnownAppMentionMatches(value, appNames)
-        : Array.from(
-            value.matchAll(new RegExp(MENTION_REGEX.source, "g")),
-          ).flatMap((match) => {
-            const { appName } = splitAppMentionTrailingDots(match[1]);
-            if (!appName) {
-              return [];
-            }
-            return [
-              {
-                appName,
-                start: match.index,
-                end: match.index + "@app:".length + appName.length,
-              },
-            ];
-          });
+    const fallbackAppMentionMatches = Array.from(
+      value.matchAll(new RegExp(MENTION_REGEX.source, "g")),
+    ).flatMap((match) => {
+      const { appName } = splitAppMentionTrailingDots(match[1]);
+      if (!appName) {
+        return [];
+      }
+      return [
+        {
+          appName,
+          start: match.index,
+          end: match.index + "@app:".length + appName.length,
+        },
+      ];
+    });
+    const knownAppMentionMatches = findKnownAppMentionMatches(value, appNames);
+    const appMentionMatches = [
+      ...knownAppMentionMatches,
+      ...fallbackAppMentionMatches.filter(
+        (fallback) =>
+          !knownAppMentionMatches.some(
+            (known) => fallback.start < known.end && fallback.end > known.start,
+          ),
+      ),
+    ].sort((a, b) => a.start - b.start);
     const appMentionSignature = JSON.stringify(appMentionMatches);
     const appMentionStructureChanged =
       lastAppMentionSignatureRef.current !== null &&
@@ -246,6 +257,7 @@ function ExternalValueSyncPlugin({
     // If the editor already reflects the same display text, do nothing to avoid loops
     if (currentText === displayText && !appMentionStructureChanged) return;
     editor.update(() => {
+      $addUpdateTag(EXTERNAL_VALUE_SYNC_TAG);
       const root = $getRoot();
       root.clear();
 
@@ -467,7 +479,10 @@ export function LexicalChatInput({
   };
 
   const handleEditorChange = useCallback(
-    (editorState: EditorState) => {
+    (editorState: EditorState, _editor: LexicalEditor, tags: Set<string>) => {
+      if (tags.has(EXTERNAL_VALUE_SYNC_TAG)) {
+        return;
+      }
       editorState.read(() => {
         const root = $getRoot();
         let textContent = root.getTextContent();

--- a/src/ipc/utils/mention_apps.test.ts
+++ b/src/ipc/utils/mention_apps.test.ts
@@ -73,4 +73,25 @@ describe("mention app utilities", () => {
       },
     ]);
   });
+
+  it("resolves an app mention whose name contains spaces", async () => {
+    dbMocks.findMany.mockResolvedValue([
+      {
+        id: 1,
+        name: "This Is My App",
+        path: "this-is-my-app",
+      },
+    ]);
+
+    const result = await extractMentionedAppsReferencesFromPrompt(
+      "Please compare @app:This Is My App with the current app",
+    );
+
+    expect(result).toEqual([
+      {
+        appName: "This Is My App",
+        appPath: "/dyad-apps/this-is-my-app",
+      },
+    ]);
+  });
 });

--- a/src/shared/parse_mention_apps.test.ts
+++ b/src/shared/parse_mention_apps.test.ts
@@ -1,5 +1,6 @@
 import {
   findKnownAppMentionMatches,
+  formatKnownAppMentionsForDisplay,
   formatKnownAppMentionsForPrompt,
   MENTION_REGEX,
   parseAppMentions,
@@ -422,5 +423,13 @@ describe("formatKnownAppMentionsForPrompt", () => {
     ]);
 
     expect(result).toBe("Fix @app:Foo");
+  });
+});
+
+describe("formatKnownAppMentionsForDisplay", () => {
+  it("formats a known non-ASCII internal app mention", () => {
+    const result = formatKnownAppMentionsForDisplay("Compare @app:猫.", ["猫"]);
+
+    expect(result).toBe("Compare @猫.");
   });
 });

--- a/src/shared/parse_mention_apps.test.ts
+++ b/src/shared/parse_mention_apps.test.ts
@@ -308,6 +308,12 @@ describe("parseKnownAppMentions", () => {
     expect(result).toEqual([]);
   });
 
+  it("does not match a Unicode app name inside a longer Unicode word", () => {
+    const result = parseKnownAppMentions("Compare @app:猫猫", ["猫"]);
+
+    expect(result).toEqual([]);
+  });
+
   it("matches dotted app names from the known app list", () => {
     const result = parseKnownAppMentions("Check @app:foo.app.com", [
       "foo.app.com",
@@ -401,6 +407,12 @@ describe("formatKnownAppMentionsForPrompt", () => {
     const result = formatKnownAppMentionsForPrompt("Fix @foo.app.com", ["foo"]);
 
     expect(result).toBe("Fix @foo.app.com");
+  });
+
+  it("does not rewrite a Unicode app name inside a longer Unicode word", () => {
+    const result = formatKnownAppMentionsForPrompt("Compare @猫猫", ["猫"]);
+
+    expect(result).toBe("Compare @猫猫");
   });
 
   it("does not rewrite already-internal app mentions", () => {

--- a/src/shared/parse_mention_apps.test.ts
+++ b/src/shared/parse_mention_apps.test.ts
@@ -1,4 +1,5 @@
 import {
+  findKnownAppMentionMatches,
   formatKnownAppMentionsForPrompt,
   MENTION_REGEX,
   parseAppMentions,
@@ -273,6 +274,40 @@ describe("splitAppMentionTrailingDots", () => {
 });
 
 describe("parseKnownAppMentions", () => {
+  it("returns the full source range for a spaced app mention", () => {
+    const prompt = "Compare @app:This Is My App with the current app";
+    const [match] = findKnownAppMentionMatches(prompt, ["This Is My App"]);
+
+    expect(prompt.slice(match.start, match.end)).toBe("@app:This Is My App");
+  });
+
+  it("matches known app names containing spaces", () => {
+    const result = parseKnownAppMentions(
+      "Compare @app:This Is My App with the current app",
+      ["This Is My App"],
+    );
+
+    expect(result).toEqual(["This Is My App"]);
+  });
+
+  it("prefers the longest spaced app name", () => {
+    const result = parseKnownAppMentions("Compare @app:This Is My App.", [
+      "This Is",
+      "This Is My App",
+    ]);
+
+    expect(result).toEqual(["This Is My App"]);
+  });
+
+  it("does not match a spaced app name inside a longer word", () => {
+    const result = parseKnownAppMentions(
+      "Compare @app:This Is My Application",
+      ["This Is My App"],
+    );
+
+    expect(result).toEqual([]);
+  });
+
   it("matches dotted app names from the known app list", () => {
     const result = parseKnownAppMentions("Check @app:foo.app.com", [
       "foo.app.com",
@@ -336,6 +371,15 @@ describe("parseKnownAppMentions", () => {
 });
 
 describe("formatKnownAppMentionsForPrompt", () => {
+  it("formats visible app names containing spaces", () => {
+    const result = formatKnownAppMentionsForPrompt(
+      "Compare @This Is My App with the current app",
+      ["This Is My App"],
+    );
+
+    expect(result).toBe("Compare @app:This Is My App with the current app");
+  });
+
   it("allows terminal periods after visible app mentions", () => {
     const result = formatKnownAppMentionsForPrompt("Fix bug in @MyApp.", [
       "MyApp",

--- a/src/shared/parse_mention_apps.ts
+++ b/src/shared/parse_mention_apps.ts
@@ -153,6 +153,25 @@ export function parseKnownAppMentions(
   );
 }
 
+export function formatKnownAppMentionsForDisplay(
+  prompt: string,
+  appNames: string[],
+): string {
+  const matches = findKnownAppMentionMatches(prompt, appNames);
+  if (matches.length === 0) {
+    return prompt;
+  }
+
+  let displayText = "";
+  let lastIndex = 0;
+  for (const match of matches) {
+    displayText += prompt.slice(lastIndex, match.start);
+    displayText += `@${match.appName}`;
+    lastIndex = match.end;
+  }
+  return displayText + prompt.slice(lastIndex);
+}
+
 export function formatKnownAppMentionsForPrompt(
   text: string,
   appNames: string[],

--- a/src/shared/parse_mention_apps.ts
+++ b/src/shared/parse_mention_apps.ts
@@ -5,8 +5,8 @@ export const MENTION_REGEX = new RegExp(
 );
 
 const APP_MENTION_PREFIX_REGEX = /@app:/g;
-const APP_MENTION_CANDIDATE_CHAR_REGEX = /[a-zA-Z0-9_.-]/;
-const VISIBLE_APP_MENTION_CONTINUATION_REGEX = /[a-zA-Z0-9_:/\\-]/;
+const APP_MENTION_CANDIDATE_CHAR_REGEX = /[\p{L}\p{N}_.-]/u;
+const VISIBLE_APP_MENTION_CONTINUATION_REGEX = /[\p{L}\p{N}_:/\\-]/u;
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/src/shared/parse_mention_apps.ts
+++ b/src/shared/parse_mention_apps.ts
@@ -7,8 +7,6 @@ export const MENTION_REGEX = new RegExp(
 const APP_MENTION_PREFIX_REGEX = /@app:/g;
 const APP_MENTION_CANDIDATE_CHAR_REGEX = /[a-zA-Z0-9_.-]/;
 const VISIBLE_APP_MENTION_CONTINUATION_REGEX = /[a-zA-Z0-9_:/\\-]/;
-const TERMINAL_DOT_PUNCTUATION_REGEX = /^\.+$/;
-
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -40,17 +38,6 @@ export function parseAppMentions(prompt: string): string[] {
   }
 
   return mentions;
-}
-
-function readMentionCandidate(prompt: string, startIndex: number): string {
-  let endIndex = startIndex;
-  while (
-    endIndex < prompt.length &&
-    APP_MENTION_CANDIDATE_CHAR_REGEX.test(prompt[endIndex])
-  ) {
-    endIndex++;
-  }
-  return prompt.slice(startIndex, endIndex);
 }
 
 function hasVisibleAppMentionBoundary(
@@ -87,6 +74,71 @@ function hasVisibleAppMentionBoundary(
   );
 }
 
+function hasKnownAppMentionBoundary(text: string, nextIndex: number): boolean {
+  const nextChar = text[nextIndex];
+  if (nextChar === undefined) {
+    return true;
+  }
+
+  if (nextChar !== ".") {
+    return !APP_MENTION_CANDIDATE_CHAR_REGEX.test(nextChar);
+  }
+
+  let afterDotsIndex = nextIndex;
+  while (text[afterDotsIndex] === ".") {
+    afterDotsIndex++;
+  }
+
+  const afterDotsChar = text[afterDotsIndex];
+  return (
+    afterDotsChar === undefined ||
+    !APP_MENTION_CANDIDATE_CHAR_REGEX.test(afterDotsChar)
+  );
+}
+
+export interface KnownAppMentionMatch {
+  appName: string;
+  start: number;
+  end: number;
+}
+
+export function findKnownAppMentionMatches(
+  prompt: string,
+  appNames: string[],
+): KnownAppMentionMatch[] {
+  const sortedAppNames = [...new Set(appNames)]
+    .filter((name) => name.length > 0)
+    .sort((a, b) => b.length - a.length);
+  if (sortedAppNames.length === 0) {
+    return [];
+  }
+
+  const matches: KnownAppMentionMatch[] = [];
+  let prefixMatch: RegExpExecArray | null;
+  APP_MENTION_PREFIX_REGEX.lastIndex = 0;
+  while ((prefixMatch = APP_MENTION_PREFIX_REGEX.exec(prompt)) !== null) {
+    const nameStart = prefixMatch.index + prefixMatch[0].length;
+    const remainingLower = prompt.slice(nameStart).toLowerCase();
+    const appName = sortedAppNames.find((name) => {
+      const nameLower = name.toLowerCase();
+      return (
+        remainingLower.startsWith(nameLower) &&
+        hasKnownAppMentionBoundary(prompt, nameStart + name.length)
+      );
+    });
+
+    if (appName) {
+      matches.push({
+        appName,
+        start: prefixMatch.index,
+        end: nameStart + appName.length,
+      });
+    }
+  }
+
+  return matches;
+}
+
 /**
  * Parse app mentions by matching against known app names, preferring the
  * longest known name. This handles names with dots without letting shorter app
@@ -96,41 +148,9 @@ export function parseKnownAppMentions(
   prompt: string,
   appNames: string[],
 ): string[] {
-  const sortedAppNames = [...new Set(appNames)]
-    .filter((name) => name.length > 0)
-    .sort((a, b) => b.length - a.length);
-  if (sortedAppNames.length === 0) {
-    return [];
-  }
-
-  const mentions: string[] = [];
-  let match: RegExpExecArray | null;
-  APP_MENTION_PREFIX_REGEX.lastIndex = 0;
-  while ((match = APP_MENTION_PREFIX_REGEX.exec(prompt)) !== null) {
-    const candidate = readMentionCandidate(
-      prompt,
-      match.index + match[0].length,
-    );
-    const candidateLower = candidate.toLowerCase();
-
-    const appName = sortedAppNames.find((name) => {
-      const nameLower = name.toLowerCase();
-      if (candidateLower === nameLower) {
-        return true;
-      }
-      if (!candidateLower.startsWith(nameLower)) {
-        return false;
-      }
-      const suffix = candidate.slice(name.length);
-      return TERMINAL_DOT_PUNCTUATION_REGEX.test(suffix);
-    });
-
-    if (appName) {
-      mentions.push(appName);
-    }
-  }
-
-  return mentions;
+  return findKnownAppMentionMatches(prompt, appNames).map(
+    (match) => match.appName,
+  );
 }
 
 export function formatKnownAppMentionsForPrompt(


### PR DESCRIPTION
## Summary

- match internal app references against the loaded app-name list so names containing spaces resolve in full
- reuse exact source ranges when rebuilding Lexical mention nodes
- keep shared parsing, IPC extraction, and editor serialization aligned

## Motivation

Selecting an app such as `This Is My App` produces `@app:This Is My App`, but the previous parser stopped at the first space. The agent therefore received an unresolved partial reference instead of the selected app's code context.

Fixes #4168.

## Design

Known app names are matched case-insensitively, longest first, with an explicit boundary after the exact name. This preserves the existing stored format and the established dotted-name/terminal-period behavior without treating arbitrary trailing prose as part of the reference.

Lexical external-value synchronization consumes the same match ranges as the backend parser, so a spaced app reference is restored as one mention node.

## Testing

- `npm test -- src/components/chat/LexicalChatInput.test.tsx src/shared/parse_mention_apps.test.ts src/ipc/utils/mention_apps.test.ts` (60 passed; the script's 14 Node tests also passed)
- `npm run fmt:check`
- `npm run lint -- src/components/chat/LexicalChatInput.tsx src/components/chat/LexicalChatInput.test.tsx src/shared/parse_mention_apps.ts src/shared/parse_mention_apps.test.ts src/ipc/utils/mention_apps.test.ts`
- `npm run ts`
- `git diff --check`

The full `npm test` run passed 523/525 files and 4946/4948 tests. The two remaining failures reproduce in isolation on the unchanged upstream code paths for the implicit Google-only chat-mode baseline:

- `src/ipc/handlers/__tests__/chat_mode.integration.test.ts`
- `src/ipc/handlers/__tests__/default_chat_mode.integration.test.tsx`

## Compatibility and scope

No persisted mention format, IPC contract, database schema, or Pro source changes. The legacy no-space reconstruction remains available while the app list is still loading.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

