### PR TITLE
Rewrite tool-call ids no provider would accept

### DIFF
--- a/src/ipc/utils/ai_messages_utils.test.ts
+++ b/src/ipc/utils/ai_messages_utils.test.ts
@@ -866,6 +866,165 @@ describe("sanitizeToolCallTranscript", () => {
     expect(result[2]).toBe(messages[2]);
   });
 
+  // A tool-call id that no provider will accept fails the WHOLE request, and
+  // once persisted it replays on every later turn — the chat never recovers on
+  // its own. Rewriting the call and its result together is what unsticks it.
+  it.each([
+    ["longer than 64 characters", `call_${"x".repeat(80)}`],
+    ["not matching Anthropic's ^[A-Za-z0-9_-]+$", '{"steps":[{"index":0}]}'],
+    ["empty", ""],
+  ])("rewrites a tool-call id that is %s", (_label, badId) => {
+    const messages: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: badId,
+            toolName: "generate_test_assertions",
+            input: { steps: [] },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: badId,
+            toolName: "generate_test_assertions",
+            output: { type: "text", value: "ok" },
+          },
+        ],
+      },
+    ];
+
+    const result = sanitizeToolCallTranscript(messages);
+
+    const call = (result[0].content as any[])[0];
+    const toolResult = (result[1].content as any[])[0];
+    expect(call.toolCallId).toBe("dyad_call_0");
+    // Still paired: an unpaired exchange is rejected just as hard.
+    expect(toolResult.toolCallId).toBe(call.toolCallId);
+    expect(call.toolCallId).toMatch(/^[A-Za-z0-9_-]{1,64}$/);
+  });
+
+  it("gives each unusable id its own replacement and leaves good ones alone", () => {
+    const messages: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "x".repeat(100),
+            toolName: "a",
+            input: {},
+          },
+          {
+            type: "tool-call",
+            toolCallId: "y".repeat(100),
+            toolName: "b",
+            input: {},
+          },
+          {
+            type: "tool-call",
+            toolCallId: "call_ok-1",
+            toolName: "c",
+            input: {},
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "y".repeat(100),
+            toolName: "b",
+            output: { type: "text", value: "b" },
+          },
+          {
+            type: "tool-result",
+            toolCallId: "x".repeat(100),
+            toolName: "a",
+            output: { type: "text", value: "a" },
+          },
+          {
+            type: "tool-result",
+            toolCallId: "call_ok-1",
+            toolName: "c",
+            output: { type: "text", value: "c" },
+          },
+        ],
+      },
+    ];
+
+    const result = sanitizeToolCallTranscript(messages);
+
+    const calls = (result[0].content as any[]).map((p) => p.toolCallId);
+    const results = new Map(
+      (result[1].content as any[]).map((p) => [p.toolName, p.toolCallId]),
+    );
+    expect(calls).toEqual(["dyad_call_0", "dyad_call_1", "call_ok-1"]);
+    expect(results.get("a")).toBe("dyad_call_0");
+    expect(results.get("b")).toBe("dyad_call_1");
+    expect(results.get("c")).toBe("call_ok-1");
+  });
+
+  it("doesn't hand a replacement the name of an id already in the transcript", () => {
+    // A chat repaired once already carries a `dyad_call_0`. Reusing that name
+    // would merge two distinct exchanges: the pairing pass would match this
+    // call against the earlier call's result and drop the other.
+    const messages: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "dyad_call_0",
+            toolName: "old",
+            input: {},
+          },
+          {
+            type: "tool-call",
+            toolCallId: "!".repeat(10),
+            toolName: "new",
+            input: {},
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "dyad_call_0",
+            toolName: "old",
+            output: { type: "text", value: "old" },
+          },
+          {
+            type: "tool-result",
+            toolCallId: "!".repeat(10),
+            toolName: "new",
+            output: { type: "text", value: "new" },
+          },
+        ],
+      },
+    ];
+
+    const result = sanitizeToolCallTranscript(messages);
+
+    const calls = (result[0].content as any[]).map((p) => p.toolCallId);
+    expect(calls[0]).toBe("dyad_call_0");
+    expect(calls[1]).not.toBe("dyad_call_0");
+    expect(new Set(calls).size).toBe(2);
+    const results = new Map(
+      (result[1].content as any[]).map((p) => [p.toolName, p.toolCallId]),
+    );
+    expect(results.get("old")).toBe("dyad_call_0");
+    expect(results.get("new")).toBe(calls[1]);
+  });
+
   it("moves user messages after the matching tool result", () => {
     const messages: ModelMessage[] = [
       {

--- a/src/ipc/utils/ai_messages_utils.ts
+++ b/src/ipc/utils/ai_messages_utils.ts
@@ -116,6 +116,88 @@ export function cleanMessage<T extends ModelMessage>(message: T): T {
 }
 
 /**
+ * Providers validate tool-call ids and reject the entire request over a single
+ * bad one: Anthropic requires `^[A-Za-z0-9_-]+$`, and the OpenAI Responses API
+ * caps `call_id` at 64 characters. This is not a transient failure — once a
+ * malformed id reaches the persisted transcript, every later turn in that chat
+ * replays it and fails identically, so the chat is stuck until the id is
+ * replaced.
+ */
+const MAX_TOOL_CALL_ID_LENGTH = 64;
+const USABLE_TOOL_CALL_ID = /^[A-Za-z0-9_-]+$/;
+
+function isUsableToolCallId(id: string): boolean {
+  return (
+    id.length > 0 &&
+    id.length <= MAX_TOOL_CALL_ID_LENGTH &&
+    USABLE_TOOL_CALL_ID.test(id)
+  );
+}
+
+/** Every tool-call/result id in the transcript, usable or not. */
+function collectToolCallIds(messages: ModelMessage[]): Set<string> {
+  const ids = new Set<string>();
+  for (const message of messages) {
+    if (!Array.isArray(message.content)) continue;
+    for (const part of message.content) {
+      if (isToolCallPart(part) || isToolResultPart(part)) {
+        ids.add(part.toolCallId);
+      }
+    }
+  }
+  return ids;
+}
+
+/**
+ * Replacement ids for every unusable id in the transcript, in encounter order.
+ * Built over the whole array up front so a tool-call and its result are given
+ * the SAME replacement — renaming them independently would unpair them, which
+ * providers reject just as hard as the id we're fixing.
+ *
+ * Replacements skip every id already in the transcript: a chat repaired once
+ * already holds a `dyad_call_0`, and handing that name to a different call would
+ * merge two distinct exchanges into one and lose a tool result.
+ */
+function buildToolCallIdRenames(messages: ModelMessage[]): Map<string, string> {
+  const taken = collectToolCallIds(messages);
+  const renames = new Map<string, string>();
+  let next = 0;
+  const allocate = () => {
+    let candidate = `dyad_call_${next++}`;
+    while (taken.has(candidate)) candidate = `dyad_call_${next++}`;
+    taken.add(candidate);
+    return candidate;
+  };
+
+  for (const message of messages) {
+    if (!Array.isArray(message.content)) continue;
+    for (const part of message.content) {
+      if (!isToolCallPart(part) && !isToolResultPart(part)) continue;
+      const id = part.toolCallId;
+      if (renames.has(id) || isUsableToolCallId(id)) continue;
+      renames.set(id, allocate());
+    }
+  }
+  return renames;
+}
+
+function renameToolCallIds<T extends ModelMessage>(
+  message: T,
+  renames: Map<string, string>,
+): T {
+  if (!Array.isArray(message.content)) return message;
+  let didModify = false;
+  const content = message.content.map((part) => {
+    if (!isToolCallPart(part) && !isToolResultPart(part)) return part;
+    const replacement = renames.get(part.toolCallId);
+    if (!replacement) return part;
+    didModify = true;
+    return { ...part, toolCallId: replacement };
+  });
+  return didModify ? ({ ...message, content } as T) : message;
+}
+
+/**
  * Anthropic requires every assistant tool-call to be followed immediately by a
  * tool message containing the matching results. Persisted or dynamically
  * injected local-agent messages can occasionally violate that shape after
@@ -125,7 +207,21 @@ export function cleanMessage<T extends ModelMessage>(message: T): T {
 export function sanitizeToolCallTranscript(
   messages: ModelMessage[],
 ): ModelMessage[] {
-  const cleaned = messages.map(cleanMessage);
+  const renames = buildToolCallIdRenames(messages);
+  if (renames.size > 0) {
+    logger.warn(
+      // Folded rather than spread into Math.max: a transcript with enough
+      // distinct bad ids would blow the argument limit and crash the repair.
+      `Rewrote ${renames.size} tool-call id(s) no provider would accept (longest was ${[
+        ...renames.keys(),
+      ].reduce((longest, id) => Math.max(longest, id.length), 0)} chars)`,
+    );
+  }
+  const cleaned = messages.map((message) =>
+    cleanMessage(
+      renames.size > 0 ? renameToolCallIds(message, renames) : message,
+    ),
+  );
   const sanitized: ModelMessage[] = [];
 
   for (let i = 0; i < cleaned.length; i++) {


### PR DESCRIPTION
Providers validate tool-call ids and reject the entire request over a single bad one: Anthropic requires `^[A-Za-z0-9_-]+$`, and the OpenAI Responses API caps `call_id` at 64 characters. This is not a transient failure — the transcript is persisted and replayed in full on every later turn, so one malformed id fails identically every time and the chat is stuck with nothing the user can do to recover it.

sanitizeToolCallTranscript now rewrites unusable ids to `dyad_call_N` before sending. Two things the repair has to get right:

- A call and its result are renamed together. Renaming them independently would unpair them, which providers reject just as hard as the id being fixed.
- Replacements skip every id already in the transcript. A chat repaired once already holds a `dyad_call_0`, and handing that name to a different call would merge two distinct exchanges and drop a tool result — a quieter failure than the one being fixed.

Usable ids are left untouched, and messages with nothing to rename are returned by identity, so a healthy transcript passes through unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

