### PR TITLE
fix: stop asking for OAuth once an MCP token works

### DIFF
--- a/src/components/plugins/usePluginConnect.test.tsx
+++ b/src/components/plugins/usePluginConnect.test.tsx
@@ -1,0 +1,180 @@
+import { createStore, Provider } from "jotai";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+import type { McpListToolsResult, McpServer } from "@/ipc/types";
+
+const mocks = vi.hoisted(() => ({
+  listServers: vi.fn(),
+  listTools: vi.fn(),
+  getToolConsents: vi.fn(),
+  probeConnection: vi.fn(),
+  updateServer: vi.fn(),
+  listCatalog: vi.fn(),
+  showError: vi.fn(),
+}));
+
+vi.mock("@/ipc/types", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/ipc/types")>()),
+  ipc: {
+    mcp: {
+      listServers: mocks.listServers,
+      listTools: mocks.listTools,
+      getToolConsents: mocks.getToolConsents,
+      probeConnection: mocks.probeConnection,
+      updateServer: mocks.updateServer,
+      listCatalog: mocks.listCatalog,
+    },
+  },
+}));
+
+vi.mock("./AddPluginDialog", () => ({
+  useOauthCallbackPort: () => 53682,
+}));
+
+vi.mock("@/lib/toast", () => ({
+  showError: mocks.showError,
+  showInfo: vi.fn(),
+  showSuccess: vi.fn(),
+}));
+
+import { useMcp } from "@/hooks/useMcp";
+import { usePluginConnect } from "./usePluginConnect";
+
+const SERVER_ID = 7;
+
+function makeServer(overrides: Partial<McpServer> = {}): McpServer {
+  return {
+    id: SERVER_ID,
+    name: "GitHub",
+    transport: "http",
+    command: null,
+    args: null,
+    envJson: null,
+    headersJson: null,
+    url: "https://api.githubcopilot.com/mcp/",
+    enabled: true,
+    oauthEnabled: false,
+    oauthConnected: false,
+    oauthCallbackPort: null,
+    oauthClientId: null,
+    envUnreadable: false,
+    headersUnreadable: false,
+    // No catalog slug, so a 401 here reads as "enable OAuth".
+    catalogSlug: null,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    ...overrides,
+  };
+}
+
+const UNAUTHORIZED: McpListToolsResult = { tools: [], status: "unauthorized" };
+const AUTHORIZED: McpListToolsResult = {
+  tools: [{ name: "list_repos", description: null }],
+  status: "ok",
+};
+
+function renderConnect() {
+  const store = createStore();
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <Provider store={store}>{children}</Provider>
+    </QueryClientProvider>
+  );
+  return renderHook(() => ({ connect: usePluginConnect(), mcp: useMcp() }), {
+    wrapper,
+  });
+}
+
+describe("usePluginConnect feedback ownership", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.listServers.mockResolvedValue([makeServer()]);
+    mocks.getToolConsents.mockResolvedValue([]);
+    mocks.listCatalog.mockResolvedValue({ entries: [] });
+    mocks.updateServer.mockImplementation(async () => makeServer());
+  });
+
+  it("drops the auth alert once credentials make discovery succeed", async () => {
+    // A manual HTTP server has no Headers field at creation, so the
+    // post-create probe always runs before the token exists.
+    mocks.listTools.mockResolvedValue(UNAUTHORIZED);
+    mocks.probeConnection.mockResolvedValue({
+      status: "unauthorized",
+      error: "MCP HTTP Transport Error: POSTing to endpoint (HTTP 401)",
+    });
+
+    const { result } = renderConnect();
+    await waitFor(() => expect(result.current.mcp.servers).toHaveLength(1));
+
+    await act(async () => {
+      await result.current.connect.onServerCreated(makeServer(), {
+        wantsOAuth: false,
+      });
+    });
+
+    // The probe reports the 401 immediately; the alert follows from
+    // discovery.
+    expect(mocks.showError).toHaveBeenCalledWith(
+      "Server connection failed. This server requires authentication. Try enabling OAuth.",
+    );
+    await waitFor(() =>
+      expect(result.current.connect.feedbackFor(makeServer())?.kind).toBe(
+        "unauthorized",
+      ),
+    );
+
+    // The user now saves a personal access token. Discovery starts
+    // succeeding, so the alert must go with it.
+    mocks.listTools.mockResolvedValue(AUTHORIZED);
+    await act(async () => {
+      await result.current.mcp.updateServer({
+        id: SERVER_ID,
+        headersJson: { Authorization: "Bearer ghp_example" },
+      });
+    });
+
+    await waitFor(() =>
+      expect(result.current.connect.feedbackFor(makeServer())).toBeNull(),
+    );
+    expect(result.current.mcp.statusByServer[SERVER_ID]).toBe("ok");
+  });
+
+  it("keeps the auth alert while discovery still reports a 401", async () => {
+    mocks.listTools.mockResolvedValue(UNAUTHORIZED);
+    mocks.probeConnection.mockResolvedValue({
+      status: "unauthorized",
+      error: "HTTP 401",
+    });
+
+    const { result } = renderConnect();
+    await waitFor(() => expect(result.current.mcp.servers).toHaveLength(1));
+
+    await act(async () => {
+      await result.current.connect.onServerCreated(makeServer(), {
+        wantsOAuth: false,
+      });
+    });
+
+    // A wrong token still fails discovery, so the alert stays.
+    await act(async () => {
+      await result.current.mcp.updateServer({
+        id: SERVER_ID,
+        headersJson: { Authorization: "Bearer wrong" },
+      });
+    });
+
+    await waitFor(() =>
+      expect(result.current.connect.feedbackFor(makeServer())?.kind).toBe(
+        "unauthorized",
+      ),
+    );
+  });
+});

--- a/src/components/plugins/usePluginConnect.ts
+++ b/src/components/plugins/usePluginConnect.ts
@@ -15,10 +15,15 @@ export type ConnectFeedback = {
   message: string;
 };
 
+// Only an OAuth flow outcome is stored: the flow drops its terminal
+// state when it settles, so this is the sole copy. Auth status has a
+// live owner in `statusByServer` and is read from there.
+type StoredConnectFeedback = ConnectFeedback & { kind: "discovery_failed" };
+
 // Connect state survives navigation between the plugins list and a
 // plugin detail page, so a failure raised on one is visible on the
 // other and an in-flight flow can't be started twice.
-const connectFeedbackAtom = atom<ConnectFeedback | null>(null);
+const connectFeedbackAtom = atom<StoredConnectFeedback | null>(null);
 const connectingServerIdAtom = atom<number | null>(null);
 const disconnectingServerIdAtom = atom<number | null>(null);
 
@@ -117,23 +122,15 @@ export function usePluginConnect() {
     opts?: { showToast?: boolean; callbackPort?: number },
   ) => withConnectSlot(serverId, () => autoConnect(serverId, opts));
 
-  const runProbe = async (serverId: number, opts?: { showToast?: boolean }) => {
+  // Reports a 401 right after an add, ahead of the tool discovery that
+  // the new row triggers. The alert itself comes from that discovery.
+  const runProbe = async (serverId: number) => {
     try {
       const result = await ipc.mcp.probeConnection(serverId);
       if (result.status === "unauthorized") {
-        setConnectFeedback({
-          serverId,
-          kind: "unauthorized",
-          message:
-            "This server requires authentication. Enable OAuth and try again.",
-        });
-        if (opts?.showToast) {
-          showError(
-            "Server connection failed. This server requires authentication. Try enabling OAuth.",
-          );
-        }
-      } else {
-        setConnectFeedback(null);
+        showError(
+          "Server connection failed. This server requires authentication. Try enabling OAuth.",
+        );
       }
     } catch {
       // Best-effort probe; swallow on failure.
@@ -155,7 +152,7 @@ export function usePluginConnect() {
           typeof callbackPort === "number" ? callbackPort : undefined,
       });
     } else {
-      await runProbe(created.id, { showToast: true });
+      await runProbe(created.id);
     }
   };
 
@@ -193,9 +190,9 @@ export function usePluginConnect() {
 
   const onDisableOAuthAndRetry = async (serverId: number) =>
     withConnectSlot(serverId, async () => {
+      // The update re-runs discovery, which is what the alert reads.
       await updateServer({ id: serverId, oauthEnabled: false });
       setConnectFeedback(null);
-      await runProbe(serverId);
     });
 
   const onDisconnect = async (serverId: number) => {
@@ -213,7 +210,8 @@ export function usePluginConnect() {
   };
 
   // An OAuth-off server that returns 401 needs auth; surface that from
-  // the live probe status so the alert stays put.
+  // the live probe status so the alert stays put. Auth kinds are built
+  // on each read, so they clear as soon as discovery stops seeing a 401.
   const feedbackFor = (server: McpServer): ConnectFeedback | null => {
     if (connectFeedback && connectFeedback.serverId === server.id) {
       return connectFeedback;


### PR DESCRIPTION
*Generated by Claude; reviewed by me*

A server that accepts either OAuth or a personal access token kept showing "This server requires authentication. Enable OAuth and try again." after a working token was saved. Its tools listed and calls through them succeeded, but the alert stayed.

The add dialog has no Headers field, so a token can only be entered on the server's detail page once the server exists. Dyad probes the server in between and gets a 401, which is correct at that moment because there is no token yet. Saving the token did not clear it: the renderer kept that probe result and showed it ahead of the live one. "Enable OAuth & retry" then reported that the server has no OAuth support, and only "Disable OAuth & retry" made the alert go away, because that path probes again.

Build the auth alert from the live tool discovery on each read rather than keeping the probe's answer. Discovery already re-runs whenever a server's config changes, so the alert now ends with the 401 it describes.

The renderer still holds OAuth flow failures, which have nowhere else to live. Its type is narrowed to that one kind so an auth status cannot go back in. The probe is left reporting its 401 as a toast; the retry path reads the discovery its own update triggers.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

