### PR TITLE
Make long error messages easier to inspect

### DIFF
--- a/src/components/CustomErrorToast.test.tsx
+++ b/src/components/CustomErrorToast.test.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactElement, ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CustomErrorToast } from "./CustomErrorToast";
+
+const { dismiss } = vi.hoisted(() => ({
+  dismiss: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { dismiss },
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => children,
+  TooltipTrigger: ({ render }: { render: ReactElement }) => render,
+  TooltipContent: () => null,
+}));
+
+describe("CustomErrorToast", () => {
+  beforeEach(() => {
+    dismiss.mockClear();
+  });
+
+  it("makes long error details keyboard-scrollable", () => {
+    const message = `Build failed\n${"A very long error line ".repeat(40)}`;
+
+    render(<CustomErrorToast message={message} toastId="error-toast" />);
+
+    const details = screen.getByRole("region", { name: "Error details" });
+    expect(details.getAttribute("tabindex")).toBe("0");
+    expect(details.classList.contains("overflow-y-auto")).toBe(true);
+    expect(details.classList.contains("overscroll-contain")).toBe(true);
+    expect(details.textContent).toContain(message);
+  });
+
+  it("keeps copy and close controls accessible", () => {
+    const onCopy = vi.fn();
+
+    render(
+      <CustomErrorToast
+        message="Something went wrong"
+        toastId="error-toast"
+        onCopy={onCopy}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy error details" }));
+    expect(onCopy).toHaveBeenCalledOnce();
+
+    fireEvent.click(screen.getByRole("button", { name: "Close error" }));
+    expect(dismiss).toHaveBeenCalledWith("error-toast");
+  });
+});

--- a/src/components/CustomErrorToast.tsx
+++ b/src/components/CustomErrorToast.tsx
@@ -36,59 +36,78 @@ export function CustomErrorToast({
   };
 
   return (
-    <div className="relative bg-red-50/95 backdrop-blur-sm border border-red-200 rounded-xl shadow-lg min-w-[400px] max-w-[500px] overflow-hidden">
+    <div className="relative w-[min(500px,calc(100vw-2rem))] overflow-hidden rounded-xl border border-red-200 bg-red-50/95 shadow-md backdrop-blur-sm dark:border-red-900 dark:bg-red-950/95">
       {/* Content */}
       <div className="p-4">
         <div className="flex items-start">
           <div className="flex-1">
             <div className="flex items-center mb-3">
               <div className="flex-shrink-0">
-                <div className="w-5 h-5 bg-gradient-to-br from-red-400 to-red-500 rounded-full flex items-center justify-center shadow-sm">
+                <div className="flex size-5 items-center justify-center rounded-full bg-red-500">
                   <X className="w-3 h-3 text-white" />
                 </div>
               </div>
-              <h3 className="ml-3 text-sm font-medium text-red-900">Error</h3>
+              <h3 className="ml-3 text-sm font-medium text-red-900 dark:text-red-100">
+                Error
+              </h3>
 
               {/* Action buttons */}
               <div className="flex items-center space-x-1.5 ml-auto">
                 <Tooltip>
-                  <TooltipTrigger>
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleCopy();
-                      }}
-                      className="p-1.5 text-red-500 hover:text-red-700 hover:bg-red-100/70 rounded-lg transition-all duration-150"
-                    >
-                      {copied ? (
-                        <Check className="w-4 h-4 text-green-500" />
-                      ) : (
-                        <Copy className="w-4 h-4" />
-                      )}
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent>Copy to clipboard</TooltipContent>
+                  <TooltipTrigger
+                    render={
+                      <button
+                        type="button"
+                        aria-label={copied ? "Copied" : "Copy error details"}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleCopy();
+                        }}
+                        className="rounded-lg p-1.5 text-red-600 transition-colors duration-150 hover:bg-red-100/70 hover:text-red-800 focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:outline-none dark:text-red-300 dark:hover:bg-red-900/70 dark:hover:text-red-100"
+                      >
+                        {copied ? (
+                          <Check className="w-4 h-4 text-green-500" />
+                        ) : (
+                          <Copy className="w-4 h-4" />
+                        )}
+                      </button>
+                    }
+                  />
+                  <TooltipContent>
+                    {copied ? "Copied" : "Copy error details"}
+                  </TooltipContent>
                 </Tooltip>
                 <Tooltip>
-                  <TooltipTrigger>
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleClose();
-                      }}
-                      className="p-1.5 text-red-500 hover:text-red-700 hover:bg-red-100/70 rounded-lg transition-all duration-150"
-                    >
-                      <X className="w-4 h-4" />
-                    </button>
-                  </TooltipTrigger>
+                  <TooltipTrigger
+                    render={
+                      <button
+                        type="button"
+                        aria-label="Close error"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleClose();
+                        }}
+                        className="rounded-lg p-1.5 text-red-600 transition-colors duration-150 hover:bg-red-100/70 hover:text-red-800 focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:outline-none dark:text-red-300 dark:hover:bg-red-900/70 dark:hover:text-red-100"
+                      >
+                        <X className="w-4 h-4" />
+                      </button>
+                    }
+                  />
                   <TooltipContent>Close</TooltipContent>
                 </Tooltip>
               </div>
             </div>
             <div>
-              <p className="text-sm text-red-800 leading-relaxed whitespace-pre-wrap bg-red-100/50 backdrop-blur-sm p-3 rounded-lg border border-red-200/50">
-                {message}
-              </p>
+              <div
+                role="region"
+                aria-label="Error details"
+                tabIndex={0}
+                className="scrollbar-on-hover max-h-[min(50vh,20rem)] overflow-x-hidden overflow-y-auto overscroll-contain rounded-lg border border-red-200/50 bg-red-100/50 p-3 focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:outline-none dark:border-red-800/70 dark:bg-red-900/40"
+              >
+                <p className="text-sm leading-relaxed whitespace-pre-wrap text-red-900 [overflow-wrap:anywhere] dark:text-red-100">
+                  {message}
+                </p>
+              </div>
               {action && (
                 <button
                   type="button"
@@ -97,7 +116,7 @@ export function CustomErrorToast({
                     action.onClick();
                     handleClose();
                   }}
-                  className="mt-3 inline-flex items-center gap-1.5 rounded-md border border-red-300 bg-white px-3 py-1.5 text-sm font-medium text-red-800 shadow-sm hover:bg-red-50"
+                  className="mt-3 inline-flex items-center gap-1.5 rounded-md border border-red-300 bg-white px-3 py-1.5 text-sm font-medium text-red-800 shadow-sm hover:bg-red-50 focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:outline-none dark:border-red-800 dark:bg-red-950 dark:text-red-100 dark:hover:bg-red-900"
                 >
                   <ExternalLink className="h-3.5 w-3.5" />
                   {action.label}


### PR DESCRIPTION
## Summary

Long error messages are now contained in a keyboard-accessible, independently scrollable details area so the toast header and actions stay easy to reach.

- Caps error details at half the viewport height (up to 20rem) while keeping short errors compact.
- Wraps unbroken technical strings and uses the existing hover/focus scrollbar treatment to prevent horizontal overflow and heavy scrollbar chrome.
- Makes copy and close controls explicitly labeled and focus-visible, fixes their Base UI tooltip trigger composition, and adds dark-theme styling.
- Adds focused component coverage for scrolling semantics and the copy/close interactions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit b00f38c0993f2bb9a565f05382fe051b275d9b13. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

