### PR TITLE
Bump to v1.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dyad",
-  "version": "1.10.0-beta.3",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dyad",
-      "version": "1.10.0-beta.3",
+      "version": "1.10.0",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/amazon-bedrock": "^4.0.46",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dyad",
-  "version": "1.10.0-beta.3",
+  "version": "1.10.0",
   "description": "Free, local, open-source AI app builder",
   "keywords": [],
   "license": "MIT",


### PR DESCRIPTION
#skip-bb

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata only; no runtime or behavioral changes in the diff.
> 
> **Overview**
> Promotes the **dyad** package from **`1.10.0-beta.3`** to stable **`1.10.0`**.
> 
> The version field is updated in **`package.json`** and the root package entry in **`package-lock.json`**; no dependency or application code changes are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e59d855c47742471fe206f4966f22f9a9ffe8a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->