### PR TITLE
Fix recorded-test assertion model configuration

### DIFF
--- a/rules/electron-ipc.md
+++ b/rules/electron-ipc.md
@@ -68,7 +68,9 @@ ipc.chatStream.start(params, { onChunk, onEnd, onError });
 - Pass an authoritative per-turn model selection through an explicit
   `ModelSelection` parameter. Do not hide it inside a `UserSettings` override or
   detect it by duck-typing `settings.selectedModel`; that reverses chat/model
-  precedence and creates an undeclared type contract.
+  precedence and creates an undeclared type contract. When changing
+  `GetProviderOptionsParams`, audit every `getProviderOptions` caller, including
+  assertion synthesis, compaction, and local-agent subagents.
 - Keep durable first-turn acceptance atomic with latching an implicit chat
   mode. The idempotent user-message insert and conditional mode update belong
   in one synchronous SQLite transaction, duplicate replay must repair legacy

--- a/src/ipc/handlers/test_assertion_handlers.test.ts
+++ b/src/ipc/handlers/test_assertion_handlers.test.ts
@@ -47,6 +47,12 @@ vi.mock("../utils/get_model_client", () => ({
   }),
 }));
 
+vi.mock("../utils/model_effort", () => ({
+  resolveDefaultModelSelection: async (settings: {
+    selectedModel: { provider: string; name: string };
+  }) => ({ ...settings.selectedModel, effortLevel: "medium" }),
+}));
+
 vi.mock("../utils/provider_options", () => ({
   getAiHeaders: () => ({}),
   getProviderOptions: () => ({}),

--- a/src/ipc/handlers/test_assertion_handlers.ts
+++ b/src/ipc/handlers/test_assertion_handlers.ts
@@ -24,6 +24,7 @@ import {
 } from "../utils/git_utils";
 import { extractJson } from "../utils/extract_json";
 import { getModelClient } from "../utils/get_model_client";
+import { resolveDefaultModelSelection } from "../utils/model_effort";
 import { fastTextOutput } from "../utils/stream_text_utils";
 import { getAiHeaders, getProviderOptions } from "../utils/provider_options";
 import {
@@ -678,8 +679,16 @@ async function callStructuredModel<T>({
     // operation, and `getModelClient` can reach the provider registry. Without
     // this the budget only ever covered the streaming half, and a slow client
     // resolution aborted a stream that did not exist yet.
-    const { modelClient } = await Promise.race([
-      getModelClient(settings.selectedModel, settings),
+    const { modelClient, modelSelection } = await Promise.race([
+      (async () => {
+        const modelSelection = await resolveDefaultModelSelection(settings);
+        const { modelClient } = await getModelClient(
+          modelSelection,
+          settings,
+          modelSelection,
+        );
+        return { modelClient, modelSelection };
+      })(),
       timeout,
     ]);
     const dyadRequestId = crypto.randomUUID();
@@ -700,7 +709,8 @@ async function callStructuredModel<T>({
         files: [],
         mentionedAppsCodebases: [],
         builtinProviderId: modelClient.builtinProviderId,
-        settings,
+        reasoningEffortProviderId: modelClient.reasoningEffortProviderId,
+        modelSelection,
       }),
       messages: [{ role: "user", content: payload }],
     });


### PR DESCRIPTION
## Summary

Fix a missed call site from the model-effort changes in #4255.

Recorded-test assertion generation was still passing `settings` to `getProviderOptions`, causing the TypeScript build to fail. This updates the handler to pass the resolved model selection and provider reasoning configuration expected by the new API.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

