### PR TITLE
Fix merge conflict recovery UX

### DIFF
--- a/rules/state-machines.md
+++ b/rules/state-machines.md
@@ -600,6 +600,10 @@ timers or nondeterministic UUIDs; retrofitting existing machines is optional.
   tests; new machines may instead use `exploreReachableStates` when a finite
   event generator can discover the reachable graph. Existing bespoke suites
   need not be migrated mechanically.
+- If reachable states contain an unbounded correlation counter (such as a
+  retry attempt), normalize only that counter in the explorer's `stateKey` so
+  the graph stays finite; keep direct transition tests for exact stale-token
+  acceptance and rejection.
 - Use `assertCapabilityTransitionConsistency` with domain-supplied
   representative valid events for every capability. Every enabled
   capability/state pair must supply at least one valid representative so the

--- a/rules/state-machines.md
+++ b/rules/state-machines.md
@@ -232,6 +232,10 @@ Background and before/after examples of why this pattern exists:
 - When a generation token suppresses superseded async probe results, apply the
   same token check to rejection handling. A stale failure must not emit a
   toast, settle newer state, or trigger recovery for the replacement probe.
+- Do not treat an ambient reconciliation probe as proof that a long-running
+  workflow finished. Preserve the in-progress phase until an explicit
+  completion event, then enter a checking phase whose probe result decides the
+  terminal or retry state.
 - When a resume event can come from a global watcher as well as explicit UI
   senders, validate the captured payload in the transition. Caller-only guards
   can be bypassed after navigation or another asynchronous detour.

--- a/src/components/GitHubConnector.tsx
+++ b/src/components/GitHubConnector.tsx
@@ -33,6 +33,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { GithubBranchManager } from "@/components/GithubBranchManager";
 import { useResolveMergeConflictsWithAI } from "@/hooks/useResolveMergeConflictsWithAI";
+import { useChatStreamState } from "@/hooks/useChatStream";
 import { slugifyAppPath } from "@/shared/slugify";
 import {
   isAppliedGithubOpsReceipt,
@@ -115,6 +116,7 @@ function ConnectedGitHubConnector({
     isSyncing,
     conflicts,
     conflictRecoveryStage,
+    conflictResolutionChatId,
     syncContinuationOperation,
     rebaseAction,
     showForcePush,
@@ -134,6 +136,26 @@ function ConnectedGitHubConnector({
       void dispatchWithErrorFeedback({ type: "CONFLICT_RESOLUTION_FINISHED" });
     },
   });
+
+  const conflictResolutionChat = useChatStreamState(
+    conflictResolutionChatId ?? undefined,
+  );
+
+  useEffect(() => {
+    if (
+      conflictRecoveryStage !== "resolving" ||
+      !conflictResolutionChat?.lastCompletion
+    ) {
+      return;
+    }
+    void dispatchWithErrorFeedback({
+      type: "CONFLICT_RESOLUTION_FINISHED",
+    });
+  }, [
+    conflictRecoveryStage,
+    conflictResolutionChat?.lastCompletion,
+    dispatchWithErrorFeedback,
+  ]);
 
   const startConflictResolution = useCallback(async () => {
     const receipt = await dispatchWithErrorFeedback({

--- a/src/components/GitHubConnector.tsx
+++ b/src/components/GitHubConnector.tsx
@@ -118,6 +118,7 @@ function ConnectedGitHubConnector({
     conflicts,
     conflictRecoveryStage,
     conflictResolutionChatId,
+    conflictVerificationError,
     syncContinuationOperation,
     rebaseAction,
     showForcePush,
@@ -133,12 +134,6 @@ function ConnectedGitHubConnector({
     conflicts,
     onStartResolving: dispatchConflictResolutionStarted,
     onStartFailed: dispatchConflictResolutionCancelled,
-    onSettled: (chatId) => {
-      void dispatchWithErrorFeedback({
-        type: "CONFLICT_RESOLUTION_FINISHED",
-        chatId,
-      });
-    },
   });
 
   const conflictResolutionChat = useChatStreamState(
@@ -387,30 +382,32 @@ function ConnectedGitHubConnector({
               )}
             </div>
             <div className="min-w-0 flex-1">
-              <p className="text-sm font-medium text-foreground">
-                {conflictRecoveryStage === "resolving"
-                  ? "Resolving conflicts in chat…"
-                  : conflictRecoveryStage === "checking"
-                    ? "Verifying resolution…"
-                    : conflictRecoveryStage === "verification-failed"
-                      ? "Couldn't verify the resolution"
-                      : conflictRecoveryStage === "ready-to-sync"
-                        ? "Conflicts resolved"
-                        : isSyncConflict
-                          ? "Sync paused"
-                          : "Merge paused"}
-              </p>
-              <p className="mt-0.5 text-sm text-muted-foreground">
-                {conflictRecoveryStage === "resolving"
-                  ? "Follow progress in the chat."
-                  : conflictRecoveryStage === "checking"
-                    ? "Checking the repository for remaining conflicts."
-                    : conflictRecoveryStage === "verification-failed"
-                      ? "Your resolved changes are still safe. Try checking the repository again."
-                      : conflictRecoveryStage === "ready-to-sync"
-                        ? "Your changes are ready to sync to GitHub."
-                        : `Resolve ${conflicts.length} conflict${conflicts.length === 1 ? "" : "s"} to ${isSyncConflict ? "continue syncing" : "finish merging"}.`}
-              </p>
+              <div role="status" aria-live="polite" aria-atomic="true">
+                <p className="text-sm font-medium text-foreground">
+                  {conflictRecoveryStage === "resolving"
+                    ? "Resolving conflicts in chat…"
+                    : conflictRecoveryStage === "checking"
+                      ? "Verifying resolution…"
+                      : conflictRecoveryStage === "verification-failed"
+                        ? "Couldn't verify the resolution"
+                        : conflictRecoveryStage === "ready-to-sync"
+                          ? "Conflicts resolved"
+                          : isSyncConflict
+                            ? "Sync paused"
+                            : "Merge paused"}
+                </p>
+                <p className="mt-0.5 text-sm text-muted-foreground">
+                  {conflictRecoveryStage === "resolving"
+                    ? "Follow progress in the chat."
+                    : conflictRecoveryStage === "checking"
+                      ? "Checking the repository for remaining conflicts."
+                      : conflictRecoveryStage === "verification-failed"
+                        ? `${conflictVerificationError ?? "Dyad couldn't check the repository."} Your resolved changes are still safe.`
+                        : conflictRecoveryStage === "ready-to-sync"
+                          ? "Your changes are ready to sync to GitHub."
+                          : `Resolve ${conflicts.length} conflict${conflicts.length === 1 ? "" : "s"} to ${isSyncConflict ? "continue syncing" : "finish merging"}.`}
+                </p>
+              </div>
 
               {conflictRecoveryStage === "conflicted" && (
                 <ul className="mt-2 space-y-1" aria-label="Conflicted files">
@@ -471,30 +468,68 @@ function ConnectedGitHubConnector({
 
               {conflictRecoveryStage === "ready-to-sync" &&
                 syncContinuationOperation && (
-                  <Button
-                    className="mt-3"
-                    size="sm"
-                    disabled={!canContinueSync}
-                    onClick={() =>
-                      send({
-                        type: "OP_REQUESTED",
-                        op: syncContinuationOperation,
-                      })
-                    }
-                  >
-                    Continue to Sync
-                  </Button>
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    <Button
+                      size="sm"
+                      disabled={!canContinueSync}
+                      onClick={() =>
+                        send({
+                          type: "OP_REQUESTED",
+                          op: syncContinuationOperation,
+                        })
+                      }
+                    >
+                      Continue to Sync
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      disabled={!canCancelSync || isCancellingSync}
+                      onClick={() =>
+                        send({
+                          type: "OP_REQUESTED",
+                          op: { type: abortOperation },
+                        })
+                      }
+                    >
+                      {isCancellingSync
+                        ? "Cancelling…"
+                        : isSyncConflict
+                          ? "Cancel sync"
+                          : "Cancel merge"}
+                    </Button>
+                  </div>
                 )}
 
               {conflictRecoveryStage === "verification-failed" && (
-                <Button
-                  className="mt-3"
-                  size="sm"
-                  disabled={!canRetryConflictVerification}
-                  onClick={() => send({ type: "RECONCILE_REQUESTED" })}
-                >
-                  Try again
-                </Button>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <Button
+                    size="sm"
+                    disabled={!canRetryConflictVerification}
+                    onClick={() =>
+                      send({ type: "RETRY_CONFLICT_VERIFICATION" })
+                    }
+                  >
+                    Try again
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={!canCancelSync || isCancellingSync}
+                    onClick={() =>
+                      send({
+                        type: "OP_REQUESTED",
+                        op: { type: abortOperation },
+                      })
+                    }
+                  >
+                    {isCancellingSync
+                      ? "Cancelling…"
+                      : isSyncConflict
+                        ? "Cancel sync"
+                        : "Cancel merge"}
+                  </Button>
+                </div>
               )}
             </div>
           </div>

--- a/src/components/GitHubConnector.tsx
+++ b/src/components/GitHubConnector.tsx
@@ -133,8 +133,11 @@ function ConnectedGitHubConnector({
     conflicts,
     onStartResolving: dispatchConflictResolutionStarted,
     onStartFailed: dispatchConflictResolutionCancelled,
-    onSettled: () => {
-      void dispatchWithErrorFeedback({ type: "CONFLICT_RESOLUTION_FINISHED" });
+    onSettled: (chatId) => {
+      void dispatchWithErrorFeedback({
+        type: "CONFLICT_RESOLUTION_FINISHED",
+        chatId,
+      });
     },
   });
 
@@ -145,15 +148,18 @@ function ConnectedGitHubConnector({
   useEffect(() => {
     if (
       conflictRecoveryStage !== "resolving" ||
+      conflictResolutionChatId === null ||
       !conflictResolutionChat?.lastCompletion
     ) {
       return;
     }
     void dispatchWithErrorFeedback({
       type: "CONFLICT_RESOLUTION_FINISHED",
+      chatId: conflictResolutionChatId,
     });
   }, [
     conflictRecoveryStage,
+    conflictResolutionChatId,
     conflictResolutionChat?.lastCompletion,
     dispatchWithErrorFeedback,
   ]);

--- a/src/components/GitHubConnector.tsx
+++ b/src/components/GitHubConnector.tsx
@@ -173,6 +173,9 @@ function ConnectedGitHubConnector({
     (githubOpsState.origin.type === "push" ||
       githubOpsState.origin.type === "rebase" ||
       githubOpsState.origin.type === "rebase-continue");
+  const showErrorBanner =
+    banner?.kind === "error" &&
+    (banner.code !== "MERGE_CONFLICT" || !conflictRecoveryStage);
 
   return (
     <div className="w-full" data-testid="github-connected-repo">
@@ -247,7 +250,7 @@ function ConnectedGitHubConnector({
           {isDisconnecting ? "Disconnecting..." : "Disconnect from repo"}
         </Button>
       </div>
-      {banner?.kind === "error" && banner.code !== "MERGE_CONFLICT" && (
+      {showErrorBanner && (
         <div className="mt-2 space-y-2">
           <p className="text-red-600">
             {banner.message}{" "}
@@ -356,7 +359,8 @@ function ConnectedGitHubConnector({
         >
           <div className="flex items-start gap-3">
             <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-full bg-background text-muted-foreground ring-1 ring-border">
-              {conflictRecoveryStage === "resolving" ? (
+              {conflictRecoveryStage === "resolving" ||
+              conflictRecoveryStage === "checking" ? (
                 <LoaderCircle
                   className="size-4 animate-spin motion-reduce:animate-none"
                   aria-hidden="true"
@@ -374,18 +378,22 @@ function ConnectedGitHubConnector({
               <p className="text-sm font-medium text-foreground">
                 {conflictRecoveryStage === "resolving"
                   ? "Resolving conflicts in chat…"
-                  : conflictRecoveryStage === "ready-to-sync"
-                    ? "Conflicts resolved"
-                    : isSyncConflict
-                      ? "Sync paused"
-                      : "Merge paused"}
+                  : conflictRecoveryStage === "checking"
+                    ? "Verifying resolution…"
+                    : conflictRecoveryStage === "ready-to-sync"
+                      ? "Conflicts resolved"
+                      : isSyncConflict
+                        ? "Sync paused"
+                        : "Merge paused"}
               </p>
               <p className="mt-0.5 text-sm text-muted-foreground">
                 {conflictRecoveryStage === "resolving"
                   ? "Follow progress in the chat."
-                  : conflictRecoveryStage === "ready-to-sync"
-                    ? "Your changes are ready to sync to GitHub."
-                    : `Resolve ${conflicts.length} conflict${conflicts.length === 1 ? "" : "s"} to ${isSyncConflict ? "continue syncing" : "finish merging"}.`}
+                  : conflictRecoveryStage === "checking"
+                    ? "Checking the repository for remaining conflicts."
+                    : conflictRecoveryStage === "ready-to-sync"
+                      ? "Your changes are ready to sync to GitHub."
+                      : `Resolve ${conflicts.length} conflict${conflicts.length === 1 ? "" : "s"} to ${isSyncConflict ? "continue syncing" : "finish merging"}.`}
               </p>
 
               {conflictRecoveryStage === "conflicted" && (

--- a/src/components/GitHubConnector.tsx
+++ b/src/components/GitHubConnector.tsx
@@ -104,6 +104,7 @@ function ConnectedGitHubConnector({
       canAbortRebase,
       canCancelSync,
       canContinueSync,
+      canRetryConflictVerification,
       canContinueRebase,
       canDisconnect,
       canForcePush,
@@ -365,6 +366,11 @@ function ConnectedGitHubConnector({
                   className="size-4 animate-spin motion-reduce:animate-none"
                   aria-hidden="true"
                 />
+              ) : conflictRecoveryStage === "verification-failed" ? (
+                <AlertTriangle
+                  className="size-4 text-amber-600 dark:text-amber-400"
+                  aria-hidden="true"
+                />
               ) : conflictRecoveryStage === "ready-to-sync" ? (
                 <CircleCheck
                   className="size-4 text-emerald-600 dark:text-emerald-400"
@@ -380,20 +386,24 @@ function ConnectedGitHubConnector({
                   ? "Resolving conflicts in chat…"
                   : conflictRecoveryStage === "checking"
                     ? "Verifying resolution…"
-                    : conflictRecoveryStage === "ready-to-sync"
-                      ? "Conflicts resolved"
-                      : isSyncConflict
-                        ? "Sync paused"
-                        : "Merge paused"}
+                    : conflictRecoveryStage === "verification-failed"
+                      ? "Couldn't verify the resolution"
+                      : conflictRecoveryStage === "ready-to-sync"
+                        ? "Conflicts resolved"
+                        : isSyncConflict
+                          ? "Sync paused"
+                          : "Merge paused"}
               </p>
               <p className="mt-0.5 text-sm text-muted-foreground">
                 {conflictRecoveryStage === "resolving"
                   ? "Follow progress in the chat."
                   : conflictRecoveryStage === "checking"
                     ? "Checking the repository for remaining conflicts."
-                    : conflictRecoveryStage === "ready-to-sync"
-                      ? "Your changes are ready to sync to GitHub."
-                      : `Resolve ${conflicts.length} conflict${conflicts.length === 1 ? "" : "s"} to ${isSyncConflict ? "continue syncing" : "finish merging"}.`}
+                    : conflictRecoveryStage === "verification-failed"
+                      ? "Your resolved changes are still safe. Try checking the repository again."
+                      : conflictRecoveryStage === "ready-to-sync"
+                        ? "Your changes are ready to sync to GitHub."
+                        : `Resolve ${conflicts.length} conflict${conflicts.length === 1 ? "" : "s"} to ${isSyncConflict ? "continue syncing" : "finish merging"}.`}
               </p>
 
               {conflictRecoveryStage === "conflicted" && (
@@ -469,6 +479,17 @@ function ConnectedGitHubConnector({
                     Continue to Sync
                   </Button>
                 )}
+
+              {conflictRecoveryStage === "verification-failed" && (
+                <Button
+                  className="mt-3"
+                  size="sm"
+                  disabled={!canRetryConflictVerification}
+                  onClick={() => send({ type: "RECONCILE_REQUESTED" })}
+                >
+                  Try again
+                </Button>
+              )}
             </div>
           </div>
         </div>

--- a/src/components/GitHubConnector.tsx
+++ b/src/components/GitHubConnector.tsx
@@ -4,9 +4,12 @@ import {
   Github,
   Clipboard,
   Check,
+  CircleCheck,
   AlertTriangle,
   ChevronRight,
+  FileCode2,
   GitMerge,
+  LoaderCircle,
 } from "lucide-react";
 import { ipc } from "@/ipc/types";
 import { useSettings } from "@/hooks/useSettings";
@@ -95,9 +98,11 @@ function ConnectedGitHubConnector({
   } = useGithubOps(appId);
   const {
     banner,
+    state: githubOpsState,
     capabilities: {
       canAbortRebase,
       canCancelSync,
+      canContinueSync,
       canContinueRebase,
       canDisconnect,
       canForcePush,
@@ -109,6 +114,8 @@ function ConnectedGitHubConnector({
     isOperationInFlight,
     isSyncing,
     conflicts,
+    conflictRecoveryStage,
+    syncContinuationOperation,
     rebaseAction,
     showForcePush,
     showRebaseAndSync,
@@ -123,6 +130,9 @@ function ConnectedGitHubConnector({
     conflicts,
     onStartResolving: dispatchConflictResolutionStarted,
     onStartFailed: dispatchConflictResolutionCancelled,
+    onSettled: () => {
+      void dispatchWithErrorFeedback({ type: "CONFLICT_RESOLUTION_FINISHED" });
+    },
   });
 
   const startConflictResolution = useCallback(async () => {
@@ -136,6 +146,11 @@ function ConnectedGitHubConnector({
 
   const isDisconnecting = runningOperation?.type === "disconnect";
   const isRebaseActionPending = isOperationInFlight || !!rebaseAction;
+  const isSyncConflict =
+    githubOpsState.type === "conflicted" &&
+    (githubOpsState.origin.type === "push" ||
+      githubOpsState.origin.type === "rebase" ||
+      githubOpsState.origin.type === "rebase-continue");
 
   return (
     <div className="w-full" data-testid="github-connected-repo">
@@ -210,7 +225,7 @@ function ConnectedGitHubConnector({
           {isDisconnecting ? "Disconnecting..." : "Disconnect from repo"}
         </Button>
       </div>
-      {banner?.kind === "error" && (
+      {banner?.kind === "error" && banner.code !== "MERGE_CONFLICT" && (
         <div className="mt-2 space-y-2">
           <p className="text-red-600">
             {banner.message}{" "}
@@ -312,40 +327,119 @@ function ConnectedGitHubConnector({
           )}
         </div>
       )}
-      {conflicts.length > 0 && (
+      {conflictRecoveryStage && (
         <div
-          className="mt-3 p-3 rounded-md border border-yellow-200 bg-yellow-50 dark:border-yellow-800 dark:bg-yellow-900/20"
+          className="mt-3 rounded-lg border border-border bg-muted/35 p-3.5"
           data-testid="github-conflict-recovery"
         >
-          <p className="text-sm text-yellow-800 dark:text-yellow-200 mb-3">
-            {conflicts.length} file{conflicts.length > 1 ? "s" : ""} with merge
-            conflicts: {conflicts.join(", ")}
-          </p>
-          <div className="flex gap-2">
-            <Button
-              onClick={() => void startConflictResolution()}
-              disabled={
-                !canResolveConflicts ||
-                conflictResolutionClaimed ||
-                isCancellingSync ||
-                isResolving
-              }
-            >
-              {isResolving
-                ? "Resolving..."
-                : conflictResolutionClaimed
-                  ? "Conflict resolution starting..."
-                  : "Resolve merge conflicts with AI"}
-            </Button>
-            <Button
-              variant="outline"
-              onClick={() =>
-                send({ type: "OP_REQUESTED", op: { type: abortOperation } })
-              }
-              disabled={!canCancelSync || isCancellingSync || isResolving}
-            >
-              {isCancellingSync ? "Cancelling..." : "Cancel sync"}
-            </Button>
+          <div className="flex items-start gap-3">
+            <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-full bg-background text-muted-foreground ring-1 ring-border">
+              {conflictRecoveryStage === "resolving" ? (
+                <LoaderCircle
+                  className="size-4 animate-spin motion-reduce:animate-none"
+                  aria-hidden="true"
+                />
+              ) : conflictRecoveryStage === "ready-to-sync" ? (
+                <CircleCheck
+                  className="size-4 text-emerald-600 dark:text-emerald-400"
+                  aria-hidden="true"
+                />
+              ) : (
+                <GitMerge className="size-4" aria-hidden="true" />
+              )}
+            </div>
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-medium text-foreground">
+                {conflictRecoveryStage === "resolving"
+                  ? "Resolving conflicts in chat…"
+                  : conflictRecoveryStage === "ready-to-sync"
+                    ? "Conflicts resolved"
+                    : isSyncConflict
+                      ? "Sync paused"
+                      : "Merge paused"}
+              </p>
+              <p className="mt-0.5 text-sm text-muted-foreground">
+                {conflictRecoveryStage === "resolving"
+                  ? "Follow progress in the chat."
+                  : conflictRecoveryStage === "ready-to-sync"
+                    ? "Your changes are ready to sync to GitHub."
+                    : `Resolve ${conflicts.length} conflict${conflicts.length === 1 ? "" : "s"} to ${isSyncConflict ? "continue syncing" : "finish merging"}.`}
+              </p>
+
+              {conflictRecoveryStage === "conflicted" && (
+                <ul className="mt-2 space-y-1" aria-label="Conflicted files">
+                  {conflicts.map((file) => (
+                    <li
+                      key={file}
+                      className="flex min-w-0 items-center gap-2 text-sm text-foreground"
+                    >
+                      <FileCode2
+                        className="size-4 shrink-0 text-muted-foreground"
+                        aria-hidden="true"
+                      />
+                      <span className="truncate font-mono text-xs" title={file}>
+                        {file}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+
+              {conflictRecoveryStage === "conflicted" && (
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <Button
+                    size="sm"
+                    onClick={() => void startConflictResolution()}
+                    disabled={
+                      !canResolveConflicts ||
+                      conflictResolutionClaimed ||
+                      isCancellingSync ||
+                      isResolving
+                    }
+                  >
+                    {isResolving
+                      ? "Opening chat…"
+                      : conflictResolutionClaimed
+                        ? "Opening chat…"
+                        : "Resolve with AI"}
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() =>
+                      send({
+                        type: "OP_REQUESTED",
+                        op: { type: abortOperation },
+                      })
+                    }
+                    disabled={!canCancelSync || isCancellingSync || isResolving}
+                  >
+                    {isCancellingSync
+                      ? "Cancelling…"
+                      : isSyncConflict
+                        ? "Cancel sync"
+                        : "Cancel merge"}
+                  </Button>
+                </div>
+              )}
+
+              {conflictRecoveryStage === "ready-to-sync" &&
+                syncContinuationOperation && (
+                  <Button
+                    className="mt-3"
+                    size="sm"
+                    disabled={!canContinueSync}
+                    onClick={() =>
+                      send({
+                        type: "OP_REQUESTED",
+                        op: syncContinuationOperation,
+                      })
+                    }
+                  >
+                    Continue to Sync
+                  </Button>
+                )}
+            </div>
           </div>
         </div>
       )}

--- a/src/components/GithubBranchManager.test.tsx
+++ b/src/components/GithubBranchManager.test.tsx
@@ -95,7 +95,7 @@ describe("GithubBranchManager machine projection", () => {
     expect(screen.queryByTestId("branch-conflict-status")).toBeNull();
     expect(
       screen.queryByRole("button", {
-        name: "Resolve merge conflicts with AI",
+        name: "Resolve with AI",
       }),
     ).toBeNull();
     expect(screen.queryByRole("button", { name: "Cancel sync" })).toBeNull();

--- a/src/github_ops/capabilities.test.ts
+++ b/src/github_ops/capabilities.test.ts
@@ -40,6 +40,20 @@ const states: GithubOpsState[] = [
     origin: { type: "rebase" },
     banner: null,
   },
+  {
+    type: "conflicted",
+    files: ["src/conflicted.ts"],
+    origin: { type: "push", mode: "normal" },
+    resolution: "resolving",
+    banner: null,
+  },
+  {
+    type: "conflicted",
+    files: ["src/conflicted.ts"],
+    origin: { type: "push", mode: "normal" },
+    resolution: "ready-to-sync",
+    banner: null,
+  },
   { type: "rebase-paused", banner: null },
   {
     type: "switch-blocked",
@@ -117,6 +131,11 @@ describe("github_ops capabilities", () => {
                       : "merge-abort",
                 }),
               ],
+            }),
+          },
+          canContinueSync: {
+            representativeEvents: () => ({
+              valid: [request({ type: "push", mode: "normal" })],
             }),
           },
           canMutateBranches: {

--- a/src/github_ops/capabilities.test.ts
+++ b/src/github_ops/capabilities.test.ts
@@ -154,7 +154,11 @@ describe("github_ops capabilities", () => {
           },
           canRetryConflictVerification: {
             representativeEvents: () => ({
-              valid: [{ type: "RECONCILE_REQUESTED" } satisfies GithubOpsEvent],
+              valid: [
+                {
+                  type: "RETRY_CONFLICT_VERIFICATION",
+                } satisfies GithubOpsEvent,
+              ],
             }),
           },
           canMutateBranches: {

--- a/src/github_ops/capabilities.test.ts
+++ b/src/github_ops/capabilities.test.ts
@@ -51,6 +51,13 @@ const states: GithubOpsState[] = [
     type: "conflicted",
     files: ["src/conflicted.ts"],
     origin: { type: "push", mode: "normal" },
+    resolution: "checking",
+    banner: null,
+  },
+  {
+    type: "conflicted",
+    files: ["src/conflicted.ts"],
+    origin: { type: "push", mode: "normal" },
     resolution: "ready-to-sync",
     banner: null,
   },

--- a/src/github_ops/capabilities.test.ts
+++ b/src/github_ops/capabilities.test.ts
@@ -58,6 +58,13 @@ const states: GithubOpsState[] = [
     type: "conflicted",
     files: ["src/conflicted.ts"],
     origin: { type: "push", mode: "normal" },
+    resolution: "verification-failed",
+    banner: null,
+  },
+  {
+    type: "conflicted",
+    files: ["src/conflicted.ts"],
+    origin: { type: "push", mode: "normal" },
     resolution: "ready-to-sync",
     banner: null,
   },
@@ -143,6 +150,11 @@ describe("github_ops capabilities", () => {
           canContinueSync: {
             representativeEvents: () => ({
               valid: [request({ type: "push", mode: "normal" })],
+            }),
+          },
+          canRetryConflictVerification: {
+            representativeEvents: () => ({
+              valid: [{ type: "RECONCILE_REQUESTED" } satisfies GithubOpsEvent],
             }),
           },
           canMutateBranches: {

--- a/src/github_ops/capabilities.ts
+++ b/src/github_ops/capabilities.ts
@@ -11,6 +11,7 @@ export interface GithubOpsCapabilities {
   readonly canResolveConflicts: boolean;
   readonly canCancelSync: boolean;
   readonly canContinueSync: boolean;
+  readonly canRetryConflictVerification: boolean;
   readonly canMutateBranches: boolean;
   readonly canSwitchBranches: boolean;
   readonly canConfirmBlockedSwitch: boolean;
@@ -43,6 +44,8 @@ export function selectGithubOpsCapabilities(
     canCancelSync: isActionableConflict,
     canContinueSync:
       state.type === "conflicted" && state.resolution === "ready-to-sync",
+    canRetryConflictVerification:
+      state.type === "conflicted" && state.resolution === "verification-failed",
     canMutateBranches: isIdle,
     canSwitchBranches:
       isIdle || isActionableConflict || state.type === "rebase-paused",

--- a/src/github_ops/capabilities.ts
+++ b/src/github_ops/capabilities.ts
@@ -10,6 +10,7 @@ export interface GithubOpsCapabilities {
   readonly canRebaseAndSync: boolean;
   readonly canResolveConflicts: boolean;
   readonly canCancelSync: boolean;
+  readonly canContinueSync: boolean;
   readonly canMutateBranches: boolean;
   readonly canSwitchBranches: boolean;
   readonly canConfirmBlockedSwitch: boolean;
@@ -22,6 +23,8 @@ export function selectGithubOpsCapabilities(
   state: GithubOpsState,
 ): GithubOpsCapabilities {
   const isIdle = state.type === "idle";
+  const isActionableConflict =
+    state.type === "conflicted" && state.resolution === undefined;
   return {
     canSync: isIdle,
     canDisconnect: isIdle,
@@ -36,11 +39,13 @@ export function selectGithubOpsCapabilities(
       isIdle &&
       state.banner?.kind === "error" &&
       state.banner.code === "DIVERGENT_BRANCHES",
-    canResolveConflicts: state.type === "conflicted",
-    canCancelSync: state.type === "conflicted",
+    canResolveConflicts: isActionableConflict,
+    canCancelSync: isActionableConflict,
+    canContinueSync:
+      state.type === "conflicted" && state.resolution === "ready-to-sync",
     canMutateBranches: isIdle,
     canSwitchBranches:
-      isIdle || state.type === "conflicted" || state.type === "rebase-paused",
+      isIdle || isActionableConflict || state.type === "rebase-paused",
     canConfirmBlockedSwitch: state.type === "switch-blocked",
     canDismissBlockedSwitch: state.type === "switch-blocked",
     canConnectRepository: isIdle,

--- a/src/github_ops/capabilities.ts
+++ b/src/github_ops/capabilities.ts
@@ -26,6 +26,11 @@ export function selectGithubOpsCapabilities(
   const isIdle = state.type === "idle";
   const isActionableConflict =
     state.type === "conflicted" && state.resolution === undefined;
+  const isStableConflictRecovery =
+    state.type === "conflicted" &&
+    (state.resolution === undefined ||
+      state.resolution === "verification-failed" ||
+      state.resolution === "ready-to-sync");
   return {
     canSync: isIdle,
     canDisconnect: isIdle,
@@ -41,14 +46,14 @@ export function selectGithubOpsCapabilities(
       state.banner?.kind === "error" &&
       state.banner.code === "DIVERGENT_BRANCHES",
     canResolveConflicts: isActionableConflict,
-    canCancelSync: isActionableConflict,
+    canCancelSync: isStableConflictRecovery,
     canContinueSync:
       state.type === "conflicted" && state.resolution === "ready-to-sync",
     canRetryConflictVerification:
       state.type === "conflicted" && state.resolution === "verification-failed",
     canMutateBranches: isIdle,
     canSwitchBranches:
-      isIdle || isActionableConflict || state.type === "rebase-paused",
+      isIdle || isStableConflictRecovery || state.type === "rebase-paused",
     canConfirmBlockedSwitch: state.type === "switch-blocked",
     canDismissBlockedSwitch: state.type === "switch-blocked",
     canConnectRepository: isIdle,

--- a/src/github_ops/main_actor.test.ts
+++ b/src/github_ops/main_actor.test.ts
@@ -414,10 +414,11 @@ describe("main-hosted github_ops actor", () => {
       type: "conflicted",
       resolution: "verification-failed",
       resolutionChatId: 42,
+      verificationError: "temporary Git-state failure",
     });
     expect(presentation.showError).not.toHaveBeenCalled();
 
-    await actorA.dispatch({ type: "RECONCILE_REQUESTED" });
+    await actorA.dispatch({ type: "RETRY_CONFLICT_VERIFICATION" });
     await flush();
 
     expect(service.getGitState).toHaveBeenCalledTimes(2);
@@ -463,10 +464,11 @@ describe("main-hosted github_ops actor", () => {
       type: "conflicted",
       resolution: "verification-failed",
       resolutionChatId: 42,
+      verificationError: "temporary conflict probe failure",
     });
     expect(presentation.showError).not.toHaveBeenCalled();
 
-    await actorA.dispatch({ type: "RECONCILE_REQUESTED" });
+    await actorA.dispatch({ type: "RETRY_CONFLICT_VERIFICATION" });
     await flush();
 
     expect(service.getConflicts).toHaveBeenCalledTimes(2);
@@ -670,7 +672,7 @@ describe("main-hosted github_ops actor", () => {
     expect(presentation.showError).toHaveBeenCalledExactlyOnceWith(
       7,
       undefined,
-      "Could not refresh the repository state",
+      "temporary repository refresh failure",
     );
   });
 

--- a/src/github_ops/main_actor.test.ts
+++ b/src/github_ops/main_actor.test.ts
@@ -264,6 +264,7 @@ describe("main-hosted github_ops actor", () => {
       actor.dispatch({
         type: "CONFLICT_RESOLUTION_STARTED",
         claimId: "missing-claim",
+        chatId: 42,
       }),
     ).resolves.toMatchObject({
       kind: "ignored",
@@ -279,6 +280,7 @@ describe("main-hosted github_ops actor", () => {
       actor.dispatch({
         type: "CONFLICT_RESOLUTION_STARTED",
         claimId: "claim-after-sync",
+        chatId: 42,
       }),
     ).resolves.toMatchObject({ kind: "applied" });
   });
@@ -315,11 +317,66 @@ describe("main-hosted github_ops actor", () => {
     await actorA.dispatch({
       type: "CONFLICT_RESOLUTION_STARTED",
       claimId: "claim-a",
+      chatId: 42,
     });
     expect(actorA.getSnapshot().state).toMatchObject({
       type: "conflicted",
       resolution: "resolving",
     });
+  });
+
+  it("continues a resolved rebase conflict before pushing", async () => {
+    service.getGitState.mockResolvedValue({
+      mergeInProgress: false,
+      rebaseInProgress: true,
+    });
+    const { actorA, host } = createHarness();
+    await actorA.resync();
+    const local: GithubOpsHostedActor = host.ensure(
+      githubOpsDefinition,
+      githubOpsKey(7),
+    );
+    local.send({
+      type: "GIT_STATE",
+      mergeInProgress: false,
+      rebaseInProgress: true,
+    });
+    await flush();
+    local.send({ type: "CONFLICTS", files: ["src/conflicted.ts"] });
+    await flush();
+
+    await actorA.dispatch({
+      type: "RESOLVE_WITH_AI_STARTED",
+      claimId: "rebase-claim",
+    });
+    await actorA.dispatch({
+      type: "CONFLICT_RESOLUTION_STARTED",
+      claimId: "rebase-claim",
+      chatId: 42,
+    });
+    await actorA.dispatch({ type: "CONFLICT_RESOLUTION_FINISHED" });
+    await flush();
+    expect(actorA.getSnapshot().state).toMatchObject({
+      type: "conflicted",
+      origin: { type: "rebase" },
+      resolution: "ready-to-sync",
+    });
+
+    await actorA.dispatch({
+      type: "OP_REQUESTED",
+      op: { type: "rebase-continue" },
+      operationId: "continue-rebase-and-push",
+    });
+    await flush();
+
+    expect(service.run).toHaveBeenNthCalledWith(1, 7, {
+      type: "rebase-continue",
+    });
+    expect(service.run).toHaveBeenNthCalledWith(2, 7, {
+      type: "push",
+      mode: "normal",
+    });
+    expect(actorA.getSnapshot().state.type).toBe("idle");
   });
 
   it("preserves the claim through reconcile and rejects a second window", async () => {
@@ -375,6 +432,7 @@ describe("main-hosted github_ops actor", () => {
         encodedEvent: {
           type: "CONFLICT_RESOLUTION_STARTED",
           claimId: "claim-a",
+          chatId: 42,
         },
         messageId: "stale-claim-follow-up",
         expectedActorInstanceId: local.actorInstanceId,

--- a/src/github_ops/main_actor.test.ts
+++ b/src/github_ops/main_actor.test.ts
@@ -379,6 +379,85 @@ describe("main-hosted github_ops actor", () => {
     expect(actorA.getSnapshot().state.type).toBe("idle");
   });
 
+  it("makes a failed Git-state verification retryable without restarting AI", async () => {
+    service.getGitState.mockRejectedValueOnce(
+      new Error("temporary Git-state failure"),
+    );
+    const { actorA, host } = createHarness();
+    await actorA.resync();
+    const local: GithubOpsHostedActor = host.ensure(
+      githubOpsDefinition,
+      githubOpsKey(7),
+    );
+    local.send({ type: "CONFLICTS", files: ["src/conflicted.ts"] });
+    await flush();
+
+    await actorA.dispatch({
+      type: "RESOLVE_WITH_AI_STARTED",
+      claimId: "verification-claim",
+    });
+    await actorA.dispatch({
+      type: "CONFLICT_RESOLUTION_STARTED",
+      claimId: "verification-claim",
+      chatId: 42,
+    });
+    await actorA.dispatch({ type: "CONFLICT_RESOLUTION_FINISHED" });
+    await flush();
+
+    expect(actorA.getSnapshot().state).toMatchObject({
+      type: "conflicted",
+      resolution: "verification-failed",
+      resolutionChatId: 42,
+    });
+    expect(presentation.showError).not.toHaveBeenCalled();
+
+    await actorA.dispatch({ type: "RECONCILE_REQUESTED" });
+    await flush();
+
+    expect(service.getGitState).toHaveBeenCalledTimes(2);
+    expect(actorA.getSnapshot().state).toMatchObject({
+      type: "idle",
+      banner: {
+        kind: "success",
+        message: "Merge conflicts resolved.",
+      },
+    });
+  });
+
+  it("makes a failed conflict-file verification retryable", async () => {
+    service.getConflicts.mockRejectedValueOnce(
+      new Error("temporary conflict probe failure"),
+    );
+    const { actorA, host } = createHarness();
+    await actorA.resync();
+    const local: GithubOpsHostedActor = host.ensure(
+      githubOpsDefinition,
+      githubOpsKey(7),
+    );
+    local.send({ type: "CONFLICTS", files: ["src/conflicted.ts"] });
+    await flush();
+
+    await actorA.dispatch({
+      type: "RESOLVE_WITH_AI_STARTED",
+      claimId: "conflict-probe-claim",
+    });
+    await actorA.dispatch({
+      type: "CONFLICT_RESOLUTION_STARTED",
+      claimId: "conflict-probe-claim",
+      chatId: 42,
+    });
+    await actorA.dispatch({ type: "CONFLICT_RESOLUTION_FINISHED" });
+    await flush();
+
+    expect(service.getConflicts).toHaveBeenCalledOnce();
+    expect(actorA.getSnapshot().state).toMatchObject({
+      type: "conflicted",
+      resolution: "verification-failed",
+      resolutionChatId: 42,
+    });
+    expect(presentation.showError).not.toHaveBeenCalled();
+  });
+
   it("preserves the claim through reconcile and rejects a second window", async () => {
     service.getConflicts.mockResolvedValue(["src/conflicted.ts"]);
     const { actorA, actorB, host } = createHarness();

--- a/src/github_ops/main_actor.test.ts
+++ b/src/github_ops/main_actor.test.ts
@@ -316,7 +316,10 @@ describe("main-hosted github_ops actor", () => {
       type: "CONFLICT_RESOLUTION_STARTED",
       claimId: "claim-a",
     });
-    expect(actorA.getSnapshot().state.type).toBe("idle");
+    expect(actorA.getSnapshot().state).toMatchObject({
+      type: "conflicted",
+      resolution: "resolving",
+    });
   });
 
   it("preserves the claim through reconcile and rejects a second window", async () => {
@@ -378,7 +381,10 @@ describe("main-hosted github_ops actor", () => {
         expectedRevision: staleRevision,
       }),
     ).resolves.toMatchObject({ kind: "applied" });
-    expect(local.getSnapshot().state.type).toBe("idle");
+    expect(local.getSnapshot().state).toMatchObject({
+      type: "conflicted",
+      resolution: "resolving",
+    });
   });
 
   it("rejects a follow-up from the wrong claimant", async () => {

--- a/src/github_ops/main_actor.test.ts
+++ b/src/github_ops/main_actor.test.ts
@@ -354,7 +354,10 @@ describe("main-hosted github_ops actor", () => {
       claimId: "rebase-claim",
       chatId: 42,
     });
-    await actorA.dispatch({ type: "CONFLICT_RESOLUTION_FINISHED" });
+    await actorA.dispatch({
+      type: "CONFLICT_RESOLUTION_FINISHED",
+      chatId: 42,
+    });
     await flush();
     expect(actorA.getSnapshot().state).toMatchObject({
       type: "conflicted",
@@ -401,7 +404,10 @@ describe("main-hosted github_ops actor", () => {
       claimId: "verification-claim",
       chatId: 42,
     });
-    await actorA.dispatch({ type: "CONFLICT_RESOLUTION_FINISHED" });
+    await actorA.dispatch({
+      type: "CONFLICT_RESOLUTION_FINISHED",
+      chatId: 42,
+    });
     await flush();
 
     expect(actorA.getSnapshot().state).toMatchObject({
@@ -446,7 +452,10 @@ describe("main-hosted github_ops actor", () => {
       claimId: "conflict-probe-claim",
       chatId: 42,
     });
-    await actorA.dispatch({ type: "CONFLICT_RESOLUTION_FINISHED" });
+    await actorA.dispatch({
+      type: "CONFLICT_RESOLUTION_FINISHED",
+      chatId: 42,
+    });
     await flush();
 
     expect(service.getConflicts).toHaveBeenCalledOnce();
@@ -456,6 +465,12 @@ describe("main-hosted github_ops actor", () => {
       resolutionChatId: 42,
     });
     expect(presentation.showError).not.toHaveBeenCalled();
+
+    await actorA.dispatch({ type: "RECONCILE_REQUESTED" });
+    await flush();
+
+    expect(service.getConflicts).toHaveBeenCalledTimes(2);
+    expect(actorA.getSnapshot().state.type).toBe("idle");
   });
 
   it("preserves the claim through reconcile and rejects a second window", async () => {
@@ -639,6 +654,24 @@ describe("main-hosted github_ops actor", () => {
     await flush();
 
     expect(presentation.showError).not.toHaveBeenCalled();
+  });
+
+  it("shows a toast for a generic probe failure without emitting verification recovery", async () => {
+    service.getGitState.mockRejectedValueOnce(
+      new Error("temporary repository refresh failure"),
+    );
+    const { actorA } = createHarness();
+    await actorA.resync();
+
+    await actorA.dispatch({ type: "RECONCILE_REQUESTED" });
+    await flush();
+
+    expect(actorA.getSnapshot().state.type).toBe("idle");
+    expect(presentation.showError).toHaveBeenCalledExactlyOnceWith(
+      7,
+      undefined,
+      "Could not refresh the repository state",
+    );
   });
 
   it("rejects dispatch for the null-app subscription sentinel", async () => {

--- a/src/github_ops/projection.test.ts
+++ b/src/github_ops/projection.test.ts
@@ -102,4 +102,23 @@ describe("projectGithubOps", () => {
     expect(conflicted.capabilities.canDisconnect).toBe(false);
     expect(rebasePaused.capabilities.canDisconnect).toBe(false);
   });
+
+  it("projects a resolved sync conflict as a single continuation action", () => {
+    const projection = projectGithubOps({
+      type: "conflicted",
+      files: ["src/conflicted.ts"],
+      origin: { type: "push", mode: "normal" },
+      resolution: "ready-to-sync",
+      banner: null,
+    });
+
+    expect(projection.conflictRecoveryStage).toBe("ready-to-sync");
+    expect(projection.syncContinuationOperation).toEqual({
+      type: "push",
+      mode: "normal",
+    });
+    expect(projection.capabilities.canContinueSync).toBe(true);
+    expect(projection.capabilities.canResolveConflicts).toBe(false);
+    expect(projection.capabilities.canCancelSync).toBe(false);
+  });
 });

--- a/src/github_ops/projection.test.ts
+++ b/src/github_ops/projection.test.ts
@@ -122,6 +122,19 @@ describe("projectGithubOps", () => {
     expect(projection.capabilities.canCancelSync).toBe(false);
   });
 
+  it("projects Git verification separately from active chat resolution", () => {
+    const projection = projectGithubOps({
+      type: "conflicted",
+      files: ["src/conflicted.ts"],
+      origin: { type: "push", mode: "normal" },
+      resolution: "checking",
+      banner: null,
+    });
+
+    expect(projection.conflictRecoveryStage).toBe("checking");
+    expect(projection.syncContinuationOperation).toBeNull();
+  });
+
   it("projects rebase recovery as rebase continuation", () => {
     const projection = projectGithubOps({
       type: "conflicted",

--- a/src/github_ops/projection.test.ts
+++ b/src/github_ops/projection.test.ts
@@ -119,7 +119,7 @@ describe("projectGithubOps", () => {
     });
     expect(projection.capabilities.canContinueSync).toBe(true);
     expect(projection.capabilities.canResolveConflicts).toBe(false);
-    expect(projection.capabilities.canCancelSync).toBe(false);
+    expect(projection.capabilities.canCancelSync).toBe(true);
   });
 
   it("projects Git verification separately from active chat resolution", () => {
@@ -141,10 +141,14 @@ describe("projectGithubOps", () => {
       files: ["src/conflicted.ts"],
       origin: { type: "push", mode: "normal" },
       resolution: "verification-failed",
+      verificationError: "temporary Git-state failure",
       banner: null,
     });
 
     expect(projection.conflictRecoveryStage).toBe("verification-failed");
+    expect(projection.conflictVerificationError).toBe(
+      "temporary Git-state failure",
+    );
     expect(projection.capabilities.canRetryConflictVerification).toBe(true);
     expect(projection.capabilities.canContinueSync).toBe(false);
     expect(projection.capabilities.canResolveConflicts).toBe(false);

--- a/src/github_ops/projection.test.ts
+++ b/src/github_ops/projection.test.ts
@@ -135,6 +135,21 @@ describe("projectGithubOps", () => {
     expect(projection.syncContinuationOperation).toBeNull();
   });
 
+  it("projects a recoverable verification failure", () => {
+    const projection = projectGithubOps({
+      type: "conflicted",
+      files: ["src/conflicted.ts"],
+      origin: { type: "push", mode: "normal" },
+      resolution: "verification-failed",
+      banner: null,
+    });
+
+    expect(projection.conflictRecoveryStage).toBe("verification-failed");
+    expect(projection.capabilities.canRetryConflictVerification).toBe(true);
+    expect(projection.capabilities.canContinueSync).toBe(false);
+    expect(projection.capabilities.canResolveConflicts).toBe(false);
+  });
+
   it("projects rebase recovery as rebase continuation", () => {
     const projection = projectGithubOps({
       type: "conflicted",

--- a/src/github_ops/projection.test.ts
+++ b/src/github_ops/projection.test.ts
@@ -121,4 +121,18 @@ describe("projectGithubOps", () => {
     expect(projection.capabilities.canResolveConflicts).toBe(false);
     expect(projection.capabilities.canCancelSync).toBe(false);
   });
+
+  it("projects rebase recovery as rebase continuation", () => {
+    const projection = projectGithubOps({
+      type: "conflicted",
+      files: ["src/conflicted.ts"],
+      origin: { type: "rebase" },
+      resolution: "ready-to-sync",
+      banner: null,
+    });
+
+    expect(projection.syncContinuationOperation).toEqual({
+      type: "rebase-continue",
+    });
+  });
 });

--- a/src/github_ops/projection.ts
+++ b/src/github_ops/projection.ts
@@ -17,6 +17,7 @@ export interface GithubOpsProjection {
     | "resolving"
     | "ready-to-sync"
     | null;
+  readonly conflictResolutionChatId: number | null;
   readonly syncContinuationOperation: GithubOperation | null;
   readonly rebaseInProgress: boolean;
   readonly rebaseAction: "abort" | "continue" | "safe-push" | null;
@@ -69,13 +70,15 @@ export function projectGithubOps(state: GithubOpsState): GithubOpsProjection {
             ? "ready-to-sync"
             : "conflicted"
         : null,
+    conflictResolutionChatId:
+      state.type === "conflicted" ? (state.resolutionChatId ?? null) : null,
     syncContinuationOperation:
       state.type === "conflicted" && state.resolution === "ready-to-sync"
         ? state.origin.type === "push"
           ? state.origin
           : state.origin.type === "rebase" ||
               state.origin.type === "rebase-continue"
-            ? { type: "push", mode: "normal" }
+            ? { type: "rebase-continue" }
             : null
         : null,
     rebaseInProgress:

--- a/src/github_ops/projection.ts
+++ b/src/github_ops/projection.ts
@@ -17,6 +17,7 @@ export interface GithubOpsProjection {
     | "conflicted"
     | "resolving"
     | "checking"
+    | "verification-failed"
     | "ready-to-sync"
     | null;
   readonly conflictResolutionChatId: number | null;
@@ -70,9 +71,11 @@ export function projectGithubOps(state: GithubOpsState): GithubOpsProjection {
           ? "resolving"
           : state.resolution === "checking"
             ? "checking"
-            : state.resolution === "ready-to-sync"
-              ? "ready-to-sync"
-              : "conflicted"
+            : state.resolution === "verification-failed"
+              ? "verification-failed"
+              : state.resolution === "ready-to-sync"
+                ? "ready-to-sync"
+                : "conflicted"
         : null,
     conflictResolutionChatId:
       state.type === "conflicted" ? (state.resolutionChatId ?? null) : null,

--- a/src/github_ops/projection.ts
+++ b/src/github_ops/projection.ts
@@ -3,6 +3,7 @@ import {
   selectGithubOpsCapabilities,
   type GithubOpsCapabilities,
 } from "./capabilities";
+import { continuationOperation } from "./transition";
 
 export interface GithubOpsProjection {
   readonly state: GithubOpsState;
@@ -15,6 +16,7 @@ export interface GithubOpsProjection {
   readonly conflictRecoveryStage:
     | "conflicted"
     | "resolving"
+    | "checking"
     | "ready-to-sync"
     | null;
   readonly conflictResolutionChatId: number | null;
@@ -64,22 +66,19 @@ export function projectGithubOps(state: GithubOpsState): GithubOpsProjection {
     conflicts: state.type === "conflicted" ? state.files : EMPTY_CONFLICTS,
     conflictRecoveryStage:
       state.type === "conflicted"
-        ? state.resolution === "resolving" || state.resolution === "checking"
+        ? state.resolution === "resolving"
           ? "resolving"
-          : state.resolution === "ready-to-sync"
-            ? "ready-to-sync"
-            : "conflicted"
+          : state.resolution === "checking"
+            ? "checking"
+            : state.resolution === "ready-to-sync"
+              ? "ready-to-sync"
+              : "conflicted"
         : null,
     conflictResolutionChatId:
       state.type === "conflicted" ? (state.resolutionChatId ?? null) : null,
     syncContinuationOperation:
       state.type === "conflicted" && state.resolution === "ready-to-sync"
-        ? state.origin.type === "push"
-          ? state.origin
-          : state.origin.type === "rebase" ||
-              state.origin.type === "rebase-continue"
-            ? { type: "rebase-continue" }
-            : null
+        ? (continuationOperation(state.origin) ?? null)
         : null,
     rebaseInProgress:
       state.type === "rebase-paused" ||

--- a/src/github_ops/projection.ts
+++ b/src/github_ops/projection.ts
@@ -21,6 +21,7 @@ export interface GithubOpsProjection {
     | "ready-to-sync"
     | null;
   readonly conflictResolutionChatId: number | null;
+  readonly conflictVerificationError: string | null;
   readonly syncContinuationOperation: GithubOperation | null;
   readonly rebaseInProgress: boolean;
   readonly rebaseAction: "abort" | "continue" | "safe-push" | null;
@@ -79,6 +80,8 @@ export function projectGithubOps(state: GithubOpsState): GithubOpsProjection {
         : null,
     conflictResolutionChatId:
       state.type === "conflicted" ? (state.resolutionChatId ?? null) : null,
+    conflictVerificationError:
+      state.type === "conflicted" ? (state.verificationError ?? null) : null,
     syncContinuationOperation:
       state.type === "conflicted" && state.resolution === "ready-to-sync"
         ? (continuationOperation(state.origin) ?? null)

--- a/src/github_ops/projection.ts
+++ b/src/github_ops/projection.ts
@@ -12,6 +12,12 @@ export interface GithubOpsProjection {
   readonly isOperationInFlight: boolean;
   readonly isSyncing: boolean;
   readonly conflicts: readonly string[];
+  readonly conflictRecoveryStage:
+    | "conflicted"
+    | "resolving"
+    | "ready-to-sync"
+    | null;
+  readonly syncContinuationOperation: GithubOperation | null;
   readonly rebaseInProgress: boolean;
   readonly rebaseAction: "abort" | "continue" | "safe-push" | null;
   readonly showForcePush: boolean;
@@ -55,6 +61,23 @@ export function projectGithubOps(state: GithubOpsState): GithubOpsProjection {
       state.type === "running" &&
       (state.op.type === "push" || state.op.type === "rebase"),
     conflicts: state.type === "conflicted" ? state.files : EMPTY_CONFLICTS,
+    conflictRecoveryStage:
+      state.type === "conflicted"
+        ? state.resolution === "resolving" || state.resolution === "checking"
+          ? "resolving"
+          : state.resolution === "ready-to-sync"
+            ? "ready-to-sync"
+            : "conflicted"
+        : null,
+    syncContinuationOperation:
+      state.type === "conflicted" && state.resolution === "ready-to-sync"
+        ? state.origin.type === "push"
+          ? state.origin
+          : state.origin.type === "rebase" ||
+              state.origin.type === "rebase-continue"
+            ? { type: "push", mode: "normal" }
+            : null
+        : null,
     rebaseInProgress:
       state.type === "rebase-paused" ||
       (state.type === "switch-blocked" && state.blockingOp === "rebase") ||

--- a/src/github_ops/state.ts
+++ b/src/github_ops/state.ts
@@ -95,7 +95,11 @@ export type GithubOpsState =
       type: "conflicted";
       files: readonly string[];
       origin: ConflictOrigin;
-      resolution?: "resolving" | "checking" | "ready-to-sync";
+      resolution?:
+        | "resolving"
+        | "checking"
+        | "verification-failed"
+        | "ready-to-sync";
       resolutionChatId?: number;
     } & GithubOpsContext)
   | ({ type: "rebase-paused" } & GithubOpsContext)
@@ -131,6 +135,7 @@ export type GithubOpsEvent =
   | { type: "RESOLVE_WITH_AI_STARTED" }
   | { type: "CONFLICT_RESOLUTION_STARTED"; chatId: number }
   | { type: "CONFLICT_RESOLUTION_FINISHED" }
+  | { type: "CONFLICT_VERIFICATION_FAILED" }
   | { type: "BANNER_DISMISSED" }
   | { type: "RECONCILE_REQUESTED" };
 

--- a/src/github_ops/state.ts
+++ b/src/github_ops/state.ts
@@ -101,6 +101,7 @@ export type GithubOpsState =
         | "verification-failed"
         | "ready-to-sync";
       resolutionChatId?: number;
+      verificationAttempt?: number;
     } & GithubOpsContext)
   | ({ type: "rebase-paused" } & GithubOpsContext)
   | ({
@@ -124,25 +125,34 @@ export type GithubOpsEvent =
       op: GithubOperation;
       failure: GithubOperationFailure;
     }
-  | { type: "CONFLICTS"; files: readonly string[] }
+  | {
+      type: "CONFLICTS";
+      files: readonly string[];
+      verificationAttempt?: number;
+    }
   | {
       type: "GIT_STATE";
       mergeInProgress: boolean;
       rebaseInProgress: boolean;
+      verificationAttempt?: number;
     }
   | { type: "ABORT_AND_SWITCH_CONFIRMED" }
   | { type: "BLOCKED_DISMISSED" }
   | { type: "RESOLVE_WITH_AI_STARTED" }
   | { type: "CONFLICT_RESOLUTION_STARTED"; chatId: number }
-  | { type: "CONFLICT_RESOLUTION_FINISHED" }
-  | { type: "CONFLICT_VERIFICATION_FAILED" }
+  | { type: "CONFLICT_RESOLUTION_FINISHED"; chatId: number }
+  | { type: "CONFLICT_VERIFICATION_FAILED"; verificationAttempt: number }
   | { type: "BANNER_DISMISSED" }
   | { type: "RECONCILE_REQUESTED" };
 
 export type GithubOpsCommand =
   | { type: "run-op"; op: GithubOperation }
-  | { type: "probe-git-state" }
-  | { type: "probe-conflicts"; settleOnError?: boolean }
+  | { type: "probe-git-state"; verificationAttempt?: number }
+  | {
+      type: "probe-conflicts";
+      settleOnError?: boolean;
+      verificationAttempt?: number;
+    }
   | { type: "invalidate-branches" }
   | { type: "refresh-app" }
   | {

--- a/src/github_ops/state.ts
+++ b/src/github_ops/state.ts
@@ -96,6 +96,7 @@ export type GithubOpsState =
       files: readonly string[];
       origin: ConflictOrigin;
       resolution?: "resolving" | "checking" | "ready-to-sync";
+      resolutionChatId?: number;
     } & GithubOpsContext)
   | ({ type: "rebase-paused" } & GithubOpsContext)
   | ({
@@ -128,7 +129,7 @@ export type GithubOpsEvent =
   | { type: "ABORT_AND_SWITCH_CONFIRMED" }
   | { type: "BLOCKED_DISMISSED" }
   | { type: "RESOLVE_WITH_AI_STARTED" }
-  | { type: "CONFLICT_RESOLUTION_STARTED" }
+  | { type: "CONFLICT_RESOLUTION_STARTED"; chatId: number }
   | { type: "CONFLICT_RESOLUTION_FINISHED" }
   | { type: "BANNER_DISMISSED" }
   | { type: "RECONCILE_REQUESTED" };

--- a/src/github_ops/state.ts
+++ b/src/github_ops/state.ts
@@ -102,6 +102,7 @@ export type GithubOpsState =
         | "ready-to-sync";
       resolutionChatId?: number;
       verificationAttempt?: number;
+      verificationError?: string;
     } & GithubOpsContext)
   | ({ type: "rebase-paused" } & GithubOpsContext)
   | ({
@@ -141,7 +142,12 @@ export type GithubOpsEvent =
   | { type: "RESOLVE_WITH_AI_STARTED" }
   | { type: "CONFLICT_RESOLUTION_STARTED"; chatId: number }
   | { type: "CONFLICT_RESOLUTION_FINISHED"; chatId: number }
-  | { type: "CONFLICT_VERIFICATION_FAILED"; verificationAttempt: number }
+  | {
+      type: "CONFLICT_VERIFICATION_FAILED";
+      verificationAttempt: number;
+      message: string;
+    }
+  | { type: "RETRY_CONFLICT_VERIFICATION" }
   | { type: "BANNER_DISMISSED" }
   | { type: "RECONCILE_REQUESTED" };
 

--- a/src/github_ops/state.ts
+++ b/src/github_ops/state.ts
@@ -95,6 +95,7 @@ export type GithubOpsState =
       type: "conflicted";
       files: readonly string[];
       origin: ConflictOrigin;
+      resolution?: "resolving" | "checking" | "ready-to-sync";
     } & GithubOpsContext)
   | ({ type: "rebase-paused" } & GithubOpsContext)
   | ({
@@ -127,6 +128,8 @@ export type GithubOpsEvent =
   | { type: "ABORT_AND_SWITCH_CONFIRMED" }
   | { type: "BLOCKED_DISMISSED" }
   | { type: "RESOLVE_WITH_AI_STARTED" }
+  | { type: "CONFLICT_RESOLUTION_STARTED" }
+  | { type: "CONFLICT_RESOLUTION_FINISHED" }
   | { type: "BANNER_DISMISSED" }
   | { type: "RECONCILE_REQUESTED" };
 

--- a/src/github_ops/transition.test.ts
+++ b/src/github_ops/transition.test.ts
@@ -62,6 +62,12 @@ const COMMAND_KINDS = [
   "start-conflict-resolution",
 ] as const satisfies readonly GithubOpsCommand["type"][];
 
+function explorationStateKey(state: GithubOpsState): string {
+  return JSON.stringify(state, (key, value) =>
+    key === "verificationAttempt" && value !== undefined ? 1 : value,
+  );
+}
+
 function eventsFor(state: GithubOpsState): readonly GithubOpsEvent[] {
   const activeOp =
     state.type === "running"
@@ -114,10 +120,20 @@ function eventsFor(state: GithubOpsState): readonly GithubOpsEvent[] {
     { type: "RESOLVE_WITH_AI_STARTED" },
     { type: "CONFLICT_RESOLUTION_STARTED", chatId: 42 },
     ...(state.type === "conflicted" && state.resolution === "resolving"
-      ? ([{ type: "CONFLICT_RESOLUTION_FINISHED" }] satisfies GithubOpsEvent[])
+      ? ([
+          {
+            type: "CONFLICT_RESOLUTION_FINISHED",
+            chatId: state.resolutionChatId ?? 42,
+          },
+        ] satisfies GithubOpsEvent[])
       : []),
     ...(state.type === "conflicted" && state.resolution === "checking"
-      ? ([{ type: "CONFLICT_VERIFICATION_FAILED" }] satisfies GithubOpsEvent[])
+      ? ([
+          {
+            type: "CONFLICT_VERIFICATION_FAILED",
+            verificationAttempt: state.verificationAttempt ?? 1,
+          },
+        ] satisfies GithubOpsEvent[])
       : []),
     { type: "BANNER_DISMISSED" },
     { type: "RECONCILE_REQUESTED" },
@@ -130,7 +146,7 @@ describe("github_ops transition", () => {
       initialState: INITIAL_GITHUB_OPS_STATE,
       events: eventsFor,
       transition,
-      stateKey: JSON.stringify,
+      stateKey: explorationStateKey,
       maxStates: 2_000,
     };
     assertAllStatesReachable({
@@ -150,7 +166,7 @@ describe("github_ops transition", () => {
       initialState: INITIAL_GITHUB_OPS_STATE,
       events: eventsFor,
       transition,
-      stateKey: (state) => JSON.stringify(state),
+      stateKey: explorationStateKey,
       maxStates: 2_000,
     });
     const states = graph.nodes.map(({ state }) => state);
@@ -353,21 +369,27 @@ describe("github_ops transition", () => {
 
     const reconciling = transition(resolving.state, {
       type: "CONFLICT_RESOLUTION_FINISHED",
+      chatId: 42,
     });
-    expect(commandsOf(reconciling)).toEqual([{ type: "probe-git-state" }]);
+    expect(commandsOf(reconciling)).toEqual([
+      { type: "probe-git-state", verificationAttempt: 1 },
+    ]);
     const checkedGitState = transition(reconciling.state, {
       type: "GIT_STATE",
       mergeInProgress: false,
       rebaseInProgress: false,
+      verificationAttempt: 1,
     });
     const ready = transition(checkedGitState.state, {
       type: "CONFLICTS",
       files: [],
+      verificationAttempt: 1,
     });
     expect(ready.state).toEqual({
       ...conflicted,
       resolution: "ready-to-sync",
       resolutionChatId: 42,
+      verificationAttempt: 1,
     });
 
     const continued = transition(ready.state, {
@@ -395,6 +417,25 @@ describe("github_ops transition", () => {
     expect(ignoreReasonOf(result)).toBe("no-change");
   });
 
+  it("rejects completion from an older conflict-resolution chat", () => {
+    const resolving: GithubOpsState = {
+      type: "conflicted",
+      files: ["src/conflicted.ts"],
+      origin: { type: "push", mode: "normal" },
+      resolution: "resolving",
+      resolutionChatId: 42,
+      banner: null,
+    };
+
+    const result = transition(resolving, {
+      type: "CONFLICT_RESOLUTION_FINISHED",
+      chatId: 41,
+    });
+
+    expect(result.state).toBe(resolving);
+    expect(ignoreReasonOf(result)).toBe("stale-op");
+  });
+
   it("offers an explicit retry when conflict verification fails", () => {
     const checking: GithubOpsState = {
       type: "conflicted",
@@ -402,11 +443,13 @@ describe("github_ops transition", () => {
       origin: { type: "push", mode: "normal" },
       resolution: "checking",
       resolutionChatId: 42,
+      verificationAttempt: 1,
       banner: null,
     };
 
     const failed = transition(checking, {
       type: "CONFLICT_VERIFICATION_FAILED",
+      verificationAttempt: 1,
     });
     expect(failed.state).toEqual({
       ...checking,
@@ -422,8 +465,41 @@ describe("github_ops transition", () => {
     expect(ignoreReasonOf(ambientProbe)).toBe("no-change");
 
     const retry = transition(failed.state, { type: "RECONCILE_REQUESTED" });
-    expect(retry.state).toEqual(checking);
-    expect(commandsOf(retry)).toEqual([{ type: "probe-git-state" }]);
+    expect(retry.state).toEqual({
+      ...checking,
+      verificationAttempt: 2,
+    });
+    expect(commandsOf(retry)).toEqual([
+      { type: "probe-git-state", verificationAttempt: 2 },
+    ]);
+  });
+
+  it("rejects results from an older verification attempt", () => {
+    const checking: GithubOpsState = {
+      type: "conflicted",
+      files: ["src/conflicted.ts"],
+      origin: { type: "push", mode: "normal" },
+      resolution: "checking",
+      resolutionChatId: 42,
+      verificationAttempt: 2,
+      banner: null,
+    };
+    const staleEvents: GithubOpsEvent[] = [
+      { type: "CONFLICT_VERIFICATION_FAILED", verificationAttempt: 1 },
+      {
+        type: "GIT_STATE",
+        mergeInProgress: false,
+        rebaseInProgress: false,
+        verificationAttempt: 1,
+      },
+      { type: "CONFLICTS", files: [], verificationAttempt: 1 },
+    ];
+
+    for (const event of staleEvents) {
+      const result = transition(checking, event);
+      expect(result.state).toBe(checking);
+      expect(ignoreReasonOf(result)).toBe("stale-op");
+    }
   });
 
   it("continues an active rebase before pushing resolved changes", () => {
@@ -532,6 +608,7 @@ describe("github_ops transition", () => {
       files: ["src/old.ts"],
       origin: { type: "push", mode: "normal" },
       resolution: "resolving",
+      resolutionChatId: 42,
       banner: null,
     };
 
@@ -546,17 +623,21 @@ describe("github_ops transition", () => {
 
     const checking = transition(stillResolving.state, {
       type: "CONFLICT_RESOLUTION_FINISHED",
+      chatId: 42,
     });
     expect(
       transition(checking.state, {
         type: "CONFLICTS",
         files: ["src/still-conflicted.ts"],
+        verificationAttempt: 1,
       }).state,
     ).toEqual({
       type: "conflicted",
       files: ["src/still-conflicted.ts"],
       origin: { type: "push", mode: "normal" },
       resolution: undefined,
+      resolutionChatId: undefined,
+      verificationAttempt: undefined,
       banner: null,
     });
   });

--- a/src/github_ops/transition.test.ts
+++ b/src/github_ops/transition.test.ts
@@ -112,6 +112,7 @@ function eventsFor(state: GithubOpsState): readonly GithubOpsEvent[] {
     { type: "ABORT_AND_SWITCH_CONFIRMED" },
     { type: "BLOCKED_DISMISSED" },
     { type: "RESOLVE_WITH_AI_STARTED" },
+    { type: "CONFLICT_RESOLUTION_STARTED" },
     { type: "BANNER_DISMISSED" },
     { type: "RECONCILE_REQUESTED" },
   ];
@@ -324,6 +325,135 @@ describe("github_ops transition", () => {
         files: conflicted.files,
       },
     ]);
+  });
+
+  it("moves a resolved sync conflict to an explicit continuation state", () => {
+    const conflicted: GithubOpsState = {
+      type: "conflicted",
+      files: ["src/conflicted.ts"],
+      origin: { type: "push", mode: "normal" },
+      banner: null,
+    };
+
+    const resolving = transition(conflicted, {
+      type: "CONFLICT_RESOLUTION_STARTED",
+    });
+    expect(resolving.state).toEqual({
+      ...conflicted,
+      resolution: "resolving",
+    });
+
+    const reconciling = transition(resolving.state, {
+      type: "CONFLICT_RESOLUTION_FINISHED",
+    });
+    expect(commandsOf(reconciling)).toEqual([{ type: "probe-git-state" }]);
+    const checkedGitState = transition(reconciling.state, {
+      type: "GIT_STATE",
+      mergeInProgress: false,
+      rebaseInProgress: false,
+    });
+    const ready = transition(checkedGitState.state, {
+      type: "CONFLICTS",
+      files: [],
+    });
+    expect(ready.state).toEqual({
+      ...conflicted,
+      resolution: "ready-to-sync",
+    });
+
+    const continued = transition(ready.state, {
+      type: "OP_REQUESTED",
+      op: { type: "push", mode: "normal" },
+    });
+    expect(continued.state).toMatchObject({
+      type: "running",
+      op: { type: "push", mode: "normal" },
+    });
+  });
+
+  it("keeps ready-to-sync visible across repository reconciliation", () => {
+    const ready: GithubOpsState = {
+      type: "conflicted",
+      files: ["src/conflicted.ts"],
+      origin: { type: "push", mode: "normal" },
+      resolution: "ready-to-sync",
+      banner: null,
+    };
+
+    const gitState = transition(ready, {
+      type: "GIT_STATE",
+      mergeInProgress: false,
+      rebaseInProgress: false,
+    });
+    const conflicts = transition(gitState.state, {
+      type: "CONFLICTS",
+      files: [],
+    });
+
+    expect(conflicts.state).toBe(gitState.state);
+    expect(ignoreReasonOf(conflicts)).toBe("no-change");
+  });
+
+  it("uses the dedicated recovery surface without a duplicate banner or toast", () => {
+    const push = { type: "push", mode: "normal" } as const;
+    const running = transition(INITIAL_GITHUB_OPS_STATE, {
+      type: "OP_REQUESTED",
+      op: push,
+    }).state;
+    const probing = transition(running, {
+      type: "OP_FAILED",
+      op: push,
+      failure: {
+        kind: "conflict",
+        code: "MERGE_CONFLICT",
+        message: "merge conflict",
+      },
+    }).state;
+    const conflicted = transition(probing, {
+      type: "CONFLICTS",
+      files: ["src/conflicted.ts"],
+    });
+
+    expect(conflicted.state).toMatchObject({
+      type: "conflicted",
+      banner: null,
+    });
+    expect(commandsOf(conflicted)).toEqual([]);
+  });
+
+  it("returns to actionable conflicts when AI leaves conflicts unresolved", () => {
+    const resolving: GithubOpsState = {
+      type: "conflicted",
+      files: ["src/old.ts"],
+      origin: { type: "push", mode: "normal" },
+      resolution: "resolving",
+      banner: null,
+    };
+
+    const stillResolving = transition(resolving, {
+      type: "CONFLICTS",
+      files: ["src/still-conflicted.ts"],
+    });
+    expect(stillResolving.state).toEqual({
+      ...resolving,
+      files: ["src/still-conflicted.ts"],
+    });
+
+    const checking = transition(stillResolving.state, {
+      type: "CONFLICT_RESOLUTION_FINISHED",
+    });
+    expect(
+      transition(checking.state, {
+        type: "CONFLICTS",
+        files: ["src/still-conflicted.ts"],
+      }).state,
+    ).toEqual({
+      type: "conflicted",
+      files: ["src/still-conflicted.ts"],
+      origin: { type: "push", mode: "normal" },
+      resolution: undefined,
+      banner: null,
+    });
   });
 
   it("atomically clears conflicted UI when abort-and-switch begins", () => {

--- a/src/github_ops/transition.test.ts
+++ b/src/github_ops/transition.test.ts
@@ -116,6 +116,9 @@ function eventsFor(state: GithubOpsState): readonly GithubOpsEvent[] {
     ...(state.type === "conflicted" && state.resolution === "resolving"
       ? ([{ type: "CONFLICT_RESOLUTION_FINISHED" }] satisfies GithubOpsEvent[])
       : []),
+    ...(state.type === "conflicted" && state.resolution === "checking"
+      ? ([{ type: "CONFLICT_VERIFICATION_FAILED" }] satisfies GithubOpsEvent[])
+      : []),
     { type: "BANNER_DISMISSED" },
     { type: "RECONCILE_REQUESTED" },
   ];
@@ -390,6 +393,37 @@ describe("github_ops transition", () => {
 
     expect(result.state).toBe(resolving);
     expect(ignoreReasonOf(result)).toBe("no-change");
+  });
+
+  it("offers an explicit retry when conflict verification fails", () => {
+    const checking: GithubOpsState = {
+      type: "conflicted",
+      files: ["src/conflicted.ts"],
+      origin: { type: "push", mode: "normal" },
+      resolution: "checking",
+      resolutionChatId: 42,
+      banner: null,
+    };
+
+    const failed = transition(checking, {
+      type: "CONFLICT_VERIFICATION_FAILED",
+    });
+    expect(failed.state).toEqual({
+      ...checking,
+      resolution: "verification-failed",
+    });
+    expect(commandsOf(failed)).toEqual([]);
+
+    const ambientProbe = transition(failed.state, {
+      type: "CONFLICTS",
+      files: [],
+    });
+    expect(ambientProbe.state).toBe(failed.state);
+    expect(ignoreReasonOf(ambientProbe)).toBe("no-change");
+
+    const retry = transition(failed.state, { type: "RECONCILE_REQUESTED" });
+    expect(retry.state).toEqual(checking);
+    expect(commandsOf(retry)).toEqual([{ type: "probe-git-state" }]);
   });
 
   it("continues an active rebase before pushing resolved changes", () => {

--- a/src/github_ops/transition.test.ts
+++ b/src/github_ops/transition.test.ts
@@ -132,10 +132,12 @@ function eventsFor(state: GithubOpsState): readonly GithubOpsEvent[] {
           {
             type: "CONFLICT_VERIFICATION_FAILED",
             verificationAttempt: state.verificationAttempt ?? 1,
+            message: "Could not verify the resolved conflicts",
           },
         ] satisfies GithubOpsEvent[])
       : []),
     { type: "BANNER_DISMISSED" },
+    { type: "RETRY_CONFLICT_VERIFICATION" },
     { type: "RECONCILE_REQUESTED" },
   ];
 }
@@ -450,10 +452,12 @@ describe("github_ops transition", () => {
     const failed = transition(checking, {
       type: "CONFLICT_VERIFICATION_FAILED",
       verificationAttempt: 1,
+      message: "temporary Git-state failure",
     });
     expect(failed.state).toEqual({
       ...checking,
       resolution: "verification-failed",
+      verificationError: "temporary Git-state failure",
     });
     expect(commandsOf(failed)).toEqual([]);
 
@@ -464,10 +468,13 @@ describe("github_ops transition", () => {
     expect(ambientProbe.state).toBe(failed.state);
     expect(ignoreReasonOf(ambientProbe)).toBe("no-change");
 
-    const retry = transition(failed.state, { type: "RECONCILE_REQUESTED" });
+    const retry = transition(failed.state, {
+      type: "RETRY_CONFLICT_VERIFICATION",
+    });
     expect(retry.state).toEqual({
       ...checking,
       verificationAttempt: 2,
+      verificationError: undefined,
     });
     expect(commandsOf(retry)).toEqual([
       { type: "probe-git-state", verificationAttempt: 2 },
@@ -485,7 +492,11 @@ describe("github_ops transition", () => {
       banner: null,
     };
     const staleEvents: GithubOpsEvent[] = [
-      { type: "CONFLICT_VERIFICATION_FAILED", verificationAttempt: 1 },
+      {
+        type: "CONFLICT_VERIFICATION_FAILED",
+        verificationAttempt: 1,
+        message: "stale failure",
+      },
       {
         type: "GIT_STATE",
         mergeInProgress: false,
@@ -575,7 +586,7 @@ describe("github_ops transition", () => {
     expect(ignoreReasonOf(conflicts)).toBe("no-change");
   });
 
-  it("uses the dedicated recovery surface without a duplicate banner or toast", () => {
+  it("uses the dedicated recovery surface with one background-sync notice", () => {
     const push = { type: "push", mode: "normal" } as const;
     const running = transition(INITIAL_GITHUB_OPS_STATE, {
       type: "OP_REQUESTED",
@@ -599,7 +610,13 @@ describe("github_ops transition", () => {
       type: "conflicted",
       banner: null,
     });
-    expect(commandsOf(conflicted)).toEqual([]);
+    expect(commandsOf(conflicted)).toEqual([
+      {
+        type: "notify",
+        kind: "info",
+        message: "Sync paused. Resolve merge conflicts to continue.",
+      },
+    ]);
   });
 
   it("returns to actionable conflicts when AI leaves conflicts unresolved", () => {

--- a/src/github_ops/transition.test.ts
+++ b/src/github_ops/transition.test.ts
@@ -113,6 +113,9 @@ function eventsFor(state: GithubOpsState): readonly GithubOpsEvent[] {
     { type: "BLOCKED_DISMISSED" },
     { type: "RESOLVE_WITH_AI_STARTED" },
     { type: "CONFLICT_RESOLUTION_STARTED", chatId: 42 },
+    ...(state.type === "conflicted" && state.resolution === "resolving"
+      ? ([{ type: "CONFLICT_RESOLUTION_FINISHED" }] satisfies GithubOpsEvent[])
+      : []),
     { type: "BANNER_DISMISSED" },
     { type: "RECONCILE_REQUESTED" },
   ];
@@ -125,7 +128,7 @@ describe("github_ops transition", () => {
       events: eventsFor,
       transition,
       stateKey: JSON.stringify,
-      maxStates: 500,
+      maxStates: 2_000,
     };
     assertAllStatesReachable({
       ...options,
@@ -145,7 +148,7 @@ describe("github_ops transition", () => {
       events: eventsFor,
       transition,
       stateKey: (state) => JSON.stringify(state),
-      maxStates: 500,
+      maxStates: 2_000,
     });
     const states = graph.nodes.map(({ state }) => state);
 

--- a/src/github_ops/transition.test.ts
+++ b/src/github_ops/transition.test.ts
@@ -112,7 +112,7 @@ function eventsFor(state: GithubOpsState): readonly GithubOpsEvent[] {
     { type: "ABORT_AND_SWITCH_CONFIRMED" },
     { type: "BLOCKED_DISMISSED" },
     { type: "RESOLVE_WITH_AI_STARTED" },
-    { type: "CONFLICT_RESOLUTION_STARTED" },
+    { type: "CONFLICT_RESOLUTION_STARTED", chatId: 42 },
     { type: "BANNER_DISMISSED" },
     { type: "RECONCILE_REQUESTED" },
   ];
@@ -337,10 +337,12 @@ describe("github_ops transition", () => {
 
     const resolving = transition(conflicted, {
       type: "CONFLICT_RESOLUTION_STARTED",
+      chatId: 42,
     });
     expect(resolving.state).toEqual({
       ...conflicted,
       resolution: "resolving",
+      resolutionChatId: 42,
     });
 
     const reconciling = transition(resolving.state, {
@@ -359,6 +361,7 @@ describe("github_ops transition", () => {
     expect(ready.state).toEqual({
       ...conflicted,
       resolution: "ready-to-sync",
+      resolutionChatId: 42,
     });
 
     const continued = transition(ready.state, {
@@ -368,6 +371,71 @@ describe("github_ops transition", () => {
     expect(continued.state).toMatchObject({
       type: "running",
       op: { type: "push", mode: "normal" },
+    });
+  });
+
+  it("keeps ambient clean probes in resolving until the chat finishes", () => {
+    const resolving: GithubOpsState = {
+      type: "conflicted",
+      files: ["src/conflicted.ts"],
+      origin: { type: "push", mode: "normal" },
+      resolution: "resolving",
+      banner: null,
+    };
+
+    const result = transition(resolving, { type: "CONFLICTS", files: [] });
+
+    expect(result.state).toBe(resolving);
+    expect(ignoreReasonOf(result)).toBe("no-change");
+  });
+
+  it("continues an active rebase before pushing resolved changes", () => {
+    const checking: GithubOpsState = {
+      type: "conflicted",
+      files: ["src/conflicted.ts"],
+      origin: { type: "rebase" },
+      resolution: "checking",
+      banner: null,
+    };
+    const gitState = transition(checking, {
+      type: "GIT_STATE",
+      mergeInProgress: false,
+      rebaseInProgress: true,
+    });
+    const ready = transition(gitState.state, {
+      type: "CONFLICTS",
+      files: [],
+    });
+    const continued = transition(ready.state, {
+      type: "OP_REQUESTED",
+      op: { type: "rebase-continue" },
+    });
+
+    expect(continued.state).toMatchObject({
+      type: "running",
+      op: { type: "rebase-continue" },
+      next: { type: "push", mode: "normal" },
+    });
+  });
+
+  it("pushes directly when the AI already completed the rebase", () => {
+    const checking: GithubOpsState = {
+      type: "conflicted",
+      files: ["src/conflicted.ts"],
+      origin: { type: "rebase" },
+      resolution: "checking",
+      banner: null,
+    };
+
+    const gitState = transition(checking, {
+      type: "GIT_STATE",
+      mergeInProgress: false,
+      rebaseInProgress: false,
+    });
+
+    expect(gitState.state).toMatchObject({
+      type: "conflicted",
+      origin: { type: "push", mode: "normal" },
     });
   });
 

--- a/src/github_ops/transition.ts
+++ b/src/github_ops/transition.ts
@@ -27,7 +27,7 @@ export function transition(
     case "OP_FAILED":
       return operationFailed(state, event.op, event.failure);
     case "CONFLICTS":
-      return conflictsReceived(state, event.files);
+      return conflictsReceived(state, event);
     case "GIT_STATE":
       return gitStateReceived(state, event);
     case "ABORT_AND_SWITCH_CONFIRMED":
@@ -39,9 +39,9 @@ export function transition(
     case "CONFLICT_RESOLUTION_STARTED":
       return conflictResolutionStarted(state, event.chatId);
     case "CONFLICT_RESOLUTION_FINISHED":
-      return conflictResolutionFinished(state);
+      return conflictResolutionFinished(state, event.chatId);
     case "CONFLICT_VERIFICATION_FAILED":
-      return conflictVerificationFailed(state);
+      return conflictVerificationFailed(state, event.verificationAttempt);
     case "BANNER_DISMISSED":
       return dismissBanner(state);
     case "RECONCILE_REQUESTED":
@@ -256,8 +256,16 @@ function awaitConflicts(
 
 function conflictsReceived(
   state: GithubOpsState,
-  files: readonly string[],
+  event: Extract<GithubOpsEvent, { type: "CONFLICTS" }>,
 ): GithubOpsTransitionResult {
+  const { files } = event;
+  if (
+    state.type === "conflicted" &&
+    state.resolution === "checking" &&
+    state.verificationAttempt !== event.verificationAttempt
+  ) {
+    return ignore(state, "stale-op");
+  }
   switch (state.type) {
     case "running": {
       if (!state.awaitingConflicts) return ignore(state, "no-change");
@@ -339,6 +347,7 @@ function conflictsReceived(
             files,
             resolution: undefined,
             resolutionChatId: undefined,
+            verificationAttempt: undefined,
             banner: null,
           });
     case "rebase-paused":
@@ -358,6 +367,13 @@ function gitStateReceived(
   state: GithubOpsState,
   event: Extract<GithubOpsEvent, { type: "GIT_STATE" }>,
 ): GithubOpsTransitionResult {
+  if (
+    state.type === "conflicted" &&
+    state.resolution === "checking" &&
+    state.verificationAttempt !== event.verificationAttempt
+  ) {
+    return ignore(state, "stale-op");
+  }
   switch (state.type) {
     case "running":
       return ignore(state, "op-in-flight");
@@ -384,7 +400,12 @@ function gitStateReceived(
       return {
         kind: "applied",
         state: nextState,
-        commands: [{ type: "probe-conflicts" }],
+        commands: [
+          {
+            type: "probe-conflicts",
+            verificationAttempt: event.verificationAttempt,
+          },
+        ],
       };
     }
     case "idle":
@@ -497,16 +518,21 @@ function conflictResolutionStarted(
 
 function conflictResolutionFinished(
   state: GithubOpsState,
+  chatId: number,
 ): GithubOpsTransitionResult {
   switch (state.type) {
     case "conflicted":
       if (state.resolution !== "resolving") {
         return ignore(state, "invalid-in-current-state");
       }
+      if (state.resolutionChatId !== chatId) {
+        return ignore(state, "stale-op");
+      }
+      const verificationAttempt = (state.verificationAttempt ?? 0) + 1;
       return {
         kind: "applied",
-        state: { ...state, resolution: "checking" },
-        commands: [{ type: "probe-git-state" }],
+        state: { ...state, resolution: "checking", verificationAttempt },
+        commands: [{ type: "probe-git-state", verificationAttempt }],
       };
     case "idle":
     case "running":
@@ -520,12 +546,16 @@ function conflictResolutionFinished(
 
 function conflictVerificationFailed(
   state: GithubOpsState,
+  verificationAttempt: number,
 ): GithubOpsTransitionResult {
   switch (state.type) {
     case "conflicted":
-      return state.resolution === "checking"
+      if (state.resolution !== "checking") {
+        return ignore(state, "invalid-in-current-state");
+      }
+      return state.verificationAttempt === verificationAttempt
         ? changed({ ...state, resolution: "verification-failed" })
-        : ignore(state, "invalid-in-current-state");
+        : ignore(state, "stale-op");
     case "idle":
     case "running":
     case "rebase-paused":
@@ -561,16 +591,25 @@ function reconcile(state: GithubOpsState): GithubOpsTransitionResult {
       };
     case "conflicted":
       if (state.resolution === "verification-failed") {
+        const verificationAttempt = (state.verificationAttempt ?? 0) + 1;
         return {
           kind: "applied",
-          state: { ...state, resolution: "checking" },
-          commands: [{ type: "probe-git-state" }],
+          state: { ...state, resolution: "checking", verificationAttempt },
+          commands: [{ type: "probe-git-state", verificationAttempt }],
         };
       }
       return {
         kind: "applied",
         state,
-        commands: [{ type: "probe-git-state" }],
+        commands: [
+          {
+            type: "probe-git-state",
+            verificationAttempt:
+              state.resolution === "checking"
+                ? state.verificationAttempt
+                : undefined,
+          },
+        ],
       };
     case "rebase-paused":
     case "switch-blocked":

--- a/src/github_ops/transition.ts
+++ b/src/github_ops/transition.ts
@@ -36,6 +36,10 @@ export function transition(
       return dismissBlocked(state);
     case "RESOLVE_WITH_AI_STARTED":
       return startResolvingConflicts(state);
+    case "CONFLICT_RESOLUTION_STARTED":
+      return conflictResolutionStarted(state);
+    case "CONFLICT_RESOLUTION_FINISHED":
+      return conflictResolutionFinished(state);
     case "BANNER_DISMISSED":
       return dismissBanner(state);
     case "RECONCILE_REQUESTED":
@@ -55,6 +59,15 @@ function requestOperation(
     case "running":
       return ignore(state, "op-in-flight");
     case "conflicted":
+      if (state.resolution === "resolving" || state.resolution === "checking") {
+        return ignore(state, "op-in-flight");
+      }
+      if (state.resolution === "ready-to-sync") {
+        const continuation = continuationOperation(state.origin);
+        return continuation && operationsEqual(op, continuation)
+          ? beginOperation(state, op)
+          : ignore(state, "blocked-by-conflicts");
+      }
       return op.type === "merge-abort" ||
         op.type === "rebase-abort" ||
         op.type === "switch"
@@ -256,7 +269,7 @@ function conflictsReceived(
             : [],
         };
       }
-      return enterConflicted(files, state.op, true);
+      return enterConflicted(files, state.op);
     }
     case "switch-blocked": {
       const hasConflicts = files.length > 0;
@@ -280,18 +293,45 @@ function conflictsReceived(
     }
     case "conflicted":
       if (files.length === 0) {
-        return changed({ type: "idle", banner: state.banner });
+        if (state.resolution === "ready-to-sync") {
+          return ignore(state, "no-change");
+        }
+        const continuation = continuationOperation(state.origin);
+        return (state.resolution === "resolving" ||
+          state.resolution === "checking") &&
+          continuation
+          ? changed({
+              ...state,
+              resolution: "ready-to-sync",
+              banner: null,
+            })
+          : changed({
+              type: "idle",
+              banner:
+                state.resolution === "resolving" ||
+                state.resolution === "checking"
+                  ? {
+                      kind: "success",
+                      message: "Merge conflicts resolved.",
+                    }
+                  : state.banner,
+            });
       }
-      return sameFiles(state.files, files)
+      if (state.resolution === "resolving") {
+        return sameFiles(state.files, files)
+          ? ignore(state, "no-change")
+          : changed({ ...state, files });
+      }
+      return sameFiles(state.files, files) && state.resolution === undefined
         ? ignore(state, "no-change")
-        : changed({ ...state, files });
+        : changed({ ...state, files, resolution: undefined, banner: null });
     case "rebase-paused":
       return files.length > 0
-        ? enterConflicted(files, { type: "rebase" }, false)
+        ? enterConflicted(files, { type: "rebase" })
         : ignore(state, "no-change");
     case "idle":
       return files.length > 0
-        ? enterConflicted(files, { type: "reconcile" }, false)
+        ? enterConflicted(files, { type: "reconcile" })
         : ignore(state, "no-change");
     default:
       return assertNever(state);
@@ -313,10 +353,10 @@ function gitStateReceived(
       };
     case "conflicted": {
       const nextOrigin: ConflictOrigin = event.rebaseInProgress
-        ? isRebaseConflictOrigin(state.origin)
+        ? state.resolution !== undefined || isRebaseConflictOrigin(state.origin)
           ? state.origin
           : { type: "rebase" }
-        : isRebaseConflictOrigin(state.origin)
+        : state.resolution === undefined && isRebaseConflictOrigin(state.origin)
           ? { type: "reconcile" }
           : state.origin;
       const nextState =
@@ -387,6 +427,9 @@ function startResolvingConflicts(
 ): GithubOpsTransitionResult {
   switch (state.type) {
     case "conflicted":
+      if (state.resolution !== undefined) {
+        return ignore(state, "invalid-in-current-state");
+      }
       return {
         kind: "applied",
         state,
@@ -396,6 +439,48 @@ function startResolvingConflicts(
             files: state.files,
           },
         ],
+      };
+    case "idle":
+    case "running":
+    case "rebase-paused":
+    case "switch-blocked":
+      return ignore(state, "invalid-in-current-state");
+    default:
+      return assertNever(state);
+  }
+}
+
+function conflictResolutionStarted(
+  state: GithubOpsState,
+): GithubOpsTransitionResult {
+  switch (state.type) {
+    case "conflicted":
+      if (state.resolution !== undefined) {
+        return ignore(state, "invalid-in-current-state");
+      }
+      return changed({ ...state, resolution: "resolving", banner: null });
+    case "idle":
+    case "running":
+    case "rebase-paused":
+    case "switch-blocked":
+      return ignore(state, "invalid-in-current-state");
+    default:
+      return assertNever(state);
+  }
+}
+
+function conflictResolutionFinished(
+  state: GithubOpsState,
+): GithubOpsTransitionResult {
+  switch (state.type) {
+    case "conflicted":
+      if (state.resolution !== "resolving") {
+        return ignore(state, "invalid-in-current-state");
+      }
+      return {
+        kind: "applied",
+        state: { ...state, resolution: "checking" },
+        commands: [{ type: "probe-git-state" }],
       };
     case "idle":
     case "running":
@@ -467,32 +552,44 @@ function abortAndSwitch(state: GithubOpsState): GithubOpsTransitionResult {
 function enterConflicted(
   files: readonly string[],
   origin: ConflictOrigin,
-  notify: boolean,
 ): GithubOpsTransitionResult {
-  const message =
-    "Merge conflicts detected. Use the buttons below to resolve them.";
   return {
     kind: "applied",
     state: {
       type: "conflicted",
       files,
       origin,
-      banner: {
-        kind: "error",
-        code: "MERGE_CONFLICT",
-        message,
-      },
+      banner: null,
     },
-    commands: notify
-      ? [
-          {
-            type: "notify",
-            kind: "error",
-            message: "Merge conflicts detected while syncing to GitHub.",
-          },
-        ]
-      : [],
+    commands: [],
   };
+}
+
+function continuationOperation(
+  origin: ConflictOrigin,
+): GithubOperation | undefined {
+  switch (origin.type) {
+    case "push":
+      return origin;
+    case "rebase":
+    case "rebase-continue":
+      return PUSH_NORMAL;
+    case "reconcile":
+    case "pull":
+    case "fetch":
+    case "rebase-abort":
+    case "merge-abort":
+    case "merge":
+    case "switch":
+    case "create-branch":
+    case "delete-branch":
+    case "rename-branch":
+    case "disconnect":
+    case "connect-repo":
+      return undefined;
+    default:
+      return assertNever(origin);
+  }
 }
 
 function isRebaseOperation(op: GithubOperation): boolean {

--- a/src/github_ops/transition.ts
+++ b/src/github_ops/transition.ts
@@ -586,7 +586,7 @@ function enterConflicted(
   };
 }
 
-function continuationOperation(
+export function continuationOperation(
   origin: ConflictOrigin,
 ): GithubOperation | undefined {
   switch (origin.type) {

--- a/src/github_ops/transition.ts
+++ b/src/github_ops/transition.ts
@@ -41,7 +41,13 @@ export function transition(
     case "CONFLICT_RESOLUTION_FINISHED":
       return conflictResolutionFinished(state, event.chatId);
     case "CONFLICT_VERIFICATION_FAILED":
-      return conflictVerificationFailed(state, event.verificationAttempt);
+      return conflictVerificationFailed(
+        state,
+        event.verificationAttempt,
+        event.message,
+      );
+    case "RETRY_CONFLICT_VERIFICATION":
+      return retryConflictVerification(state);
     case "BANNER_DISMISSED":
       return dismissBanner(state);
     case "RECONCILE_REQUESTED":
@@ -65,6 +71,13 @@ function requestOperation(
         return ignore(state, "op-in-flight");
       }
       if (state.resolution === "ready-to-sync") {
+        if (
+          op.type === "merge-abort" ||
+          op.type === "rebase-abort" ||
+          op.type === "switch"
+        ) {
+          return beginOperation(state, op);
+        }
         const continuation = continuationOperation(state.origin);
         return continuation && operationsEqual(op, continuation)
           ? beginOperation(
@@ -284,7 +297,7 @@ function conflictsReceived(
             : [],
         };
       }
-      return enterConflicted(files, state.op);
+      return enterConflicted(files, state.op, true);
     }
     case "switch-blocked": {
       const hasConflicts = files.length > 0;
@@ -322,6 +335,7 @@ function conflictsReceived(
           ? changed({
               ...state,
               resolution: "ready-to-sync",
+              verificationError: undefined,
               banner: null,
             })
           : changed({
@@ -348,15 +362,16 @@ function conflictsReceived(
             resolution: undefined,
             resolutionChatId: undefined,
             verificationAttempt: undefined,
+            verificationError: undefined,
             banner: null,
           });
     case "rebase-paused":
       return files.length > 0
-        ? enterConflicted(files, { type: "rebase" })
+        ? enterConflicted(files, { type: "rebase" }, false)
         : ignore(state, "no-change");
     case "idle":
       return files.length > 0
-        ? enterConflicted(files, { type: "reconcile" })
+        ? enterConflicted(files, { type: "reconcile" }, false)
         : ignore(state, "no-change");
     default:
       return assertNever(state);
@@ -504,6 +519,7 @@ function conflictResolutionStarted(
         ...state,
         resolution: "resolving",
         resolutionChatId: chatId,
+        verificationError: undefined,
         banner: null,
       });
     case "idle":
@@ -531,7 +547,12 @@ function conflictResolutionFinished(
       const verificationAttempt = (state.verificationAttempt ?? 0) + 1;
       return {
         kind: "applied",
-        state: { ...state, resolution: "checking", verificationAttempt },
+        state: {
+          ...state,
+          resolution: "checking",
+          verificationAttempt,
+          verificationError: undefined,
+        },
         commands: [{ type: "probe-git-state", verificationAttempt }],
       };
     case "idle":
@@ -547,6 +568,7 @@ function conflictResolutionFinished(
 function conflictVerificationFailed(
   state: GithubOpsState,
   verificationAttempt: number,
+  message: string,
 ): GithubOpsTransitionResult {
   switch (state.type) {
     case "conflicted":
@@ -554,8 +576,42 @@ function conflictVerificationFailed(
         return ignore(state, "invalid-in-current-state");
       }
       return state.verificationAttempt === verificationAttempt
-        ? changed({ ...state, resolution: "verification-failed" })
+        ? changed({
+            ...state,
+            resolution: "verification-failed",
+            verificationError: message,
+          })
         : ignore(state, "stale-op");
+    case "idle":
+    case "running":
+    case "rebase-paused":
+    case "switch-blocked":
+      return ignore(state, "invalid-in-current-state");
+    default:
+      return assertNever(state);
+  }
+}
+
+function retryConflictVerification(
+  state: GithubOpsState,
+): GithubOpsTransitionResult {
+  switch (state.type) {
+    case "conflicted": {
+      if (state.resolution !== "verification-failed") {
+        return ignore(state, "invalid-in-current-state");
+      }
+      const verificationAttempt = (state.verificationAttempt ?? 0) + 1;
+      return {
+        kind: "applied",
+        state: {
+          ...state,
+          resolution: "checking",
+          verificationAttempt,
+          verificationError: undefined,
+        },
+        commands: [{ type: "probe-git-state", verificationAttempt }],
+      };
+    }
     case "idle":
     case "running":
     case "rebase-paused":
@@ -591,12 +647,7 @@ function reconcile(state: GithubOpsState): GithubOpsTransitionResult {
       };
     case "conflicted":
       if (state.resolution === "verification-failed") {
-        const verificationAttempt = (state.verificationAttempt ?? 0) + 1;
-        return {
-          kind: "applied",
-          state: { ...state, resolution: "checking", verificationAttempt },
-          commands: [{ type: "probe-git-state", verificationAttempt }],
-        };
+        return ignore(state, "no-change");
       }
       return {
         kind: "applied",
@@ -652,6 +703,7 @@ function abortAndSwitch(state: GithubOpsState): GithubOpsTransitionResult {
 function enterConflicted(
   files: readonly string[],
   origin: ConflictOrigin,
+  notify: boolean,
 ): GithubOpsTransitionResult {
   return {
     kind: "applied",
@@ -661,7 +713,15 @@ function enterConflicted(
       origin,
       banner: null,
     },
-    commands: [],
+    commands: notify
+      ? [
+          {
+            type: "notify",
+            kind: "info",
+            message: "Sync paused. Resolve merge conflicts to continue.",
+          },
+        ]
+      : [],
   };
 }
 

--- a/src/github_ops/transition.ts
+++ b/src/github_ops/transition.ts
@@ -37,7 +37,7 @@ export function transition(
     case "RESOLVE_WITH_AI_STARTED":
       return startResolvingConflicts(state);
     case "CONFLICT_RESOLUTION_STARTED":
-      return conflictResolutionStarted(state);
+      return conflictResolutionStarted(state, event.chatId);
     case "CONFLICT_RESOLUTION_FINISHED":
       return conflictResolutionFinished(state);
     case "BANNER_DISMISSED":
@@ -65,7 +65,11 @@ function requestOperation(
       if (state.resolution === "ready-to-sync") {
         const continuation = continuationOperation(state.origin);
         return continuation && operationsEqual(op, continuation)
-          ? beginOperation(state, op)
+          ? beginOperation(
+              state,
+              op,
+              continuation.type === "rebase-continue" ? PUSH_NORMAL : undefined,
+            )
           : ignore(state, "blocked-by-conflicts");
       }
       return op.type === "merge-abort" ||
@@ -90,8 +94,9 @@ function requestOperation(
 function beginOperation(
   state: GithubOpsState,
   op: GithubOperation,
+  nextOverride?: GithubOperation,
 ): GithubOpsTransitionResult {
-  const next = compositeNext(op);
+  const next = nextOverride ?? compositeNext(op);
   const blockedSwitchResume =
     op.type === "switch" ? getBlockedSwitchResume(state) : undefined;
   return {
@@ -296,10 +301,11 @@ function conflictsReceived(
         if (state.resolution === "ready-to-sync") {
           return ignore(state, "no-change");
         }
+        if (state.resolution === "resolving") {
+          return ignore(state, "no-change");
+        }
         const continuation = continuationOperation(state.origin);
-        return (state.resolution === "resolving" ||
-          state.resolution === "checking") &&
-          continuation
+        return state.resolution === "checking" && continuation
           ? changed({
               ...state,
               resolution: "ready-to-sync",
@@ -308,7 +314,6 @@ function conflictsReceived(
           : changed({
               type: "idle",
               banner:
-                state.resolution === "resolving" ||
                 state.resolution === "checking"
                   ? {
                       kind: "success",
@@ -324,7 +329,13 @@ function conflictsReceived(
       }
       return sameFiles(state.files, files) && state.resolution === undefined
         ? ignore(state, "no-change")
-        : changed({ ...state, files, resolution: undefined, banner: null });
+        : changed({
+            ...state,
+            files,
+            resolution: undefined,
+            resolutionChatId: undefined,
+            banner: null,
+          });
     case "rebase-paused":
       return files.length > 0
         ? enterConflicted(files, { type: "rebase" })
@@ -356,9 +367,13 @@ function gitStateReceived(
         ? state.resolution !== undefined || isRebaseConflictOrigin(state.origin)
           ? state.origin
           : { type: "rebase" }
-        : state.resolution === undefined && isRebaseConflictOrigin(state.origin)
-          ? { type: "reconcile" }
-          : state.origin;
+        : state.resolution !== undefined &&
+            isResumableRebaseOrigin(state.origin)
+          ? PUSH_NORMAL
+          : state.resolution === undefined &&
+              isRebaseConflictOrigin(state.origin)
+            ? { type: "reconcile" }
+            : state.origin;
       const nextState =
         nextOrigin === state.origin ? state : { ...state, origin: nextOrigin };
       return {
@@ -452,13 +467,19 @@ function startResolvingConflicts(
 
 function conflictResolutionStarted(
   state: GithubOpsState,
+  chatId: number,
 ): GithubOpsTransitionResult {
   switch (state.type) {
     case "conflicted":
       if (state.resolution !== undefined) {
         return ignore(state, "invalid-in-current-state");
       }
-      return changed({ ...state, resolution: "resolving", banner: null });
+      return changed({
+        ...state,
+        resolution: "resolving",
+        resolutionChatId: chatId,
+        banner: null,
+      });
     case "idle":
     case "running":
     case "rebase-paused":
@@ -573,7 +594,7 @@ function continuationOperation(
       return origin;
     case "rebase":
     case "rebase-continue":
-      return PUSH_NORMAL;
+      return { type: "rebase-continue" };
     case "reconcile":
     case "pull":
     case "fetch":
@@ -602,6 +623,10 @@ function isRebaseOperation(op: GithubOperation): boolean {
 
 function isRebaseConflictOrigin(origin: ConflictOrigin): boolean {
   return origin.type !== "reconcile" && isRebaseOperation(origin);
+}
+
+function isResumableRebaseOrigin(origin: ConflictOrigin): boolean {
+  return origin.type === "rebase" || origin.type === "rebase-continue";
 }
 
 function blockedSwitch(

--- a/src/github_ops/transition.ts
+++ b/src/github_ops/transition.ts
@@ -40,6 +40,8 @@ export function transition(
       return conflictResolutionStarted(state, event.chatId);
     case "CONFLICT_RESOLUTION_FINISHED":
       return conflictResolutionFinished(state);
+    case "CONFLICT_VERIFICATION_FAILED":
+      return conflictVerificationFailed(state);
     case "BANNER_DISMISSED":
       return dismissBanner(state);
     case "RECONCILE_REQUESTED":
@@ -304,6 +306,9 @@ function conflictsReceived(
         if (state.resolution === "resolving") {
           return ignore(state, "no-change");
         }
+        if (state.resolution === "verification-failed") {
+          return ignore(state, "no-change");
+        }
         const continuation = continuationOperation(state.origin);
         return state.resolution === "checking" && continuation
           ? changed({
@@ -513,6 +518,24 @@ function conflictResolutionFinished(
   }
 }
 
+function conflictVerificationFailed(
+  state: GithubOpsState,
+): GithubOpsTransitionResult {
+  switch (state.type) {
+    case "conflicted":
+      return state.resolution === "checking"
+        ? changed({ ...state, resolution: "verification-failed" })
+        : ignore(state, "invalid-in-current-state");
+    case "idle":
+    case "running":
+    case "rebase-paused":
+    case "switch-blocked":
+      return ignore(state, "invalid-in-current-state");
+    default:
+      return assertNever(state);
+  }
+}
+
 function dismissBanner(state: GithubOpsState): GithubOpsTransitionResult {
   switch (state.type) {
     case "idle":
@@ -531,7 +554,24 @@ function dismissBanner(state: GithubOpsState): GithubOpsTransitionResult {
 function reconcile(state: GithubOpsState): GithubOpsTransitionResult {
   switch (state.type) {
     case "idle":
+      return {
+        kind: "applied",
+        state,
+        commands: [{ type: "probe-git-state" }],
+      };
     case "conflicted":
+      if (state.resolution === "verification-failed") {
+        return {
+          kind: "applied",
+          state: { ...state, resolution: "checking" },
+          commands: [{ type: "probe-git-state" }],
+        };
+      }
+      return {
+        kind: "applied",
+        state,
+        commands: [{ type: "probe-git-state" }],
+      };
     case "rebase-paused":
     case "switch-blocked":
       return {

--- a/src/github_ops/transport.test.ts
+++ b/src/github_ops/transport.test.ts
@@ -34,12 +34,24 @@ describe("github_ops wire contracts", () => {
         callback: () => undefined,
       }).success,
     ).toBe(false);
+    expect(
+      GithubOpsIntentEventSchema.safeParse({
+        type: "CONFLICT_RESOLUTION_FINISHED",
+        chatId: 42,
+      }).success,
+    ).toBe(true);
+    expect(
+      GithubOpsIntentEventSchema.safeParse({
+        type: "CONFLICT_RESOLUTION_FINISHED",
+      }).success,
+    ).toBe(false);
   });
 
   it("rejects Error instances and absolute conflict paths", () => {
     expect(
       GithubOpsProducerEventSchema.safeParse({
         type: "CONFLICT_VERIFICATION_FAILED",
+        verificationAttempt: 1,
       }).success,
     ).toBe(true);
     expect(

--- a/src/github_ops/transport.test.ts
+++ b/src/github_ops/transport.test.ts
@@ -52,6 +52,7 @@ describe("github_ops wire contracts", () => {
       GithubOpsProducerEventSchema.safeParse({
         type: "CONFLICT_VERIFICATION_FAILED",
         verificationAttempt: 1,
+        message: "Could not verify the resolved conflicts",
       }).success,
     ).toBe(true);
     expect(

--- a/src/github_ops/transport.test.ts
+++ b/src/github_ops/transport.test.ts
@@ -39,6 +39,11 @@ describe("github_ops wire contracts", () => {
   it("rejects Error instances and absolute conflict paths", () => {
     expect(
       GithubOpsProducerEventSchema.safeParse({
+        type: "CONFLICT_VERIFICATION_FAILED",
+      }).success,
+    ).toBe(true);
+    expect(
+      GithubOpsProducerEventSchema.safeParse({
         type: "OP_FAILED",
         op: { type: "pull" },
         failure: new Error("not encodable"),

--- a/src/github_ops/transport.ts
+++ b/src/github_ops/transport.ts
@@ -190,6 +190,7 @@ export const GithubOpsStateSchema: z.ZodType<GithubOpsState> =
           .optional(),
         resolutionChatId: z.number().int().positive().optional(),
         verificationAttempt: z.number().int().positive().optional(),
+        verificationError: z.string().max(1_000).optional(),
         banner: githubOpsBannerSchema.nullable(),
       })
       .strict(),
@@ -237,6 +238,7 @@ export const GithubOpsIntentEventSchema = z.union([
     .strict(),
   z.object({ type: z.literal("BANNER_DISMISSED") }).strict(),
   z.object({ type: z.literal("RECONCILE_REQUESTED") }).strict(),
+  z.object({ type: z.literal("RETRY_CONFLICT_VERIFICATION") }).strict(),
   z
     .object({
       type: z.literal("CONFLICT_RESOLUTION_STARTED"),
@@ -310,6 +312,7 @@ export const GithubOpsProducerEventSchema = z.union([
     .object({
       type: z.literal("CONFLICT_VERIFICATION_FAILED"),
       verificationAttempt: z.number().int().positive(),
+      message: z.string().max(1_000),
     })
     .strict(),
 ]);
@@ -375,6 +378,7 @@ export function isGithubOpsStateSensitiveIntent(
       return false;
     case "BANNER_DISMISSED":
     case "RECONCILE_REQUESTED":
+    case "RETRY_CONFLICT_VERIFICATION":
       return false;
   }
 }
@@ -401,6 +405,7 @@ export function toGithubOpsDomainEvent(
       return {
         type: "CONFLICT_VERIFICATION_FAILED",
         verificationAttempt: event.verificationAttempt,
+        message: event.message,
       };
     case "CONFLICT_RESOLUTION_CANCELLED":
       return { type: "RECONCILE_REQUESTED" };
@@ -411,6 +416,7 @@ export function toGithubOpsDomainEvent(
     case "RESOLVE_WITH_AI_STARTED":
     case "BANNER_DISMISSED":
     case "RECONCILE_REQUESTED":
+    case "RETRY_CONFLICT_VERIFICATION":
       return { type: event.type };
   }
 }

--- a/src/github_ops/transport.ts
+++ b/src/github_ops/transport.ts
@@ -181,7 +181,12 @@ export const GithubOpsStateSchema: z.ZodType<GithubOpsState> =
         files: z.array(repositoryRelativePathSchema),
         origin: conflictOriginSchema,
         resolution: z
-          .enum(["resolving", "checking", "ready-to-sync"])
+          .enum([
+            "resolving",
+            "checking",
+            "verification-failed",
+            "ready-to-sync",
+          ])
           .optional(),
         resolutionChatId: z.number().int().positive().optional(),
         banner: githubOpsBannerSchema.nullable(),
@@ -293,6 +298,7 @@ export const GithubOpsProducerEventSchema = z.union([
       claimId: conflictResolutionClaimIdSchema,
     })
     .strict(),
+  z.object({ type: z.literal("CONFLICT_VERIFICATION_FAILED") }).strict(),
 ]);
 export type GithubOpsProducerEvent = z.infer<
   typeof GithubOpsProducerEventSchema
@@ -378,6 +384,8 @@ export function toGithubOpsDomainEvent(
       return { type: "CONFLICT_RESOLUTION_STARTED", chatId: event.chatId };
     case "CONFLICT_RESOLUTION_FINISHED":
       return { type: "CONFLICT_RESOLUTION_FINISHED" };
+    case "CONFLICT_VERIFICATION_FAILED":
+      return { type: "CONFLICT_VERIFICATION_FAILED" };
     case "CONFLICT_RESOLUTION_CANCELLED":
       return { type: "RECONCILE_REQUESTED" };
     case "CONFLICT_RESOLUTION_CLAIM_EXPIRED":

--- a/src/github_ops/transport.ts
+++ b/src/github_ops/transport.ts
@@ -183,6 +183,7 @@ export const GithubOpsStateSchema: z.ZodType<GithubOpsState> =
         resolution: z
           .enum(["resolving", "checking", "ready-to-sync"])
           .optional(),
+        resolutionChatId: z.number().int().positive().optional(),
         banner: githubOpsBannerSchema.nullable(),
       })
       .strict(),
@@ -234,6 +235,7 @@ export const GithubOpsIntentEventSchema = z.union([
     .object({
       type: z.literal("CONFLICT_RESOLUTION_STARTED"),
       claimId: conflictResolutionClaimIdSchema,
+      chatId: z.number().int().positive(),
     })
     .strict(),
   z.object({ type: z.literal("CONFLICT_RESOLUTION_FINISHED") }).strict(),
@@ -373,7 +375,7 @@ export function toGithubOpsDomainEvent(
     case "GIT_STATE":
       return event;
     case "CONFLICT_RESOLUTION_STARTED":
-      return { type: "CONFLICT_RESOLUTION_STARTED" };
+      return { type: "CONFLICT_RESOLUTION_STARTED", chatId: event.chatId };
     case "CONFLICT_RESOLUTION_FINISHED":
       return { type: "CONFLICT_RESOLUTION_FINISHED" };
     case "CONFLICT_RESOLUTION_CANCELLED":

--- a/src/github_ops/transport.ts
+++ b/src/github_ops/transport.ts
@@ -180,6 +180,9 @@ export const GithubOpsStateSchema: z.ZodType<GithubOpsState> =
         type: z.literal("conflicted"),
         files: z.array(repositoryRelativePathSchema),
         origin: conflictOriginSchema,
+        resolution: z
+          .enum(["resolving", "checking", "ready-to-sync"])
+          .optional(),
         banner: githubOpsBannerSchema.nullable(),
       })
       .strict(),
@@ -233,6 +236,7 @@ export const GithubOpsIntentEventSchema = z.union([
       claimId: conflictResolutionClaimIdSchema,
     })
     .strict(),
+  z.object({ type: z.literal("CONFLICT_RESOLUTION_FINISHED") }).strict(),
   z
     .object({
       type: z.literal("CONFLICT_RESOLUTION_CANCELLED"),
@@ -343,9 +347,10 @@ export function isGithubOpsStateSensitiveIntent(
     case "RESOLVE_WITH_AI_STARTED":
       return true;
     case "CONFLICT_RESOLUTION_STARTED":
+    case "CONFLICT_RESOLUTION_FINISHED":
     case "CONFLICT_RESOLUTION_CANCELLED":
-      // The exact claim ID is the concurrency guard, so a follow-up remains
-      // safe even when its renderer has not received the claim snapshot yet.
+      // Follow-ups validate their expected phase (and, while claiming, the
+      // exact claim ID), so they remain safe from a stale renderer snapshot.
       return false;
     case "BANNER_DISMISSED":
     case "RECONCILE_REQUESTED":
@@ -368,7 +373,9 @@ export function toGithubOpsDomainEvent(
     case "GIT_STATE":
       return event;
     case "CONFLICT_RESOLUTION_STARTED":
-      return { type: "CONFLICTS", files: [] };
+      return { type: "CONFLICT_RESOLUTION_STARTED" };
+    case "CONFLICT_RESOLUTION_FINISHED":
+      return { type: "CONFLICT_RESOLUTION_FINISHED" };
     case "CONFLICT_RESOLUTION_CANCELLED":
       return { type: "RECONCILE_REQUESTED" };
     case "CONFLICT_RESOLUTION_CLAIM_EXPIRED":

--- a/src/github_ops/transport.ts
+++ b/src/github_ops/transport.ts
@@ -189,6 +189,7 @@ export const GithubOpsStateSchema: z.ZodType<GithubOpsState> =
           ])
           .optional(),
         resolutionChatId: z.number().int().positive().optional(),
+        verificationAttempt: z.number().int().positive().optional(),
         banner: githubOpsBannerSchema.nullable(),
       })
       .strict(),
@@ -243,7 +244,12 @@ export const GithubOpsIntentEventSchema = z.union([
       chatId: z.number().int().positive(),
     })
     .strict(),
-  z.object({ type: z.literal("CONFLICT_RESOLUTION_FINISHED") }).strict(),
+  z
+    .object({
+      type: z.literal("CONFLICT_RESOLUTION_FINISHED"),
+      chatId: z.number().int().positive(),
+    })
+    .strict(),
   z
     .object({
       type: z.literal("CONFLICT_RESOLUTION_CANCELLED"),
@@ -282,6 +288,7 @@ export const GithubOpsProducerEventSchema = z.union([
       type: z.literal("CONFLICTS"),
       files: z.array(repositoryRelativePathSchema),
       recoveryInvocationRef: GithubOpsInvocationRefSchema.optional(),
+      verificationAttempt: z.number().int().positive().optional(),
     })
     .strict(),
   z
@@ -290,6 +297,7 @@ export const GithubOpsProducerEventSchema = z.union([
       mergeInProgress: z.boolean(),
       rebaseInProgress: z.boolean(),
       recoveryInvocationRef: GithubOpsInvocationRefSchema.optional(),
+      verificationAttempt: z.number().int().positive().optional(),
     })
     .strict(),
   z
@@ -298,7 +306,12 @@ export const GithubOpsProducerEventSchema = z.union([
       claimId: conflictResolutionClaimIdSchema,
     })
     .strict(),
-  z.object({ type: z.literal("CONFLICT_VERIFICATION_FAILED") }).strict(),
+  z
+    .object({
+      type: z.literal("CONFLICT_VERIFICATION_FAILED"),
+      verificationAttempt: z.number().int().positive(),
+    })
+    .strict(),
 ]);
 export type GithubOpsProducerEvent = z.infer<
   typeof GithubOpsProducerEventSchema
@@ -383,9 +396,12 @@ export function toGithubOpsDomainEvent(
     case "CONFLICT_RESOLUTION_STARTED":
       return { type: "CONFLICT_RESOLUTION_STARTED", chatId: event.chatId };
     case "CONFLICT_RESOLUTION_FINISHED":
-      return { type: "CONFLICT_RESOLUTION_FINISHED" };
+      return { type: "CONFLICT_RESOLUTION_FINISHED", chatId: event.chatId };
     case "CONFLICT_VERIFICATION_FAILED":
-      return { type: "CONFLICT_VERIFICATION_FAILED" };
+      return {
+        type: "CONFLICT_VERIFICATION_FAILED",
+        verificationAttempt: event.verificationAttempt,
+      };
     case "CONFLICT_RESOLUTION_CANCELLED":
       return { type: "RECONCILE_REQUESTED" };
     case "CONFLICT_RESOLUTION_CLAIM_EXPIRED":

--- a/src/github_ops/useGithubOps.ts
+++ b/src/github_ops/useGithubOps.ts
@@ -145,23 +145,27 @@ export function useGithubOps(
     return () => window.removeEventListener("focus", reconcile);
   }, [appId, reconcileOnMount, remote.connection, sendWithoutReceipt]);
 
-  const dispatchConflictResolutionStarted = useCallback(async () => {
-    const claimId = conflictClaimRef.current;
-    if (!claimId) {
-      throw new Error("Conflict-resolution claim is no longer available");
-    }
-    try {
-      const receipt = await remote.dispatch({
-        type: "CONFLICT_RESOLUTION_STARTED",
-        claimId,
-      });
-      if (receipt.kind !== "applied") {
-        throw new Error("Conflict-resolution claim was not accepted");
+  const dispatchConflictResolutionStarted = useCallback(
+    async (chatId: number) => {
+      const claimId = conflictClaimRef.current;
+      if (!claimId) {
+        throw new Error("Conflict-resolution claim is no longer available");
       }
-    } finally {
-      conflictClaimRef.current = null;
-    }
-  }, [remote.dispatch]);
+      try {
+        const receipt = await remote.dispatch({
+          type: "CONFLICT_RESOLUTION_STARTED",
+          claimId,
+          chatId,
+        });
+        if (receipt.kind !== "applied") {
+          throw new Error("Conflict-resolution claim was not accepted");
+        }
+      } finally {
+        conflictClaimRef.current = null;
+      }
+    },
+    [remote.dispatch],
+  );
 
   const dispatchConflictResolutionCancelled = useCallback(async () => {
     const claimId = conflictClaimRef.current;

--- a/src/github_ops/useGithubOps.ts
+++ b/src/github_ops/useGithubOps.ts
@@ -16,6 +16,7 @@ const UNAVAILABLE_CAPABILITIES = {
   canRebaseAndSync: false,
   canResolveConflicts: false,
   canCancelSync: false,
+  canContinueSync: false,
   canMutateBranches: false,
   canSwitchBranches: false,
   canConfirmBlockedSwitch: false,
@@ -65,6 +66,7 @@ export function useGithubOps(
         case "BLOCKED_DISMISSED":
         case "BANNER_DISMISSED":
         case "RECONCILE_REQUESTED":
+        case "CONFLICT_RESOLUTION_FINISHED":
           intent = event;
           break;
         case "RESOLVE_WITH_AI_STARTED": {
@@ -78,6 +80,7 @@ export function useGithubOps(
         case "OP_FAILED":
         case "CONFLICTS":
         case "GIT_STATE":
+        case "CONFLICT_RESOLUTION_STARTED":
           throw new Error(
             `${event.type} is a host-only GitHub operation event`,
           );

--- a/src/github_ops/useGithubOps.ts
+++ b/src/github_ops/useGithubOps.ts
@@ -67,6 +67,7 @@ export function useGithubOps(
         case "BLOCKED_DISMISSED":
         case "BANNER_DISMISSED":
         case "RECONCILE_REQUESTED":
+        case "RETRY_CONFLICT_VERIFICATION":
         case "CONFLICT_RESOLUTION_FINISHED":
           intent = event;
           break;

--- a/src/github_ops/useGithubOps.ts
+++ b/src/github_ops/useGithubOps.ts
@@ -17,6 +17,7 @@ const UNAVAILABLE_CAPABILITIES = {
   canResolveConflicts: false,
   canCancelSync: false,
   canContinueSync: false,
+  canRetryConflictVerification: false,
   canMutateBranches: false,
   canSwitchBranches: false,
   canConfirmBlockedSwitch: false,
@@ -81,6 +82,7 @@ export function useGithubOps(
         case "CONFLICTS":
         case "GIT_STATE":
         case "CONFLICT_RESOLUTION_STARTED":
+        case "CONFLICT_VERIFICATION_FAILED":
           throw new Error(
             `${event.type} is a host-only GitHub operation event`,
           );

--- a/src/hooks/useResolveMergeConflictsWithAI.test.tsx
+++ b/src/hooks/useResolveMergeConflictsWithAI.test.tsx
@@ -20,6 +20,7 @@ const mocks = vi.hoisted(() => ({
   navigate: vi.fn(),
   onStartFailed: vi.fn(),
   onStartResolving: vi.fn(),
+  onSettled: vi.fn(),
   refreshApp: vi.fn(),
   showError: vi.fn(),
 }));
@@ -77,6 +78,7 @@ describe("useResolveMergeConflictsWithAI", () => {
           appId: APP_ID,
           conflicts: ["src/one.ts", "src/two.ts"],
           onStartResolving: mocks.onStartResolving,
+          onSettled: mocks.onSettled,
         }),
       { wrapper: Wrapper },
     );
@@ -119,6 +121,7 @@ describe("useResolveMergeConflictsWithAI", () => {
     expect(result.current.isResolving).toBe(false);
     expect(mocks.invalidateChats).toHaveBeenCalledOnce();
     expect(mocks.refreshApp).toHaveBeenCalledOnce();
+    expect(mocks.onSettled).toHaveBeenCalledOnce();
   });
 
   it("blocks reentrant creation and clears resolving when chat creation fails", async () => {

--- a/src/hooks/useResolveMergeConflictsWithAI.test.tsx
+++ b/src/hooks/useResolveMergeConflictsWithAI.test.tsx
@@ -91,7 +91,7 @@ describe("useResolveMergeConflictsWithAI", () => {
       appId: APP_ID,
       initialChatMode: "local-agent",
     });
-    expect(mocks.onStartResolving).toHaveBeenCalledOnce();
+    expect(mocks.onStartResolving).toHaveBeenCalledExactlyOnceWith(CHAT_ID);
     expect(store.get(selectedChatIdAtom)).toBe(CHAT_ID);
     expect(store.get(selectedAppIdAtom)).toBe(APP_ID);
     expect(mocks.navigate).toHaveBeenCalledExactlyOnceWith({

--- a/src/hooks/useResolveMergeConflictsWithAI.test.tsx
+++ b/src/hooks/useResolveMergeConflictsWithAI.test.tsx
@@ -20,7 +20,6 @@ const mocks = vi.hoisted(() => ({
   navigate: vi.fn(),
   onStartFailed: vi.fn(),
   onStartResolving: vi.fn(),
-  onSettled: vi.fn(),
   refreshApp: vi.fn(),
   showError: vi.fn(),
 }));
@@ -78,7 +77,6 @@ describe("useResolveMergeConflictsWithAI", () => {
           appId: APP_ID,
           conflicts: ["src/one.ts", "src/two.ts"],
           onStartResolving: mocks.onStartResolving,
-          onSettled: mocks.onSettled,
         }),
       { wrapper: Wrapper },
     );
@@ -130,7 +128,6 @@ describe("useResolveMergeConflictsWithAI", () => {
     expect(result.current.isResolving).toBe(false);
     expect(mocks.invalidateChats).toHaveBeenCalledOnce();
     expect(mocks.refreshApp).toHaveBeenCalledOnce();
-    expect(mocks.onSettled).toHaveBeenCalledExactlyOnceWith(CHAT_ID);
   });
 
   it("blocks reentrant creation and clears resolving when chat creation fails", async () => {

--- a/src/hooks/useResolveMergeConflictsWithAI.test.tsx
+++ b/src/hooks/useResolveMergeConflictsWithAI.test.tsx
@@ -130,7 +130,7 @@ describe("useResolveMergeConflictsWithAI", () => {
     expect(result.current.isResolving).toBe(false);
     expect(mocks.invalidateChats).toHaveBeenCalledOnce();
     expect(mocks.refreshApp).toHaveBeenCalledOnce();
-    expect(mocks.onSettled).toHaveBeenCalledOnce();
+    expect(mocks.onSettled).toHaveBeenCalledExactlyOnceWith(CHAT_ID);
   });
 
   it("blocks reentrant creation and clears resolving when chat creation fails", async () => {

--- a/src/hooks/useResolveMergeConflictsWithAI.test.tsx
+++ b/src/hooks/useResolveMergeConflictsWithAI.test.tsx
@@ -110,6 +110,15 @@ describe("useResolveMergeConflictsWithAI", () => {
     expect(event.type === "submit" && event.request.prompt).toContain(
       "- src/one.ts\n- src/two.ts",
     );
+    expect(event.type === "submit" && event.request.prompt).toContain(
+      "resolve every Git conflict by editing the file in place",
+    );
+    expect(event.type === "submit" && event.request.prompt).toContain(
+      "Do not only describe the resolution or paste the file contents into chat",
+    );
+    expect(event.type === "submit" && event.request.prompt).toContain(
+      "verify that none of the listed files contain conflict markers",
+    );
     expect(result.current.isResolving).toBe(true);
 
     await act(async () => {

--- a/src/hooks/useResolveMergeConflictsWithAI.ts
+++ b/src/hooks/useResolveMergeConflictsWithAI.ts
@@ -12,7 +12,7 @@ import { useLoadApp } from "@/hooks/useLoadApp";
 interface UseResolveMergeConflictsWithAIProps {
   appId: number;
   conflicts: readonly string[];
-  onStartResolving?: () => void | Promise<void>;
+  onStartResolving?: (chatId: number) => void | Promise<void>;
   onStartFailed?: () => void | Promise<void>;
   onSettled?: () => void;
 }
@@ -62,7 +62,7 @@ export function useResolveMergeConflictsWithAI({
         });
         try {
           // Clear conflicts state after successful chat creation.
-          await onStartResolving?.();
+          await onStartResolving?.(newChatId);
         } catch (error) {
           // The claim can expire while durable chat creation is in flight.
           // Remove the chat if main does not accept the corresponding start.
@@ -76,7 +76,6 @@ export function useResolveMergeConflictsWithAI({
           }
           throw error;
         }
-
         // Build the prompt for resolving all conflicts
         const fileList = requestedConflicts.map((f) => `- ${f}`).join("\n");
         const prompt = `Please resolve the Git merge conflicts in the following file${requestedConflicts.length > 1 ? "s" : ""}:
@@ -104,9 +103,9 @@ For each file, review the conflict markers (<<<<<<<, =======, >>>>>>>) and choos
             onSettled: () => {
               isResolvingRef.current = false;
               setIsResolving(false);
+              onSettled?.();
               invalidateChats();
               void refreshApp();
-              onSettled?.();
             },
           },
         });

--- a/src/hooks/useResolveMergeConflictsWithAI.ts
+++ b/src/hooks/useResolveMergeConflictsWithAI.ts
@@ -14,7 +14,6 @@ interface UseResolveMergeConflictsWithAIProps {
   conflicts: readonly string[];
   onStartResolving?: (chatId: number) => void | Promise<void>;
   onStartFailed?: () => void | Promise<void>;
-  onSettled?: (chatId: number) => void;
 }
 
 /**
@@ -26,7 +25,6 @@ export function useResolveMergeConflictsWithAI({
   conflicts,
   onStartResolving,
   onStartFailed,
-  onSettled,
 }: UseResolveMergeConflictsWithAIProps) {
   const setSelectedChatId = useSetAtom(selectedChatIdAtom);
   const setSelectedAppId = useSetAtom(selectedAppIdAtom);
@@ -103,7 +101,6 @@ For each listed file, resolve every Git conflict by editing the file in place. P
             onSettled: () => {
               isResolvingRef.current = false;
               setIsResolving(false);
-              onSettled?.(newChatId);
               invalidateChats();
               void refreshApp();
             },
@@ -131,7 +128,6 @@ For each listed file, resolve every Git conflict by editing the file in place. P
       appId,
       onStartResolving,
       onStartFailed,
-      onSettled,
       setSelectedChatId,
       setSelectedAppId,
       navigate,

--- a/src/hooks/useResolveMergeConflictsWithAI.ts
+++ b/src/hooks/useResolveMergeConflictsWithAI.ts
@@ -82,7 +82,7 @@ export function useResolveMergeConflictsWithAI({
 
 ${fileList}
 
-For each file, review the conflict markers (<<<<<<<, =======, >>>>>>>) and choose the best resolution that preserves the intended functionality from both sides. Remove all conflict markers and provide the complete resolved file content.`;
+For each listed file, resolve every Git conflict by editing the file in place. Preserve the intended behavior from both sides where compatible, and remove all conflict markers (<<<<<<<, =======, >>>>>>>). Do not only describe the resolution or paste the file contents into chat. Before finishing, verify that none of the listed files contain conflict markers.`;
 
         // Set up the chat state and navigate
         setSelectedChatId(newChatId);

--- a/src/hooks/useResolveMergeConflictsWithAI.ts
+++ b/src/hooks/useResolveMergeConflictsWithAI.ts
@@ -14,6 +14,7 @@ interface UseResolveMergeConflictsWithAIProps {
   conflicts: readonly string[];
   onStartResolving?: () => void | Promise<void>;
   onStartFailed?: () => void | Promise<void>;
+  onSettled?: () => void;
 }
 
 /**
@@ -25,6 +26,7 @@ export function useResolveMergeConflictsWithAI({
   conflicts,
   onStartResolving,
   onStartFailed,
+  onSettled,
 }: UseResolveMergeConflictsWithAIProps) {
   const setSelectedChatId = useSetAtom(selectedChatIdAtom);
   const setSelectedAppId = useSetAtom(selectedAppIdAtom);
@@ -104,6 +106,7 @@ For each file, review the conflict markers (<<<<<<<, =======, >>>>>>>) and choos
               setIsResolving(false);
               invalidateChats();
               void refreshApp();
+              onSettled?.();
             },
           },
         });
@@ -129,6 +132,7 @@ For each file, review the conflict markers (<<<<<<<, =======, >>>>>>>) and choos
       appId,
       onStartResolving,
       onStartFailed,
+      onSettled,
       setSelectedChatId,
       setSelectedAppId,
       navigate,

--- a/src/hooks/useResolveMergeConflictsWithAI.ts
+++ b/src/hooks/useResolveMergeConflictsWithAI.ts
@@ -14,7 +14,7 @@ interface UseResolveMergeConflictsWithAIProps {
   conflicts: readonly string[];
   onStartResolving?: (chatId: number) => void | Promise<void>;
   onStartFailed?: () => void | Promise<void>;
-  onSettled?: () => void;
+  onSettled?: (chatId: number) => void;
 }
 
 /**
@@ -103,7 +103,7 @@ For each listed file, resolve every Git conflict by editing the file in place. P
             onSettled: () => {
               isResolvingRef.current = false;
               setIsResolving(false);
-              onSettled?.();
+              onSettled?.(newChatId);
               invalidateChats();
               void refreshApp();
             },

--- a/src/ipc/handlers/__tests__/git_collaboration.integration.test.tsx
+++ b/src/ipc/handlers/__tests__/git_collaboration.integration.test.tsx
@@ -387,8 +387,15 @@ describe("Git collaboration actions (integration)", () => {
       { timeout: 20_000 },
     );
     await harness.bridge.settleInFlight();
+    await gitNetwork(app.appDir, "fetch", "origin", "main");
     expect(git(app.appDir, "branch", "--show-current").trim()).toBe("main");
     expect(git(app.appDir, "status", "--porcelain").trim()).toBe("");
+    expect(git(app.appDir, "rev-parse", "HEAD").trim()).toBe(
+      git(app.appDir, "rev-parse", "origin/main").trim(),
+    );
+    expect(git(app.appDir, "show", "origin/main:conflict.txt")).not.toMatch(
+      /<<<<<<<|=======|>>>>>>>/,
+    );
   }, 90_000);
 
   it("cancels sync when merge conflicts occur", async () => {

--- a/src/ipc/handlers/__tests__/git_collaboration.integration.test.tsx
+++ b/src/ipc/handlers/__tests__/git_collaboration.integration.test.tsx
@@ -386,6 +386,9 @@ describe("Git collaboration actions (integration)", () => {
       },
       { timeout: 20_000 },
     );
+    await harness.bridge.settleInFlight();
+    expect(git(app.appDir, "branch", "--show-current").trim()).toBe("main");
+    expect(git(app.appDir, "status", "--porcelain").trim()).toBe("");
   }, 90_000);
 
   it("cancels sync when merge conflicts occur", async () => {

--- a/src/ipc/handlers/__tests__/git_collaboration.integration.test.tsx
+++ b/src/ipc/handlers/__tests__/git_collaboration.integration.test.tsx
@@ -1,6 +1,7 @@
-import { execFileSync } from "node:child_process";
+import { execFile, execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import { promisify } from "node:util";
 
 import {
   cleanup,
@@ -25,6 +26,8 @@ type TestApp = {
   appDir: string;
 };
 
+const execFileAsync = promisify(execFile);
+
 const fixtureAppDir = path.join(
   process.cwd(),
   "e2e-tests",
@@ -47,6 +50,26 @@ function git(appDir: string, ...args: string[]): string {
     ],
     { cwd: appDir, stdio: "pipe" },
   ).toString();
+}
+
+async function gitNetwork(appDir: string, ...args: string[]): Promise<string> {
+  const result = await execFileAsync(
+    "git",
+    [
+      "-c",
+      "user.email=test@example.com",
+      "-c",
+      "user.name=Test User",
+      "-c",
+      "commit.gpgsign=false",
+      ...args,
+    ],
+    {
+      cwd: appDir,
+      env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+    },
+  );
+  return result.stdout;
 }
 
 function slug(name: string): string {
@@ -252,27 +275,70 @@ describe("Git collaboration actions (integration)", () => {
     await mergeBranch("feature-conflict");
     await screen.findByRole(
       "button",
-      { name: "Resolve merge conflicts with AI" },
+      { name: "Resolve with AI" },
       { timeout: 15_000 },
     );
     expect(
-      screen.getAllByText(
-        `1 file with merge conflicts: ${conflict.conflictFile}`,
-      ),
+      screen.getAllByText(`Resolve 1 conflict to finish merging.`),
     ).toHaveLength(1);
+    expect(
+      screen.queryByText("Merge conflicts detected while syncing to GitHub."),
+    ).toBeNull();
     return conflict;
   }
 
-  it("resolves merge conflicts with AI", async () => {
+  async function startSyncConflict(app: TestApp) {
+    const conflictFile = "conflict.txt";
+    const conflictFilePath = path.join(app.appDir, conflictFile);
+    fs.writeFileSync(conflictFilePath, "Line 1\nLine 2\nLine 3");
+    git(app.appDir, "add", conflictFile);
+    git(app.appDir, "commit", "-m", "Add sync conflict fixture");
+    await gitNetwork(app.appDir, "push", "origin", "main");
+
+    const remoteClone = path.join(appsRoot, `${slug(app.name)}-remote`);
+    const remoteUrl = git(app.appDir, "remote", "get-url", "origin").trim();
+    await gitNetwork(appsRoot, "clone", remoteUrl, remoteClone);
+    fs.writeFileSync(
+      path.join(remoteClone, conflictFile),
+      "Line 1\nLine 2 Modified Main\nLine 3",
+    );
+    git(remoteClone, "add", conflictFile);
+    git(remoteClone, "commit", "-m", "Modify conflict fixture remotely");
+    await gitNetwork(remoteClone, "push", "origin", "main");
+
+    fs.writeFileSync(
+      conflictFilePath,
+      "Line 1\nLine 2 Modified Feature\nLine 3",
+    );
+    git(app.appDir, "add", conflictFile);
+    git(app.appDir, "commit", "-m", "Modify conflict fixture locally");
+
+    cleanup();
+    await mountAppDetails(app);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Sync to GitHub" }),
+    );
+    await screen.findByRole(
+      "button",
+      { name: "Resolve with AI" },
+      { timeout: 15_000 },
+    );
+    expect(
+      screen.getByText("Resolve 1 conflict to continue syncing."),
+    ).toBeTruthy();
+    return { conflictFilePath };
+  }
+
+  it("resolves sync conflicts with AI and continues the interrupted sync", async () => {
     const app = await setupLinkedApp(
       "git-collab-resolve",
       `test-git-conflict-resolve-hybrid-${Date.now()}`,
     );
-    const { conflictFilePath } = await startConflictMerge(app);
+    const { conflictFilePath } = await startSyncConflict(app);
 
     fireEvent.click(
       await screen.findByRole("button", {
-        name: "Resolve merge conflicts with AI",
+        name: "Resolve with AI",
       }),
     );
 
@@ -287,6 +353,39 @@ describe("Git collaboration actions (integration)", () => {
       },
       { timeout: 30_000 },
     );
+    await harness.bridge.settleInFlight();
+
+    cleanup();
+    await mountAppDetails(app);
+    await waitFor(
+      () => {
+        expect(
+          screen.getByTestId("github-connected-repo").textContent,
+        ).toContain("Conflicts resolved");
+      },
+      { timeout: 15_000 },
+    );
+    const continueButton = await screen.findByRole(
+      "button",
+      { name: "Continue to Sync" },
+      { timeout: 15_000 },
+    );
+    expect(
+      screen.queryByRole("button", { name: "Resolve with AI" }),
+    ).toBeNull();
+
+    await harness.github.clearPushEvents();
+    fireEvent.click(continueButton);
+    await waitFor(
+      async () => {
+        expect(await harness.github.pushEvents()).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ operation: "push", branch: "main" }),
+          ]),
+        );
+      },
+      { timeout: 20_000 },
+    );
   }, 90_000);
 
   it("cancels sync when merge conflicts occur", async () => {
@@ -296,12 +395,14 @@ describe("Git collaboration actions (integration)", () => {
     );
     await startConflictMerge(app);
 
-    fireEvent.click(await screen.findByRole("button", { name: "Cancel sync" }));
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Cancel merge" }),
+    );
     await waitFor(
       () => {
         expect(
           screen.queryByRole("button", {
-            name: "Resolve merge conflicts with AI",
+            name: "Resolve with AI",
           }),
         ).toBeNull();
         expect(fs.existsSync(path.join(app.appDir, ".git", "MERGE_HEAD"))).toBe(

--- a/src/ipc/services/github_ops_definition.ts
+++ b/src/ipc/services/github_ops_definition.ts
@@ -204,6 +204,7 @@ function createCommandRunner(
         emit({
           type: "CONFLICT_VERIFICATION_FAILED",
           verificationAttempt,
+          message,
         });
       }
       return;
@@ -279,10 +280,10 @@ function createCommandRunner(
               });
             }
           },
-          () => {
+          (error) => {
             if (generation !== gitStateProbeGeneration) return;
             reportProbeFailure(
-              "Could not refresh the repository state",
+              errorMessage(error, "Could not refresh the repository state"),
               invocationRef?.operationId,
               command.verificationAttempt,
             );
@@ -309,10 +310,13 @@ function createCommandRunner(
               });
             }
           },
-          () => {
+          (error) => {
             if (generation !== conflictProbeGeneration) return;
             reportProbeFailure(
-              "Could not check the repository for merge conflicts",
+              errorMessage(
+                error,
+                "Could not check the repository for merge conflicts",
+              ),
               invocationRef?.operationId,
               command.verificationAttempt,
             );

--- a/src/ipc/services/github_ops_definition.ts
+++ b/src/ipc/services/github_ops_definition.ts
@@ -193,18 +193,26 @@ function createCommandRunner(
   const reportProbeFailure = (
     message: string,
     operationId: string | undefined,
+    verificationAttempt: number | undefined,
   ) => {
     const state = context.getSnapshot().state;
-    const isConflictVerification =
-      state.type === "conflicted" && state.resolution === "checking";
-    if (!isConflictVerification) {
-      githubOpsPresentationService.showError(
-        context.key.appId,
-        operationId,
-        message,
-      );
+    if (state.type === "conflicted" && state.resolution === "checking") {
+      if (
+        verificationAttempt !== undefined &&
+        state.verificationAttempt === verificationAttempt
+      ) {
+        emit({
+          type: "CONFLICT_VERIFICATION_FAILED",
+          verificationAttempt,
+        });
+      }
+      return;
     }
-    emit({ type: "CONFLICT_VERIFICATION_FAILED" });
+    githubOpsPresentationService.showError(
+      context.key.appId,
+      operationId,
+      message,
+    );
   };
 
   return (actorCommand: GithubOpsActorCommand): void => {
@@ -263,7 +271,12 @@ function createCommandRunner(
         void githubOpsService.getGitState(appId).then(
           (state) => {
             if (generation === gitStateProbeGeneration) {
-              emit({ type: "GIT_STATE", ...state, recoveryInvocationRef });
+              emit({
+                type: "GIT_STATE",
+                ...state,
+                recoveryInvocationRef,
+                verificationAttempt: command.verificationAttempt,
+              });
             }
           },
           () => {
@@ -271,6 +284,7 @@ function createCommandRunner(
             reportProbeFailure(
               "Could not refresh the repository state",
               invocationRef?.operationId,
+              command.verificationAttempt,
             );
           },
         );
@@ -287,7 +301,12 @@ function createCommandRunner(
         void githubOpsService.getConflicts(appId).then(
           (files) => {
             if (generation === conflictProbeGeneration) {
-              emit({ type: "CONFLICTS", files, recoveryInvocationRef });
+              emit({
+                type: "CONFLICTS",
+                files,
+                recoveryInvocationRef,
+                verificationAttempt: command.verificationAttempt,
+              });
             }
           },
           () => {
@@ -295,6 +314,7 @@ function createCommandRunner(
             reportProbeFailure(
               "Could not check the repository for merge conflicts",
               invocationRef?.operationId,
+              command.verificationAttempt,
             );
             if (command.settleOnError) {
               emit({ type: "CONFLICTS", files: [] });

--- a/src/ipc/services/github_ops_definition.ts
+++ b/src/ipc/services/github_ops_definition.ts
@@ -190,6 +190,22 @@ function createCommandRunner(
   let gitStateProbeGeneration = 0;
   let conflictProbeGeneration = 0;
   const emit = (event: GithubOpsProducerEvent) => context.send(event);
+  const reportProbeFailure = (
+    message: string,
+    operationId: string | undefined,
+  ) => {
+    const state = context.getSnapshot().state;
+    const isConflictVerification =
+      state.type === "conflicted" && state.resolution === "checking";
+    if (!isConflictVerification) {
+      githubOpsPresentationService.showError(
+        context.key.appId,
+        operationId,
+        message,
+      );
+    }
+    emit({ type: "CONFLICT_VERIFICATION_FAILED" });
+  };
 
   return (actorCommand: GithubOpsActorCommand): void => {
     if (actorCommand.type === "schedule-conflict-claim-expiry") {
@@ -252,10 +268,9 @@ function createCommandRunner(
           },
           () => {
             if (generation !== gitStateProbeGeneration) return;
-            githubOpsPresentationService.showError(
-              appId,
-              invocationRef?.operationId,
+            reportProbeFailure(
               "Could not refresh the repository state",
+              invocationRef?.operationId,
             );
           },
         );
@@ -277,10 +292,9 @@ function createCommandRunner(
           },
           () => {
             if (generation !== conflictProbeGeneration) return;
-            githubOpsPresentationService.showError(
-              appId,
-              invocationRef?.operationId,
+            reportProbeFailure(
               "Could not check the repository for merge conflicts",
+              invocationRef?.operationId,
             );
             if (command.settleOnError) {
               emit({ type: "CONFLICTS", files: [] });


### PR DESCRIPTION
## Summary

Make AI-assisted merge-conflict recovery a clear, resumable sync flow instead of leaving stale controls behind after the chat resolves conflicts.

- Keep users in the conflict-resolution chat while the GitHub panel remains available, and explicitly track resolving, verifying, and ready-to-sync phases in the main-owned GitHub operation state.
- Correlate the recovery state with the exact main-owned chat, so completion survives navigation or a renderer remount instead of depending on a window-local callback.
- Replace the stale AI action with **Continue to Sync** only after Git confirms the conflicts are gone; continuing resumes the interrupted push, including `rebase --continue` before the final push when needed.
- Remove the duplicate merge-conflict error banner so the dedicated recovery surface is the single source of guidance.
- Restyle the recovery surface as a compact, neutral status panel with clearer hierarchy, file rows, state-specific icons, and concise actions inspired by GitHub/Linear/Vercel patterns.
- Preserve the in-progress phase across ambient repository reconciliation, so background probes cannot incorrectly reset the workflow while the AI chat is still working.
- If repository verification fails, keep the resolved work intact and show one inline **Try again** action that retries verification without rerunning the AI chat.
- Preserve the sanitized verification failure inline, and require the explicit retry action so focus-driven repository reconciliation cannot silently clear or restart the failed phase.
- Keep cancel and branch-switch escape hatches available in stable recovery phases, while intentionally blocking them during active AI edits and Git verification to avoid racing repository mutations.
- Notify users when a foreground sync first pauses for conflicts, while avoiding a duplicate persistent error banner and keeping ambient conflict discovery quiet.
- Announce recovery-phase changes through a polite live region for screen-reader users.
- Correlate completion with the exact resolution chat and each verification attempt, so delayed events from earlier work cannot advance or fail the current recovery.
- Use the retained chat snapshot as the single completion source, avoiding duplicate completion dispatches from both the hook callback and connector effect.
- Tell the AI to edit conflicted files in place and verify that no markers remain, rather than merely describing or pasting a resolution in chat.
- Keep the scope intentionally narrow: this does not redesign the broader GitHub settings panel.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches main-owned GitHub sync state machine, probe failure routing, and push/rebase continuation after conflicts—important for data integrity but heavily tested and scoped to conflict recovery.
> 
> **Overview**
> **GitHub merge/sync conflict recovery** is now a phased, main-owned workflow instead of treating a clean ambient probe as “done” or leaving a stale **Resolve with AI** control after chat finishes.
> 
> The `github_ops` **conflicted** state gains optional `resolution` phases (`resolving` → `checking` → `ready-to-sync` or `verification-failed`), chat correlation (`resolutionChatId`), and **verification attempt** tokens so stale probe/chat events cannot advance or fail the wrong recovery. New events include `CONFLICT_RESOLUTION_STARTED` / `FINISHED` (with `chatId`), `CONFLICT_VERIFICATION_FAILED`, and `RETRY_CONFLICT_VERIFICATION`; probe commands carry `verificationAttempt`. After Git confirms no markers, users get **Continue to Sync** (push or `rebase-continue` then push) instead of restarting AI. Verification errors surface inline with **Try again** (no error toast during dedicated checking). Conflict entry drops the duplicate `MERGE_CONFLICT` error banner in favor of a single info-style recovery panel.
> 
> **GitHubConnector** watches the correlated chat stream and dispatches `CONFLICT_RESOLUTION_FINISHED` when the resolution chat completes, and renders the new status panel (file list, spinners, continue/retry/cancel). **Capabilities** gate resolve/cancel/continue/retry by phase. **Main command runner** routes probe failures during `checking` to `CONFLICT_VERIFICATION_FAILED` instead of generic toasts. **AI prompt** instructs in-place file edits and marker verification. Tests and `state-machines.md` document the in-progress vs checking probe rule and finite graph exploration for retry counters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b36b9d76afee7374ec63af7046192d6d6ea1f1d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

