### PR TITLE
Fix Value model reasoning and model picker interactions

### DIFF
--- a/rules/base-ui-components.md
+++ b/rules/base-ui-components.md
@@ -70,6 +70,13 @@ focusable or exposed as a separate control to assistive technology. Because an
 explicit name replaces descendant text, include meaningful visible state such
 as quota, selection, and disclosure badges in that name.
 
+## Submenu trigger event cancellation
+
+With `openOnHover={false}`, Base UI opens a submenu on `mousedown`, before a
+consumer `onClick` runs. When only part of a submenu trigger should open the
+submenu, cancel Base UI's handler with `event.preventBaseUIHandler()` from both
+`onMouseDown` and `onClick` for the trigger's primary action.
+
 ## Accordion (Base UI vs Radix/shadcn)
 
 The `Accordion` component in `src/components/ui/accordion.tsx` wraps `@base-ui/react/accordion`, **not** Radix or shadcn. The APIs differ:

--- a/rules/openai-reasoning-models.md
+++ b/rules/openai-reasoning-models.md
@@ -13,3 +13,7 @@ OpenAI's Responses API requires reasoning items to always be followed by an outp
 - Only reasoning was generated in a turn
 
 The fix in `src/ipc/utils/ai_messages_utils.ts` filters orphaned reasoning parts within `cleanMessage()` before sending conversation history back to OpenAI.
+
+## Dyad Engine model aliases
+
+When a Dyad Engine alias is backed by an OpenAI reasoning model, create it with `provider.responses(...)` and pass `providerId: "openai"`. Passing the alias provider (for example, `"auto"`) prevents `getExtraProviderOptionsForEngine()` from adding reasoning effort, summaries, encrypted reasoning content, and `store: false`.

--- a/src/components/ModelPicker.test.tsx
+++ b/src/components/ModelPicker.test.tsx
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   navigate: vi.fn(),
   posthogCapture: vi.fn(),
   openExternalUrl: vi.fn(),
+  preventBaseUIHandler: vi.fn(),
   selectedMode: "build",
   isTrial: false,
   renderSubContent: false,
@@ -347,11 +348,43 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
   DropdownMenuSubTrigger: ({
     children,
     hideChevron: _hideChevron,
+    onMouseDown,
+    onClick,
     ...props
   }: {
     children: React.ReactNode;
     hideChevron?: boolean;
-  }) => <button {...props}>{children}</button>,
+    onMouseDown?: (
+      event: React.MouseEvent<HTMLButtonElement> & {
+        preventBaseUIHandler: () => void;
+      },
+    ) => void;
+    onClick?: (
+      event: React.MouseEvent<HTMLButtonElement> & {
+        preventBaseUIHandler: () => void;
+      },
+    ) => void;
+  }) => (
+    <button
+      {...props}
+      onMouseDown={(event) =>
+        onMouseDown?.(
+          Object.assign(event, {
+            preventBaseUIHandler: mocks.preventBaseUIHandler,
+          }),
+        )
+      }
+      onClick={(event) =>
+        onClick?.(
+          Object.assign(event, {
+            preventBaseUIHandler: mocks.preventBaseUIHandler,
+          }),
+        )
+      }
+    >
+      {children}
+    </button>
+  ),
   DropdownMenuSubContent: ({ children }: { children: React.ReactNode }) =>
     mocks.renderSubContent ? <div>{children}</div> : null,
 }));
@@ -372,6 +405,7 @@ describe("ModelPicker", () => {
     mocks.navigate.mockReset();
     mocks.posthogCapture.mockReset();
     mocks.openExternalUrl.mockReset();
+    mocks.preventBaseUIHandler.mockReset();
     mocks.selectedMode = "build";
     mocks.renderSubContent = false;
     mocks.settingsLoading = false;
@@ -449,6 +483,17 @@ describe("ModelPicker", () => {
         },
       });
     });
+  });
+
+  it("only opens the effort submenu from its chevron", () => {
+    render(<ModelPicker />);
+
+    const gpt5Row = screen.getByText("GPT 5").closest("button")!;
+    fireEvent.mouseDown(gpt5Row);
+    expect(mocks.preventBaseUIHandler).toHaveBeenCalledTimes(1);
+
+    fireEvent.mouseDown(gpt5Row.querySelector("[data-effort-chevron]")!);
+    expect(mocks.preventBaseUIHandler).toHaveBeenCalledTimes(1);
   });
 
   it("disables selection while an existing chat is still loading", () => {

--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -101,6 +101,9 @@ const PRICE_TIERS: Tier[] = [
 const isFreeOpenRouterModelName = (apiName: string) =>
   apiName.endsWith(":free") || apiName.endsWith("/free");
 
+const isEffortChevronTarget = (target: EventTarget) =>
+  (target as HTMLElement).closest("[data-effort-chevron]") !== null;
+
 function tierFor(dollarSigns: number | undefined): Tier {
   const ds = dollarSigns ?? Number.NEGATIVE_INFINITY;
   return (
@@ -692,8 +695,14 @@ export function ModelPicker() {
         aria-label={`${unlockedAriaLabel}.`}
         disabled={isFreeProRow && freeModelQuota.isQuotaExceeded}
         hideChevron
+        onMouseDown={(event) => {
+          if (!isEffortChevronTarget(event.target)) {
+            event.preventBaseUIHandler();
+          }
+        }}
         onClick={(event) => {
-          if (!(event.target as HTMLElement).closest("[data-effort-chevron]")) {
+          if (!isEffortChevronTarget(event.target)) {
+            event.preventBaseUIHandler();
             handleCloudModelSelect(providerId, model);
           }
         }}
@@ -829,10 +838,14 @@ export function ModelPicker() {
             isSelected &&
               "bg-primary/8 before:absolute before:inset-y-1.5 before:left-0 before:w-[3px] before:rounded-r-full before:bg-primary",
           )}
+          onMouseDown={(event) => {
+            if (!isEffortChevronTarget(event.target)) {
+              event.preventBaseUIHandler();
+            }
+          }}
           onClick={(event) => {
-            if (
-              !(event.target as HTMLElement).closest("[data-effort-chevron]")
-            ) {
+            if (!isEffortChevronTarget(event.target)) {
+              event.preventBaseUIHandler();
               selectLocalModel();
             }
           }}
@@ -939,12 +952,14 @@ export function ModelPicker() {
                   hideChevron
                   aria-label={`Auto. Trial. Selected. Effort: ${formatEffortLevel(trialAutoEffort)}. Press Enter to select; press Right Arrow to configure effort.`}
                   className="relative py-2 bg-primary/8 before:absolute before:inset-y-1.5 before:left-0 before:w-[3px] before:rounded-r-full before:bg-primary"
+                  onMouseDown={(event) => {
+                    if (!isEffortChevronTarget(event.target)) {
+                      event.preventBaseUIHandler();
+                    }
+                  }}
                   onClick={(event) => {
-                    if (
-                      !(event.target as HTMLElement).closest(
-                        "[data-effort-chevron]",
-                      )
-                    ) {
+                    if (!isEffortChevronTarget(event.target)) {
+                      event.preventBaseUIHandler();
                       void onModelSelect({
                         model: { name: "auto", provider: "auto" },
                         catalogModel: autoModels.find(

--- a/src/ipc/shared/language_model_constants.ts
+++ b/src/ipc/shared/language_model_constants.ts
@@ -378,7 +378,7 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
       description: "Uses the most cost-effective models available",
       maxOutputTokens: 32_000,
       contextWindow: 256_000,
-      temperature: 0,
+      temperature: 1,
       tag: "Budget",
       tagColor: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300",
     },

--- a/src/ipc/utils/get_model_client.test.ts
+++ b/src/ipc/utils/get_model_client.test.ts
@@ -208,6 +208,80 @@ describe("getModelClient", () => {
     expect(modelClient.builtinProviderId).toBe("auto");
   });
 
+  test("routes the Value model through the Responses API in local agent mode", async () => {
+    let capturedUrl: string | undefined;
+    let capturedBody: Record<string, unknown> | undefined;
+    setModelClientFetchForTesting(
+      vi.fn(async (url, init) => {
+        capturedUrl = url.toString();
+        capturedBody = JSON.parse(init?.body as string);
+        return new Response(
+          JSON.stringify({
+            id: "resp-test",
+            created_at: 1_700_000_000,
+            model: "dyad/value",
+            output: [
+              {
+                type: "message",
+                role: "assistant",
+                id: "msg-test",
+                content: [
+                  {
+                    type: "output_text",
+                    text: "ok",
+                    annotations: [],
+                  },
+                ],
+              },
+            ],
+            usage: {
+              input_tokens: 1,
+              output_tokens: 1,
+            },
+          }),
+          { headers: { "Content-Type": "application/json" } },
+        );
+      }),
+    );
+
+    const { modelClient } = await getModelClient(
+      {
+        provider: "auto",
+        name: "value",
+      },
+      {
+        enableDyadPro: true,
+        selectedChatMode: "local-agent",
+        providerSettings: {
+          auto: {
+            apiKey: {
+              value: "dyad-pro-key",
+            },
+          },
+        },
+      } as unknown as UserSettings,
+    );
+
+    await generateText({
+      model: modelClient.model,
+      prompt: "hi",
+      maxRetries: 0,
+    });
+
+    expect(capturedUrl).toMatch(/\/v1\/responses$/);
+    expect(capturedBody).toMatchObject({
+      reasoning: {
+        summary: "detailed",
+        effort: "medium",
+      },
+      include: ["reasoning.encrypted_content"],
+      store: false,
+    });
+    expect((modelClient.model as { modelId: string }).modelId).toBe(
+      "dyad/value",
+    );
+  });
+
   test("sends OpenRouter app attribution headers", async () => {
     let capturedHeaders: Headers | undefined;
     setModelClientFetchForTesting(

--- a/src/ipc/utils/get_model_client.ts
+++ b/src/ipc/utils/get_model_client.ts
@@ -370,7 +370,7 @@ async function getProModelClient({
   ) {
     return {
       model: provider.responses(modelId, {
-        providerId: model.provider === "auto" ? "openai" : model.provider,
+        providerId: "openai",
       }),
       builtinProviderId: model.provider,
     };

--- a/src/ipc/utils/get_model_client.ts
+++ b/src/ipc/utils/get_model_client.ts
@@ -365,10 +365,13 @@ async function getProModelClient({
   }
   if (
     settings.selectedChatMode === "local-agent" &&
-    model.provider === "openai"
+    (model.provider === "openai" ||
+      (model.provider === "auto" && model.name === "value"))
   ) {
     return {
-      model: provider.responses(modelId, { providerId: model.provider }),
+      model: provider.responses(modelId, {
+        providerId: model.provider === "auto" ? "openai" : model.provider,
+      }),
       builtinProviderId: model.provider,
     };
   }


### PR DESCRIPTION
## Summary

This branch preserves OpenAI reasoning behavior for Dyad's Value model in local-agent mode and removes an unintended effort-menu flash when users select a model. It keeps provider aliases and split-action menu rows aligned with the underlying SDK and Base UI behavior.

- Route the `auto/value` alias through the OpenAI Responses API while retaining `auto` as the builtin provider identity, so reasoning effort, summaries, encrypted reasoning content, and `store: false` are still applied.
- Set Super Value's configured temperature to `1`, matching the supported behavior of its reasoning-model backend.
- Treat each ModelPicker row as the primary model-selection action and reserve effort configuration for the chevron; cancel Base UI's submenu handler on both pointer and keyboard selection paths.
- Apply the split-action behavior consistently to cloud, local, and trial rows, and cover the Base UI cancellation boundary with a focused regression test.
- Record the non-obvious provider-alias and submenu-event constraints in the repository rules for future changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 18ce1e68f919f391868ab92b08323a9a15fa74a9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

