### PR TITLE
Use GPT-5.6 Luna for MCP consent classification

### DIFF
--- a/src/pro/main/ipc/handlers/local_agent/mcp_auto_consent.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/mcp_auto_consent.spec.ts
@@ -42,7 +42,7 @@ describe("classifyMcpToolConsent", () => {
     expect(d.decision).toBe("allow");
     expect(d.reason).toBe("safe read");
     expect(mocks.getModelClient).toHaveBeenCalledWith(
-      { name: "gpt-5.4-mini", provider: "openai" },
+      { name: "gpt-5.6-luna", provider: "openai" },
       baseInput.settings,
     );
   });

--- a/src/pro/main/ipc/handlers/local_agent/mcp_auto_consent.ts
+++ b/src/pro/main/ipc/handlers/local_agent/mcp_auto_consent.ts
@@ -16,7 +16,7 @@ const logger = log.scope("mcp-auto-consent");
 
 // Fixed classifier model routed through the Dyad Pro engine gateway.
 const MCP_CONSENT_MODEL: LargeLanguageModel = {
-  name: "gpt-5.4-mini",
+  name: "gpt-5.6-luna",
   provider: "openai",
 };
 


### PR DESCRIPTION
## Summary

Updates the Dyad Pro MCP auto-consent classifier to use GPT-5.6 Luna instead of GPT-5.4 Mini, keeping this safety decision on the newer value-tier model already used by other production sub-agent flows.

- Preserves the existing opt-in, Pro-only gating, timeout, and fail-closed behavior; only the fixed classifier model changes.
- Updates the focused unit assertion so the intended routing choice remains explicit.
- Leaves historical benchmark pricing records untouched because they describe completed GPT-5.4 Mini benchmark runs rather than current runtime configuration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit fc0ac8c3e5ab0c57df5093f92eb58d000f642f76. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

