### PR TITLE
Fix Claude issue triage artifact generation

### DIFF
--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
-      # Strip project Claude settings so the narrow allowed_tools below is authoritative.
+      # Strip project Claude settings so the narrow allowedTools below is authoritative.
       # Without this, .claude/settings.json's permissions.allow list (Bash(git:*), etc.)
       # merges in and silently widens the agent's effective allowlist — which matters here
       # because the triage prompt embeds untrusted issue title/body content.
@@ -58,9 +58,18 @@ jobs:
         with:
           #   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          model: claude-opus-5
-          allowed_tools: "Bash(echo:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Write"
           prompt: ${{ steps.render-prompt.outputs.prompt }}
+          claude_args: |
+            --model claude-opus-5
+            --setting-sources user
+            --allowedTools "Bash(echo:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Write(tmp/issue-triage/**)"
+
+      - name: Verify issue triage output
+        run: |
+          if [[ ! -s "$TRIAGE_OUTPUT_PATH" ]]; then
+            echo "::error::Claude did not write $TRIAGE_OUTPUT_PATH"
+            exit 1
+          fi
 
       - name: Upload issue triage artifact
         uses: actions/upload-artifact@v6

--- a/rules/claude-github-workflows.md
+++ b/rules/claude-github-workflows.md
@@ -24,7 +24,7 @@ When a headless Claude job must write local handoff artifacts, exclude project/l
 
 Both `claude-code-action` and `claude-code-base-action` read `.claude/settings.json` from the workspace after `actions/checkout`, and the project's file is committed (tracked in git). **`permissions.allow` arrays merge across scopes — they do not replace each other.** From the Claude Code docs: _"Array settings merge across scopes. When the same array-valued setting (such as `permissions.allow`) appears in multiple scopes, the arrays are concatenated and deduplicated, not replaced."_ ([source](https://code.claude.com/docs/en/settings)).
 
-When upgrading the standalone `claude-code-base-action`, do not infer its bundled Claude Code version from the latest release tag: the repository can continue receiving immutable sync commits after tagged releases stop. Inspect `action.yml` at the exact commit, pin that SHA, and annotate the bundled CLI version so model compatibility is reviewable.
+When upgrading the standalone `claude-code-base-action`, do not infer its bundled Claude Code version from the latest release tag: the repository can continue receiving immutable sync commits after tagged releases stop. Inspect `action.yml` at the exact commit, pin that SHA, and annotate the bundled CLI version so model compatibility is reviewable. Also verify its declared inputs: versions that do not declare `model` or `allowed_tools` ignore those top-level inputs with an `Unexpected input(s)` warning, so pass the equivalent `--model` and `--allowedTools` flags through `claude_args`.
 
 This has two consequences that bite in CI:
 


### PR DESCRIPTION
## Summary

Restore issue triage after the Opus 5 base-action upgrade caused every run to finish without its required JSON handoff. The workflow now supplies model and tool permissions through the action's supported CLI arguments and detects missing output before artifact upload.

- Keep the existing read-only/credential-separated job design while limiting Claude's local write access to `tmp/issue-triage/**`.
- Continue excluding project settings via `--setting-sources user`, in addition to stripping the checked-out settings files, so repository-level permissions cannot widen the triage agent's tool access.
- Fail at the producer boundary when `triage.json` is missing or empty instead of surfacing the problem indirectly from `upload-artifact`.
- Document that standalone base-action upgrades must be checked for input-schema changes as well as bundled Claude Code/model compatibility.

#skip-bugbot

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow and internal docs only; tightens agent permissions and adds an explicit output gate with no app or data-path changes.
> 
> **Overview**
> **Restores issue triage** after the Opus 5 `claude-code-base-action` upgrade left runs without `triage.json`. The action no longer honors top-level `model` / `allowed_tools`, so the workflow passes **`--model`**, **`--setting-sources user`**, and a scoped **`--allowedTools`** list (including **`Write(tmp/issue-triage/**)`** only) through **`claude_args`**.
> 
> Adds a **producer-step check** that fails fast when **`TRIAGE_OUTPUT_PATH`** is missing or empty, instead of relying only on artifact upload.
> 
> **Docs:** when pinning **`claude-code-base-action`**, confirm declared inputs and route model/tool limits through **`claude_args`** if legacy inputs are ignored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a49bd39d3e1e425a6904d160b646b660dee46c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->