### PR TITLE
Remove sub-agent from Claude PR review to fix missing-output flake

### DIFF
--- a/.github/prompts/claude-pr-review.txt
+++ b/.github/prompts/claude-pr-review.txt
@@ -8,8 +8,8 @@ Important workflow boundary:
 - Do not mutate repository or PR state.
 - Write the requested local output files only.
 
-Sub-agent budget:
-{{REVIEW_SUBAGENT_INSTRUCTIONS}}
+Review execution:
+Perform the entire review yourself in this session, applying all three personas together: Correctness & Debugging Expert, Code Health Expert, and UX Wizard. Do not spawn sub-agents or background tasks. Do not end your turn until both mandatory output files below have been written.
 
 Dyad-specific review focus:
 - Electron IPC changes must preserve the secure main/renderer boundary, validate inputs, and avoid exposing broad filesystem or process access.

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -37,11 +37,6 @@ jobs:
       REVIEW_PROMPT_PATH: tmp/pr-review/claude-prompt.txt
       REVIEW_OUTPUT_PATH: tmp/pr-review/claude-review.md
       REVIEW_FINDINGS_PATH: tmp/pr-review/claude-findings.json
-      REVIEW_SUBAGENT_INSTRUCTIONS: >-
-        Use exactly 1 review sub-agent total. That single sub-agent must apply
-        all three personas together: Correctness & Debugging Expert, Code
-        Health Expert, and UX Wizard. Do not spawn one sub-agent per persona,
-        and do not spawn any additional review sub-agents.
     steps:
       - name: Checkout trusted workflow repo
         uses: actions/checkout@v5
@@ -106,7 +101,7 @@ jobs:
           claude_args: |
             --model claude-opus-5
             --setting-sources user
-            --allowedTools "Agent,Read,Glob,Grep,Edit(tmp/pr-review/**)"
+            --allowedTools "Read,Glob,Grep,Edit(tmp/pr-review/**)"
 
       - name: Verify Claude review outputs
         run: |


### PR DESCRIPTION
## Why

The Claude PR Review workflow intermittently fails with `Claude did not write tmp/pr-review/claude-review.md` (e.g. runs on #4195 and the `fix-merge-conflict-recovery` PR). With `show_full_output` enabled (#4198), the transcript of failing run [31049396656](https://github.com/dyad-sh/dyad/actions/runs/31049396656) shows the exact mechanism:

1. The orchestrator launches the single review sub-agent via the `Agent` tool, which now runs **asynchronously** ("Async agent launched successfully… you will be notified when it completes").
2. The orchestrator ends its turn, saying it will "write both output files once its findings arrive".
3. In headless SDK mode, ending the main turn terminates the run — the background sub-agent's work is discarded and the output files are never written, so the `Verify Claude review outputs` step fails.

Whether a run passes or fails depends on whether the model happens to wait for the sub-agent, hence the flakiness (failing runs finish in 1–3 minutes).

The single sub-agent is vestigial anyway: #3484 already collapsed the original three persona reviewers into one sub-agent applying all personas, so the isolation rationale is gone and the orchestrator is just a pass-through.

## What

- Drop `Agent` from `--allowedTools` so the reviewer cannot spawn sub-agents.
- Remove the `REVIEW_SUBAGENT_INSTRUCTIONS` env and its template placeholder; the prompt now instructs the agent to perform the whole multi-persona review itself and to not end its turn until both output files are written.

Same model and personas, one fewer moving part, slightly cheaper — and the async-launch failure mode becomes structurally impossible.

## Test plan

- Rendered the prompt with `scripts/issue-agent/render-template.mjs` (no missing template variables).
- Since this runs via `pull_request_target`, the change takes effect on PRs only after merge; behavior verified against transcripts from runs before/after.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

