### PR TITLE
Enable show_full_output for Claude PR review debugging

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -95,6 +95,12 @@ jobs:
           track_progress: false
           display_report: false
 
+          # Log the full Claude transcript so flaky runs where Claude exits
+          # without writing the review output files can be diagnosed.
+          # Review inputs/outputs are derived from public PR data, so the
+          # logs do not expose anything sensitive.
+          show_full_output: true
+
           prompt: ${{ steps.render-prompt.outputs.prompt }}
 
           claude_args: |


### PR DESCRIPTION
## Why

The Claude PR Review workflow intermittently fails at the `Verify Claude review outputs` step with `Claude did not write tmp/pr-review/claude-review.md` — the agent reports success but ends its turn without writing the mandatory output files (e.g. runs [31030895502](https://github.com/dyad-sh/dyad/actions/runs/31030895502) and [31028376586](https://github.com/dyad-sh/dyad/actions/runs/31028376586) on #4195, plus failures on other PRs since the Opus 5 upgrade in #4158). Because the action hides the transcript by default, there is nothing in the logs to diagnose; a debug re-run of one failure passed, so the flake can't be reproduced on demand.

## What

Sets `show_full_output: true` on the `anthropics/claude-code-action` step so every run logs the full SDK message stream (assistant text, tool calls, tool results). The next organic failure will then carry a complete transcript showing why the agent exits early.

The review prompt and context are derived entirely from public PR data and the job's allowed tools are read-only plus `Edit(tmp/pr-review/**)`, so the transcript does not expose secrets.

This can be reverted once the flake is root-caused.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI observability-only change with no application or auth logic touched; slightly more verbose public PR-related logs in Actions.
> 
> **Overview**
> Turns on **`show_full_output: true`** for the `anthropics/claude-code-action` step in the Claude PR Review workflow so CI logs include the full SDK message stream (assistant text, tool calls, and results).
> 
> This is meant to debug intermittent failures where the agent finishes without writing `tmp/pr-review/claude-review.md` / findings, which then trips **Verify Claude review outputs**. Inline comments note the transcript is considered safe because review context comes from public PR data and tools are read-only plus `Edit(tmp/pr-review/**)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf59bf3530a801f9bb6238a7299decb25ca7bb63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

