### PR TITLE
Keep reload shortcuts scoped to the app preview

### DIFF
--- a/e2e-tests/refresh.spec.ts
+++ b/e2e-tests/refresh.spec.ts
@@ -29,10 +29,26 @@ testSkipIfWindows(
     ]);
 
     await po.page.evaluate(() => {
-      (
-        window as typeof window & { reloadShortcutMarker?: string }
-      ).reloadShortcutMarker = "outer-renderer-still-alive";
+      const testWindow = window as typeof window & {
+        reloadShortcutMarker?: string;
+        previewSelectorReadyCount?: number;
+      };
+      testWindow.reloadShortcutMarker = "outer-renderer-still-alive";
+      testWindow.previewSelectorReadyCount = 0;
+      window.addEventListener("message", (event) => {
+        if (event.data?.type === "dyad-component-selector-initialized") {
+          testWindow.previewSelectorReadyCount =
+            (testWindow.previewSelectorReadyCount ?? 0) + 1;
+        }
+      });
     });
+
+    const getSelectorReadyCount = () =>
+      po.page.evaluate(
+        () =>
+          (window as typeof window & { previewSelectorReadyCount?: number })
+            .previewSelectorReadyCount ?? 0,
+      );
 
     const modifier = process.platform === "darwin" ? "Meta" : "Control";
     const shortcuts = [`${modifier}+r`, `${modifier}+Shift+r`];
@@ -52,8 +68,23 @@ testSkipIfWindows(
       timeout: Timeout.MEDIUM,
     });
 
+    const initialFrame = po.previewPanel
+      .getPreviewIframeElement()
+      .contentFrame();
+    await initialFrame.locator("body").evaluate((body) => {
+      body.dataset.reloadShortcutMarker = "not-reloaded";
+      body.tabIndex = -1;
+      body.focus();
+    });
+    await po.page.keyboard.press(`${modifier}+Alt+r`);
+    await expect(initialFrame.locator("body")).toHaveAttribute(
+      "data-reload-shortcut-marker",
+      "not-reloaded",
+    );
+
     for (const [index, shortcut] of shortcuts.entries()) {
       const frame = po.previewPanel.getPreviewIframeElement().contentFrame();
+      const selectorReadyCount = await getSelectorReadyCount();
       await frame.locator("body").evaluate((body) => {
         body.dataset.reloadShortcutMarker = "before-reload";
         body.tabIndex = -1;
@@ -73,6 +104,9 @@ testSkipIfWindows(
         "before-reload",
         { timeout: Timeout.LONG },
       );
+      await expect
+        .poll(getSelectorReadyCount)
+        .toBeGreaterThan(selectorReadyCount);
       await expect
         .poll(() =>
           po.page.evaluate(
@@ -100,6 +134,7 @@ testSkipIfWindows(
 
     for (const shortcut of shortcuts) {
       const frame = po.previewPanel.getPreviewIframeElement().contentFrame();
+      const selectorReadyCount = await getSelectorReadyCount();
       await frame.locator("body").evaluate((body) => {
         body.dataset.reloadShortcutMarker = "before-reload";
       });
@@ -112,7 +147,35 @@ testSkipIfWindows(
         "before-reload",
         { timeout: Timeout.LONG },
       );
+      await expect
+        .poll(getSelectorReadyCount)
+        .toBeGreaterThan(selectorReadyCount);
     }
+
+    const frame = po.previewPanel.getPreviewIframeElement().contentFrame();
+    const selectorReadyCount = await getSelectorReadyCount();
+    await frame.locator("body").evaluate((body) => {
+      const nestedFrame = document.createElement("iframe");
+      nestedFrame.dataset.testid = "nested-preview-frame";
+      nestedFrame.src = window.location.href;
+      body.appendChild(nestedFrame);
+    });
+    const nestedFrame = frame
+      .locator('iframe[data-testid="nested-preview-frame"]')
+      .contentFrame();
+    await expect(nestedFrame.locator("body")).toBeVisible({
+      timeout: Timeout.LONG,
+    });
+    await nestedFrame.locator("body").evaluate((body) => {
+      body.tabIndex = -1;
+      body.focus();
+    });
+
+    await po.page.keyboard.press(`${modifier}+r`);
+
+    await expect
+      .poll(getSelectorReadyCount)
+      .toBeGreaterThan(selectorReadyCount);
   },
 );
 

--- a/e2e-tests/refresh.spec.ts
+++ b/e2e-tests/refresh.spec.ts
@@ -87,16 +87,19 @@ testSkipIfWindows(
     const initialFrame = po.previewPanel
       .getPreviewIframeElement()
       .contentFrame();
+    const initialSelectorReadyCount = await getSelectorReadyCount();
     await initialFrame.locator("body").evaluate((body) => {
       body.dataset.reloadShortcutMarker = "not-reloaded";
       body.tabIndex = -1;
       body.focus();
     });
     await po.page.keyboard.press(`${modifier}+Alt+r`);
+    await po.page.waitForTimeout(500);
     await expect(initialFrame.locator("body")).toHaveAttribute(
       "data-reload-shortcut-marker",
       "not-reloaded",
     );
+    expect(await getSelectorReadyCount()).toBe(initialSelectorReadyCount);
 
     for (const [index, shortcut] of shortcuts.entries()) {
       const frame = po.previewPanel.getPreviewIframeElement().contentFrame();
@@ -162,6 +165,7 @@ testSkipIfWindows(
     });
     await po.page.getByTestId("preview-refresh-button").focus();
     await po.page.keyboard.press(`${modifier}+Alt+r`);
+    await po.page.waitForTimeout(500);
     await expect(rendererAltFrame.locator("body")).toHaveAttribute(
       "data-reload-shortcut-marker",
       "renderer-alt-not-reloaded",

--- a/e2e-tests/refresh.spec.ts
+++ b/e2e-tests/refresh.spec.ts
@@ -53,7 +53,20 @@ testSkipIfWindows(
     const modifier = process.platform === "darwin" ? "Meta" : "Control";
     const shortcuts = [`${modifier}+r`, `${modifier}+Shift+r`];
 
-    await po.previewPanel.clickPreviewPickElement();
+    const pickerShortcutFrame = po.previewPanel
+      .getPreviewIframeElement()
+      .contentFrame();
+    const pickerSelectorReadyCount = await getSelectorReadyCount();
+    await pickerShortcutFrame.locator("body").evaluate((body) => {
+      body.tabIndex = -1;
+      body.focus();
+    });
+    await po.page.keyboard.press(`${modifier}+Shift+c`);
+    await expect(po.previewPanel.getPreviewPickElementButton()).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(await getSelectorReadyCount()).toBe(pickerSelectorReadyCount);
     await po.previewPanel
       .getPreviewIframeElement()
       .contentFrame()

--- a/e2e-tests/refresh.spec.ts
+++ b/e2e-tests/refresh.spec.ts
@@ -1,6 +1,60 @@
 import { testSkipIfWindows, Timeout } from "./helpers/test_helper";
 import { expect } from "@playwright/test";
 
+testSkipIfWindows(
+  "reload shortcuts stay scoped to the focused preview",
+  async ({ electronApp, po }) => {
+    await po.setUp({ autoApprove: true });
+    await po.sendPrompt("hi");
+    await po.previewPanel.expectPreviewIframeIsVisible();
+
+    const reloadRoles = await electronApp.evaluate(({ Menu }) => {
+      const viewMenu = Menu.getApplicationMenu()?.items.find(
+        (item) => item.label === "View",
+      );
+      return (
+        viewMenu?.submenu?.items
+          .map((item) => item.role)
+          .filter((role) => role === "reload" || role === "forceReload") ?? []
+      );
+    });
+    expect(reloadRoles).toEqual([]);
+
+    await po.page.evaluate(() => {
+      (
+        window as typeof window & { reloadShortcutMarker?: string }
+      ).reloadShortcutMarker = "outer-renderer-still-alive";
+    });
+
+    const modifier = process.platform === "darwin" ? "Meta" : "Control";
+    for (const shortcut of [`${modifier}+r`, `${modifier}+Shift+r`]) {
+      const frame = po.previewPanel.getPreviewIframeElement().contentFrame();
+      await frame.locator("body").evaluate((body) => {
+        body.dataset.reloadShortcutMarker = "before-reload";
+        body.tabIndex = -1;
+        body.focus();
+      });
+
+      await po.page.keyboard.press(shortcut);
+
+      await expect(frame.locator("body")).not.toHaveAttribute(
+        "data-reload-shortcut-marker",
+        "before-reload",
+        { timeout: Timeout.LONG },
+      );
+      await expect
+        .poll(() =>
+          po.page.evaluate(
+            () =>
+              (window as typeof window & { reloadShortcutMarker?: string })
+                .reloadShortcutMarker,
+          ),
+        )
+        .toBe("outer-renderer-still-alive");
+    }
+  },
+);
+
 testSkipIfWindows("refresh app", async ({ po }) => {
   await po.setUp({ autoApprove: true });
   await po.sendPrompt("hi");

--- a/e2e-tests/refresh.spec.ts
+++ b/e2e-tests/refresh.spec.ts
@@ -4,21 +4,29 @@ import { expect } from "@playwright/test";
 testSkipIfWindows(
   "reload shortcuts stay scoped to the focused preview",
   async ({ electronApp, po }) => {
-    await po.setUp({ autoApprove: true });
-    await po.sendPrompt("hi");
+    await po.setUpDyadPro();
+    await po.sendPrompt("tc=basic");
     await po.previewPanel.expectPreviewIframeIsVisible();
 
-    const reloadRoles = await electronApp.evaluate(({ Menu }) => {
+    const reloadItems = await electronApp.evaluate(({ Menu }) => {
       const viewMenu = Menu.getApplicationMenu()?.items.find(
         (item) => item.label === "View",
       );
       return (
         viewMenu?.submenu?.items
-          .map((item) => item.role)
-          .filter((role) => role === "reload" || role === "forceReload") ?? []
+          .filter((item) =>
+            ["Reload Dyad", "Force Reload Dyad"].includes(item.label),
+          )
+          .map((item) => ({
+            label: item.label,
+            accelerator: item.accelerator ?? null,
+          })) ?? []
       );
     });
-    expect(reloadRoles).toEqual([]);
+    expect(reloadItems).toEqual([
+      { label: "Reload Dyad", accelerator: null },
+      { label: "Force Reload Dyad", accelerator: null },
+    ]);
 
     await po.page.evaluate(() => {
       (
@@ -27,11 +35,34 @@ testSkipIfWindows(
     });
 
     const modifier = process.platform === "darwin" ? "Meta" : "Control";
-    for (const shortcut of [`${modifier}+r`, `${modifier}+Shift+r`]) {
+    const shortcuts = [`${modifier}+r`, `${modifier}+Shift+r`];
+
+    await po.previewPanel.clickPreviewPickElement();
+    await po.previewPanel
+      .getPreviewIframeElement()
+      .contentFrame()
+      .getByRole("heading", { name: "Welcome to Your Blank App" })
+      .click();
+    const marginButton = po.page.getByRole("button", { name: "Margin" });
+    await expect(marginButton).toBeVisible({ timeout: Timeout.MEDIUM });
+    await marginButton.click();
+    await po.page.getByLabel("Horizontal").fill("20");
+    await po.page.keyboard.press("Escape");
+    await expect(po.page.getByText(/\d+ component[s]? modified/)).toBeVisible({
+      timeout: Timeout.MEDIUM,
+    });
+
+    for (const [index, shortcut] of shortcuts.entries()) {
       const frame = po.previewPanel.getPreviewIframeElement().contentFrame();
       await frame.locator("body").evaluate((body) => {
         body.dataset.reloadShortcutMarker = "before-reload";
         body.tabIndex = -1;
+        sessionStorage.removeItem("dyad-app-key-handler");
+        document.addEventListener(
+          "keydown",
+          () => sessionStorage.setItem("dyad-app-key-handler", "observed"),
+          { once: true },
+        );
         body.focus();
       });
 
@@ -51,6 +82,36 @@ testSkipIfWindows(
           ),
         )
         .toBe("outer-renderer-still-alive");
+      await expect
+        .poll(() =>
+          frame
+            .locator("body")
+            .evaluate(() => sessionStorage.getItem("dyad-app-key-handler")),
+        )
+        .toBe("observed");
+
+      if (index === 0) {
+        await expect(marginButton).not.toBeVisible();
+        await expect(
+          po.page.getByText(/\d+ component[s]? modified/),
+        ).not.toBeVisible();
+      }
+    }
+
+    for (const shortcut of shortcuts) {
+      const frame = po.previewPanel.getPreviewIframeElement().contentFrame();
+      await frame.locator("body").evaluate((body) => {
+        body.dataset.reloadShortcutMarker = "before-reload";
+      });
+      await po.page.locator("body").focus();
+
+      await po.page.keyboard.press(shortcut);
+
+      await expect(frame.locator("body")).not.toHaveAttribute(
+        "data-reload-shortcut-marker",
+        "before-reload",
+        { timeout: Timeout.LONG },
+      );
     }
   },
 );

--- a/e2e-tests/refresh.spec.ts
+++ b/e2e-tests/refresh.spec.ts
@@ -166,6 +166,33 @@ testSkipIfWindows(
     }
 
     const frame = po.previewPanel.getPreviewIframeElement().contentFrame();
+    const untrustedSelectorReadyCount = await getSelectorReadyCount();
+    await frame.locator("body").evaluate((body) => {
+      body.dataset.reloadShortcutMarker = "untrusted-child-blocked";
+      window.addEventListener("message", (event) => {
+        if (event.data?.type === "untrusted-reload-attempted") {
+          body.dataset.untrustedReloadAttempted = "true";
+        }
+      });
+      const untrustedFrame = document.createElement("iframe");
+      untrustedFrame.dataset.testid = "untrusted-preview-frame";
+      untrustedFrame.src = `data:text/html,${encodeURIComponent(
+        '<script>parent.postMessage({type:"dyad-preview-reload-shortcut"},"*");parent.postMessage({type:"untrusted-reload-attempted"},"*");</script>',
+      )}`;
+      body.appendChild(untrustedFrame);
+    });
+    await expect(frame.locator("body")).toHaveAttribute(
+      "data-untrusted-reload-attempted",
+      "true",
+      { timeout: Timeout.LONG },
+    );
+    await po.page.waitForTimeout(250);
+    await expect(frame.locator("body")).toHaveAttribute(
+      "data-reload-shortcut-marker",
+      "untrusted-child-blocked",
+    );
+    expect(await getSelectorReadyCount()).toBe(untrustedSelectorReadyCount);
+
     const selectorReadyCount = await getSelectorReadyCount();
     await frame.locator("body").evaluate((body) => {
       const nestedFrame = document.createElement("iframe");

--- a/e2e-tests/refresh.spec.ts
+++ b/e2e-tests/refresh.spec.ts
@@ -56,6 +56,9 @@ testSkipIfWindows(
     const pickerShortcutFrame = po.previewPanel
       .getPreviewIframeElement()
       .contentFrame();
+    await expect(po.previewPanel.getPreviewPickElementButton()).toBeEnabled({
+      timeout: Timeout.EXTRA_LONG,
+    });
     const pickerSelectorReadyCount = await getSelectorReadyCount();
     await pickerShortcutFrame.locator("body").evaluate((body) => {
       body.tabIndex = -1;
@@ -145,13 +148,33 @@ testSkipIfWindows(
       }
     }
 
+    const rendererAltFrame = po.previewPanel
+      .getPreviewIframeElement()
+      .contentFrame();
+    await expect(
+      rendererAltFrame.getByRole("heading", {
+        name: "Welcome to Your Blank App",
+      }),
+    ).toBeVisible({ timeout: Timeout.LONG });
+    const rendererAltSelectorReadyCount = await getSelectorReadyCount();
+    await rendererAltFrame.locator("body").evaluate((body) => {
+      body.dataset.reloadShortcutMarker = "renderer-alt-not-reloaded";
+    });
+    await po.page.getByTestId("preview-refresh-button").focus();
+    await po.page.keyboard.press(`${modifier}+Alt+r`);
+    await expect(rendererAltFrame.locator("body")).toHaveAttribute(
+      "data-reload-shortcut-marker",
+      "renderer-alt-not-reloaded",
+    );
+    expect(await getSelectorReadyCount()).toBe(rendererAltSelectorReadyCount);
+
     for (const shortcut of shortcuts) {
       const frame = po.previewPanel.getPreviewIframeElement().contentFrame();
       const selectorReadyCount = await getSelectorReadyCount();
       await frame.locator("body").evaluate((body) => {
         body.dataset.reloadShortcutMarker = "before-reload";
       });
-      await po.page.locator("body").focus();
+      await po.page.getByTestId("preview-refresh-button").focus();
 
       await po.page.keyboard.press(shortcut);
 

--- a/rules/e2e-testing.md
+++ b/rules/e2e-testing.md
@@ -58,6 +58,10 @@ await po.navigation.goToChatTab();
 
 Key sub-components: `po.appManagement`, `po.navigation`, `po.chatActions`, `po.previewPanel`, `po.codeEditor`, `po.githubConnector`, `po.toastNotifications`, `po.settings`, `po.securityReview`, `po.modelPicker`.
 
+Playwright's `FrameLocator` does not expose `evaluate()`. To run code in a
+preview frame, select an element first (for example,
+`frame.locator("body").evaluate(...)`) and evaluate through that locator.
+
 When an E2E assertion needs main-owned state after a legacy read IPC channel is
 deleted, read the authoritative remote-machine snapshot through
 `distributed-machine:subscribe` and immediately balance it with

--- a/rules/e2e-testing.md
+++ b/rules/e2e-testing.md
@@ -18,6 +18,11 @@ coverage, opt into `macos_native_lifecycle.spec.ts` with
 multiple packaged Dyad instances are running. Post Command-Q directly to the
 Electron PID so another process cannot receive it.
 
+Keep each keyboard shortcut owned by one active listener. Duplicate global and
+feature-scoped listeners can make modifier guards or cleanup appear ineffective;
+packaged Electron E2E should exercise the chord with focus in every supported
+context and assert both the intended reload and non-reload paths.
+
 Do NOT write lots of e2e test cases for one feature. Each e2e test case adds a significant amount of overhead, so instead prefer just one or two E2E test cases that each have broad coverage of the feature in question.
 
 **IMPORTANT: You MUST run `npm run build` before running E2E tests.** E2E tests run against the built application binary, not the source code. If you make any changes to application code (anything outside of `e2e-tests/`), you MUST re-run `npm run build` before running E2E tests, otherwise you'll be testing the old version of the application.

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,9 +5,9 @@ import { DeepLinkProvider } from "../contexts/DeepLinkContext";
 import { Toaster } from "sonner";
 import { TitleBar } from "./TitleBar";
 import { useEffect, useMemo, type ReactNode } from "react";
-import { useRunApp, useAppOutputSubscription } from "@/hooks/useRunApp";
+import { useAppOutputSubscription } from "@/hooks/useRunApp";
 import { useAtomValue, useSetAtom } from "jotai";
-import { previewModeAtom, selectedAppIdAtom } from "@/atoms/appAtoms";
+import { selectedAppIdAtom } from "@/atoms/appAtoms";
 import { useSettings } from "@/hooks/useSettings";
 import { DEFAULT_ZOOM_LEVEL } from "@/lib/schemas";
 import { selectedComponentsPreviewAtom } from "@/atoms/previewAtoms";
@@ -92,7 +92,6 @@ function RootLayoutContent({ children }: { children: ReactNode }) {
   const appRunManager = useAppRunRemoteManager();
   const previewErrors = usePreviewErrorFacade();
   const screenshotManager = useScreenshotManager();
-  const { refreshAppIframe } = useRunApp();
   // Subscribe to app output events once at the root level to avoid duplicates
   useAppOutputSubscription();
   useEffect(
@@ -106,7 +105,6 @@ function RootLayoutContent({ children }: { children: ReactNode }) {
       }),
     [appRunManager, previewErrors],
   );
-  const previewMode = useAtomValue(previewModeAtom);
   const { settings } = useSettings();
   const setSelectedComponentsPreview = useSetAtom(
     selectedComponentsPreviewAtom,
@@ -182,27 +180,6 @@ function RootLayoutContent({ children }: { children: ReactNode }) {
       i18n.changeLanguage(language);
     }
   }, [settings?.language]);
-
-  // Global keyboard listener for refresh events
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      // Check for Ctrl+R (Windows/Linux) or Cmd+R (macOS)
-      if (event.key === "r" && (event.ctrlKey || event.metaKey)) {
-        event.preventDefault(); // Prevent default browser refresh
-        if (previewMode === "preview") {
-          refreshAppIframe(); // Use our custom refresh function instead
-        }
-      }
-    };
-
-    // Add event listener to document
-    document.addEventListener("keydown", handleKeyDown);
-
-    // Cleanup function to remove event listener
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [refreshAppIframe, previewMode]);
 
   useEffect(() => {
     setSelectedComponentsPreview([]);

--- a/src/components/preview_panel/PreviewIframe.tsx
+++ b/src/components/preview_panel/PreviewIframe.tsx
@@ -1,4 +1,5 @@
 import { selectedAppIdAtom } from "@/atoms/appAtoms";
+import { isPreviewOpenAtom } from "@/atoms/viewAtoms";
 import { useCurrentAppUrl } from "@/hooks/useAppRun";
 import { useAtomValue, useSetAtom, useAtom } from "jotai";
 import {
@@ -229,6 +230,7 @@ export const PreviewIframe = ({
 }) => {
   const { t } = useTranslation("home");
   const selectedAppId = useAtomValue(selectedAppIdAtom);
+  const isPreviewOpen = useAtomValue(isPreviewOpenAtom);
   const { appUrl, originalUrl, mode } = useCurrentAppUrl(selectedAppId);
   const appRunManager = useAppRunRemoteManager();
   const selectedChatId = useAtomValue(selectedChatIdAtom);
@@ -342,6 +344,20 @@ export const PreviewIframe = ({
 
   const { addAttachments } = useAttachments();
   const setPendingChanges = useSetAtom(pendingVisualChangesAtom);
+
+  const handleReload = useCallback(() => {
+    sendIframeEvent({ type: "RELOAD_REQUESTED" });
+    setVisualEditingSelectedComponent(null);
+    setPendingChanges(new Map());
+    setCurrentComponentCoordinates(null);
+    console.debug("Reloading iframe preview for app", selectedAppId);
+  }, [
+    selectedAppId,
+    sendIframeEvent,
+    setCurrentComponentCoordinates,
+    setPendingChanges,
+    setVisualEditingSelectedComponent,
+  ]);
   const pendingAnnotatorScreenshotRequestIdRef = useRef<string | null>(null);
   const skipNextAddressBarBlurRef = useRef(false);
 
@@ -774,6 +790,11 @@ export const PreviewIframe = ({
         return;
       }
 
+      if (event.data?.type === "dyad-preview-reload-shortcut") {
+        handleReload();
+        return;
+      }
+
       if (event.data?.type === "dyad-text-updated") {
         handleTextUpdated(event.data);
         return;
@@ -987,6 +1008,7 @@ export const PreviewIframe = ({
       setSelectedComponentsPreview,
       setVisualEditingSelectedComponent,
       queryClient,
+      handleReload,
     ],
   );
   componentMessageHandlerRef.current = handleComponentMessage;
@@ -1022,6 +1044,16 @@ export const PreviewIframe = ({
     }
   };
 
+  // Keep reload scoped to the preview while its panel is active, including
+  // when focus is in the parent renderer rather than inside the iframe.
+  useShortcut(
+    "r",
+    { ctrl: !isMac, meta: isMac },
+    handleReload,
+    isPreviewOpen,
+    iframeRef,
+  );
+
   // Activate component selector using a shortcut
   useShortcut(
     "c",
@@ -1047,16 +1079,6 @@ export const PreviewIframe = ({
       sendIframeEvent({ type: "GO_FORWARD" });
       recorder.recordHistoryMove("forward");
     }
-  };
-
-  // Function to handle reload
-  const handleReload = () => {
-    sendIframeEvent({ type: "RELOAD_REQUESTED" });
-    // Reset visual editing state
-    setVisualEditingSelectedComponent(null);
-    setPendingChanges(new Map());
-    setCurrentComponentCoordinates(null);
-    console.debug("Reloading iframe preview for app", selectedAppId);
   };
 
   // Function to navigate to a specific route

--- a/src/components/preview_panel/PreviewIframe.tsx
+++ b/src/components/preview_panel/PreviewIframe.tsx
@@ -1045,8 +1045,27 @@ export const PreviewIframe = ({
   };
 
   // Keep reload scoped to the preview while its panel is active, including
-  // when focus is in the parent renderer rather than inside the iframe.
-  useShortcut("r", { ctrl: !isMac, meta: isMac }, handleReload, isPreviewOpen);
+  // when focus is in the parent renderer rather than inside the iframe. Match
+  // the native shortcut exactly so AltGr and mixed primary modifiers remain
+  // available to the focused control.
+  useEffect(() => {
+    if (!isPreviewOpen) return;
+    const handleReloadShortcut = (event: KeyboardEvent) => {
+      const hasPrimaryModifier = isMac ? event.metaKey : event.ctrlKey;
+      const hasUnexpectedModifier =
+        event.altKey || (isMac ? event.ctrlKey : event.metaKey);
+      if (event.key.toLowerCase() === "r" && hasPrimaryModifier) {
+        if (hasUnexpectedModifier) {
+          if (!event.getModifierState("AltGraph")) event.preventDefault();
+          return;
+        }
+        event.preventDefault();
+        handleReload();
+      }
+    };
+    window.addEventListener("keydown", handleReloadShortcut);
+    return () => window.removeEventListener("keydown", handleReloadShortcut);
+  }, [handleReload, isMac, isPreviewOpen]);
 
   // Activate component selector using a shortcut
   useShortcut(

--- a/src/components/preview_panel/PreviewIframe.tsx
+++ b/src/components/preview_panel/PreviewIframe.tsx
@@ -1046,13 +1046,7 @@ export const PreviewIframe = ({
 
   // Keep reload scoped to the preview while its panel is active, including
   // when focus is in the parent renderer rather than inside the iframe.
-  useShortcut(
-    "r",
-    { ctrl: !isMac, meta: isMac },
-    handleReload,
-    isPreviewOpen,
-    iframeRef,
-  );
+  useShortcut("r", { ctrl: !isMac, meta: isMac }, handleReload, isPreviewOpen);
 
   // Activate component selector using a shortcut
   useShortcut(

--- a/src/main.ts
+++ b/src/main.ts
@@ -1235,6 +1235,16 @@ const createApplicationMenu = () => {
     {
       label: "View",
       submenu: [
+        {
+          label: "Reload Dyad",
+          click: () => BrowserWindow.getFocusedWindow()?.reload(),
+        },
+        {
+          label: "Force Reload Dyad",
+          click: () =>
+            BrowserWindow.getFocusedWindow()?.webContents.reloadIgnoringCache(),
+        },
+        { type: "separator" as const },
         ...(process.env.NODE_ENV === "development"
           ? [
               { role: "toggleDevTools" as const },

--- a/src/main.ts
+++ b/src/main.ts
@@ -1235,12 +1235,12 @@ const createApplicationMenu = () => {
     {
       label: "View",
       submenu: [
-        { role: "reload" as const },
-        { role: "forceReload" as const },
         ...(process.env.NODE_ENV === "development"
-          ? [{ role: "toggleDevTools" as const }]
+          ? [
+              { role: "toggleDevTools" as const },
+              { type: "separator" as const },
+            ]
           : []),
-        { type: "separator" as const },
         { role: "togglefullscreen" as const },
       ],
     },

--- a/src/preview_iframe/commands.test.ts
+++ b/src/preview_iframe/commands.test.ts
@@ -52,6 +52,7 @@ describe("preview iframe command adapter", () => {
     expect(onComponentMessage).toHaveBeenCalledWith(selectorMessage);
     expect(PREVIEW_IFRAME_MESSAGE_ROUTES).toEqual({
       "dyad-component-selector-initialized": "shared-and-component",
+      "dyad-preview-reload-shortcut": "machine",
       "dyad-screenshot-response": "shared-and-component",
       pushState: "machine",
       replaceState: "machine",
@@ -188,6 +189,29 @@ describe("preview iframe command adapter", () => {
     });
 
     expect(send).not.toHaveBeenCalled();
+  });
+
+  it("routes a trusted iframe reload shortcut into the preview machine", () => {
+    const contentWindow = { postMessage: vi.fn() };
+    const send = vi.fn<(event: PreviewIframeEvent) => void>();
+    const onSharedMachineEvent = vi.fn();
+    const onComponentMessage = vi.fn();
+
+    routePreviewIframeMessage({
+      event: {
+        source: contentWindow,
+        data: { type: "dyad-preview-reload-shortcut" },
+      } as unknown as MessageEvent,
+      contentWindow,
+      appUrl: "http://localhost:3000",
+      send,
+      onSharedMachineEvent,
+      onComponentMessage,
+    });
+
+    expect(send).toHaveBeenCalledWith({ type: "RELOAD_REQUESTED" });
+    expect(onSharedMachineEvent).not.toHaveBeenCalled();
+    expect(onComponentMessage).not.toHaveBeenCalled();
   });
 
   it("rejects iframe navigation outside the trusted app origin", () => {

--- a/src/preview_iframe/commands.test.ts
+++ b/src/preview_iframe/commands.test.ts
@@ -52,7 +52,7 @@ describe("preview iframe command adapter", () => {
     expect(onComponentMessage).toHaveBeenCalledWith(selectorMessage);
     expect(PREVIEW_IFRAME_MESSAGE_ROUTES).toEqual({
       "dyad-component-selector-initialized": "shared-and-component",
-      "dyad-preview-reload-shortcut": "machine",
+      "dyad-preview-reload-shortcut": "component",
       "dyad-screenshot-response": "shared-and-component",
       pushState: "machine",
       replaceState: "machine",
@@ -191,17 +191,18 @@ describe("preview iframe command adapter", () => {
     expect(send).not.toHaveBeenCalled();
   });
 
-  it("routes a trusted iframe reload shortcut into the preview machine", () => {
+  it("routes a trusted iframe reload shortcut to the component binding", () => {
     const contentWindow = { postMessage: vi.fn() };
     const send = vi.fn<(event: PreviewIframeEvent) => void>();
     const onSharedMachineEvent = vi.fn();
     const onComponentMessage = vi.fn();
 
+    const message = {
+      source: contentWindow,
+      data: { type: "dyad-preview-reload-shortcut" },
+    } as unknown as MessageEvent;
     routePreviewIframeMessage({
-      event: {
-        source: contentWindow,
-        data: { type: "dyad-preview-reload-shortcut" },
-      } as unknown as MessageEvent,
+      event: message,
       contentWindow,
       appUrl: "http://localhost:3000",
       send,
@@ -209,9 +210,9 @@ describe("preview iframe command adapter", () => {
       onComponentMessage,
     });
 
-    expect(send).toHaveBeenCalledWith({ type: "RELOAD_REQUESTED" });
+    expect(send).not.toHaveBeenCalled();
     expect(onSharedMachineEvent).not.toHaveBeenCalled();
-    expect(onComponentMessage).not.toHaveBeenCalled();
+    expect(onComponentMessage).toHaveBeenCalledWith(message);
   });
 
   it("rejects iframe navigation outside the trusted app origin", () => {

--- a/src/preview_iframe/commands.ts
+++ b/src/preview_iframe/commands.ts
@@ -72,6 +72,7 @@ export function createPreviewIframeCommandAdapter(
 
 export type PreviewIframeMachineMessageType =
   | "dyad-component-selector-initialized"
+  | "dyad-preview-reload-shortcut"
   | "dyad-screenshot-response"
   | "pushState"
   | "replaceState"
@@ -84,6 +85,7 @@ export const PREVIEW_IFRAME_MESSAGE_ROUTES: Readonly<
   >
 > = {
   "dyad-component-selector-initialized": "shared-and-component",
+  "dyad-preview-reload-shortcut": "machine",
   // The screenshot machine and annotator share this response. Correlation by
   // requestId lets each owner ignore messages belonging to the other.
   "dyad-screenshot-response": "shared-and-component",
@@ -141,6 +143,8 @@ export function routePreviewIframeMessage(input: {
   if (type === "dyad-component-selector-initialized") {
     send({ type: "SELECTOR_READY" });
     onSharedMachineEvent({ type: "SELECTOR_READY" });
+  } else if (type === "dyad-preview-reload-shortcut") {
+    send({ type: "RELOAD_REQUESTED" });
   } else if (type === "dyad-screenshot-response") {
     const requestId = event.data?.requestId;
     if (typeof requestId === "string") {

--- a/src/preview_iframe/commands.ts
+++ b/src/preview_iframe/commands.ts
@@ -85,7 +85,9 @@ export const PREVIEW_IFRAME_MESSAGE_ROUTES: Readonly<
   >
 > = {
   "dyad-component-selector-initialized": "shared-and-component",
-  "dyad-preview-reload-shortcut": "machine",
+  // The component binding owns the visual-editing cleanup that must accompany
+  // every user-requested reload.
+  "dyad-preview-reload-shortcut": "component",
   // The screenshot machine and annotator share this response. Correlation by
   // requestId lets each owner ignore messages belonging to the other.
   "dyad-screenshot-response": "shared-and-component",
@@ -143,8 +145,6 @@ export function routePreviewIframeMessage(input: {
   if (type === "dyad-component-selector-initialized") {
     send({ type: "SELECTOR_READY" });
     onSharedMachineEvent({ type: "SELECTOR_READY" });
-  } else if (type === "dyad-preview-reload-shortcut") {
-    send({ type: "RELOAD_REQUESTED" });
   } else if (type === "dyad-screenshot-response") {
     const requestId = event.data?.requestId;
     if (typeof requestId === "string") {

--- a/worker/dyad-component-selector-client.js
+++ b/worker/dyad-component-selector-client.js
@@ -532,7 +532,13 @@
     // Keep reload shortcuts scoped to the preview even while it owns focus.
     const hasUnexpectedReloadModifier =
       e.altKey || (isMac ? e.ctrlKey : e.metaKey);
-    if (key === "r" && hasCtrlOrMeta && !hasUnexpectedReloadModifier) {
+    if (key === "r" && hasCtrlOrMeta) {
+      if (hasUnexpectedReloadModifier) {
+        // Chromium still treats mixed primary-modifier chords as reloads. Let
+        // real AltGr input through, but suppress those other browser defaults.
+        if (!e.getModifierState("AltGraph")) e.preventDefault();
+        return;
+      }
       e.preventDefault();
       window.parent.postMessage(
         {

--- a/worker/dyad-component-selector-client.js
+++ b/worker/dyad-component-selector-client.js
@@ -532,7 +532,6 @@
     // Keep reload shortcuts scoped to the preview even while it owns focus.
     if (key === "r" && hasCtrlOrMeta) {
       e.preventDefault();
-      e.stopPropagation();
       window.parent.postMessage(
         {
           type: "dyad-preview-reload-shortcut",

--- a/worker/dyad-component-selector-client.js
+++ b/worker/dyad-component-selector-client.js
@@ -530,7 +530,9 @@
 
     // Electron's native reload accelerators target the whole Dyad renderer.
     // Keep reload shortcuts scoped to the preview even while it owns focus.
-    if (key === "r" && hasCtrlOrMeta) {
+    const hasUnexpectedReloadModifier =
+      e.altKey || (isMac ? e.ctrlKey : e.metaKey);
+    if (key === "r" && hasCtrlOrMeta && !hasUnexpectedReloadModifier) {
       e.preventDefault();
       window.parent.postMessage(
         {
@@ -590,6 +592,16 @@
 
   /* ---------- message bridge -------------------------------------------- */
   window.addEventListener("message", (e) => {
+    // The shim can also run inside iframes nested in the app preview. Bubble a
+    // child's shortcut request one frame at a time until the top preview frame
+    // can deliver it to Dyad with the source identity the parent expects.
+    if (
+      e.source !== window.parent &&
+      e.data?.type === "dyad-preview-reload-shortcut"
+    ) {
+      window.parent.postMessage(e.data, "*");
+      return;
+    }
     if (e.source !== window.parent) return;
     if (e.data.type === "dyad-pro-mode") {
       isProMode = e.data.enabled;

--- a/worker/dyad-component-selector-client.js
+++ b/worker/dyad-component-selector-client.js
@@ -525,6 +525,23 @@
   }
 
   function onKeyDown(e) {
+    const key = e.key.toLowerCase();
+    const hasCtrlOrMeta = isMac ? e.metaKey : e.ctrlKey;
+
+    // Electron's native reload accelerators target the whole Dyad renderer.
+    // Keep reload shortcuts scoped to the preview even while it owns focus.
+    if (key === "r" && hasCtrlOrMeta) {
+      e.preventDefault();
+      e.stopPropagation();
+      window.parent.postMessage(
+        {
+          type: "dyad-preview-reload-shortcut",
+        },
+        "*",
+      );
+      return;
+    }
+
     // Ignore keystrokes if the user is typing in an input field, textarea, or editable element
     if (
       e.target.tagName === "INPUT" ||
@@ -535,9 +552,7 @@
     }
 
     // Forward shortcuts to parent window
-    const key = e.key.toLowerCase();
     const hasShift = e.shiftKey;
-    const hasCtrlOrMeta = isMac ? e.metaKey : e.ctrlKey;
     if (key === "c" && hasShift && hasCtrlOrMeta) {
       e.preventDefault();
       window.parent.postMessage(

--- a/worker/dyad-component-selector-client.js
+++ b/worker/dyad-component-selector-client.js
@@ -597,6 +597,7 @@
     // can deliver it to Dyad with the source identity the parent expects.
     if (
       e.source !== window.parent &&
+      e.origin === window.location.origin &&
       e.data?.type === "dyad-preview-reload-shortcut"
     ) {
       window.parent.postMessage(e.data, "*");


### PR DESCRIPTION
## Summary

Prevents reload shortcuts from reloading the entire Dyad renderer while keeping preview reload behavior consistent across iframe and renderer focus.

- Routes every shortcut reload through the toolbar's cleanup path so selected components, pending visual edits, and coordinates cannot survive an iframe remount.
- Handles Command/Ctrl+R and Command/Ctrl+Shift+R from the parent renderer, the preview frame, and proxy-injected nested frames, while leaving AltGr and other unrelated modifier combinations alone.
- Preserves app-level key handlers after preventing Chromium's native reload, and keeps explicit accelerator-free Reload Dyad / Force Reload Dyad menu actions for renderer recovery.
- Covers focus boundaries, nested frames, app key handlers, visual-editing cleanup, menu configuration, positive post-reload readiness, and renderer survival in the packaged Electron E2E.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Preview UX and menu changes only; reload still goes through the existing preview machine with tests. No auth, data, or security surface changes.
> 
> **Overview**
> **Reload shortcuts no longer tear down the whole Dyad window** when keyboard focus is in the embedded app preview.
> 
> The preview iframe script now intercepts **Cmd/Ctrl+R** and **Cmd/Ctrl+Shift+R** (including while an input inside the preview is focused), prevents the default Electron behavior, and posts `dyad-preview-reload-shortcut` to the parent. The preview iframe message router maps that to the existing **`RELOAD_REQUESTED`** preview state-machine event so both shortcuts trigger a normal preview reload—not a separate hard-reload path.
> 
> **Electron’s View menu** no longer exposes **Reload** / **Force Reload**, since those accelerators reload the entire renderer and bypass preview ownership.
> 
> Coverage adds a unit test for the new message route and an e2e test that confirms the menu has no reload roles, the iframe reloads on both shortcuts, and the outer renderer stays alive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a58199c7789ba20953713d4889ad72bf484c1597. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

