### PR TITLE
Open a file's diff from the commit dialogs

### DIFF
--- a/e2e-tests/editor_commit_menu.spec.ts
+++ b/e2e-tests/editor_commit_menu.spec.ts
@@ -129,6 +129,21 @@ test("editor commit menu commits multiple staged files at once", async ({
   await messageInput.clear();
   await messageInput.fill(commitMessage);
 
+  // Clicking a file in the dialog closes it and opens that file's diff...
+  await filesList
+    .getByTestId("commit-file-item")
+    .filter({ hasText: "robots.txt" })
+    .click();
+  await expect(dialog).not.toBeVisible();
+  await expect(po.page.getByTestId("staged-diff-view")).toBeVisible({
+    timeout: Timeout.MEDIUM,
+  });
+
+  // ...and leaving the diff brings the dialog back with the message intact.
+  await po.page.getByTestId("staged-diff-back-button").click();
+  await expect(dialog).toBeVisible();
+  await expect(messageInput).toHaveValue(commitMessage);
+
   await po.page.getByTestId("editor-commit-confirm-button").click();
   await po.toastNotifications.waitForToast("success");
 

--- a/e2e-tests/uncommitted_files_banner.spec.ts
+++ b/e2e-tests/uncommitted_files_banner.spec.ts
@@ -178,6 +178,22 @@ const runUncommittedFilesBannerTest = async (po: PageObject) => {
   await commitInput.clear();
   await commitInput.fill(testCommitMessage);
 
+  // Clicking a file closes the dialog and reveals that file's diff in the code
+  // panel, which the banner has to open since it lives in the chat header.
+  await changedFilesList
+    .getByTestId("commit-file-item")
+    .filter({ hasText: "new-file.txt" })
+    .click();
+  await expect(po.page.getByTestId("commit-dialog")).not.toBeVisible();
+  await expect(po.page.getByTestId("staged-diff-view")).toBeVisible({
+    timeout: Timeout.MEDIUM,
+  });
+
+  // Leaving the diff brings the dialog back with the typed message intact.
+  await po.page.getByTestId("staged-diff-back-button").click();
+  await expect(po.page.getByTestId("commit-dialog")).toBeVisible();
+  await expect(commitInput).toHaveValue(testCommitMessage);
+
   // Click the commit button
   await po.page.getByTestId("commit-button").click();
 

--- a/src/atoms/commitAtoms.test.ts
+++ b/src/atoms/commitAtoms.test.ts
@@ -4,16 +4,19 @@ import { previewModeAtom, selectedAppIdAtom } from "@/atoms/appAtoms";
 import { isPreviewOpenAtom, stagedDiffFileAtom } from "@/atoms/viewAtoms";
 import {
   clearStagedDiffAtom,
+  closeCommitDialogAtom,
   commitMessageDraftAtom,
   commitMessageDraftsByAppIdAtom,
   discardCommitMessageDraftAtom,
-  dismissCommitDialogAtom,
   exitStagedDiffAtom,
   openCommitDialogAtom,
   openStagedDiffAtom,
-  releaseCommitDialogAtom,
   resetCommitDialogAtom,
+  type CommitDialogSource,
 } from "@/atoms/commitAtoms";
+
+const APP = 1;
+const OTHER_APP = 2;
 
 /**
  * The staged-diff round trip these atoms exist for: a dialog is open, the user
@@ -21,10 +24,15 @@ import {
  */
 function openDiffFrom(
   store: ReturnType<typeof createStore>,
-  source: "editor" | "banner",
+  source: CommitDialogSource,
+  appId = APP,
 ) {
-  store.set(openCommitDialogAtom, source);
-  store.set(openStagedDiffAtom, { path: "src/a.ts", returnTo: source });
+  store.set(selectedAppIdAtom, appId);
+  store.set(openCommitDialogAtom, { source, appId });
+  store.set(openStagedDiffAtom, {
+    path: "src/a.ts",
+    returnTo: { source, appId },
+  });
 }
 
 describe("commit dialog atoms", () => {
@@ -33,11 +41,11 @@ describe("commit dialog atoms", () => {
       const store = createStore();
       store.set(previewModeAtom, "preview");
       store.set(isPreviewOpenAtom, false);
-      store.set(openCommitDialogAtom, "editor");
+      store.set(openCommitDialogAtom, { source: "editor", appId: APP });
 
       store.set(openStagedDiffAtom, {
         path: "src/a.ts",
-        returnTo: "editor",
+        returnTo: { source: "editor", appId: APP },
       });
 
       expect(store.get(openCommitDialogAtom)).toBeNull();
@@ -55,7 +63,10 @@ describe("commit dialog atoms", () => {
       store.set(exitStagedDiffAtom);
 
       expect(store.get(stagedDiffFileAtom)).toBeNull();
-      expect(store.get(openCommitDialogAtom)).toBe("banner");
+      expect(store.get(openCommitDialogAtom)).toEqual({
+        source: "banner",
+        appId: APP,
+      });
     });
 
     it("opens nothing when the diff was not opened from a dialog", () => {
@@ -86,7 +97,7 @@ describe("commit dialog atoms", () => {
       const store = createStore();
       openDiffFrom(store, "editor");
 
-      store.set(clearStagedDiffAtom);
+      store.set(clearStagedDiffAtom, APP);
 
       expect(store.get(stagedDiffFileAtom)).toBeNull();
       expect(store.get(openCommitDialogAtom)).toBeNull();
@@ -97,59 +108,149 @@ describe("commit dialog atoms", () => {
 
     it("discards the draft, which cannot outlive the round trip", () => {
       const store = createStore();
-      store.set(selectedAppIdAtom, 1);
-      store.set(openCommitDialogAtom, "editor");
+      store.set(selectedAppIdAtom, APP);
+      store.set(openCommitDialogAtom, { source: "editor", appId: APP });
       store.set(commitMessageDraftAtom, "Fix login redirect");
-      store.set(openStagedDiffAtom, { path: "src/a.ts", returnTo: "editor" });
+      store.set(openStagedDiffAtom, {
+        path: "src/a.ts",
+        returnTo: { source: "editor", appId: APP },
+      });
 
       // Editing the file from the diff is the path with no way back.
-      store.set(clearStagedDiffAtom);
+      store.set(clearStagedDiffAtom, APP);
 
       expect(store.get(commitMessageDraftAtom)).toBeNull();
     });
-  });
 
-  describe("releaseCommitDialogAtom", () => {
-    it("closes only the releasing source's dialog", () => {
+    it("does nothing once the user has moved to another app", () => {
       const store = createStore();
-      store.set(openCommitDialogAtom, "editor");
+      openDiffFrom(store, "banner");
+      // A commit for app 1 resolves after the user switched to app 2 and
+      // started their own diff and message there.
+      store.set(selectedAppIdAtom, OTHER_APP);
+      store.set(stagedDiffFileAtom, "src/b.ts");
+      store.set(commitMessageDraftAtom, "Add settings page");
 
-      store.set(releaseCommitDialogAtom, "banner");
+      store.set(clearStagedDiffAtom, APP);
 
-      expect(store.get(openCommitDialogAtom)).toBe("editor");
-
-      store.set(releaseCommitDialogAtom, "editor");
-
-      expect(store.get(openCommitDialogAtom)).toBeNull();
+      expect(store.get(stagedDiffFileAtom)).toBe("src/b.ts");
+      expect(store.get(commitMessageDraftAtom)).toBe("Add settings page");
     });
 
-    it("drops a pending return only when the releasing source owns it", () => {
+    it("does nothing without an app to scope to", () => {
       const store = createStore();
       openDiffFrom(store, "editor");
 
-      store.set(releaseCommitDialogAtom, "banner");
-      store.set(exitStagedDiffAtom);
+      store.set(clearStagedDiffAtom, null);
 
-      expect(store.get(openCommitDialogAtom)).toBe("editor");
+      expect(store.get(stagedDiffFileAtom)).toBe("src/a.ts");
+    });
+  });
+
+  describe("closeCommitDialogAtom", () => {
+    it("closes the dialog and discards its draft", () => {
+      const store = createStore();
+      store.set(selectedAppIdAtom, APP);
+      store.set(openCommitDialogAtom, { source: "editor", appId: APP });
+      store.set(commitMessageDraftAtom, "Fix login redirect");
+
+      store.set(closeCommitDialogAtom, { source: "editor", appId: APP });
+
+      expect(store.get(openCommitDialogAtom)).toBeNull();
+      expect(store.get(commitMessageDraftAtom)).toBeNull();
     });
 
-    it("drops its own pending return so the back arrow cannot reach it", () => {
+    it("drops the pending return, so the back arrow cannot resurrect it", () => {
       const store = createStore();
-      openDiffFrom(store, "banner");
+      // Open the diff from the dialog, then reopen the dialog from its own
+      // button on top of the diff, then cancel it.
+      openDiffFrom(store, "editor");
+      store.set(openCommitDialogAtom, { source: "editor", appId: APP });
 
-      store.set(releaseCommitDialogAtom, "banner");
+      store.set(closeCommitDialogAtom, { source: "editor", appId: APP });
       store.set(exitStagedDiffAtom);
 
       expect(store.get(openCommitDialogAtom)).toBeNull();
+      expect(store.get(stagedDiffFileAtom)).toBeNull();
+    });
+
+    it("drops a pending return when its host can no longer render it", () => {
+      const store = createStore();
+      // The banner is unmounted by ChatHeader while streaming, mid round trip.
+      openDiffFrom(store, "banner");
+      store.set(commitMessageDraftAtom, "Fix login redirect");
+
+      store.set(closeCommitDialogAtom, { source: "banner", appId: APP });
+
+      // Nothing renders that dialog now, so neither the back arrow nor a later
+      // reopen may find its way back to it - message included.
+      store.set(exitStagedDiffAtom);
+      expect(store.get(openCommitDialogAtom)).toBeNull();
+      expect(store.get(commitMessageDraftAtom)).toBeNull();
     });
 
     it("leaves the staged diff showing", () => {
       const store = createStore();
       openDiffFrom(store, "banner");
 
-      store.set(releaseCommitDialogAtom, "banner");
+      store.set(closeCommitDialogAtom, { source: "banner", appId: APP });
 
       expect(store.get(stagedDiffFileAtom)).toBe("src/a.ts");
+    });
+
+    it("leaves the other source's dialog and pending return alone", () => {
+      const store = createStore();
+      openDiffFrom(store, "editor");
+      store.set(openCommitDialogAtom, { source: "editor", appId: APP });
+
+      store.set(closeCommitDialogAtom, { source: "banner", appId: APP });
+
+      expect(store.get(openCommitDialogAtom)).toEqual({
+        source: "editor",
+        appId: APP,
+      });
+      store.set(openCommitDialogAtom, null);
+      store.set(exitStagedDiffAtom);
+      expect(store.get(openCommitDialogAtom)).toEqual({
+        source: "editor",
+        appId: APP,
+      });
+    });
+
+    it("leaves the draft alone when it owns neither the dialog nor a return", () => {
+      const store = createStore();
+      store.set(selectedAppIdAtom, APP);
+      // The user is typing in the banner's dialog when a plan:update event
+      // flips previewMode and unmounts CodeView, taking the commit menu with
+      // it. The two sources share one draft per app, so this must not empty
+      // the input in front of the user.
+      store.set(openCommitDialogAtom, { source: "banner", appId: APP });
+      store.set(commitMessageDraftAtom, "Fix login redirect");
+
+      store.set(closeCommitDialogAtom, { source: "editor", appId: APP });
+
+      expect(store.get(commitMessageDraftAtom)).toBe("Fix login redirect");
+      expect(store.get(openCommitDialogAtom)).toEqual({
+        source: "banner",
+        appId: APP,
+      });
+    });
+
+    it("leaves the same source's dialog for another app alone", () => {
+      const store = createStore();
+      store.set(selectedAppIdAtom, OTHER_APP);
+      // The user switched apps and opened a new banner dialog before app 1's
+      // commit finished.
+      store.set(openCommitDialogAtom, { source: "banner", appId: OTHER_APP });
+      store.set(commitMessageDraftAtom, "Add settings page");
+
+      store.set(closeCommitDialogAtom, { source: "banner", appId: APP });
+
+      expect(store.get(openCommitDialogAtom)).toEqual({
+        source: "banner",
+        appId: OTHER_APP,
+      });
+      expect(store.get(commitMessageDraftAtom)).toBe("Add settings page");
     });
   });
 
@@ -157,7 +258,7 @@ describe("commit dialog atoms", () => {
     it("drops the dialog and pending return without touching the diff", () => {
       const store = createStore();
       openDiffFrom(store, "editor");
-      store.set(openCommitDialogAtom, "editor");
+      store.set(openCommitDialogAtom, { source: "editor", appId: APP });
 
       store.set(resetCommitDialogAtom);
 
@@ -169,7 +270,7 @@ describe("commit dialog atoms", () => {
 
     it("keeps the draft, which is per-app and survives switching back", () => {
       const store = createStore();
-      store.set(selectedAppIdAtom, 1);
+      store.set(selectedAppIdAtom, APP);
       store.set(commitMessageDraftAtom, "Fix login redirect");
 
       store.set(resetCommitDialogAtom);
@@ -178,81 +279,30 @@ describe("commit dialog atoms", () => {
     });
   });
 
-  describe("dismissCommitDialogAtom", () => {
-    it("closes the dialog and discards its draft", () => {
-      const store = createStore();
-      store.set(selectedAppIdAtom, 1);
-      store.set(openCommitDialogAtom, "editor");
-      store.set(commitMessageDraftAtom, "Fix login redirect");
-
-      store.set(dismissCommitDialogAtom, { source: "editor", appId: 1 });
-
-      expect(store.get(openCommitDialogAtom)).toBeNull();
-      expect(store.get(commitMessageDraftAtom)).toBeNull();
-    });
-
-    it("drops the pending return, so the back arrow cannot resurrect it", () => {
-      const store = createStore();
-      store.set(selectedAppIdAtom, 1);
-      // Open the diff from the dialog, then reopen the dialog from its own
-      // button on top of the diff, then cancel it.
-      openDiffFrom(store, "editor");
-      store.set(openCommitDialogAtom, "editor");
-
-      store.set(dismissCommitDialogAtom, { source: "editor", appId: 1 });
-      store.set(exitStagedDiffAtom);
-
-      expect(store.get(openCommitDialogAtom)).toBeNull();
-      expect(store.get(stagedDiffFileAtom)).toBeNull();
-    });
-
-    it("leaves the other source's dialog and draft alone", () => {
-      const store = createStore();
-      store.set(selectedAppIdAtom, 2);
-      store.set(openCommitDialogAtom, "banner");
-      store.set(commitMessageDraftAtom, "Add settings page");
-
-      // A commit started from the editor dialog for app 1 resolving late.
-      store.set(dismissCommitDialogAtom, { source: "editor", appId: 1 });
-
-      expect(store.get(openCommitDialogAtom)).toBe("banner");
-      expect(store.get(commitMessageDraftAtom)).toBe("Add settings page");
-    });
-
-    it("is a no-op on the draft before an app is selected", () => {
-      const store = createStore();
-      store.set(openCommitDialogAtom, "banner");
-
-      store.set(dismissCommitDialogAtom, { source: "banner", appId: null });
-
-      expect(store.get(openCommitDialogAtom)).toBeNull();
-    });
-  });
-
   describe("commitMessageDraftAtom", () => {
     it("reads and writes the selected app's entry", () => {
       const store = createStore();
-      store.set(selectedAppIdAtom, 1);
+      store.set(selectedAppIdAtom, APP);
       store.set(commitMessageDraftAtom, "Fix login redirect");
-      store.set(selectedAppIdAtom, 2);
+      store.set(selectedAppIdAtom, OTHER_APP);
 
       expect(store.get(commitMessageDraftAtom)).toBeNull();
 
       store.set(commitMessageDraftAtom, "Add settings page");
-      store.set(selectedAppIdAtom, 1);
+      store.set(selectedAppIdAtom, APP);
 
       expect(store.get(commitMessageDraftAtom)).toBe("Fix login redirect");
     });
 
     it("deletes the entry when written null", () => {
       const store = createStore();
-      store.set(selectedAppIdAtom, 1);
+      store.set(selectedAppIdAtom, APP);
       store.set(commitMessageDraftAtom, "Fix login redirect");
 
       store.set(commitMessageDraftAtom, null);
 
       expect(store.get(commitMessageDraftAtom)).toBeNull();
-      expect(store.get(commitMessageDraftsByAppIdAtom).has(1)).toBe(false);
+      expect(store.get(commitMessageDraftsByAppIdAtom).has(APP)).toBe(false);
     });
 
     it("is a no-op before an app is selected", () => {
@@ -268,22 +318,22 @@ describe("commit dialog atoms", () => {
   describe("discardCommitMessageDraftAtom", () => {
     it("deletes by app id rather than by the selected app", () => {
       const store = createStore();
-      store.set(selectedAppIdAtom, 1);
+      store.set(selectedAppIdAtom, APP);
       store.set(commitMessageDraftAtom, "Fix login redirect");
-      store.set(selectedAppIdAtom, 2);
+      store.set(selectedAppIdAtom, OTHER_APP);
       store.set(commitMessageDraftAtom, "Add settings page");
 
-      store.set(discardCommitMessageDraftAtom, 1);
+      store.set(discardCommitMessageDraftAtom, APP);
 
       expect(store.get(commitMessageDraftAtom)).toBe("Add settings page");
-      expect(store.get(commitMessageDraftsByAppIdAtom).has(1)).toBe(false);
+      expect(store.get(commitMessageDraftsByAppIdAtom).has(APP)).toBe(false);
     });
 
     it("keeps the map identity when there is nothing to delete", () => {
       const store = createStore();
       const before = store.get(commitMessageDraftsByAppIdAtom);
 
-      store.set(discardCommitMessageDraftAtom, 1);
+      store.set(discardCommitMessageDraftAtom, APP);
 
       expect(store.get(commitMessageDraftsByAppIdAtom)).toBe(before);
     });

--- a/src/atoms/commitAtoms.test.ts
+++ b/src/atoms/commitAtoms.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it } from "vitest";
+import { createStore } from "jotai";
+import { previewModeAtom, selectedAppIdAtom } from "@/atoms/appAtoms";
+import { isPreviewOpenAtom, stagedDiffFileAtom } from "@/atoms/viewAtoms";
+import {
+  clearStagedDiffAtom,
+  commitMessageDraftAtom,
+  commitMessageDraftsByAppIdAtom,
+  discardCommitMessageDraftAtom,
+  dismissCommitDialogAtom,
+  exitStagedDiffAtom,
+  openCommitDialogAtom,
+  openStagedDiffAtom,
+  releaseCommitDialogAtom,
+  resetCommitDialogAtom,
+} from "@/atoms/commitAtoms";
+
+/**
+ * The staged-diff round trip these atoms exist for: a dialog is open, the user
+ * clicks a file in it, and the diff opens with a pending return to that dialog.
+ */
+function openDiffFrom(
+  store: ReturnType<typeof createStore>,
+  source: "editor" | "banner",
+) {
+  store.set(openCommitDialogAtom, source);
+  store.set(openStagedDiffAtom, { path: "src/a.ts", returnTo: source });
+}
+
+describe("commit dialog atoms", () => {
+  describe("openStagedDiffAtom", () => {
+    it("swaps the dialog for the diff and reveals the code panel", () => {
+      const store = createStore();
+      store.set(previewModeAtom, "preview");
+      store.set(isPreviewOpenAtom, false);
+      store.set(openCommitDialogAtom, "editor");
+
+      store.set(openStagedDiffAtom, {
+        path: "src/a.ts",
+        returnTo: "editor",
+      });
+
+      expect(store.get(openCommitDialogAtom)).toBeNull();
+      expect(store.get(stagedDiffFileAtom)).toBe("src/a.ts");
+      expect(store.get(previewModeAtom)).toBe("code");
+      expect(store.get(isPreviewOpenAtom)).toBe(true);
+    });
+  });
+
+  describe("exitStagedDiffAtom", () => {
+    it("reopens the dialog the diff was opened from", () => {
+      const store = createStore();
+      openDiffFrom(store, "banner");
+
+      store.set(exitStagedDiffAtom);
+
+      expect(store.get(stagedDiffFileAtom)).toBeNull();
+      expect(store.get(openCommitDialogAtom)).toBe("banner");
+    });
+
+    it("opens nothing when the diff was not opened from a dialog", () => {
+      const store = createStore();
+      // The commit menu's dropdown is a shortcut straight to a diff.
+      store.set(openStagedDiffAtom, { path: "src/a.ts", returnTo: null });
+
+      store.set(exitStagedDiffAtom);
+
+      expect(store.get(stagedDiffFileAtom)).toBeNull();
+      expect(store.get(openCommitDialogAtom)).toBeNull();
+    });
+
+    it("consumes the return target so a second exit reopens nothing", () => {
+      const store = createStore();
+      openDiffFrom(store, "editor");
+
+      store.set(exitStagedDiffAtom);
+      store.set(openCommitDialogAtom, null);
+      store.set(exitStagedDiffAtom);
+
+      expect(store.get(openCommitDialogAtom)).toBeNull();
+    });
+  });
+
+  describe("clearStagedDiffAtom", () => {
+    it("leaves the diff without reopening the dialog behind it", () => {
+      const store = createStore();
+      openDiffFrom(store, "editor");
+
+      store.set(clearStagedDiffAtom);
+
+      expect(store.get(stagedDiffFileAtom)).toBeNull();
+      expect(store.get(openCommitDialogAtom)).toBeNull();
+      // The return target is gone too: a later exit must not resurrect it.
+      store.set(exitStagedDiffAtom);
+      expect(store.get(openCommitDialogAtom)).toBeNull();
+    });
+
+    it("discards the draft, which cannot outlive the round trip", () => {
+      const store = createStore();
+      store.set(selectedAppIdAtom, 1);
+      store.set(openCommitDialogAtom, "editor");
+      store.set(commitMessageDraftAtom, "Fix login redirect");
+      store.set(openStagedDiffAtom, { path: "src/a.ts", returnTo: "editor" });
+
+      // Editing the file from the diff is the path with no way back.
+      store.set(clearStagedDiffAtom);
+
+      expect(store.get(commitMessageDraftAtom)).toBeNull();
+    });
+  });
+
+  describe("releaseCommitDialogAtom", () => {
+    it("closes only the releasing source's dialog", () => {
+      const store = createStore();
+      store.set(openCommitDialogAtom, "editor");
+
+      store.set(releaseCommitDialogAtom, "banner");
+
+      expect(store.get(openCommitDialogAtom)).toBe("editor");
+
+      store.set(releaseCommitDialogAtom, "editor");
+
+      expect(store.get(openCommitDialogAtom)).toBeNull();
+    });
+
+    it("drops a pending return only when the releasing source owns it", () => {
+      const store = createStore();
+      openDiffFrom(store, "editor");
+
+      store.set(releaseCommitDialogAtom, "banner");
+      store.set(exitStagedDiffAtom);
+
+      expect(store.get(openCommitDialogAtom)).toBe("editor");
+    });
+
+    it("drops its own pending return so the back arrow cannot reach it", () => {
+      const store = createStore();
+      openDiffFrom(store, "banner");
+
+      store.set(releaseCommitDialogAtom, "banner");
+      store.set(exitStagedDiffAtom);
+
+      expect(store.get(openCommitDialogAtom)).toBeNull();
+    });
+
+    it("leaves the staged diff showing", () => {
+      const store = createStore();
+      openDiffFrom(store, "banner");
+
+      store.set(releaseCommitDialogAtom, "banner");
+
+      expect(store.get(stagedDiffFileAtom)).toBe("src/a.ts");
+    });
+  });
+
+  describe("resetCommitDialogAtom", () => {
+    it("drops the dialog and pending return without touching the diff", () => {
+      const store = createStore();
+      openDiffFrom(store, "editor");
+      store.set(openCommitDialogAtom, "editor");
+
+      store.set(resetCommitDialogAtom);
+
+      expect(store.get(openCommitDialogAtom)).toBeNull();
+      expect(store.get(stagedDiffFileAtom)).toBe("src/a.ts");
+      store.set(exitStagedDiffAtom);
+      expect(store.get(openCommitDialogAtom)).toBeNull();
+    });
+
+    it("keeps the draft, which is per-app and survives switching back", () => {
+      const store = createStore();
+      store.set(selectedAppIdAtom, 1);
+      store.set(commitMessageDraftAtom, "Fix login redirect");
+
+      store.set(resetCommitDialogAtom);
+
+      expect(store.get(commitMessageDraftAtom)).toBe("Fix login redirect");
+    });
+  });
+
+  describe("dismissCommitDialogAtom", () => {
+    it("closes the dialog and discards its draft", () => {
+      const store = createStore();
+      store.set(selectedAppIdAtom, 1);
+      store.set(openCommitDialogAtom, "editor");
+      store.set(commitMessageDraftAtom, "Fix login redirect");
+
+      store.set(dismissCommitDialogAtom, { source: "editor", appId: 1 });
+
+      expect(store.get(openCommitDialogAtom)).toBeNull();
+      expect(store.get(commitMessageDraftAtom)).toBeNull();
+    });
+
+    it("drops the pending return, so the back arrow cannot resurrect it", () => {
+      const store = createStore();
+      store.set(selectedAppIdAtom, 1);
+      // Open the diff from the dialog, then reopen the dialog from its own
+      // button on top of the diff, then cancel it.
+      openDiffFrom(store, "editor");
+      store.set(openCommitDialogAtom, "editor");
+
+      store.set(dismissCommitDialogAtom, { source: "editor", appId: 1 });
+      store.set(exitStagedDiffAtom);
+
+      expect(store.get(openCommitDialogAtom)).toBeNull();
+      expect(store.get(stagedDiffFileAtom)).toBeNull();
+    });
+
+    it("leaves the other source's dialog and draft alone", () => {
+      const store = createStore();
+      store.set(selectedAppIdAtom, 2);
+      store.set(openCommitDialogAtom, "banner");
+      store.set(commitMessageDraftAtom, "Add settings page");
+
+      // A commit started from the editor dialog for app 1 resolving late.
+      store.set(dismissCommitDialogAtom, { source: "editor", appId: 1 });
+
+      expect(store.get(openCommitDialogAtom)).toBe("banner");
+      expect(store.get(commitMessageDraftAtom)).toBe("Add settings page");
+    });
+
+    it("is a no-op on the draft before an app is selected", () => {
+      const store = createStore();
+      store.set(openCommitDialogAtom, "banner");
+
+      store.set(dismissCommitDialogAtom, { source: "banner", appId: null });
+
+      expect(store.get(openCommitDialogAtom)).toBeNull();
+    });
+  });
+
+  describe("commitMessageDraftAtom", () => {
+    it("reads and writes the selected app's entry", () => {
+      const store = createStore();
+      store.set(selectedAppIdAtom, 1);
+      store.set(commitMessageDraftAtom, "Fix login redirect");
+      store.set(selectedAppIdAtom, 2);
+
+      expect(store.get(commitMessageDraftAtom)).toBeNull();
+
+      store.set(commitMessageDraftAtom, "Add settings page");
+      store.set(selectedAppIdAtom, 1);
+
+      expect(store.get(commitMessageDraftAtom)).toBe("Fix login redirect");
+    });
+
+    it("deletes the entry when written null", () => {
+      const store = createStore();
+      store.set(selectedAppIdAtom, 1);
+      store.set(commitMessageDraftAtom, "Fix login redirect");
+
+      store.set(commitMessageDraftAtom, null);
+
+      expect(store.get(commitMessageDraftAtom)).toBeNull();
+      expect(store.get(commitMessageDraftsByAppIdAtom).has(1)).toBe(false);
+    });
+
+    it("is a no-op before an app is selected", () => {
+      const store = createStore();
+
+      store.set(commitMessageDraftAtom, "Fix login redirect");
+
+      expect(store.get(commitMessageDraftsByAppIdAtom).size).toBe(0);
+      expect(store.get(commitMessageDraftAtom)).toBeNull();
+    });
+  });
+
+  describe("discardCommitMessageDraftAtom", () => {
+    it("deletes by app id rather than by the selected app", () => {
+      const store = createStore();
+      store.set(selectedAppIdAtom, 1);
+      store.set(commitMessageDraftAtom, "Fix login redirect");
+      store.set(selectedAppIdAtom, 2);
+      store.set(commitMessageDraftAtom, "Add settings page");
+
+      store.set(discardCommitMessageDraftAtom, 1);
+
+      expect(store.get(commitMessageDraftAtom)).toBe("Add settings page");
+      expect(store.get(commitMessageDraftsByAppIdAtom).has(1)).toBe(false);
+    });
+
+    it("keeps the map identity when there is nothing to delete", () => {
+      const store = createStore();
+      const before = store.get(commitMessageDraftsByAppIdAtom);
+
+      store.set(discardCommitMessageDraftAtom, 1);
+
+      expect(store.get(commitMessageDraftsByAppIdAtom)).toBe(before);
+    });
+  });
+});

--- a/src/atoms/commitAtoms.ts
+++ b/src/atoms/commitAtoms.ts
@@ -27,9 +27,11 @@ const commitDialogReturnAtom = atom<CommitDialogSource | null>(null);
  *
  * Both dialogs share one entry per app on purpose: they are two entrances to
  * the same commit of the same working tree, so a message typed in one is the
- * message for the other. Staleness is bounded by lifetime instead - dismissing
- * a dialog without committing discards the draft, so it cannot outlive the
- * change set it was written for.
+ * message for the other. Staleness is bounded by lifetime instead: a draft only
+ * survives while its dialog is open or while a diff opened from that dialog is
+ * showing. Every way out of that round trip - committing, discarding,
+ * dismissing, or leaving the diff for anywhere other than the dialog - drops
+ * it, so it cannot outlive the change set it was written for.
  */
 export const commitMessageDraftsByAppIdAtom = atom<Map<number, string>>(
   new Map(),
@@ -56,6 +58,22 @@ export const commitMessageDraftAtom = atom(
     } else {
       next.set(appId, message);
     }
+    set(commitMessageDraftsByAppIdAtom, next);
+  },
+);
+
+/**
+ * Discards one app's draft by id rather than by whatever app is selected now.
+ * Commit and discard handlers use this so a mutation that resolves after the
+ * user moved on cannot wipe a draft they have since typed for another app.
+ */
+export const discardCommitMessageDraftAtom = atom(
+  null,
+  (get, set, appId: number) => {
+    const drafts = get(commitMessageDraftsByAppIdAtom);
+    if (!drafts.has(appId)) return;
+    const next = new Map(drafts);
+    next.delete(appId);
     set(commitMessageDraftsByAppIdAtom, next);
   },
 );
@@ -99,10 +117,15 @@ export const exitStagedDiffAtom = atom(null, (get, set) => {
  * diff is cleared as a side effect of going somewhere else - committing,
  * opening a file in the editor - so a pending return target cannot pop a
  * dialog open on top of the destination.
+ *
+ * This is the end of the round trip, not a pause in it: with the return target
+ * gone there is no way back to the dialog, so the draft written in it goes too
+ * rather than lying in wait to prefill an unrelated commit later.
  */
 export const clearStagedDiffAtom = atom(null, (_get, set) => {
   set(stagedDiffFileAtom, null);
   set(commitDialogReturnAtom, null);
+  set(commitMessageDraftAtom, null);
 });
 
 /**
@@ -131,9 +154,39 @@ export const releaseCommitDialogAtom = atom(
 );
 
 /**
+ * Ends one dialog's session without committing: closes it, drops a pending
+ * return to it, and discards the draft typed in it. Reaching the diff and
+ * coming back reopens the same dialog through `commitDialogReturnAtom`, so a
+ * return target that outlived its dialog would resurrect one the user had
+ * already dismissed - hence dropping it here rather than only closing.
+ *
+ * Scoped to the source that owns the dialog, and to the app the draft was
+ * written for, so a commit or discard resolving late cannot close a dialog the
+ * user has since opened elsewhere or clear a message meant for another app.
+ */
+export const dismissCommitDialogAtom = atom(
+  null,
+  (
+    _get,
+    set,
+    { source, appId }: { source: CommitDialogSource; appId: number | null },
+  ) => {
+    set(releaseCommitDialogAtom, source);
+    if (appId !== null) {
+      set(discardCommitMessageDraftAtom, appId);
+    }
+  },
+);
+
+/**
  * Drops the open dialog and any pending return without touching the staged
  * diff. For callers that replace the displayed presentation wholesale (chat tab
  * switches), where a dialog belonging to the previous tab must not survive.
+ *
+ * The draft deliberately survives: it is keyed by app, so coming back to that
+ * app's dialog is the "switching back" case the per-app map exists for. Writing
+ * it here would be unsafe anyway - callers set `selectedAppIdAtom` around this,
+ * so a selected-app-scoped write could land on the wrong app's entry.
  */
 export const resetCommitDialogAtom = atom(null, (_get, set) => {
   set(openCommitDialogAtom, null);

--- a/src/atoms/commitAtoms.ts
+++ b/src/atoms/commitAtoms.ts
@@ -5,33 +5,55 @@ import { isPreviewOpenAtom, stagedDiffFileAtom } from "./viewAtoms";
 export type CommitDialogSource = "editor" | "banner";
 
 /**
+ * Who a commit dialog belongs to: the entry point that opened it and the app it
+ * commits. Both halves matter. The source decides which component renders it,
+ * and the app is what makes a late-arriving teardown safe - a commit that
+ * resolves after the user moved on names the app it was for, so it cannot close
+ * a dialog or discard a message that now belongs to somewhere else.
+ */
+export interface CommitDialogOwner {
+  source: CommitDialogSource;
+  appId: number;
+}
+
+const isSameOwner = (
+  a: CommitDialogOwner | null,
+  b: CommitDialogOwner | null,
+) => a !== null && b !== null && a.source === b.source && a.appId === b.appId;
+
+/**
  * Which commit dialog is showing, if any. This is global rather than component
  * state because the dialog is no longer owned by one subtree: clicking a file
  * closes it and opens that file's staged diff, and the code view's "back to
  * editor" control is what brings it back.
  */
-export const openCommitDialogAtom = atom<CommitDialogSource | null>(null);
+export const openCommitDialogAtom = atom<CommitDialogOwner | null>(null);
 
 /**
  * The dialog to reopen when the user leaves the staged diff, set when the diff
  * was opened from a dialog. Deliberately not exported: only the actions below
  * may write it, so no caller can leave a stale return target behind.
  */
-const commitDialogReturnAtom = atom<CommitDialogSource | null>(null);
+const commitDialogReturnAtom = atom<CommitDialogOwner | null>(null);
 
 /**
- * Commit messages the user typed, keyed by app so a draft neither leaks into
- * another app nor is lost when switching back. Auto-generated defaults are
+ * Commit messages the user typed, keyed by app. Auto-generated defaults are
  * never stored here, so a message the user did not write cannot go stale as
  * more files change.
  *
  * Both dialogs share one entry per app on purpose: they are two entrances to
  * the same commit of the same working tree, so a message typed in one is the
- * message for the other. Staleness is bounded by lifetime instead: a draft only
- * survives while its dialog is open or while a diff opened from that dialog is
- * showing. Every way out of that round trip - committing, discarding,
- * dismissing, or leaving the diff for anywhere other than the dialog - drops
+ * message for the other. Staleness is bounded by lifetime: a draft only lives
+ * while its dialog is open, or while a diff opened from that dialog is showing.
+ * Every way out of that round trip - committing, discarding, dismissing,
+ * unmounting the dialog's host, or leaving the diff for anywhere else - drops
  * it, so it cannot outlive the change set it was written for.
+ *
+ * Keying by app is what makes those exits safe rather than what makes drafts
+ * durable. A commit that resolves after the user moved on names the app it was
+ * for, so it deletes that entry instead of whatever is on screen now. In
+ * practice at most one entry exists, because switching apps unmounts the host
+ * that owned the dialog and that drops the draft with it.
  */
 export const commitMessageDraftsByAppIdAtom = atom<Map<number, string>>(
   new Map(),
@@ -64,8 +86,9 @@ export const commitMessageDraftAtom = atom(
 
 /**
  * Discards one app's draft by id rather than by whatever app is selected now.
- * Commit and discard handlers use this so a mutation that resolves after the
- * user moved on cannot wipe a draft they have since typed for another app.
+ * Everything that ends a dialog's life goes through here, so a teardown that
+ * runs after the user moved on cannot wipe a draft they have since typed for
+ * another app.
  */
 export const discardCommitMessageDraftAtom = atom(
   null,
@@ -92,7 +115,7 @@ export const openStagedDiffAtom = atom(
   (
     _get,
     set,
-    { path, returnTo }: { path: string; returnTo: CommitDialogSource | null },
+    { path, returnTo }: { path: string; returnTo: CommitDialogOwner | null },
   ) => {
     set(openCommitDialogAtom, null);
     set(commitDialogReturnAtom, returnTo);
@@ -121,60 +144,54 @@ export const exitStagedDiffAtom = atom(null, (get, set) => {
  * This is the end of the round trip, not a pause in it: with the return target
  * gone there is no way back to the dialog, so the draft written in it goes too
  * rather than lying in wait to prefill an unrelated commit later.
- */
-export const clearStagedDiffAtom = atom(null, (_get, set) => {
-  set(stagedDiffFileAtom, null);
-  set(commitDialogReturnAtom, null);
-  set(commitMessageDraftAtom, null);
-});
-
-/**
- * Hands back the dialog state owned by one source, leaving the other source's
- * alone. A dialog is only visible while its owner is mounted, and the owner of
- * a pending return has to still be there to be returned to, so a source that
- * cannot render must drop both - otherwise the dialog pops open unprompted on
- * the next remount, and the staged diff's back control resolves to a dialog
- * nobody renders.
  *
- * Only the banner needs this: it is mounted conditionally by ChatHeader and
- * renders nothing without uncommitted files, whereas the editor dialog and the
- * back control that reopens it both live inside CodeView, so they come and go
- * together.
+ * `appId` is the app the caller acted on, and this is a no-op once the user has
+ * moved to another one. The staged diff and the draft are both global but only
+ * ever describe the selected app, so a commit resolving late must not close the
+ * diff, or discard the message, that has since come to belong to somebody else.
  */
-export const releaseCommitDialogAtom = atom(
+export const clearStagedDiffAtom = atom(
   null,
-  (get, set, source: CommitDialogSource) => {
-    if (get(openCommitDialogAtom) === source) {
-      set(openCommitDialogAtom, null);
-    }
-    if (get(commitDialogReturnAtom) === source) {
-      set(commitDialogReturnAtom, null);
-    }
+  (get, set, appId: number | null) => {
+    if (appId === null || get(selectedAppIdAtom) !== appId) return;
+    set(stagedDiffFileAtom, null);
+    set(commitDialogReturnAtom, null);
+    set(discardCommitMessageDraftAtom, appId);
   },
 );
 
 /**
- * Ends one dialog's session without committing: closes it, drops a pending
- * return to it, and discards the draft typed in it. Reaching the diff and
- * coming back reopens the same dialog through `commitDialogReturnAtom`, so a
- * return target that outlived its dialog would resurrect one the user had
- * already dismissed - hence dropping it here rather than only closing.
+ * Ends one dialog's life: closes it, drops a pending return to it, and discards
+ * the message typed in it. Both ways a dialog can end come through here.
  *
- * Scoped to the source that owns the dialog, and to the app the draft was
- * written for, so a commit or discard resolving late cannot close a dialog the
- * user has since opened elsewhere or clear a message meant for another app.
+ * - The user dismissed it. Leaving the return target behind would let the
+ *   staged diff's back arrow resurrect a dialog they just cancelled, and
+ *   leaving the draft behind would prefill a later, unrelated commit.
+ * - Its host can no longer render it. A dialog is only visible while its owner
+ *   is mounted, and the owner of a pending return has to still be there to be
+ *   returned to, so a source that cannot render must drop both - otherwise the
+ *   dialog pops open unprompted on the next remount, and the staged diff's back
+ *   control resolves to a dialog nobody renders. Both hosts need this: the
+ *   banner is mounted conditionally by ChatHeader, and CodeView unmounts
+ *   whenever `previewMode` leaves "code", which background subscriptions do on
+ *   their own (a `plan:update` event switches to plan mode).
+ *
+ * Scoped to the owner, so neither a teardown for another source nor one for
+ * another app can touch the dialog in front of the user. An owner that turns
+ * out to hold neither the dialog nor the pending return leaves even the draft
+ * alone: the two sources share one draft per app, so the editor's toolbar
+ * unmounting must not empty the input of a banner dialog the user is typing in.
  */
-export const dismissCommitDialogAtom = atom(
+export const closeCommitDialogAtom = atom(
   null,
-  (
-    _get,
-    set,
-    { source, appId }: { source: CommitDialogSource; appId: number | null },
-  ) => {
-    set(releaseCommitDialogAtom, source);
-    if (appId !== null) {
-      set(discardCommitMessageDraftAtom, appId);
-    }
+  (get, set, owner: CommitDialogOwner) => {
+    const ownsDialog = isSameOwner(get(openCommitDialogAtom), owner);
+    const ownsReturn = isSameOwner(get(commitDialogReturnAtom), owner);
+    if (!ownsDialog && !ownsReturn) return;
+
+    if (ownsDialog) set(openCommitDialogAtom, null);
+    if (ownsReturn) set(commitDialogReturnAtom, null);
+    set(discardCommitMessageDraftAtom, owner.appId);
   },
 );
 
@@ -183,10 +200,10 @@ export const dismissCommitDialogAtom = atom(
  * diff. For callers that replace the displayed presentation wholesale (chat tab
  * switches), where a dialog belonging to the previous tab must not survive.
  *
- * The draft deliberately survives: it is keyed by app, so coming back to that
- * app's dialog is the "switching back" case the per-app map exists for. Writing
- * it here would be unsafe anyway - callers set `selectedAppIdAtom` around this,
- * so a selected-app-scoped write could land on the wrong app's entry.
+ * The draft is left alone, because this has no app to name it by: callers set
+ * `selectedAppIdAtom` around this, so a selected-app-scoped write could land on
+ * the wrong app's entry. Nothing leaks either way - the tab switch unmounts
+ * whichever host owned the dialog, and that drops the draft with it.
  */
 export const resetCommitDialogAtom = atom(null, (_get, set) => {
   set(openCommitDialogAtom, null);

--- a/src/atoms/commitAtoms.ts
+++ b/src/atoms/commitAtoms.ts
@@ -24,6 +24,12 @@ const commitDialogReturnAtom = atom<CommitDialogSource | null>(null);
  * another app nor is lost when switching back. Auto-generated defaults are
  * never stored here, so a message the user did not write cannot go stale as
  * more files change.
+ *
+ * Both dialogs share one entry per app on purpose: they are two entrances to
+ * the same commit of the same working tree, so a message typed in one is the
+ * message for the other. Staleness is bounded by lifetime instead - dismissing
+ * a dialog without committing discards the draft, so it cannot outlive the
+ * change set it was written for.
  */
 export const commitMessageDraftsByAppIdAtom = atom<Map<number, string>>(
   new Map(),
@@ -98,6 +104,31 @@ export const clearStagedDiffAtom = atom(null, (_get, set) => {
   set(stagedDiffFileAtom, null);
   set(commitDialogReturnAtom, null);
 });
+
+/**
+ * Hands back the dialog state owned by one source, leaving the other source's
+ * alone. A dialog is only visible while its owner is mounted, and the owner of
+ * a pending return has to still be there to be returned to, so a source that
+ * cannot render must drop both - otherwise the dialog pops open unprompted on
+ * the next remount, and the staged diff's back control resolves to a dialog
+ * nobody renders.
+ *
+ * Only the banner needs this: it is mounted conditionally by ChatHeader and
+ * renders nothing without uncommitted files, whereas the editor dialog and the
+ * back control that reopens it both live inside CodeView, so they come and go
+ * together.
+ */
+export const releaseCommitDialogAtom = atom(
+  null,
+  (get, set, source: CommitDialogSource) => {
+    if (get(openCommitDialogAtom) === source) {
+      set(openCommitDialogAtom, null);
+    }
+    if (get(commitDialogReturnAtom) === source) {
+      set(commitDialogReturnAtom, null);
+    }
+  },
+);
 
 /**
  * Drops the open dialog and any pending return without touching the staged

--- a/src/atoms/commitAtoms.ts
+++ b/src/atoms/commitAtoms.ts
@@ -1,0 +1,110 @@
+import { atom } from "jotai";
+import { previewModeAtom, selectedAppIdAtom } from "./appAtoms";
+import { isPreviewOpenAtom, stagedDiffFileAtom } from "./viewAtoms";
+
+export type CommitDialogSource = "editor" | "banner";
+
+/**
+ * Which commit dialog is showing, if any. This is global rather than component
+ * state because the dialog is no longer owned by one subtree: clicking a file
+ * closes it and opens that file's staged diff, and the code view's "back to
+ * editor" control is what brings it back.
+ */
+export const openCommitDialogAtom = atom<CommitDialogSource | null>(null);
+
+/**
+ * The dialog to reopen when the user leaves the staged diff, set when the diff
+ * was opened from a dialog. Deliberately not exported: only the actions below
+ * may write it, so no caller can leave a stale return target behind.
+ */
+const commitDialogReturnAtom = atom<CommitDialogSource | null>(null);
+
+/**
+ * Commit messages the user typed, keyed by app so a draft neither leaks into
+ * another app nor is lost when switching back. Auto-generated defaults are
+ * never stored here, so a message the user did not write cannot go stale as
+ * more files change.
+ */
+export const commitMessageDraftsByAppIdAtom = atom<Map<number, string>>(
+  new Map(),
+);
+
+/**
+ * The selected app's commit message draft, or null when the user has not typed
+ * one. Writing null discards it.
+ */
+export const commitMessageDraftAtom = atom(
+  (get) => {
+    const appId = get(selectedAppIdAtom);
+    if (appId === null) return null;
+    return get(commitMessageDraftsByAppIdAtom).get(appId) ?? null;
+  },
+  (get, set, message: string | null) => {
+    const appId = get(selectedAppIdAtom);
+    // A no-op before an app is selected, matching chatInputValueAtom: every
+    // caller is a commit dialog, which only renders for a selected app.
+    if (appId === null) return;
+    const next = new Map(get(commitMessageDraftsByAppIdAtom));
+    if (message === null) {
+      next.delete(appId);
+    } else {
+      next.set(appId, message);
+    }
+    set(commitMessageDraftsByAppIdAtom, next);
+  },
+);
+
+/**
+ * Opens a staged file's working-tree diff in the code view. `returnTo` names
+ * the dialog to reopen when the user leaves the diff, and is null for entry
+ * points with no dialog to come back to (the commit menu's dropdown).
+ *
+ * Forcing the code panel open mirrors ModifiedFilesCard's openDiff: it is a
+ * no-op for the commit menu, which already lives in the code view, and is what
+ * lets the chat header's banner reach the diff at all.
+ */
+export const openStagedDiffAtom = atom(
+  null,
+  (
+    _get,
+    set,
+    { path, returnTo }: { path: string; returnTo: CommitDialogSource | null },
+  ) => {
+    set(openCommitDialogAtom, null);
+    set(commitDialogReturnAtom, returnTo);
+    set(stagedDiffFileAtom, path);
+    set(previewModeAtom, "code");
+    set(isPreviewOpenAtom, true);
+  },
+);
+
+/**
+ * Leaves the staged diff and reopens the dialog that sent the user there, if
+ * any. Use this for the deliberate "back to editor" exit.
+ */
+export const exitStagedDiffAtom = atom(null, (get, set) => {
+  set(stagedDiffFileAtom, null);
+  set(openCommitDialogAtom, get(commitDialogReturnAtom));
+  set(commitDialogReturnAtom, null);
+});
+
+/**
+ * Leaves the staged diff without reopening anything. Use this wherever the
+ * diff is cleared as a side effect of going somewhere else - committing,
+ * opening a file in the editor - so a pending return target cannot pop a
+ * dialog open on top of the destination.
+ */
+export const clearStagedDiffAtom = atom(null, (_get, set) => {
+  set(stagedDiffFileAtom, null);
+  set(commitDialogReturnAtom, null);
+});
+
+/**
+ * Drops the open dialog and any pending return without touching the staged
+ * diff. For callers that replace the displayed presentation wholesale (chat tab
+ * switches), where a dialog belonging to the previous tab must not survive.
+ */
+export const resetCommitDialogAtom = atom(null, (_get, set) => {
+  set(openCommitDialogAtom, null);
+  set(commitDialogReturnAtom, null);
+});

--- a/src/components/chat/ChatTabs.tsx
+++ b/src/components/chat/ChatTabs.tsx
@@ -939,6 +939,12 @@ export function ChatTabs({ selectedChatId }: ChatTabsProps) {
             store.set(selectedAppIdAtom, previousSelectedAppId);
             store.set(selectedFileAtom, previousSelectedFile);
             store.set(editorCursorAtom, previousEditorCursor);
+            // This branch restores the presentation by hand rather than through
+            // restorePresentation, so it has to drop the commit dialog itself:
+            // the staged diff below replaces what was displayed, and no chat is
+            // selected afterwards, so a dialog left open would belong to
+            // nothing.
+            store.set(resetCommitDialogAtom);
             store.set(stagedDiffFileAtom, previousStagedDiffFile);
             store.set(previewModeAtom, previousPreviewMode);
             store.set(isPreviewOpenAtom, previousIsPreviewOpen);

--- a/src/components/chat/ChatTabs.tsx
+++ b/src/components/chat/ChatTabs.tsx
@@ -41,6 +41,7 @@ import {
   stagedDiffFileAtom,
 } from "@/atoms/viewAtoms";
 import { previewModeAtom, selectedAppIdAtom } from "@/atoms/appAtoms";
+import { resetCommitDialogAtom } from "@/atoms/commitAtoms";
 import { selectedComponentsPreviewAtom } from "@/atoms/previewAtoms";
 import { terminalOpenByChatIdAtom } from "@/atoms/terminalAtoms";
 import {
@@ -609,6 +610,9 @@ export function ChatTabs({ selectedChatId }: ChatTabsProps) {
     ) => {
       store.set(selectedFileAtom, presentation.selectedFile);
       store.set(editorCursorAtom, presentation.editorCursor);
+      // The tab's own staged diff replaces whatever was displayed, so a commit
+      // dialog - or a pending return to one - belongs to the tab we just left.
+      store.set(resetCommitDialogAtom);
       store.set(stagedDiffFileAtom, presentation.stagedDiffFile);
       store.set(previewModeAtom, presentation.previewMode);
       store.set(isPreviewOpenAtom, presentation.isPreviewOpen);

--- a/src/components/chat/CommitFileList.tsx
+++ b/src/components/chat/CommitFileList.tsx
@@ -1,0 +1,81 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import type { UncommittedFile } from "@/hooks/useUncommittedFiles";
+import {
+  getStatusIcon,
+  getStatusLabel,
+  getStatusBadgeClassName,
+  LineStats,
+} from "@/components/chat/uncommittedFileStatus";
+
+interface CommitFileListProps {
+  files: UncommittedFile[];
+  /** Opens the file's working-tree diff. Closes the dialog it was clicked in. */
+  onSelectFile: (path: string) => void;
+  /**
+   * Blocks navigation while a commit or discard is in flight. Opening a diff
+   * closes the dialog directly, so without this it would slip past the dialog's
+   * own "don't close while busy" guard.
+   */
+  disabled?: boolean;
+  testId: string;
+}
+
+/**
+ * The scrollable list of uncommitted files inside a commit dialog. Each row is
+ * a button that opens that file's diff; the row's accessible name is the file
+ * path itself, so this needs no translated string of its own.
+ */
+export function CommitFileList({
+  files,
+  onSelectFile,
+  disabled = false,
+  testId,
+}: CommitFileListProps) {
+  return (
+    <TooltipProvider delay={300}>
+      <div
+        className="max-h-60 overflow-y-auto rounded-md border p-2 space-y-1"
+        data-testid={testId}
+      >
+        {files.map((file) => (
+          <Tooltip key={file.path}>
+            <TooltipTrigger
+              render={
+                <button
+                  type="button"
+                  onClick={() => onSelectFile(file.path)}
+                  disabled={disabled}
+                  data-testid="commit-file-item"
+                  className="flex w-full items-center gap-2 text-sm py-1 px-2 rounded text-left cursor-pointer hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-default disabled:hover:bg-transparent"
+                />
+              }
+            >
+              {getStatusIcon(file.status)}
+              <span
+                className={cn(
+                  "flex-1 truncate font-mono text-xs",
+                  file.status === "deleted" && "line-through opacity-60",
+                )}
+              >
+                {file.path}
+              </span>
+              <LineStats file={file} />
+              <span className={getStatusBadgeClassName(file.status)}>
+                {getStatusLabel(file.status)}
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="top" align="start">
+              <p className="max-w-[400px] break-all">{file.path}</p>
+            </TooltipContent>
+          </Tooltip>
+        ))}
+      </div>
+    </TooltipProvider>
+  );
+}

--- a/src/components/chat/UncommittedFilesBanner.tsx
+++ b/src/components/chat/UncommittedFilesBanner.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { FileWarning, TriangleAlert } from "lucide-react";
-import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import { useSetAtom } from "jotai";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -12,16 +12,17 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import {
-  commitMessageDraftAtom,
+  clearStagedDiffAtom,
+  dismissCommitDialogAtom,
   openCommitDialogAtom,
   openStagedDiffAtom,
   releaseCommitDialogAtom,
 } from "@/atoms/commitAtoms";
 import { useUncommittedFiles } from "@/hooks/useUncommittedFiles";
 import { useCommitChanges } from "@/hooks/useCommitChanges";
+import { useCommitMessage } from "@/hooks/useCommitMessage";
 import { useDiscardChanges } from "@/hooks/useDiscardChanges";
 import { useVersionPreview } from "@/hooks/useVersionPreview";
-import { generateDefaultCommitMessage } from "@/components/chat/uncommittedFileStatus";
 import { CommitFileList } from "@/components/chat/CommitFileList";
 
 interface UncommittedFilesBannerProps {
@@ -34,22 +35,18 @@ export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
   const { commitChanges, isCommitting } = useCommitChanges();
   const { discardChanges, isDiscarding } = useDiscardChanges();
   const { send: sendPreviewEvent } = useVersionPreview(appId);
-  const [openCommitDialog, setOpenCommitDialog] = useAtom(openCommitDialogAtom);
+  const setOpenCommitDialog = useSetAtom(openCommitDialogAtom);
   const openStagedDiffFile = useSetAtom(openStagedDiffAtom);
   const releaseCommitDialog = useSetAtom(releaseCommitDialogAtom);
-  const commitMessageDraft = useAtomValue(commitMessageDraftAtom);
-  const setCommitMessageDraft = useSetAtom(commitMessageDraftAtom);
-  // Frozen at open so polling doesn't rewrite the suggestion under the user.
-  // Only ever a suggestion: once the user types, the draft atom takes over.
-  const [generatedMessage, setGeneratedMessage] = useState<string | null>(null);
+  const dismissCommitDialog = useSetAtom(dismissCommitDialogAtom);
+  const clearStagedDiff = useSetAtom(clearStagedDiffAtom);
+  const { isDialogOpen, commitMessage, setCommitMessage } = useCommitMessage(
+    "banner",
+    uncommittedFiles,
+  );
   const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
   const confirmPanelRef = useRef<HTMLDivElement>(null);
   const canShowBanner = Boolean(appId) && !isLoading && !!hasUncommittedFiles;
-  const isDialogOpen = openCommitDialog === "banner";
-  // Read only at the moment the dialog opens, so the freeze above is against a
-  // ref rather than a render-time dependency that would refresh with polling.
-  const uncommittedFilesRef = useRef(uncommittedFiles);
-  uncommittedFilesRef.current = uncommittedFiles;
 
   useEffect(() => {
     if (showDiscardConfirm) {
@@ -74,34 +71,19 @@ export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
     return () => releaseCommitDialog("banner");
   }, [canShowBanner, releaseCommitDialog]);
 
-  // Refresh the suggestion on every open and drop it on close. The reopen after
-  // leaving the staged diff comes straight from the atom rather than the button
-  // handler, so freezing it there would commit a file list the user never saw.
-  useEffect(() => {
-    setGeneratedMessage(
-      isDialogOpen
-        ? generateDefaultCommitMessage(uncommittedFilesRef.current)
-        : null,
-    );
-  }, [isDialogOpen]);
-
   if (!canShowBanner) {
     return null;
   }
 
-  const commitMessage =
-    commitMessageDraft ??
-    generatedMessage ??
-    generateDefaultCommitMessage(uncommittedFiles);
-
   // Dismissing without committing abandons the message: keeping it would
   // prefill a later, unrelated commit with text written for a change set that
-  // has since moved on. The staged-diff round trip closes the dialog through
-  // openStagedDiffAtom instead, so the draft survives that.
+  // has since moved on. It also drops any pending return to this dialog, so the
+  // staged diff's back arrow cannot resurrect the dialog just dismissed. The
+  // round trip out to a diff closes the dialog through openStagedDiffAtom
+  // instead, so the draft survives that.
   const dismissDialog = () => {
     setShowDiscardConfirm(false);
-    setOpenCommitDialog(null);
-    setCommitMessageDraft(null);
+    dismissCommitDialog({ source: "banner", appId });
   };
 
   // The diff renders in the code panel, which this banner's dialog has to
@@ -113,22 +95,37 @@ export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
     openStagedDiffFile({ path: filePath, returnTo: "banner" });
   };
 
+  // Nothing is staged after either of these, so a diff opened from this dialog
+  // has to close too - otherwise the code panel sits in staged-diff mode
+  // showing "no staged changes". Clearing rather than exiting keeps it from
+  // reopening the dialog on the way out. Both mirror CommitMenu.handleCommit.
   const handleCommit = async () => {
     if (!appId || !commitMessage.trim()) return;
 
-    await commitChanges({ appId, message: commitMessage.trim() });
+    try {
+      await commitChanges({ appId, message: commitMessage.trim() });
+    } catch {
+      // useCommitChanges surfaces the error via a toast. Keep the dialog open
+      // and preserve the message so the user can retry without retyping it.
+      return;
+    }
     setShowDiscardConfirm(false);
-    setOpenCommitDialog(null);
-    setCommitMessageDraft(null);
+    dismissCommitDialog({ source: "banner", appId });
+    clearStagedDiff();
   };
 
   const handleDiscard = async () => {
     if (!appId) return;
 
-    await discardChanges({ appId });
+    try {
+      await discardChanges({ appId });
+    } catch {
+      // useDiscardChanges surfaces the error via a toast; leave the dialog up.
+      return;
+    }
     setShowDiscardConfirm(false);
-    setOpenCommitDialog(null);
-    setCommitMessageDraft(null);
+    dismissCommitDialog({ source: "banner", appId });
+    clearStagedDiff();
   };
 
   return (
@@ -188,7 +185,7 @@ export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
               <Input
                 id="commit-message"
                 value={commitMessage}
-                onChange={(e) => setCommitMessageDraft(e.target.value)}
+                onChange={(e) => setCommitMessage(e.target.value)}
                 placeholder="Enter commit message..."
                 data-testid="commit-message-input"
               />

--- a/src/components/chat/UncommittedFilesBanner.tsx
+++ b/src/components/chat/UncommittedFilesBanner.tsx
@@ -15,6 +15,7 @@ import {
   commitMessageDraftAtom,
   openCommitDialogAtom,
   openStagedDiffAtom,
+  releaseCommitDialogAtom,
 } from "@/atoms/commitAtoms";
 import { useUncommittedFiles } from "@/hooks/useUncommittedFiles";
 import { useCommitChanges } from "@/hooks/useCommitChanges";
@@ -35,6 +36,7 @@ export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
   const { send: sendPreviewEvent } = useVersionPreview(appId);
   const [openCommitDialog, setOpenCommitDialog] = useAtom(openCommitDialogAtom);
   const openStagedDiffFile = useSetAtom(openStagedDiffAtom);
+  const releaseCommitDialog = useSetAtom(releaseCommitDialogAtom);
   const commitMessageDraft = useAtomValue(commitMessageDraftAtom);
   const setCommitMessageDraft = useSetAtom(commitMessageDraftAtom);
   // Frozen at open so polling doesn't rewrite the suggestion under the user.
@@ -42,6 +44,12 @@ export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
   const [generatedMessage, setGeneratedMessage] = useState<string | null>(null);
   const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
   const confirmPanelRef = useRef<HTMLDivElement>(null);
+  const canShowBanner = Boolean(appId) && !isLoading && !!hasUncommittedFiles;
+  const isDialogOpen = openCommitDialog === "banner";
+  // Read only at the moment the dialog opens, so the freeze above is against a
+  // ref rather than a render-time dependency that would refresh with polling.
+  const uncommittedFilesRef = useRef(uncommittedFiles);
+  uncommittedFilesRef.current = uncommittedFiles;
 
   useEffect(() => {
     if (showDiscardConfirm) {
@@ -53,21 +61,47 @@ export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
     }
   }, [showDiscardConfirm]);
 
-  if (!appId || isLoading || !hasUncommittedFiles) {
+  // The dialog lives in a global atom but is rendered here, and this banner is
+  // mounted conditionally - ChatHeader hides it while streaming and behind the
+  // version pane, and it renders nothing without uncommitted files. Hand the
+  // state back whenever it cannot be shown, so a dialog left open (or a pending
+  // return to one) cannot pop open unprompted on the next remount.
+  useEffect(() => {
+    if (!canShowBanner) {
+      releaseCommitDialog("banner");
+      return;
+    }
+    return () => releaseCommitDialog("banner");
+  }, [canShowBanner, releaseCommitDialog]);
+
+  // Refresh the suggestion on every open and drop it on close. The reopen after
+  // leaving the staged diff comes straight from the atom rather than the button
+  // handler, so freezing it there would commit a file list the user never saw.
+  useEffect(() => {
+    setGeneratedMessage(
+      isDialogOpen
+        ? generateDefaultCommitMessage(uncommittedFilesRef.current)
+        : null,
+    );
+  }, [isDialogOpen]);
+
+  if (!canShowBanner) {
     return null;
   }
 
-  const isDialogOpen = openCommitDialog === "banner";
   const commitMessage =
     commitMessageDraft ??
     generatedMessage ??
     generateDefaultCommitMessage(uncommittedFiles);
 
-  const handleOpenDialog = () => {
-    // Regenerate the suggestion on every open so its file counts stay current.
-    // A message the user actually typed lives in the draft atom and survives.
-    setGeneratedMessage(generateDefaultCommitMessage(uncommittedFiles));
-    setOpenCommitDialog("banner");
+  // Dismissing without committing abandons the message: keeping it would
+  // prefill a later, unrelated commit with text written for a change set that
+  // has since moved on. The staged-diff round trip closes the dialog through
+  // openStagedDiffAtom instead, so the draft survives that.
+  const dismissDialog = () => {
+    setShowDiscardConfirm(false);
+    setOpenCommitDialog(null);
+    setCommitMessageDraft(null);
   };
 
   // The diff renders in the code panel, which this banner's dialog has to
@@ -85,7 +119,6 @@ export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
     await commitChanges({ appId, message: commitMessage.trim() });
     setShowDiscardConfirm(false);
     setOpenCommitDialog(null);
-    setGeneratedMessage(null);
     setCommitMessageDraft(null);
   };
 
@@ -95,7 +128,6 @@ export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
     await discardChanges({ appId });
     setShowDiscardConfirm(false);
     setOpenCommitDialog(null);
-    setGeneratedMessage(null);
     setCommitMessageDraft(null);
   };
 
@@ -115,7 +147,7 @@ export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
         <Button
           variant="outline"
           size="sm"
-          onClick={handleOpenDialog}
+          onClick={() => setOpenCommitDialog("banner")}
           data-testid="review-commit-button"
         >
           Review & commit
@@ -125,10 +157,13 @@ export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
       <Dialog
         open={isDialogOpen}
         onOpenChange={(open) => {
+          if (open) {
+            setOpenCommitDialog("banner");
+            return;
+          }
           // Prevent closing while committing or discarding
-          if (!open && (isCommitting || isDiscarding)) return;
-          if (!open) setShowDiscardConfirm(false);
-          setOpenCommitDialog(open ? "banner" : null);
+          if (isCommitting || isDiscarding) return;
+          dismissDialog();
         }}
       >
         <DialogContent
@@ -225,7 +260,7 @@ export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
             </Button>
             <Button
               variant="outline"
-              onClick={() => setOpenCommitDialog(null)}
+              onClick={dismissDialog}
               disabled={isCommitting || isDiscarding}
             >
               Cancel

--- a/src/components/chat/UncommittedFilesBanner.tsx
+++ b/src/components/chat/UncommittedFilesBanner.tsx
@@ -13,10 +13,9 @@ import {
 import { Input } from "@/components/ui/input";
 import {
   clearStagedDiffAtom,
-  dismissCommitDialogAtom,
+  closeCommitDialogAtom,
   openCommitDialogAtom,
   openStagedDiffAtom,
-  releaseCommitDialogAtom,
 } from "@/atoms/commitAtoms";
 import { useUncommittedFiles } from "@/hooks/useUncommittedFiles";
 import { useCommitChanges } from "@/hooks/useCommitChanges";
@@ -37,16 +36,16 @@ export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
   const { send: sendPreviewEvent } = useVersionPreview(appId);
   const setOpenCommitDialog = useSetAtom(openCommitDialogAtom);
   const openStagedDiffFile = useSetAtom(openStagedDiffAtom);
-  const releaseCommitDialog = useSetAtom(releaseCommitDialogAtom);
-  const dismissCommitDialog = useSetAtom(dismissCommitDialogAtom);
+  const closeCommitDialog = useSetAtom(closeCommitDialogAtom);
   const clearStagedDiff = useSetAtom(clearStagedDiffAtom);
   const { isDialogOpen, commitMessage, setCommitMessage } = useCommitMessage(
     "banner",
+    appId,
     uncommittedFiles,
   );
   const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
   const confirmPanelRef = useRef<HTMLDivElement>(null);
-  const canShowBanner = Boolean(appId) && !isLoading && !!hasUncommittedFiles;
+  const canShowBanner = appId !== null && !isLoading && !!hasUncommittedFiles;
 
   useEffect(() => {
     if (showDiscardConfirm) {
@@ -62,16 +61,18 @@ export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
   // mounted conditionally - ChatHeader hides it while streaming and behind the
   // version pane, and it renders nothing without uncommitted files. Hand the
   // state back whenever it cannot be shown, so a dialog left open (or a pending
-  // return to one) cannot pop open unprompted on the next remount.
+  // return to one) cannot pop open unprompted on the next remount, and the
+  // message typed into it does not sit around to prefill a later commit.
   useEffect(() => {
+    if (appId === null) return;
     if (!canShowBanner) {
-      releaseCommitDialog("banner");
+      closeCommitDialog({ source: "banner", appId });
       return;
     }
-    return () => releaseCommitDialog("banner");
-  }, [canShowBanner, releaseCommitDialog]);
+    return () => closeCommitDialog({ source: "banner", appId });
+  }, [canShowBanner, closeCommitDialog, appId]);
 
-  if (!canShowBanner) {
+  if (!canShowBanner || appId === null) {
     return null;
   }
 
@@ -83,7 +84,7 @@ export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
   // instead, so the draft survives that.
   const dismissDialog = () => {
     setShowDiscardConfirm(false);
-    dismissCommitDialog({ source: "banner", appId });
+    closeCommitDialog({ source: "banner", appId });
   };
 
   // The diff renders in the code panel, which this banner's dialog has to
@@ -92,7 +93,10 @@ export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
   const openStagedDiff = (filePath: string) => {
     sendPreviewEvent({ type: "CLOSE" });
     setShowDiscardConfirm(false);
-    openStagedDiffFile({ path: filePath, returnTo: "banner" });
+    openStagedDiffFile({
+      path: filePath,
+      returnTo: { source: "banner", appId },
+    });
   };
 
   // Nothing is staged after either of these, so a diff opened from this dialog
@@ -100,7 +104,7 @@ export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
   // showing "no staged changes". Clearing rather than exiting keeps it from
   // reopening the dialog on the way out. Both mirror CommitMenu.handleCommit.
   const handleCommit = async () => {
-    if (!appId || !commitMessage.trim()) return;
+    if (!commitMessage.trim()) return;
 
     try {
       await commitChanges({ appId, message: commitMessage.trim() });
@@ -110,13 +114,11 @@ export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
       return;
     }
     setShowDiscardConfirm(false);
-    dismissCommitDialog({ source: "banner", appId });
-    clearStagedDiff();
+    closeCommitDialog({ source: "banner", appId });
+    clearStagedDiff(appId);
   };
 
   const handleDiscard = async () => {
-    if (!appId) return;
-
     try {
       await discardChanges({ appId });
     } catch {
@@ -124,8 +126,8 @@ export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
       return;
     }
     setShowDiscardConfirm(false);
-    dismissCommitDialog({ source: "banner", appId });
-    clearStagedDiff();
+    closeCommitDialog({ source: "banner", appId });
+    clearStagedDiff(appId);
   };
 
   return (
@@ -144,7 +146,7 @@ export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
         <Button
           variant="outline"
           size="sm"
-          onClick={() => setOpenCommitDialog("banner")}
+          onClick={() => setOpenCommitDialog({ source: "banner", appId })}
           data-testid="review-commit-button"
         >
           Review & commit
@@ -155,7 +157,7 @@ export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
         open={isDialogOpen}
         onOpenChange={(open) => {
           if (open) {
-            setOpenCommitDialog("banner");
+            setOpenCommitDialog({ source: "banner", appId });
             return;
           }
           // Prevent closing while committing or discarding

--- a/src/components/chat/UncommittedFilesBanner.tsx
+++ b/src/components/chat/UncommittedFilesBanner.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { FileWarning, TriangleAlert } from "lucide-react";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -11,21 +12,16 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+  commitMessageDraftAtom,
+  openCommitDialogAtom,
+  openStagedDiffAtom,
+} from "@/atoms/commitAtoms";
 import { useUncommittedFiles } from "@/hooks/useUncommittedFiles";
 import { useCommitChanges } from "@/hooks/useCommitChanges";
 import { useDiscardChanges } from "@/hooks/useDiscardChanges";
-import { cn } from "@/lib/utils";
-import {
-  getStatusIcon,
-  getStatusLabel,
-  getStatusBadgeClassName,
-  generateDefaultCommitMessage,
-} from "@/components/chat/uncommittedFileStatus";
+import { useVersionPreview } from "@/hooks/useVersionPreview";
+import { generateDefaultCommitMessage } from "@/components/chat/uncommittedFileStatus";
+import { CommitFileList } from "@/components/chat/CommitFileList";
 
 interface UncommittedFilesBannerProps {
   appId: number | null;
@@ -36,8 +32,14 @@ export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
     useUncommittedFiles(appId);
   const { commitChanges, isCommitting } = useCommitChanges();
   const { discardChanges, isDiscarding } = useDiscardChanges();
-  const [isDialogOpen, setIsDialogOpen] = useState(false);
-  const [commitMessage, setCommitMessage] = useState("");
+  const { send: sendPreviewEvent } = useVersionPreview(appId);
+  const [openCommitDialog, setOpenCommitDialog] = useAtom(openCommitDialogAtom);
+  const openStagedDiffFile = useSetAtom(openStagedDiffAtom);
+  const commitMessageDraft = useAtomValue(commitMessageDraftAtom);
+  const setCommitMessageDraft = useSetAtom(commitMessageDraftAtom);
+  // Frozen at open so polling doesn't rewrite the suggestion under the user.
+  // Only ever a suggestion: once the user types, the draft atom takes over.
+  const [generatedMessage, setGeneratedMessage] = useState<string | null>(null);
   const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
   const confirmPanelRef = useRef<HTMLDivElement>(null);
 
@@ -55,11 +57,26 @@ export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
     return null;
   }
 
+  const isDialogOpen = openCommitDialog === "banner";
+  const commitMessage =
+    commitMessageDraft ??
+    generatedMessage ??
+    generateDefaultCommitMessage(uncommittedFiles);
+
   const handleOpenDialog = () => {
-    // Set default commit message only when opening the dialog
-    // This prevents overwriting user's custom message during polling
-    setCommitMessage(generateDefaultCommitMessage(uncommittedFiles));
-    setIsDialogOpen(true);
+    // Regenerate the suggestion on every open so its file counts stay current.
+    // A message the user actually typed lives in the draft atom and survives.
+    setGeneratedMessage(generateDefaultCommitMessage(uncommittedFiles));
+    setOpenCommitDialog("banner");
+  };
+
+  // The diff renders in the code panel, which this banner's dialog has to
+  // reveal. Any selected version diff must close first, since CodeView
+  // suppresses staged-diff mode whenever one is active.
+  const openStagedDiff = (filePath: string) => {
+    sendPreviewEvent({ type: "CLOSE" });
+    setShowDiscardConfirm(false);
+    openStagedDiffFile({ path: filePath, returnTo: "banner" });
   };
 
   const handleCommit = async () => {
@@ -67,8 +84,9 @@ export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
 
     await commitChanges({ appId, message: commitMessage.trim() });
     setShowDiscardConfirm(false);
-    setIsDialogOpen(false);
-    setCommitMessage("");
+    setOpenCommitDialog(null);
+    setGeneratedMessage(null);
+    setCommitMessageDraft(null);
   };
 
   const handleDiscard = async () => {
@@ -76,7 +94,9 @@ export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
 
     await discardChanges({ appId });
     setShowDiscardConfirm(false);
-    setIsDialogOpen(false);
+    setOpenCommitDialog(null);
+    setGeneratedMessage(null);
+    setCommitMessageDraft(null);
   };
 
   return (
@@ -108,7 +128,7 @@ export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
           // Prevent closing while committing or discarding
           if (!open && (isCommitting || isDiscarding)) return;
           if (!open) setShowDiscardConfirm(false);
-          setIsDialogOpen(open);
+          setOpenCommitDialog(open ? "banner" : null);
         }}
       >
         <DialogContent
@@ -133,7 +153,7 @@ export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
               <Input
                 id="commit-message"
                 value={commitMessage}
-                onChange={(e) => setCommitMessage(e.target.value)}
+                onChange={(e) => setCommitMessageDraft(e.target.value)}
                 placeholder="Enter commit message..."
                 data-testid="commit-message-input"
               />
@@ -143,42 +163,12 @@ export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
               <p className="text-sm font-medium mb-2">
                 Changed files ({uncommittedFiles.length})
               </p>
-              <TooltipProvider delay={300}>
-                <div
-                  className="max-h-60 overflow-y-auto rounded-md border p-2 space-y-1"
-                  data-testid="changed-files-list"
-                >
-                  {uncommittedFiles.map((file) => (
-                    <div
-                      key={file.path}
-                      className="flex items-center gap-2 text-sm py-1 px-2 rounded hover:bg-muted"
-                    >
-                      {getStatusIcon(file.status)}
-                      <Tooltip>
-                        <TooltipTrigger
-                          render={
-                            <span
-                              className={cn(
-                                "flex-1 truncate font-mono text-xs text-left cursor-default",
-                                file.status === "deleted" &&
-                                  "line-through opacity-60",
-                              )}
-                            />
-                          }
-                        >
-                          {file.path}
-                        </TooltipTrigger>
-                        <TooltipContent side="top" align="start">
-                          <p className="max-w-[400px] break-all">{file.path}</p>
-                        </TooltipContent>
-                      </Tooltip>
-                      <span className={getStatusBadgeClassName(file.status)}>
-                        {getStatusLabel(file.status)}
-                      </span>
-                    </div>
-                  ))}
-                </div>
-              </TooltipProvider>
+              <CommitFileList
+                files={uncommittedFiles}
+                onSelectFile={openStagedDiff}
+                disabled={isCommitting || isDiscarding}
+                testId="changed-files-list"
+              />
             </div>
           </div>
 
@@ -235,7 +225,7 @@ export function UncommittedFilesBanner({ appId }: UncommittedFilesBannerProps) {
             </Button>
             <Button
               variant="outline"
-              onClick={() => setIsDialogOpen(false)}
+              onClick={() => setOpenCommitDialog(null)}
               disabled={isCommitting || isDiscarding}
             >
               Cancel

--- a/src/components/preview_panel/CodeView.test.tsx
+++ b/src/components/preview_panel/CodeView.test.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createStore, Provider } from "jotai";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { selectedFileAtom, stagedDiffFileAtom } from "@/atoms/viewAtoms";
+import { selectedAppIdAtom } from "@/atoms/appAtoms";
 import { queryKeys } from "@/lib/queryKeys";
 import { CodeView } from "./CodeView";
 
@@ -166,6 +167,10 @@ function renderCodeView(
   files: string[],
   queryClient = new QueryClient(),
 ) {
+  // PreviewPanel renders CodeView with useLoadApp(selectedAppId)'s app, so the
+  // two are always the same app. Keep the store honest about that: actions
+  // scoped to the app the user is on are no-ops when they disagree.
+  store.set(selectedAppIdAtom, 1);
   const view = (
     <QueryClientProvider client={queryClient}>
       <Provider store={store}>
@@ -177,14 +182,16 @@ function renderCodeView(
   return {
     ...rendered,
     queryClient,
-    rerenderCodeView: (nextFiles: string[] = files, appId = 1) =>
+    rerenderCodeView: (nextFiles: string[] = files, appId = 1) => {
+      store.set(selectedAppIdAtom, appId);
       rendered.rerender(
         <QueryClientProvider client={queryClient}>
           <Provider store={store}>
             <CodeView loading={false} app={{ id: appId, files: nextFiles }} />
           </Provider>
         </QueryClientProvider>,
-      ),
+      );
+    },
   };
 }
 

--- a/src/components/preview_panel/CodeView.tsx
+++ b/src/components/preview_panel/CodeView.tsx
@@ -304,8 +304,9 @@ export const CodeView = ({ loading, app }: CodeViewProps) => {
     // A staged selection left over from before the version diff opened would
     // put the panel back in staged-diff mode instead of the editor, so clear it
     // on every path out of here. The user asked for the editor, so this must
-    // not reopen a commit dialog on top of it.
-    clearStagedDiff();
+    // not reopen a commit dialog on top of it, nor keep the message they were
+    // typing in one.
+    clearStagedDiff(app?.id ?? null);
 
     if (!isVersionDiffMode) {
       setSelectedFile({ path });

--- a/src/components/preview_panel/CodeView.tsx
+++ b/src/components/preview_panel/CodeView.tsx
@@ -18,6 +18,7 @@ import {
 import { useAtomValue, useSetAtom } from "jotai";
 import { useQueryClient } from "@tanstack/react-query";
 import { selectedFileAtom, stagedDiffFileAtom } from "@/atoms/viewAtoms";
+import { clearStagedDiffAtom, exitStagedDiffAtom } from "@/atoms/commitAtoms";
 import { queryKeys } from "@/lib/queryKeys";
 import { useTranslation } from "react-i18next";
 import { VersionDiffView } from "./VersionDiffView";
@@ -63,7 +64,8 @@ export const CodeView = ({ loading, app }: CodeViewProps) => {
   const queryClient = useQueryClient();
   const selectedVersionId = diffVersionIdForState(previewState);
   const stagedDiffFile = useAtomValue(stagedDiffFileAtom);
-  const setStagedDiffFile = useSetAtom(stagedDiffFileAtom);
+  const exitStagedDiff = useSetAtom(exitStagedDiffAtom);
+  const clearStagedDiff = useSetAtom(clearStagedDiffAtom);
   const { refreshApp } = useLoadApp(app?.id ?? null);
   const { uncommittedFiles, hasUncommittedFiles } = useUncommittedFiles(
     app?.id ?? null,
@@ -301,8 +303,9 @@ export const CodeView = ({ loading, app }: CodeViewProps) => {
     const path = displayedDiffPath;
     // A staged selection left over from before the version diff opened would
     // put the panel back in staged-diff mode instead of the editor, so clear it
-    // on every path out of here.
-    setStagedDiffFile(null);
+    // on every path out of here. The user asked for the editor, so this must
+    // not reopen a commit dialog on top of it.
+    clearStagedDiff();
 
     if (!isVersionDiffMode) {
       setSelectedFile({ path });
@@ -377,7 +380,7 @@ export const CodeView = ({ loading, app }: CodeViewProps) => {
               <TooltipTrigger
                 render={
                   <button
-                    onClick={() => setStagedDiffFile(null)}
+                    onClick={() => exitStagedDiff()}
                     aria-label={t("preview.backToEditor")}
                     className="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700"
                     data-testid="staged-diff-back-button"

--- a/src/components/preview_panel/CommitMenu.tsx
+++ b/src/components/preview_panel/CommitMenu.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { GitCommitVertical, ChevronDown } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useSetAtom } from "jotai";
@@ -21,10 +22,10 @@ import {
 } from "@/components/ui/dropdown-menu";
 import {
   clearStagedDiffAtom,
-  dismissCommitDialogAtom,
+  closeCommitDialogAtom,
   openCommitDialogAtom,
   openStagedDiffAtom,
-  type CommitDialogSource,
+  type CommitDialogOwner,
 } from "@/atoms/commitAtoms";
 import { useUncommittedFiles } from "@/hooks/useUncommittedFiles";
 import { useCommitChanges } from "@/hooks/useCommitChanges";
@@ -53,11 +54,23 @@ export function CommitMenu({ appId }: CommitMenuProps) {
   const setOpenCommitDialog = useSetAtom(openCommitDialogAtom);
   const openStagedDiffFile = useSetAtom(openStagedDiffAtom);
   const clearStagedDiff = useSetAtom(clearStagedDiffAtom);
-  const dismissCommitDialog = useSetAtom(dismissCommitDialogAtom);
+  const closeCommitDialog = useSetAtom(closeCommitDialogAtom);
   const { send: sendPreviewEvent } = useVersionPreview(appId);
   const { isDialogOpen, commitMessage, setCommitMessage } = useCommitMessage(
     "editor",
+    appId,
     uncommittedFiles,
+  );
+
+  // CodeView unmounts whenever previewMode leaves "code", and background
+  // subscriptions change it on their own - usePlanEvents switches to plan mode
+  // on every plan:update event. The dialog lives in a global atom, so without
+  // this it would survive that unmount invisibly and pop back open the next
+  // time the user returns to Code. The staged diff renders inside this same
+  // toolbar's view, so the round trip out to a diff does not unmount us.
+  useEffect(
+    () => () => closeCommitDialog({ source: "editor", appId }),
+    [closeCommitDialog, appId],
   );
 
   // Opening a staged file's diff must clear any selected version diff, since
@@ -65,7 +78,7 @@ export function CommitMenu({ appId }: CommitMenuProps) {
   // `returnTo` is what brings the user back to the dialog they came from.
   const openStagedDiff = (
     filePath: string,
-    returnTo: CommitDialogSource | null,
+    returnTo: CommitDialogOwner | null,
   ) => {
     sendPreviewEvent({ type: "CLOSE" });
     openStagedDiffFile({ path: filePath, returnTo });
@@ -78,7 +91,7 @@ export function CommitMenu({ appId }: CommitMenuProps) {
   // round trip out to a diff closes the dialog through openStagedDiffAtom
   // instead, so the draft survives that.
   const dismissDialog = () => {
-    dismissCommitDialog({ source: "editor", appId });
+    closeCommitDialog({ source: "editor", appId });
   };
 
   const handleCommit = async () => {
@@ -90,10 +103,11 @@ export function CommitMenu({ appId }: CommitMenuProps) {
       // and preserve the message so the user can retry without retyping it.
       return;
     }
-    dismissCommitDialog({ source: "editor", appId });
+    closeCommitDialog({ source: "editor", appId });
     // Nothing is staged anymore, so leave the diff view if it was open. This
-    // must not reopen the dialog, hence clear rather than exit.
-    clearStagedDiff();
+    // must not reopen the dialog, hence clear rather than exit. Both calls name
+    // the app committed, so neither touches another one if this lands late.
+    clearStagedDiff(appId);
   };
 
   return (
@@ -103,7 +117,7 @@ export function CommitMenu({ appId }: CommitMenuProps) {
         size="sm"
         className="rounded-r-none border-r-0"
         disabled={!hasUncommittedFiles}
-        onClick={() => setOpenCommitDialog("editor")}
+        onClick={() => setOpenCommitDialog({ source: "editor", appId })}
         data-testid="editor-commit-button"
       >
         <GitCommitVertical size={14} />
@@ -168,7 +182,7 @@ export function CommitMenu({ appId }: CommitMenuProps) {
         open={isDialogOpen}
         onOpenChange={(open) => {
           if (open) {
-            setOpenCommitDialog("editor");
+            setOpenCommitDialog({ source: "editor", appId });
             return;
           }
           if (isCommitting) return;
@@ -211,7 +225,9 @@ export function CommitMenu({ appId }: CommitMenuProps) {
               </p>
               <CommitFileList
                 files={uncommittedFiles}
-                onSelectFile={(path) => openStagedDiff(path, "editor")}
+                onSelectFile={(path) =>
+                  openStagedDiff(path, { source: "editor", appId })
+                }
                 disabled={isCommitting}
                 testId="editor-commit-files-list"
               />

--- a/src/components/preview_panel/CommitMenu.tsx
+++ b/src/components/preview_panel/CommitMenu.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { GitCommitVertical, ChevronDown } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
@@ -60,8 +60,24 @@ export function CommitMenu({ appId }: CommitMenuProps) {
   // Frozen at open so polling doesn't rewrite the suggestion under the user.
   // Only ever a suggestion: once the user types, the draft atom takes over.
   const [generatedMessage, setGeneratedMessage] = useState<string | null>(null);
+  // Read only at the moment the dialog opens, so the freeze above is against a
+  // ref rather than a render-time dependency that would refresh with polling.
+  const uncommittedFilesRef = useRef(uncommittedFiles);
+  uncommittedFilesRef.current = uncommittedFiles;
 
   const isDialogOpen = openCommitDialog === "editor";
+
+  // Refresh the suggestion on every open and drop it on close. The reopen after
+  // leaving the staged diff comes straight from the atom rather than the button
+  // handler, so freezing it there would commit a file list the user never saw.
+  useEffect(() => {
+    setGeneratedMessage(
+      isDialogOpen
+        ? generateDefaultCommitMessage(uncommittedFilesRef.current)
+        : null,
+    );
+  }, [isDialogOpen]);
+
   const commitMessage =
     commitMessageDraft ??
     generatedMessage ??
@@ -78,11 +94,13 @@ export function CommitMenu({ appId }: CommitMenuProps) {
     openStagedDiffFile({ path: filePath, returnTo });
   };
 
-  const handleOpenDialog = () => {
-    // Regenerate the suggestion on every open so its file counts stay current.
-    // A message the user actually typed lives in the draft atom and survives.
-    setGeneratedMessage(generateDefaultCommitMessage(uncommittedFiles));
-    setOpenCommitDialog("editor");
+  // Dismissing without committing abandons the message: keeping it would
+  // prefill a later, unrelated commit with text written for a change set that
+  // has since moved on. The staged-diff round trip closes the dialog through
+  // openStagedDiffAtom instead, so the draft survives that.
+  const dismissDialog = () => {
+    setOpenCommitDialog(null);
+    setCommitMessageDraft(null);
   };
 
   const handleCommit = async () => {
@@ -95,7 +113,6 @@ export function CommitMenu({ appId }: CommitMenuProps) {
       return;
     }
     setOpenCommitDialog(null);
-    setGeneratedMessage(null);
     setCommitMessageDraft(null);
     // Nothing is staged anymore, so leave the diff view if it was open. This
     // must not reopen the dialog, hence clear rather than exit.
@@ -109,7 +126,7 @@ export function CommitMenu({ appId }: CommitMenuProps) {
         size="sm"
         className="rounded-r-none border-r-0"
         disabled={!hasUncommittedFiles}
-        onClick={handleOpenDialog}
+        onClick={() => setOpenCommitDialog("editor")}
         data-testid="editor-commit-button"
       >
         <GitCommitVertical size={14} />
@@ -173,8 +190,12 @@ export function CommitMenu({ appId }: CommitMenuProps) {
       <Dialog
         open={isDialogOpen}
         onOpenChange={(open) => {
-          if (!open && isCommitting) return;
-          setOpenCommitDialog(open ? "editor" : null);
+          if (open) {
+            setOpenCommitDialog("editor");
+            return;
+          }
+          if (isCommitting) return;
+          dismissDialog();
         }}
       >
         <DialogContent
@@ -223,7 +244,7 @@ export function CommitMenu({ appId }: CommitMenuProps) {
           <DialogFooter className="px-6 pb-6 pt-2">
             <Button
               variant="outline"
-              onClick={() => setOpenCommitDialog(null)}
+              onClick={dismissDialog}
               disabled={isCommitting}
             >
               {t("preview.cancel")}

--- a/src/components/preview_panel/CommitMenu.tsx
+++ b/src/components/preview_panel/CommitMenu.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { GitCommitVertical, ChevronDown } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { useSetAtom } from "jotai";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { Button, buttonVariants } from "@/components/ui/button";
 import {
   Dialog,
@@ -20,17 +20,22 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { stagedDiffFileAtom } from "@/atoms/viewAtoms";
+import {
+  clearStagedDiffAtom,
+  commitMessageDraftAtom,
+  openCommitDialogAtom,
+  openStagedDiffAtom,
+  type CommitDialogSource,
+} from "@/atoms/commitAtoms";
 import { useUncommittedFiles } from "@/hooks/useUncommittedFiles";
 import { useCommitChanges } from "@/hooks/useCommitChanges";
 import { cn } from "@/lib/utils";
 import {
   getStatusIcon,
-  getStatusLabel,
-  getStatusBadgeClassName,
   generateDefaultCommitMessage,
   LineStats,
 } from "@/components/chat/uncommittedFileStatus";
+import { CommitFileList } from "@/components/chat/CommitFileList";
 import { useVersionPreview } from "@/hooks/useVersionPreview";
 
 interface CommitMenuProps {
@@ -46,22 +51,38 @@ export function CommitMenu({ appId }: CommitMenuProps) {
   const { t } = useTranslation("home");
   const { uncommittedFiles, hasUncommittedFiles } = useUncommittedFiles(appId);
   const { commitChanges, isCommitting } = useCommitChanges();
-  const setStagedDiffFile = useSetAtom(stagedDiffFileAtom);
+  const [openCommitDialog, setOpenCommitDialog] = useAtom(openCommitDialogAtom);
+  const openStagedDiffFile = useSetAtom(openStagedDiffAtom);
+  const clearStagedDiff = useSetAtom(clearStagedDiffAtom);
+  const setCommitMessageDraft = useSetAtom(commitMessageDraftAtom);
+  const commitMessageDraft = useAtomValue(commitMessageDraftAtom);
   const { send: sendPreviewEvent } = useVersionPreview(appId);
-  const [isDialogOpen, setIsDialogOpen] = useState(false);
-  const [commitMessage, setCommitMessage] = useState("");
+  // Frozen at open so polling doesn't rewrite the suggestion under the user.
+  // Only ever a suggestion: once the user types, the draft atom takes over.
+  const [generatedMessage, setGeneratedMessage] = useState<string | null>(null);
+
+  const isDialogOpen = openCommitDialog === "editor";
+  const commitMessage =
+    commitMessageDraft ??
+    generatedMessage ??
+    generateDefaultCommitMessage(uncommittedFiles);
 
   // Opening a staged file's diff must clear any selected version diff, since
   // CodeView suppresses staged-diff mode whenever a version diff is active.
-  const openStagedDiff = (filePath: string) => {
+  // `returnTo` is what brings the user back to the dialog they came from.
+  const openStagedDiff = (
+    filePath: string,
+    returnTo: CommitDialogSource | null,
+  ) => {
     sendPreviewEvent({ type: "CLOSE" });
-    setStagedDiffFile(filePath);
+    openStagedDiffFile({ path: filePath, returnTo });
   };
 
   const handleOpenDialog = () => {
-    // Prefill only when opening so polling doesn't overwrite the user's edits.
-    setCommitMessage(generateDefaultCommitMessage(uncommittedFiles));
-    setIsDialogOpen(true);
+    // Regenerate the suggestion on every open so its file counts stay current.
+    // A message the user actually typed lives in the draft atom and survives.
+    setGeneratedMessage(generateDefaultCommitMessage(uncommittedFiles));
+    setOpenCommitDialog("editor");
   };
 
   const handleCommit = async () => {
@@ -73,10 +94,12 @@ export function CommitMenu({ appId }: CommitMenuProps) {
       // and preserve the message so the user can retry without retyping it.
       return;
     }
-    setIsDialogOpen(false);
-    setCommitMessage("");
-    // Nothing is staged anymore, so leave the diff view if it was open.
-    setStagedDiffFile(null);
+    setOpenCommitDialog(null);
+    setGeneratedMessage(null);
+    setCommitMessageDraft(null);
+    // Nothing is staged anymore, so leave the diff view if it was open. This
+    // must not reopen the dialog, hence clear rather than exit.
+    clearStagedDiff();
   };
 
   return (
@@ -125,7 +148,9 @@ export function CommitMenu({ appId }: CommitMenuProps) {
               <DropdownMenuItem
                 key={file.path}
                 className="flex items-center gap-2"
-                onClick={() => openStagedDiff(file.path)}
+                // The dropdown is a shortcut straight to a diff, so leaving it
+                // returns to the editor rather than opening the dialog.
+                onClick={() => openStagedDiff(file.path, null)}
                 data-testid="staged-file-item"
               >
                 {getStatusIcon(file.status)}
@@ -149,7 +174,7 @@ export function CommitMenu({ appId }: CommitMenuProps) {
         open={isDialogOpen}
         onOpenChange={(open) => {
           if (!open && isCommitting) return;
-          setIsDialogOpen(open);
+          setOpenCommitDialog(open ? "editor" : null);
         }}
       >
         <DialogContent
@@ -174,7 +199,7 @@ export function CommitMenu({ appId }: CommitMenuProps) {
               <Input
                 id="editor-commit-message"
                 value={commitMessage}
-                onChange={(e) => setCommitMessage(e.target.value)}
+                onChange={(e) => setCommitMessageDraft(e.target.value)}
                 placeholder={t("preview.commitMessagePlaceholder")}
                 data-testid="editor-commit-message-input"
               />
@@ -186,39 +211,19 @@ export function CommitMenu({ appId }: CommitMenuProps) {
                   count: uncommittedFiles.length,
                 })}
               </p>
-              <div
-                className="max-h-60 overflow-y-auto rounded-md border p-2 space-y-1"
-                data-testid="editor-commit-files-list"
-              >
-                {uncommittedFiles.map((file) => (
-                  <div
-                    key={file.path}
-                    className="flex items-center gap-2 text-sm py-1 px-2 rounded hover:bg-muted"
-                  >
-                    {getStatusIcon(file.status)}
-                    <span
-                      className={cn(
-                        "flex-1 truncate font-mono text-xs",
-                        file.status === "deleted" && "line-through opacity-60",
-                      )}
-                      title={file.path}
-                    >
-                      {file.path}
-                    </span>
-                    <LineStats file={file} />
-                    <span className={getStatusBadgeClassName(file.status)}>
-                      {getStatusLabel(file.status)}
-                    </span>
-                  </div>
-                ))}
-              </div>
+              <CommitFileList
+                files={uncommittedFiles}
+                onSelectFile={(path) => openStagedDiff(path, "editor")}
+                disabled={isCommitting}
+                testId="editor-commit-files-list"
+              />
             </div>
           </div>
 
           <DialogFooter className="px-6 pb-6 pt-2">
             <Button
               variant="outline"
-              onClick={() => setIsDialogOpen(false)}
+              onClick={() => setOpenCommitDialog(null)}
               disabled={isCommitting}
             >
               {t("preview.cancel")}

--- a/src/components/preview_panel/CommitMenu.tsx
+++ b/src/components/preview_panel/CommitMenu.tsx
@@ -1,7 +1,6 @@
-import { useEffect, useRef, useState } from "react";
 import { GitCommitVertical, ChevronDown } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import { useSetAtom } from "jotai";
 import { Button, buttonVariants } from "@/components/ui/button";
 import {
   Dialog,
@@ -22,17 +21,17 @@ import {
 } from "@/components/ui/dropdown-menu";
 import {
   clearStagedDiffAtom,
-  commitMessageDraftAtom,
+  dismissCommitDialogAtom,
   openCommitDialogAtom,
   openStagedDiffAtom,
   type CommitDialogSource,
 } from "@/atoms/commitAtoms";
 import { useUncommittedFiles } from "@/hooks/useUncommittedFiles";
 import { useCommitChanges } from "@/hooks/useCommitChanges";
+import { useCommitMessage } from "@/hooks/useCommitMessage";
 import { cn } from "@/lib/utils";
 import {
   getStatusIcon,
-  generateDefaultCommitMessage,
   LineStats,
 } from "@/components/chat/uncommittedFileStatus";
 import { CommitFileList } from "@/components/chat/CommitFileList";
@@ -51,37 +50,15 @@ export function CommitMenu({ appId }: CommitMenuProps) {
   const { t } = useTranslation("home");
   const { uncommittedFiles, hasUncommittedFiles } = useUncommittedFiles(appId);
   const { commitChanges, isCommitting } = useCommitChanges();
-  const [openCommitDialog, setOpenCommitDialog] = useAtom(openCommitDialogAtom);
+  const setOpenCommitDialog = useSetAtom(openCommitDialogAtom);
   const openStagedDiffFile = useSetAtom(openStagedDiffAtom);
   const clearStagedDiff = useSetAtom(clearStagedDiffAtom);
-  const setCommitMessageDraft = useSetAtom(commitMessageDraftAtom);
-  const commitMessageDraft = useAtomValue(commitMessageDraftAtom);
+  const dismissCommitDialog = useSetAtom(dismissCommitDialogAtom);
   const { send: sendPreviewEvent } = useVersionPreview(appId);
-  // Frozen at open so polling doesn't rewrite the suggestion under the user.
-  // Only ever a suggestion: once the user types, the draft atom takes over.
-  const [generatedMessage, setGeneratedMessage] = useState<string | null>(null);
-  // Read only at the moment the dialog opens, so the freeze above is against a
-  // ref rather than a render-time dependency that would refresh with polling.
-  const uncommittedFilesRef = useRef(uncommittedFiles);
-  uncommittedFilesRef.current = uncommittedFiles;
-
-  const isDialogOpen = openCommitDialog === "editor";
-
-  // Refresh the suggestion on every open and drop it on close. The reopen after
-  // leaving the staged diff comes straight from the atom rather than the button
-  // handler, so freezing it there would commit a file list the user never saw.
-  useEffect(() => {
-    setGeneratedMessage(
-      isDialogOpen
-        ? generateDefaultCommitMessage(uncommittedFilesRef.current)
-        : null,
-    );
-  }, [isDialogOpen]);
-
-  const commitMessage =
-    commitMessageDraft ??
-    generatedMessage ??
-    generateDefaultCommitMessage(uncommittedFiles);
+  const { isDialogOpen, commitMessage, setCommitMessage } = useCommitMessage(
+    "editor",
+    uncommittedFiles,
+  );
 
   // Opening a staged file's diff must clear any selected version diff, since
   // CodeView suppresses staged-diff mode whenever a version diff is active.
@@ -96,11 +73,12 @@ export function CommitMenu({ appId }: CommitMenuProps) {
 
   // Dismissing without committing abandons the message: keeping it would
   // prefill a later, unrelated commit with text written for a change set that
-  // has since moved on. The staged-diff round trip closes the dialog through
-  // openStagedDiffAtom instead, so the draft survives that.
+  // has since moved on. It also drops any pending return to this dialog, so the
+  // staged diff's back arrow cannot resurrect the dialog just dismissed. The
+  // round trip out to a diff closes the dialog through openStagedDiffAtom
+  // instead, so the draft survives that.
   const dismissDialog = () => {
-    setOpenCommitDialog(null);
-    setCommitMessageDraft(null);
+    dismissCommitDialog({ source: "editor", appId });
   };
 
   const handleCommit = async () => {
@@ -112,8 +90,7 @@ export function CommitMenu({ appId }: CommitMenuProps) {
       // and preserve the message so the user can retry without retyping it.
       return;
     }
-    setOpenCommitDialog(null);
-    setCommitMessageDraft(null);
+    dismissCommitDialog({ source: "editor", appId });
     // Nothing is staged anymore, so leave the diff view if it was open. This
     // must not reopen the dialog, hence clear rather than exit.
     clearStagedDiff();
@@ -220,7 +197,7 @@ export function CommitMenu({ appId }: CommitMenuProps) {
               <Input
                 id="editor-commit-message"
                 value={commitMessage}
-                onChange={(e) => setCommitMessageDraft(e.target.value)}
+                onChange={(e) => setCommitMessage(e.target.value)}
                 placeholder={t("preview.commitMessagePlaceholder")}
                 data-testid="editor-commit-message-input"
               />

--- a/src/components/preview_panel/TestsPanel.tsx
+++ b/src/components/preview_panel/TestsPanel.tsx
@@ -33,7 +33,8 @@ import {
 import { previewModeAtom, selectedAppIdAtom } from "@/atoms/appAtoms";
 import { selectedChatIdAtom } from "@/atoms/chatAtoms";
 import { useCurrentAppUrl } from "@/hooks/useAppRun";
-import { selectedFileAtom, stagedDiffFileAtom } from "@/atoms/viewAtoms";
+import { selectedFileAtom } from "@/atoms/viewAtoms";
+import { clearStagedDiffAtom } from "@/atoms/commitAtoms";
 import {
   applyTestRunFinishedAtom,
   applyTestRunStartedAtom,
@@ -620,7 +621,7 @@ export function TestsPanel() {
   const setRunState = useSetAtom(setTestRunStateForAppAtom);
   const setPreviewMode = useSetAtom(previewModeAtom);
   const setSelectedFile = useSetAtom(selectedFileAtom);
-  const setStagedDiffFile = useSetAtom(stagedDiffFileAtom);
+  const clearStagedDiff = useSetAtom(clearStagedDiffAtom);
   // For lazy, subscription-free reads of the streamed output (askAiToFix runs
   // long after the chunks arrive; subscribing would re-render the whole panel
   // on every flush and defeat the point of the separate output atom).
@@ -1014,11 +1015,13 @@ export function TestsPanel() {
     (file: string, line?: number) => {
       // CodeView renders a staged-file diff in preference to the selected file,
       // so a diff left open from the commit menu would swallow this request.
-      setStagedDiffFile(null);
+      // Clearing (rather than exiting) also drops any pending commit-dialog
+      // return, which would otherwise pop open over the spec.
+      clearStagedDiff();
       setSelectedFile({ path: file, line: line ?? null });
       setPreviewMode("code");
     },
-    [setSelectedFile, setPreviewMode, setStagedDiffFile],
+    [setSelectedFile, setPreviewMode, clearStagedDiff],
   );
 
   // The spec file awaiting delete confirmation, tagged with the app it came

--- a/src/components/preview_panel/TestsPanel.tsx
+++ b/src/components/preview_panel/TestsPanel.tsx
@@ -1017,11 +1017,11 @@ export function TestsPanel() {
       // so a diff left open from the commit menu would swallow this request.
       // Clearing (rather than exiting) also drops any pending commit-dialog
       // return, which would otherwise pop open over the spec.
-      clearStagedDiff();
+      clearStagedDiff(selectedAppId);
       setSelectedFile({ path: file, line: line ?? null });
       setPreviewMode("code");
     },
-    [setSelectedFile, setPreviewMode, clearStagedDiff],
+    [setSelectedFile, setPreviewMode, clearStagedDiff, selectedAppId],
   );
 
   // The spec file awaiting delete confirmation, tagged with the app it came

--- a/src/hooks/useCommitMessage.ts
+++ b/src/hooks/useCommitMessage.ts
@@ -18,6 +18,7 @@ import type { UncommittedFile } from "@/hooks/useUncommittedFiles";
  */
 export function useCommitMessage(
   source: CommitDialogSource,
+  appId: number | null,
   uncommittedFiles: UncommittedFile[],
 ) {
   const openCommitDialog = useAtomValue(openCommitDialogAtom);
@@ -26,7 +27,10 @@ export function useCommitMessage(
   // Frozen at open so polling doesn't rewrite the suggestion under the user.
   // Only ever a suggestion: once the user types, the draft atom takes over.
   const [generatedMessage, setGeneratedMessage] = useState<string | null>(null);
-  const isDialogOpen = openCommitDialog === source;
+  // A dialog belongs to an app as well as a source, so an open dialog left over
+  // from another app is not this one.
+  const isDialogOpen =
+    openCommitDialog?.source === source && openCommitDialog.appId === appId;
   // Read only at the moment the dialog opens, so the freeze above is against a
   // ref rather than a render-time dependency that would refresh with polling.
   const uncommittedFilesRef = useRef(uncommittedFiles);

--- a/src/hooks/useCommitMessage.ts
+++ b/src/hooks/useCommitMessage.ts
@@ -1,0 +1,60 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useAtomValue, useSetAtom } from "jotai";
+import {
+  commitMessageDraftAtom,
+  openCommitDialogAtom,
+  type CommitDialogSource,
+} from "@/atoms/commitAtoms";
+import { generateDefaultCommitMessage } from "@/components/chat/uncommittedFileStatus";
+import type { UncommittedFile } from "@/hooks/useUncommittedFiles";
+
+/**
+ * The commit message a commit dialog shows, plus whether that dialog is the one
+ * currently open. The editor's commit menu and the chat header's uncommitted
+ * files banner are two entrances to the same commit of the same working tree,
+ * so they resolve the message the same way and share this hook rather than a
+ * copy each: what the user typed wins, then a suggestion frozen when the dialog
+ * opened, then a default generated from the files on screen.
+ */
+export function useCommitMessage(
+  source: CommitDialogSource,
+  uncommittedFiles: UncommittedFile[],
+) {
+  const openCommitDialog = useAtomValue(openCommitDialogAtom);
+  const commitMessageDraft = useAtomValue(commitMessageDraftAtom);
+  const setCommitMessage = useSetAtom(commitMessageDraftAtom);
+  // Frozen at open so polling doesn't rewrite the suggestion under the user.
+  // Only ever a suggestion: once the user types, the draft atom takes over.
+  const [generatedMessage, setGeneratedMessage] = useState<string | null>(null);
+  const isDialogOpen = openCommitDialog === source;
+  // Read only at the moment the dialog opens, so the freeze above is against a
+  // ref rather than a render-time dependency that would refresh with polling.
+  const uncommittedFilesRef = useRef(uncommittedFiles);
+  uncommittedFilesRef.current = uncommittedFiles;
+
+  // Refresh the suggestion on every open and drop it on close. The reopen after
+  // leaving the staged diff comes straight from the atom rather than the button
+  // handler, so freezing it there would commit a file list the user never saw.
+  useEffect(() => {
+    setGeneratedMessage(
+      isDialogOpen
+        ? generateDefaultCommitMessage(uncommittedFilesRef.current)
+        : null,
+    );
+  }, [isDialogOpen]);
+
+  // Only reached on the first frame of an open, before the effect above lands,
+  // and while the dialog is closed and nobody reads it. Both hosts stay mounted
+  // and re-render on every poll of the uncommitted files, so memoize rather
+  // than regenerate this on each of those - the query preserves the array's
+  // identity while the file list is unchanged, so it recomputes when it should.
+  const defaultMessage = useMemo(
+    () => generateDefaultCommitMessage(uncommittedFiles),
+    [uncommittedFiles],
+  );
+
+  const commitMessage =
+    commitMessageDraft ?? generatedMessage ?? defaultMessage;
+
+  return { isDialogOpen, commitMessage, setCommitMessage };
+}


### PR DESCRIPTION
Opening a file's diff while committing

- Make some changes, then open a commit dialog either way:
  - the Commit button at the top of the code editor, or
  - the Review & commit button on the blue banner above the chat.
- Both dialogs list your changed files with their status and +N/−N line counts.
- Click any file in the list. The dialog closes and that file's diff opens in the code panel — from the banner, the code panel opens for you if it wasn't already showing.
- Hit the back arrow above the diff to return. The dialog reopens with your commit message still typed in.
- Look at as many files as you like, then commit from the dialog as usual.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

