### PR TITLE
Fix queue revision error when stopping chat

### DIFF
--- a/drizzle/0047_vengeful_tyger_tiger.sql
+++ b/drizzle/0047_vengeful_tyger_tiger.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `chat_queue_states` ADD `pause_reason` text;

--- a/drizzle/meta/0047_snapshot.json
+++ b/drizzle/meta/0047_snapshot.json
@@ -1,0 +1,2000 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "6c686ab3-dae1-4b56-82f8-0ac8779ba34a",
+  "prevId": "85584c68-34cb-4bfc-9440-852bbcf8d836",
+  "tables": {
+    "agent_activities": {
+      "name": "agent_activities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "presentation_xml": {
+          "name": "presentation_xml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_json": {
+          "name": "input_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_text": {
+          "name": "output_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_activities_thread_tool_call_unique": {
+          "name": "agent_activities_thread_tool_call_unique",
+          "columns": [
+            "thread_id",
+            "tool_call_id"
+          ],
+          "isUnique": true
+        },
+        "agent_activities_thread_sequence_unique": {
+          "name": "agent_activities_thread_sequence_unique",
+          "columns": [
+            "thread_id",
+            "sequence"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_activities_thread_id_agent_threads_id_fk": {
+          "name": "agent_activities_thread_id_agent_threads_id_fk",
+          "tableFrom": "agent_activities",
+          "tableTo": "agent_threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_messages": {
+      "name": "agent_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed": {
+          "name": "consumed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "agent_messages_thread_sequence_unique": {
+          "name": "agent_messages_thread_sequence_unique",
+          "columns": [
+            "thread_id",
+            "sequence"
+          ],
+          "isUnique": true
+        },
+        "agent_messages_thread_message_unique": {
+          "name": "agent_messages_thread_message_unique",
+          "columns": [
+            "thread_id",
+            "message_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_messages_thread_id_agent_threads_id_fk": {
+          "name": "agent_messages_thread_id_agent_threads_id_fk",
+          "tableFrom": "agent_messages",
+          "tableTo": "agent_threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_threads": {
+      "name": "agent_threads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "persona": {
+          "name": "persona",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_name": {
+          "name": "task_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assignment": {
+          "name": "assignment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reasoning_effort": {
+          "name": "reasoning_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_json": {
+          "name": "context_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "result_json": {
+          "name": "result_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_base_commit": {
+          "name": "review_base_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_target_commit": {
+          "name": "review_target_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_diff_hash": {
+          "name": "review_diff_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "invocation_source": {
+          "name": "invocation_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remediation_source": {
+          "name": "remediation_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_fix_at": {
+          "name": "auto_fix_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tool_call_count": {
+          "name": "tool_call_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "agent_threads_chat_id_idx": {
+          "name": "agent_threads_chat_id_idx",
+          "columns": [
+            "chat_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_threads_chat_id_chats_id_fk": {
+          "name": "agent_threads_chat_id_chats_id_fk",
+          "tableFrom": "agent_threads",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_collections": {
+      "name": "app_collections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "app_collections_name_unique": {
+          "name": "app_collections_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apps": {
+      "name": "apps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "github_org": {
+          "name": "github_org",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_repo": {
+          "name": "github_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_branch": {
+          "name": "github_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supabase_project_id": {
+          "name": "supabase_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supabase_parent_project_id": {
+          "name": "supabase_parent_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supabase_organization_slug": {
+          "name": "supabase_organization_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supabase_test_user_id": {
+          "name": "supabase_test_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_project_id": {
+          "name": "neon_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_development_branch_id": {
+          "name": "neon_development_branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_preview_branch_id": {
+          "name": "neon_preview_branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_active_branch_id": {
+          "name": "neon_active_branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_test_branch_id": {
+          "name": "neon_test_branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_production_auth_cookie_secret": {
+          "name": "neon_production_auth_cookie_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_development_auth_cookie_secret": {
+          "name": "neon_development_auth_cookie_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selected_database_branch_type": {
+          "name": "selected_database_branch_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vercel_project_id": {
+          "name": "vercel_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vercel_project_name": {
+          "name": "vercel_project_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vercel_team_id": {
+          "name": "vercel_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vercel_deployment_url": {
+          "name": "vercel_deployment_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "install_command": {
+          "name": "install_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_command": {
+          "name": "start_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chat_context": {
+          "name": "chat_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "theme_id": {
+          "name": "theme_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "needs_app_blueprint": {
+          "name": "needs_app_blueprint",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "testing_enabled": {
+          "name": "testing_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apps_collection_id_app_collections_id_fk": {
+          "name": "apps_collection_id_app_collections_id_fk",
+          "tableFrom": "apps",
+          "tableTo": "app_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_queue_entries": {
+      "name": "chat_queue_entries",
+      "columns": {
+        "intent_id": {
+          "name": "intent_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_queue_entries_intent_id_chat_turn_intents_intent_id_fk": {
+          "name": "chat_queue_entries_intent_id_chat_turn_intents_intent_id_fk",
+          "tableFrom": "chat_queue_entries",
+          "tableTo": "chat_turn_intents",
+          "columnsFrom": [
+            "intent_id"
+          ],
+          "columnsTo": [
+            "intent_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_queue_states": {
+      "name": "chat_queue_states",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "paused": {
+          "name": "paused",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "pause_reason": {
+          "name": "pause_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_queue_states_chat_id_chats_id_fk": {
+          "name": "chat_queue_states_chat_id_chats_id_fk",
+          "tableFrom": "chat_queue_states",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_search_dirty_chats": {
+      "name": "chat_search_dirty_chats",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_search_dirty_messages": {
+      "name": "chat_search_dirty_messages",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_search_meta": {
+      "name": "chat_search_meta",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_turn_intents": {
+      "name": "chat_turn_intents",
+      "columns": {
+        "intent_id": {
+          "name": "intent_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "intent": {
+          "name": "intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "acceptance": {
+          "name": "acceptance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "recovery": {
+          "name": "recovery",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'not-started'"
+        },
+        "accepted_message_id": {
+          "name": "accepted_message_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "chat_turn_intents_chat_idx": {
+          "name": "chat_turn_intents_chat_idx",
+          "columns": [
+            "chat_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "chat_turn_intents_chat_id_chats_id_fk": {
+          "name": "chat_turn_intents_chat_id_chats_id_fk",
+          "tableFrom": "chat_turn_intents",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chats": {
+      "name": "chats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "initial_commit_hash": {
+          "name": "initial_commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "compacted_at": {
+          "name": "compacted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "compaction_backup_path": {
+          "name": "compaction_backup_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pending_compaction": {
+          "name": "pending_compaction",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chat_mode": {
+          "name": "chat_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_selection": {
+          "name": "model_selection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "referenced_app_ids": {
+          "name": "referenced_app_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chats_app_id_apps_id_fk": {
+          "name": "chats_app_id_apps_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_themes": {
+      "name": "custom_themes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "language_model_providers": {
+      "name": "language_model_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_base_url": {
+          "name": "api_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "env_var_name": {
+          "name": "env_var_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "language_models": {
+      "name": "language_models",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_name": {
+          "name": "api_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "builtin_provider_id": {
+          "name": "builtin_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "custom_provider_id": {
+          "name": "custom_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_output_tokens": {
+          "name": "max_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "language_models_custom_provider_id_language_model_providers_id_fk": {
+          "name": "language_models_custom_provider_id_language_model_providers_id_fk",
+          "tableFrom": "language_models",
+          "tableTo": "language_model_providers",
+          "columnsFrom": [
+            "custom_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "env_json": {
+          "name": "env_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "headers_json": {
+          "name": "headers_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "env_encrypted": {
+          "name": "env_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "headers_encrypted": {
+          "name": "headers_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "oauth_enabled": {
+          "name": "oauth_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "oauth_state": {
+          "name": "oauth_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client_secret": {
+          "name": "oauth_client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_scope": {
+          "name": "oauth_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_callback_port": {
+          "name": "oauth_callback_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "catalog_slug": {
+          "name": "catalog_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "uniq_mcp_catalog_slug": {
+          "name": "uniq_mcp_catalog_slug",
+          "columns": [
+            "catalog_slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_tool_consents": {
+      "name": "mcp_tool_consents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consent": {
+          "name": "consent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ask'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "uniq_mcp_consent": {
+          "name": "uniq_mcp_consent",
+          "columns": [
+            "server_id",
+            "tool_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "mcp_tool_consents_server_id_mcp_servers_id_fk": {
+          "name": "mcp_tool_consents_server_id_mcp_servers_id_fk",
+          "tableFrom": "mcp_tool_consents",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "approval_state": {
+          "name": "approval_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_commit_hash": {
+          "name": "source_commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "commit_hash": {
+          "name": "commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_input_request_id": {
+          "name": "user_input_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chat_turn_intent_id": {
+          "name": "chat_turn_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_tokens_used": {
+          "name": "max_tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ai_messages_json": {
+          "name": "ai_messages_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "using_free_agent_mode_quota": {
+          "name": "using_free_agent_mode_quota",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_compaction_summary": {
+          "name": "is_compaction_summary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "messages_chat_user_input_request_unique": {
+          "name": "messages_chat_user_input_request_unique",
+          "columns": [
+            "chat_id",
+            "user_input_request_id"
+          ],
+          "isUnique": true
+        },
+        "messages_chat_turn_intent_unique": {
+          "name": "messages_chat_turn_intent_unique",
+          "columns": [
+            "chat_id",
+            "chat_turn_intent_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "messages_chat_id_chats_id_fk": {
+          "name": "messages_chat_id_chats_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompts": {
+      "name": "prompts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "prompts_slug_unique": {
+          "name": "prompts_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "security_fix_chats": {
+      "name": "security_fix_chats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "review_chat_id": {
+          "name": "review_chat_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finding_key": {
+          "name": "finding_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fix_chat_id": {
+          "name": "fix_chat_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "security_fix_chats_review_chat_id_idx": {
+          "name": "security_fix_chats_review_chat_id_idx",
+          "columns": [
+            "review_chat_id"
+          ],
+          "isUnique": false
+        },
+        "security_fix_chats_fix_chat_id_idx": {
+          "name": "security_fix_chats_fix_chat_id_idx",
+          "columns": [
+            "fix_chat_id"
+          ],
+          "isUnique": false
+        },
+        "security_fix_chats_unique": {
+          "name": "security_fix_chats_unique",
+          "columns": [
+            "app_id",
+            "review_chat_id",
+            "finding_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "security_fix_chats_app_id_apps_id_fk": {
+          "name": "security_fix_chats_app_id_apps_id_fk",
+          "tableFrom": "security_fix_chats",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "security_fix_chats_review_chat_id_chats_id_fk": {
+          "name": "security_fix_chats_review_chat_id_chats_id_fk",
+          "tableFrom": "security_fix_chats",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "review_chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "security_fix_chats_fix_chat_id_chats_id_fk": {
+          "name": "security_fix_chats_fix_chat_id_chats_id_fk",
+          "tableFrom": "security_fix_chats",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "fix_chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "versions": {
+      "name": "versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "commit_hash": {
+          "name": "commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "neon_db_timestamp": {
+          "name": "neon_db_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "versions_app_commit_unique": {
+          "name": "versions_app_commit_unique",
+          "columns": [
+            "app_id",
+            "commit_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "versions_app_id_apps_id_fk": {
+          "name": "versions_app_id_apps_id_fk",
+          "tableFrom": "versions",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -330,6 +330,13 @@
       "when": 1786682405029,
       "tag": "0046_amusing_malice",
       "breakpoints": true
+    },
+    {
+      "idx": 47,
+      "version": "6",
+      "when": 1786692204598,
+      "tag": "0047_vengeful_tyger_tiger",
+      "breakpoints": true
     }
   ]
 }

--- a/e2e-tests/queued_message.spec.ts
+++ b/e2e-tests/queued_message.spec.ts
@@ -172,7 +172,7 @@ test.describe("queued messages", () => {
     });
     await expect(chatInput).toBeVisible();
 
-    await queueMessage(po.page, chatInput, "queued before stop");
+    await queueMessage(po.page, chatInput, "tc=2 [sleep=medium]");
     const queueHeader = po.page.getByTestId("queue-header");
     await expect(queueHeader).toContainText("1 Queued");
     await expect(queueHeader).not.toContainText("Paused");
@@ -188,7 +188,23 @@ test.describe("queued messages", () => {
     ).not.toBeVisible({ timeout: Timeout.MEDIUM });
     await expect(queueHeader).toContainText("1 Queued");
     await expect(
-      queueHeader.getByText("queued before stop", { exact: true }),
+      queueHeader.getByText("tc=2 [sleep=medium]", { exact: true }),
+    ).toBeVisible();
+    await po.toastNotifications.expectNoToast();
+
+    await chatInput.fill("tc=3");
+    await chatInput.press("Enter");
+
+    await expect(
+      po.page.getByRole("button", { name: /cancel generation/i }),
+    ).toBeVisible({ timeout: Timeout.MEDIUM });
+    await expect(queueHeader).not.toContainText("Paused");
+    await expect(queueHeader).toContainText("1 Queued");
+    await expect(queueHeader.getByText("tc=3", { exact: true })).toBeVisible();
+    await expect(
+      po.page
+        .locator('[data-testid="messages-list"]')
+        .getByText("tc=2 [sleep=medium]", { exact: true }),
     ).toBeVisible();
     await po.toastNotifications.expectNoToast();
   });

--- a/e2e-tests/queued_message.spec.ts
+++ b/e2e-tests/queued_message.spec.ts
@@ -205,7 +205,7 @@ test.describe("queued messages", () => {
       po.page
         .locator('[data-testid="messages-list"]')
         .getByText("tc=2 [sleep=medium]", { exact: true }),
-    ).toBeVisible();
+    ).toBeVisible({ timeout: Timeout.MEDIUM });
     await po.toastNotifications.expectNoToast();
   });
 

--- a/e2e-tests/queued_message.spec.ts
+++ b/e2e-tests/queued_message.spec.ts
@@ -164,6 +164,32 @@ test.describe("queued messages", () => {
     await expect(messagesList.getByText("tc=second")).not.toBeVisible();
   });
 
+  test("stops and parks an unpaused queue without an error toast", async ({
+    po,
+  }) => {
+    await po.sendPrompt("tc=1 [sleep=long]", {
+      skipWaitForCompletion: true,
+    });
+    await expect(chatInput).toBeVisible();
+
+    await queueMessage(po.page, chatInput, "queued before stop");
+    const queueHeader = po.page.getByTestId("queue-header");
+    await expect(queueHeader).toContainText("1 Queued");
+    await expect(queueHeader).not.toContainText("Paused");
+    await po.toastNotifications.dismissAllToasts();
+
+    await po.page.getByRole("button", { name: /cancel generation/i }).click();
+
+    await expect(queueHeader).toContainText("Paused", {
+      timeout: Timeout.MEDIUM,
+    });
+    await expect(queueHeader).toContainText("1 Queued");
+    await expect(
+      po.page.getByRole("button", { name: /cancel generation/i }),
+    ).not.toBeVisible({ timeout: Timeout.MEDIUM });
+    await po.toastNotifications.expectNoToast();
+  });
+
   test("fires queued message while on another page", async ({ po }) => {
     // Send a message with a medium sleep to simulate a slow response
     await po.sendPrompt("tc=1 [sleep=medium]", {

--- a/e2e-tests/queued_message.spec.ts
+++ b/e2e-tests/queued_message.spec.ts
@@ -183,10 +183,13 @@ test.describe("queued messages", () => {
     await expect(queueHeader).toContainText("Paused", {
       timeout: Timeout.MEDIUM,
     });
-    await expect(queueHeader).toContainText("1 Queued");
     await expect(
       po.page.getByRole("button", { name: /cancel generation/i }),
     ).not.toBeVisible({ timeout: Timeout.MEDIUM });
+    await expect(queueHeader).toContainText("1 Queued");
+    await expect(
+      queueHeader.getByText("queued before stop", { exact: true }),
+    ).toBeVisible();
     await po.toastNotifications.expectNoToast();
   });
 

--- a/rules/state-machines.md
+++ b/rules/state-machines.md
@@ -123,6 +123,9 @@ Background and before/after examples of why this pattern exists:
   idempotency key through every queue, IPC, and persistence boundary. Make the
   receiving boundary durably deduplicate acceptance, and acknowledge only
   after that acceptance; a renderer-local enqueue is not durable acceptance.
+  Cross-window cancellation cutoffs must likewise be main-owned and versioned;
+  have submissions echo the authoritative version they observed so delayed
+  pre-cancel work cannot masquerade as an explicit post-cancel resume.
   Bounded dedup caches may evict settled history, never unresolved receipts;
   reject excess in-flight work through a separate bounded admission limit.
   Scope renderer retries to the stable window-session identity, not an

--- a/rules/state-machines.md
+++ b/rules/state-machines.md
@@ -548,6 +548,10 @@ timers or nondeterministic UUIDs; retrofitting existing machines is optional.
 - Model hydration explicitly when persisted state gates machine behavior.
   Persist through an adapter-owned, debounced command using a versioned zod
   schema; do not let components write snapshots independently.
+- Persist semantic discriminators that affect post-restart transitions, not
+  only coarse flags derived from them. For legacy rows, choose an explicit
+  conservative fallback (for example, a paused queue without a reason hydrates
+  as manually paused) and test both legacy and fully persisted recovery paths.
 - When a side effect can make recovery state externally observable (for
   example, detaching Git HEAD), force and await persistence of the exact
   committed checkpoint before starting it. Observer error isolation must not

--- a/rules/state-machines.md
+++ b/rules/state-machines.md
@@ -126,7 +126,10 @@ Background and before/after examples of why this pattern exists:
   Cross-window cancellation cutoffs must likewise be main-owned and versioned;
   have every submission source, including main-owned follow-ups and internal
   redispatch, echo the authoritative version it observed so delayed pre-cancel
-  work cannot masquerade as an explicit post-cancel resume. When admission or
+  work cannot masquerade as an explicit post-cancel resume. If a renderer has
+  not bootstrapped its actor snapshot, observe or reserve that version in main
+  when submission begins; never fill it from a later bootstrap snapshot, which
+  may already include an intervening Stop. When admission or
   persistence completes asynchronously, gate follow-up dispatch on the current
   main-owned cutoff as well as the completion payload; a stale unpaused result
   must not override a newer Stop latch.

--- a/rules/state-machines.md
+++ b/rules/state-machines.md
@@ -132,7 +132,10 @@ Background and before/after examples of why this pattern exists:
   may already include an intervening Stop. When admission or
   persistence completes asynchronously, gate follow-up dispatch on the current
   main-owned cutoff as well as the completion payload; a stale unpaused result
-  must not override a newer Stop latch.
+  must not override a newer Stop latch. Establish every in-memory guard used by
+  later transitions in the policy-starting transition itself (for example,
+  set both the Stop reason/version and `queuePaused` before asynchronously
+  persisting the pause); metadata alone does not close the command-yield race.
   Bounded dedup caches may evict settled history, never unresolved receipts;
   reject excess in-flight work through a separate bounded admission limit.
   Scope renderer retries to the stable window-session identity, not an

--- a/rules/state-machines.md
+++ b/rules/state-machines.md
@@ -124,8 +124,12 @@ Background and before/after examples of why this pattern exists:
   receiving boundary durably deduplicate acceptance, and acknowledge only
   after that acceptance; a renderer-local enqueue is not durable acceptance.
   Cross-window cancellation cutoffs must likewise be main-owned and versioned;
-  have submissions echo the authoritative version they observed so delayed
-  pre-cancel work cannot masquerade as an explicit post-cancel resume.
+  have every submission source, including main-owned follow-ups and internal
+  redispatch, echo the authoritative version it observed so delayed pre-cancel
+  work cannot masquerade as an explicit post-cancel resume. When admission or
+  persistence completes asynchronously, gate follow-up dispatch on the current
+  main-owned cutoff as well as the completion payload; a stale unpaused result
+  must not override a newer Stop latch.
   Bounded dedup caches may evict settled history, never unresolved receipts;
   reject excess in-flight work through a separate bounded admission limit.
   Scope renderer retries to the stable window-session identity, not an

--- a/src/chat_stream/__tests__/host_transition.test.ts
+++ b/src/chat_stream/__tests__/host_transition.test.ts
@@ -193,6 +193,28 @@ describe("main-hosted chat stream terminal projection", () => {
       commands: [{ type: "resume-after-review" }],
     });
 
+    const remediation = transitionChatStreamHost(
+      { ...state, stopPolicyVersion: 4 },
+      {
+        type: "REVIEW_BARRIER_RESULT",
+        outcome: "fix_required",
+        threadId: "review-1",
+        prompt: "Fix the verified issue",
+      },
+    );
+    expect(remediation).toMatchObject({
+      kind: "applied",
+      state: { reviewBarrier: { phase: "remediating" } },
+      commands: [
+        {
+          type: "submit-review-remediation",
+          threadId: "review-1",
+          prompt: "Fix the verified issue",
+          observedStopPolicyVersion: 4,
+        },
+      ],
+    });
+
     const verificationFailed = transitionChatStreamHost(
       {
         ...state,

--- a/src/chat_stream/definition.ts
+++ b/src/chat_stream/definition.ts
@@ -707,17 +707,24 @@ export const chatStreamDefinition = {
         }
         event.intent.originWindowSessionId = sender.windowSessionId;
       }
-      if (
-        event.type === "CANCEL" &&
-        event.pauseQueue !== true &&
-        (!currentState?.active ||
-          currentState.active.invocationRef.operationId !==
-            event.invocationRef.operationId)
-      ) {
-        throw new DyadError(
-          "Cancellation does not target the active chat stream",
-          DyadErrorKind.Auth,
-        );
+      if (event.type === "CANCEL") {
+        if (event.invocationRef.entityKey !== key.chatId) {
+          throw new DyadError(
+            "Cancellation does not belong to the routed chat",
+            DyadErrorKind.Auth,
+          );
+        }
+        if (
+          event.pauseQueue !== true &&
+          (!currentState?.active ||
+            currentState.active.invocationRef.operationId !==
+              event.invocationRef.operationId)
+        ) {
+          throw new DyadError(
+            "Cancellation does not target the active chat stream",
+            DyadErrorKind.Auth,
+          );
+        }
       }
     },
   },

--- a/src/chat_stream/definition.ts
+++ b/src/chat_stream/definition.ts
@@ -85,6 +85,7 @@ function projectSnapshot(
     queueRevision: state.queueRevision,
     queuePaused: state.queuePaused,
     queue: [...state.queue],
+    stopPolicyVersion: state.stopPolicyVersion,
     capabilities: {
       canSubmit: true,
       canCancel: canCancelActiveChatStreamPhase(state.phase),
@@ -718,6 +719,16 @@ export const chatStreamDefinition = {
         if (event.intent.owner || event.intent.userInputRequestId) {
           throw new DyadError(
             "Main-owned follow-up identity cannot be submitted by a renderer",
+            DyadErrorKind.Auth,
+          );
+        }
+        if (
+          event.observedStopPolicyVersion !== undefined &&
+          currentState &&
+          event.observedStopPolicyVersion > currentState.stopPolicyVersion
+        ) {
+          throw new DyadError(
+            "Chat submission observed an unknown Stop policy version",
             DyadErrorKind.Auth,
           );
         }

--- a/src/chat_stream/definition.ts
+++ b/src/chat_stream/definition.ts
@@ -387,6 +387,7 @@ function createCommandRunner(
           const queue = markIntentTerminal(
             db,
             active.intent,
+            command.pausePromptQueue === true ||
             command.response?.pausePromptQueue === true ||
               active.intent.owner?.kind === "review-remediation" ||
               context.getSnapshot().reviewBarrier.phase ===

--- a/src/chat_stream/definition.ts
+++ b/src/chat_stream/definition.ts
@@ -185,6 +185,13 @@ function createCommandRunner(
                 queueRevision: result.queue.queueRevision,
                 paused: result.queue.queuePaused,
                 entries: result.queue.queue,
+                resumeQueue: command.resumeQueue,
+                ...(command.observedStopPolicyVersion === undefined
+                  ? {}
+                  : {
+                      observedStopPolicyVersion:
+                        command.observedStopPolicyVersion,
+                    }),
               });
             }
           } else {
@@ -195,6 +202,12 @@ function createCommandRunner(
               queueRevision: result.queueRevision,
               queuePaused: result.queuePaused,
               resumeQueue: command.resumeQueue,
+              ...(command.observedStopPolicyVersion === undefined
+                ? {}
+                : {
+                    observedStopPolicyVersion:
+                      command.observedStopPolicyVersion,
+                  }),
             });
           }
         } catch (error) {
@@ -423,18 +436,23 @@ function createCommandRunner(
           throw new Error("Finalization does not match the active chat intent");
         }
         try {
+          const pauseForStepLimit = command.response?.pausePromptQueue === true;
+          const pauseForReview =
+            active.intent.owner?.kind === "review-remediation" ||
+            context.getSnapshot().reviewBarrier.phase ===
+              "awaiting-continuation";
+          const pauseForStop =
+            active.queueResumedAfterCancel !== true &&
+            (active.pauseQueueOnCancel === true ||
+              command.pausePromptQueue === true) &&
+            !pauseForStepLimit;
           const queue = markIntentTerminal(
             db,
             active.intent,
-            command.response?.pausePromptQueue === true ||
-              active.intent.owner?.kind === "review-remediation" ||
-              context.getSnapshot().reviewBarrier.phase ===
-                "awaiting-continuation" ||
-              (active.queueResumedAfterCancel !== true &&
-                (active.pauseQueueOnCancel === true ||
-                  command.pausePromptQueue === true)),
+            pauseForStepLimit || pauseForReview || pauseForStop,
             command.error !== undefined ||
               command.response?.wasCancelled === true,
+            pauseForStepLimit ? "step-limit" : pauseForStop ? "stop" : "manual",
           );
           publishChatInvalidations(context.key.chatId, active.targetAppId);
           emit({

--- a/src/chat_stream/definition.ts
+++ b/src/chat_stream/definition.ts
@@ -408,15 +408,24 @@ function createCommandRunner(
       }
       case "mutate-queue": {
         try {
-          let queue = await mutateChatQueue(db, context.key.chatId, command);
           if (
             command.mutation.type === "resume" &&
             command.observedStopPolicyVersion !== undefined &&
             command.observedStopPolicyVersion !==
               context.getSnapshot().stopPolicyVersion
           ) {
-            queue = await parkChatQueue(db, context.key.chatId);
+            const queue = loadAuthoritativeQueue();
+            emit({
+              type: "QUEUE_MUTATION_REJECTED",
+              mutationId: command.mutationId,
+              error: "A newer Stop changed the queue; try resuming again.",
+              queueRevision: queue.queueRevision,
+              paused: queue.queuePaused,
+              entries: queue.queue,
+            });
+            return;
           }
+          const queue = await mutateChatQueue(db, context.key.chatId, command);
           emit({
             type: "QUEUE_MUTATED",
             mutationId: command.mutationId,

--- a/src/chat_stream/definition.ts
+++ b/src/chat_stream/definition.ts
@@ -410,12 +410,13 @@ function createCommandRunner(
           const queue = markIntentTerminal(
             db,
             active.intent,
-            active.pauseQueueOnCancel === true ||
-            command.pausePromptQueue === true ||
-              command.response?.pausePromptQueue === true ||
+            command.response?.pausePromptQueue === true ||
               active.intent.owner?.kind === "review-remediation" ||
               context.getSnapshot().reviewBarrier.phase ===
-                "awaiting-continuation",
+                "awaiting-continuation" ||
+              (active.queueResumedAfterCancel !== true &&
+                (active.pauseQueueOnCancel === true ||
+                  command.pausePromptQueue === true)),
             command.error !== undefined ||
               command.response?.wasCancelled === true,
           );

--- a/src/chat_stream/definition.ts
+++ b/src/chat_stream/definition.ts
@@ -84,6 +84,7 @@ function projectSnapshot(
     error: state.error,
     queueRevision: state.queueRevision,
     queuePaused: state.queuePaused,
+    queuePauseReason: state.queuePauseReason,
     queue: [...state.queue],
     stopPolicyVersion: state.stopPolicyVersion,
     capabilities: {

--- a/src/chat_stream/definition.ts
+++ b/src/chat_stream/definition.ts
@@ -36,6 +36,7 @@ import {
   isSessionQueuedIntent,
   markIntentTerminal,
   mutateChatQueue,
+  parkChatQueue,
   claimQueueHead,
   persistQueuedIntent,
   persistSessionQueuedIntent,
@@ -346,6 +347,27 @@ function createCommandRunner(
             command: "cancel-active",
             intentId: active.intent.intentId,
             invocationRef: command.invocationRef,
+            error: error instanceof Error ? error.message : String(error),
+            queueRevision: queue.queueRevision,
+            paused: queue.queuePaused,
+            entries: queue.queue,
+          });
+        }
+        return;
+      }
+      case "park-queue": {
+        try {
+          const queue = await parkChatQueue(db, context.key.chatId);
+          emit({
+            type: "QUEUE_PARKED",
+            queueRevision: queue.queueRevision,
+            paused: true,
+            entries: queue.queue,
+          });
+        } catch (error) {
+          const queue = loadAuthoritativeQueue();
+          emit({
+            type: "QUEUE_PARK_FAILED",
             error: error instanceof Error ? error.message : String(error),
             queueRevision: queue.queueRevision,
             paused: queue.queuePaused,

--- a/src/chat_stream/definition.ts
+++ b/src/chat_stream/definition.ts
@@ -459,17 +459,14 @@ function createCommandRunner(
               "awaiting-continuation";
           const pauseForStop =
             active.queueResumedAfterCancel !== true &&
-            (active.pauseQueueOnCancel === true ||
-              command.pausePromptQueue === true) &&
-            !pauseForStepLimit &&
-            !pauseForReview;
+            active.pauseQueueOnCancel === true;
           const queue = markIntentTerminal(
             db,
             active.intent,
             pauseForStepLimit || pauseForReview || pauseForStop,
             command.error !== undefined ||
               command.response?.wasCancelled === true,
-            pauseForStepLimit ? "step-limit" : pauseForStop ? "stop" : "manual",
+            pauseForStop ? "stop" : pauseForStepLimit ? "step-limit" : "manual",
           );
           publishChatInvalidations(context.key.chatId, active.targetAppId);
           emit({

--- a/src/chat_stream/definition.ts
+++ b/src/chat_stream/definition.ts
@@ -164,8 +164,12 @@ function createCommandRunner(
         try {
           const result =
             command.intent.owner?.kind === "user-input-follow-up"
-              ? persistSessionQueuedIntent(db, command.intent)
-              : persistQueuedIntent(db, command.intent);
+              ? persistSessionQueuedIntent(db, command.intent, {
+                  resumeQueue: command.resumeQueue,
+                })
+              : persistQueuedIntent(db, command.intent, {
+                  resumeQueue: command.resumeQueue,
+                });
           if (result.kind === "replayed") {
             emit({
               type: "ADMISSION_REPLAYED",
@@ -179,6 +183,8 @@ function createCommandRunner(
               intentId: command.intent.intentId,
               entry: result.entry,
               queueRevision: result.queueRevision,
+              queuePaused: result.queuePaused,
+              resumeQueue: command.resumeQueue,
             });
           }
         } catch (error) {

--- a/src/chat_stream/definition.ts
+++ b/src/chat_stream/definition.ts
@@ -56,6 +56,7 @@ import {
   type ChatStreamWireEvent,
   unavailableChatStreamSnapshot,
 } from "./transport";
+import { canCancelChatStreamPhase } from "./transition";
 
 async function requireExistingChat(chatId: number): Promise<number> {
   const chat = db
@@ -86,7 +87,7 @@ function projectSnapshot(
     queue: [...state.queue],
     capabilities: {
       canSubmit: true,
-      canCancel: state.phase === "admitting" || state.phase === "streaming",
+      canCancel: canCancelChatStreamPhase(state.phase),
       canPauseQueue: !state.queuePaused,
       canResumeQueue: state.queuePaused,
     },
@@ -409,8 +410,9 @@ function createCommandRunner(
           const queue = markIntentTerminal(
             db,
             active.intent,
+            active.pauseQueueOnCancel === true ||
             command.pausePromptQueue === true ||
-            command.response?.pausePromptQueue === true ||
+              command.response?.pausePromptQueue === true ||
               active.intent.owner?.kind === "review-remediation" ||
               context.getSnapshot().reviewBarrier.phase ===
                 "awaiting-continuation",
@@ -707,6 +709,7 @@ export const chatStreamDefinition = {
       }
       if (
         event.type === "CANCEL" &&
+        event.pauseQueue !== true &&
         (!currentState?.active ||
           currentState.active.invocationRef.operationId !==
             event.invocationRef.operationId)

--- a/src/chat_stream/definition.ts
+++ b/src/chat_stream/definition.ts
@@ -408,13 +408,26 @@ function createCommandRunner(
       }
       case "mutate-queue": {
         try {
-          const queue = await mutateChatQueue(db, context.key.chatId, command);
+          let queue = await mutateChatQueue(db, context.key.chatId, command);
+          if (
+            command.mutation.type === "resume" &&
+            command.observedStopPolicyVersion !== undefined &&
+            command.observedStopPolicyVersion !==
+              context.getSnapshot().stopPolicyVersion
+          ) {
+            queue = await parkChatQueue(db, context.key.chatId);
+          }
           emit({
             type: "QUEUE_MUTATED",
             mutationId: command.mutationId,
             queueRevision: queue.queueRevision,
             paused: queue.queuePaused,
             entries: queue.queue,
+            ...(command.observedStopPolicyVersion === undefined
+              ? {}
+              : {
+                  observedStopPolicyVersion: command.observedStopPolicyVersion,
+                }),
           });
         } catch (error) {
           console.error("[chat-stream] Queue mutation failed", error);
@@ -436,8 +449,11 @@ function createCommandRunner(
           throw new Error("Finalization does not match the active chat intent");
         }
         try {
-          const pauseForStepLimit = command.response?.pausePromptQueue === true;
+          const pauseForStepLimit =
+            command.response?.pausePromptQueue === true &&
+            command.response.reviewBarrierRequested !== true;
           const pauseForReview =
+            command.response?.reviewBarrierRequested === true ||
             active.intent.owner?.kind === "review-remediation" ||
             context.getSnapshot().reviewBarrier.phase ===
               "awaiting-continuation";
@@ -445,7 +461,8 @@ function createCommandRunner(
             active.queueResumedAfterCancel !== true &&
             (active.pauseQueueOnCancel === true ||
               command.pausePromptQueue === true) &&
-            !pauseForStepLimit;
+            !pauseForStepLimit &&
+            !pauseForReview;
           const queue = markIntentTerminal(
             db,
             active.intent,

--- a/src/chat_stream/definition.ts
+++ b/src/chat_stream/definition.ts
@@ -177,6 +177,14 @@ function createCommandRunner(
               acceptance: result.acceptance,
               acceptedMessageId: result.acceptedMessageId,
             });
+            if (result.queue) {
+              emit({
+                type: "QUEUE_MUTATED",
+                queueRevision: result.queue.queueRevision,
+                paused: result.queue.queuePaused,
+                entries: result.queue.queue,
+              });
+            }
           } else {
             emit({
               type: "ADMISSION_QUEUED",
@@ -561,10 +569,11 @@ function createCommandRunner(
               });
               return;
             }
-            const phaseBeforeDispatch = context.getSnapshot().phase;
+            const snapshotBeforeDispatch = context.getSnapshot();
             if (
-              phaseBeforeDispatch !== "idle" &&
-              phaseBeforeDispatch !== "errored"
+              snapshotBeforeDispatch.queuePaused ||
+              (snapshotBeforeDispatch.phase !== "idle" &&
+                snapshotBeforeDispatch.phase !== "errored")
             ) {
               const queue = await retryQueueDispatchPersistence(() =>
                 restoreClaimedQueueHead(

--- a/src/chat_stream/definition.ts
+++ b/src/chat_stream/definition.ts
@@ -137,7 +137,7 @@ function createCommandRunner(
       try {
         const queue = await mutateChatQueue(db, context.key.chatId, {
           type: "mutate-queue",
-          mutation: { type: "resume" },
+          mutation: { type: "resume", preserveStopPause: true },
           expectedQueueRevision: snapshot.queueRevision,
           mutationId: randomUUID(),
         });
@@ -552,6 +552,7 @@ function createCommandRunner(
               ...withoutHash,
               payloadHash: computeChatTurnPayloadHash(withoutHash),
             },
+            observedStopPolicyVersion: command.observedStopPolicyVersion,
           });
         } catch (error) {
           emit({

--- a/src/chat_stream/definition.ts
+++ b/src/chat_stream/definition.ts
@@ -56,7 +56,7 @@ import {
   type ChatStreamWireEvent,
   unavailableChatStreamSnapshot,
 } from "./transport";
-import { canCancelChatStreamPhase } from "./transition";
+import { canCancelActiveChatStreamPhase } from "./transition";
 
 async function requireExistingChat(chatId: number): Promise<number> {
   const chat = db
@@ -87,7 +87,7 @@ function projectSnapshot(
     queue: [...state.queue],
     capabilities: {
       canSubmit: true,
-      canCancel: canCancelChatStreamPhase(state.phase),
+      canCancel: canCancelActiveChatStreamPhase(state.phase),
       canPauseQueue: !state.queuePaused,
       canResumeQueue: state.queuePaused,
     },

--- a/src/chat_stream/definition.ts
+++ b/src/chat_stream/definition.ts
@@ -743,6 +743,16 @@ export const chatStreamDefinition = {
           );
         }
         if (
+          event.observedStopPolicyVersion !== undefined &&
+          currentState &&
+          event.observedStopPolicyVersion > currentState.stopPolicyVersion
+        ) {
+          throw new DyadError(
+            "Chat cancellation observed an unknown Stop policy version",
+            DyadErrorKind.Auth,
+          );
+        }
+        if (
           event.pauseQueue !== true &&
           (!currentState?.active ||
             currentState.active.invocationRef.operationId !==

--- a/src/chat_stream/definition.ts
+++ b/src/chat_stream/definition.ts
@@ -594,7 +594,12 @@ function createCommandRunner(
             }
             // Move the actor out of idle before publishing the shorter queue so
             // that projection refresh cannot schedule a second head concurrently.
-            emit({ type: "SUBMIT", intent: claimed.intent });
+            emit({
+              type: "SUBMIT",
+              intent: claimed.intent,
+              observedStopPolicyVersion:
+                snapshotBeforeDispatch.stopPolicyVersion,
+            });
             emit({
               type: "QUEUE_MUTATED",
               queueRevision: claimed.queue.queueRevision,

--- a/src/chat_stream/host_state.ts
+++ b/src/chat_stream/host_state.ts
@@ -89,7 +89,7 @@ export type ChatStreamHostCommand =
       readonly type: "mutate-queue";
       readonly mutation:
         | { type: "pause" }
-        | { type: "resume" }
+        | { type: "resume"; preserveStopPause?: boolean }
         | {
             type: "edit";
             itemId: string;
@@ -102,6 +102,7 @@ export type ChatStreamHostCommand =
         | { type: "clear" };
       readonly expectedQueueRevision: number;
       readonly mutationId: string;
+      readonly observedStopPolicyVersion?: number;
     }
   | {
       readonly type: "finalize";

--- a/src/chat_stream/host_state.ts
+++ b/src/chat_stream/host_state.ts
@@ -76,6 +76,7 @@ export type ChatStreamHostCommand =
       readonly type: "cancel-active";
       readonly invocationRef: ChatStreamInvocationRef;
     }
+  | { readonly type: "park-queue" }
   | {
       readonly type: "mutate-queue";
       readonly mutation:

--- a/src/chat_stream/host_state.ts
+++ b/src/chat_stream/host_state.ts
@@ -14,6 +14,7 @@ export interface ChatStreamHostState {
     readonly intent: SerializableChatTurnIntent;
     readonly invocationRef: ChatStreamInvocationRef;
     readonly targetAppId: number | null;
+    readonly pauseQueueOnCancel?: boolean;
   } | null;
   readonly error: string | null;
   readonly queueRevision: number;
@@ -98,6 +99,7 @@ export type ChatStreamHostCommand =
       readonly intentId: string;
       readonly response?: ChatResponseEnd;
       readonly error?: string;
+      readonly pausePromptQueue?: boolean;
     }
   | {
       readonly type: "run-review-barrier";

--- a/src/chat_stream/host_state.ts
+++ b/src/chat_stream/host_state.ts
@@ -120,6 +120,7 @@ export type ChatStreamHostCommand =
       readonly type: "submit-review-remediation";
       readonly threadId: string;
       readonly prompt: string;
+      readonly observedStopPolicyVersion: number;
     }
   | {
       readonly type: "fail-review-remediation";

--- a/src/chat_stream/host_state.ts
+++ b/src/chat_stream/host_state.ts
@@ -109,7 +109,6 @@ export type ChatStreamHostCommand =
       readonly intentId: string;
       readonly response?: ChatResponseEnd;
       readonly error?: string;
-      readonly pausePromptQueue?: boolean;
     }
   | {
       readonly type: "run-review-barrier";

--- a/src/chat_stream/host_state.ts
+++ b/src/chat_stream/host_state.ts
@@ -21,6 +21,8 @@ export interface ChatStreamHostState {
   readonly queueRevision: number;
   readonly queuePaused: boolean;
   readonly queue: readonly ChatQueueEntry[];
+  readonly stopPolicyVersion: number;
+  readonly lastStopId: string | null;
   readonly lastAcceptance: {
     readonly intentId: string;
     readonly acceptance:

--- a/src/chat_stream/host_state.ts
+++ b/src/chat_stream/host_state.ts
@@ -15,6 +15,7 @@ export interface ChatStreamHostState {
     readonly invocationRef: ChatStreamInvocationRef;
     readonly targetAppId: number | null;
     readonly pauseQueueOnCancel?: boolean;
+    readonly queueResumedAfterCancel?: boolean;
   } | null;
   readonly error: string | null;
   readonly queueRevision: number;

--- a/src/chat_stream/host_state.ts
+++ b/src/chat_stream/host_state.ts
@@ -78,6 +78,7 @@ export type ChatStreamHostCommand =
       readonly type: "persist-queued";
       readonly intent: SerializableChatTurnIntent;
       readonly resumeQueue: boolean;
+      readonly observedStopPolicyVersion?: number;
     }
   | {
       readonly type: "cancel-active";

--- a/src/chat_stream/host_state.ts
+++ b/src/chat_stream/host_state.ts
@@ -46,6 +46,7 @@ export interface ChatStreamHostState {
     readonly error?: string;
   } | null;
   readonly pendingQueueMutationId: string | null;
+  readonly pendingQueueResumeMutationId: string | null;
   readonly lastQueueMutation: {
     readonly mutationId: string;
     readonly outcome: "applied" | "rejected";
@@ -72,6 +73,7 @@ export type ChatStreamHostCommand =
   | {
       readonly type: "persist-queued";
       readonly intent: SerializableChatTurnIntent;
+      readonly resumeQueue: boolean;
     }
   | {
       readonly type: "cancel-active";

--- a/src/chat_stream/host_state.ts
+++ b/src/chat_stream/host_state.ts
@@ -20,6 +20,7 @@ export interface ChatStreamHostState {
   readonly error: string | null;
   readonly queueRevision: number;
   readonly queuePaused: boolean;
+  readonly queuePauseReason: "stop" | "manual" | "step-limit" | null;
   readonly queue: readonly ChatQueueEntry[];
   readonly stopPolicyVersion: number;
   readonly lastStopId: string | null;
@@ -48,6 +49,7 @@ export interface ChatStreamHostState {
     readonly error?: string;
   } | null;
   readonly pendingQueueMutationId: string | null;
+  readonly pendingQueuePauseMutationId: string | null;
   readonly pendingQueueResumeMutationId: string | null;
   readonly lastQueueMutation: {
     readonly mutationId: string;

--- a/src/chat_stream/host_transition.test.ts
+++ b/src/chat_stream/host_transition.test.ts
@@ -364,6 +364,43 @@ describe("transitionChatStreamHost", () => {
     });
   });
 
+  it("keeps Stop authoritative over a late manual-pause acknowledgement", () => {
+    const activeIntent = intent("active");
+    const active = {
+      ...initialChatStreamHostState(),
+      phase: "streaming" as const,
+      active: {
+        intent: activeIntent,
+        invocationRef: activeIntent.invocationRef!,
+        targetAppId: 3,
+        pauseQueueOnCancel: false,
+      },
+      pendingQueueMutationId: "manual-pause",
+      pendingQueuePauseMutationId: "manual-pause",
+    };
+    const stopped = transitionChatStreamHost(active, {
+      type: "CANCEL",
+      invocationRef: activeIntent.invocationRef!,
+      pauseQueue: true,
+      stopId: "stop-1",
+      observedStopPolicyVersion: 0,
+    });
+    expect(stopped.kind).toBe("applied");
+    if (stopped.kind !== "applied") return;
+    expect(stopped.state.pendingQueuePauseMutationId).toBeNull();
+
+    const latePause = transitionChatStreamHost(stopped.state, {
+      type: "QUEUE_MUTATED",
+      mutationId: "manual-pause",
+      queueRevision: 1,
+      paused: true,
+      entries: [],
+    });
+    expect(latePause.kind).toBe("applied");
+    if (latePause.kind !== "applied") return;
+    expect(latePause.state.queuePauseReason).toBe("stop");
+  });
+
   it("parks a late Stop while finalization is already in progress", () => {
     const activeIntent = intent("active");
     const submitted = transitionChatStreamHost(initialChatStreamHostState(), {

--- a/src/chat_stream/host_transition.test.ts
+++ b/src/chat_stream/host_transition.test.ts
@@ -760,6 +760,60 @@ describe("transitionChatStreamHost", () => {
     expect(confirmed.commands).toEqual([]);
   });
 
+  it("lets an idle explicit resume release the current Stop latch", () => {
+    const queuedEntry = {
+      itemId: "queued",
+      intentId: "queued",
+      prompt: "Run me",
+      persistence: "durable" as const,
+      editable: true,
+      removable: true,
+    };
+    const state = {
+      ...initialChatStreamHostState({
+        queueRevision: 4,
+        queuePaused: true,
+        queuePauseReason: "stop",
+        queue: [queuedEntry],
+      }),
+      stopPolicyVersion: 2,
+    };
+    const requested = transitionChatStreamHost(state, {
+      type: "RESUME_QUEUE",
+      expectedQueueRevision: 4,
+      mutationId: "idle-resume",
+      observedStopPolicyVersion: 2,
+    });
+    expect(requested.kind).toBe("applied");
+    if (requested.kind !== "applied") return;
+    expect(requested.commands).toEqual([
+      {
+        type: "mutate-queue",
+        mutation: { type: "resume", preserveStopPause: false },
+        expectedQueueRevision: 4,
+        mutationId: "idle-resume",
+        observedStopPolicyVersion: 2,
+      },
+    ]);
+
+    const confirmed = transitionChatStreamHost(requested.state, {
+      type: "QUEUE_MUTATED",
+      mutationId: "idle-resume",
+      queueRevision: 5,
+      paused: false,
+      entries: [queuedEntry],
+      observedStopPolicyVersion: 2,
+    });
+    expect(confirmed.kind).toBe("applied");
+    if (confirmed.kind !== "applied") return;
+    expect(confirmed.state).toMatchObject({
+      queuePaused: false,
+      queuePauseReason: null,
+      pendingQueueResumeMutationId: null,
+    });
+    expect(confirmed.commands).toEqual([{ type: "dispatch-next" }]);
+  });
+
   it("retains the Stop latch when an explicit queue resume is rejected", () => {
     const activeIntent = intent("active");
     const state = {
@@ -907,6 +961,52 @@ describe("transitionChatStreamHost", () => {
         entries: [],
       }),
     ).toEqual({ kind: "ignored", state, reason: "invalid-host-event" });
+  });
+
+  it("keeps Stop fail-closed when queue parking fails", () => {
+    const stopped = {
+      ...initialChatStreamHostState({
+        queueRevision: 2,
+        queuePaused: false,
+        queue: [],
+      }),
+      stopPolicyVersion: 1,
+      queuePauseReason: "stop" as const,
+    };
+    const failed = transitionChatStreamHost(stopped, {
+      type: "QUEUE_PARK_FAILED",
+      error: "database unavailable",
+      queueRevision: 2,
+      paused: false,
+      entries: [],
+    });
+    expect(failed.kind).toBe("applied");
+    if (failed.kind !== "applied") return;
+    expect(failed.state).toMatchObject({
+      queuePaused: true,
+      queuePauseReason: "stop",
+    });
+
+    const delayed = transitionChatStreamHost(failed.state, {
+      type: "ADMISSION_QUEUED",
+      intentId: "delayed",
+      entry: {
+        itemId: "delayed",
+        intentId: "delayed",
+        prompt: "Stay parked",
+        persistence: "durable",
+        editable: true,
+        removable: true,
+      },
+      queueRevision: 3,
+      queuePaused: false,
+      resumeQueue: false,
+      observedStopPolicyVersion: 0,
+    });
+    expect(delayed.kind).toBe("applied");
+    if (delayed.kind !== "applied") return;
+    expect(delayed.state.queuePaused).toBe(true);
+    expect(delayed.commands).toEqual([]);
   });
 
   it("advertises Stop through lifecycle settlement", () => {

--- a/src/chat_stream/host_transition.test.ts
+++ b/src/chat_stream/host_transition.test.ts
@@ -651,6 +651,7 @@ describe("transitionChatStreamHost", () => {
       type: "RESUME_QUEUE",
       expectedQueueRevision: stopped.state.queueRevision,
       mutationId: "resume-after-stop",
+      observedStopPolicyVersion: stopped.state.stopPolicyVersion,
     });
     expect(resumed.kind).toBe("applied");
     if (resumed.kind !== "applied") return;
@@ -667,6 +668,7 @@ describe("transitionChatStreamHost", () => {
       queueRevision: resumed.state.queueRevision + 1,
       paused: false,
       entries: [],
+      observedStopPolicyVersion: stopped.state.stopPolicyVersion,
     });
     expect(confirmed.kind).toBe("applied");
     if (confirmed.kind !== "applied") return;
@@ -703,6 +705,59 @@ describe("transitionChatStreamHost", () => {
         },
       },
     ]);
+  });
+
+  it("keeps a newer Stop authoritative over a late resume acknowledgement", () => {
+    const activeIntent = intent("active");
+    const state = {
+      ...initialChatStreamHostState(),
+      phase: "cancelling" as const,
+      stopPolicyVersion: 1,
+      queuePaused: true,
+      queuePauseReason: "stop" as const,
+      active: {
+        intent: activeIntent,
+        invocationRef: activeIntent.invocationRef!,
+        targetAppId: 3,
+        pauseQueueOnCancel: true,
+      },
+    };
+    const requested = transitionChatStreamHost(state, {
+      type: "RESUME_QUEUE",
+      expectedQueueRevision: 0,
+      mutationId: "stale-resume",
+      observedStopPolicyVersion: 1,
+    });
+    expect(requested.kind).toBe("applied");
+    if (requested.kind !== "applied") return;
+
+    const stoppedAgain = transitionChatStreamHost(requested.state, {
+      type: "CANCEL",
+      invocationRef: activeIntent.invocationRef!,
+      pauseQueue: true,
+      stopId: "newer-stop",
+      observedStopPolicyVersion: 1,
+    });
+    expect(stoppedAgain.kind).toBe("applied");
+    if (stoppedAgain.kind !== "applied") return;
+
+    const confirmed = transitionChatStreamHost(stoppedAgain.state, {
+      type: "QUEUE_MUTATED",
+      mutationId: "stale-resume",
+      queueRevision: 1,
+      paused: false,
+      entries: [],
+      observedStopPolicyVersion: 1,
+    });
+    expect(confirmed.kind).toBe("applied");
+    if (confirmed.kind !== "applied") return;
+    expect(confirmed.state).toMatchObject({
+      stopPolicyVersion: 2,
+      queuePaused: true,
+      queuePauseReason: "stop",
+      active: { pauseQueueOnCancel: true },
+    });
+    expect(confirmed.commands).toEqual([]);
   });
 
   it("retains the Stop latch when an explicit queue resume is rejected", () => {

--- a/src/chat_stream/host_transition.test.ts
+++ b/src/chat_stream/host_transition.test.ts
@@ -85,7 +85,7 @@ describe("transitionChatStreamHost", () => {
     expect(cancelling.kind).toBe("applied");
     if (cancelling.kind !== "applied") return;
     expect(cancelling.state.active?.pauseQueueOnCancel).toBe(true);
-    expect(cancelling.state.queuePaused).toBe(true);
+    expect(cancelling.state.queuePaused).toBe(false);
     expect(cancelling.commands).toEqual([
       { type: "park-queue" },
       {
@@ -156,7 +156,7 @@ describe("transitionChatStreamHost", () => {
     if (stopped.kind !== "applied") return;
     expect(stopped.state).toMatchObject({
       phase: "finalizing",
-      queuePaused: true,
+      queuePaused: false,
       active: { pauseQueueOnCancel: true },
     });
     expect(stopped.commands).toEqual([{ type: "park-queue" }]);
@@ -215,7 +215,6 @@ describe("transitionChatStreamHost", () => {
       response: {
         chatId: 7,
         invocationRef: activeIntent.invocationRef!,
-        pausePromptQueue: true,
         updatedFiles: false,
         wasCancelled: true,
       },
@@ -231,10 +230,54 @@ describe("transitionChatStreamHost", () => {
         response: {
           chatId: 7,
           invocationRef: activeIntent.invocationRef!,
-          pausePromptQueue: true,
           updatedFiles: false,
           wasCancelled: true,
         },
+      },
+    ]);
+  });
+
+  it("preserves a genuine response pause after the Stop latch is resumed", () => {
+    const activeIntent = intent("step-limited");
+    const state = {
+      ...initialChatStreamHostState(),
+      phase: "cancelling" as const,
+      active: {
+        intent: activeIntent,
+        invocationRef: activeIntent.invocationRef!,
+        targetAppId: 3,
+        pauseQueueOnCancel: false,
+        queueResumedAfterCancel: true,
+      },
+    };
+
+    const ended = transitionChatStreamHost(state, {
+      type: "STREAM_ENDED",
+      intentId: activeIntent.intentId,
+      invocationRef: activeIntent.invocationRef!,
+      response: {
+        chatId: 7,
+        invocationRef: activeIntent.invocationRef!,
+        pausePromptQueue: true,
+        updatedFiles: false,
+      },
+      targetAppId: 3,
+    });
+
+    expect(ended.kind).toBe("applied");
+    if (ended.kind !== "applied") return;
+    expect(ended.state.lastCompletion?.pausePromptQueue).toBe(true);
+    expect(ended.commands).toEqual([
+      {
+        type: "finalize",
+        intentId: activeIntent.intentId,
+        response: {
+          chatId: 7,
+          invocationRef: activeIntent.invocationRef!,
+          pausePromptQueue: true,
+          updatedFiles: false,
+        },
+        pausePromptQueue: true,
       },
     ]);
   });
@@ -261,7 +304,7 @@ describe("transitionChatStreamHost", () => {
     expect(stopped.kind).toBe("applied");
     if (stopped.kind !== "applied") return;
     expect(stopped.state.active).toBe(state.active);
-    expect(stopped.state.queuePaused).toBe(true);
+    expect(stopped.state.queuePaused).toBe(false);
     expect(stopped.commands).toEqual([{ type: "park-queue" }]);
   });
 

--- a/src/chat_stream/host_transition.test.ts
+++ b/src/chat_stream/host_transition.test.ts
@@ -4,7 +4,10 @@ import {
   transitionChatStreamHost,
 } from "./host_transition";
 import type { SerializableChatTurnIntent } from "./transport";
-import { canCancelChatStreamPhase } from "./transition";
+import {
+  canCancelActiveChatStreamPhase,
+  canCancelChatStreamPhase,
+} from "./transition";
 
 function intent(intentId: string): SerializableChatTurnIntent {
   return {
@@ -63,6 +66,25 @@ describe("transitionChatStreamHost", () => {
     expect(submitted.kind).toBe("applied");
     if (submitted.kind !== "applied") return;
     expect(submitted.state).toBe(cancelling);
+    expect(submitted.commands).toEqual([
+      { type: "persist-queued", intent: intent("late") },
+    ]);
+  });
+
+  it("queues a submission that reaches an idle but parked actor", () => {
+    const parked = {
+      ...initialChatStreamHostState(),
+      queuePaused: true,
+    };
+
+    const submitted = transitionChatStreamHost(parked, {
+      type: "SUBMIT",
+      intent: intent("late"),
+    });
+
+    expect(submitted.kind).toBe("applied");
+    if (submitted.kind !== "applied") return;
+    expect(submitted.state).toBe(parked);
     expect(submitted.commands).toEqual([
       { type: "persist-queued", intent: intent("late") },
     ]);
@@ -344,6 +366,13 @@ describe("transitionChatStreamHost", () => {
     ).toBe(true);
     expect(canCancelChatStreamPhase("idle")).toBe(false);
     expect(canCancelChatStreamPhase("errored")).toBe(false);
+  });
+
+  it("advertises active cancellation only before settlement", () => {
+    expect(canCancelActiveChatStreamPhase("admitting")).toBe(true);
+    expect(canCancelActiveChatStreamPhase("streaming")).toBe(true);
+    expect(canCancelActiveChatStreamPhase("cancelling")).toBe(false);
+    expect(canCancelActiveChatStreamPhase("finalizing")).toBe(false);
   });
 
   it("retries queue parking when cancellation fails", () => {

--- a/src/chat_stream/host_transition.test.ts
+++ b/src/chat_stream/host_transition.test.ts
@@ -376,7 +376,7 @@ describe("transitionChatStreamHost", () => {
     if (failed.kind !== "applied") return;
     expect(failed.state).toMatchObject({
       phase: "errored",
-      queuePaused: true,
+      queuePaused: false,
       active: null,
     });
     expect(failed.commands).toEqual([{ type: "park-queue" }]);

--- a/src/chat_stream/host_transition.test.ts
+++ b/src/chat_stream/host_transition.test.ts
@@ -67,6 +67,60 @@ describe("transitionChatStreamHost", () => {
     ]);
   });
 
+  it("cancels and parks the queue through one authoritative intent", () => {
+    const activeIntent = intent("active");
+    const submitted = transitionChatStreamHost(initialChatStreamHostState(), {
+      type: "SUBMIT",
+      intent: activeIntent,
+    });
+    expect(submitted.kind).toBe("applied");
+    if (submitted.kind !== "applied") return;
+
+    const cancelling = transitionChatStreamHost(submitted.state, {
+      type: "CANCEL",
+      invocationRef: activeIntent.invocationRef!,
+      pauseQueue: true,
+    });
+    expect(cancelling.kind).toBe("applied");
+    if (cancelling.kind !== "applied") return;
+    expect(cancelling.state.active?.pauseQueueOnCancel).toBe(true);
+    expect(cancelling.commands).toEqual([
+      {
+        type: "cancel-active",
+        invocationRef: activeIntent.invocationRef!,
+      },
+    ]);
+
+    const ended = transitionChatStreamHost(cancelling.state, {
+      type: "STREAM_ENDED",
+      intentId: activeIntent.intentId,
+      invocationRef: activeIntent.invocationRef!,
+      response: {
+        chatId: 7,
+        invocationRef: activeIntent.invocationRef!,
+        updatedFiles: false,
+        wasCancelled: true,
+      },
+      targetAppId: 3,
+    });
+    expect(ended.kind).toBe("applied");
+    if (ended.kind !== "applied") return;
+    expect(ended.state.lastCompletion?.pausePromptQueue).toBe(true);
+    expect(ended.commands).toEqual([
+      {
+        type: "finalize",
+        intentId: activeIntent.intentId,
+        response: {
+          chatId: 7,
+          invocationRef: activeIntent.invocationRef!,
+          updatedFiles: false,
+          wasCancelled: true,
+        },
+        pausePromptQueue: true,
+      },
+    ]);
+  });
+
   it("does not leave a replayed accepted turn stuck in admitting", () => {
     const admitted = transitionChatStreamHost(initialChatStreamHostState(), {
       type: "SUBMIT",

--- a/src/chat_stream/host_transition.test.ts
+++ b/src/chat_stream/host_transition.test.ts
@@ -181,6 +181,64 @@ describe("transitionChatStreamHost", () => {
     expect(finalized.commands).toEqual([]);
   });
 
+  it("lets an explicit queue resume supersede the Stop latch", () => {
+    const activeIntent = intent("active");
+    const submitted = transitionChatStreamHost(initialChatStreamHostState(), {
+      type: "SUBMIT",
+      intent: activeIntent,
+    });
+    expect(submitted.kind).toBe("applied");
+    if (submitted.kind !== "applied") return;
+    const stopped = transitionChatStreamHost(submitted.state, {
+      type: "CANCEL",
+      invocationRef: activeIntent.invocationRef!,
+      pauseQueue: true,
+    });
+    expect(stopped.kind).toBe("applied");
+    if (stopped.kind !== "applied") return;
+    const resumed = transitionChatStreamHost(stopped.state, {
+      type: "RESUME_QUEUE",
+      expectedQueueRevision: stopped.state.queueRevision,
+      mutationId: "resume-after-stop",
+    });
+    expect(resumed.kind).toBe("applied");
+    if (resumed.kind !== "applied") return;
+    expect(resumed.state.active).toMatchObject({
+      pauseQueueOnCancel: false,
+      queueResumedAfterCancel: true,
+    });
+
+    const ended = transitionChatStreamHost(resumed.state, {
+      type: "STREAM_ENDED",
+      intentId: activeIntent.intentId,
+      invocationRef: activeIntent.invocationRef!,
+      response: {
+        chatId: 7,
+        invocationRef: activeIntent.invocationRef!,
+        pausePromptQueue: true,
+        updatedFiles: false,
+        wasCancelled: true,
+      },
+      targetAppId: 3,
+    });
+    expect(ended.kind).toBe("applied");
+    if (ended.kind !== "applied") return;
+    expect(ended.state.lastCompletion?.pausePromptQueue).toBeUndefined();
+    expect(ended.commands).toEqual([
+      {
+        type: "finalize",
+        intentId: activeIntent.intentId,
+        response: {
+          chatId: 7,
+          invocationRef: activeIntent.invocationRef!,
+          pausePromptQueue: true,
+          updatedFiles: false,
+          wasCancelled: true,
+        },
+      },
+    ]);
+  });
+
   it("parks a stale Stop without cancelling a newer invocation", () => {
     const newerIntent = intent("newer");
     const state = {

--- a/src/chat_stream/host_transition.test.ts
+++ b/src/chat_stream/host_transition.test.ts
@@ -101,6 +101,7 @@ describe("transitionChatStreamHost", () => {
     const submitted = transitionChatStreamHost(parked, {
       type: "SUBMIT",
       intent: intent("late"),
+      observedStopPolicyVersion: 0,
     });
 
     expect(submitted.kind).toBe("applied");
@@ -186,6 +187,30 @@ describe("transitionChatStreamHost", () => {
         type: "persist-queued",
         intent: intent("after-stop"),
         resumeQueue: true,
+      },
+    ]);
+  });
+
+  it("does not resume a Stop-parked queue without an observed policy version", () => {
+    const parked = {
+      ...initialChatStreamHostState(),
+      queuePaused: true,
+      queuePauseReason: "stop" as const,
+      stopPolicyVersion: 2,
+    };
+
+    const submitted = transitionChatStreamHost(parked, {
+      type: "SUBMIT",
+      intent: intent("missing-version"),
+    });
+
+    expect(submitted.kind).toBe("applied");
+    if (submitted.kind !== "applied") return;
+    expect(submitted.commands).toEqual([
+      {
+        type: "persist-queued",
+        intent: intent("missing-version"),
+        resumeQueue: false,
       },
     ]);
   });
@@ -320,6 +345,39 @@ describe("transitionChatStreamHost", () => {
     expect(queued.commands).toEqual([{ type: "dispatch-next" }]);
   });
 
+  it("keeps an admission parked when Stop takes ownership before persistence settles", () => {
+    const stopped = {
+      ...initialChatStreamHostState(),
+      queuePaused: false,
+      queuePauseReason: "stop" as const,
+      stopPolicyVersion: 1,
+    };
+    const queued = transitionChatStreamHost(stopped, {
+      type: "ADMISSION_QUEUED",
+      intentId: "late",
+      entry: {
+        itemId: "late",
+        intentId: "late",
+        prompt: "Late prompt",
+        persistence: "durable",
+        editable: true,
+        removable: true,
+      },
+      queueRevision: 1,
+      queuePaused: false,
+      resumeQueue: false,
+    });
+
+    expect(queued.kind).toBe("applied");
+    if (queued.kind !== "applied") return;
+    expect(queued.state).toMatchObject({
+      queuePaused: true,
+      queuePauseReason: "stop",
+      queue: [{ intentId: "late" }],
+    });
+    expect(queued.commands).toEqual([]);
+  });
+
   it("does not advance or reapply an already-observed Stop cutoff", () => {
     const stopped = {
       ...initialChatStreamHostState(),
@@ -399,6 +457,39 @@ describe("transitionChatStreamHost", () => {
     expect(latePause.kind).toBe("applied");
     if (latePause.kind !== "applied") return;
     expect(latePause.state.queuePauseReason).toBe("stop");
+  });
+
+  it("keeps Stop authoritative when an in-flight manual pause is rejected", () => {
+    const activeIntent = intent("active");
+    const stopped = {
+      ...initialChatStreamHostState(),
+      phase: "cancelling" as const,
+      active: {
+        intent: activeIntent,
+        invocationRef: activeIntent.invocationRef!,
+        targetAppId: 3,
+        pauseQueueOnCancel: true,
+      },
+      queuePauseReason: "stop" as const,
+      pendingQueueMutationId: "manual-pause",
+    };
+
+    const rejected = transitionChatStreamHost(stopped, {
+      type: "QUEUE_MUTATION_REJECTED",
+      mutationId: "manual-pause",
+      error: "revision conflict",
+      queueRevision: 1,
+      paused: false,
+      entries: [],
+    });
+
+    expect(rejected.kind).toBe("applied");
+    if (rejected.kind !== "applied") return;
+    expect(rejected.state).toMatchObject({
+      queuePaused: true,
+      queuePauseReason: "stop",
+      pendingQueueMutationId: null,
+    });
   });
 
   it("parks a late Stop while finalization is already in progress", () => {
@@ -816,6 +907,13 @@ describe("transitionChatStreamHost", () => {
     );
     expect(admitted.kind).toBe("applied");
     if (admitted.kind !== "applied") return;
+    expect(admitted.commands).toEqual([
+      {
+        type: "persist-queued",
+        intent: intent("queued"),
+        resumeQueue: false,
+      },
+    ]);
 
     const replayed = transitionChatStreamHost(admitted.state, {
       type: "ADMISSION_REPLAYED",

--- a/src/chat_stream/host_transition.test.ts
+++ b/src/chat_stream/host_transition.test.ts
@@ -756,8 +756,39 @@ describe("transitionChatStreamHost", () => {
       queuePaused: true,
       queuePauseReason: "stop",
       active: { pauseQueueOnCancel: true },
+      lastQueueMutation: {
+        mutationId: "stale-resume",
+        outcome: "rejected",
+      },
     });
     expect(confirmed.commands).toEqual([]);
+  });
+
+  it("rejects a resume that already predates the current Stop", () => {
+    const state = {
+      ...initialChatStreamHostState({
+        queueRevision: 4,
+        queuePaused: true,
+        queuePauseReason: "stop",
+        queue: [],
+      }),
+      stopPolicyVersion: 2,
+    };
+
+    const resumed = transitionChatStreamHost(state, {
+      type: "RESUME_QUEUE",
+      expectedQueueRevision: 4,
+      mutationId: "stale-resume",
+      observedStopPolicyVersion: 1,
+    });
+
+    expect(resumed.kind).toBe("applied");
+    if (resumed.kind !== "applied") return;
+    expect(resumed.state.lastQueueMutation).toMatchObject({
+      mutationId: "stale-resume",
+      outcome: "rejected",
+    });
+    expect(resumed.commands).toEqual([]);
   });
 
   it("lets an idle explicit resume release the current Stop latch", () => {
@@ -896,7 +927,6 @@ describe("transitionChatStreamHost", () => {
           pausePromptQueue: true,
           updatedFiles: false,
         },
-        pausePromptQueue: true,
       },
     ]);
 

--- a/src/chat_stream/host_transition.test.ts
+++ b/src/chat_stream/host_transition.test.ts
@@ -4,6 +4,7 @@ import {
   transitionChatStreamHost,
 } from "./host_transition";
 import type { SerializableChatTurnIntent } from "./transport";
+import { canCancelChatStreamPhase } from "./transition";
 
 function intent(intentId: string): SerializableChatTurnIntent {
   return {
@@ -159,6 +160,89 @@ describe("transitionChatStreamHost", () => {
       active: { pauseQueueOnCancel: true },
     });
     expect(stopped.commands).toEqual([{ type: "park-queue" }]);
+
+    const finalized = transitionChatStreamHost(stopped.state, {
+      type: "QUEUE_MUTATED",
+      queueRevision: 1,
+      paused: false,
+      entries: [
+        {
+          itemId: "queued",
+          intentId: "queued",
+          prompt: "Keep this parked",
+          persistence: "main-session",
+          editable: true,
+          removable: true,
+        },
+      ],
+    });
+    expect(finalized.kind).toBe("applied");
+    if (finalized.kind !== "applied") return;
+    expect(finalized.commands).toEqual([]);
+  });
+
+  it("parks a stale Stop without cancelling a newer invocation", () => {
+    const newerIntent = intent("newer");
+    const state = {
+      ...initialChatStreamHostState(),
+      phase: "streaming" as const,
+      active: {
+        intent: newerIntent,
+        invocationRef: newerIntent.invocationRef!,
+        targetAppId: 3,
+        pauseQueueOnCancel: false,
+      },
+    };
+
+    const stopped = transitionChatStreamHost(state, {
+      type: "CANCEL",
+      invocationRef: intent("stale").invocationRef!,
+      pauseQueue: true,
+    });
+
+    expect(stopped.kind).toBe("applied");
+    if (stopped.kind !== "applied") return;
+    expect(stopped.state.active).toBe(state.active);
+    expect(stopped.state.queuePaused).toBe(true);
+    expect(stopped.commands).toEqual([{ type: "park-queue" }]);
+  });
+
+  it("ignores stale queue parking results", () => {
+    const state = initialChatStreamHostState({
+      queueRevision: 5,
+      queuePaused: false,
+      queue: [],
+    });
+
+    expect(
+      transitionChatStreamHost(state, {
+        type: "QUEUE_PARKED",
+        queueRevision: 4,
+        paused: true,
+        entries: [],
+      }),
+    ).toEqual({ kind: "ignored", state, reason: "invalid-host-event" });
+    expect(
+      transitionChatStreamHost(state, {
+        type: "QUEUE_PARK_FAILED",
+        error: "stale failure",
+        queueRevision: 4,
+        paused: true,
+        entries: [],
+      }),
+    ).toEqual({ kind: "ignored", state, reason: "invalid-host-event" });
+  });
+
+  it("advertises Stop through lifecycle settlement", () => {
+    expect(
+      ["admitting", "streaming", "cancelling", "finalizing"].every((phase) =>
+        canCancelChatStreamPhase(
+          phase as Parameters<typeof canCancelChatStreamPhase>[0],
+        ),
+      ),
+    ).toBe(true);
+    expect(canCancelChatStreamPhase("idle")).toBe(false);
+    expect(canCancelChatStreamPhase("errored")).toBe(false);
   });
 
   it("retries queue parking when cancellation fails", () => {

--- a/src/chat_stream/host_transition.test.ts
+++ b/src/chat_stream/host_transition.test.ts
@@ -95,6 +95,7 @@ describe("transitionChatStreamHost", () => {
           },
         ],
       }),
+      queuePauseReason: "stop" as const,
     };
 
     const submitted = transitionChatStreamHost(parked, {
@@ -141,6 +142,7 @@ describe("transitionChatStreamHost", () => {
     const parked = {
       ...initialChatStreamHostState(),
       queuePaused: true,
+      queuePauseReason: "stop" as const,
       stopPolicyVersion: 1,
     };
 
@@ -166,6 +168,7 @@ describe("transitionChatStreamHost", () => {
     const parked = {
       ...initialChatStreamHostState(),
       queuePaused: true,
+      queuePauseReason: "stop" as const,
       stopPolicyVersion: 2,
       lastStopId: "stop-2",
     };
@@ -229,7 +232,7 @@ describe("transitionChatStreamHost", () => {
     });
     expect(ended.kind).toBe("applied");
     if (ended.kind !== "applied") return;
-    expect(ended.state.lastCompletion?.pausePromptQueue).toBe(true);
+    expect(ended.state.lastCompletion?.pausePromptQueue).toBeUndefined();
     expect(ended.commands).toEqual([
       {
         type: "finalize",
@@ -240,9 +243,81 @@ describe("transitionChatStreamHost", () => {
           updatedFiles: false,
           wasCancelled: true,
         },
-        pausePromptQueue: true,
       },
     ]);
+
+    const finalized = transitionChatStreamHost(ended.state, {
+      type: "QUEUE_MUTATED",
+      queueRevision: 1,
+      paused: true,
+      entries: [],
+    });
+    expect(finalized.kind).toBe("applied");
+    if (finalized.kind !== "applied") return;
+    expect(finalized.state.queuePauseReason).toBe("stop");
+  });
+
+  it.each(["manual", "step-limit"] as const)(
+    "starts a new turn immediately while a %s pause keeps older prompts parked",
+    (queuePauseReason) => {
+      const paused = {
+        ...initialChatStreamHostState({
+          queueRevision: 2,
+          queuePaused: true,
+          queue: [
+            {
+              itemId: "older",
+              intentId: "older",
+              prompt: "Older prompt",
+              persistence: "durable" as const,
+              editable: true,
+              removable: true,
+            },
+          ],
+        }),
+        queuePauseReason,
+      };
+
+      const submitted = transitionChatStreamHost(paused, {
+        type: "SUBMIT",
+        intent: intent("new"),
+      });
+
+      expect(submitted.kind).toBe("applied");
+      if (submitted.kind !== "applied") return;
+      expect(submitted.state).toMatchObject({
+        phase: "admitting",
+        queuePaused: true,
+        queuePauseReason,
+        queue: [expect.objectContaining({ intentId: "older" })],
+      });
+      expect(submitted.commands).toEqual([
+        { type: "admit-and-start", intent: intent("new") },
+      ]);
+    },
+  );
+
+  it("drains a queued admission that lands after the queue was unpaused", () => {
+    const idle = initialChatStreamHostState();
+    const queued = transitionChatStreamHost(idle, {
+      type: "ADMISSION_QUEUED",
+      intentId: "late",
+      entry: {
+        itemId: "late",
+        intentId: "late",
+        prompt: "Late prompt",
+        persistence: "durable",
+        editable: true,
+        removable: true,
+      },
+      queueRevision: 1,
+      queuePaused: false,
+      resumeQueue: false,
+    });
+
+    expect(queued.kind).toBe("applied");
+    if (queued.kind !== "applied") return;
+    expect(queued.commands).toEqual([{ type: "dispatch-next" }]);
   });
 
   it("does not advance or reapply an already-observed Stop cutoff", () => {
@@ -482,6 +557,16 @@ describe("transitionChatStreamHost", () => {
         pausePromptQueue: true,
       },
     ]);
+
+    const finalized = transitionChatStreamHost(ended.state, {
+      type: "QUEUE_MUTATED",
+      queueRevision: 1,
+      paused: true,
+      entries: [],
+    });
+    expect(finalized.kind).toBe("applied");
+    if (finalized.kind !== "applied") return;
+    expect(finalized.state.queuePauseReason).toBe("step-limit");
   });
 
   it("parks a stale Stop without cancelling a newer invocation", () => {
@@ -816,6 +901,32 @@ describe("transitionChatStreamHost", () => {
       state,
       reason: "queue-revision-conflict",
     });
+  });
+
+  it("records an explicit queue pause separately from Stop and step limit", () => {
+    const state = initialChatStreamHostState({
+      queueRevision: 4,
+      queuePaused: false,
+      queue: [],
+    });
+    const requested = transitionChatStreamHost(state, {
+      type: "PAUSE_QUEUE",
+      expectedQueueRevision: 4,
+      mutationId: "pause-1",
+    });
+    expect(requested.kind).toBe("applied");
+    if (requested.kind !== "applied") return;
+
+    const confirmed = transitionChatStreamHost(requested.state, {
+      type: "QUEUE_MUTATED",
+      mutationId: "pause-1",
+      queueRevision: 5,
+      paused: true,
+      entries: [],
+    });
+    expect(confirmed.kind).toBe("applied");
+    if (confirmed.kind !== "applied") return;
+    expect(confirmed.state.queuePauseReason).toBe("manual");
   });
 
   it("does not clear or dispatch across an uncorrelated queue refresh", () => {

--- a/src/chat_stream/host_transition.test.ts
+++ b/src/chat_stream/host_transition.test.ts
@@ -141,12 +141,13 @@ describe("transitionChatStreamHost", () => {
     const parked = {
       ...initialChatStreamHostState(),
       queuePaused: true,
+      stopPolicyVersion: 1,
     };
 
     const submitted = transitionChatStreamHost(parked, {
       type: "SUBMIT",
       intent: intent("late"),
-      queueOnly: true,
+      observedStopPolicyVersion: 0,
     });
 
     expect(submitted.kind).toBe("applied");
@@ -157,6 +158,31 @@ describe("transitionChatStreamHost", () => {
         type: "persist-queued",
         intent: intent("late"),
         resumeQueue: false,
+      },
+    ]);
+  });
+
+  it("resumes only after a submission observes the latest Stop policy", () => {
+    const parked = {
+      ...initialChatStreamHostState(),
+      queuePaused: true,
+      stopPolicyVersion: 2,
+      lastStopId: "stop-2",
+    };
+
+    const submitted = transitionChatStreamHost(parked, {
+      type: "SUBMIT",
+      intent: intent("after-stop"),
+      observedStopPolicyVersion: 2,
+    });
+
+    expect(submitted.kind).toBe("applied");
+    if (submitted.kind !== "applied") return;
+    expect(submitted.commands).toEqual([
+      {
+        type: "persist-queued",
+        intent: intent("after-stop"),
+        resumeQueue: true,
       },
     ]);
   });
@@ -174,10 +200,12 @@ describe("transitionChatStreamHost", () => {
       type: "CANCEL",
       invocationRef: activeIntent.invocationRef!,
       pauseQueue: true,
+      stopId: "stop-1",
     });
     expect(cancelling.kind).toBe("applied");
     if (cancelling.kind !== "applied") return;
     expect(cancelling.state.active?.pauseQueueOnCancel).toBe(true);
+    expect(cancelling.state.stopPolicyVersion).toBe(1);
     expect(cancelling.state.queuePaused).toBe(false);
     expect(cancelling.commands).toEqual([
       { type: "park-queue" },
@@ -215,6 +243,28 @@ describe("transitionChatStreamHost", () => {
         pausePromptQueue: true,
       },
     ]);
+  });
+
+  it("does not advance or reapply an already-observed Stop cutoff", () => {
+    const stopped = {
+      ...initialChatStreamHostState(),
+      stopPolicyVersion: 1,
+      lastStopId: "stop-1",
+      queuePaused: true,
+    };
+
+    const duplicate = transitionChatStreamHost(stopped, {
+      type: "CANCEL",
+      invocationRef: intent("old").invocationRef!,
+      pauseQueue: true,
+      stopId: "stop-1",
+    });
+
+    expect(duplicate).toEqual({
+      kind: "ignored",
+      state: stopped,
+      reason: "not-cancellable",
+    });
   });
 
   it("parks a late Stop while finalization is already in progress", () => {

--- a/src/chat_stream/host_transition.test.ts
+++ b/src/chat_stream/host_transition.test.ts
@@ -317,7 +317,7 @@ describe("transitionChatStreamHost", () => {
     if (cancelling.kind !== "applied") return;
     expect(cancelling.state.active?.pauseQueueOnCancel).toBe(true);
     expect(cancelling.state.stopPolicyVersion).toBe(1);
-    expect(cancelling.state.queuePaused).toBe(false);
+    expect(cancelling.state.queuePaused).toBe(true);
     expect(cancelling.commands).toEqual([
       { type: "park-queue" },
       {
@@ -607,7 +607,7 @@ describe("transitionChatStreamHost", () => {
     if (stopped.kind !== "applied") return;
     expect(stopped.state).toMatchObject({
       phase: "finalizing",
-      queuePaused: false,
+      queuePaused: true,
       active: { pauseQueueOnCancel: true },
     });
     expect(stopped.commands).toEqual([{ type: "park-queue" }]);
@@ -963,8 +963,55 @@ describe("transitionChatStreamHost", () => {
     expect(stopped.kind).toBe("applied");
     if (stopped.kind !== "applied") return;
     expect(stopped.state.active).toBe(state.active);
-    expect(stopped.state.queuePaused).toBe(false);
+    expect(stopped.state.queuePaused).toBe(true);
     expect(stopped.commands).toEqual([{ type: "park-queue" }]);
+  });
+
+  it("latches Stop before asynchronous queue parking completes", () => {
+    const queued = {
+      itemId: "already-queued",
+      intentId: "already-queued",
+      prompt: "Run first",
+      persistence: "durable" as const,
+      editable: true,
+      removable: true,
+    };
+    const state = initialChatStreamHostState({
+      queueRevision: 3,
+      queuePaused: false,
+      queue: [queued],
+    });
+
+    const stopped = transitionChatStreamHost(state, {
+      type: "CANCEL",
+      invocationRef: intent("already-finished").invocationRef!,
+      pauseQueue: true,
+      observedStopPolicyVersion: 0,
+    });
+    expect(stopped.kind).toBe("applied");
+    if (stopped.kind !== "applied") return;
+    expect(stopped.state).toMatchObject({
+      queuePaused: true,
+      queuePauseReason: "stop",
+      stopPolicyVersion: 1,
+    });
+
+    const submitted = transitionChatStreamHost(stopped.state, {
+      type: "SUBMIT",
+      intent: intent("submitted-before-park"),
+      observedStopPolicyVersion: 1,
+    });
+    expect(submitted.kind).toBe("applied");
+    if (submitted.kind !== "applied") return;
+    expect(submitted.state.active).toBeNull();
+    expect(submitted.commands).toEqual([
+      {
+        type: "persist-queued",
+        intent: intent("submitted-before-park"),
+        observedStopPolicyVersion: 1,
+        resumeQueue: true,
+      },
+    ]);
   });
 
   it("ignores stale queue parking results", () => {

--- a/src/chat_stream/host_transition.test.ts
+++ b/src/chat_stream/host_transition.test.ts
@@ -84,7 +84,9 @@ describe("transitionChatStreamHost", () => {
     expect(cancelling.kind).toBe("applied");
     if (cancelling.kind !== "applied") return;
     expect(cancelling.state.active?.pauseQueueOnCancel).toBe(true);
+    expect(cancelling.state.queuePaused).toBe(true);
     expect(cancelling.commands).toEqual([
+      { type: "park-queue" },
       {
         type: "cancel-active",
         invocationRef: activeIntent.invocationRef!,
@@ -119,6 +121,80 @@ describe("transitionChatStreamHost", () => {
         pausePromptQueue: true,
       },
     ]);
+  });
+
+  it("parks a late Stop while finalization is already in progress", () => {
+    const activeIntent = intent("active");
+    const submitted = transitionChatStreamHost(initialChatStreamHostState(), {
+      type: "SUBMIT",
+      intent: activeIntent,
+    });
+    expect(submitted.kind).toBe("applied");
+    if (submitted.kind !== "applied") return;
+    const finalizing = transitionChatStreamHost(submitted.state, {
+      type: "STREAM_ENDED",
+      intentId: activeIntent.intentId,
+      invocationRef: activeIntent.invocationRef!,
+      response: {
+        chatId: 7,
+        invocationRef: activeIntent.invocationRef!,
+        updatedFiles: false,
+      },
+      targetAppId: 3,
+    });
+    expect(finalizing.kind).toBe("applied");
+    if (finalizing.kind !== "applied") return;
+    expect(finalizing.state.lastCompletion?.pausePromptQueue).toBeUndefined();
+
+    const stopped = transitionChatStreamHost(finalizing.state, {
+      type: "CANCEL",
+      invocationRef: activeIntent.invocationRef!,
+      pauseQueue: true,
+    });
+    expect(stopped.kind).toBe("applied");
+    if (stopped.kind !== "applied") return;
+    expect(stopped.state).toMatchObject({
+      phase: "finalizing",
+      queuePaused: true,
+      active: { pauseQueueOnCancel: true },
+    });
+    expect(stopped.commands).toEqual([{ type: "park-queue" }]);
+  });
+
+  it("retries queue parking when cancellation fails", () => {
+    const activeIntent = intent("active");
+    const submitted = transitionChatStreamHost(initialChatStreamHostState(), {
+      type: "SUBMIT",
+      intent: activeIntent,
+    });
+    expect(submitted.kind).toBe("applied");
+    if (submitted.kind !== "applied") return;
+    const cancelling = transitionChatStreamHost(submitted.state, {
+      type: "CANCEL",
+      invocationRef: activeIntent.invocationRef!,
+      pauseQueue: true,
+    });
+    expect(cancelling.kind).toBe("applied");
+    if (cancelling.kind !== "applied") return;
+
+    const failed = transitionChatStreamHost(cancelling.state, {
+      type: "LIFECYCLE_COMMAND_FAILED",
+      command: "cancel-active",
+      intentId: activeIntent.intentId,
+      invocationRef: activeIntent.invocationRef!,
+      error: "cancel failed",
+      queueRevision: 4,
+      paused: false,
+      entries: [],
+    });
+    expect(failed.kind).toBe("applied");
+    if (failed.kind !== "applied") return;
+    expect(failed.state).toMatchObject({
+      phase: "errored",
+      queuePaused: true,
+      active: null,
+    });
+    expect(failed.commands).toEqual([{ type: "park-queue" }]);
   });
 
   it("does not leave a replayed accepted turn stuck in admitting", () => {

--- a/src/chat_stream/host_transition.test.ts
+++ b/src/chat_stream/host_transition.test.ts
@@ -342,6 +342,28 @@ describe("transitionChatStreamHost", () => {
     });
   });
 
+  it("ignores an older Stop that arrives after a newer cutoff", () => {
+    const resumed = {
+      ...initialChatStreamHostState(),
+      stopPolicyVersion: 2,
+      lastStopId: "newer-stop",
+    };
+
+    const stale = transitionChatStreamHost(resumed, {
+      type: "CANCEL",
+      invocationRef: intent("old").invocationRef!,
+      pauseQueue: true,
+      stopId: "older-stop",
+      observedStopPolicyVersion: 1,
+    });
+
+    expect(stale).toEqual({
+      kind: "ignored",
+      state: resumed,
+      reason: "not-cancellable",
+    });
+  });
+
   it("parks a late Stop while finalization is already in progress", () => {
     const activeIntent = intent("active");
     const submitted = transitionChatStreamHost(initialChatStreamHostState(), {

--- a/src/chat_stream/host_transition.test.ts
+++ b/src/chat_stream/host_transition.test.ts
@@ -42,7 +42,11 @@ describe("transitionChatStreamHost", () => {
     if (second.kind !== "applied") return;
     expect(second.state.active?.intent.intentId).toBe("first");
     expect(second.commands).toEqual([
-      { type: "persist-queued", intent: intent("second") },
+      {
+        type: "persist-queued",
+        intent: intent("second"),
+        resumeQueue: false,
+      },
     ]);
   });
 
@@ -67,14 +71,30 @@ describe("transitionChatStreamHost", () => {
     if (submitted.kind !== "applied") return;
     expect(submitted.state).toBe(cancelling);
     expect(submitted.commands).toEqual([
-      { type: "persist-queued", intent: intent("late") },
+      {
+        type: "persist-queued",
+        intent: intent("late"),
+        resumeQueue: false,
+      },
     ]);
   });
 
-  it("queues a submission that reaches an idle but parked actor", () => {
+  it("appends and resumes an explicit submission into an idle parked queue", () => {
     const parked = {
-      ...initialChatStreamHostState(),
-      queuePaused: true,
+      ...initialChatStreamHostState({
+        queueRevision: 4,
+        queuePaused: true,
+        queue: [
+          {
+            itemId: "first",
+            intentId: "first",
+            prompt: "First queued prompt",
+            persistence: "durable" as const,
+            editable: true,
+            removable: true,
+          },
+        ],
+      }),
     };
 
     const submitted = transitionChatStreamHost(parked, {
@@ -86,7 +106,58 @@ describe("transitionChatStreamHost", () => {
     if (submitted.kind !== "applied") return;
     expect(submitted.state).toBe(parked);
     expect(submitted.commands).toEqual([
-      { type: "persist-queued", intent: intent("late") },
+      {
+        type: "persist-queued",
+        intent: intent("late"),
+        resumeQueue: true,
+      },
+    ]);
+
+    const queued = transitionChatStreamHost(submitted.state, {
+      type: "ADMISSION_QUEUED",
+      intentId: "late",
+      entry: {
+        itemId: "late",
+        intentId: "late",
+        prompt: "Build it",
+        persistence: "durable",
+        editable: true,
+        removable: true,
+      },
+      queueRevision: 5,
+      queuePaused: false,
+      resumeQueue: true,
+    });
+    expect(queued.kind).toBe("applied");
+    if (queued.kind !== "applied") return;
+    expect(queued.state.queue.map((entry) => entry.intentId)).toEqual([
+      "first",
+      "late",
+    ]);
+    expect(queued.commands).toEqual([{ type: "dispatch-next" }]);
+  });
+
+  it("keeps a pre-Stop tail parked after the actor becomes idle", () => {
+    const parked = {
+      ...initialChatStreamHostState(),
+      queuePaused: true,
+    };
+
+    const submitted = transitionChatStreamHost(parked, {
+      type: "SUBMIT",
+      intent: intent("late"),
+      queueOnly: true,
+    });
+
+    expect(submitted.kind).toBe("applied");
+    if (submitted.kind !== "applied") return;
+    expect(submitted.state).toBe(parked);
+    expect(submitted.commands).toEqual([
+      {
+        type: "persist-queued",
+        intent: intent("late"),
+        resumeQueue: false,
+      },
     ]);
   });
 
@@ -225,12 +296,29 @@ describe("transitionChatStreamHost", () => {
     });
     expect(resumed.kind).toBe("applied");
     if (resumed.kind !== "applied") return;
+    expect(resumed.state.pendingQueueResumeMutationId).toBe(
+      "resume-after-stop",
+    );
     expect(resumed.state.active).toMatchObject({
+      pauseQueueOnCancel: true,
+    });
+
+    const confirmed = transitionChatStreamHost(resumed.state, {
+      type: "QUEUE_MUTATED",
+      mutationId: "resume-after-stop",
+      queueRevision: resumed.state.queueRevision + 1,
+      paused: false,
+      entries: [],
+    });
+    expect(confirmed.kind).toBe("applied");
+    if (confirmed.kind !== "applied") return;
+    expect(confirmed.state.pendingQueueResumeMutationId).toBeNull();
+    expect(confirmed.state.active).toMatchObject({
       pauseQueueOnCancel: false,
       queueResumedAfterCancel: true,
     });
 
-    const ended = transitionChatStreamHost(resumed.state, {
+    const ended = transitionChatStreamHost(confirmed.state, {
       type: "STREAM_ENDED",
       intentId: activeIntent.intentId,
       invocationRef: activeIntent.invocationRef!,
@@ -257,6 +345,48 @@ describe("transitionChatStreamHost", () => {
         },
       },
     ]);
+  });
+
+  it("retains the Stop latch when an explicit queue resume is rejected", () => {
+    const activeIntent = intent("active");
+    const state = {
+      ...initialChatStreamHostState({
+        queueRevision: 4,
+        queuePaused: true,
+        queue: [],
+      }),
+      phase: "cancelling" as const,
+      active: {
+        intent: activeIntent,
+        invocationRef: activeIntent.invocationRef!,
+        targetAppId: 3,
+        pauseQueueOnCancel: true,
+        queueResumedAfterCancel: false,
+      },
+    };
+    const requested = transitionChatStreamHost(state, {
+      type: "RESUME_QUEUE",
+      expectedQueueRevision: 4,
+      mutationId: "failed-resume",
+    });
+    expect(requested.kind).toBe("applied");
+    if (requested.kind !== "applied") return;
+
+    const rejected = transitionChatStreamHost(requested.state, {
+      type: "QUEUE_MUTATION_REJECTED",
+      mutationId: "failed-resume",
+      error: "revision conflict",
+      queueRevision: 4,
+      paused: true,
+      entries: [],
+    });
+    expect(rejected.kind).toBe("applied");
+    if (rejected.kind !== "applied") return;
+    expect(rejected.state.pendingQueueResumeMutationId).toBeNull();
+    expect(rejected.state.active).toMatchObject({
+      pauseQueueOnCancel: true,
+      queueResumedAfterCancel: false,
+    });
   });
 
   it("preserves a genuine response pause after the Stop latch is resumed", () => {

--- a/src/chat_stream/host_transition.test.ts
+++ b/src/chat_stream/host_transition.test.ts
@@ -112,6 +112,7 @@ describe("transitionChatStreamHost", () => {
         type: "persist-queued",
         intent: intent("late"),
         resumeQueue: true,
+        observedStopPolicyVersion: 0,
       },
     ]);
 
@@ -129,6 +130,7 @@ describe("transitionChatStreamHost", () => {
       queueRevision: 5,
       queuePaused: false,
       resumeQueue: true,
+      observedStopPolicyVersion: 0,
     });
     expect(queued.kind).toBe("applied");
     if (queued.kind !== "applied") return;
@@ -161,6 +163,7 @@ describe("transitionChatStreamHost", () => {
         type: "persist-queued",
         intent: intent("late"),
         resumeQueue: false,
+        observedStopPolicyVersion: 0,
       },
     ]);
   });
@@ -187,8 +190,88 @@ describe("transitionChatStreamHost", () => {
         type: "persist-queued",
         intent: intent("after-stop"),
         resumeQueue: true,
+        observedStopPolicyVersion: 2,
       },
     ]);
+  });
+
+  it("does not let an older queued admission clear a newer Stop", () => {
+    const parked = {
+      ...initialChatStreamHostState(),
+      queuePaused: true,
+      queuePauseReason: "stop" as const,
+      stopPolicyVersion: 1,
+      lastStopId: "stop-1",
+    };
+    const submitted = transitionChatStreamHost(parked, {
+      type: "SUBMIT",
+      intent: intent("after-stop-1"),
+      observedStopPolicyVersion: 1,
+    });
+    expect(submitted.kind).toBe("applied");
+    if (submitted.kind !== "applied") return;
+
+    const stoppedAgain = transitionChatStreamHost(submitted.state, {
+      type: "CANCEL",
+      invocationRef: intent("stale").invocationRef!,
+      pauseQueue: true,
+      stopId: "stop-2",
+      observedStopPolicyVersion: 1,
+    });
+    expect(stoppedAgain.kind).toBe("applied");
+    if (stoppedAgain.kind !== "applied") return;
+
+    const queued = transitionChatStreamHost(stoppedAgain.state, {
+      type: "ADMISSION_QUEUED",
+      intentId: "after-stop-1",
+      entry: {
+        itemId: "after-stop-1",
+        intentId: "after-stop-1",
+        prompt: "Build it",
+        persistence: "durable",
+        editable: true,
+        removable: true,
+      },
+      queueRevision: 1,
+      queuePaused: false,
+      resumeQueue: true,
+      observedStopPolicyVersion: 1,
+    });
+
+    expect(queued.kind).toBe("applied");
+    if (queued.kind !== "applied") return;
+    expect(queued.state).toMatchObject({
+      stopPolicyVersion: 2,
+      queuePaused: true,
+      queuePauseReason: "stop",
+    });
+    expect(queued.commands).toEqual([]);
+
+    const replayed = transitionChatStreamHost(stoppedAgain.state, {
+      type: "QUEUE_MUTATED",
+      queueRevision: 1,
+      paused: false,
+      entries: [
+        {
+          itemId: "after-stop-1",
+          intentId: "after-stop-1",
+          prompt: "Build it",
+          persistence: "durable",
+          editable: true,
+          removable: true,
+        },
+      ],
+      resumeQueue: true,
+      observedStopPolicyVersion: 1,
+    });
+    expect(replayed.kind).toBe("applied");
+    if (replayed.kind !== "applied") return;
+    expect(replayed.state).toMatchObject({
+      stopPolicyVersion: 2,
+      queuePaused: true,
+      queuePauseReason: "stop",
+    });
+    expect(replayed.commands).toEqual([]);
   });
 
   it("does not resume a Stop-parked queue without an observed policy version", () => {

--- a/src/chat_stream/host_transition.ts
+++ b/src/chat_stream/host_transition.ts
@@ -149,10 +149,22 @@ export function transitionChatStreamHost(
     }
     case "CANCEL":
       if (!state.active) {
-        return ignore(state, "not-cancellable");
+        return event.pauseQueue
+          ? {
+              kind: "applied",
+              state: { ...state, queuePaused: true },
+              commands: [{ type: "park-queue" }],
+            }
+          : ignore(state, "not-cancellable");
       }
       if (!sameInvocationRef(state.active.invocationRef, event.invocationRef)) {
-        return ignore(state, "stale-invocation");
+        return event.pauseQueue
+          ? {
+              kind: "applied",
+              state: { ...state, queuePaused: true },
+              commands: [{ type: "park-queue" }],
+            }
+          : ignore(state, "stale-invocation");
       }
       if (
         state.phase !== "admitting" &&
@@ -591,6 +603,7 @@ export function transitionChatStreamHost(
               ? reviewCommands
               : pendingQueueMutationId === null &&
                   !event.paused &&
+                  !state.active?.pauseQueueOnCancel &&
                   event.entries.length > 0 &&
                   (state.phase === "idle" || state.phase === "finalizing")
                 ? [{ type: "dispatch-next" }]
@@ -711,6 +724,9 @@ export function transitionChatStreamHost(
         commands: [],
       };
     case "QUEUE_PARKED":
+      if (event.queueRevision < state.queueRevision) {
+        return ignore(state, "invalid-host-event");
+      }
       return {
         kind: "applied",
         state: {
@@ -722,6 +738,9 @@ export function transitionChatStreamHost(
         commands: [],
       };
     case "QUEUE_PARK_FAILED":
+      if (event.queueRevision < state.queueRevision) {
+        return ignore(state, "invalid-host-event");
+      }
       return {
         kind: "applied",
         state: {

--- a/src/chat_stream/host_transition.ts
+++ b/src/chat_stream/host_transition.ts
@@ -74,7 +74,12 @@ function queueMutation(
     event.type === "PAUSE_QUEUE"
       ? { type: "pause" }
       : event.type === "RESUME_QUEUE"
-        ? { type: "resume" }
+        ? {
+            type: "resume",
+            preserveStopPause:
+              state.queuePauseReason === "stop" &&
+              state.active?.pauseQueueOnCancel !== true,
+          }
         : event.type === "EDIT_QUEUE_ENTRY"
           ? {
               type: "edit",
@@ -110,6 +115,10 @@ function queueMutation(
         mutation,
         expectedQueueRevision: event.expectedQueueRevision,
         mutationId: event.mutationId,
+        ...(event.type === "RESUME_QUEUE" &&
+        event.observedStopPolicyVersion !== undefined
+          ? { observedStopPolicyVersion: event.observedStopPolicyVersion }
+          : {}),
       },
     ],
   };
@@ -653,7 +662,8 @@ export function transitionChatStreamHost(
               : [];
         const resumeStopLatch =
           event.mutationId === state.pendingQueueResumeMutationId &&
-          !event.paused;
+          !event.paused &&
+          event.observedStopPolicyVersion === state.stopPolicyVersion;
         const queuedAdmissionResumesCurrentStop =
           event.resumeQueue === true &&
           event.observedStopPolicyVersion === state.stopPolicyVersion;

--- a/src/chat_stream/host_transition.ts
+++ b/src/chat_stream/host_transition.ts
@@ -86,7 +86,19 @@ function queueMutation(
               : { type: "clear" };
   return {
     kind: "applied",
-    state: { ...state, pendingQueueMutationId: event.mutationId },
+    state: {
+      ...state,
+      pendingQueueMutationId: event.mutationId,
+      ...(event.type === "RESUME_QUEUE" && state.active?.pauseQueueOnCancel
+        ? {
+            active: {
+              ...state.active,
+              pauseQueueOnCancel: false,
+              queueResumedAfterCancel: true,
+            },
+          }
+        : {}),
+    },
     commands: [
       {
         type: "mutate-queue",
@@ -187,6 +199,9 @@ export function transitionChatStreamHost(
               ...state.active,
               pauseQueueOnCancel:
                 shouldParkQueue || state.active.pauseQueueOnCancel,
+              queueResumedAfterCancel: shouldParkQueue
+                ? false
+                : state.active.queueResumedAfterCancel,
             },
           },
           commands: [
@@ -400,8 +415,9 @@ export function transitionChatStreamHost(
       }
       {
         const pausePromptQueue =
-          event.response.pausePromptQueue === true ||
-          state.active.pauseQueueOnCancel;
+          !state.active.queueResumedAfterCancel &&
+          (event.response.pausePromptQueue === true ||
+            state.active.pauseQueueOnCancel);
         return {
           kind: "applied",
           state: {

--- a/src/chat_stream/host_transition.ts
+++ b/src/chat_stream/host_transition.ts
@@ -22,6 +22,8 @@ export function initialChatStreamHostState(input?: {
     queueRevision: input?.queueRevision ?? 0,
     queuePaused: input?.queuePaused ?? false,
     queue: input?.queue ?? [],
+    stopPolicyVersion: 0,
+    lastStopId: null,
     lastAcceptance: null,
     lastCompletion: null,
     pendingQueueMutationId: null,
@@ -116,10 +118,13 @@ export function transitionChatStreamHost(
 > {
   switch (event.type) {
     case "SUBMIT": {
+      const predatesLatestStop =
+        event.observedStopPolicyVersion !== undefined &&
+        event.observedStopPolicyVersion < state.stopPolicyVersion;
       if (
         (state.phase === "idle" || state.phase === "errored") &&
         !state.queuePaused &&
-        event.queueOnly !== true
+        !predatesLatestStop
       ) {
         const invocationRef = event.intent.invocationRef;
         if (!invocationRef) {
@@ -161,28 +166,38 @@ export function transitionChatStreamHost(
             type: "persist-queued",
             intent: event.intent,
             resumeQueue:
-              event.queueOnly !== true &&
+              !predatesLatestStop &&
               state.queuePaused &&
               (state.phase === "idle" || state.phase === "errored"),
           },
         ],
       };
     }
-    case "CANCEL":
+    case "CANCEL": {
+      const isNewStop =
+        event.pauseQueue === true &&
+        (event.stopId === undefined || event.stopId !== state.lastStopId);
+      const stoppedState = isNewStop
+        ? {
+            ...state,
+            stopPolicyVersion: state.stopPolicyVersion + 1,
+            lastStopId: event.stopId ?? null,
+          }
+        : state;
       if (!state.active) {
-        return event.pauseQueue
+        return isNewStop
           ? {
               kind: "applied",
-              state,
+              state: stoppedState,
               commands: [{ type: "park-queue" }],
             }
           : ignore(state, "not-cancellable");
       }
       if (!sameInvocationRef(state.active.invocationRef, event.invocationRef)) {
-        return event.pauseQueue
+        return isNewStop
           ? {
               kind: "applied",
-              state,
+              state: stoppedState,
               commands: [{ type: "park-queue" }],
             }
           : ignore(state, "stale-invocation");
@@ -190,14 +205,14 @@ export function transitionChatStreamHost(
       if (
         state.phase !== "admitting" &&
         state.phase !== "streaming" &&
-        !event.pauseQueue
+        !isNewStop
       ) {
         return ignore(state, "not-cancellable");
       }
       {
         const shouldCancelActive =
           state.phase === "admitting" || state.phase === "streaming";
-        const shouldParkQueue = event.pauseQueue === true;
+        const shouldParkQueue = isNewStop;
         const shouldUpdateStopPolicy =
           shouldParkQueue &&
           (!state.active.pauseQueueOnCancel ||
@@ -207,7 +222,7 @@ export function transitionChatStreamHost(
           state:
             shouldCancelActive || shouldUpdateStopPolicy
               ? {
-                  ...state,
+                  ...stoppedState,
                   phase: shouldCancelActive ? "cancelling" : state.phase,
                   active: {
                     ...state.active,
@@ -218,7 +233,7 @@ export function transitionChatStreamHost(
                       : state.active.queueResumedAfterCancel,
                   },
                 }
-              : state,
+              : stoppedState,
           commands: [
             ...(shouldParkQueue ? [{ type: "park-queue" as const }] : []),
             ...(shouldCancelActive
@@ -232,6 +247,7 @@ export function transitionChatStreamHost(
           ],
         };
       }
+    }
     case "REPORT_ERROR":
       return {
         kind: "applied",

--- a/src/chat_stream/host_transition.ts
+++ b/src/chat_stream/host_transition.ts
@@ -70,6 +70,24 @@ function queueMutation(
   const resumesCurrentStop =
     event.type === "RESUME_QUEUE" &&
     event.observedStopPolicyVersion === state.stopPolicyVersion;
+  if (
+    event.type === "RESUME_QUEUE" &&
+    state.queuePauseReason === "stop" &&
+    !resumesCurrentStop
+  ) {
+    return {
+      kind: "applied",
+      state: {
+        ...state,
+        lastQueueMutation: {
+          mutationId: event.mutationId,
+          outcome: "rejected",
+          error: "A newer Stop changed the queue; try resuming again.",
+        },
+      },
+      commands: [],
+    };
+  }
   const mutation: Extract<
     ChatStreamHostCommand,
     { type: "mutate-queue" }
@@ -523,7 +541,6 @@ export function transitionChatStreamHost(
               type: "finalize",
               intentId: event.intentId,
               response: event.response,
-              ...(pausePromptQueue ? { pausePromptQueue: true } : {}),
             },
           ],
         };
@@ -674,6 +691,9 @@ export function transitionChatStreamHost(
           event.observedStopPolicyVersion === state.stopPolicyVersion;
         const resumesCurrentStop =
           resumeStopLatch || queuedAdmissionResumesCurrentStop;
+        const staleStopResume =
+          event.mutationId === state.pendingQueueResumeMutationId &&
+          event.observedStopPolicyVersion !== state.stopPolicyVersion;
         const stopOwnsQueue =
           state.queuePauseReason === "stop" ||
           state.active?.pauseQueueOnCancel === true;
@@ -720,7 +740,13 @@ export function transitionChatStreamHost(
               ? {
                   lastQueueMutation: {
                     mutationId: event.mutationId,
-                    outcome: "applied" as const,
+                    ...(staleStopResume
+                      ? {
+                          outcome: "rejected" as const,
+                          error:
+                            "A newer Stop changed the queue; try resuming again.",
+                        }
+                      : { outcome: "applied" as const }),
                   },
                 }
               : {}),

--- a/src/chat_stream/host_transition.ts
+++ b/src/chat_stream/host_transition.ts
@@ -164,7 +164,7 @@ export function transitionChatStreamHost(
         return event.pauseQueue
           ? {
               kind: "applied",
-              state: { ...state, queuePaused: true },
+              state,
               commands: [{ type: "park-queue" }],
             }
           : ignore(state, "not-cancellable");
@@ -173,7 +173,7 @@ export function transitionChatStreamHost(
         return event.pauseQueue
           ? {
               kind: "applied",
-              state: { ...state, queuePaused: true },
+              state,
               commands: [{ type: "park-queue" }],
             }
           : ignore(state, "stale-invocation");
@@ -194,7 +194,6 @@ export function transitionChatStreamHost(
           state: {
             ...state,
             phase: shouldCancelActive ? "cancelling" : state.phase,
-            queuePaused: shouldParkQueue || state.queuePaused,
             active: {
               ...state.active,
               pauseQueueOnCancel:
@@ -415,8 +414,8 @@ export function transitionChatStreamHost(
       }
       {
         const pausePromptQueue =
-          !state.active.queueResumedAfterCancel &&
-          (event.response.pausePromptQueue === true ||
+          event.response.pausePromptQueue === true ||
+          (!state.active.queueResumedAfterCancel &&
             state.active.pauseQueueOnCancel);
         return {
           kind: "applied",

--- a/src/chat_stream/host_transition.ts
+++ b/src/chat_stream/host_transition.ts
@@ -125,6 +125,9 @@ export function transitionChatStreamHost(
       const predatesLatestStop =
         event.observedStopPolicyVersion !== undefined &&
         event.observedStopPolicyVersion < state.stopPolicyVersion;
+      const observesLatestStop =
+        event.observedStopPolicyVersion !== undefined &&
+        event.observedStopPolicyVersion >= state.stopPolicyVersion;
       const replaysQueuedIntent = state.queue.some(
         (entry) => entry.intentId === event.intent.intentId,
       );
@@ -174,10 +177,10 @@ export function transitionChatStreamHost(
             type: "persist-queued",
             intent: event.intent,
             resumeQueue:
-              !predatesLatestStop &&
+              observesLatestStop &&
               state.queuePaused &&
               (state.phase === "idle" || state.phase === "errored") &&
-              (state.queuePauseReason === "stop" || replaysQueuedIntent),
+              state.queuePauseReason === "stop",
           },
         ],
       };
@@ -305,14 +308,23 @@ export function transitionChatStreamHost(
         },
         commands: [],
       };
-    case "ADMISSION_QUEUED":
+    case "ADMISSION_QUEUED": {
+      const stopOwnsQueue =
+        state.queuePauseReason === "stop" ||
+        state.active?.pauseQueueOnCancel === true;
+      const queuePaused =
+        event.queuePaused || (stopOwnsQueue && !event.resumeQueue);
       return {
         kind: "applied",
         state: {
           ...state,
           queueRevision: event.queueRevision,
-          queuePaused: event.queuePaused,
-          queuePauseReason: event.queuePaused ? state.queuePauseReason : null,
+          queuePaused,
+          queuePauseReason: queuePaused
+            ? stopOwnsQueue
+              ? "stop"
+              : state.queuePauseReason
+            : null,
           queue: [...state.queue, event.entry],
           lastAcceptance: {
             intentId: event.intentId,
@@ -320,11 +332,11 @@ export function transitionChatStreamHost(
           },
         },
         commands:
-          !event.queuePaused &&
-          (state.phase === "idle" || state.phase === "errored")
+          !queuePaused && (state.phase === "idle" || state.phase === "errored")
             ? [{ type: "dispatch-next" }]
             : [],
       };
+    }
     case "ADMISSION_REPLAYED":
       if (
         state.active?.intent.intentId === event.intentId &&
@@ -626,7 +638,7 @@ export function transitionChatStreamHost(
                         ? "queued-override"
                         : "user-setting",
                   },
-              ]
+                ]
               : [];
         const resumeStopLatch =
           event.mutationId === state.pendingQueueResumeMutationId &&
@@ -649,9 +661,7 @@ export function transitionChatStreamHost(
               : event.mutationId === undefined &&
                   state.lastCompletion?.pausePromptQueue === true
                 ? ("step-limit" as const)
-                : state.active?.pauseQueueOnCancel
-                  ? ("stop" as const)
-                  : state.queuePauseReason;
+                : state.queuePauseReason;
         return {
           kind: "applied",
           state: {
@@ -798,31 +808,40 @@ export function transitionChatStreamHost(
       if (event.mutationId !== state.pendingQueueMutationId) {
         return ignore(state, "invalid-host-event");
       }
-      return {
-        kind: "applied",
-        state: {
-          ...state,
-          queueRevision: event.queueRevision,
-          queuePaused: event.paused,
-          queuePauseReason: event.paused ? state.queuePauseReason : null,
-          queue: event.entries,
-          pendingQueueMutationId: null,
-          pendingQueuePauseMutationId:
-            event.mutationId === state.pendingQueuePauseMutationId
-              ? null
-              : state.pendingQueuePauseMutationId,
-          pendingQueueResumeMutationId:
-            event.mutationId === state.pendingQueueResumeMutationId
-              ? null
-              : state.pendingQueueResumeMutationId,
-          lastQueueMutation: {
-            mutationId: event.mutationId,
-            outcome: "rejected",
-            error: event.error,
+      {
+        const stopOwnsQueue =
+          state.queuePauseReason === "stop" ||
+          state.active?.pauseQueueOnCancel === true;
+        return {
+          kind: "applied",
+          state: {
+            ...state,
+            queueRevision: event.queueRevision,
+            queuePaused: stopOwnsQueue || event.paused,
+            queuePauseReason: stopOwnsQueue
+              ? "stop"
+              : event.paused
+                ? state.queuePauseReason
+                : null,
+            queue: event.entries,
+            pendingQueueMutationId: null,
+            pendingQueuePauseMutationId:
+              event.mutationId === state.pendingQueuePauseMutationId
+                ? null
+                : state.pendingQueuePauseMutationId,
+            pendingQueueResumeMutationId:
+              event.mutationId === state.pendingQueueResumeMutationId
+                ? null
+                : state.pendingQueueResumeMutationId,
+            lastQueueMutation: {
+              mutationId: event.mutationId,
+              outcome: "rejected",
+              error: event.error,
+            },
           },
-        },
-        commands: [],
-      };
+          commands: [],
+        };
+      }
     case "QUEUE_PARKED":
       if (event.queueRevision < state.queueRevision) {
         return ignore(state, "invalid-host-event");

--- a/src/chat_stream/host_transition.ts
+++ b/src/chat_stream/host_transition.ts
@@ -148,29 +148,48 @@ export function transitionChatStreamHost(
       };
     }
     case "CANCEL":
-      if (
-        !state.active ||
-        (state.phase !== "admitting" && state.phase !== "streaming")
-      ) {
+      if (!state.active) {
         return ignore(state, "not-cancellable");
       }
       if (!sameInvocationRef(state.active.invocationRef, event.invocationRef)) {
         return ignore(state, "stale-invocation");
       }
-      return {
-        kind: "applied",
-        state: {
-          ...state,
-          phase: "cancelling",
-          active: {
-            ...state.active,
-            pauseQueueOnCancel: event.pauseQueue === true,
+      if (
+        state.phase !== "admitting" &&
+        state.phase !== "streaming" &&
+        !event.pauseQueue
+      ) {
+        return ignore(state, "not-cancellable");
+      }
+      {
+        const shouldCancelActive =
+          state.phase === "admitting" || state.phase === "streaming";
+        const shouldParkQueue = event.pauseQueue === true;
+        return {
+          kind: "applied",
+          state: {
+            ...state,
+            phase: shouldCancelActive ? "cancelling" : state.phase,
+            queuePaused: shouldParkQueue || state.queuePaused,
+            active: {
+              ...state.active,
+              pauseQueueOnCancel:
+                shouldParkQueue || state.active.pauseQueueOnCancel,
+            },
           },
-        },
-        commands: [
-          { type: "cancel-active", invocationRef: event.invocationRef },
-        ],
-      };
+          commands: [
+            ...(shouldParkQueue ? [{ type: "park-queue" as const }] : []),
+            ...(shouldCancelActive
+              ? [
+                  {
+                    type: "cancel-active" as const,
+                    invocationRef: event.invocationRef,
+                  },
+                ]
+              : []),
+          ],
+        };
+      }
     case "REPORT_ERROR":
       return {
         kind: "applied",
@@ -381,7 +400,7 @@ export function transitionChatStreamHost(
               invocationRef: event.invocationRef,
               outcome: event.response.wasCancelled ? "cancelled" : "completed",
               chatSummary: event.response.chatSummary,
-              pausePromptQueue,
+              ...(pausePromptQueue ? { pausePromptQueue: true } : {}),
               reviewBarrierRequested: event.response.reviewBarrierRequested,
               updatedFiles: event.response.updatedFiles,
               extraFiles: event.response.extraFiles,
@@ -691,6 +710,29 @@ export function transitionChatStreamHost(
         },
         commands: [],
       };
+    case "QUEUE_PARKED":
+      return {
+        kind: "applied",
+        state: {
+          ...state,
+          queueRevision: event.queueRevision,
+          queuePaused: true,
+          queue: event.entries,
+        },
+        commands: [],
+      };
+    case "QUEUE_PARK_FAILED":
+      return {
+        kind: "applied",
+        state: {
+          ...state,
+          error: event.error,
+          queueRevision: event.queueRevision,
+          queuePaused: event.paused,
+          queue: event.entries,
+        },
+        commands: [],
+      };
     case "LIFECYCLE_COMMAND_FAILED":
       if (
         !state.active ||
@@ -707,7 +749,7 @@ export function transitionChatStreamHost(
           active: null,
           error: event.error,
           queueRevision: event.queueRevision,
-          queuePaused: event.paused,
+          queuePaused: state.active.pauseQueueOnCancel || event.paused,
           queue: event.entries,
           lastCompletion: {
             intentId: event.intentId,
@@ -717,7 +759,9 @@ export function transitionChatStreamHost(
             targetAppId: state.active.targetAppId,
           },
         },
-        commands: [],
+        commands: state.active.pauseQueueOnCancel
+          ? [{ type: "park-queue" }]
+          : [],
       };
   }
 }

--- a/src/chat_stream/host_transition.ts
+++ b/src/chat_stream/host_transition.ts
@@ -185,6 +185,8 @@ export function transitionChatStreamHost(
     case "CANCEL": {
       const isNewStop =
         event.pauseQueue === true &&
+        (event.observedStopPolicyVersion === undefined ||
+          event.observedStopPolicyVersion >= state.stopPolicyVersion) &&
         (event.stopId === undefined || event.stopId !== state.lastStopId);
       const stoppedState = isNewStop
         ? {

--- a/src/chat_stream/host_transition.ts
+++ b/src/chat_stream/host_transition.ts
@@ -193,6 +193,8 @@ export function transitionChatStreamHost(
             ...state,
             stopPolicyVersion: state.stopPolicyVersion + 1,
             lastStopId: event.stopId ?? null,
+            queuePauseReason: "stop" as const,
+            pendingQueuePauseMutationId: null,
           }
         : state;
       if (!state.active) {
@@ -639,14 +641,17 @@ export function transitionChatStreamHost(
             : state.active;
         const queuePauseReason = !event.paused
           ? null
-          : event.mutationId === state.pendingQueuePauseMutationId
-            ? ("manual" as const)
-            : event.mutationId === undefined &&
-                state.lastCompletion?.pausePromptQueue === true
-              ? ("step-limit" as const)
-              : state.active?.pauseQueueOnCancel
-                ? ("stop" as const)
-                : state.queuePauseReason;
+          : state.queuePauseReason === "stop" ||
+              state.active?.pauseQueueOnCancel
+            ? ("stop" as const)
+            : event.mutationId === state.pendingQueuePauseMutationId
+              ? ("manual" as const)
+              : event.mutationId === undefined &&
+                  state.lastCompletion?.pausePromptQueue === true
+                ? ("step-limit" as const)
+                : state.active?.pauseQueueOnCancel
+                  ? ("stop" as const)
+                  : state.queuePauseReason;
         return {
           kind: "applied",
           state: {

--- a/src/chat_stream/host_transition.ts
+++ b/src/chat_stream/host_transition.ts
@@ -13,6 +13,7 @@ export type ChatStreamHostIgnoreReason =
 export function initialChatStreamHostState(input?: {
   queueRevision: number;
   queuePaused: boolean;
+  queuePauseReason?: ChatStreamHostState["queuePauseReason"];
   queue: ChatStreamHostState["queue"];
 }): ChatStreamHostState {
   return {
@@ -21,7 +22,9 @@ export function initialChatStreamHostState(input?: {
     error: null,
     queueRevision: input?.queueRevision ?? 0,
     queuePaused: input?.queuePaused ?? false,
-    queuePauseReason: input?.queuePaused ? "manual" : null,
+    queuePauseReason: input?.queuePaused
+      ? (input.queuePauseReason ?? "manual")
+      : null,
     queue: input?.queue ?? [],
     stopPolicyVersion: 0,
     lastStopId: null,
@@ -176,6 +179,11 @@ export function transitionChatStreamHost(
           {
             type: "persist-queued",
             intent: event.intent,
+            ...(event.observedStopPolicyVersion === undefined
+              ? {}
+              : {
+                  observedStopPolicyVersion: event.observedStopPolicyVersion,
+                }),
             resumeQueue:
               observesLatestStop &&
               state.queuePaused &&
@@ -312,8 +320,11 @@ export function transitionChatStreamHost(
       const stopOwnsQueue =
         state.queuePauseReason === "stop" ||
         state.active?.pauseQueueOnCancel === true;
+      const resumesCurrentStop =
+        event.resumeQueue &&
+        event.observedStopPolicyVersion === state.stopPolicyVersion;
       const queuePaused =
-        event.queuePaused || (stopOwnsQueue && !event.resumeQueue);
+        event.queuePaused || (stopOwnsQueue && !resumesCurrentStop);
       return {
         kind: "applied",
         state: {
@@ -643,6 +654,16 @@ export function transitionChatStreamHost(
         const resumeStopLatch =
           event.mutationId === state.pendingQueueResumeMutationId &&
           !event.paused;
+        const queuedAdmissionResumesCurrentStop =
+          event.resumeQueue === true &&
+          event.observedStopPolicyVersion === state.stopPolicyVersion;
+        const resumesCurrentStop =
+          resumeStopLatch || queuedAdmissionResumesCurrentStop;
+        const stopOwnsQueue =
+          state.queuePauseReason === "stop" ||
+          state.active?.pauseQueueOnCancel === true;
+        const queuePaused =
+          event.paused || (stopOwnsQueue && !resumesCurrentStop);
         const active =
           resumeStopLatch && state.active
             ? {
@@ -651,10 +672,9 @@ export function transitionChatStreamHost(
                 queueResumedAfterCancel: true,
               }
             : state.active;
-        const queuePauseReason = !event.paused
+        const queuePauseReason = !queuePaused
           ? null
-          : state.queuePauseReason === "stop" ||
-              state.active?.pauseQueueOnCancel
+          : stopOwnsQueue && !resumesCurrentStop
             ? ("stop" as const)
             : event.mutationId === state.pendingQueuePauseMutationId
               ? ("manual" as const)
@@ -667,7 +687,7 @@ export function transitionChatStreamHost(
           state: {
             ...state,
             queueRevision: event.queueRevision,
-            queuePaused: event.paused,
+            queuePaused,
             queuePauseReason,
             queue: event.entries,
             pendingQueueMutationId,
@@ -703,7 +723,7 @@ export function transitionChatStreamHost(
             reviewCommands.length > 0
               ? reviewCommands
               : pendingQueueMutationId === null &&
-                  !event.paused &&
+                  !queuePaused &&
                   !active?.pauseQueueOnCancel &&
                   event.entries.length > 0 &&
                   (state.phase === "idle" || state.phase === "finalizing")

--- a/src/chat_stream/host_transition.ts
+++ b/src/chat_stream/host_transition.ts
@@ -783,7 +783,7 @@ export function transitionChatStreamHost(
           active: null,
           error: event.error,
           queueRevision: event.queueRevision,
-          queuePaused: state.active.pauseQueueOnCancel || event.paused,
+          queuePaused: event.paused,
           queue: event.entries,
           lastCompletion: {
             intentId: event.intentId,

--- a/src/chat_stream/host_transition.ts
+++ b/src/chat_stream/host_transition.ts
@@ -236,6 +236,7 @@ export function transitionChatStreamHost(
             ...state,
             stopPolicyVersion: state.stopPolicyVersion + 1,
             lastStopId: event.stopId ?? null,
+            queuePaused: true,
             queuePauseReason: "stop" as const,
             pendingQueuePauseMutationId: null,
           }

--- a/src/chat_stream/host_transition.ts
+++ b/src/chat_stream/host_transition.ts
@@ -25,6 +25,7 @@ export function initialChatStreamHostState(input?: {
     lastAcceptance: null,
     lastCompletion: null,
     pendingQueueMutationId: null,
+    pendingQueueResumeMutationId: null,
     lastQueueMutation: null,
     reviewBarrier: {
       phase: "idle",
@@ -89,15 +90,10 @@ function queueMutation(
     state: {
       ...state,
       pendingQueueMutationId: event.mutationId,
-      ...(event.type === "RESUME_QUEUE" && state.active?.pauseQueueOnCancel
-        ? {
-            active: {
-              ...state.active,
-              pauseQueueOnCancel: false,
-              queueResumedAfterCancel: true,
-            },
-          }
-        : {}),
+      pendingQueueResumeMutationId:
+        event.type === "RESUME_QUEUE" && state.active?.pauseQueueOnCancel
+          ? event.mutationId
+          : null,
     },
     commands: [
       {
@@ -122,7 +118,8 @@ export function transitionChatStreamHost(
     case "SUBMIT": {
       if (
         (state.phase === "idle" || state.phase === "errored") &&
-        !state.queuePaused
+        !state.queuePaused &&
+        event.queueOnly !== true
       ) {
         const invocationRef = event.intent.invocationRef;
         if (!invocationRef) {
@@ -159,7 +156,16 @@ export function transitionChatStreamHost(
       return {
         kind: "applied",
         state,
-        commands: [{ type: "persist-queued", intent: event.intent }],
+        commands: [
+          {
+            type: "persist-queued",
+            intent: event.intent,
+            resumeQueue:
+              event.queueOnly !== true &&
+              state.queuePaused &&
+              (state.phase === "idle" || state.phase === "errored"),
+          },
+        ],
       };
     }
     case "CANCEL":
@@ -192,20 +198,27 @@ export function transitionChatStreamHost(
         const shouldCancelActive =
           state.phase === "admitting" || state.phase === "streaming";
         const shouldParkQueue = event.pauseQueue === true;
+        const shouldUpdateStopPolicy =
+          shouldParkQueue &&
+          (!state.active.pauseQueueOnCancel ||
+            state.active.queueResumedAfterCancel === true);
         return {
           kind: "applied",
-          state: {
-            ...state,
-            phase: shouldCancelActive ? "cancelling" : state.phase,
-            active: {
-              ...state.active,
-              pauseQueueOnCancel:
-                shouldParkQueue || state.active.pauseQueueOnCancel,
-              queueResumedAfterCancel: shouldParkQueue
-                ? false
-                : state.active.queueResumedAfterCancel,
-            },
-          },
+          state:
+            shouldCancelActive || shouldUpdateStopPolicy
+              ? {
+                  ...state,
+                  phase: shouldCancelActive ? "cancelling" : state.phase,
+                  active: {
+                    ...state.active,
+                    pauseQueueOnCancel:
+                      shouldParkQueue || state.active.pauseQueueOnCancel,
+                    queueResumedAfterCancel: shouldParkQueue
+                      ? false
+                      : state.active.queueResumedAfterCancel,
+                  },
+                }
+              : state,
           commands: [
             ...(shouldParkQueue ? [{ type: "park-queue" as const }] : []),
             ...(shouldCancelActive
@@ -269,13 +282,19 @@ export function transitionChatStreamHost(
         state: {
           ...state,
           queueRevision: event.queueRevision,
+          queuePaused: event.queuePaused,
           queue: [...state.queue, event.entry],
           lastAcceptance: {
             intentId: event.intentId,
             acceptance: "queued",
           },
         },
-        commands: [],
+        commands:
+          event.resumeQueue &&
+          !event.queuePaused &&
+          (state.phase === "idle" || state.phase === "errored")
+            ? [{ type: "dispatch-next" }]
+            : [],
       };
     case "ADMISSION_REPLAYED":
       if (
@@ -587,8 +606,19 @@ export function transitionChatStreamHost(
                         ? "queued-override"
                         : "user-setting",
                   },
-                ]
+              ]
               : [];
+        const resumeStopLatch =
+          event.mutationId === state.pendingQueueResumeMutationId &&
+          !event.paused;
+        const active =
+          resumeStopLatch && state.active
+            ? {
+                ...state.active,
+                pauseQueueOnCancel: false,
+                queueResumedAfterCancel: true,
+              }
+            : state.active;
         return {
           kind: "applied",
           state: {
@@ -598,6 +628,11 @@ export function transitionChatStreamHost(
             queue: event.entries,
             pendingQueueMutationId,
             reviewBarrier,
+            pendingQueueResumeMutationId:
+              event.mutationId === state.pendingQueueResumeMutationId
+                ? null
+                : state.pendingQueueResumeMutationId,
+            active,
             ...(event.mutationId
               ? {
                   lastQueueMutation: {
@@ -621,7 +656,7 @@ export function transitionChatStreamHost(
               ? reviewCommands
               : pendingQueueMutationId === null &&
                   !event.paused &&
-                  !state.active?.pauseQueueOnCancel &&
+                  !active?.pauseQueueOnCancel &&
                   event.entries.length > 0 &&
                   (state.phase === "idle" || state.phase === "finalizing")
                 ? [{ type: "dispatch-next" }]
@@ -733,6 +768,10 @@ export function transitionChatStreamHost(
           queuePaused: event.paused,
           queue: event.entries,
           pendingQueueMutationId: null,
+          pendingQueueResumeMutationId:
+            event.mutationId === state.pendingQueueResumeMutationId
+              ? null
+              : state.pendingQueueResumeMutationId,
           lastQueueMutation: {
             mutationId: event.mutationId,
             outcome: "rejected",

--- a/src/chat_stream/host_transition.ts
+++ b/src/chat_stream/host_transition.ts
@@ -134,6 +134,7 @@ export function transitionChatStreamHost(
               intent: event.intent,
               invocationRef,
               targetAppId: event.intent.appId ?? null,
+              pauseQueueOnCancel: false,
             },
             error: null,
           },
@@ -158,7 +159,14 @@ export function transitionChatStreamHost(
       }
       return {
         kind: "applied",
-        state: { ...state, phase: "cancelling" },
+        state: {
+          ...state,
+          phase: "cancelling",
+          active: {
+            ...state.active,
+            pauseQueueOnCancel: event.pauseQueue === true,
+          },
+        },
         commands: [
           { type: "cancel-active", invocationRef: event.invocationRef },
         ],
@@ -341,7 +349,14 @@ export function transitionChatStreamHost(
           },
         },
         commands: [
-          { type: "finalize", intentId: event.intentId, error: event.error },
+          {
+            type: "finalize",
+            intentId: event.intentId,
+            error: event.error,
+            ...(state.active.pauseQueueOnCancel
+              ? { pausePromptQueue: true }
+              : {}),
+          },
         ],
       };
     case "STREAM_ENDED":
@@ -352,33 +367,39 @@ export function transitionChatStreamHost(
       ) {
         return ignore(state, "stale-invocation");
       }
-      return {
-        kind: "applied",
-        state: {
-          ...state,
-          phase: "finalizing",
-          lastCompletion: {
-            intentId: event.intentId,
-            invocationRef: event.invocationRef,
-            outcome: event.response.wasCancelled ? "cancelled" : "completed",
-            chatSummary: event.response.chatSummary,
-            pausePromptQueue: event.response.pausePromptQueue,
-            reviewBarrierRequested: event.response.reviewBarrierRequested,
-            updatedFiles: event.response.updatedFiles,
-            extraFiles: event.response.extraFiles,
-            extraFilesError: event.response.extraFilesError,
-            warningMessages: event.response.warningMessages,
-            targetAppId: event.targetAppId,
+      {
+        const pausePromptQueue =
+          event.response.pausePromptQueue === true ||
+          state.active.pauseQueueOnCancel;
+        return {
+          kind: "applied",
+          state: {
+            ...state,
+            phase: "finalizing",
+            lastCompletion: {
+              intentId: event.intentId,
+              invocationRef: event.invocationRef,
+              outcome: event.response.wasCancelled ? "cancelled" : "completed",
+              chatSummary: event.response.chatSummary,
+              pausePromptQueue,
+              reviewBarrierRequested: event.response.reviewBarrierRequested,
+              updatedFiles: event.response.updatedFiles,
+              extraFiles: event.response.extraFiles,
+              extraFilesError: event.response.extraFilesError,
+              warningMessages: event.response.warningMessages,
+              targetAppId: event.targetAppId,
+            },
           },
-        },
-        commands: [
-          {
-            type: "finalize",
-            intentId: event.intentId,
-            response: event.response,
-          },
-        ],
-      };
+          commands: [
+            {
+              type: "finalize",
+              intentId: event.intentId,
+              response: event.response,
+              ...(pausePromptQueue ? { pausePromptQueue: true } : {}),
+            },
+          ],
+        };
+      }
     case "STREAM_ERRORED":
       if (
         !state.active ||
@@ -403,7 +424,14 @@ export function transitionChatStreamHost(
           },
         },
         commands: [
-          { type: "finalize", intentId: event.intentId, error: event.error },
+          {
+            type: "finalize",
+            intentId: event.intentId,
+            error: event.error,
+            ...(state.active.pauseQueueOnCancel
+              ? { pausePromptQueue: true }
+              : {}),
+          },
         ],
       };
     case "QUEUE_MUTATED":

--- a/src/chat_stream/host_transition.ts
+++ b/src/chat_stream/host_transition.ts
@@ -21,12 +21,14 @@ export function initialChatStreamHostState(input?: {
     error: null,
     queueRevision: input?.queueRevision ?? 0,
     queuePaused: input?.queuePaused ?? false,
+    queuePauseReason: input?.queuePaused ? "manual" : null,
     queue: input?.queue ?? [],
     stopPolicyVersion: 0,
     lastStopId: null,
     lastAcceptance: null,
     lastCompletion: null,
     pendingQueueMutationId: null,
+    pendingQueuePauseMutationId: null,
     pendingQueueResumeMutationId: null,
     lastQueueMutation: null,
     reviewBarrier: {
@@ -92,6 +94,8 @@ function queueMutation(
     state: {
       ...state,
       pendingQueueMutationId: event.mutationId,
+      pendingQueuePauseMutationId:
+        event.type === "PAUSE_QUEUE" ? event.mutationId : null,
       pendingQueueResumeMutationId:
         event.type === "RESUME_QUEUE" && state.active?.pauseQueueOnCancel
           ? event.mutationId
@@ -121,9 +125,13 @@ export function transitionChatStreamHost(
       const predatesLatestStop =
         event.observedStopPolicyVersion !== undefined &&
         event.observedStopPolicyVersion < state.stopPolicyVersion;
+      const replaysQueuedIntent = state.queue.some(
+        (entry) => entry.intentId === event.intent.intentId,
+      );
       if (
         (state.phase === "idle" || state.phase === "errored") &&
-        !state.queuePaused &&
+        (!state.queuePaused ||
+          (state.queuePauseReason !== "stop" && !replaysQueuedIntent)) &&
         !predatesLatestStop
       ) {
         const invocationRef = event.intent.invocationRef;
@@ -168,7 +176,8 @@ export function transitionChatStreamHost(
             resumeQueue:
               !predatesLatestStop &&
               state.queuePaused &&
-              (state.phase === "idle" || state.phase === "errored"),
+              (state.phase === "idle" || state.phase === "errored") &&
+              (state.queuePauseReason === "stop" || replaysQueuedIntent),
           },
         ],
       };
@@ -299,6 +308,7 @@ export function transitionChatStreamHost(
           ...state,
           queueRevision: event.queueRevision,
           queuePaused: event.queuePaused,
+          queuePauseReason: event.queuePaused ? state.queuePauseReason : null,
           queue: [...state.queue, event.entry],
           lastAcceptance: {
             intentId: event.intentId,
@@ -306,7 +316,6 @@ export function transitionChatStreamHost(
           },
         },
         commands:
-          event.resumeQueue &&
           !event.queuePaused &&
           (state.phase === "idle" || state.phase === "errored")
             ? [{ type: "dispatch-next" }]
@@ -436,9 +445,6 @@ export function transitionChatStreamHost(
             type: "finalize",
             intentId: event.intentId,
             error: event.error,
-            ...(state.active.pauseQueueOnCancel
-              ? { pausePromptQueue: true }
-              : {}),
           },
         ],
       };
@@ -451,10 +457,7 @@ export function transitionChatStreamHost(
         return ignore(state, "stale-invocation");
       }
       {
-        const pausePromptQueue =
-          event.response.pausePromptQueue === true ||
-          (!state.active.queueResumedAfterCancel &&
-            state.active.pauseQueueOnCancel);
+        const pausePromptQueue = event.response.pausePromptQueue === true;
         return {
           kind: "applied",
           state: {
@@ -512,9 +515,6 @@ export function transitionChatStreamHost(
             type: "finalize",
             intentId: event.intentId,
             error: event.error,
-            ...(state.active.pauseQueueOnCancel
-              ? { pausePromptQueue: true }
-              : {}),
           },
         ],
       };
@@ -635,15 +635,30 @@ export function transitionChatStreamHost(
                 queueResumedAfterCancel: true,
               }
             : state.active;
+        const queuePauseReason = !event.paused
+          ? null
+          : event.mutationId === state.pendingQueuePauseMutationId
+            ? ("manual" as const)
+            : event.mutationId === undefined &&
+                state.lastCompletion?.pausePromptQueue === true
+              ? ("step-limit" as const)
+              : state.active?.pauseQueueOnCancel
+                ? ("stop" as const)
+                : state.queuePauseReason;
         return {
           kind: "applied",
           state: {
             ...state,
             queueRevision: event.queueRevision,
             queuePaused: event.paused,
+            queuePauseReason,
             queue: event.entries,
             pendingQueueMutationId,
             reviewBarrier,
+            pendingQueuePauseMutationId:
+              event.mutationId === state.pendingQueuePauseMutationId
+                ? null
+                : state.pendingQueuePauseMutationId,
             pendingQueueResumeMutationId:
               event.mutationId === state.pendingQueueResumeMutationId
                 ? null
@@ -782,8 +797,13 @@ export function transitionChatStreamHost(
           ...state,
           queueRevision: event.queueRevision,
           queuePaused: event.paused,
+          queuePauseReason: event.paused ? state.queuePauseReason : null,
           queue: event.entries,
           pendingQueueMutationId: null,
+          pendingQueuePauseMutationId:
+            event.mutationId === state.pendingQueuePauseMutationId
+              ? null
+              : state.pendingQueuePauseMutationId,
           pendingQueueResumeMutationId:
             event.mutationId === state.pendingQueueResumeMutationId
               ? null
@@ -806,6 +826,7 @@ export function transitionChatStreamHost(
           ...state,
           queueRevision: event.queueRevision,
           queuePaused: true,
+          queuePauseReason: "stop",
           queue: event.entries,
         },
         commands: [],
@@ -821,6 +842,7 @@ export function transitionChatStreamHost(
           error: event.error,
           queueRevision: event.queueRevision,
           queuePaused: event.paused,
+          queuePauseReason: event.paused ? state.queuePauseReason : null,
           queue: event.entries,
         },
         commands: [],
@@ -842,6 +864,7 @@ export function transitionChatStreamHost(
           error: event.error,
           queueRevision: event.queueRevision,
           queuePaused: event.paused,
+          queuePauseReason: event.paused ? state.queuePauseReason : null,
           queue: event.entries,
           lastCompletion: {
             intentId: event.intentId,

--- a/src/chat_stream/host_transition.ts
+++ b/src/chat_stream/host_transition.ts
@@ -67,6 +67,9 @@ function queueMutation(
   if (state.pendingQueueMutationId !== null) {
     return ignore(state, "queue-revision-conflict");
   }
+  const resumesCurrentStop =
+    event.type === "RESUME_QUEUE" &&
+    event.observedStopPolicyVersion === state.stopPolicyVersion;
   const mutation: Extract<
     ChatStreamHostCommand,
     { type: "mutate-queue" }
@@ -77,8 +80,7 @@ function queueMutation(
         ? {
             type: "resume",
             preserveStopPause:
-              state.queuePauseReason === "stop" &&
-              state.active?.pauseQueueOnCancel !== true,
+              state.queuePauseReason === "stop" && !resumesCurrentStop,
           }
         : event.type === "EDIT_QUEUE_ENTRY"
           ? {
@@ -105,7 +107,10 @@ function queueMutation(
       pendingQueuePauseMutationId:
         event.type === "PAUSE_QUEUE" ? event.mutationId : null,
       pendingQueueResumeMutationId:
-        event.type === "RESUME_QUEUE" && state.active?.pauseQueueOnCancel
+        event.type === "RESUME_QUEUE" &&
+        resumesCurrentStop &&
+        (state.queuePauseReason === "stop" ||
+          state.active?.pauseQueueOnCancel === true)
           ? event.mutationId
           : null,
     },
@@ -797,6 +802,7 @@ export function transitionChatStreamHost(
               type: "submit-review-remediation",
               threadId: event.threadId,
               prompt: event.prompt,
+              observedStopPolicyVersion: state.stopPolicyVersion,
             },
           ],
         };
@@ -891,18 +897,27 @@ export function transitionChatStreamHost(
       if (event.queueRevision < state.queueRevision) {
         return ignore(state, "invalid-host-event");
       }
-      return {
-        kind: "applied",
-        state: {
-          ...state,
-          error: event.error,
-          queueRevision: event.queueRevision,
-          queuePaused: event.paused,
-          queuePauseReason: event.paused ? state.queuePauseReason : null,
-          queue: event.entries,
-        },
-        commands: [],
-      };
+      {
+        const stopOwnsQueue =
+          state.queuePauseReason === "stop" ||
+          state.active?.pauseQueueOnCancel === true;
+        return {
+          kind: "applied",
+          state: {
+            ...state,
+            error: event.error,
+            queueRevision: event.queueRevision,
+            queuePaused: stopOwnsQueue || event.paused,
+            queuePauseReason: stopOwnsQueue
+              ? "stop"
+              : event.paused
+                ? state.queuePauseReason
+                : null,
+            queue: event.entries,
+          },
+          commands: [],
+        };
+      }
     case "LIFECYCLE_COMMAND_FAILED":
       if (
         !state.active ||

--- a/src/chat_stream/host_transition.ts
+++ b/src/chat_stream/host_transition.ts
@@ -120,7 +120,10 @@ export function transitionChatStreamHost(
 > {
   switch (event.type) {
     case "SUBMIT": {
-      if (state.phase === "idle" || state.phase === "errored") {
+      if (
+        (state.phase === "idle" || state.phase === "errored") &&
+        !state.queuePaused
+      ) {
         const invocationRef = event.intent.invocationRef;
         if (!invocationRef) {
           return {

--- a/src/chat_stream/main_actor.test.ts
+++ b/src/chat_stream/main_actor.test.ts
@@ -21,6 +21,7 @@ import {
 import { computeChatTurnPayloadHash } from "@/ipc/utils/chat_turn_intent_hash";
 import { chatStreamDefinition } from "./definition";
 import { initialChatStreamHostState } from "./host_transition";
+import { markIntentTerminal } from "./persistence";
 import { ChatStreamRemoteManager } from "./remote_manager";
 import {
   chatStreamClientDefinition,
@@ -1582,6 +1583,60 @@ describe("main-hosted chat stream actor", () => {
     release();
     manager.dispose();
     await transport.dispose();
+    await host.dispose();
+  });
+
+  it("keeps Stop precedence when a cancelled turn requests review", async () => {
+    let resolveCancel!: (cancelled: boolean) => void;
+    vi.mocked(cancelActiveStreamsForChat).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveCancel = resolve;
+        }),
+    );
+    vi.mocked(markIntentTerminal).mockClear();
+    const host = new ActorHost({
+      placement: "main",
+      clock: createFakeClock(),
+      ids: createSequentialIdSource(),
+    });
+    host.register(chatStreamDefinition);
+    const actor = host.ensure(chatStreamDefinition, chatStreamKey(7));
+    const activeIntent = turn("stopped-review");
+
+    actor.enqueue({ type: "SUBMIT", intent: activeIntent });
+    await vi.waitFor(() =>
+      expect(execution.observers.has(activeIntent.intentId)).toBe(true),
+    );
+    actor.enqueue({
+      type: "CANCEL",
+      invocationRef: activeIntent.invocationRef!,
+      pauseQueue: true,
+      observedStopPolicyVersion: 0,
+    });
+    await vi.waitFor(() =>
+      expect(actor.getSnapshot().phase).toBe("cancelling"),
+    );
+
+    execution.observers.get(activeIntent.intentId)?.onEnd?.({
+      chatId: 7,
+      invocationRef: activeIntent.invocationRef!,
+      updatedFiles: true,
+      wasCancelled: true,
+      pausePromptQueue: true,
+      reviewBarrierRequested: true,
+    });
+
+    await vi.waitFor(() =>
+      expect(markIntentTerminal).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ intentId: activeIntent.intentId }),
+        true,
+        true,
+        "stop",
+      ),
+    );
+    resolveCancel(true);
     await host.dispose();
   });
 

--- a/src/chat_stream/main_actor.test.ts
+++ b/src/chat_stream/main_actor.test.ts
@@ -594,12 +594,12 @@ describe("main-hosted chat stream actor", () => {
     await vi.waitFor(() => expect(persisted.paused).toBe(true));
     expect(onSettled).toHaveBeenCalledExactlyOnceWith({ success: false });
     expect(actor.getSnapshot().phase).toBe("idle");
+    manager.dispose();
     releaseAttachment();
     await flush();
     expect(execution.admissions).toEqual([]);
 
     release();
-    manager.dispose();
     await transport.dispose();
     await host.dispose();
   });

--- a/src/chat_stream/main_actor.test.ts
+++ b/src/chat_stream/main_actor.test.ts
@@ -594,12 +594,12 @@ describe("main-hosted chat stream actor", () => {
     await vi.waitFor(() => expect(persisted.paused).toBe(true));
     expect(onSettled).toHaveBeenCalledExactlyOnceWith({ success: false });
     expect(actor.getSnapshot().phase).toBe("idle");
-    manager.dispose();
     releaseAttachment();
     await flush();
     expect(execution.admissions).toEqual([]);
 
     release();
+    manager.dispose();
     await transport.dispose();
     await host.dispose();
   });

--- a/src/chat_stream/main_actor.test.ts
+++ b/src/chat_stream/main_actor.test.ts
@@ -949,6 +949,27 @@ describe("main-hosted chat stream actor", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("rejects a queue-parking cancellation routed from another chat", async () => {
+    await expect(
+      chatStreamDefinition.remote.authorizeDispatch({
+        sender: {
+          webContentsId: 1,
+          windowSessionId: "renderer-window",
+        },
+        key: chatStreamKey(7),
+        event: {
+          type: "CANCEL",
+          invocationRef: {
+            ...turn("other-chat").invocationRef!,
+            entityKey: 8,
+          },
+          pauseQueue: true,
+        },
+        currentState: initialChatStreamHostState(),
+      }),
+    ).rejects.toMatchObject({ kind: "auth" });
+  });
+
   it("rejects subscriptions and dispatches while chat deletion is fenced", async () => {
     const releaseDeletion = beginChatActorDeletion(7);
     try {

--- a/src/chat_stream/main_actor.test.ts
+++ b/src/chat_stream/main_actor.test.ts
@@ -1092,6 +1092,8 @@ describe("main-hosted chat stream actor", () => {
   });
 
   it("settles a durable review barrier without renderer ownership", async () => {
+    const { markIntentTerminal } = await import("./persistence");
+    vi.mocked(markIntentTerminal).mockClear();
     const clock = createFakeClock();
     const host = new ActorHost({
       placement: "main",
@@ -1137,6 +1139,13 @@ describe("main-hosted chat stream actor", () => {
       expect(actor.getSnapshot().queuePaused).toBe(false);
       expect(execution.admissions).toContain("queued");
     });
+    expect(markIntentTerminal).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ intentId: "review" }),
+      true,
+      false,
+      "manual",
+    );
 
     const reloaded = new ChatStreamRemoteManager(
       createStore(),

--- a/src/chat_stream/main_actor.test.ts
+++ b/src/chat_stream/main_actor.test.ts
@@ -1477,7 +1477,7 @@ describe("main-hosted chat stream actor", () => {
     await vi.waitFor(() =>
       expect(onSettled).toHaveBeenCalledExactlyOnceWith({
         success: false,
-        pausedByStepLimit: true,
+        pausedByStepLimit: undefined,
       }),
     );
     await flush();

--- a/src/chat_stream/main_actor.test.ts
+++ b/src/chat_stream/main_actor.test.ts
@@ -746,15 +746,22 @@ describe("main-hosted chat stream actor", () => {
 
     actor.send({
       type: "submit",
-      request: {
-        chatId: 7,
-        prompt: "cancel before serialization",
-        attachments: [{ file: {} as File, type: "chat-context" }],
-      },
+      request: { chatId: 7, prompt: "active before Stop" },
     });
+    await vi.waitFor(() =>
+      expect(
+        [...execution.observers.values()].some(
+          (observer) => observer.intent.prompt === "active before Stop",
+        ),
+      ).toBe(true),
+    );
     actor.send({
       type: "submit",
-      request: { chatId: 7, prompt: "keep this queued" },
+      request: {
+        chatId: 7,
+        prompt: "keep this queued",
+        attachments: [{ file: {} as File, type: "chat-context" }],
+      },
     });
     actor.send({ type: "cancel" });
 
@@ -765,7 +772,11 @@ describe("main-hosted chat stream actor", () => {
         expect.objectContaining({ prompt: "keep this queued" }),
       ]),
     );
-    expect(execution.observers.size).toBe(0);
+    expect(
+      [...execution.observers.values()].map(
+        (observer) => observer.intent.prompt,
+      ),
+    ).not.toContain("keep this queued");
     expect(actor.getSnapshot()).toMatchObject({
       phase: "idle",
       queuePaused: true,
@@ -782,8 +793,13 @@ describe("main-hosted chat stream actor", () => {
         [...execution.observers.values()].map(
           (observer) => observer.intent.prompt,
         ),
-      ).toEqual(["keep this queued"]),
+      ).toContain("keep this queued"),
     );
+    expect(
+      [...execution.observers.values()].map(
+        (observer) => observer.intent.prompt,
+      ),
+    ).not.toContain("send after Stop");
     expect(persisted.paused).toBe(false);
     expect(persisted.entries).toEqual([
       expect.objectContaining({ prompt: "send after Stop" }),

--- a/src/chat_stream/main_actor.test.ts
+++ b/src/chat_stream/main_actor.test.ts
@@ -197,6 +197,15 @@ vi.mock("./persistence", () => ({
       };
     },
   ),
+  parkChatQueue: vi.fn(async () => {
+    persisted.paused = true;
+    persisted.revision += 1;
+    return {
+      queueRevision: persisted.revision,
+      queuePaused: persisted.paused,
+      queue: [...persisted.entries],
+    };
+  }),
   markIntentTerminal: vi.fn(() => ({
     queueRevision: persisted.revision,
     queuePaused: persisted.paused,
@@ -524,6 +533,70 @@ describe("main-hosted chat stream actor", () => {
       phase: "admitting",
       capabilities: { canCancel: false },
     });
+
+    release();
+    manager.dispose();
+    await transport.dispose();
+    await host.dispose();
+  });
+
+  it("stops a renderer-only optimistic admission and parks the queue", async () => {
+    let releaseAttachment!: () => void;
+    const attachmentGate = new Promise<void>((resolve) => {
+      releaseAttachment = resolve;
+    });
+    execution.convertAttachments.mockImplementationOnce(async () => {
+      await attachmentGate;
+      return [];
+    });
+    const clock = createFakeClock();
+    const host = new ActorHost({
+      placement: "main",
+      clock,
+      ids: createSequentialIdSource(),
+    });
+    const manifest = createRemoteMachineManifest([chatStreamDefinition]);
+    const windows = new TwoWindowHarness();
+    const transport = new RemoteMachineTransport({
+      host,
+      manifest,
+      windows: windows.registry,
+      clock,
+    });
+    const duplex = new FakeDuplexRemoteTransport(transport, manifest, windows);
+    const manager = new ChatStreamRemoteManager(
+      createStore(),
+      createSequentialIdSource(),
+      duplex.connect(),
+    );
+    const onSettled = vi.fn();
+    manager.start();
+    const actor = manager.ensure(7);
+    const release = actor.subscribe(() => undefined);
+    await flush();
+
+    actor.send({
+      type: "submit",
+      request: {
+        chatId: 7,
+        prompt: "cancel before serialization",
+        attachments: [{ file: {} as File, type: "chat-context" }],
+        onSettled,
+      },
+    });
+    expect(actor.getSnapshot()).toMatchObject({
+      phase: "admitting",
+      capabilities: { canCancel: false },
+    });
+
+    actor.send({ type: "cancel" });
+
+    await vi.waitFor(() => expect(persisted.paused).toBe(true));
+    expect(onSettled).toHaveBeenCalledExactlyOnceWith({ success: false });
+    expect(actor.getSnapshot().phase).toBe("idle");
+    releaseAttachment();
+    await flush();
+    expect(execution.admissions).toEqual([]);
 
     release();
     manager.dispose();

--- a/src/chat_stream/main_actor.test.ts
+++ b/src/chat_stream/main_actor.test.ts
@@ -800,6 +800,106 @@ describe("main-hosted chat stream actor", () => {
     await host.dispose();
   });
 
+  it("keeps delayed cross-window submissions behind the authoritative Stop cutoff", async () => {
+    let releaseAttachment!: () => void;
+    const attachmentGate = new Promise<void>((resolve) => {
+      releaseAttachment = resolve;
+    });
+    execution.convertAttachments.mockImplementationOnce(async () => {
+      await attachmentGate;
+      return [];
+    });
+    const clock = createFakeClock();
+    const host = new ActorHost({
+      placement: "main",
+      clock,
+      ids: createSequentialIdSource(),
+    });
+    const manifest = createRemoteMachineManifest([chatStreamDefinition]);
+    const windows = new TwoWindowHarness();
+    const [windowA, windowB] = windows.createPair();
+    const transport = new RemoteMachineTransport({
+      host,
+      manifest,
+      windows: windows.registry,
+      clock,
+    });
+    const duplex = new FakeDuplexRemoteTransport(transport, manifest, windows);
+    const managerA = new ChatStreamRemoteManager(
+      createStore(),
+      createSequentialIdSource(),
+      duplex.connect(windowA),
+    );
+    const managerB = new ChatStreamRemoteManager(
+      createStore(),
+      createSequentialIdSource(1_000),
+      duplex.connect(windowB),
+    );
+    managerA.start();
+    managerB.start();
+    const actorA = managerA.ensure(7);
+    const actorB = managerB.ensure(7);
+    const releaseA = actorA.subscribe(() => undefined);
+    const releaseB = actorB.subscribe(() => undefined);
+    await flush();
+
+    actorA.send({
+      type: "submit",
+      request: { chatId: 7, prompt: "active in window A" },
+    });
+    await vi.waitFor(() =>
+      expect(
+        [...execution.observers.values()].some(
+          (observer) => observer.intent.prompt === "active in window A",
+        ),
+      ).toBe(true),
+    );
+
+    actorB.send({
+      type: "submit",
+      request: {
+        chatId: 7,
+        prompt: "serializing in window B",
+        attachments: [{ file: {} as File, type: "chat-context" }],
+      },
+    });
+    actorA.send({ type: "cancel" });
+    expect(actorB.getSnapshot().stopPolicyVersion).toBe(0);
+    actorB.send({
+      type: "submit",
+      request: { chatId: 7, prompt: "submitted just after Stop" },
+    });
+
+    await vi.waitFor(() => expect(persisted.paused).toBe(true));
+    await vi.waitFor(() =>
+      expect(actorB.getSnapshot().stopPolicyVersion).toBe(1),
+    );
+    releaseAttachment();
+    await vi.waitFor(() =>
+      expect(persisted.entries.map((entry) => entry.prompt)).toEqual([
+        "serializing in window B",
+        "submitted just after Stop",
+      ]),
+    );
+    const observedPrompts = [...execution.observers.values()].map(
+      (observer) => observer.intent.prompt,
+    );
+    expect(observedPrompts).not.toContain("serializing in window B");
+    expect(observedPrompts).not.toContain("submitted just after Stop");
+    expect(actorA.getSnapshot()).toMatchObject({
+      phase: "idle",
+      queuePaused: true,
+      stopPolicyVersion: 1,
+    });
+
+    releaseA();
+    releaseB();
+    managerA.dispose();
+    managerB.dispose();
+    await transport.dispose();
+    await host.dispose();
+  });
+
   it("bootstraps actor interest before dispatching a first submission", async () => {
     const clock = createFakeClock();
     const host = new ActorHost({

--- a/src/chat_stream/main_actor.test.ts
+++ b/src/chat_stream/main_actor.test.ts
@@ -36,6 +36,8 @@ const execution = vi.hoisted(() => ({
   replayedQueuedIntentIds: new Set<string>(),
   claimFailures: 0,
   claimAttempts: 0,
+  afterClaim: null as (() => Promise<void>) | null,
+  claimedEntries: new Map<string, ChatQueueEntry>(),
   convertAttachments: vi.fn(async () => []),
 }));
 const review = vi.hoisted(() => ({
@@ -171,9 +173,26 @@ vi.mock("./persistence", () => ({
       options?: { resumeQueue?: boolean },
     ) => {
       if (persisted.intents.has(intent.intentId)) {
+        let queue:
+          | {
+              queueRevision: number;
+              queuePaused: boolean;
+              queue: ChatQueueEntry[];
+            }
+          | undefined;
+        if (options?.resumeQueue) {
+          if (persisted.paused) persisted.revision += 1;
+          persisted.paused = false;
+          queue = {
+            queueRevision: persisted.revision,
+            queuePaused: persisted.paused,
+            queue: [...persisted.entries],
+          };
+        }
         return {
           kind: "replayed" as const,
           acceptance: "queued" as const,
+          queue,
         };
       }
       execution.admissions.push(intent.prompt);
@@ -238,6 +257,8 @@ vi.mock("./persistence", () => ({
     const intent = persisted.intents.get(entry.intentId);
     if (!intent) return null;
     persisted.revision += 1;
+    execution.claimedEntries.set(entry.intentId, entry);
+    await execution.afterClaim?.();
     return {
       intent,
       queue: {
@@ -247,11 +268,20 @@ vi.mock("./persistence", () => ({
       },
     };
   }),
-  restoreClaimedQueueHead: vi.fn(async () => ({
-    queueRevision: persisted.revision,
-    queuePaused: persisted.paused,
-    queue: [...persisted.entries],
-  })),
+  restoreClaimedQueueHead: vi.fn(async () => {
+    const [intentId, entry] =
+      execution.claimedEntries.entries().next().value ?? [];
+    if (intentId && entry) {
+      execution.claimedEntries.delete(intentId);
+      persisted.entries.unshift(entry);
+      persisted.revision += 1;
+    }
+    return {
+      queueRevision: persisted.revision,
+      queuePaused: persisted.paused,
+      queue: [...persisted.entries],
+    };
+  }),
 }));
 
 function turn(intentId: string): SerializableChatTurnIntent {
@@ -284,6 +314,8 @@ describe("main-hosted chat stream actor", () => {
     execution.replayedQueuedIntentIds.clear();
     execution.claimFailures = 0;
     execution.claimAttempts = 0;
+    execution.afterClaim = null;
+    execution.claimedEntries.clear();
     execution.convertAttachments.mockReset();
     execution.convertAttachments.mockResolvedValue([]);
     review.runAutoReviewBarrier.mockReset();
@@ -296,7 +328,7 @@ describe("main-hosted chat stream actor", () => {
     persisted.intents.clear();
   });
 
-  it("keeps a replayed durable intent in its recovered paused queue", async () => {
+  it("resumes a replayed durable intent from its recovered paused queue", async () => {
     const queued = turn("queued");
     persisted.paused = true;
     persisted.revision = 2;
@@ -311,8 +343,6 @@ describe("main-hosted chat stream actor", () => {
         removable: true,
       },
     ];
-    execution.replayedQueuedIntentIds.add(queued.intentId);
-
     const clock = createFakeClock();
     const host = new ActorHost({
       placement: "main",
@@ -341,12 +371,11 @@ describe("main-hosted chat stream actor", () => {
     await flush();
 
     expect(actor.getSnapshot()).toMatchObject({
-      phase: "idle",
-      queuePaused: true,
-      queue: [{ intentId: "queued" }],
-      lastAcceptance: { intentId: "queued", acceptance: "queued" },
+      phase: "streaming",
+      queuePaused: false,
+      queue: [],
     });
-    expect(execution.observers.size).toBe(0);
+    expect(execution.observers.has("queued")).toBe(true);
 
     release();
     client.dispose();
@@ -398,6 +427,68 @@ describe("main-hosted chat stream actor", () => {
       phase: "streaming",
       queue: [],
     });
+
+    release();
+    client.dispose();
+    await transport.dispose();
+    await host.dispose();
+  });
+
+  it("restores a claimed queue head when the queue is parked before dispatch", async () => {
+    const clock = createFakeClock();
+    const host = new ActorHost({
+      placement: "main",
+      clock,
+      ids: createSequentialIdSource(),
+    });
+    const manifest = createRemoteMachineManifest([chatStreamDefinition]);
+    const windows = new TwoWindowHarness();
+    const transport = new RemoteMachineTransport({
+      host,
+      manifest,
+      windows: windows.registry,
+      clock,
+    });
+    const duplex = new FakeDuplexRemoteTransport(transport, manifest, windows);
+    const client = new RemoteMachineClient(
+      duplex.connect(),
+      createSequentialIdSource(),
+    );
+    client.start();
+    const actor = client.actor(chatStreamClientDefinition, chatStreamKey(7));
+    const release = actor.subscribe(() => undefined);
+    await actor.resync();
+
+    await actor.dispatch({ type: "SUBMIT", intent: turn("first") });
+    await flush();
+    await actor.dispatch({ type: "SUBMIT", intent: turn("second") });
+    await flush();
+    execution.afterClaim = async () => {
+      execution.afterClaim = null;
+      await actor.dispatch({
+        type: "PAUSE_QUEUE",
+        expectedQueueRevision: actor.getSnapshot().queueRevision,
+        mutationId: "park-after-claim",
+      });
+      await vi.waitFor(() =>
+        expect(actor.getSnapshot().queuePaused).toBe(true),
+      );
+    };
+
+    execution.observers.get("first")?.onEnd?.({
+      chatId: 7,
+      invocationRef: turn("first").invocationRef,
+      updatedFiles: false,
+    });
+
+    await vi.waitFor(() =>
+      expect(actor.getSnapshot()).toMatchObject({
+        phase: "idle",
+        queuePaused: true,
+        queue: [{ intentId: "second" }],
+      }),
+    );
+    expect(execution.observers.has("second")).toBe(false);
 
     release();
     client.dispose();

--- a/src/chat_stream/main_actor.test.ts
+++ b/src/chat_stream/main_actor.test.ts
@@ -17,6 +17,7 @@ import {
 } from "@/ipc/services/chat_actor_deletion_fence";
 import { computeChatTurnPayloadHash } from "@/ipc/utils/chat_turn_intent_hash";
 import { chatStreamDefinition } from "./definition";
+import { initialChatStreamHostState } from "./host_transition";
 import { ChatStreamRemoteManager } from "./remote_manager";
 import {
   chatStreamClientDefinition,
@@ -928,6 +929,24 @@ describe("main-hosted chat stream actor", () => {
     const { payloadHash, ...authorizedPayload } = event.intent;
     expect(authorizedPayload.originWindowSessionId).toBe("renderer-window");
     expect(computeChatTurnPayloadHash(authorizedPayload)).toBe(payloadHash);
+  });
+
+  it("allows a stale cancellation intent to park the queue", async () => {
+    await expect(
+      chatStreamDefinition.remote.authorizeDispatch({
+        sender: {
+          webContentsId: 1,
+          windowSessionId: "renderer-window",
+        },
+        key: chatStreamKey(7),
+        event: {
+          type: "CANCEL",
+          invocationRef: turn("stale").invocationRef!,
+          pauseQueue: true,
+        },
+        currentState: initialChatStreamHostState(),
+      }),
+    ).resolves.toBeUndefined();
   });
 
   it("rejects subscriptions and dispatches while chat deletion is fenced", async () => {

--- a/src/chat_stream/main_actor.test.ts
+++ b/src/chat_stream/main_actor.test.ts
@@ -57,6 +57,7 @@ vi.mock("@/lib/chatAttachmentConversion", () => ({
 const persisted = vi.hoisted(() => ({
   revision: 0,
   paused: false,
+  pauseReason: null as "stop" | "manual" | "step-limit" | null,
   entries: [] as ChatQueueEntry[],
   intents: new Map<string, SerializableChatTurnIntent>(),
 }));
@@ -133,11 +134,13 @@ vi.mock("./persistence", () => ({
   loadChatQueue: vi.fn(() => ({
     queueRevision: persisted.revision,
     queuePaused: persisted.paused,
+    queuePauseReason: persisted.pauseReason,
     queue: [...persisted.entries],
   })),
   hydrateChatStreamPersistence: vi.fn(() => ({
     queueRevision: persisted.revision,
     queuePaused: persisted.paused,
+    queuePauseReason: persisted.pauseReason,
     queue: [...persisted.entries],
   })),
   stageActiveIntent: vi.fn(
@@ -183,6 +186,7 @@ vi.mock("./persistence", () => ({
         if (options?.resumeQueue) {
           if (persisted.paused) persisted.revision += 1;
           persisted.paused = false;
+          persisted.pauseReason = null;
           queue = {
             queueRevision: persisted.revision,
             queuePaused: persisted.paused,
@@ -207,7 +211,10 @@ vi.mock("./persistence", () => ({
       persisted.intents.set(intent.intentId, intent);
       persisted.entries.push(entry);
       persisted.revision += 1;
-      if (options?.resumeQueue) persisted.paused = false;
+      if (options?.resumeQueue) {
+        persisted.paused = false;
+        persisted.pauseReason = null;
+      }
       return {
         kind: "queued" as const,
         entry,
@@ -223,6 +230,7 @@ vi.mock("./persistence", () => ({
       command: { mutation: { type: string } },
     ) => {
       persisted.paused = command.mutation.type === "pause";
+      persisted.pauseReason = persisted.paused ? "manual" : null;
       persisted.revision += 1;
       return {
         queueRevision: persisted.revision,
@@ -233,6 +241,7 @@ vi.mock("./persistence", () => ({
   ),
   parkChatQueue: vi.fn(async () => {
     persisted.paused = true;
+    persisted.pauseReason = "stop";
     persisted.revision += 1;
     return {
       queueRevision: persisted.revision,
@@ -324,6 +333,7 @@ describe("main-hosted chat stream actor", () => {
     review.skipReviewAutoFix.mockResolvedValue(undefined);
     persisted.revision = 0;
     persisted.paused = false;
+    persisted.pauseReason = null;
     persisted.entries = [];
     persisted.intents.clear();
   });
@@ -376,6 +386,67 @@ describe("main-hosted chat stream actor", () => {
       queue: [{ intentId: "queued" }],
     });
     expect(execution.observers.has("queued")).toBe(false);
+
+    release();
+    client.dispose();
+    await transport.dispose();
+    await host.dispose();
+  });
+
+  it("resumes a recovered Stop-parked queue FIFO on the next send", async () => {
+    const queued = turn("queued-before-restart");
+    persisted.paused = true;
+    persisted.pauseReason = "stop";
+    persisted.revision = 2;
+    persisted.intents.set(queued.intentId, queued);
+    persisted.entries = [
+      {
+        itemId: queued.intentId,
+        intentId: queued.intentId,
+        prompt: queued.prompt,
+        persistence: "durable",
+        editable: true,
+        removable: true,
+      },
+    ];
+    const clock = createFakeClock();
+    const host = new ActorHost({
+      placement: "main",
+      clock,
+      ids: createSequentialIdSource(),
+    });
+    const manifest = createRemoteMachineManifest([chatStreamDefinition]);
+    const windows = new TwoWindowHarness();
+    const transport = new RemoteMachineTransport({
+      host,
+      manifest,
+      windows: windows.registry,
+      clock,
+    });
+    const duplex = new FakeDuplexRemoteTransport(transport, manifest, windows);
+    const client = new RemoteMachineClient(
+      duplex.connect(),
+      createSequentialIdSource(),
+    );
+    client.start();
+    const actor = client.actor(chatStreamClientDefinition, chatStreamKey(7));
+    const release = actor.subscribe(() => undefined);
+    await actor.resync();
+
+    await actor.dispatch({
+      type: "SUBMIT",
+      intent: turn("sent-after-restart"),
+      observedStopPolicyVersion: 0,
+    });
+    await flush();
+
+    expect(actor.getSnapshot()).toMatchObject({
+      phase: "streaming",
+      queuePaused: false,
+      queue: [{ intentId: "sent-after-restart" }],
+    });
+    expect(execution.observers.has("queued-before-restart")).toBe(true);
+    expect(execution.observers.has("sent-after-restart")).toBe(false);
 
     release();
     client.dispose();

--- a/src/chat_stream/main_actor.test.ts
+++ b/src/chat_stream/main_actor.test.ts
@@ -163,6 +163,12 @@ vi.mock("./persistence", () => ({
   persistSessionQueuedIntent: vi.fn(),
   persistQueuedIntent: vi.fn(
     (_database: unknown, intent: SerializableChatTurnIntent) => {
+      if (persisted.intents.has(intent.intentId)) {
+        return {
+          kind: "replayed" as const,
+          acceptance: "queued" as const,
+        };
+      }
       execution.admissions.push(intent.prompt);
       const entry: ChatQueueEntry = {
         itemId: intent.intentId,
@@ -597,6 +603,74 @@ describe("main-hosted chat stream actor", () => {
     releaseAttachment();
     await flush();
     expect(execution.admissions).toEqual([]);
+
+    release();
+    manager.dispose();
+    await transport.dispose();
+    await host.dispose();
+  });
+
+  it("parks later optimistic submissions that predate Stop", async () => {
+    let releaseAttachment!: () => void;
+    const attachmentGate = new Promise<void>((resolve) => {
+      releaseAttachment = resolve;
+    });
+    execution.convertAttachments.mockImplementationOnce(async () => {
+      await attachmentGate;
+      return [];
+    });
+    const clock = createFakeClock();
+    const host = new ActorHost({
+      placement: "main",
+      clock,
+      ids: createSequentialIdSource(),
+    });
+    const manifest = createRemoteMachineManifest([chatStreamDefinition]);
+    const windows = new TwoWindowHarness();
+    const transport = new RemoteMachineTransport({
+      host,
+      manifest,
+      windows: windows.registry,
+      clock,
+    });
+    const duplex = new FakeDuplexRemoteTransport(transport, manifest, windows);
+    const manager = new ChatStreamRemoteManager(
+      createStore(),
+      createSequentialIdSource(),
+      duplex.connect(),
+    );
+    manager.start();
+    const actor = manager.ensure(7);
+    const release = actor.subscribe(() => undefined);
+    await flush();
+
+    actor.send({
+      type: "submit",
+      request: {
+        chatId: 7,
+        prompt: "cancel before serialization",
+        attachments: [{ file: {} as File, type: "chat-context" }],
+      },
+    });
+    actor.send({
+      type: "submit",
+      request: { chatId: 7, prompt: "keep this queued" },
+    });
+    actor.send({ type: "cancel" });
+
+    await vi.waitFor(() => expect(persisted.paused).toBe(true));
+    releaseAttachment();
+    await vi.waitFor(() =>
+      expect(persisted.entries).toEqual([
+        expect.objectContaining({ prompt: "keep this queued" }),
+      ]),
+    );
+    expect(execution.observers.size).toBe(0);
+    expect(actor.getSnapshot()).toMatchObject({
+      phase: "idle",
+      queuePaused: true,
+      queue: [expect.objectContaining({ prompt: "keep this queued" })],
+    });
 
     release();
     manager.dispose();

--- a/src/chat_stream/main_actor.test.ts
+++ b/src/chat_stream/main_actor.test.ts
@@ -328,7 +328,7 @@ describe("main-hosted chat stream actor", () => {
     persisted.intents.clear();
   });
 
-  it("resumes a replayed durable intent from its recovered paused queue", async () => {
+  it("keeps a replayed durable intent in its recovered paused queue", async () => {
     const queued = turn("queued");
     persisted.paused = true;
     persisted.revision = 2;
@@ -371,11 +371,11 @@ describe("main-hosted chat stream actor", () => {
     await flush();
 
     expect(actor.getSnapshot()).toMatchObject({
-      phase: "streaming",
-      queuePaused: false,
-      queue: [],
+      phase: "idle",
+      queuePaused: true,
+      queue: [{ intentId: "queued" }],
     });
-    expect(execution.observers.has("queued")).toBe(true);
+    expect(execution.observers.has("queued")).toBe(false);
 
     release();
     client.dispose();

--- a/src/chat_stream/main_actor.test.ts
+++ b/src/chat_stream/main_actor.test.ts
@@ -10,7 +10,10 @@ import {
   createSequentialIdSource,
 } from "@/state_machines/testing";
 import { TwoWindowHarness } from "@/testing/two_window_harness";
-import type { ChatStreamExecutionObserver } from "@/ipc/handlers/chat_stream_handlers";
+import {
+  cancelActiveStreamsForChat,
+  type ChatStreamExecutionObserver,
+} from "@/ipc/handlers/chat_stream_handlers";
 import {
   beginChatActorDeletion,
   assertChatActorAdmissionOpen,
@@ -162,7 +165,11 @@ vi.mock("./persistence", () => ({
   disposeSessionChatQueue: vi.fn(),
   persistSessionQueuedIntent: vi.fn(),
   persistQueuedIntent: vi.fn(
-    (_database: unknown, intent: SerializableChatTurnIntent) => {
+    (
+      _database: unknown,
+      intent: SerializableChatTurnIntent,
+      options?: { resumeQueue?: boolean },
+    ) => {
       if (persisted.intents.has(intent.intentId)) {
         return {
           kind: "replayed" as const,
@@ -181,10 +188,12 @@ vi.mock("./persistence", () => ({
       persisted.intents.set(intent.intentId, intent);
       persisted.entries.push(entry);
       persisted.revision += 1;
+      if (options?.resumeQueue) persisted.paused = false;
       return {
         kind: "queued" as const,
         entry,
         queueRevision: persisted.revision,
+        queuePaused: persisted.paused,
       };
     },
   ),
@@ -610,7 +619,7 @@ describe("main-hosted chat stream actor", () => {
     await host.dispose();
   });
 
-  it("parks later optimistic submissions that predate Stop", async () => {
+  it("parks pre-Stop tails and resumes them FIFO on a later Send", async () => {
     let releaseAttachment!: () => void;
     const attachmentGate = new Promise<void>((resolve) => {
       releaseAttachment = resolve;
@@ -670,6 +679,28 @@ describe("main-hosted chat stream actor", () => {
       phase: "idle",
       queuePaused: true,
       queue: [expect.objectContaining({ prompt: "keep this queued" })],
+    });
+
+    actor.send({
+      type: "submit",
+      request: { chatId: 7, prompt: "send after Stop" },
+    });
+
+    await vi.waitFor(() =>
+      expect(
+        [...execution.observers.values()].map(
+          (observer) => observer.intent.prompt,
+        ),
+      ).toEqual(["keep this queued"]),
+    );
+    expect(persisted.paused).toBe(false);
+    expect(persisted.entries).toEqual([
+      expect.objectContaining({ prompt: "send after Stop" }),
+    ]);
+    expect(actor.getSnapshot()).toMatchObject({
+      phase: "streaming",
+      queuePaused: false,
+      queue: [expect.objectContaining({ prompt: "send after Stop" })],
     });
 
     release();
@@ -1200,6 +1231,68 @@ describe("main-hosted chat stream actor", () => {
       }),
     );
 
+    manager.dispose();
+    await transport.dispose();
+    await host.dispose();
+  });
+
+  it("keeps a main-accepted submission pending across a second Stop", async () => {
+    let resolveFirstCancel!: (cancelled: boolean) => void;
+    vi.mocked(cancelActiveStreamsForChat).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFirstCancel = resolve;
+        }),
+    );
+    const clock = createFakeClock();
+    const host = new ActorHost({
+      placement: "main",
+      clock,
+      ids: createSequentialIdSource(),
+    });
+    const manifest = createRemoteMachineManifest([chatStreamDefinition]);
+    const windows = new TwoWindowHarness();
+    const transport = new RemoteMachineTransport({
+      host,
+      manifest,
+      windows: windows.registry,
+      clock,
+    });
+    const duplex = new FakeDuplexRemoteTransport(transport, manifest, windows);
+    const manager = new ChatStreamRemoteManager(
+      createStore(),
+      createSequentialIdSource(),
+      duplex.connect(),
+    );
+    const actor = manager.ensure(7);
+    const release = actor.subscribe(() => undefined);
+    const onSettled = vi.fn();
+
+    actor.send({
+      type: "submit",
+      request: { chatId: 7, prompt: "stop twice", onSettled },
+    });
+    await vi.waitFor(() => expect(actor.getSnapshot().phase).toBe("streaming"));
+
+    actor.send({ type: "cancel" });
+    await vi.waitFor(() =>
+      expect(actor.getSnapshot().phase).toBe("cancelling"),
+    );
+    actor.send({ type: "cancel" });
+
+    await flush();
+    expect(onSettled).not.toHaveBeenCalled();
+    resolveFirstCancel(true);
+    await vi.waitFor(() =>
+      expect(onSettled).toHaveBeenCalledExactlyOnceWith({
+        success: false,
+        pausedByStepLimit: true,
+      }),
+    );
+    await flush();
+    expect(onSettled).toHaveBeenCalledTimes(1);
+
+    release();
     manager.dispose();
     await transport.dispose();
     await host.dispose();

--- a/src/chat_stream/persistence.test.ts
+++ b/src/chat_stream/persistence.test.ts
@@ -146,7 +146,7 @@ describe("chat stream persistence", () => {
     ).toMatchObject({ revision: 3, paused: false });
   });
 
-  it("does not durably clear an idle Stop pause for a queue resume", async () => {
+  it("does not durably clear a Stop pause for a guarded review release", async () => {
     persistQueuedIntent(database, intent("queued"));
     const parked = await parkChatQueue(database, chatId);
 

--- a/src/chat_stream/persistence.test.ts
+++ b/src/chat_stream/persistence.test.ts
@@ -145,6 +145,36 @@ describe("chat stream persistence", () => {
     ).toMatchObject({ revision: 3, paused: false });
   });
 
+  it("resumes the authoritative queue when a queued send is replayed", async () => {
+    const queuedIntent = intent("queued");
+    persistQueuedIntent(database, queuedIntent);
+    await parkChatQueue(database, chatId);
+
+    expect(
+      persistQueuedIntent(database, queuedIntent, { resumeQueue: true }),
+    ).toMatchObject({
+      kind: "replayed",
+      acceptance: "queued",
+      queue: {
+        queueRevision: 3,
+        queuePaused: false,
+        queue: [{ intentId: "queued" }],
+      },
+    });
+    expect(loadChatQueue(database, chatId)).toMatchObject({
+      queueRevision: 3,
+      queuePaused: false,
+      queue: [{ intentId: "queued" }],
+    });
+    expect(
+      database
+        .select()
+        .from(chatQueueStates)
+        .where(eq(chatQueueStates.chatId, chatId))
+        .get(),
+    ).toMatchObject({ revision: 3, paused: false });
+  });
+
   it("bounds the aggregate queue projection before transport", () => {
     expect(() =>
       assertQueueSnapshotWithinLimit(

--- a/src/chat_stream/persistence.test.ts
+++ b/src/chat_stream/persistence.test.ts
@@ -14,6 +14,7 @@ import {
   markIntentAccepted,
   markIntentTerminal,
   mutateChatQueue,
+  parkChatQueue,
   persistAcceptedChatTurn,
   persistQueuedIntent,
   restoreClaimedQueueHead,
@@ -90,6 +91,20 @@ describe("chat stream persistence", () => {
 
     expect(database.select().from(chatTurnIntents).all()).toEqual([]);
     expect(database.select().from(chatQueueEntries).all()).toEqual([]);
+  });
+
+  it("parks the queue idempotently without a renderer revision", async () => {
+    persistQueuedIntent(database, intent("turn-1"));
+
+    await expect(parkChatQueue(database, chatId)).resolves.toMatchObject({
+      queueRevision: 2,
+      queuePaused: true,
+      queue: [{ intentId: "turn-1" }],
+    });
+    await expect(parkChatQueue(database, chatId)).resolves.toMatchObject({
+      queueRevision: 2,
+      queuePaused: true,
+    });
   });
 
   it("bounds the aggregate queue projection before transport", () => {

--- a/src/chat_stream/persistence.test.ts
+++ b/src/chat_stream/persistence.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { eq } from "drizzle-orm";
-import { apps, chats, chatQueueEntries, chatTurnIntents } from "@/db/schema";
+import {
+  apps,
+  chats,
+  chatQueueEntries,
+  chatQueueStates,
+  chatTurnIntents,
+} from "@/db/schema";
 import { DyadErrorKind } from "@/errors/dyad_error";
 import { createInMemoryTestDb, type TestDb } from "@/testing/test_db";
 import {
@@ -105,6 +111,13 @@ describe("chat stream persistence", () => {
       queueRevision: 2,
       queuePaused: true,
     });
+    expect(
+      database
+        .select()
+        .from(chatQueueStates)
+        .where(eq(chatQueueStates.chatId, chatId))
+        .get(),
+    ).toMatchObject({ revision: 2, paused: true });
   });
 
   it("bounds the aggregate queue projection before transport", () => {

--- a/src/chat_stream/persistence.test.ts
+++ b/src/chat_stream/persistence.test.ts
@@ -105,6 +105,7 @@ describe("chat stream persistence", () => {
     await expect(parkChatQueue(database, chatId)).resolves.toMatchObject({
       queueRevision: 2,
       queuePaused: true,
+      queuePauseReason: "stop",
       queue: [{ intentId: "turn-1" }],
     });
     await expect(parkChatQueue(database, chatId)).resolves.toMatchObject({
@@ -117,7 +118,7 @@ describe("chat stream persistence", () => {
         .from(chatQueueStates)
         .where(eq(chatQueueStates.chatId, chatId))
         .get(),
-    ).toMatchObject({ revision: 2, paused: true });
+    ).toMatchObject({ revision: 2, paused: true, pauseReason: "stop" });
   });
 
   it("atomically appends and resumes an explicitly sent queued intent", async () => {
@@ -396,7 +397,21 @@ describe("chat stream persistence", () => {
     expect(hydrated).toEqual({
       queueRevision: 2,
       queuePaused: true,
+      queuePauseReason: "manual",
       queue: [expect.objectContaining({ intentId: "turn-1" })],
+    });
+  });
+
+  it("restores a Stop-parked durable queue with its pause reason", async () => {
+    persistQueuedIntent(database, intent("turn-1"));
+    await parkChatQueue(database, chatId);
+    disposeSessionChatQueue(chatId);
+
+    expect(hydrateChatStreamPersistence(database, chatId)).toMatchObject({
+      queueRevision: 2,
+      queuePaused: true,
+      queuePauseReason: "stop",
+      queue: [{ intentId: "turn-1" }],
     });
   });
 

--- a/src/chat_stream/persistence.test.ts
+++ b/src/chat_stream/persistence.test.ts
@@ -120,6 +120,31 @@ describe("chat stream persistence", () => {
     ).toMatchObject({ revision: 2, paused: true });
   });
 
+  it("atomically appends and resumes an explicitly sent queued intent", async () => {
+    persistQueuedIntent(database, intent("first"));
+    await parkChatQueue(database, chatId);
+
+    expect(
+      persistQueuedIntent(database, intent("second"), { resumeQueue: true }),
+    ).toMatchObject({
+      kind: "queued",
+      queueRevision: 3,
+      queuePaused: false,
+    });
+    expect(loadChatQueue(database, chatId)).toMatchObject({
+      queueRevision: 3,
+      queuePaused: false,
+      queue: [{ intentId: "first" }, { intentId: "second" }],
+    });
+    expect(
+      database
+        .select()
+        .from(chatQueueStates)
+        .where(eq(chatQueueStates.chatId, chatId))
+        .get(),
+    ).toMatchObject({ revision: 3, paused: false });
+  });
+
   it("bounds the aggregate queue projection before transport", () => {
     expect(() =>
       assertQueueSnapshotWithinLimit(

--- a/src/chat_stream/persistence.test.ts
+++ b/src/chat_stream/persistence.test.ts
@@ -146,6 +146,31 @@ describe("chat stream persistence", () => {
     ).toMatchObject({ revision: 3, paused: false });
   });
 
+  it("does not durably clear an idle Stop pause for a queue resume", async () => {
+    persistQueuedIntent(database, intent("queued"));
+    const parked = await parkChatQueue(database, chatId);
+
+    const queue = await mutateChatQueue(database, chatId, {
+      type: "mutate-queue",
+      mutation: { type: "resume", preserveStopPause: true },
+      expectedQueueRevision: parked.queueRevision,
+      mutationId: "idle-resume",
+      observedStopPolicyVersion: 1,
+    });
+
+    expect(queue).toMatchObject({
+      queuePaused: true,
+      queuePauseReason: "stop",
+    });
+    expect(
+      database
+        .select()
+        .from(chatQueueStates)
+        .where(eq(chatQueueStates.chatId, chatId))
+        .get(),
+    ).toMatchObject({ paused: true, pauseReason: "stop" });
+  });
+
   it("resumes the authoritative queue when a queued send is replayed", async () => {
     const queuedIntent = intent("queued");
     persistQueuedIntent(database, queuedIntent);

--- a/src/chat_stream/persistence.ts
+++ b/src/chat_stream/persistence.ts
@@ -916,6 +916,9 @@ export async function parkChatQueue(
   database: ChatDatabase,
   chatId: number,
 ): Promise<ReturnType<typeof loadChatQueue>> {
+  // Chat-stream queue lifecycle is intentionally process-memory-only
+  // (`restartPersistence: "ephemeral"`). There is no durable queue-state row
+  // to update; the database parameter is retained for the shared facade shape.
   return withChatQueueLock(chatId, async () => {
     const aggregate = queueFor(chatId);
     if (!aggregate.paused) {

--- a/src/chat_stream/persistence.ts
+++ b/src/chat_stream/persistence.ts
@@ -845,8 +845,10 @@ export async function mutateChatQueue(
         aggregate.pauseReason = "manual";
         break;
       case "resume":
-        aggregate.paused = false;
-        aggregate.pauseReason = null;
+        if (!(mutation.preserveStopPause && aggregate.pauseReason === "stop")) {
+          aggregate.paused = false;
+          aggregate.pauseReason = null;
+        }
         break;
       case "edit": {
         const selectedRecord = selected[0]?.record;

--- a/src/chat_stream/persistence.ts
+++ b/src/chat_stream/persistence.ts
@@ -916,14 +916,21 @@ export async function parkChatQueue(
   database: ChatDatabase,
   chatId: number,
 ): Promise<ReturnType<typeof loadChatQueue>> {
-  // Chat-stream queue lifecycle is intentionally process-memory-only
-  // (`restartPersistence: "ephemeral"`). There is no durable queue-state row
-  // to update; the database parameter is retained for the shared facade shape.
   return withChatQueueLock(chatId, async () => {
     const aggregate = queueFor(chatId);
     if (!aggregate.paused) {
+      const nextRevision = aggregate.revision + 1;
+      database
+        .update(chatQueueStates)
+        .set({
+          revision: nextRevision,
+          paused: true,
+          updatedAt: new Date(),
+        })
+        .where(eq(chatQueueStates.chatId, chatId))
+        .run();
       aggregate.paused = true;
-      aggregate.revision += 1;
+      aggregate.revision = nextRevision;
     }
     return loadChatQueue(database, chatId);
   });

--- a/src/chat_stream/persistence.ts
+++ b/src/chat_stream/persistence.ts
@@ -350,7 +350,32 @@ export type PersistAdmissionResult =
       kind: "replayed";
       acceptance: "queued" | "message-accepted" | "rejected";
       acceptedMessageId?: number;
+      queue?: ReturnType<typeof loadChatQueue>;
     };
+
+function resumeReplayedQueue(
+  database: ChatDatabase,
+  existing: IntentRecord,
+): ReturnType<typeof loadChatQueue> {
+  const aggregate = queueFor(existing.chatId);
+  if (aggregate.paused) {
+    const nextRevision = aggregate.revision + 1;
+    if (existing.durable) {
+      database
+        .update(chatQueueStates)
+        .set({
+          revision: nextRevision,
+          paused: false,
+          updatedAt: new Date(),
+        })
+        .where(eq(chatQueueStates.chatId, existing.chatId))
+        .run();
+    }
+    aggregate.revision = nextRevision;
+    aggregate.paused = false;
+  }
+  return loadChatQueue(database, existing.chatId);
+}
 
 function persistIntentInQueue(
   database: ChatDatabase,
@@ -381,7 +406,12 @@ function persistIntentInQueue(
   }
   if (existing) {
     assertMatchingIntent(existing, intent);
-    return replay(existing);
+    return {
+      ...replay(existing),
+      ...(resumeQueue && existing.acceptance === "queued"
+        ? { queue: resumeReplayedQueue(database, existing) }
+        : {}),
+    };
   }
   const aggregate = queueFor(intent.chatId);
   assertQueueSnapshotWithinLimit([

--- a/src/chat_stream/persistence.ts
+++ b/src/chat_stream/persistence.ts
@@ -41,6 +41,7 @@ interface IntentRecord {
 interface QueueAggregate {
   revision: number;
   paused: boolean;
+  pauseReason: "stop" | "manual" | "step-limit" | null;
   intentIds: string[];
 }
 
@@ -50,7 +51,7 @@ const queues = new Map<number, QueueAggregate>();
 function queueFor(chatId: number): QueueAggregate {
   let queue = queues.get(chatId);
   if (!queue) {
-    queue = { revision: 0, paused: false, intentIds: [] };
+    queue = { revision: 0, paused: false, pauseReason: null, intentIds: [] };
     queues.set(chatId, queue);
   }
   return queue;
@@ -152,12 +153,14 @@ export function loadChatQueue(
 ): {
   queueRevision: number;
   queuePaused: boolean;
+  queuePauseReason: QueueAggregate["pauseReason"];
   queue: ChatQueueEntry[];
 } {
   const aggregate = queueFor(chatId);
   return {
     queueRevision: aggregate.revision,
     queuePaused: aggregate.paused,
+    queuePauseReason: aggregate.pauseReason,
     queue: aggregate.intentIds.flatMap((intentId) => {
       const record = liveRecordFor(intentId);
       return record ? [toQueueEntry(record.intent)] : [];
@@ -250,6 +253,9 @@ export function hydrateChatStreamPersistence(
     });
     let revision = persistedState?.revision ?? 0;
     let paused = persistedState?.paused ?? false;
+    let pauseReason: QueueAggregate["pauseReason"] = paused
+      ? (persistedState?.pauseReason ?? "manual")
+      : null;
     // A process restart may happen long after admission or while the head was
     // claimed. Restore every durable queue paused so no work runs invisibly.
     if (
@@ -258,11 +264,18 @@ export function hydrateChatStreamPersistence(
     ) {
       revision += 1;
       paused = true;
+      pauseReason ??= "manual";
       tx.insert(chatQueueStates)
-        .values({ chatId, revision, paused, updatedAt: new Date() })
+        .values({
+          chatId,
+          revision,
+          paused,
+          pauseReason,
+          updatedAt: new Date(),
+        })
         .onConflictDoUpdate({
           target: chatQueueStates.chatId,
-          set: { revision, paused, updatedAt: new Date() },
+          set: { revision, paused, pauseReason, updatedAt: new Date() },
         })
         .run();
       for (const entry of persistedEntries) {
@@ -273,7 +286,7 @@ export function hydrateChatStreamPersistence(
           .run();
       }
     }
-    queues.set(chatId, { revision, paused, intentIds });
+    queues.set(chatId, { revision, paused, pauseReason, intentIds });
   });
   return loadChatQueue(database, chatId);
 }
@@ -366,6 +379,7 @@ function resumeReplayedQueue(
         .set({
           revision: nextRevision,
           paused: false,
+          pauseReason: null,
           updatedAt: new Date(),
         })
         .where(eq(chatQueueStates.chatId, existing.chatId))
@@ -373,6 +387,7 @@ function resumeReplayedQueue(
     }
     aggregate.revision = nextRevision;
     aggregate.paused = false;
+    aggregate.pauseReason = null;
   }
   return loadChatQueue(database, existing.chatId);
 }
@@ -429,6 +444,7 @@ function persistIntentInQueue(
           chatId: intent.chatId,
           revision: aggregate.revision,
           paused: aggregate.paused,
+          pauseReason: aggregate.pauseReason,
           updatedAt: new Date(),
         })
         .onConflictDoNothing({ target: chatQueueStates.chatId })
@@ -464,7 +480,7 @@ function persistIntentInQueue(
       tx.update(chatQueueStates)
         .set({
           revision: nextRevision,
-          ...(resumeQueue ? { paused: false } : {}),
+          ...(resumeQueue ? { paused: false, pauseReason: null } : {}),
           updatedAt: new Date(),
         })
         .where(eq(chatQueueStates.chatId, intent.chatId))
@@ -481,7 +497,10 @@ function persistIntentInQueue(
   });
   aggregate.intentIds.push(intent.intentId);
   aggregate.revision = nextRevision;
-  if (resumeQueue) aggregate.paused = false;
+  if (resumeQueue) {
+    aggregate.paused = false;
+    aggregate.pauseReason = null;
+  }
   return {
     kind: "queued",
     entry: toQueueEntry(intent),
@@ -670,6 +689,7 @@ function persistDurableQueueMutation(
       .set({
         revision: aggregate.revision,
         paused: aggregate.paused,
+        pauseReason: aggregate.pauseReason,
         updatedAt: new Date(),
       })
       .where(eq(chatQueueStates.chatId, chatId))
@@ -806,6 +826,7 @@ export async function mutateChatQueue(
 
     const originalIntentIds = [...aggregate.intentIds];
     const originalPaused = aggregate.paused;
+    const originalPauseReason = aggregate.pauseReason;
     const originalRevision = aggregate.revision;
     const originalRecords = new Map(
       selected.map(({ record }) => [
@@ -821,9 +842,11 @@ export async function mutateChatQueue(
     switch (mutation.type) {
       case "pause":
         aggregate.paused = true;
+        aggregate.pauseReason = "manual";
         break;
       case "resume":
         aggregate.paused = false;
+        aggregate.pauseReason = null;
         break;
       case "edit": {
         const selectedRecord = selected[0]?.record;
@@ -904,6 +927,7 @@ export async function mutateChatQueue(
     } catch (error) {
       aggregate.intentIds = originalIntentIds;
       aggregate.paused = originalPaused;
+      aggregate.pauseReason = originalPauseReason;
       aggregate.revision = originalRevision;
       for (const [record, original] of originalRecords) {
         record.intent = original.intent;
@@ -968,18 +992,20 @@ export async function parkChatQueue(
 ): Promise<ReturnType<typeof loadChatQueue>> {
   return withChatQueueLock(chatId, async () => {
     const aggregate = queueFor(chatId);
-    if (!aggregate.paused) {
+    if (!aggregate.paused || aggregate.pauseReason !== "stop") {
       const nextRevision = aggregate.revision + 1;
       database
         .update(chatQueueStates)
         .set({
           revision: nextRevision,
           paused: true,
+          pauseReason: "stop",
           updatedAt: new Date(),
         })
         .where(eq(chatQueueStates.chatId, chatId))
         .run();
       aggregate.paused = true;
+      aggregate.pauseReason = "stop";
       aggregate.revision = nextRevision;
     }
     return loadChatQueue(database, chatId);
@@ -991,6 +1017,7 @@ export function markIntentTerminal(
   intent: Pick<SerializableChatTurnIntent, "chatId" | "intentId" | "owner">,
   pauseQueue: boolean,
   rejectBeforeAcceptance = false,
+  pauseReason: QueueAggregate["pauseReason"] = "manual",
 ): ReturnType<typeof loadChatQueue> {
   const record = recordFor(intent.intentId);
   if (!record) {
@@ -1003,6 +1030,7 @@ export function markIntentTerminal(
   const originalAggregate = {
     revision: aggregate.revision,
     paused: aggregate.paused,
+    pauseReason: aggregate.pauseReason,
     intentIds: [...aggregate.intentIds],
   };
   const originalRecord = {
@@ -1020,8 +1048,13 @@ export function markIntentTerminal(
     record.acceptance = "rejected";
   }
   record.recovery = "terminal";
-  if (pauseQueue && !aggregate.paused) {
+  if (
+    pauseQueue &&
+    (!aggregate.paused ||
+      (pauseReason === "stop" && aggregate.pauseReason !== "stop"))
+  ) {
     aggregate.paused = true;
+    aggregate.pauseReason = pauseReason;
     changed = true;
   }
   if (changed) aggregate.revision += 1;
@@ -1044,6 +1077,7 @@ export function markIntentTerminal(
           .set({
             revision: aggregate.revision,
             paused: aggregate.paused,
+            pauseReason: aggregate.pauseReason,
             updatedAt: new Date(),
           })
           .where(eq(chatQueueStates.chatId, record.chatId))
@@ -1052,6 +1086,7 @@ export function markIntentTerminal(
     } catch (error) {
       aggregate.revision = originalAggregate.revision;
       aggregate.paused = originalAggregate.paused;
+      aggregate.pauseReason = originalAggregate.pauseReason;
       aggregate.intentIds = originalAggregate.intentIds;
       record.intent = originalRecord.intent;
       record.acceptance = originalRecord.acceptance;

--- a/src/chat_stream/persistence.ts
+++ b/src/chat_stream/persistence.ts
@@ -912,6 +912,20 @@ export async function mutateChatQueue(
   });
 }
 
+export async function parkChatQueue(
+  database: ChatDatabase,
+  chatId: number,
+): Promise<ReturnType<typeof loadChatQueue>> {
+  return withChatQueueLock(chatId, async () => {
+    const aggregate = queueFor(chatId);
+    if (!aggregate.paused) {
+      aggregate.paused = true;
+      aggregate.revision += 1;
+    }
+    return loadChatQueue(database, chatId);
+  });
+}
+
 export function markIntentTerminal(
   database: ChatDatabase,
   intent: Pick<SerializableChatTurnIntent, "chatId" | "intentId" | "owner">,

--- a/src/chat_stream/persistence.ts
+++ b/src/chat_stream/persistence.ts
@@ -302,9 +302,15 @@ function assertMatchingDueFollowUp(intent: SerializableChatTurnIntent): void {
 export function persistSessionQueuedIntent(
   database: ChatDatabase,
   intent: SerializableChatTurnIntent,
+  options?: { resumeQueue?: boolean },
 ): PersistAdmissionResult {
   assertMatchingDueFollowUp(intent);
-  return persistIntentInQueue(database, intent, false);
+  return persistIntentInQueue(
+    database,
+    intent,
+    false,
+    options?.resumeQueue === true,
+  );
 }
 
 export function isSessionQueuedIntent(intentId: string): boolean {
@@ -338,6 +344,7 @@ export type PersistAdmissionResult =
       kind: "queued";
       entry: ChatQueueEntry;
       queueRevision: number;
+      queuePaused: boolean;
     }
   | {
       kind: "replayed";
@@ -349,6 +356,7 @@ function persistIntentInQueue(
   database: ChatDatabase,
   intent: SerializableChatTurnIntent,
   durable: boolean,
+  resumeQueue: boolean,
 ): PersistAdmissionResult {
   assertChatTurnPayloadHash(intent);
   let existing = recordFor(intent.intentId);
@@ -424,7 +432,11 @@ function persistIntentInQueue(
         })
         .run();
       tx.update(chatQueueStates)
-        .set({ revision: nextRevision, updatedAt: new Date() })
+        .set({
+          revision: nextRevision,
+          ...(resumeQueue ? { paused: false } : {}),
+          updatedAt: new Date(),
+        })
         .where(eq(chatQueueStates.chatId, intent.chatId))
         .run();
     });
@@ -439,16 +451,19 @@ function persistIntentInQueue(
   });
   aggregate.intentIds.push(intent.intentId);
   aggregate.revision = nextRevision;
+  if (resumeQueue) aggregate.paused = false;
   return {
     kind: "queued",
     entry: toQueueEntry(intent),
     queueRevision: aggregate.revision,
+    queuePaused: aggregate.paused,
   };
 }
 
 export function persistQueuedIntent(
   database: ChatDatabase,
   intent: SerializableChatTurnIntent,
+  options?: { resumeQueue?: boolean },
 ): PersistAdmissionResult {
   if (intent.owner?.kind === "user-input-follow-up") {
     throw new DyadError(
@@ -456,7 +471,12 @@ export function persistQueuedIntent(
       DyadErrorKind.Validation,
     );
   }
-  return persistIntentInQueue(database, intent, intent.owner === undefined);
+  return persistIntentInQueue(
+    database,
+    intent,
+    intent.owner === undefined,
+    options?.resumeQueue === true,
+  );
 }
 
 export function stageActiveIntent(

--- a/src/chat_stream/remote_manager.test.ts
+++ b/src/chat_stream/remote_manager.test.ts
@@ -478,6 +478,17 @@ describe("ChatStreamRemoteManager", () => {
     ref.send({ type: "cancel" });
 
     await vi.waitFor(() =>
+      expect(dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          encodedEvent: expect.objectContaining({
+            type: "CANCEL",
+            pauseQueue: true,
+          }),
+        }),
+      ),
+    );
+
+    await vi.waitFor(() =>
       expect(consoleError).toHaveBeenCalledWith(
         "[chat-stream] Failed to cancel the chat",
         expect.any(Error),

--- a/src/chat_stream/remote_manager.test.ts
+++ b/src/chat_stream/remote_manager.test.ts
@@ -237,6 +237,72 @@ describe("ChatStreamRemoteManager", () => {
     manager.dispose();
   });
 
+  it("stamps queued submissions before a Stop can overtake bootstrap", async () => {
+    let resolveBootstrap!: (snapshot: MachineSnapshotEnvelope) => void;
+    let subscribedAddress!: MachineAddress;
+    const dispatch = vi.fn(async (envelope: MachineDispatchEnvelope) => ({
+      kind: "applied" as const,
+      actorInstanceId: "actor",
+      revision: 5,
+      transactionSequence: 1,
+      messageId: envelope.messageId,
+    }));
+    const connection: ChatStreamRemoteConnection = {
+      getStatus: () => "connected",
+      onStatusChange: () => () => undefined,
+      onSnapshot: () => () => undefined,
+      onDisposed: () => () => undefined,
+      subscribe: (address) => {
+        subscribedAddress = address;
+        return new Promise((resolve) => {
+          resolveBootstrap = resolve;
+        });
+      },
+      unsubscribe: () => Promise.resolve(),
+      dispatch,
+    };
+    const manager = new ChatStreamRemoteManager(
+      createStore(),
+      createSequentialIdSource(),
+      connection,
+    );
+    const actor = manager.ensure(7);
+
+    actor.send({ type: "submit", request: { chatId: 7, prompt: "first" } });
+    actor.send({ type: "submit", request: { chatId: 7, prompt: "second" } });
+    actor.send({ type: "cancel" });
+
+    resolveBootstrap({
+      ...subscribedAddress,
+      actorInstanceId: "actor",
+      revision: 4,
+      encodedState: {
+        ...unavailableChatStreamSnapshot(7),
+        revision: 4,
+        queuePaused: true,
+        queuePauseReason: "stop",
+        stopPolicyVersion: 3,
+      },
+    });
+
+    await vi.waitFor(() => {
+      const submit = dispatch.mock.calls.find(
+        ([envelope]) =>
+          (envelope.encodedEvent as { type?: string }).type === "SUBMIT",
+      );
+      expect(submit?.[0]).toEqual(
+        expect.objectContaining({
+          encodedEvent: expect.objectContaining({
+            type: "SUBMIT",
+            observedStopPolicyVersion: 0,
+          }),
+        }),
+      );
+    });
+
+    manager.dispose();
+  });
+
   it("handles a pending completion in the first bootstrap snapshot", async () => {
     let resolveBootstrap!: (snapshot: MachineSnapshotEnvelope) => void;
     const dispatch = vi.fn(

--- a/src/chat_stream/remote_manager.test.ts
+++ b/src/chat_stream/remote_manager.test.ts
@@ -500,6 +500,114 @@ describe("ChatStreamRemoteManager", () => {
     manager.dispose();
   });
 
+  it("resyncs before re-cancelling an optimistic submission dispatched in flight", async () => {
+    let resolveSubmit!: () => void;
+    let submittedInvocationRef:
+      | { kind: "chat-stream"; entityKey: number; operationId: string }
+      | undefined;
+    let submitResolved = false;
+    let revision = 1;
+    const dispatch = vi.fn((envelope: MachineDispatchEnvelope) => {
+      const event = envelope.encodedEvent as {
+        type: string;
+        intent?: {
+          invocationRef?: {
+            kind: "chat-stream";
+            entityKey: number;
+            operationId: string;
+          };
+        };
+      };
+      const receipt = () => ({
+        kind: "applied" as const,
+        actorInstanceId: "actor",
+        revision: ++revision,
+        transactionSequence: revision,
+        messageId: envelope.messageId,
+      });
+      if (event.type !== "SUBMIT") return Promise.resolve(receipt());
+      submittedInvocationRef = event.intent?.invocationRef;
+      return new Promise<ReturnType<typeof receipt>>((resolve) => {
+        resolveSubmit = () => {
+          submitResolved = true;
+          resolve(receipt());
+        };
+      });
+    });
+    const connection: ChatStreamRemoteConnection = {
+      getStatus: () => "connected",
+      onStatusChange: () => () => undefined,
+      onSnapshot: () => () => undefined,
+      onDisposed: () => () => undefined,
+      subscribe: async (address) => ({
+        ...address,
+        actorInstanceId: "actor",
+        revision,
+        encodedState:
+          submitResolved && submittedInvocationRef
+            ? {
+                ...unavailableChatStreamSnapshot(7),
+                revision,
+                phase: "streaming",
+                invocationRef: submittedInvocationRef,
+                capabilities: {
+                  canSubmit: true,
+                  canCancel: true,
+                  canPauseQueue: true,
+                  canResumeQueue: false,
+                },
+              }
+            : unavailableChatStreamSnapshot(7),
+      }),
+      unsubscribe: () => Promise.resolve(),
+      dispatch,
+    };
+    const manager = new ChatStreamRemoteManager(
+      createStore(),
+      createSequentialIdSource(),
+      connection,
+    );
+    const actor = manager.ensure(7);
+    const release = actor.subscribe(() => undefined);
+    await vi.waitFor(() => expect(actor.getSnapshot().phase).toBe("idle"));
+
+    actor.send({
+      type: "submit",
+      request: { chatId: 7, prompt: "cancel while dispatching" },
+    });
+    await vi.waitFor(() =>
+      expect(
+        dispatch.mock.calls.some(
+          ([envelope]) =>
+            (envelope.encodedEvent as { type: string }).type === "SUBMIT",
+        ),
+      ).toBe(true),
+    );
+    actor.send({ type: "cancel" });
+    await vi.waitFor(() =>
+      expect(
+        dispatch.mock.calls.filter(
+          ([envelope]) =>
+            (envelope.encodedEvent as { type: string }).type === "CANCEL",
+        ),
+      ).toHaveLength(1),
+    );
+
+    resolveSubmit();
+
+    await vi.waitFor(() =>
+      expect(
+        dispatch.mock.calls.filter(
+          ([envelope]) =>
+            (envelope.encodedEvent as { type: string }).type === "CANCEL",
+        ),
+      ).toHaveLength(2),
+    );
+
+    release();
+    manager.dispose();
+  });
+
   it.each(["resolves", "rejects"] as const)(
     "ignores a completion refresh that %s after disposal",
     async (settlement) => {

--- a/src/chat_stream/remote_manager.test.ts
+++ b/src/chat_stream/remote_manager.test.ts
@@ -237,7 +237,7 @@ describe("ChatStreamRemoteManager", () => {
     manager.dispose();
   });
 
-  it("stamps queued submissions before a Stop can overtake bootstrap", async () => {
+  it("reserves queued submissions before a cross-window Stop overtakes bootstrap", async () => {
     let resolveBootstrap!: (snapshot: MachineSnapshotEnvelope) => void;
     let subscribedAddress!: MachineAddress;
     const dispatch = vi.fn(async (envelope: MachineDispatchEnvelope) => ({
@@ -260,6 +260,7 @@ describe("ChatStreamRemoteManager", () => {
       },
       unsubscribe: () => Promise.resolve(),
       dispatch,
+      observeChatSubmissionStopPolicy: vi.fn(async () => 0),
     };
     const manager = new ChatStreamRemoteManager(
       createStore(),

--- a/src/chat_stream/remote_manager.test.ts
+++ b/src/chat_stream/remote_manager.test.ts
@@ -174,6 +174,69 @@ describe("ChatStreamRemoteManager", () => {
     manager.dispose();
   });
 
+  it("captures the Stop policy from bootstrap instead of the unavailable placeholder", async () => {
+    let resolveBootstrap!: (snapshot: MachineSnapshotEnvelope) => void;
+    let subscribedAddress!: MachineAddress;
+    const dispatch = vi.fn(async (envelope: MachineDispatchEnvelope) => ({
+      kind: "applied" as const,
+      actorInstanceId: "actor",
+      revision: 5,
+      transactionSequence: 1,
+      messageId: envelope.messageId,
+    }));
+    const connection: ChatStreamRemoteConnection = {
+      getStatus: () => "connected",
+      onStatusChange: () => () => undefined,
+      onSnapshot: () => () => undefined,
+      onDisposed: () => () => undefined,
+      subscribe: (address) => {
+        subscribedAddress = address;
+        return new Promise((resolve) => {
+          resolveBootstrap = resolve;
+        });
+      },
+      unsubscribe: () => Promise.resolve(),
+      dispatch,
+    };
+    const manager = new ChatStreamRemoteManager(
+      createStore(),
+      createSequentialIdSource(),
+      connection,
+    );
+    const actor = manager.ensure(7);
+
+    actor.send({
+      type: "submit",
+      request: { chatId: 7, prompt: "send after an earlier Stop" },
+    });
+    expect(dispatch).not.toHaveBeenCalled();
+
+    resolveBootstrap({
+      ...subscribedAddress,
+      actorInstanceId: "actor",
+      revision: 4,
+      encodedState: {
+        ...unavailableChatStreamSnapshot(7),
+        revision: 4,
+        queuePaused: true,
+        queuePauseReason: "stop",
+        stopPolicyVersion: 3,
+      },
+    });
+
+    await vi.waitFor(() => expect(dispatch).toHaveBeenCalledOnce());
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        encodedEvent: expect.objectContaining({
+          type: "SUBMIT",
+          observedStopPolicyVersion: 3,
+        }),
+      }),
+    );
+
+    manager.dispose();
+  });
+
   it("handles a pending completion in the first bootstrap snapshot", async () => {
     let resolveBootstrap!: (snapshot: MachineSnapshotEnvelope) => void;
     const dispatch = vi.fn(

--- a/src/chat_stream/remote_manager.test.ts
+++ b/src/chat_stream/remote_manager.test.ts
@@ -617,6 +617,16 @@ describe("ChatStreamRemoteManager", () => {
         ),
       ).toHaveLength(2),
     );
+    const cancelEvents = dispatch.mock.calls
+      .map(
+        ([envelope]) =>
+          envelope.encodedEvent as {
+            type: string;
+            invocationRef?: typeof submittedInvocationRef;
+          },
+      )
+      .filter((event) => event.type === "CANCEL");
+    expect(cancelEvents[1]?.invocationRef).toEqual(submittedInvocationRef);
 
     release();
     manager.dispose();

--- a/src/chat_stream/remote_manager.test.ts
+++ b/src/chat_stream/remote_manager.test.ts
@@ -500,12 +500,13 @@ describe("ChatStreamRemoteManager", () => {
     manager.dispose();
   });
 
-  it("resyncs before re-cancelling an optimistic submission dispatched in flight", async () => {
+  it("re-cancels the specific optimistic submission when a later tail fails", async () => {
     let resolveSubmit!: () => void;
     let submittedInvocationRef:
       | { kind: "chat-stream"; entityKey: number; operationId: string }
       | undefined;
     let submitResolved = false;
+    let submitCount = 0;
     let revision = 1;
     const dispatch = vi.fn((envelope: MachineDispatchEnvelope) => {
       const event = envelope.encodedEvent as {
@@ -526,6 +527,14 @@ describe("ChatStreamRemoteManager", () => {
         messageId: envelope.messageId,
       });
       if (event.type !== "SUBMIT") return Promise.resolve(receipt());
+      submitCount += 1;
+      if (submitCount > 1) {
+        return Promise.resolve({
+          kind: "rejected" as const,
+          messageId: envelope.messageId,
+          reason: "revision-conflict" as const,
+        });
+      }
       submittedInvocationRef = event.intent?.invocationRef;
       return new Promise<ReturnType<typeof receipt>>((resolve) => {
         resolveSubmit = () => {
@@ -583,6 +592,10 @@ describe("ChatStreamRemoteManager", () => {
         ),
       ).toBe(true),
     );
+    actor.send({
+      type: "submit",
+      request: { chatId: 7, prompt: "later tail that fails" },
+    });
     actor.send({ type: "cancel" });
     await vi.waitFor(() =>
       expect(
@@ -595,6 +608,7 @@ describe("ChatStreamRemoteManager", () => {
 
     resolveSubmit();
 
+    await vi.waitFor(() => expect(submitCount).toBe(2));
     await vi.waitFor(() =>
       expect(
         dispatch.mock.calls.filter(

--- a/src/chat_stream/remote_manager.ts
+++ b/src/chat_stream/remote_manager.ts
@@ -349,7 +349,7 @@ export class ChatStreamRemoteManager {
         if (!invocationRef) return;
         this.dispatchCompatibilityCommand(
           chatId,
-          { type: "CANCEL", invocationRef },
+          { type: "CANCEL", invocationRef, pauseQueue: true },
           "cancel the chat",
         );
         return;

--- a/src/chat_stream/remote_manager.ts
+++ b/src/chat_stream/remote_manager.ts
@@ -51,6 +51,7 @@ interface PendingSubmission {
   request: StreamRequest;
   invocationRef: NonNullable<ChatStreamRemoteSnapshot["invocationRef"]>;
   dispatch: Promise<boolean>;
+  queueOnly: boolean;
   acceptanceDelivered: boolean;
   releaseSubscription: () => void;
 }
@@ -349,46 +350,48 @@ export class ChatStreamRemoteManager {
         const snapshot = this.getSnapshot(chatId);
         const invocationRef = snapshot.invocationRef;
         if (!invocationRef) return;
-        if (!snapshot.capabilities.canCancel) {
-          const optimistic = [...this.pendingSubmissions.entries()].find(
-            ([, pending]) =>
-              pending.request.chatId === chatId &&
-              pending.invocationRef.operationId === invocationRef.operationId,
-          );
-          if (optimistic) {
-            const [intentId] = optimistic;
-            const pending = this.takePendingSubmission(intentId);
-            this.notifySnapshotListeners(chatId);
-            pending?.request.onSettled?.({ success: false });
-            if (pending) {
-              void pending.dispatch
-                .then(async (wasDispatched) => {
-                  if (!wasDispatched || this.disposed) return;
-                  const actor = this.actor(chatId);
-                  await actor.resync();
-                  if (this.disposed) return;
-                  const current = actor.getSnapshot();
-                  if (
-                    current.invocationRef?.operationId ===
-                      invocationRef.operationId &&
-                    current.capabilities.canCancel
-                  ) {
-                    this.dispatchCompatibilityCommand(
-                      chatId,
-                      { type: "CANCEL", invocationRef, pauseQueue: true },
-                      "cancel the chat",
-                    );
-                  }
-                })
-                .catch((error) => {
-                  if (!this.disposed) {
-                    this.reportCompatibilityDispatchFailure(
-                      "cancel the chat",
-                      error,
-                    );
-                  }
-                });
-            }
+        for (const pending of this.pendingSubmissions.values()) {
+          if (pending.request.chatId === chatId) pending.queueOnly = true;
+        }
+        const optimistic = [...this.pendingSubmissions.entries()].find(
+          ([, pending]) =>
+            !pending.acceptanceDelivered &&
+            pending.request.chatId === chatId &&
+            pending.invocationRef.operationId === invocationRef.operationId,
+        );
+        if (optimistic) {
+          const [intentId] = optimistic;
+          const pending = this.takePendingSubmission(intentId);
+          this.notifySnapshotListeners(chatId);
+          pending?.request.onSettled?.({ success: false });
+          if (pending) {
+            void pending.dispatch
+              .then(async (wasDispatched) => {
+                if (!wasDispatched || this.disposed) return;
+                const actor = this.actor(chatId);
+                await actor.resync();
+                if (this.disposed) return;
+                const current = actor.getSnapshot();
+                if (
+                  current.invocationRef?.operationId ===
+                    invocationRef.operationId &&
+                  current.capabilities.canCancel
+                ) {
+                  this.dispatchCompatibilityCommand(
+                    chatId,
+                    { type: "CANCEL", invocationRef, pauseQueue: true },
+                    "cancel the chat",
+                  );
+                }
+              })
+              .catch((error) => {
+                if (!this.disposed) {
+                  this.reportCompatibilityDispatchFailure(
+                    "cancel the chat",
+                    error,
+                  );
+                }
+              });
           }
         }
         this.dispatchCompatibilityCommand(
@@ -449,6 +452,7 @@ export class ChatStreamRemoteManager {
       request,
       invocationRef,
       dispatch: Promise.resolve(false),
+      queueOnly: false,
       acceptanceDelivered: false,
       releaseSubscription: release,
     };
@@ -509,7 +513,13 @@ export class ChatStreamRemoteManager {
         ),
       };
       if (this.disposed || !this.pendingSubmissions.has(intentId)) return false;
-      const receipt = await actor.dispatch({ type: "SUBMIT", intent });
+      const pending = this.pendingSubmissions.get(intentId);
+      if (!pending) return false;
+      const receipt = await actor.dispatch({
+        type: "SUBMIT",
+        intent,
+        ...(pending.queueOnly ? { queueOnly: true } : {}),
+      });
       if (receipt.kind === "rejected") {
         throw new Error(`Chat submission rejected: ${receipt.reason}`);
       }

--- a/src/chat_stream/remote_manager.ts
+++ b/src/chat_stream/remote_manager.ts
@@ -362,6 +362,7 @@ export class ChatStreamRemoteManager {
             pending?.request.onSettled?.({ success: false });
             if (submission) {
               void submission.finally(() => {
+                if (this.disposed) return;
                 const current = this.actor(chatId).getSnapshot();
                 if (
                   current.invocationRef?.operationId ===

--- a/src/chat_stream/remote_manager.ts
+++ b/src/chat_stream/remote_manager.ts
@@ -35,6 +35,7 @@ type JotaiStore = ReturnType<typeof createStore>;
 
 export type ChatStreamRemoteConnection = RemoteMachineClientConnection & {
   start?: () => () => void;
+  observeChatSubmissionStopPolicy?: (chatId: number) => Promise<number>;
 };
 
 export interface StreamFinishedEvent {
@@ -51,7 +52,9 @@ interface PendingSubmission {
   request: StreamRequest;
   invocationRef: NonNullable<ChatStreamRemoteSnapshot["invocationRef"]>;
   dispatch: Promise<boolean>;
-  observedStopPolicyVersion: number | undefined;
+  observedStopPolicyVersion: Promise<
+    { kind: "observed"; value: number } | { kind: "failed"; error: unknown }
+  >;
   acceptanceDelivered: boolean;
   releaseSubscription: () => void;
 }
@@ -354,14 +357,6 @@ export class ChatStreamRemoteManager {
         if (!invocationRef) return;
         const stopId = this.ids.next("chat-stop");
         const observedStopPolicyVersion = snapshot.stopPolicyVersion;
-        for (const pending of this.pendingSubmissions.values()) {
-          if (
-            pending.request.chatId === chatId &&
-            pending.observedStopPolicyVersion === undefined
-          ) {
-            pending.observedStopPolicyVersion = observedStopPolicyVersion;
-          }
-        }
         const optimistic = [...this.pendingSubmissions.entries()].find(
           ([, pending]) =>
             !pending.acceptanceDelivered &&
@@ -470,14 +465,23 @@ export class ChatStreamRemoteManager {
       operationId: this.ids.next("chat-stream"),
     } as const;
     const actorView = actor.getView();
+    const stopPolicyObservation =
+      actorView.snapshot.kind === "available"
+        ? Promise.resolve(actorView.state.stopPolicyVersion)
+        : this.connection.observeChatSubmissionStopPolicy
+          ? this.connection.observeChatSubmissionStopPolicy(request.chatId)
+          : this.subscriptions
+              .get(request.chatId)!
+              .bootstrap.then(() => actor.getSnapshot().stopPolicyVersion);
+    const observedStopPolicyVersion = stopPolicyObservation.then(
+      (value) => ({ kind: "observed" as const, value }),
+      (error: unknown) => ({ kind: "failed" as const, error }),
+    );
     const pending: PendingSubmission = {
       request,
       invocationRef,
       dispatch: Promise.resolve(false),
-      observedStopPolicyVersion:
-        actorView.snapshot.kind === "available"
-          ? actorView.state.stopPolicyVersion
-          : undefined,
+      observedStopPolicyVersion,
       acceptanceDelivered: false,
       releaseSubscription: release,
     };
@@ -511,16 +515,15 @@ export class ChatStreamRemoteManager {
   ): Promise<boolean> {
     try {
       if (this.disposed || !this.pendingSubmissions.has(intentId)) return false;
-      await this.subscriptions.get(request.chatId)?.bootstrap;
-      if (this.disposed || !this.pendingSubmissions.has(intentId)) return false;
-      const pendingAfterBootstrap = this.pendingSubmissions.get(intentId);
-      if (
-        pendingAfterBootstrap &&
-        pendingAfterBootstrap.observedStopPolicyVersion === undefined
-      ) {
-        pendingAfterBootstrap.observedStopPolicyVersion =
-          actor.getSnapshot().stopPolicyVersion;
+      const [stopPolicyObservation] = await Promise.all([
+        this.pendingSubmissions.get(intentId)!.observedStopPolicyVersion,
+        this.subscriptions.get(request.chatId)?.bootstrap,
+      ]);
+      if (stopPolicyObservation.kind === "failed") {
+        throw stopPolicyObservation.error;
       }
+      const observedStopPolicyVersion = stopPolicyObservation.value;
+      if (this.disposed || !this.pendingSubmissions.has(intentId)) return false;
       const attachments =
         request.attachments && request.attachments.length > 0
           ? await convertFileAttachmentsToChatAttachments(request.attachments)
@@ -546,12 +549,10 @@ export class ChatStreamRemoteManager {
         ),
       };
       if (this.disposed || !this.pendingSubmissions.has(intentId)) return false;
-      const pending = this.pendingSubmissions.get(intentId);
-      if (!pending) return false;
       const receipt = await actor.dispatch({
         type: "SUBMIT",
         intent,
-        observedStopPolicyVersion: pending.observedStopPolicyVersion,
+        observedStopPolicyVersion,
       });
       if (receipt.kind === "rejected") {
         throw new Error(`Chat submission rejected: ${receipt.reason}`);

--- a/src/chat_stream/remote_manager.ts
+++ b/src/chat_stream/remote_manager.ts
@@ -51,7 +51,7 @@ interface PendingSubmission {
   request: StreamRequest;
   invocationRef: NonNullable<ChatStreamRemoteSnapshot["invocationRef"]>;
   dispatch: Promise<boolean>;
-  observedStopPolicyVersion: number;
+  observedStopPolicyVersion: number | undefined;
   acceptanceDelivered: boolean;
   releaseSubscription: () => void;
 }
@@ -351,6 +351,7 @@ export class ChatStreamRemoteManager {
         const invocationRef = snapshot.invocationRef;
         if (!invocationRef) return;
         const stopId = this.ids.next("chat-stop");
+        const observedStopPolicyVersion = snapshot.stopPolicyVersion;
         const optimistic = [...this.pendingSubmissions.entries()].find(
           ([, pending]) =>
             !pending.acceptanceDelivered &&
@@ -382,6 +383,7 @@ export class ChatStreamRemoteManager {
                       invocationRef,
                       pauseQueue: true,
                       stopId,
+                      observedStopPolicyVersion,
                     },
                     "cancel the chat",
                   );
@@ -399,7 +401,13 @@ export class ChatStreamRemoteManager {
         }
         this.dispatchCompatibilityCommand(
           chatId,
-          { type: "CANCEL", invocationRef, pauseQueue: true, stopId },
+          {
+            type: "CANCEL",
+            invocationRef,
+            pauseQueue: true,
+            stopId,
+            observedStopPolicyVersion,
+          },
           "cancel the chat",
         );
         return;
@@ -451,11 +459,15 @@ export class ChatStreamRemoteManager {
       entityKey: request.chatId,
       operationId: this.ids.next("chat-stream"),
     } as const;
+    const actorView = actor.getView();
     const pending: PendingSubmission = {
       request,
       invocationRef,
       dispatch: Promise.resolve(false),
-      observedStopPolicyVersion: actor.getSnapshot().stopPolicyVersion,
+      observedStopPolicyVersion:
+        actorView.snapshot.kind === "available"
+          ? actorView.state.stopPolicyVersion
+          : undefined,
       acceptanceDelivered: false,
       releaseSubscription: release,
     };
@@ -491,6 +503,14 @@ export class ChatStreamRemoteManager {
       if (this.disposed || !this.pendingSubmissions.has(intentId)) return false;
       await this.subscriptions.get(request.chatId)?.bootstrap;
       if (this.disposed || !this.pendingSubmissions.has(intentId)) return false;
+      const pendingAfterBootstrap = this.pendingSubmissions.get(intentId);
+      if (
+        pendingAfterBootstrap &&
+        pendingAfterBootstrap.observedStopPolicyVersion === undefined
+      ) {
+        pendingAfterBootstrap.observedStopPolicyVersion =
+          actor.getSnapshot().stopPolicyVersion;
+      }
       const attachments =
         request.attachments && request.attachments.length > 0
           ? await convertFileAttachmentsToChatAttachments(request.attachments)

--- a/src/chat_stream/remote_manager.ts
+++ b/src/chat_stream/remote_manager.ts
@@ -50,6 +50,7 @@ export interface StreamFinishedEvent {
 interface PendingSubmission {
   request: StreamRequest;
   invocationRef: NonNullable<ChatStreamRemoteSnapshot["invocationRef"]>;
+  dispatch: Promise<boolean>;
   acceptanceDelivered: boolean;
   releaseSubscription: () => void;
 }
@@ -356,12 +357,11 @@ export class ChatStreamRemoteManager {
           );
           if (optimistic) {
             const [intentId] = optimistic;
-            const submission = this.submissionTails.get(chatId);
             const pending = this.takePendingSubmission(intentId);
             this.notifySnapshotListeners(chatId);
             pending?.request.onSettled?.({ success: false });
-            if (submission) {
-              void submission
+            if (pending) {
+              void pending.dispatch
                 .then(async (wasDispatched) => {
                   if (!wasDispatched || this.disposed) return;
                   const actor = this.actor(chatId);
@@ -445,12 +445,14 @@ export class ChatStreamRemoteManager {
       entityKey: request.chatId,
       operationId: this.ids.next("chat-stream"),
     } as const;
-    this.pendingSubmissions.set(intentId, {
+    const pending: PendingSubmission = {
       request,
       invocationRef,
+      dispatch: Promise.resolve(false),
       acceptanceDelivered: false,
       releaseSubscription: release,
-    });
+    };
+    this.pendingSubmissions.set(intentId, pending);
     this.notifySnapshotListeners(request.chatId);
     const previous = this.submissionTails.get(request.chatId);
     const submission = (previous ?? Promise.resolve(false))
@@ -463,6 +465,7 @@ export class ChatStreamRemoteManager {
           invocationRef,
         ),
       );
+    pending.dispatch = submission;
     this.submissionTails.set(request.chatId, submission);
     void submission.finally(() => {
       if (this.submissionTails.get(request.chatId) === submission) {

--- a/src/chat_stream/remote_manager.ts
+++ b/src/chat_stream/remote_manager.ts
@@ -51,7 +51,7 @@ interface PendingSubmission {
   request: StreamRequest;
   invocationRef: NonNullable<ChatStreamRemoteSnapshot["invocationRef"]>;
   dispatch: Promise<boolean>;
-  queueOnly: boolean;
+  observedStopPolicyVersion: number;
   acceptanceDelivered: boolean;
   releaseSubscription: () => void;
 }
@@ -350,9 +350,7 @@ export class ChatStreamRemoteManager {
         const snapshot = this.getSnapshot(chatId);
         const invocationRef = snapshot.invocationRef;
         if (!invocationRef) return;
-        for (const pending of this.pendingSubmissions.values()) {
-          if (pending.request.chatId === chatId) pending.queueOnly = true;
-        }
+        const stopId = this.ids.next("chat-stop");
         const optimistic = [...this.pendingSubmissions.entries()].find(
           ([, pending]) =>
             !pending.acceptanceDelivered &&
@@ -379,7 +377,12 @@ export class ChatStreamRemoteManager {
                 ) {
                   this.dispatchCompatibilityCommand(
                     chatId,
-                    { type: "CANCEL", invocationRef, pauseQueue: true },
+                    {
+                      type: "CANCEL",
+                      invocationRef,
+                      pauseQueue: true,
+                      stopId,
+                    },
                     "cancel the chat",
                   );
                 }
@@ -396,7 +399,7 @@ export class ChatStreamRemoteManager {
         }
         this.dispatchCompatibilityCommand(
           chatId,
-          { type: "CANCEL", invocationRef, pauseQueue: true },
+          { type: "CANCEL", invocationRef, pauseQueue: true, stopId },
           "cancel the chat",
         );
         return;
@@ -452,7 +455,7 @@ export class ChatStreamRemoteManager {
       request,
       invocationRef,
       dispatch: Promise.resolve(false),
-      queueOnly: false,
+      observedStopPolicyVersion: actor.getSnapshot().stopPolicyVersion,
       acceptanceDelivered: false,
       releaseSubscription: release,
     };
@@ -518,7 +521,7 @@ export class ChatStreamRemoteManager {
       const receipt = await actor.dispatch({
         type: "SUBMIT",
         intent,
-        ...(pending.queueOnly ? { queueOnly: true } : {}),
+        observedStopPolicyVersion: pending.observedStopPolicyVersion,
       });
       if (receipt.kind === "rejected") {
         throw new Error(`Chat submission rejected: ${receipt.reason}`);

--- a/src/chat_stream/remote_manager.ts
+++ b/src/chat_stream/remote_manager.ts
@@ -118,7 +118,7 @@ export class ChatStreamRemoteManager {
     (event: StreamFinishedEvent) => void
   >();
   private readonly pendingSubmissions = new Map<string, PendingSubmission>();
-  private readonly submissionTails = new Map<number, Promise<void>>();
+  private readonly submissionTails = new Map<number, Promise<boolean>>();
   private readonly snapshotListeners = new Map<number, Set<() => void>>();
   private readonly optimisticSnapshots = new Map<
     number,
@@ -361,21 +361,33 @@ export class ChatStreamRemoteManager {
             this.notifySnapshotListeners(chatId);
             pending?.request.onSettled?.({ success: false });
             if (submission) {
-              void submission.finally(() => {
-                if (this.disposed) return;
-                const current = this.actor(chatId).getSnapshot();
-                if (
-                  current.invocationRef?.operationId ===
-                    invocationRef.operationId &&
-                  current.capabilities.canCancel
-                ) {
-                  this.dispatchCompatibilityCommand(
-                    chatId,
-                    { type: "CANCEL", invocationRef, pauseQueue: true },
-                    "cancel the chat",
-                  );
-                }
-              });
+              void submission
+                .then(async (wasDispatched) => {
+                  if (!wasDispatched || this.disposed) return;
+                  const actor = this.actor(chatId);
+                  await actor.resync();
+                  if (this.disposed) return;
+                  const current = actor.getSnapshot();
+                  if (
+                    current.invocationRef?.operationId ===
+                      invocationRef.operationId &&
+                    current.capabilities.canCancel
+                  ) {
+                    this.dispatchCompatibilityCommand(
+                      chatId,
+                      { type: "CANCEL", invocationRef, pauseQueue: true },
+                      "cancel the chat",
+                    );
+                  }
+                })
+                .catch((error) => {
+                  if (!this.disposed) {
+                    this.reportCompatibilityDispatchFailure(
+                      "cancel the chat",
+                      error,
+                    );
+                  }
+                });
             }
           }
         }
@@ -441,8 +453,8 @@ export class ChatStreamRemoteManager {
     });
     this.notifySnapshotListeners(request.chatId);
     const previous = this.submissionTails.get(request.chatId);
-    const submission = (previous ?? Promise.resolve())
-      .catch(() => undefined)
+    const submission = (previous ?? Promise.resolve(false))
+      .catch(() => false)
       .then(() =>
         this.prepareAndDispatchSubmission(
           request,
@@ -464,11 +476,11 @@ export class ChatStreamRemoteManager {
     actor: ReturnType<ChatStreamRemoteManager["actor"]>,
     intentId: string,
     invocationRef: NonNullable<ChatStreamRemoteSnapshot["invocationRef"]>,
-  ): Promise<void> {
+  ): Promise<boolean> {
     try {
-      if (this.disposed || !this.pendingSubmissions.has(intentId)) return;
+      if (this.disposed || !this.pendingSubmissions.has(intentId)) return false;
       await this.subscriptions.get(request.chatId)?.bootstrap;
-      if (this.disposed || !this.pendingSubmissions.has(intentId)) return;
+      if (this.disposed || !this.pendingSubmissions.has(intentId)) return false;
       const attachments =
         request.attachments && request.attachments.length > 0
           ? await convertFileAttachmentsToChatAttachments(request.attachments)
@@ -493,19 +505,21 @@ export class ChatStreamRemoteManager {
           serializeImmutableChatTurnPayload(withoutHash),
         ),
       };
-      if (this.disposed || !this.pendingSubmissions.has(intentId)) return;
+      if (this.disposed || !this.pendingSubmissions.has(intentId)) return false;
       const receipt = await actor.dispatch({ type: "SUBMIT", intent });
       if (receipt.kind === "rejected") {
         throw new Error(`Chat submission rejected: ${receipt.reason}`);
       }
+      return true;
     } catch (error) {
       const pending = this.takePendingSubmission(intentId);
-      if (!pending) return;
+      if (!pending) return false;
       this.notifySnapshotListeners(request.chatId);
       pending.request.onAcceptanceError?.(
         error instanceof Error ? error : new Error(String(error)),
       );
       pending.request.onSettled?.({ success: false });
+      return false;
     }
   }
 

--- a/src/chat_stream/remote_manager.ts
+++ b/src/chat_stream/remote_manager.ts
@@ -261,6 +261,7 @@ export class ChatStreamRemoteManager {
     let releaseSettlement = IDLE_UNSUBSCRIBE;
     try {
       await actor.resync();
+      const observedStopPolicyVersion = actor.getSnapshot().stopPolicyVersion;
       const mutationId = this.ids.next("chat-queue");
       const settlement = new Promise<
         NonNullable<ChatStreamRemoteSnapshot["lastQueueMutation"]>
@@ -278,6 +279,7 @@ export class ChatStreamRemoteManager {
         ...event,
         mutationId,
         expectedQueueRevision: mutationQueueRevision,
+        ...(event.type === "RESUME_QUEUE" ? { observedStopPolicyVersion } : {}),
       } as ChatStreamIntentEvent);
       if (receipt.kind === "rejected") {
         throw new Error(`Chat queue request rejected: ${receipt.reason}`);
@@ -352,6 +354,14 @@ export class ChatStreamRemoteManager {
         if (!invocationRef) return;
         const stopId = this.ids.next("chat-stop");
         const observedStopPolicyVersion = snapshot.stopPolicyVersion;
+        for (const pending of this.pendingSubmissions.values()) {
+          if (
+            pending.request.chatId === chatId &&
+            pending.observedStopPolicyVersion === undefined
+          ) {
+            pending.observedStopPolicyVersion = observedStopPolicyVersion;
+          }
+        }
         const optimistic = [...this.pendingSubmissions.entries()].find(
           ([, pending]) =>
             !pending.acceptanceDelivered &&

--- a/src/chat_stream/remote_manager.ts
+++ b/src/chat_stream/remote_manager.ts
@@ -345,8 +345,39 @@ export class ChatStreamRemoteManager {
         this.submit(event.request);
         return;
       case "cancel": {
-        const invocationRef = this.getSnapshot(chatId).invocationRef;
+        const snapshot = this.getSnapshot(chatId);
+        const invocationRef = snapshot.invocationRef;
         if (!invocationRef) return;
+        if (!snapshot.capabilities.canCancel) {
+          const optimistic = [...this.pendingSubmissions.entries()].find(
+            ([, pending]) =>
+              pending.request.chatId === chatId &&
+              pending.invocationRef.operationId === invocationRef.operationId,
+          );
+          if (optimistic) {
+            const [intentId] = optimistic;
+            const submission = this.submissionTails.get(chatId);
+            const pending = this.takePendingSubmission(intentId);
+            this.notifySnapshotListeners(chatId);
+            pending?.request.onSettled?.({ success: false });
+            if (submission) {
+              void submission.finally(() => {
+                const current = this.actor(chatId).getSnapshot();
+                if (
+                  current.invocationRef?.operationId ===
+                    invocationRef.operationId &&
+                  current.capabilities.canCancel
+                ) {
+                  this.dispatchCompatibilityCommand(
+                    chatId,
+                    { type: "CANCEL", invocationRef, pauseQueue: true },
+                    "cancel the chat",
+                  );
+                }
+              });
+            }
+          }
+        }
         this.dispatchCompatibilityCommand(
           chatId,
           { type: "CANCEL", invocationRef, pauseQueue: true },

--- a/src/chat_stream/session_queue.test.ts
+++ b/src/chat_stream/session_queue.test.ts
@@ -298,6 +298,7 @@ describe("main-session follow-up queue", () => {
     expect(markIntentTerminal(database, intent, false)).toEqual({
       queueRevision: 0,
       queuePaused: false,
+      queuePauseReason: null,
       queue: [],
     });
     expect(getIntentAcceptance(intent.intentId)).toBeUndefined();

--- a/src/chat_stream/transition.ts
+++ b/src/chat_stream/transition.ts
@@ -1,5 +1,11 @@
 import type { ChatStreamRemoteSnapshot } from "./transport";
 
+export function canCancelActiveChatStreamPhase(
+  phase: ChatStreamRemoteSnapshot["phase"],
+): boolean {
+  return phase === "admitting" || phase === "streaming";
+}
+
 export function canCancelChatStreamPhase(
   phase: ChatStreamRemoteSnapshot["phase"],
 ): boolean {

--- a/src/chat_stream/transition.ts
+++ b/src/chat_stream/transition.ts
@@ -1,16 +1,22 @@
 import type { ChatStreamRemoteSnapshot } from "./transport";
 
+export function canCancelChatStreamPhase(
+  phase: ChatStreamRemoteSnapshot["phase"],
+): boolean {
+  return (
+    phase === "admitting" ||
+    phase === "streaming" ||
+    phase === "cancelling" ||
+    phase === "finalizing"
+  );
+}
+
 /** True while the main-owned stream is active from the user's point of view. */
 export function isStreamActive(
   state: Pick<ChatStreamRemoteSnapshot, "phase"> | { readonly type: string },
 ): boolean {
   if ("phase" in state) {
-    return (
-      state.phase === "admitting" ||
-      state.phase === "streaming" ||
-      state.phase === "cancelling" ||
-      state.phase === "finalizing"
-    );
+    return canCancelChatStreamPhase(state.phase);
   }
   return (
     state.type === "starting" ||

--- a/src/chat_stream/transport.ts
+++ b/src/chat_stream/transport.ts
@@ -123,6 +123,7 @@ export const ChatStreamIntentEventSchema = z.discriminatedUnion("type", [
       invocationRef: ChatStreamInvocationRefSchema,
       pauseQueue: z.boolean().optional(),
       stopId: z.string().min(1).max(MAX_CHAT_WIRE_ID_CHARS).optional(),
+      observedStopPolicyVersion: z.number().int().nonnegative().optional(),
     })
     .strict(),
   z

--- a/src/chat_stream/transport.ts
+++ b/src/chat_stream/transport.ts
@@ -120,6 +120,7 @@ export const ChatStreamIntentEventSchema = z.discriminatedUnion("type", [
     .object({
       type: z.literal("CANCEL"),
       invocationRef: ChatStreamInvocationRefSchema,
+      pauseQueue: z.boolean().optional(),
     })
     .strict(),
   z

--- a/src/chat_stream/transport.ts
+++ b/src/chat_stream/transport.ts
@@ -114,7 +114,7 @@ export const ChatStreamIntentEventSchema = z.discriminatedUnion("type", [
     .object({
       type: z.literal("SUBMIT"),
       intent: SerializableChatTurnIntentSchema,
-      queueOnly: z.boolean().optional(),
+      observedStopPolicyVersion: z.number().int().nonnegative().optional(),
     })
     .strict(),
   z
@@ -122,6 +122,7 @@ export const ChatStreamIntentEventSchema = z.discriminatedUnion("type", [
       type: z.literal("CANCEL"),
       invocationRef: ChatStreamInvocationRefSchema,
       pauseQueue: z.boolean().optional(),
+      stopId: z.string().min(1).max(MAX_CHAT_WIRE_ID_CHARS).optional(),
     })
     .strict(),
   z
@@ -327,6 +328,7 @@ export const ChatStreamRemoteSnapshotSchema = z
     queueRevision: expectedQueueRevision,
     queuePaused: z.boolean(),
     queue: z.array(ChatQueueEntrySchema),
+    stopPolicyVersion: z.number().int().nonnegative(),
     capabilities: z
       .object({
         canSubmit: z.boolean(),
@@ -393,6 +395,7 @@ export function unavailableChatStreamSnapshot(
     queueRevision: 0,
     queuePaused: false,
     queue: [],
+    stopPolicyVersion: 0,
     capabilities: {
       canSubmit: true,
       canCancel: false,

--- a/src/chat_stream/transport.ts
+++ b/src/chat_stream/transport.ts
@@ -327,6 +327,7 @@ export const ChatStreamRemoteSnapshotSchema = z
     error: z.string().nullable(),
     queueRevision: expectedQueueRevision,
     queuePaused: z.boolean(),
+    queuePauseReason: z.enum(["stop", "manual", "step-limit"]).nullable(),
     queue: z.array(ChatQueueEntrySchema),
     stopPolicyVersion: z.number().int().nonnegative(),
     capabilities: z
@@ -394,6 +395,7 @@ export function unavailableChatStreamSnapshot(
     error: null,
     queueRevision: 0,
     queuePaused: false,
+    queuePauseReason: null,
     queue: [],
     stopPolicyVersion: 0,
     capabilities: {

--- a/src/chat_stream/transport.ts
+++ b/src/chat_stream/transport.ts
@@ -114,6 +114,7 @@ export const ChatStreamIntentEventSchema = z.discriminatedUnion("type", [
     .object({
       type: z.literal("SUBMIT"),
       intent: SerializableChatTurnIntentSchema,
+      queueOnly: z.boolean().optional(),
     })
     .strict(),
   z
@@ -197,6 +198,8 @@ export const ChatStreamHostEventSchema = z.discriminatedUnion("type", [
       intentId: z.string(),
       entry: ChatQueueEntrySchema,
       queueRevision: expectedQueueRevision,
+      queuePaused: z.boolean(),
+      resumeQueue: z.boolean(),
     })
     .strict(),
   z

--- a/src/chat_stream/transport.ts
+++ b/src/chat_stream/transport.ts
@@ -254,6 +254,23 @@ export const ChatStreamHostEventSchema = z.discriminatedUnion("type", [
     .strict(),
   z
     .object({
+      type: z.literal("QUEUE_PARKED"),
+      queueRevision: expectedQueueRevision,
+      paused: z.literal(true),
+      entries: z.array(ChatQueueEntrySchema),
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal("QUEUE_PARK_FAILED"),
+      error: z.string(),
+      queueRevision: expectedQueueRevision,
+      paused: z.boolean(),
+      entries: z.array(ChatQueueEntrySchema),
+    })
+    .strict(),
+  z
+    .object({
       type: z.literal("LIFECYCLE_COMMAND_FAILED"),
       command: z.enum(["cancel-active", "finalize"]),
       intentId: z.string(),

--- a/src/chat_stream/transport.ts
+++ b/src/chat_stream/transport.ts
@@ -202,6 +202,7 @@ export const ChatStreamHostEventSchema = z.discriminatedUnion("type", [
       queueRevision: expectedQueueRevision,
       queuePaused: z.boolean(),
       resumeQueue: z.boolean(),
+      observedStopPolicyVersion: z.number().int().nonnegative().optional(),
     })
     .strict(),
   z
@@ -245,6 +246,8 @@ export const ChatStreamHostEventSchema = z.discriminatedUnion("type", [
       queueRevision: expectedQueueRevision,
       paused: z.boolean(),
       entries: z.array(ChatQueueEntrySchema),
+      resumeQueue: z.boolean().optional(),
+      observedStopPolicyVersion: z.number().int().nonnegative().optional(),
     })
     .strict(),
   z

--- a/src/chat_stream/transport.ts
+++ b/src/chat_stream/transport.ts
@@ -144,6 +144,7 @@ export const ChatStreamIntentEventSchema = z.discriminatedUnion("type", [
       type: z.literal("RESUME_QUEUE"),
       expectedQueueRevision,
       mutationId: queueMutationId,
+      observedStopPolicyVersion: z.number().int().nonnegative().optional(),
     })
     .strict(),
   z

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -661,27 +661,17 @@ export function ChatInput({ chatId }: { chatId?: number }) {
     // still has prompts they care about queued — deleting them here silently
     // lost work, including the queue restored (paused) after a restart.
     //
-    // Latch unconditionally rather than gating on `queuedMessages`: that is a
-    // render-time snapshot, and the machine can admit a follow-up into the live
-    // queue after it. Skipping the latch on a stale empty snapshot would let
-    // finalization dispatch that item, so Stop would start a new generation.
-    // A latch with a genuinely empty queue is harmless — the empty-queue effect
-    // above clears it after cancellation settles.
+    // The cancel intent also tells the authoritative actor to park the queue.
+    // Keeping those actions in one actor transition prevents queue revision
+    // races while still parking follow-ups admitted during cancellation.
     // Always reset editing state when cancelling, regardless of pause state
     if (editingQueuedMessageId) {
       resetEditingState();
     }
-    // Enter the authoritative cancelling state before publishing the pause
-    // latch. This prevents the empty-queue effect from observing the latch
-    // without also observing that cancellation is settling.
     if (chatId) {
       // The stream machine reconciles the cancel with the real terminal
       // event (including cancels fired before main registered the stream).
       cancelStream();
-    }
-    // Do NOT reset pause state here; queued messages should remain paused after stopping
-    if (!isPaused) {
-      pauseQueue();
     }
   };
 

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -619,9 +619,9 @@ export function ChatInput({ chatId }: { chatId?: number }) {
       return;
     }
 
-    // Queue while actively streaming. When the queue is paused but the actor
-    // is idle, the normal Send path appends this prompt and resumes FIFO so
-    // the oldest queued prompt runs first.
+    // Queue while actively streaming. When Stop parked the queue but the actor
+    // is idle, the main actor appends this prompt and resumes FIFO. Explicit
+    // Pause and step-limit pauses instead let this new turn run immediately.
     if (isStreaming) {
       const queued = queueMessage({
         prompt: currentInput,

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -619,8 +619,9 @@ export function ChatInput({ chatId }: { chatId?: number }) {
       return;
     }
 
-    // Queue while actively streaming. If we're paused but currently idle,
-    // send the new message immediately and keep existing queued items paused.
+    // Queue while actively streaming. When the queue is paused but the actor
+    // is idle, the normal Send path appends this prompt and resumes FIFO so
+    // the oldest queued prompt runs first.
     if (isStreaming) {
       const queued = queueMessage({
         prompt: currentInput,

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -436,9 +436,9 @@ export function ChatInput({ chatId }: { chatId?: number }) {
   }, []);
 
   // Auto-clear pause state when queue becomes empty (Users expect that deleting
-  // all queued messages returns them to normal send mode). Keep the Stop latch
-  // until cancellation settles so a late submission admitted by the stream
-  // machine cannot land in an unpaused queue.
+  // all queued messages returns them to normal send mode). Keep the
+  // authoritative Stop policy until cancellation settles so a late submission
+  // admitted by the stream machine cannot land in an unpaused queue.
 
   useEffect(() => {
     if (

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -248,6 +248,9 @@ export const chatQueueStates = sqliteTable("chat_queue_states", {
     .references(() => chats.id, { onDelete: "cascade" }),
   revision: integer("revision").notNull().default(0),
   paused: integer("paused", { mode: "boolean" }).notNull().default(false),
+  pauseReason: text("pause_reason", {
+    enum: ["stop", "manual", "step-limit"],
+  }),
   updatedAt: integer("updated_at", { mode: "timestamp" })
     .notNull()
     .default(sql`(unixepoch())`),

--- a/src/distributed_machines/ipc_connection.ts
+++ b/src/distributed_machines/ipc_connection.ts
@@ -57,6 +57,10 @@ export class IpcRemoteMachineConnection implements RemoteMachineClientConnection
     return ipc.distributedMachine.dispatch(envelope);
   }
 
+  observeChatSubmissionStopPolicy(chatId: number): Promise<number> {
+    return ipc.chat.observeSubmissionStopPolicy(chatId);
+  }
+
   start(): () => void {
     this.setStatus("connected");
     const unsubscribe = ipc.events.distributedMachine.onProtocolMismatch(() => {

--- a/src/hooks/useStreamChat.test.tsx
+++ b/src/hooks/useStreamChat.test.tsx
@@ -262,7 +262,7 @@ describe("useStreamChat lifecycle intents", () => {
     expect(mocks.send).toHaveBeenLastCalledWith({ type: "cancel" });
   });
 
-  it("does not dispatch Stop for an optimistic admission", () => {
+  it("dispatches Stop for an optimistic admission", () => {
     mocks.streamState.current = {
       phase: "admitting",
       capabilities: { canCancel: false },
@@ -276,7 +276,7 @@ describe("useStreamChat lifecycle intents", () => {
 
     act(() => result.current.cancelStream());
 
-    expect(mocks.send).not.toHaveBeenCalled();
+    expect(mocks.send).toHaveBeenCalledExactlyOnceWith({ type: "cancel" });
   });
 
   it("routes external errors through the main actor", () => {

--- a/src/hooks/useStreamChat.test.tsx
+++ b/src/hooks/useStreamChat.test.tsx
@@ -250,7 +250,7 @@ describe("useStreamChat lifecycle intents", () => {
 
     mocks.streamState.current = {
       phase: "cancelling",
-      capabilities: { canCancel: false },
+      capabilities: { canCancel: true },
       error: null,
       queue: [],
       queuePaused: false,
@@ -260,6 +260,23 @@ describe("useStreamChat lifecycle intents", () => {
     act(() => result.current.cancelStream());
     expect(mocks.send).toHaveBeenCalledTimes(2);
     expect(mocks.send).toHaveBeenLastCalledWith({ type: "cancel" });
+  });
+
+  it("does not dispatch Stop for an optimistic admission", () => {
+    mocks.streamState.current = {
+      phase: "admitting",
+      capabilities: { canCancel: false },
+      error: null,
+      queue: [],
+      queuePaused: false,
+      queueRevision: 7,
+    };
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useStreamChat(), { wrapper: Wrapper });
+
+    act(() => result.current.cancelStream());
+
+    expect(mocks.send).not.toHaveBeenCalled();
   });
 
   it("routes external errors through the main actor", () => {

--- a/src/hooks/useStreamChat.test.tsx
+++ b/src/hooks/useStreamChat.test.tsx
@@ -239,7 +239,7 @@ describe("useStreamChat lifecycle intents", () => {
     };
   });
 
-  it("cancels only while the remote capability permits it", () => {
+  it("keeps Stop dispatchable through cancellation settlement", () => {
     const { Wrapper } = makeWrapper();
     const { result, rerender } = renderHook(() => useStreamChat(), {
       wrapper: Wrapper,
@@ -258,7 +258,8 @@ describe("useStreamChat lifecycle intents", () => {
     };
     rerender();
     act(() => result.current.cancelStream());
-    expect(mocks.send).toHaveBeenCalledTimes(1);
+    expect(mocks.send).toHaveBeenCalledTimes(2);
+    expect(mocks.send).toHaveBeenLastCalledWith({ type: "cancel" });
   });
 
   it("routes external errors through the main actor", () => {

--- a/src/hooks/useStreamChat.ts
+++ b/src/hooks/useStreamChat.ts
@@ -123,11 +123,7 @@ export function useStreamChat({
   );
 
   const cancelStream = useCallback(() => {
-    if (
-      chatId === undefined ||
-      !streamState ||
-      !streamState.capabilities.canCancel
-    ) {
+    if (chatId === undefined || !streamState || !isStreamActive(streamState)) {
       return;
     }
     chatStreamManager.ensure(chatId).send({ type: "cancel" });

--- a/src/hooks/useStreamChat.ts
+++ b/src/hooks/useStreamChat.ts
@@ -101,9 +101,9 @@ export function useStreamChat({
       }
 
       // The machine decides what happens next: idle/errored chats start a
-      // stream immediately; chats with an active stream get the submission
-      // queued (never dropped, even in the render lag window where the
-      // `isStreaming` projection hasn't caught up yet).
+      // stream immediately, an idle paused queue appends and resumes FIFO,
+      // and chats with an active stream queue the submission (never dropping
+      // it during the render lag before `isStreaming` catches up).
       chatStreamManager.ensure(chatId).send({
         type: "submit",
         request: {

--- a/src/hooks/useStreamChat.ts
+++ b/src/hooks/useStreamChat.ts
@@ -123,7 +123,11 @@ export function useStreamChat({
   );
 
   const cancelStream = useCallback(() => {
-    if (chatId === undefined || !streamState || !isStreamActive(streamState)) {
+    if (
+      chatId === undefined ||
+      !streamState ||
+      !streamState.capabilities.canCancel
+    ) {
       return;
     }
     chatStreamManager.ensure(chatId).send({ type: "cancel" });

--- a/src/ipc/handlers/chat_handlers.ts
+++ b/src/ipc/handlers/chat_handlers.ts
@@ -29,7 +29,10 @@ import {
   beginChatActorMutation,
   settleChatActorsForDeletion,
 } from "@/ipc/services/chat_actor_deletion_service";
-import { waitForChatActorIdle } from "@/ipc/services/chat_actor_service";
+import {
+  observeChatSubmissionStopPolicy,
+  waitForChatActorIdle,
+} from "@/ipc/services/chat_actor_service";
 import { appOperationCoordinator } from "@/ipc/services/app_operation_coordinator";
 import { withChatQueueLock } from "@/chat_stream/queue_lock";
 import {
@@ -89,6 +92,10 @@ async function mutateChatAfterDrainingStreams({
 }
 
 export function registerChatHandlers() {
+  createTypedHandler(
+    chatContracts.observeSubmissionStopPolicy,
+    async (_, chatId) => observeChatSubmissionStopPolicy(chatId),
+  );
   createTypedHandler(chatContracts.createChat, async (event, input) => {
     const { appId, initialChatMode, firstPromptCreationOperationId } =
       typeof input === "number"

--- a/src/ipc/services/chat_actor_service.test.ts
+++ b/src/ipc/services/chat_actor_service.test.ts
@@ -62,6 +62,7 @@ const cleanup = vi.hoisted(() => ({
   deleteWhere: vi.fn(async () => undefined),
   publish: vi.fn(),
   findChats: vi.fn(async () => [] as Array<{ id: number }>),
+  findChat: vi.fn(() => ({ id: 7 }) as { id: number } | undefined),
 }));
 
 const persistence = vi.hoisted(() => ({
@@ -85,6 +86,11 @@ vi.mock("@/user_input/main", () => ({
 }));
 vi.mock("@/db", () => ({
   db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({ get: cleanup.findChat }),
+      }),
+    }),
     delete: () => ({ where: cleanup.deleteWhere }),
     query: {
       chats: {
@@ -119,6 +125,7 @@ import {
   beginAppChatActorMutation,
   deleteOwnedChatAfterSettlingActors,
   dispatchChatIntentAndWait,
+  observeChatSubmissionStopPolicy,
   waitForAppChatActorsIdle,
   waitForChatActorIdle,
 } from "./chat_actor_service";
@@ -144,9 +151,16 @@ describe("waitForChatActorIdle", () => {
     cleanup.publish.mockClear();
     cleanup.findChats.mockClear();
     cleanup.findChats.mockResolvedValue([]);
+    cleanup.findChat.mockReset();
+    cleanup.findChat.mockReturnValue({ id: 7 });
     persistence.getIntentAcceptance.mockReset();
     persistence.getIntentAcceptance.mockReturnValue(undefined);
     subagents.settle.mockClear();
+  });
+
+  it("observes a submission cutoff from the main-owned chat actor", () => {
+    expect(observeChatSubmissionStopPolicy(7)).toBe(3);
+    expect(host.localRef).toHaveBeenCalledOnce();
   });
 
   it("treats an absent actor as already idle without creating it", async () => {

--- a/src/ipc/services/chat_actor_service.test.ts
+++ b/src/ipc/services/chat_actor_service.test.ts
@@ -31,11 +31,13 @@ const actor = vi.hoisted(() => {
         } | null;
         lastAcceptance: null;
         lastCompletion: { intentId: string; outcome: string } | null;
+        stopPolicyVersion: number;
       } => ({
         phase,
         active: null,
         lastAcceptance: null,
         lastCompletion,
+        stopPolicyVersion: 3,
       }),
     ),
     subscribe: vi.fn((nextListener: () => void) => {
@@ -174,6 +176,7 @@ describe("waitForChatActorIdle", () => {
       },
       lastAcceptance: null,
       lastCompletion: null,
+      stopPolicyVersion: 0,
     });
 
     await expect(waitForChatActorIdle(7, { cancelActive: true })).resolves.toBe(
@@ -244,6 +247,9 @@ describe("waitForChatActorIdle", () => {
         },
       }),
     ).resolves.toBe("rejected");
+    expect(actor.send).toHaveBeenCalledWith(
+      expect.objectContaining({ observedStopPolicyVersion: 3 }),
+    );
   });
 
   it("rejects main-owned dispatch while chat actor admission is fenced", async () => {

--- a/src/ipc/services/chat_actor_service.ts
+++ b/src/ipc/services/chat_actor_service.ts
@@ -210,7 +210,11 @@ export async function dispatchChatIntentAndWait(
     signal?.addEventListener("abort", abort, { once: true });
     inspect();
   });
-  actor.send({ type: "SUBMIT", intent });
+  actor.send({
+    type: "SUBMIT",
+    intent,
+    observedStopPolicyVersion: actor.getSnapshot().stopPolicyVersion,
+  });
   return settled;
 }
 

--- a/src/ipc/services/chat_actor_service.ts
+++ b/src/ipc/services/chat_actor_service.ts
@@ -19,6 +19,7 @@ import { userInputRegistry } from "@/user_input/main";
 import { db } from "@/db";
 import { chats } from "@/db/schema";
 import { eq } from "drizzle-orm";
+import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
 import {
   PLAN_HANDOFF_MACHINE_ID,
   planHandoffKey,
@@ -117,6 +118,21 @@ export async function waitForChatActorIdle(
     inspect();
   });
   return didRequestCancellation;
+}
+
+export function observeChatSubmissionStopPolicy(chatId: number): number {
+  assertChatActorAdmissionOpen(chatId);
+  const chat = db
+    .select({ id: chats.id })
+    .from(chats)
+    .where(eq(chats.id, chatId))
+    .get();
+  if (!chat) {
+    throw new DyadError(`Chat ${chatId} not found`, DyadErrorKind.NotFound);
+  }
+  return remoteMachineHost
+    .localRef(chatStreamDefinition, chatStreamKey(chatId))
+    .getSnapshot().stopPolicyVersion;
 }
 
 export async function waitForAppChatActorsIdle(

--- a/src/ipc/types/chat.ts
+++ b/src/ipc/types/chat.ts
@@ -499,6 +499,12 @@ export const chatContracts = {
     output: z.boolean(),
   }),
 
+  observeSubmissionStopPolicy: defineContract({
+    channel: "chat:observe-submission-stop-policy",
+    input: z.number().int().positive(),
+    output: z.number().int().nonnegative(),
+  }),
+
   // Renderer→main ack for stress-test backpressure on the canned test
   // streaming path. The handler is registered unconditionally, but real
   // LLM streams omit `chunkSeq`, so the renderer only invokes this


### PR DESCRIPTION
## Summary

Stopping a chat generation now parks queued prompts through the authoritative main-process actor without producing a queue-revision conflict or allowing delayed cross-window submissions to restart generation.

- Makes queue parking an idempotent main-owned command and threads Stop policy through cancellation, finalization, replay, failure, and stale-invocation paths.
- Latches the actor's paused state in the Stop transition itself, closing the command-yield window before asynchronous queue persistence completes.
- Versions the actor-owned Stop cutoff; renderer submissions echo the version they observed, so work still serializing in any window—or submitted before the Stop snapshot arrives—stays queued instead of masquerading as an explicit resume.
- Captures an unavailable renderer's submission cutoff immediately through main-owned IPC instead of deriving it from a later bootstrap snapshot, and orders Stop intents by their observed version so stale cross-window events cannot re-park a resumed queue.
- Keeps explicit current-version Resume authoritative after Stop settles, while persistence failures and automatic review release remain fail-closed under a newer Stop latch.
- Versions main-owned review remediation submissions too, so a Stop during asynchronous review setup cannot be overtaken by the follow-up generation.
- Resumes FIFO only for a deliberate submission made after the renderer observes the latest Stop policy, while preserving independent step-limit pauses.
- Tracks Stop, manual, and step-limit pause reasons separately: Continue and sends during an explicit Pause run immediately while older prompts remain parked, and only Stop-parks use append-and-resume FIFO behavior.
- Starts the queue driver whenever a queued admission reaches an idle, unpaused actor, preventing late serialization from leaving visible but stranded work.
- Keeps renderer settlement semantics precise: user Stop is cancellation, while `pausedByStepLimit` is reserved for actual step-limit completions.
- Keeps destructive/main-process cancellation behavior unchanged: renderer Stop parks queued prompts rather than deleting them, and genuine parking failures remain visible.
- Covers state-machine, authorization, renderer, persistence, remote-dispatch, multi-window race, and packaged Electron behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core chat-stream queue lifecycle, cross-window races, and durable pause semantics; scope is large but heavily covered by unit, integration, and e2e tests.
> 
> **Overview**
> **Stopping a chat generation** now parks queued prompts through the main actor instead of fighting queue revisions or leaving the queue running.
> 
> The host adds a **versioned Stop cutoff** (`stopPolicyVersion`): cancellations and submissions carry the observed version so delayed or cross-window work cannot resume after a newer Stop. Queue parking is a dedicated **`park-queue`** path backed by a new **`pause_reason`** column (`stop`, `manual`, `step-limit`). User Stop sets reason `stop` and latches in memory before async DB writes; manual pause and step-limit behave separately (e.g. a new send can run immediately under manual pause while older items stay queued). An explicit send after the renderer sees the latest Stop can **append and resume FIFO**; guarded review release and stale resumes stay fail-closed.
> 
> Persistence gains **`parkChatQueue`**, resume-on-queued-send options, and hydration that restores Stop-parked queues after restart. State-machine rules and an e2e case cover “stop without error toast” and parked-queue behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecfea4d675581f4e9f32b7ad10fb8c7ce1f2ce67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
