### PR TITLE
Keep apps selectable when Supabase metadata lookup fails

### DIFF
--- a/rules/electron-ipc.md
+++ b/rules/electron-ipc.md
@@ -151,6 +151,7 @@ pre-hydration atoms can erase unrelated restored entities.
 ## Handler expectations
 
 - Handlers should `throw new Error("...")` on failure instead of returning `{ success: false }` style payloads.
+- Entity-loading handlers that enrich a valid local row with optional external metadata must catch enrichment failures and return the base entity with nullable enrichment fields. Letting an OAuth/API failure reject the whole load can make renderer queries misreport an existing entity as missing.
 - For **non-bug** failures (validation, not found, auth, user refusal, etc.), prefer `DyadError` with the right `DyadErrorKind` so PostHog does not flood with `$exception` events — see [rules/dyad-errors.md](dyad-errors.md).
 - Use `createTypedHandler(contract, handler)` which validates inputs at runtime via Zod.
 - Production invoke handlers must register through `createTypedHandler`, `createLoggedHandler`, or `registerTrustedIpcHandler`; never call `ipcMain.handle` or `ipcMain.handleOnce` directly outside `trusted_handle.ts`. The facade enforces the trusted-main-frame policy for both contract and legacy channels.

--- a/src/ipc/handlers/__tests__/get_app_supabase_failure.integration.test.ts
+++ b/src/ipc/handlers/__tests__/get_app_supabase_failure.integration.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { apps } from "@/db/schema";
+import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
+import { registerAppHandlers } from "@/ipc/handlers/app_handlers";
+import {
+  setupHandlerTestHarness,
+  type HandlerTestHarness,
+} from "@/testing/handler_test_harness";
+
+const mocks = vi.hoisted(() => ({
+  getSupabaseProjectName: vi.fn(),
+  readSettings: vi.fn(),
+}));
+
+vi.mock(
+  "@/supabase_admin/supabase_management_client",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("@/supabase_admin/supabase_management_client")
+      >();
+    return {
+      ...actual,
+      getSupabaseProjectName: mocks.getSupabaseProjectName,
+    };
+  },
+);
+
+vi.mock("@/main/settings", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/main/settings")>();
+  return {
+    ...actual,
+    readSettings: mocks.readSettings,
+  };
+});
+
+describe("get-app with unavailable Supabase metadata (integration)", () => {
+  let harness: HandlerTestHarness | undefined;
+  let appDirectory: string;
+
+  beforeEach(() => {
+    appDirectory = fs.mkdtempSync(
+      path.join(os.tmpdir(), "dyad-get-app-supabase-"),
+    );
+    fs.writeFileSync(path.join(appDirectory, "index.ts"), "// app");
+
+    mocks.readSettings.mockReturnValue({
+      supabase: {
+        organizations: {
+          "test-organization": {
+            accessToken: { value: "expired-access-token" },
+            refreshToken: { value: "stale-refresh-token" },
+            expiresIn: 86_400,
+            tokenTimestamp: 0,
+          },
+        },
+      },
+    });
+    mocks.getSupabaseProjectName.mockRejectedValue(
+      new DyadError(
+        "Supabase token refresh failed. Error status: Not Found",
+        DyadErrorKind.External,
+      ),
+    );
+
+    harness = setupHandlerTestHarness();
+    registerAppHandlers();
+  });
+
+  afterEach(() => {
+    harness?.dispose();
+    fs.rmSync(appDirectory, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  it("still returns the selected app when Supabase project-name enrichment fails", async () => {
+    const inserted = harness!.db
+      .insert(apps)
+      .values({
+        name: "TidyDay",
+        path: appDirectory,
+        supabaseProjectId: "test-project",
+        supabaseOrganizationSlug: "test-organization",
+      })
+      .returning()
+      .get();
+
+    const app = await harness!.invokeHandler<{
+      id: number;
+      name: string;
+      files: string[];
+      supabaseProjectName: string | null;
+    }>("get-app", inserted.id);
+
+    expect(mocks.getSupabaseProjectName).toHaveBeenCalledWith(
+      "test-project",
+      "test-organization",
+    );
+    expect(app).toMatchObject({
+      id: inserted.id,
+      name: "TidyDay",
+      files: ["index.ts"],
+      supabaseProjectName: null,
+    });
+  });
+});

--- a/src/ipc/handlers/app_handlers.ts
+++ b/src/ipc/handlers/app_handlers.ts
@@ -851,10 +851,17 @@ export function registerAppHandlers() {
           ?.accessToken?.value) ||
       settings.supabase?.accessToken?.value;
     if (app.supabaseProjectId && hasSupabaseCredentials) {
-      supabaseProjectName = await getSupabaseProjectName(
-        app.supabaseParentProjectId || app.supabaseProjectId,
-        app.supabaseOrganizationSlug ?? undefined,
-      );
+      try {
+        supabaseProjectName = await getSupabaseProjectName(
+          app.supabaseParentProjectId || app.supabaseProjectId,
+          app.supabaseOrganizationSlug ?? undefined,
+        );
+      } catch (error) {
+        logger.warn(
+          `Failed to load Supabase project name for app ${appId}; returning the app without it.`,
+          error,
+        );
+      }
     }
 
     let vercelTeamSlug: string | null = null;


### PR DESCRIPTION
## Summary

Keep locally valid apps available to the renderer when optional Supabase project-name enrichment fails, preventing the Publish panel from incorrectly showing “No App Selected” after an OAuth refresh error.

- Treat the Supabase project name as best-effort metadata: preserve the local app record and expose a null project name while retaining a warning in main-process logs.
- Limit the fallback to app-loading enrichment; Supabase-specific operations still surface authentication and removed-project errors so users know they must reconnect or repair the integration.
- Cover the real `get-app` handler with an integration regression using SQLite and filesystem state, while making the external Supabase failure deterministic.
- Document the IPC boundary decision so other entity loaders do not let optional remote enrichment hide valid local data.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 43c1841f7bface79f948ae8549e26654d41f5281. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

