### PR TITLE
Fix native macOS quit and Dock reopen lifecycle

### DIFF
--- a/e2e-tests/helpers/fixtures.ts
+++ b/e2e-tests/helpers/fixtures.ts
@@ -155,7 +155,11 @@ export const test = base.extend<{
 
       // After the test we can check whether the test passed or failed.
       if (testInfo.status !== testInfo.expectedStatus) {
-        const page = await electronApp.firstWindow();
+        const page = electronApp.windows()[0];
+        if (!page) {
+          console.error("Unable to take failure screenshot: no window is open");
+          return;
+        }
         try {
           const screenshot = await page.screenshot({ timeout: 5_000 });
           await testInfo.attach("screenshot", {

--- a/e2e-tests/macos_native_lifecycle.spec.ts
+++ b/e2e-tests/macos_native_lifecycle.spec.ts
@@ -1,0 +1,104 @@
+import { expect } from "@playwright/test";
+import { execFileSync, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { test, Timeout } from "./helpers/test_helper";
+
+test.skip(process.platform !== "darwin", "macOS native lifecycle behavior");
+
+function postNativeCommandQ(pid: number) {
+  const script = `
+    import AppKit
+    import ApplicationServices
+
+    guard AXIsProcessTrusted() else {
+      fatalError("Accessibility permission is required for native lifecycle testing")
+    }
+    guard let target = NSRunningApplication(processIdentifier: pid_t(${pid})) else {
+      fatalError("Dyad process ${pid} is not running")
+    }
+
+    target.activate(options: [.activateAllWindows])
+    usleep(500_000)
+
+    let source = CGEventSource(stateID: .hidSystemState)
+    let keyDown = CGEvent(
+      keyboardEventSource: source,
+      virtualKey: 12,
+      keyDown: true
+    )!
+    keyDown.flags = .maskCommand
+    keyDown.postToPid(target.processIdentifier)
+
+    let keyUp = CGEvent(
+      keyboardEventSource: source,
+      virtualKey: 12,
+      keyDown: false
+    )!
+    keyUp.flags = .maskCommand
+    keyUp.postToPid(target.processIdentifier)
+  `;
+
+  execFileSync("/usr/bin/swift", ["-e", script], {
+    encoding: "utf8",
+    timeout: 15_000,
+  });
+}
+
+function reopenPackagedApp(childProcess: ChildProcess) {
+  const executablePath = childProcess.spawnfile;
+  if (!executablePath) {
+    throw new Error("Packaged Electron process has no executable path");
+  }
+  const appBundlePath = path.resolve(executablePath, "../../..");
+  execFileSync("/usr/bin/open", [appBundlePath], { timeout: 15_000 });
+}
+
+function waitForProcessExit(
+  childProcess: ChildProcess,
+  timeoutMs: number,
+): Promise<boolean> {
+  if (childProcess.exitCode !== null || childProcess.signalCode !== null) {
+    return Promise.resolve(true);
+  }
+
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => resolve(false), timeoutMs);
+    childProcess.once("exit", () => {
+      clearTimeout(timeout);
+      resolve(true);
+    });
+  });
+}
+
+test("reopens from the Dock and exits after native Command-Q", async ({
+  electronApp,
+  po,
+}, testInfo) => {
+  testInfo.setTimeout(Timeout.EXTRA_LONG);
+  await po.setUp({ autoApprove: true });
+  await po.sendPrompt("hi");
+  await po.previewPanel.expectPreviewIframeIsVisible(Timeout.EXTRA_LONG);
+
+  const childProcess = electronApp.process();
+  const pid = childProcess.pid;
+  if (!pid) throw new Error("Packaged Electron process has no PID");
+
+  await po.page.close();
+  await expect
+    .poll(() => electronApp.windows().length, { timeout: Timeout.MEDIUM })
+    .toBe(0);
+
+  const reopenedWindow = electronApp.waitForEvent("window");
+  reopenPackagedApp(childProcess);
+  const reopenedPage = await reopenedWindow;
+  await reopenedPage.waitForLoadState("domcontentloaded");
+  await expect(reopenedPage).toHaveTitle("Dyad");
+
+  const processExited = waitForProcessExit(childProcess, 10_000);
+  postNativeCommandQ(pid);
+
+  expect(
+    await processExited,
+    "native Command-Q should terminate the packaged Electron process",
+  ).toBe(true);
+});

--- a/e2e-tests/macos_native_lifecycle.spec.ts
+++ b/e2e-tests/macos_native_lifecycle.spec.ts
@@ -4,6 +4,14 @@ import path from "node:path";
 import { test, Timeout } from "./helpers/test_helper";
 
 test.skip(process.platform !== "darwin", "macOS native lifecycle behavior");
+test.skip(
+  process.env.DYAD_E2E_NATIVE_LIFECYCLE !== "1",
+  "requires an opt-in macOS host with Accessibility permission",
+);
+test.skip(
+  Number.parseInt(process.env.PLAYWRIGHT_PARALLELISM ?? "1", 10) !== 1,
+  "native bundle activation must run with PLAYWRIGHT_PARALLELISM=1",
+);
 
 function postNativeCommandQ(pid: number) {
   const script = `

--- a/rules/e2e-testing.md
+++ b/rules/e2e-testing.md
@@ -12,9 +12,11 @@ behavior, screenshots/visual layout, or a complete app-shell user journey.
 
 On macOS, Playwright `page.keyboard.press("Meta+Q")` only sends a renderer key
 event and does not exercise Electron's native Quit menu path. For lifecycle
-coverage, post a native `CGEvent` directly to the Electron PID; reopen a closed
-app window with `/usr/bin/open <bundle>` so the test uses LaunchServices/Dock
-activation semantics rather than calling main-process handlers directly.
+coverage, opt into `macos_native_lifecycle.spec.ts` with
+`DYAD_E2E_NATIVE_LIFECYCLE=1` on an Accessibility-authorized host and keep
+`PLAYWRIGHT_PARALLELISM=1`; LaunchServices bundle activation is ambiguous when
+multiple packaged Dyad instances are running. Post Command-Q directly to the
+Electron PID so another process cannot receive it.
 
 Do NOT write lots of e2e test cases for one feature. Each e2e test case adds a significant amount of overhead, so instead prefer just one or two E2E test cases that each have broad coverage of the feature in question.
 

--- a/rules/e2e-testing.md
+++ b/rules/e2e-testing.md
@@ -10,6 +10,12 @@ launching the packaged Electron app. Use Playwright E2E when the test needs the
 packaged app, native Electron/browser behavior, real click/focus/keyboard
 behavior, screenshots/visual layout, or a complete app-shell user journey.
 
+On macOS, Playwright `page.keyboard.press("Meta+Q")` only sends a renderer key
+event and does not exercise Electron's native Quit menu path. For lifecycle
+coverage, post a native `CGEvent` directly to the Electron PID; reopen a closed
+app window with `/usr/bin/open <bundle>` so the test uses LaunchServices/Dock
+activation semantics rather than calling main-process handlers directly.
+
 Do NOT write lots of e2e test cases for one feature. Each e2e test case adds a significant amount of overhead, so instead prefer just one or two E2E test cases that each have broad coverage of the feature in question.
 
 **IMPORTANT: You MUST run `npm run build` before running E2E tests.** E2E tests run against the built application binary, not the source code. If you make any changes to application code (anything outside of `e2e-tests/`), you MUST re-run `npm run build` before running E2E tests, otherwise you'll be testing the old version of the application.

--- a/src/main.ts
+++ b/src/main.ts
@@ -652,10 +652,74 @@ let pendingActiveChatId: number | null = null;
 let pendingCrashDetected = false;
 let isAppQuitting = false;
 let safeStorageKeychainUnlockRetryScheduled = false;
+const lifecycleLogger = log.scope("app_lifecycle");
+const lifecycleStartedAt = Date.now();
+let lifecycleSequence = 0;
+
+function logLifecycle(
+  event: string,
+  details: Record<string, unknown> = {},
+): void {
+  let windows: Array<{
+    id: number;
+    destroyed: boolean;
+    visible: boolean;
+    focused: boolean;
+    webContentsDestroyed: boolean;
+  }> = [];
+  try {
+    windows = BrowserWindow.getAllWindows().map((window) => ({
+      id: window.id,
+      destroyed: window.isDestroyed(),
+      visible: window.isVisible(),
+      focused: window.isFocused(),
+      webContentsDestroyed: window.webContents.isDestroyed(),
+    }));
+  } catch (error) {
+    lifecycleLogger.warn("snapshot-failed", event, error);
+  }
+
+  lifecycleLogger.info(event, {
+    sequence: ++lifecycleSequence,
+    elapsedMs: Date.now() - lifecycleStartedAt,
+    isAppQuitting,
+    hasCreatedInitialWindow,
+    mainWindowId:
+      mainWindow && !mainWindow.isDestroyed() ? mainWindow.id : null,
+    productWindowCount: productWindows.size,
+    windows,
+    ...details,
+  });
+}
+
+async function observeLifecycleCleanup(
+  name: string,
+  cleanup: () => Promise<void>,
+): Promise<void> {
+  const startedAt = Date.now();
+  logLifecycle("cleanup:start", { name });
+  try {
+    await cleanup();
+    logLifecycle("cleanup:settled", {
+      name,
+      durationMs: Date.now() - startedAt,
+      outcome: "fulfilled",
+    });
+  } catch (error) {
+    logLifecycle("cleanup:settled", {
+      name,
+      durationMs: Date.now() - startedAt,
+      outcome: "rejected",
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  }
+}
 
 function requestRelaunchAfterQuit(deepLinkUrl?: string): void {
   if (appRelaunchRequest.request({ deepLinkUrl })) {
     logger.info("Reopen requested during shutdown; relaunching after cleanup");
+    logLifecycle("relaunch:requested", { hasDeepLink: !!deepLinkUrl });
   }
 }
 
@@ -766,6 +830,10 @@ const createWindow = ({
     windowSessionId,
     visibleEntity,
   });
+  logLifecycle("window:created", {
+    windowId: browserWindow.id,
+    windowSessionId,
+  });
   windowRegistry.register(browserWindow.webContents, windowSessionId);
   browserWindow.on("focus", () => {
     mainWindow = browserWindow;
@@ -792,6 +860,37 @@ const createWindow = ({
       deepLinkWindowReadiness.setTarget(mainWindow);
       crashRecoveryWindowReadiness.setTarget(mainWindow);
     }
+    logLifecycle("window:closed", {
+      windowId: browserWindow.id,
+      windowSessionId,
+      retainedForActivation: retainForActivation,
+    });
+  });
+  browserWindow.on("close", (event) => {
+    logLifecycle("window:close", {
+      windowId: browserWindow.id,
+      windowSessionId,
+      defaultPrevented: event.defaultPrevented,
+    });
+  });
+  browserWindow.on("unresponsive", () => {
+    logLifecycle("window:unresponsive", {
+      windowId: browserWindow.id,
+      windowSessionId,
+    });
+  });
+  browserWindow.on("responsive", () => {
+    logLifecycle("window:responsive", {
+      windowId: browserWindow.id,
+      windowSessionId,
+    });
+  });
+  browserWindow.webContents.on("will-prevent-unload", (event) => {
+    logLifecycle("renderer:will-prevent-unload", {
+      windowId: browserWindow.id,
+      windowSessionId,
+      defaultPrevented: event.defaultPrevented,
+    });
   });
   const packagedRendererUrl = pathToFileURL(
     path.join(__dirname, "../renderer/main_window/index.html"),
@@ -1452,7 +1551,12 @@ app.on("child-process-gone", (_event, details) => {
 // for applications and their menu bar to stay active until the user quits
 // explicitly with Cmd + Q.
 app.on("window-all-closed", () => {
-  if (shouldQuitAfterAllWindowsClosed(process.platform)) {
+  const shouldQuit = shouldQuitAfterAllWindowsClosed(
+    process.platform,
+    isAppQuitting,
+  );
+  logLifecycle("app:window-all-closed", { shouldQuit });
+  if (shouldQuit) {
     app.quit();
   }
 });
@@ -1461,31 +1565,54 @@ app.on("window-all-closed", () => {
 // cleanup in will-quit cannot race against OS-imposed termination timeouts
 // (e.g. Windows WM_ENDSESSION) and leave the sentinel behind as a false positive.
 const handleMcpBeforeQuit = createMcpBeforeQuitHandler({
-  quit: () =>
+  quit: () => {
+    logLifecycle("app:quit-resume");
     appRelaunchRequest.finish({
       currentArgs: process.argv.slice(1),
-      relaunch: (options) => app.relaunch(options),
-      quit: () => app.quit(),
-    }),
+      relaunch: (options) => {
+        logLifecycle("app:relaunch", {
+          argumentCount: options?.args?.length ?? 0,
+        });
+        app.relaunch(options);
+      },
+      quit: () => {
+        logLifecycle("app:quit-reentered");
+        app.quit();
+      },
+    });
+  },
   cleanup: async () => {
     await Promise.all([
-      disposeMcpClientsForShutdown(),
-      disposeMcpOAuthForShutdown(),
-      disposeConnectionFlowsForShutdown(),
-      remoteMachineHost.dispose(),
+      observeLifecycleCleanup("mcp-clients", () =>
+        disposeMcpClientsForShutdown(),
+      ),
+      observeLifecycleCleanup("mcp-oauth", () => disposeMcpOAuthForShutdown()),
+      observeLifecycleCleanup("connection-flows", () =>
+        disposeConnectionFlowsForShutdown(),
+      ),
+      observeLifecycleCleanup("remote-machine-host", () =>
+        remoteMachineHost.dispose(),
+      ),
     ]);
   },
 });
 
 app.on("before-quit", (event) => {
+  logLifecycle("app:before-quit", {
+    defaultPreventedBeforeHandler: event.defaultPrevented,
+  });
   isAppQuitting = true;
   clearCrashSentinel();
   handleMcpBeforeQuit(event);
+  logLifecycle("app:before-quit-handler-complete", {
+    defaultPreventedAfterHandler: event.defaultPrevented,
+  });
 });
 
 // IMPORTANT: This handler must be synchronous because Electron's EventEmitter
 // does not await async callbacks — the returned Promise would be silently ignored.
 app.on("will-quit", () => {
+  logLifecycle("app:will-quit");
   logger.info("App is quitting");
 
   // Stop the garbage collection timer
@@ -1502,20 +1629,31 @@ app.on("will-quit", () => {
   stopChatSearchIndexer();
 });
 
+app.on("quit", (_event, exitCode) => {
+  logLifecycle("app:quit", { exitCode });
+});
+
 app.on("activate", () => {
   const activationContext = {
     isAppQuitting,
     hasCreatedInitialWindow,
     openWindowCount: BrowserWindow.getAllWindows().length,
   };
-  if (shouldRequestRelaunchOnActivate(activationContext)) {
+  const shouldRequestRelaunch =
+    shouldRequestRelaunchOnActivate(activationContext);
+  const shouldCreateWindow = shouldCreateWindowOnActivate(activationContext);
+  logLifecycle("app:activate", {
+    shouldRequestRelaunch,
+    shouldCreateWindow,
+  });
+  if (shouldRequestRelaunch) {
     requestRelaunchAfterQuit();
   }
   if (isAppQuitting) return;
 
   // On OS X it's common to re-create a window in the app when the
   // dock icon is clicked and there are no other windows open.
-  if (shouldCreateWindowOnActivate(activationContext)) {
+  if (shouldCreateWindow) {
     const descriptor = lastClosedWindowSession ?? {
       windowSessionId: PRIMARY_WINDOW_SESSION_ID,
     };

--- a/src/main/window_lifecycle_policy.test.ts
+++ b/src/main/window_lifecycle_policy.test.ts
@@ -38,6 +38,10 @@ describe("window lifecycle policy", () => {
     expect(shouldQuitAfterAllWindowsClosed("darwin")).toBe(false);
   });
 
+  it("continues an in-progress macOS quit after the last window closes", () => {
+    expect(shouldQuitAfterAllWindowsClosed("darwin", true)).toBe(true);
+  });
+
   it("ignores activation until startup owns the initial window", () => {
     expect(
       shouldCreateWindowOnActivate({

--- a/src/main/window_lifecycle_policy.ts
+++ b/src/main/window_lifecycle_policy.ts
@@ -10,8 +10,9 @@ export function shouldRetainClosedWindowForActivation({
 
 export function shouldQuitAfterAllWindowsClosed(
   platform: NodeJS.Platform,
+  isAppQuitting = false,
 ): boolean {
-  return platform !== "darwin";
+  return isAppQuitting || platform !== "darwin";
 }
 
 export function shouldCreateWindowOnActivate({


### PR DESCRIPTION
## Summary

Restore standard macOS application lifecycle behavior: a native Command-Q now completes shutdown after asynchronous cleanup, while closing the final window still keeps Dyad available for Dock activation and recreates its main window.

- Continue an already-started quit from `window-all-closed` on macOS without changing the normal close-last-window policy.
- Add structured `app_lifecycle` logging around windows, activation, quit events, relaunch requests, and asynchronous cleanup so future packaged-app failures can be reconstructed from logs.
- Cover the real packaged behavior with a macOS Playwright test that closes and reopens through LaunchServices, then posts a native Command-Q directly to Dyad's PID.
- Make E2E failure screenshot capture tolerate lifecycle tests that intentionally have no open windows.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches main-process quit/window-all-closed behavior on macOS; the policy change is narrow and covered by unit and opt-in E2E tests, but incorrect quit logic could strand or prematurely kill the app.
> 
> **Overview**
> Fixes **macOS quit** so a native Command-Q can complete after async cleanup: `shouldQuitAfterAllWindowsClosed` now quits on `darwin` when `isAppQuitting` is already true, while closing the last window without quitting still keeps the app alive for Dock activation.
> 
> Adds structured **`app_lifecycle`** logging in the main process (windows, activate, quit/relaunch, and wrapped async shutdown cleanups) to debug packaged lifecycle failures.
> 
> Adds an **opt-in** Playwright spec (`DYAD_E2E_NATIVE_LIFECYCLE=1`, Accessibility, `PLAYWRIGHT_PARALLELISM=1`) that reopens via `open` on the app bundle and posts native Command-Q to the Electron PID via Swift; documents why renderer `Meta+Q` is insufficient. E2E failure screenshots use `electronApp.windows()[0]` and skip when no window is open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e3350da53c4b9ba0b4a8ef6bf9441bc47a12b1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->