### PR TITLE
Route Value model through OpenAI Responses API

### DIFF
--- a/rules/openai-reasoning-models.md
+++ b/rules/openai-reasoning-models.md
@@ -13,3 +13,7 @@ OpenAI's Responses API requires reasoning items to always be followed by an outp
 - Only reasoning was generated in a turn
 
 The fix in `src/ipc/utils/ai_messages_utils.ts` filters orphaned reasoning parts within `cleanMessage()` before sending conversation history back to OpenAI.
+
+## Dyad Engine model aliases
+
+When a Dyad Engine alias is backed by an OpenAI reasoning model, create it with `provider.responses(...)` and pass `providerId: "openai"`. Passing the alias provider (for example, `"auto"`) prevents `getExtraProviderOptionsForEngine()` from adding reasoning effort, summaries, encrypted reasoning content, and `store: false`.

--- a/src/ipc/shared/language_model_constants.ts
+++ b/src/ipc/shared/language_model_constants.ts
@@ -378,7 +378,7 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
       description: "Uses the most cost-effective models available",
       maxOutputTokens: 32_000,
       contextWindow: 256_000,
-      temperature: 0,
+      temperature: 1,
       tag: "Budget",
       tagColor: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300",
     },

--- a/src/ipc/utils/get_model_client.test.ts
+++ b/src/ipc/utils/get_model_client.test.ts
@@ -208,6 +208,80 @@ describe("getModelClient", () => {
     expect(modelClient.builtinProviderId).toBe("auto");
   });
 
+  test("routes the Value model through the Responses API in local agent mode", async () => {
+    let capturedUrl: string | undefined;
+    let capturedBody: Record<string, unknown> | undefined;
+    setModelClientFetchForTesting(
+      vi.fn(async (url, init) => {
+        capturedUrl = url.toString();
+        capturedBody = JSON.parse(init?.body as string);
+        return new Response(
+          JSON.stringify({
+            id: "resp-test",
+            created_at: 1_700_000_000,
+            model: "dyad/value",
+            output: [
+              {
+                type: "message",
+                role: "assistant",
+                id: "msg-test",
+                content: [
+                  {
+                    type: "output_text",
+                    text: "ok",
+                    annotations: [],
+                  },
+                ],
+              },
+            ],
+            usage: {
+              input_tokens: 1,
+              output_tokens: 1,
+            },
+          }),
+          { headers: { "Content-Type": "application/json" } },
+        );
+      }),
+    );
+
+    const { modelClient } = await getModelClient(
+      {
+        provider: "auto",
+        name: "value",
+      },
+      {
+        enableDyadPro: true,
+        selectedChatMode: "local-agent",
+        providerSettings: {
+          auto: {
+            apiKey: {
+              value: "dyad-pro-key",
+            },
+          },
+        },
+      } as unknown as UserSettings,
+    );
+
+    await generateText({
+      model: modelClient.model,
+      prompt: "hi",
+      maxRetries: 0,
+    });
+
+    expect(capturedUrl).toMatch(/\/v1\/responses$/);
+    expect(capturedBody).toMatchObject({
+      reasoning: {
+        summary: "detailed",
+        effort: "medium",
+      },
+      include: ["reasoning.encrypted_content"],
+      store: false,
+    });
+    expect((modelClient.model as { modelId: string }).modelId).toBe(
+      "dyad/value",
+    );
+  });
+
   test("sends OpenRouter app attribution headers", async () => {
     let capturedHeaders: Headers | undefined;
     setModelClientFetchForTesting(

--- a/src/ipc/utils/get_model_client.ts
+++ b/src/ipc/utils/get_model_client.ts
@@ -370,7 +370,7 @@ async function getProModelClient({
   ) {
     return {
       model: provider.responses(modelId, {
-        providerId: model.provider === "auto" ? "openai" : model.provider,
+        providerId: "openai",
       }),
       builtinProviderId: model.provider,
     };

--- a/src/ipc/utils/get_model_client.ts
+++ b/src/ipc/utils/get_model_client.ts
@@ -365,10 +365,13 @@ async function getProModelClient({
   }
   if (
     settings.selectedChatMode === "local-agent" &&
-    model.provider === "openai"
+    (model.provider === "openai" ||
+      (model.provider === "auto" && model.name === "value"))
   ) {
     return {
-      model: provider.responses(modelId, { providerId: model.provider }),
+      model: provider.responses(modelId, {
+        providerId: model.provider === "auto" ? "openai" : model.provider,
+      }),
       builtinProviderId: model.provider,
     };
   }


### PR DESCRIPTION
## Summary

Routes the Dyad Pro Super Value model through OpenAI's Responses API in local-agent mode and configures its temperature for the underlying GPT model. This gives the OpenAI-backed alias the same transport and request defaults as directly selected GPT models.

- Limits the behavior change to `auto/value` in local-agent mode; other Auto aliases and non-agent chat flows retain their current routing.
- Keeps the gateway model ID as `dyad/value` and the public model identity as `auto`, while identifying the underlying provider as OpenAI so reasoning effort, detailed summaries, encrypted reasoning content, and `store: false` are injected.
- Changes Super Value's configured temperature from `0` to the GPT-compatible default of `1`.
- Adds a request-level regression test that verifies both the `/v1/responses` endpoint and the OpenAI reasoning options.
- Documents the provider-ID requirement for future OpenAI-backed Dyad Engine aliases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes model routing and provider options for a Dyad Pro alias in local-agent mode; scope is narrow but affects live LLM request behavior.
>
> **Overview**
> In **local-agent** mode with Dyad Pro, **`auto/value`** now uses the Dyad Engine **`provider.responses()`** path (same as direct OpenAI models), so requests hit **`/v1/responses`** with OpenAI reasoning options (effort, detailed summaries, encrypted reasoning content, **`store: false`**).
>
> The important behavioral fix is passing **`providerId: "openai"`** when creating the responses model instead of **`"auto"`**, so **`getExtraProviderOptionsForEngine()`** treats the call as OpenAI-backed. Public model identity stays **`auto`** via **`builtinProviderId`**.
>
> Adds a regression test for the Value model request shape and documents the **`providerId`** requirement for future OpenAI-backed Dyad Engine aliases.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 114d6f187c41cb59f1a02c5f3c4ba7ffa7f9ae1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
