### PR TITLE
Keep app loading resilient to Supabase metadata failures

### DIFF
--- a/rules/electron-ipc.md
+++ b/rules/electron-ipc.md
@@ -151,6 +151,7 @@ pre-hydration atoms can erase unrelated restored entities.
 ## Handler expectations
 
 - Handlers should `throw new Error("...")` on failure instead of returning `{ success: false }` style payloads.
+- Entity-loading handlers that enrich a valid local row with optional external metadata must catch enrichment failures and return the base entity with nullable enrichment fields. Letting an OAuth/API failure reject the whole load can make renderer queries misreport an existing entity as missing.
 - For **non-bug** failures (validation, not found, auth, user refusal, etc.), prefer `DyadError` with the right `DyadErrorKind` so PostHog does not flood with `$exception` events — see [rules/dyad-errors.md](dyad-errors.md).
 - Use `createTypedHandler(contract, handler)` which validates inputs at runtime via Zod.
 - Production invoke handlers must register through `createTypedHandler`, `createLoggedHandler`, or `registerTrustedIpcHandler`; never call `ipcMain.handle` or `ipcMain.handleOnce` directly outside `trusted_handle.ts`. The facade enforces the trusted-main-frame policy for both contract and legacy channels.

--- a/src/ipc/handlers/__tests__/get_app_supabase_failure.integration.test.ts
+++ b/src/ipc/handlers/__tests__/get_app_supabase_failure.integration.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { apps } from "@/db/schema";
+import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
+import { registerAppHandlers } from "@/ipc/handlers/app_handlers";
+import {
+  setupHandlerTestHarness,
+  type HandlerTestHarness,
+} from "@/testing/handler_test_harness";
+
+const mocks = vi.hoisted(() => ({
+  getSupabaseProjectName: vi.fn(),
+  readSettings: vi.fn(),
+}));
+
+vi.mock(
+  "@/supabase_admin/supabase_management_client",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("@/supabase_admin/supabase_management_client")
+      >();
+    return {
+      ...actual,
+      getSupabaseProjectName: mocks.getSupabaseProjectName,
+    };
+  },
+);
+
+vi.mock("@/main/settings", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/main/settings")>();
+  return {
+    ...actual,
+    readSettings: mocks.readSettings,
+  };
+});
+
+describe("get-app with unavailable Supabase metadata (integration)", () => {
+  let harness: HandlerTestHarness | undefined;
+  let appDirectory: string;
+
+  beforeEach(() => {
+    appDirectory = fs.mkdtempSync(
+      path.join(os.tmpdir(), "dyad-get-app-supabase-"),
+    );
+    fs.writeFileSync(path.join(appDirectory, "index.ts"), "// app");
+
+    mocks.readSettings.mockReturnValue({
+      supabase: {
+        organizations: {
+          "test-organization": {
+            accessToken: { value: "expired-access-token" },
+            refreshToken: { value: "stale-refresh-token" },
+            expiresIn: 86_400,
+            tokenTimestamp: 0,
+          },
+        },
+      },
+    });
+    mocks.getSupabaseProjectName.mockRejectedValue(
+      new DyadError(
+        "Supabase token refresh failed. Error status: Not Found",
+        DyadErrorKind.External,
+      ),
+    );
+
+    harness = setupHandlerTestHarness();
+    registerAppHandlers();
+  });
+
+  afterEach(() => {
+    harness?.dispose();
+    fs.rmSync(appDirectory, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  it("still returns the selected app when Supabase project-name enrichment fails", async () => {
+    const inserted = harness!.db
+      .insert(apps)
+      .values({
+        name: "TidyDay",
+        path: appDirectory,
+        supabaseProjectId: "test-project",
+        supabaseOrganizationSlug: "test-organization",
+      })
+      .returning()
+      .get();
+
+    const app = await harness!.invokeHandler<{
+      id: number;
+      name: string;
+      files: string[];
+      supabaseProjectName: string | null;
+    }>("get-app", inserted.id);
+
+    expect(mocks.getSupabaseProjectName).toHaveBeenCalledWith(
+      "test-project",
+      "test-organization",
+    );
+    expect(app).toMatchObject({
+      id: inserted.id,
+      name: "TidyDay",
+      files: ["index.ts"],
+      supabaseProjectName: null,
+    });
+  });
+});

--- a/src/ipc/handlers/app_handlers.ts
+++ b/src/ipc/handlers/app_handlers.ts
@@ -851,10 +851,17 @@ export function registerAppHandlers() {
           ?.accessToken?.value) ||
       settings.supabase?.accessToken?.value;
     if (app.supabaseProjectId && hasSupabaseCredentials) {
-      supabaseProjectName = await getSupabaseProjectName(
-        app.supabaseParentProjectId || app.supabaseProjectId,
-        app.supabaseOrganizationSlug ?? undefined,
-      );
+      try {
+        supabaseProjectName = await getSupabaseProjectName(
+          app.supabaseParentProjectId || app.supabaseProjectId,
+          app.supabaseOrganizationSlug ?? undefined,
+        );
+      } catch (error) {
+        logger.warn(
+          `Failed to load Supabase project name for app ${appId}; returning the app without it.`,
+          error,
+        );
+      }
     }
 
     let vercelTeamSlug: string | null = null;


### PR DESCRIPTION
## Summary

Keep locally valid apps loadable when optional Supabase project-name enrichment fails instead of presenting them as missing.

- Treat Supabase project-name lookup as best-effort enrichment: authentication or API failures are logged, while the base app and a nullable project name still reach the renderer.
- Preserve the existing credential and project-selection behavior; only the failure boundary around optional metadata changes.
- Add an integration test that reproduces an expired-token refresh failure through the real app handler and verifies the local app still loads.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to optional metadata on app load with a regression test; core app data and credential gating are unchanged.
> 
> **Overview**
> **`get-app` no longer fails** when optional Supabase project-name lookup errors (e.g. expired OAuth / token refresh). Those failures are logged and the handler still returns the local app with **`supabaseProjectName: null`**, so renderer queries do not treat a valid app as missing.
> 
> IPC guidance in **`rules/electron-ipc.md`** now states that entity loaders must catch optional external enrichment failures and return the base row with nullable enrichment fields.
> 
> An integration test exercises **`get-app`** through the real app handler when **`getSupabaseProjectName`** rejects with an external auth error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43c1841f7bface79f948ae8549e26654d41f5281. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->