### PR TITLE
Add testing-for-new-apps telemetry

### DIFF
--- a/rules/adding-settings.md
+++ b/rules/adding-settings.md
@@ -3,7 +3,7 @@
 When adding a new toggle/setting to the Settings page:
 
 1. Add the field to `UserSettingsSchema` in `src/lib/schemas.ts`
-2. Add the default value in `DEFAULT_SETTINGS` in `src/main/settings.ts`
+2. Add the default value in `DEFAULT_SETTINGS` in `src/shared/settings_defaults.ts` (`src/main/settings.ts` re-exports it for existing importers). Renderer-side code must import the default from the shared module — importing `src/main/settings.ts` pulls electron/node into the renderer bundle.
 3. Add a `SETTING_IDS` entry and search index entry in `src/lib/settingsSearchIndex.ts`
 4. Create a switch component (e.g., `src/components/MySwitch.tsx`) - follow `AutoApproveSwitch.tsx` as a template
 5. Import and add the switch to the relevant section in `src/pages/settings.tsx`
@@ -12,6 +12,10 @@ When adding a new toggle/setting to the Settings page:
 If the setting adds a built-in default, update the inline snapshots in
 `src/main/settings.test.ts`; otherwise `npm test` will fail with
 default settings snapshot mismatches.
+
+For settings worth tracking in telemetry:
+
+- Add the field to `getSettingsPersonTelemetryProperties` in `src/lib/posthogTelemetry.ts`, reading it as `settings.myFlag ?? DEFAULT_SETTINGS.myFlag` so the reported value matches the real default. Several branches add properties to this one object at a time, so it conflicts often on rebase — the resolution is almost always to keep both properties, not to pick a side.
 
 For settings whose default can be overridden remotely:
 

--- a/rules/adding-settings.md
+++ b/rules/adding-settings.md
@@ -3,7 +3,7 @@
 When adding a new toggle/setting to the Settings page:
 
 1. Add the field to `UserSettingsSchema` in `src/lib/schemas.ts`
-2. Add the default value in `DEFAULT_SETTINGS` in `src/shared/settings_defaults.ts` (`src/main/settings.ts` re-exports it for existing importers). Renderer-side code must import the default from the shared module — importing `src/main/settings.ts` pulls electron/node into the renderer bundle.
+2. Add the default value in `DEFAULT_SETTINGS` in `src/main/settings.ts`. If renderer code also needs the default, export a narrowly scoped, side-effect-free constant from `src/shared/settings_defaults.ts` and reuse that constant in `DEFAULT_SETTINGS`; importing `src/main/settings.ts` pulls electron/node into the renderer bundle.
 3. Add a `SETTING_IDS` entry and search index entry in `src/lib/settingsSearchIndex.ts`
 4. Create a switch component (e.g., `src/components/MySwitch.tsx`) - follow `AutoApproveSwitch.tsx` as a template
 5. Import and add the switch to the relevant section in `src/pages/settings.tsx`
@@ -15,7 +15,8 @@ default settings snapshot mismatches.
 
 For settings worth tracking in telemetry:
 
-- Add the field to `getSettingsPersonTelemetryProperties` in `src/lib/posthogTelemetry.ts`, reading it as `settings.myFlag ?? DEFAULT_SETTINGS.myFlag` so the reported value matches the real default. Several branches add properties to this one object at a time, so it conflicts often on rebase — the resolution is almost always to keep both properties, not to pick a side.
+- Add the field to `getSettingsPersonTelemetryProperties` in `src/lib/posthogTelemetry.ts`, reading it as `settings.myFlag ?? DEFAULT_MY_FLAG`. Define that fallback in the side-effect-free `src/shared/settings_defaults.ts` module and reuse it in `DEFAULT_SETTINGS` so the reported value matches the real default without importing main-process code or evaluating unrelated defaults in the renderer. Several branches add properties to this one object at a time, so it conflicts often on rebase — the resolution is almost always to keep both properties, not to pick a side.
+- Person properties are delivered as PostHog `$set` events. Keep `$set` in `shouldBypassNonProTelemetrySampling`; otherwise successful settings updates can leave sampled users' person properties stale.
 
 For settings whose default can be overridden remotely:
 

--- a/src/lib/posthogTelemetry.test.ts
+++ b/src/lib/posthogTelemetry.test.ts
@@ -195,6 +195,17 @@ describe("shouldBypassNonProTelemetrySampling", () => {
     ).toBe(true);
   });
 
+  it("always sends PostHog person-property updates for non-Pro sampling", () => {
+    expect(
+      shouldBypassNonProTelemetrySampling({
+        event: "$set",
+        properties: {
+          $set: { enableTestingForNewApps: true },
+        },
+      }),
+    ).toBe(true);
+  });
+
   it("always sends promo_click for non-Pro sampling", () => {
     expect(
       shouldBypassNonProTelemetrySampling({

--- a/src/lib/posthogTelemetry.test.ts
+++ b/src/lib/posthogTelemetry.test.ts
@@ -93,6 +93,7 @@ describe("getInitialLoadTelemetryProperties", () => {
             auto: { apiKey: { value: "secret" } },
           },
           enableAppBlueprint: false,
+          enableTestingForNewApps: true,
         }),
         appVersion: "1.1.0",
         platform: "darwin",
@@ -105,6 +106,7 @@ describe("getInitialLoadTelemetryProperties", () => {
       releaseChannel: "beta",
       isFirstSession: false,
       enableAppBlueprint: false,
+      enableTestingForNewApps: true,
       modelProvider: "auto",
       defaultChatMode: "ask",
       runtimeMode2: "docker",
@@ -128,6 +130,7 @@ describe("getInitialLoadTelemetryProperties", () => {
       releaseChannel: "stable",
       isFirstSession: true,
       enableAppBlueprint: true,
+      enableTestingForNewApps: false,
       modelProvider: "auto",
       defaultChatMode: null,
       runtimeMode2: "host",
@@ -136,7 +139,7 @@ describe("getInitialLoadTelemetryProperties", () => {
 });
 
 describe("getSettingsPersonTelemetryProperties", () => {
-  it("includes pro and app blueprint settings for PostHog people properties", () => {
+  it("includes pro and settings toggles for PostHog people properties", () => {
     expect(
       getSettingsPersonTelemetryProperties(
         makeSettings({
@@ -144,11 +147,13 @@ describe("getSettingsPersonTelemetryProperties", () => {
             auto: { apiKey: { value: "secret" } },
           },
           enableAppBlueprint: false,
+          enableTestingForNewApps: true,
         }),
       ),
     ).toEqual({
       isPro: true,
       enableAppBlueprint: false,
+      enableTestingForNewApps: true,
     });
   });
 });

--- a/src/lib/posthogTelemetry.ts
+++ b/src/lib/posthogTelemetry.ts
@@ -15,8 +15,7 @@ export function getSettingsPersonTelemetryProperties(settings: UserSettings) {
     isPro: hasDyadProKey(settings),
     enableAppBlueprint: settings.enableAppBlueprint ?? true,
     enableTestingForNewApps:
-      settings.enableTestingForNewApps ??
-      DEFAULT_ENABLE_TESTING_FOR_NEW_APPS,
+      settings.enableTestingForNewApps ?? DEFAULT_ENABLE_TESTING_FOR_NEW_APPS,
   };
 }
 
@@ -102,6 +101,12 @@ export function shouldBypassNonProTelemetrySampling(
   }
 
   if (eventName === "app:initial-load") {
+    return true;
+  }
+
+  // PostHog people.set emits a $set event. Sampling it would leave person
+  // properties stale even though the corresponding settings update succeeded.
+  if (eventName === "$set") {
     return true;
   }
 

--- a/src/lib/posthogTelemetry.ts
+++ b/src/lib/posthogTelemetry.ts
@@ -1,4 +1,5 @@
 import { hasDyadProKey, type UserSettings } from "@/lib/schemas";
+import { DEFAULT_ENABLE_TESTING_FOR_NEW_APPS } from "@/shared/settings_defaults";
 
 type TelemetryProperties = Record<string, unknown> | undefined;
 
@@ -13,7 +14,9 @@ export function getSettingsPersonTelemetryProperties(settings: UserSettings) {
   return {
     isPro: hasDyadProKey(settings),
     enableAppBlueprint: settings.enableAppBlueprint ?? true,
-    enableTestingForNewApps: settings.enableTestingForNewApps ?? false,
+    enableTestingForNewApps:
+      settings.enableTestingForNewApps ??
+      DEFAULT_ENABLE_TESTING_FOR_NEW_APPS,
   };
 }
 

--- a/src/lib/posthogTelemetry.ts
+++ b/src/lib/posthogTelemetry.ts
@@ -13,6 +13,7 @@ export function getSettingsPersonTelemetryProperties(settings: UserSettings) {
   return {
     isPro: hasDyadProKey(settings),
     enableAppBlueprint: settings.enableAppBlueprint ?? true,
+    enableTestingForNewApps: settings.enableTestingForNewApps ?? false,
   };
 }
 

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -83,6 +83,7 @@ export const DEFAULT_SETTINGS: UserSettings = {
   nodeRuntimePreference: "system",
   disablePreviewNodeAutoInstall: false,
 };
+
 const CRASH_SENTINEL_FILE = "session.lock";
 const RENDERER_CRASH_FILE = "renderer-crash.json";
 const SETTINGS_FILE = "user-settings.json";

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -33,6 +33,7 @@ import {
   getRecoveryStats,
   recoverLegacySafeStorageSecret,
 } from "./safe_storage_legacy";
+import { DEFAULT_ENABLE_TESTING_FOR_NEW_APPS } from "@/shared/settings_defaults";
 
 const logger = log.scope("settings");
 
@@ -57,7 +58,7 @@ export const DEFAULT_SETTINGS: UserSettings = {
   enableProSmartFilesContextMode: true,
   selectedChatMode: "build",
   enableAppBlueprint: true,
-  enableTestingForNewApps: false,
+  enableTestingForNewApps: DEFAULT_ENABLE_TESTING_FOR_NEW_APPS,
   enableAutoUpdate: true,
   releaseChannel: "stable",
   selectedTemplateId: DEFAULT_TEMPLATE_ID,
@@ -82,7 +83,6 @@ export const DEFAULT_SETTINGS: UserSettings = {
   nodeRuntimePreference: "system",
   disablePreviewNodeAutoInstall: false,
 };
-
 const CRASH_SENTINEL_FILE = "session.lock";
 const RENDERER_CRASH_FILE = "renderer-crash.json";
 const SETTINGS_FILE = "user-settings.json";

--- a/src/shared/settings_defaults.ts
+++ b/src/shared/settings_defaults.ts
@@ -1,0 +1,3 @@
+// This module is safe to import in both the main and renderer processes.
+// Keep renderer-consumed defaults here free of runtime side effects.
+export const DEFAULT_ENABLE_TESTING_FOR_NEW_APPS = false;


### PR DESCRIPTION
## Summary

Adds PostHog telemetry for the effective “testing for new apps” preference so opted-in product analytics can distinguish users who retain the built-in default from users who explicitly change it. The value is included with the existing settings person properties and on `app:initial-load` without introducing a new product event.

- Uses one narrowly scoped, side-effect-free shared constant for the boolean fallback, while keeping the complete `DEFAULT_SETTINGS` object in the main process. This avoids loading UUID/template/theme defaults or generating a throwaway telemetry ID in the renderer.
- Preserves the existing `enableAppBlueprint` telemetry property after rebasing onto current `main`; both settings are reported together.
- Exempts PostHog `$set` person-property updates from non-Pro event sampling so a successful settings mutation cannot leave the analytics profile stale.
- Keeps the telemetry scope limited to this boolean product preference; no user content or additional settings are reported.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
