### PR TITLE
Add app blueprint posthog telemetry

### DIFF
--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -2,7 +2,10 @@ import { useCallback, useEffect, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { ipc } from "@/ipc/types";
 import { type UserSettings, hasDyadProKey } from "@/lib/schemas";
-import { getInitialLoadTelemetryProperties } from "@/lib/posthogTelemetry";
+import {
+  getInitialLoadTelemetryProperties,
+  getSettingsPersonTelemetryProperties,
+} from "@/lib/posthogTelemetry";
 import { usePostHog } from "posthog-js/react";
 import { useAppVersion } from "./useAppVersion";
 import { queryKeys } from "@/lib/queryKeys";
@@ -65,8 +68,9 @@ export function useSettings() {
     }
 
     processSettingsForTelemetry(settingsQuery.data);
-    const isPro = hasDyadProKey(settingsQuery.data);
-    posthog?.people?.set({ isPro });
+    posthog?.people?.set(
+      getSettingsPersonTelemetryProperties(settingsQuery.data),
+    );
 
     if (
       initialLoadTelemetryState !== "idle" ||
@@ -114,7 +118,9 @@ export function useSettings() {
     onSuccess: (updatedSettings) => {
       queryClient.setQueryData(queryKeys.settings.user, updatedSettings);
       processSettingsForTelemetry(updatedSettings);
-      posthog?.people?.set({ isPro: hasDyadProKey(updatedSettings) });
+      posthog?.people?.set(
+        getSettingsPersonTelemetryProperties(updatedSettings),
+      );
     },
     meta: { showErrorToast: true },
   });

--- a/src/lib/posthogTelemetry.test.ts
+++ b/src/lib/posthogTelemetry.test.ts
@@ -3,6 +3,7 @@ import {
   createExceptionFromTelemetry,
   getExceptionTelemetryContext,
   getInitialLoadTelemetryProperties,
+  getSettingsPersonTelemetryProperties,
   shouldBypassNonProTelemetrySampling,
   shouldFilterPostHogExceptionEvent,
 } from "@/lib/posthogTelemetry";
@@ -91,6 +92,7 @@ describe("getInitialLoadTelemetryProperties", () => {
           providerSettings: {
             auto: { apiKey: { value: "secret" } },
           },
+          enableAppBlueprint: false,
         }),
         appVersion: "1.1.0",
         platform: "darwin",
@@ -102,6 +104,7 @@ describe("getInitialLoadTelemetryProperties", () => {
       platform: "darwin",
       releaseChannel: "beta",
       isFirstSession: false,
+      enableAppBlueprint: false,
       modelProvider: "auto",
       defaultChatMode: "ask",
       runtimeMode2: "docker",
@@ -124,9 +127,28 @@ describe("getInitialLoadTelemetryProperties", () => {
       platform: null,
       releaseChannel: "stable",
       isFirstSession: true,
+      enableAppBlueprint: true,
       modelProvider: "auto",
       defaultChatMode: null,
       runtimeMode2: "host",
+    });
+  });
+});
+
+describe("getSettingsPersonTelemetryProperties", () => {
+  it("includes pro and app blueprint settings for PostHog people properties", () => {
+    expect(
+      getSettingsPersonTelemetryProperties(
+        makeSettings({
+          providerSettings: {
+            auto: { apiKey: { value: "secret" } },
+          },
+          enableAppBlueprint: false,
+        }),
+      ),
+    ).toEqual({
+      isPro: true,
+      enableAppBlueprint: false,
     });
   });
 });

--- a/src/lib/posthogTelemetry.ts
+++ b/src/lib/posthogTelemetry.ts
@@ -9,6 +9,13 @@ export type InitialLoadTelemetryInput = {
   isFirstSession: boolean;
 };
 
+export function getSettingsPersonTelemetryProperties(settings: UserSettings) {
+  return {
+    isPro: hasDyadProKey(settings),
+    enableAppBlueprint: settings.enableAppBlueprint ?? true,
+  };
+}
+
 export function getInitialLoadTelemetryProperties({
   settings,
   appVersion,
@@ -16,7 +23,7 @@ export function getInitialLoadTelemetryProperties({
   isFirstSession,
 }: InitialLoadTelemetryInput) {
   return {
-    isPro: hasDyadProKey(settings),
+    ...getSettingsPersonTelemetryProperties(settings),
     appVersion,
     platform,
     releaseChannel: settings.releaseChannel,


### PR DESCRIPTION
Adds PostHog telemetry for the App Blueprint setting so we can query whether opted-in users have App Blueprint enabled.

This sends `enableAppBlueprint` in two places:
- as a PostHog person property whenever settings load or update
- as an `app:initial-load` event property

The value follows the app’s effective default: unset settings are reported as `true`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

