### PR TITLE
Bump to v1.11.0-beta.1

### DIFF
--- a/e2e-tests/test_assertions.spec.ts
+++ b/e2e-tests/test_assertions.spec.ts
@@ -83,8 +83,10 @@ testSkipIfWindows(
     );
     await expect(assertions.first()).toBeVisible();
 
-    // The turn is parked on the card rather than finished: the way out that
-    // only exists while something is waiting is offered.
+    // The turn is parked on the card rather than finished. Every unanswered
+    // plan offers a way out, so the close button proves nothing here — the
+    // hint that only a parked plan shows is what does.
+    await expect(card).toContainText("Dyad is waiting on this before it");
     await expect(
       po.page.getByTestId("dyad-test-assertions-discard-button"),
     ).toBeVisible();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dyad",
-  "version": "1.10.0",
+  "version": "1.11.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dyad",
-      "version": "1.10.0",
+      "version": "1.11.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/amazon-bedrock": "^4.0.46",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dyad",
-  "version": "1.10.0",
+  "version": "1.11.0-beta.1",
   "description": "Free, local, open-source AI app builder",
   "keywords": [],
   "license": "MIT",

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -67,6 +67,7 @@ import { AgentConsentBanner } from "./AgentConsentBanner";
 import { TodoList } from "./TodoList";
 import { QuestionnaireInput } from "./QuestionnaireInput";
 import { QueuedMessagesList } from "./QueuedMessagesList";
+import { TestAssertionsInput } from "./TestAssertionsInput";
 import {
   selectedComponentsPreviewAtom,
   previewIframeRefAtom,
@@ -823,6 +824,9 @@ export function ChatInput({ chatId }: { chatId?: number }) {
         >
           {/* Show active questionnaire if exists */}
           <QuestionnaireInput />
+
+          {/* Show the recorded-test plan waiting on a review, if any */}
+          <TestAssertionsInput />
 
           {/* Show todo list if there are todos for this chat */}
           {chatTodos.length > 0 && <TodoList todos={chatTodos} />}

--- a/src/components/chat/DyadTestAssertionsCard.tsx
+++ b/src/components/chat/DyadTestAssertionsCard.tsx
@@ -1,69 +1,28 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
-import { useAtomValue, useSetAtom } from "jotai";
-import { useQueryClient } from "@tanstack/react-query";
-import {
-  Check,
-  ChevronRight,
-  GripVertical,
-  Loader2,
-  Plus,
-  Trash2,
-} from "lucide-react";
+import React, { useMemo } from "react";
+import { useSetAtom } from "jotai";
+import { Check, FlaskConical } from "lucide-react";
 
-import { selectedAppIdAtom, previewModeAtom } from "@/atoms/appAtoms";
-import { chatMessagesByIdAtom, selectedChatIdAtom } from "@/atoms/chatAtoms";
+import { previewModeAtom } from "@/atoms/appAtoms";
 import { selectedFileAtom } from "@/atoms/viewAtoms";
-import { useChatStreamManager } from "@/chat_stream/ChatStreamProvider";
-import { useStreamChat } from "@/hooks/useStreamChat";
-import { ipc } from "@/ipc/types";
 import { cn } from "@/lib/utils";
-import { queryKeys } from "@/lib/queryKeys";
-import { showError, showSuccess, showWarning } from "@/lib/toast";
-import { syncChatFromDb } from "@/lib/resyncChat";
-import {
-  isAssertionItem,
-  moveAssertion,
-  type AssertionPlanItem,
-} from "@/lib/test_recorder/assertion_proposal";
+import { countAssertions } from "@/lib/test_recorder/assertion_proposal";
 import { parseAssertionsPayload } from "@/lib/test_recorder/assertion_tag";
-import {
-  useUserInputReadModel,
-  useUserInputRequests,
-} from "@/user_input/hooks";
 import type { CustomTagState } from "./stateTypes";
 
 /**
- * The `<dyad-test-assertions>` card: a reviewable plan of a recorded test's steps
- * with the AI's proposed assertions interleaved, editable and drag-reorderable.
- * The test file does not exist while the card is reviewed — approving generates
- * it from this exact plan, then asks the agent to run it. The card lives in a
- * persisted assistant message, so its payload round-trips through the content.
+ * The `<dyad-test-assertions>` tag as it appears in the transcript: a receipt,
+ * not a control.
  *
- * Layout is a timeline: one rail, a neutral node per step, a filled node per
- * assertion, so the steps stay quiet context while the assertions carry the
- * weight. Color is restrained to the two places a decision happens.
+ * The plan is reviewed on the composer (`TestAssertionsInput`), where the other
+ * things waiting on the user live, so this stays a one-line record of what the
+ * plan was and what was decided. Only ONE of the two renders a given plan at a
+ * time — this one is silent while the tag still says "proposed", the composer
+ * unmounts the moment it doesn't — which is what keeps a single approve button
+ * and a single "Generated" badge on screen.
  */
 
 /** The accent, in the recorder's purple. Also readable on a dark surface. */
 const ACCENT_TEXT = "text-purple-700 dark:text-purple-300";
-const ACCENT_NODE = "bg-purple-600 text-white dark:bg-purple-500";
-
-const ICON_BUTTON =
-  "shrink-0 rounded-md p-0.5 text-muted-foreground transition-colors duration-150 " +
-  "hover:bg-(--background-darker) hover:text-foreground " +
-  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
-
-/** Hidden until the row is hovered or something inside it takes focus. */
-const ROW_ACTION =
-  "opacity-0 transition-opacity duration-150 group-hover/row:opacity-100 " +
-  "group-focus-within/row:opacity-100 focus-visible:opacity-100 " +
-  "motion-reduce:transition-none";
 
 interface DyadTestAssertionsCardProps {
   node: {
@@ -87,31 +46,15 @@ function toText(children: React.ReactNode): string {
     : String(children);
 }
 
-/**
- * The rail segment above/below a node; transparent at the ends so the line starts
- * at the first node and stops at the last. `lead` is the height above a node,
- * centering it on its row's first line of text — steps and assertions set
- * different text sizes. Tinted from the foreground rather than `--border`, which
- * in dark mode is within a hair of this card's background.
- */
-function RailSegment({
-  hidden,
-  lead,
-  grow,
-}: {
-  hidden: boolean;
-  lead?: "step" | "assertion";
-  grow?: boolean;
-}) {
+function ReceiptShell({ children }: { children: React.ReactNode }) {
   return (
-    <span
-      aria-hidden
-      className={cn(
-        "w-px",
-        grow ? "flex-1" : lead === "assertion" ? "h-1" : "h-[9px]",
-        hidden ? "bg-transparent" : "bg-muted-foreground/25",
-      )}
-    />
+    <div
+      className="my-1.5 flex flex-wrap items-center gap-x-2 gap-y-1 rounded-xl border border-border/60 bg-(--background-lightest) px-3 py-2"
+      data-testid="dyad-test-assertions-receipt"
+    >
+      <FlaskConical className={cn("size-3.5 shrink-0", ACCENT_TEXT)} />
+      {children}
+    </div>
   );
 }
 
@@ -119,302 +62,21 @@ export const DyadTestAssertionsCard: React.FC<DyadTestAssertionsCardProps> = ({
   node,
   children,
 }) => {
-  const proposalId = node.properties["proposal-id"] ?? "";
-  const requestId = node.properties["request-id"] ?? "";
-  const approvedOnServer = node.properties.status === "approved";
-  const discardedOnServer = node.properties.status === "discarded";
-
   const rawPayload = useMemo(() => toText(children), [children]);
   const payload = useMemo(
     () => parseAssertionsPayload(rawPayload),
     [rawPayload],
   );
+  const status = node.properties.status ?? "proposed";
+  const specPath = node.properties["spec-path"] || payload?.specPath || "";
 
-  const chatId = useAtomValue(selectedChatIdAtom);
-  const appId = useAtomValue(selectedAppIdAtom);
-  const setMessagesById = useSetAtom(chatMessagesByIdAtom);
   const setSelectedFile = useSetAtom(selectedFileAtom);
   const setPreviewMode = useSetAtom(previewModeAtom);
-  const queryClient = useQueryClient();
-  const chatStreamManager = useChatStreamManager();
-  const { streamMessage } = useStreamChat();
-  // The agent is parked on this card's request for as long as it's live, so
-  // answering it resumes that turn. It won't be live for a card reloaded after
-  // a restart, or one whose turn was stopped — those fall back to handing the
-  // spec over as a fresh chat turn.
-  const userInputReadModel = useUserInputReadModel();
-  const userInputRequests = useUserInputRequests();
-  const parkedRequest = requestId
-    ? userInputRequests.get(requestId)
-    : undefined;
-  const isAgentWaiting =
-    parkedRequest !== undefined && parkedRequest.status !== "settled";
-
-  const [items, setItems] = useState<AssertionPlanItem[]>(
-    () => payload?.items ?? [],
-  );
-  // Held locally until the rewritten message makes it back through
-  // `syncChatFromDb`. Without it the card flips to "Generated" with "Open test
-  // file" dead until the verification stream finishes.
-  const [approvedSpecPath, setApprovedSpecPath] = useState<string | null>(null);
-  const specPath = approvedSpecPath ?? node.properties["spec-path"] ?? "";
-  const [editingId, setEditingId] = useState<string | null>(null);
-  const [draftText, setDraftText] = useState("");
-  const [dragId, setDragId] = useState<string | null>(null);
-  const [expandedCodeId, setExpandedCodeId] = useState<string | null>(null);
-  const [optimisticApproved, setOptimisticApproved] = useState(false);
-  const [optimisticDiscarded, setOptimisticDiscarded] = useState(false);
-  const [isApproving, setIsApproving] = useState(false);
-  // Tracked apart from `isApproving` even though both disable the same
-  // controls: closing a plan writes no file, and reusing the approval flag made
-  // the card answer "Generating…" to a button that generates nothing.
-  const [isDiscarding, setIsDiscarding] = useState(false);
-  const [liveMessage, setLiveMessage] = useState("");
-  // Synchronous guard: state updates are async, so a fast double-click would
-  // otherwise fire two applies before the flags above re-render. Shared by both
-  // operations — either one in flight rules out the other.
-  const busyRef = useRef(false);
-  const editingIdRef = useRef<string | null>(null);
-  editingIdRef.current = editingId;
-
-  // Approving rewrites the message content, so re-seed from the server's plan
-  // whenever it changes — but never stomp an edit the user is mid-way through.
-  useEffect(() => {
-    if (editingIdRef.current) return;
-    setItems(payload?.items ?? []);
-  }, [payload]);
-
-  const isApproved = approvedOnServer || optimisticApproved;
-  // Discarding freezes the plan too: nothing was written, but there is nothing
-  // left to answer either. Persisted alongside the approval, so a reload can't
-  // hand back a plan the user already declined.
-  const discarded = discardedOnServer || optimisticDiscarded;
-  const isLocked = isApproved || discarded;
-  const assertions = items.filter(isAssertionItem);
-  const hasBlankAssertion = assertions.some((item) => !item.text.trim());
-  const checkCountLabel =
-    assertions.length === 1 ? "1 check" : `${assertions.length} checks`;
-
-  const updateAssertion = useCallback(
-    (id: string, text: string) => {
-      setItems((prev) =>
-        prev.map((item) =>
-          isAssertionItem(item) && item.id === id
-            ? // The code no longer matches the sentence, so mark it for
-              // re-synthesis on approve.
-              { ...item, text, needsCode: true, origin: "user" as const }
-            : item,
-        ),
-      );
-    },
-    [setItems],
-  );
-
-  const commitEdit = useCallback(() => {
-    if (!editingId) return;
-    updateAssertion(editingId, draftText.trim());
-    setEditingId(null);
-    setDraftText("");
-  }, [draftText, editingId, updateAssertion]);
-
-  const startEdit = (id: string, text: string) => {
-    if (isLocked) return;
-    setEditingId(id);
-    setDraftText(text);
-  };
-
-  const removeAssertion = (id: string) => {
-    if (isLocked) return;
-    if (editingId === id) setEditingId(null);
-    setItems((prev) =>
-      prev.filter((item) => !isAssertionItem(item) || item.id !== id),
-    );
-    setLiveMessage("Assertion removed");
-  };
-
-  const addAssertionAfter = (index: number) => {
-    if (isLocked) return;
-    const id = crypto.randomUUID();
-    setItems((prev) => {
-      const next = [...prev];
-      next.splice(index + 1, 0, {
-        kind: "assertion",
-        id,
-        text: "",
-        code: null,
-        needsCode: true,
-        origin: "user",
-      });
-      return next;
-    });
-    setEditingId(id);
-    setDraftText("");
-  };
-
-  const moveByOffset = (index: number, offset: number) => {
-    if (isLocked) return;
-    // Compute outside setItems: a state updater must stay pure.
-    const next = moveAssertion(items, index, index + offset);
-    if (next === items) return;
-    setItems(next);
-    setLiveMessage(
-      `Assertion moved to position ${index + offset + 1} of ${next.length}`,
-    );
-  };
-
-  const handleDrop = (targetIndex: number) => {
-    if (dragId === null) return;
-    const fromIndex = items.findIndex(
-      (item) => isAssertionItem(item) && item.id === dragId,
-    );
-    setDragId(null);
-    if (fromIndex === -1) return;
-    setItems((prev) => moveAssertion(prev, fromIndex, targetIndex));
-  };
-
   const openSpecFile = () => {
     if (!specPath) return;
     setSelectedFile({ path: specPath });
     setPreviewMode("code");
   };
-
-  /**
-   * Ask the agent to run the spec the approval just generated. Only for a card
-   * whose turn is no longer parked on it — a reload or a stopped stream. Sent as
-   * a normal chat turn (Agent mode, where run_tests lives) so the run and any
-   * fix are visible in the conversation.
-   */
-  const requestVerificationRun = (generatedSpecPath: string) => {
-    if (chatId == null || !generatedSpecPath) return;
-    streamMessage({
-      prompt: [
-        `I approved the assertions. Dyad generated ${generatedSpecPath} from my recording.`,
-        "",
-        `Run it with run_tests to make sure it actually works. If it fails, read the failure, decide whether the test or the app is wrong, fix it, and run it again until it passes — or tell me what's blocking it.`,
-      ].join("\n"),
-      chatId,
-      requestedChatMode: "local-agent",
-    });
-  };
-
-  const handleApprove = async () => {
-    if (busyRef.current || isLocked) return;
-    if (!proposalId || chatId == null || appId == null) return;
-    busyRef.current = true;
-    setIsApproving(true);
-    setOptimisticApproved(true);
-    try {
-      const result = await ipc.tests.applyTestAssertions({
-        appId,
-        chatId,
-        proposalId,
-        items,
-      });
-      setApprovedSpecPath(result.specPath || null);
-      queryClient.invalidateQueries({ queryKey: queryKeys.appFiles.all });
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.tests.list({ appId }),
-      });
-      // A warning can accompany a spec written perfectly well, so report success
-      // and the caveat separately: a red error toast over a file that exists
-      // reads as "nothing was saved".
-      if (result.specPath) {
-        showSuccess(`Generated ${result.specPath}`);
-        if (result.warning) showWarning(result.warning);
-      } else if (result.warning) {
-        showError(result.warning);
-      }
-      // A recorded test nobody has run is a guess: replay can behave differently
-      // from the hand-performed flow, so the agent gets the spec back either
-      // way. The parked turn picks it up as its tool result and carries on
-      // without a visible message; a card whose turn is gone — or whose request
-      // expired between render and click — needs a new turn instead.
-      const handedToParkedTurn =
-        isAgentWaiting &&
-        (await userInputReadModel.respond(requestId, {
-          kind: "test-assertions",
-          specPath: result.specPath || null,
-          appliedCount: result.appliedCount,
-        }));
-      if (!handedToParkedTurn) {
-        // The stream manager answers "is this chat streaming?" — without that
-        // guard the DB snapshot would overwrite the live messages of a stream
-        // that started meanwhile. The parked path skips the sync entirely: the
-        // resumed turn streams the approved card down itself.
-        syncChatFromDb(chatId, setMessagesById, "[TEST-ASSERTIONS]", (id) =>
-          chatStreamManager.getIsStreaming(id),
-        );
-        requestVerificationRun(result.specPath);
-      }
-    } catch (error) {
-      setOptimisticApproved(false);
-      setApprovedSpecPath(null);
-      showError(
-        error instanceof Error
-          ? error.message
-          : "Couldn't generate the test file.",
-      );
-    } finally {
-      busyRef.current = false;
-      setIsApproving(false);
-    }
-  };
-
-  /**
-   * Close the plan without writing anything. Only offered while the agent is
-   * parked on it: it exists so a turn waiting on this card has an exit that
-   * isn't the 30-minute deadline.
-   */
-  const handleDiscard = async () => {
-    if (busyRef.current || isLocked || !isAgentWaiting) return;
-    busyRef.current = true;
-    setIsDiscarding(true);
-    try {
-      // Latched BEFORE the parked request is answered. Answering resumes the
-      // agent's turn, which immediately re-reads this message row and keeps
-      // streaming into it — a discard written after that read is overwritten by
-      // the turn's own copy, and the closed plan comes back approvable on
-      // reload. Ordering it first means the turn resumes reading a row that
-      // already says "discarded".
-      if (chatId != null && appId != null && proposalId) {
-        try {
-          await ipc.tests.discardTestAssertions({ appId, chatId, proposalId });
-        } catch (error) {
-          // Leave the plan exactly as it was rather than answering the turn
-          // against a card that still reads as approvable.
-          console.warn("Couldn't record the discarded assertion plan", error);
-          const message =
-            error instanceof Error ? error.message : String(error);
-          showError(`Couldn't close the assertion plan: ${message}`);
-          return;
-        }
-      }
-      setOptimisticDiscarded(true);
-      const answered = await userInputReadModel.respond(requestId, {
-        kind: "test-assertions",
-        specPath: null,
-        appliedCount: 0,
-      });
-      if (!answered) {
-        // The card stays discarded rather than reverting: the latch above
-        // already succeeded, so the stored plan *is* declined and showing it as
-        // approvable again would only lead to "this plan was closed" on the
-        // next approve. `respond` has surfaced its own error, and a turn left
-        // parked converges on the same outcome at its deadline — a park that
-        // resolves to nothing is read as a close.
-        console.warn(
-          `Discarded assertion plan ${proposalId}, but couldn't notify the parked turn`,
-        );
-      }
-    } finally {
-      busyRef.current = false;
-      setIsDiscarding(false);
-    }
-  };
-
-  // Either operation locks the card's controls; only approving writes a file,
-  // so the labels below still have to tell them apart.
-  const isBusy = isApproving || isDiscarding;
 
   if (!payload) {
     // The tag arrives a character at a time, so incomplete JSON is the normal
@@ -427,14 +89,11 @@ export const DyadTestAssertionsCard: React.FC<DyadTestAssertionsCardProps> = ({
     // saying the proposal can't be read.
     const isPending = node.properties.state === "pending";
     return (
-      <div
-        className="my-1.5 rounded-xl border border-border/60 bg-(--background-lightest) px-3.5 py-3"
-        data-testid="dyad-test-assertions-card"
-      >
-        <p className="text-sm font-medium text-foreground">
+      <ReceiptShell>
+        <span className="text-sm text-foreground">
           {isPending ? "Preparing the test proposal…" : "Test assertions"}
-        </p>
-        <p className="mt-1 text-xs text-muted-foreground">
+        </span>
+        <span className="min-w-0 flex-1 text-xs text-muted-foreground">
           {isPending ? (
             "Naming the test, describing your recorded steps and proposing the checks."
           ) : (
@@ -444,397 +103,82 @@ export const DyadTestAssertionsCard: React.FC<DyadTestAssertionsCardProps> = ({
               get a fresh one.
             </>
           )}
-        </p>
-      </div>
+        </span>
+      </ReceiptShell>
     );
   }
 
-  // Filename only: every recorded spec lives in e2e-tests/, and in a narrow chat
-  // panel the directory eats the truncation. Before approval the title stands in.
-  const generatedPath = payload.specPath;
-  const subtitle = generatedPath
-    ? (generatedPath.split("/").pop() ?? generatedPath)
-    : payload.testTitle;
+  // Filename only: every recorded spec lives in e2e-tests/, and in a narrow
+  // chat panel the directory eats the truncation.
+  const fileName = specPath ? (specPath.split("/").pop() ?? specPath) : "";
+  const checkCount = countAssertions(payload.items);
+  const checkCountLabel = checkCount === 1 ? "1 check" : `${checkCount} checks`;
 
-  return (
-    <div
-      className="my-1.5 overflow-hidden rounded-xl border border-border/60 bg-(--background-lightest)"
-      data-testid="dyad-test-assertions-card"
-    >
-      <div className="px-3.5 pt-2.5 pb-2">
-        <div className="flex items-baseline gap-2">
-          <h3 className="text-sm font-medium text-foreground">
-            {isApproved ? "Recorded test" : "Review recorded test"}
-          </h3>
-          <span
-            className="ml-auto inline-flex shrink-0 items-center gap-1 text-xs text-muted-foreground"
-            data-testid={
-              isApproved && !isBusy
-                ? "dyad-test-assertions-approved-badge"
-                : undefined
-            }
-          >
-            {/* "Generated" only once it actually is. The approval latches
-                optimistically so the plan can't be edited or submitted twice
-                while the write is in flight, but claiming the file exists
-                before it does leaves a slow apply looking finished — and a
-                failed one silently reverting from a terminal state.
-
-                Closing gets its own label: it writes nothing, so announcing it
-                as generation promises a file that is never coming. */}
-            {isBusy ? (
-              <Loader2
-                size={12}
-                className="animate-spin motion-reduce:hidden"
-              />
-            ) : (
-              isApproved && <Check size={12} strokeWidth={2.5} />
-            )}
-            {isApproving
-              ? "Generating…"
-              : isDiscarding
-                ? "Closing…"
-                : isApproved
-                  ? "Generated"
-                  : checkCountLabel}
-          </span>
-        </div>
+  if (status === "approved") {
+    return (
+      <ReceiptShell>
+        <span className="text-sm text-foreground">Recorded test</span>
         <span
-          className={cn(
-            "mt-0.5 block truncate text-[11px] text-muted-foreground",
-            generatedPath && "font-mono",
-          )}
-          title={generatedPath ?? payload.testTitle}
+          className="min-w-0 flex-1 truncate font-mono text-xs text-muted-foreground"
+          title={specPath || payload.testTitle}
         >
-          {subtitle}
+          {fileName || payload.testTitle}
         </span>
-      </div>
+        <span
+          className="inline-flex shrink-0 items-center gap-1 text-xs text-muted-foreground"
+          data-testid="dyad-test-assertions-approved-badge"
+        >
+          <Check size={12} strokeWidth={2.5} />
+          Generated with {checkCountLabel}
+        </span>
+        <button
+          type="button"
+          onClick={openSpecFile}
+          disabled={!specPath}
+          data-testid="dyad-test-assertions-open-file-button"
+          className="shrink-0 rounded-md px-2 py-0.5 text-xs font-medium text-foreground transition-colors duration-150 hover:bg-(--background-darker) focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none disabled:cursor-default disabled:opacity-50"
+        >
+          Open test file
+        </button>
+      </ReceiptShell>
+    );
+  }
 
-      <ol className="border-t border-border/50 py-2" role="list">
-        {items.map((item, index) => {
-          const isFirst = index === 0;
-          const isLast = index === items.length - 1;
-          const isDropTarget = dragId !== null && !isLocked;
-          const dropProps = isDropTarget
-            ? {
-                onDragOver: (e: React.DragEvent) => {
-                  e.preventDefault();
-                },
-                onDrop: (e: React.DragEvent) => {
-                  e.preventDefault();
-                  handleDrop(index);
-                },
-              }
-            : {};
+  if (status === "discarded") {
+    return (
+      <ReceiptShell>
+        <span className="text-sm text-foreground">Recorded test</span>
+        <span
+          className="min-w-0 flex-1 truncate text-xs text-muted-foreground"
+          title={payload.testTitle}
+        >
+          {payload.testTitle}
+        </span>
+        <span
+          className="shrink-0 text-xs text-muted-foreground"
+          data-testid="dyad-test-assertions-discarded-note"
+        >
+          Closed without generating a test.
+        </span>
+      </ReceiptShell>
+    );
+  }
 
-          if (item.kind === "step") {
-            return (
-              <li
-                key={`step-${item.stepIndex}`}
-                data-testid={`dyad-test-assertions-step-${item.stepIndex}`}
-                className="group/row flex gap-2.5 pr-2 pl-3.5"
-                {...dropProps}
-              >
-                <div className="flex w-4 shrink-0 flex-col items-center">
-                  <RailSegment hidden={isFirst} lead="step" />
-                  <span
-                    aria-hidden
-                    className="size-1.5 shrink-0 rounded-full bg-muted-foreground/40"
-                  />
-                  <RailSegment hidden={isLast} grow />
-                </div>
-                <div className="flex min-w-0 flex-1 items-start gap-2 py-1">
-                  <span className="min-w-0 flex-1 truncate text-xs leading-4 text-muted-foreground">
-                    {item.text}
-                  </span>
-                  {!isLocked && (
-                    <button
-                      type="button"
-                      onClick={() => addAssertionAfter(index)}
-                      aria-label={`Add a check after step ${item.stepIndex + 1}`}
-                      title="Add a check after this step"
-                      className={cn(ICON_BUTTON, ROW_ACTION)}
-                    >
-                      <Plus size={13} />
-                    </button>
-                  )}
-                </div>
-              </li>
-            );
-          }
-
-          const isEditing = editingId === item.id;
-          const isCodeOpen = expandedCodeId === item.id;
-          return (
-            <li
-              key={item.id}
-              data-testid={`dyad-test-assertions-assertion-${item.id}`}
-              draggable={!isLocked && !isEditing}
-              tabIndex={isLocked ? undefined : 0}
-              aria-label={
-                isLocked
-                  ? undefined
-                  : `Assertion: ${item.text || "not described yet"}. Alt with arrow keys to reorder.`
-              }
-              onDragStart={(e) => {
-                e.dataTransfer.effectAllowed = "move";
-                e.dataTransfer.setData("text/plain", item.id);
-                setDragId(item.id);
-              }}
-              onDragEnd={() => setDragId(null)}
-              onKeyDown={(e) => {
-                // HTML5 drag is pointer-only; keep reordering reachable.
-                if (!e.altKey) return;
-                if (e.key === "ArrowUp") {
-                  e.preventDefault();
-                  moveByOffset(index, -1);
-                } else if (e.key === "ArrowDown") {
-                  e.preventDefault();
-                  moveByOffset(index, 1);
-                }
-              }}
-              className={cn(
-                "group/row flex gap-2.5 pr-2 pl-3.5 outline-none",
-                "focus-visible:bg-(--background-lighter)",
-                dragId === item.id && "opacity-50",
-              )}
-              {...dropProps}
-            >
-              <div className="flex w-4 shrink-0 flex-col items-center">
-                <RailSegment hidden={isFirst} lead="assertion" />
-                <span
-                  aria-hidden
-                  className={cn(
-                    "flex size-4 shrink-0 items-center justify-center rounded-full",
-                    ACCENT_NODE,
-                  )}
-                >
-                  <Check size={10} strokeWidth={3} />
-                </span>
-                <RailSegment hidden={isLast} grow />
-              </div>
-
-              <div className="flex min-w-0 flex-1 items-start gap-1.5 py-0.5">
-                <div className="min-w-0 flex-1">
-                  {isEditing ? (
-                    <textarea
-                      autoFocus
-                      value={draftText}
-                      onChange={(e) => setDraftText(e.target.value)}
-                      onBlur={commitEdit}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter" && !e.shiftKey) {
-                          e.preventDefault();
-                          commitEdit();
-                        } else if (e.key === "Escape") {
-                          e.preventDefault();
-                          setEditingId(null);
-                          setDraftText("");
-                        }
-                      }}
-                      rows={2}
-                      placeholder="Describe what this should check…"
-                      aria-label="Assertion description"
-                      data-testid={`dyad-test-assertions-edit-${item.id}`}
-                      className="w-full resize-none rounded-md border border-input bg-(--background-lighter) px-2 py-1 text-[13px] leading-5 text-foreground outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
-                    />
-                  ) : (
-                    <button
-                      type="button"
-                      onClick={() => startEdit(item.id, item.text)}
-                      disabled={isLocked}
-                      title={isLocked ? undefined : "Click to edit"}
-                      data-testid={`dyad-test-assertions-text-${item.id}`}
-                      className={cn(
-                        "w-full rounded-sm text-left text-[13px] leading-5 text-foreground",
-                        "focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none",
-                        // Dotted underline on hover is the editable-text
-                        // convention: the sentence itself is the control.
-                        "decoration-muted-foreground decoration-dotted underline-offset-4 hover:underline",
-                        "disabled:cursor-default disabled:hover:no-underline",
-                      )}
-                    >
-                      {item.text || (
-                        <span className="text-muted-foreground italic">
-                          Describe what this should check…
-                        </span>
-                      )}
-                    </button>
-                  )}
-
-                  {(item.code || (item.needsCode && !isLocked)) && (
-                    <div className="mt-0.5 flex flex-wrap items-center gap-x-2.5 gap-y-1">
-                      {item.code && (
-                        <button
-                          type="button"
-                          onClick={() =>
-                            setExpandedCodeId((prev) =>
-                              prev === item.id ? null : item.id,
-                            )
-                          }
-                          aria-expanded={isCodeOpen}
-                          className="inline-flex items-center gap-0.5 rounded-sm text-[11px] text-muted-foreground transition-colors duration-150 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                        >
-                          <ChevronRight
-                            size={11}
-                            className={cn(
-                              "transition-transform duration-150 motion-reduce:transition-none",
-                              isCodeOpen && "rotate-90",
-                            )}
-                          />
-                          {isCodeOpen ? "Hide code" : "Show code"}
-                        </button>
-                      )}
-                      {item.needsCode && !isLocked && (
-                        <span className={cn("text-[11px]", ACCENT_TEXT)}>
-                          Code written on approve
-                        </span>
-                      )}
-                    </div>
-                  )}
-
-                  {item.code && isCodeOpen && (
-                    <code className="mt-1 block overflow-x-auto rounded-md bg-(--background-darker) px-2 py-1.5 font-mono text-[11px] leading-relaxed whitespace-pre text-foreground">
-                      {item.code}
-                    </code>
-                  )}
-                </div>
-
-                {!isLocked && !isEditing && (
-                  <>
-                    <span
-                      aria-hidden
-                      title="Drag to move this check"
-                      className={cn(
-                        "shrink-0 cursor-grab p-0.5 text-muted-foreground",
-                        ROW_ACTION,
-                      )}
-                    >
-                      <GripVertical size={13} />
-                    </span>
-                    <button
-                      type="button"
-                      onClick={() => removeAssertion(item.id)}
-                      aria-label="Remove this check"
-                      title="Remove"
-                      data-testid={`dyad-test-assertions-remove-${item.id}`}
-                      className={cn(
-                        ICON_BUTTON,
-                        ROW_ACTION,
-                        "hover:text-destructive",
-                      )}
-                    >
-                      <Trash2 size={13} />
-                    </button>
-                  </>
-                )}
-              </div>
-            </li>
-          );
-        })}
-      </ol>
-
-      {assertions.length === 0 && (
-        <p className="px-3.5 pb-2.5 text-xs text-muted-foreground">
-          {isApproved
-            ? "No checks were added — the test replays the recorded steps only."
-            : discarded
-              ? "No checks were added."
-              : "No checks proposed. Point at a step to add your own."}
-        </p>
-      )}
-
-      <div className="flex flex-wrap items-center gap-2 border-t border-border/50 px-3.5 py-2.5">
-        {isApproving ? (
-          // The approval is latched but the file isn't written yet. Its own row
-          // rather than the terminal one: there is nothing to open, and the
-          // wait is the whole state.
-          <span
-            className="inline-flex items-center gap-1.5 text-xs text-muted-foreground"
-            data-testid="dyad-test-assertions-generating-note"
-          >
-            <Loader2 size={12} className="animate-spin motion-reduce:hidden" />
-            Generating the test file…
-          </span>
-        ) : isDiscarding ? (
-          // Same shape, opposite promise: nothing is being written, so the row
-          // says what is actually happening rather than borrowing the approval's.
-          <span
-            className="inline-flex items-center gap-1.5 text-xs text-muted-foreground"
-            data-testid="dyad-test-assertions-closing-note"
-          >
-            <Loader2 size={12} className="animate-spin motion-reduce:hidden" />
-            Closing the plan…
-          </span>
-        ) : isApproved ? (
-          <>
-            <span className="text-xs text-muted-foreground">
-              Test generated with {checkCountLabel}.
-            </span>
-            <button
-              type="button"
-              onClick={openSpecFile}
-              disabled={!specPath}
-              data-testid="dyad-test-assertions-open-file-button"
-              className="ml-auto rounded-md px-2 py-1 text-xs font-medium text-foreground transition-colors duration-150 hover:bg-(--background-darker) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-default disabled:opacity-50"
-            >
-              Open test file
-            </button>
-          </>
-        ) : discarded ? (
-          <span
-            className="text-xs text-muted-foreground"
-            data-testid="dyad-test-assertions-discarded-note"
-          >
-            Closed without generating a test.
-          </span>
-        ) : (
-          <>
-            <span className="text-xs text-muted-foreground">
-              {hasBlankAssertion
-                ? "Describe every check before approving."
-                : isAgentWaiting
-                  ? "Dyad is waiting on this before it continues."
-                  : "Approving generates the test file and runs it."}
-            </span>
-            {/* Only while the turn is parked on this card: otherwise there is
-                nothing waiting, and "close" would just hide a usable plan. */}
-            {isAgentWaiting && (
-              <button
-                type="button"
-                onClick={() => void handleDiscard()}
-                disabled={isBusy}
-                data-testid="dyad-test-assertions-discard-button"
-                className="ml-auto rounded-md px-2 py-1 text-xs font-medium text-muted-foreground transition-colors duration-150 hover:bg-(--background-darker) hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                Close without generating
-              </button>
-            )}
-            <button
-              type="button"
-              onClick={() => void handleApprove()}
-              disabled={isBusy || hasBlankAssertion || !proposalId}
-              data-testid="dyad-test-assertions-approve-button"
-              className={cn(
-                "inline-flex items-center gap-1.5 rounded-md bg-purple-600 px-2.5 py-1 text-xs font-medium text-white transition-colors duration-150 hover:bg-purple-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-600 focus-visible:ring-offset-2 focus-visible:ring-offset-(--background-lightest) disabled:cursor-not-allowed disabled:opacity-50 dark:bg-purple-600 dark:hover:bg-purple-500",
-                !isAgentWaiting && "ml-auto",
-              )}
-            >
-              {isApproving && (
-                <Loader2
-                  size={12}
-                  className="animate-spin motion-reduce:hidden"
-                />
-              )}
-              {isApproving ? "Generating…" : "Approve & generate"}
-            </button>
-          </>
-        )}
-      </div>
-
-      <span className="sr-only" role="status" aria-live="polite">
-        {liveMessage}
+  // Still up for review: the composer owns it, and duplicating the plan here
+  // would put two approve buttons on screen. The message keeps a pointer so it
+  // still reads as a step the agent took.
+  return (
+    <ReceiptShell>
+      <span className="text-sm text-foreground">Review recorded test</span>
+      <span
+        className="min-w-0 flex-1 truncate text-xs text-muted-foreground"
+        title={payload.testTitle}
+      >
+        {payload.testTitle}
       </span>
-    </div>
+      <span className="shrink-0 text-xs text-muted-foreground">
+        {checkCountLabel} · waiting for your review
+      </span>
+    </ReceiptShell>
   );
 };

--- a/src/components/chat/TestAssertionsInput.test.tsx
+++ b/src/components/chat/TestAssertionsInput.test.tsx
@@ -44,13 +44,26 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("@/user_input/hooks", () => ({
-  useUserInputReadModel: () => ({ respond: mocks.respond }),
+  useUserInputReadModel: () => ({
+    respond: mocks.respond,
+    // Read live rather than from the render snapshot, so the card can tell a
+    // request main has dropped from one a transient failure left parked.
+    getSnapshot: () => ({
+      requests: mocks.liveRequests,
+      respondingRequestIds: new Set<string>(),
+    }),
+  }),
   useUserInputRequests: () => mocks.liveRequests,
 }));
 
 /** The live user-input requests the projection exposes, set per test. */
 function setLiveRequests(requests: Map<string, { status: string }>): void {
   mocks.liveRequests = requests;
+}
+
+/** A turn parked on this card, as both the snapshot and the live read report it. */
+function parkTurn(): void {
+  setLiveRequests(new Map([[REQUEST_ID, { status: "awaiting" }]]));
 }
 
 vi.mock("@/hooks/useChatMessages", () => ({
@@ -173,7 +186,7 @@ beforeEach(() => {
 
 describe("TestAssertionsPlanCard", () => {
   it("resumes the parked turn instead of sending a chat message", async () => {
-    setLiveRequests(new Map([[REQUEST_ID, { status: "awaiting" }]]));
+    parkTurn();
     renderCard();
 
     screen.getByTestId("dyad-test-assertions-approve-button").click();
@@ -192,7 +205,7 @@ describe("TestAssertionsPlanCard", () => {
   });
 
   it("closing the card answers the parked turn with no spec", async () => {
-    setLiveRequests(new Map([[REQUEST_ID, { status: "awaiting" }]]));
+    parkTurn();
     renderCard();
 
     screen.getByTestId("dyad-test-assertions-discard-button").click();
@@ -221,7 +234,7 @@ describe("TestAssertionsPlanCard", () => {
       order.push("respond");
       return true;
     });
-    setLiveRequests(new Map([[REQUEST_ID, { status: "awaiting" }]]));
+    parkTurn();
     renderCard();
 
     screen.getByTestId("dyad-test-assertions-discard-button").click();
@@ -233,7 +246,7 @@ describe("TestAssertionsPlanCard", () => {
     // Answering the turn against a card that still reads as approvable would
     // end the turn and leave the plan live with nothing waiting on it.
     mocks.discardTestAssertions.mockRejectedValueOnce(new Error("db down"));
-    setLiveRequests(new Map([[REQUEST_ID, { status: "awaiting" }]]));
+    parkTurn();
     renderCard();
 
     screen.getByTestId("dyad-test-assertions-discard-button").click();
@@ -254,9 +267,6 @@ describe("TestAssertionsPlanCard", () => {
     // No live request: the app restarted, or the turn was stopped.
     renderCard();
 
-    expect(
-      screen.queryByTestId("dyad-test-assertions-discard-button"),
-    ).toBeNull();
     screen.getByTestId("dyad-test-assertions-approve-button").click();
 
     await waitFor(() => expect(mocks.streamMessage).toHaveBeenCalledTimes(1));
@@ -266,14 +276,52 @@ describe("TestAssertionsPlanCard", () => {
   });
 
   it("falls back to a new turn when the parked request has expired", async () => {
-    setLiveRequests(new Map([[REQUEST_ID, { status: "awaiting" }]]));
-    mocks.respond.mockResolvedValue(false);
+    parkTurn();
+    // What the read model does on a NotFound: the request is dropped, and only
+    // then is there nothing left to resume.
+    mocks.respond.mockImplementation(async () => {
+      setLiveRequests(new Map());
+      return false;
+    });
     renderCard();
 
     screen.getByTestId("dyad-test-assertions-approve-button").click();
 
     await waitFor(() => expect(mocks.streamMessage).toHaveBeenCalledTimes(1));
     expect(mocks.respond).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not start a second turn when the hand-off fails but the turn is still parked", async () => {
+    // A transient IPC failure also answers false, but leaves the agent sitting
+    // on this card. Starting a turn there queues a second generation behind the
+    // parked one and hands the agent the same spec twice.
+    parkTurn();
+    mocks.respond.mockResolvedValue(false);
+    renderCard();
+
+    screen.getByTestId("dyad-test-assertions-approve-button").click();
+
+    await waitFor(() => expect(mocks.respond).toHaveBeenCalledTimes(1));
+    await screen.findByTestId("dyad-test-assertions-open-file-button");
+    expect(mocks.streamMessage).not.toHaveBeenCalled();
+    expect(mocks.syncChatFromDb).not.toHaveBeenCalled();
+  });
+
+  it("closes a plan nothing is waiting on, without answering a request", async () => {
+    // A plan left over from a stopped turn or a restart is pinned to the
+    // composer, so approving a test the user doesn't want must not be its only
+    // exit. The latch is the whole close; the resync is what unpins the card.
+    renderCard();
+
+    screen.getByTestId("dyad-test-assertions-discard-button").click();
+
+    await waitFor(() =>
+      expect(mocks.discardTestAssertions).toHaveBeenCalledTimes(1),
+    );
+    await screen.findByTestId("dyad-test-assertions-discarded-note");
+    expect(mocks.respond).not.toHaveBeenCalled();
+    expect(mocks.applyTestAssertions).not.toHaveBeenCalled();
+    expect(mocks.syncChatFromDb).toHaveBeenCalledTimes(1);
   });
 
   it("caps the plan's height so a long recording can't push the composer away", () => {
@@ -287,7 +335,7 @@ describe("TestAssertionsPlanCard", () => {
 
 describe("TestAssertionsInput", () => {
   it("puts up the plan the transcript says is still waiting on a review", () => {
-    setLiveRequests(new Map([[REQUEST_ID, { status: "awaiting" }]]));
+    parkTurn();
     mocks.chatMessages = [
       { role: "user", content: "record this" },
       messageWithPlan("proposed"),
@@ -335,5 +383,46 @@ describe("TestAssertionsInput", () => {
     render(<TestAssertionsInput />);
 
     expect(screen.queryByTestId("dyad-test-assertions-card")).toBeNull();
+  });
+
+  it("keeps an unanswered plan reachable however far the chat has moved on", () => {
+    // The transcript only carries a receipt now, so a plan that scrolls out of
+    // reach is one that can never be approved OR closed. There is no cutoff.
+    mocks.chatMessages = [
+      messageWithPlan("proposed"),
+      ...Array.from({ length: 80 }, (_, i) => ({
+        role: i % 2 === 0 ? "user" : "assistant",
+        content: `chatter ${i}`,
+      })),
+    ];
+
+    render(<TestAssertionsInput />);
+
+    expect(screen.getByTestId("dyad-test-assertions-card")).toBeTruthy();
+    expect(
+      screen.getByTestId("dyad-test-assertions-approve-button"),
+    ).toBeTruthy();
+  });
+
+  it("puts the newest unanswered plan on top and says how many are behind it", () => {
+    // Two plans waiting is a queue, not a dead end: answering this one brings
+    // the older one up, so the older receipt's "waiting for your review" holds.
+    const older = messageWithPlan("proposed");
+    const newer = {
+      role: "assistant",
+      content: buildAssertionsTagContent({
+        proposalId: "proposal-2",
+        requestId: "user-input-2",
+        status: "proposed",
+        payload: { ...PAYLOAD, testTitle: "the newer flow" },
+      }),
+    };
+    mocks.chatMessages = [older, newer];
+
+    render(<TestAssertionsInput />);
+
+    const card = screen.getByTestId("dyad-test-assertions-card");
+    expect(card.textContent).toContain("the newer flow");
+    expect(card.textContent).toContain("(1 of 2)");
   });
 });

--- a/src/components/chat/TestAssertionsInput.test.tsx
+++ b/src/components/chat/TestAssertionsInput.test.tsx
@@ -5,23 +5,33 @@ import {
   ASSERTION_PROPOSAL_VERSION,
   type AssertionProposalPayload,
 } from "@/lib/test_recorder/assertion_proposal";
+import { buildAssertionsTagContent } from "@/lib/test_recorder/assertion_tag";
 import { RECORDED_TEST_DRAFT_VERSION } from "@/lib/test_recorder/draft";
-import { DyadTestAssertionsCard } from "./DyadTestAssertionsCard";
+import {
+  TestAssertionsInput,
+  TestAssertionsPlanCard,
+} from "./TestAssertionsInput";
 
 /**
  * Which way an approval is handed back to the agent. `generate_test_assertions`
  * parks on this card, so the normal path answers that request and the turn picks
  * it up as its tool result — invisibly. Only a card whose turn is gone (reload,
  * stopped stream) may fall back to sending a visible chat message.
+ *
+ * Plus the composer's half of the deal: it puts up the plan the transcript says
+ * is still waiting on a review, and takes it down the moment that changes.
  */
 
 const REQUEST_ID = "user-input-1";
+const PROPOSAL_ID = "proposal-1";
 const SPEC_PATH = "e2e-tests/recorded-add-an-item.spec.ts";
 
 const mocks = vi.hoisted(() => ({
   respond: vi.fn(async () => true),
   /** The live user-input requests the read model reports, set per test. */
   liveRequests: new Map<string, { status: string }>(),
+  /** The selected chat's messages, as the composer reads them. */
+  chatMessages: [] as { role: string; content: string }[],
   streamMessage: vi.fn(),
   applyTestAssertions: vi.fn(async () => ({
     specPath: SPEC_PATH,
@@ -42,6 +52,10 @@ vi.mock("@/user_input/hooks", () => ({
 function setLiveRequests(requests: Map<string, { status: string }>): void {
   mocks.liveRequests = requests;
 }
+
+vi.mock("@/hooks/useChatMessages", () => ({
+  useChatMessages: () => mocks.chatMessages,
+}));
 
 vi.mock("@/atoms/chatAtoms", async () => {
   const { atom } = await import("jotai");
@@ -125,30 +139,39 @@ const PAYLOAD: AssertionProposalPayload = {
 
 function renderCard() {
   return render(
-    <DyadTestAssertionsCard
-      node={{
-        properties: {
-          "proposal-id": "proposal-1",
-          "request-id": REQUEST_ID,
-          status: "proposed",
-          "spec-path": "",
-          state: "finished",
-        },
-      }}
-    >
-      {JSON.stringify(PAYLOAD)}
-    </DyadTestAssertionsCard>,
+    <TestAssertionsPlanCard
+      proposalId={PROPOSAL_ID}
+      requestId={REQUEST_ID}
+      payload={PAYLOAD}
+    />,
   );
 }
 
-describe("DyadTestAssertionsCard", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mocks.respond.mockResolvedValue(true);
-    mocks.discardTestAssertions.mockResolvedValue({ ok: true as const });
-    setLiveRequests(new Map());
-  });
+/** An assistant message carrying one card, as the tool writes it. */
+function messageWithPlan(status: "proposed" | "approved" | "discarded"): {
+  role: string;
+  content: string;
+} {
+  return {
+    role: "assistant",
+    content: `Here's what I'd check.\n\n${buildAssertionsTagContent({
+      proposalId: PROPOSAL_ID,
+      requestId: status === "proposed" ? REQUEST_ID : undefined,
+      status,
+      payload: PAYLOAD,
+    })}`,
+  };
+}
 
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.respond.mockResolvedValue(true);
+  mocks.discardTestAssertions.mockResolvedValue({ ok: true as const });
+  mocks.chatMessages = [];
+  setLiveRequests(new Map());
+});
+
+describe("TestAssertionsPlanCard", () => {
   it("resumes the parked turn instead of sending a chat message", async () => {
     setLiveRequests(new Map([[REQUEST_ID, { status: "awaiting" }]]));
     renderCard();
@@ -251,5 +274,66 @@ describe("DyadTestAssertionsCard", () => {
 
     await waitFor(() => expect(mocks.streamMessage).toHaveBeenCalledTimes(1));
     expect(mocks.respond).toHaveBeenCalledTimes(1);
+  });
+
+  it("caps the plan's height so a long recording can't push the composer away", () => {
+    renderCard();
+
+    const list = screen.getByRole("list");
+    expect(list.className).toContain("max-h-44");
+    expect(list.className).toContain("overflow-y-auto");
+  });
+});
+
+describe("TestAssertionsInput", () => {
+  it("puts up the plan the transcript says is still waiting on a review", () => {
+    setLiveRequests(new Map([[REQUEST_ID, { status: "awaiting" }]]));
+    mocks.chatMessages = [
+      { role: "user", content: "record this" },
+      messageWithPlan("proposed"),
+    ];
+
+    render(<TestAssertionsInput />);
+
+    expect(screen.getByTestId("dyad-test-assertions-card")).toBeTruthy();
+    expect(screen.getByTestId("dyad-test-assertions-step-0")).toBeTruthy();
+    expect(
+      screen.getByTestId("dyad-test-assertions-approve-button"),
+    ).toBeTruthy();
+  });
+
+  it.each(["approved", "discarded"] as const)(
+    "takes the plan down once the message says %s",
+    (status) => {
+      // The transcript's own receipt renders the outcome. Leaving the composer
+      // card up too would put two approve buttons — and two "Generated"
+      // badges — on screen at once.
+      mocks.chatMessages = [messageWithPlan(status)];
+
+      render(<TestAssertionsInput />);
+
+      expect(screen.queryByTestId("dyad-test-assertions-card")).toBeNull();
+    },
+  );
+
+  it("ignores a card that is still streaming in", () => {
+    // No closing tag yet: the plan is half-written, and offering a partial one
+    // for approval would generate a test from it.
+    const whole = messageWithPlan("proposed").content;
+    mocks.chatMessages = [
+      { role: "assistant", content: whole.slice(0, whole.length - 30) },
+    ];
+
+    render(<TestAssertionsInput />);
+
+    expect(screen.queryByTestId("dyad-test-assertions-card")).toBeNull();
+  });
+
+  it("shows nothing when the chat has no plan", () => {
+    mocks.chatMessages = [{ role: "assistant", content: "no cards here" }];
+
+    render(<TestAssertionsInput />);
+
+    expect(screen.queryByTestId("dyad-test-assertions-card")).toBeNull();
   });
 });

--- a/src/components/chat/TestAssertionsInput.tsx
+++ b/src/components/chat/TestAssertionsInput.tsx
@@ -1,0 +1,880 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useAtomValue, useSetAtom } from "jotai";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  Check,
+  ChevronDown,
+  ChevronRight,
+  ChevronUp,
+  FlaskConical,
+  GripVertical,
+  Loader2,
+  Plus,
+  Trash2,
+} from "lucide-react";
+
+import { selectedAppIdAtom, previewModeAtom } from "@/atoms/appAtoms";
+import { chatMessagesByIdAtom, selectedChatIdAtom } from "@/atoms/chatAtoms";
+import { selectedFileAtom } from "@/atoms/viewAtoms";
+import { useChatStreamManager } from "@/chat_stream/ChatStreamProvider";
+import { useChatMessages } from "@/hooks/useChatMessages";
+import { useStreamChat } from "@/hooks/useStreamChat";
+import { ipc } from "@/ipc/types";
+import { cn } from "@/lib/utils";
+import { queryKeys } from "@/lib/queryKeys";
+import { showError, showSuccess, showWarning } from "@/lib/toast";
+import { syncChatFromDb } from "@/lib/resyncChat";
+import {
+  isAssertionItem,
+  moveAssertion,
+  type AssertionPlanItem,
+  type AssertionProposalPayload,
+} from "@/lib/test_recorder/assertion_proposal";
+import {
+  listAssertionsTags,
+  messageMayHaveAssertionsTag,
+  parseAssertionsPayloadFromMessage,
+  type AssertionsTagSummary,
+} from "@/lib/test_recorder/assertion_tag";
+import {
+  useUserInputReadModel,
+  useUserInputRequests,
+} from "@/user_input/hooks";
+
+/**
+ * The recorded-test proposal, attached to the composer.
+ *
+ * The plan itself is persisted in an assistant message (a
+ * `<dyad-test-assertions>` tag), but a plan waiting on a decision belongs with
+ * the other things waiting on one — the questionnaire, the prompt queue, the
+ * consent banner — rather than scrolled away up the transcript. So the live
+ * plan is read back out of the message and rendered here, and the message
+ * itself keeps only a receipt of what was decided (`DyadTestAssertionsCard`).
+ *
+ * Layout is a timeline: one rail, a neutral node per step, a filled node per
+ * assertion, so the steps stay quiet context while the assertions carry the
+ * weight. Color is restrained to the two places a decision happens. Recordings
+ * run long, so the list is capped and scrolls rather than pushing the message
+ * box off the screen.
+ */
+
+/** The accent, in the recorder's purple. Also readable on a dark surface. */
+const ACCENT_TEXT = "text-purple-700 dark:text-purple-300";
+const ACCENT_NODE = "bg-purple-600 text-white dark:bg-purple-500";
+
+const ICON_BUTTON =
+  "shrink-0 rounded-md p-0.5 text-muted-foreground transition-colors duration-150 " +
+  "hover:bg-(--background-darker) hover:text-foreground " +
+  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
+
+/** Hidden until the row is hovered or something inside it takes focus. */
+const ROW_ACTION =
+  "opacity-0 transition-opacity duration-150 group-hover/row:opacity-100 " +
+  "group-focus-within/row:opacity-100 focus-visible:opacity-100 " +
+  "motion-reduce:transition-none";
+
+/**
+ * How far back to look for a plan awaiting review.
+ *
+ * A plan is proposed by a tool that then parks on it, so a live one is all but
+ * always in the last message; the slack covers a plan left unanswered when the
+ * turn was stopped and the user carried on chatting. Bounded because this scan
+ * re-runs on every chunk of every stream.
+ */
+const MAX_SCANNED_MESSAGES = 20;
+
+/**
+ * The most recent plan in this chat that nobody has answered yet, as the raw
+ * tag text.
+ *
+ * Returns the tag rather than the parsed plan so the parse can be memoized on
+ * a value that only changes when the plan does: the surrounding message is
+ * rewritten and restreamed while a card is open, and re-seeding the rows from
+ * the server's copy on every one of those would throw away the user's edits.
+ */
+function useLiveAssertionsTag(
+  chatId: number | undefined,
+): AssertionsTagSummary | null {
+  const messages = useChatMessages(chatId);
+  const raw = useMemo(() => {
+    const start = Math.max(0, messages.length - MAX_SCANNED_MESSAGES);
+    for (let i = messages.length - 1; i >= start; i--) {
+      const message = messages[i];
+      if (message.role !== "assistant") continue;
+      if (!messageMayHaveAssertionsTag(message.content)) continue;
+      const proposed = listAssertionsTags(message.content).filter(
+        (tag) => tag.status === "proposed",
+      );
+      // Last one in the message: a turn may propose twice, and the later plan
+      // is the one the agent is parked on.
+      if (proposed.length > 0) return proposed[proposed.length - 1].raw;
+    }
+    return null;
+  }, [messages]);
+
+  return useMemo(
+    () => (raw ? (listAssertionsTags(raw)[0] ?? null) : null),
+    [raw],
+  );
+}
+
+export function TestAssertionsInput() {
+  const chatId = useAtomValue(selectedChatIdAtom);
+  const tag = useLiveAssertionsTag(chatId ?? undefined);
+  const payload = useMemo(
+    () => (tag ? parseAssertionsPayloadFromMessage(tag.raw) : null),
+    [tag],
+  );
+
+  if (!tag || !payload) return null;
+
+  return (
+    <TestAssertionsPlanCard
+      // A fresh plan starts from the server's rows, never from the previous
+      // card's edits.
+      key={tag.proposalId}
+      proposalId={tag.proposalId}
+      requestId={tag.requestId}
+      payload={payload}
+    />
+  );
+}
+
+/**
+ * The rail segment above/below a node; transparent at the ends so the line starts
+ * at the first node and stops at the last. `lead` is the height above a node,
+ * centering it on its row's first line of text — steps and assertions set
+ * different text sizes. Tinted from the foreground rather than `--border`, which
+ * in dark mode is within a hair of this card's background.
+ */
+function RailSegment({
+  hidden,
+  lead,
+  grow,
+}: {
+  hidden: boolean;
+  lead?: "step" | "assertion";
+  grow?: boolean;
+}) {
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "w-px",
+        grow ? "flex-1" : lead === "assertion" ? "h-0.5" : "h-[7px]",
+        hidden ? "bg-transparent" : "bg-muted-foreground/25",
+      )}
+    />
+  );
+}
+
+export function TestAssertionsPlanCard({
+  proposalId,
+  requestId,
+  payload,
+}: {
+  proposalId: string;
+  /** Empty when no turn is parked on the plan — a reload, or a stopped stream. */
+  requestId: string;
+  payload: AssertionProposalPayload;
+}) {
+  const chatId = useAtomValue(selectedChatIdAtom);
+  const appId = useAtomValue(selectedAppIdAtom);
+  const setMessagesById = useSetAtom(chatMessagesByIdAtom);
+  const setSelectedFile = useSetAtom(selectedFileAtom);
+  const setPreviewMode = useSetAtom(previewModeAtom);
+  const queryClient = useQueryClient();
+  const chatStreamManager = useChatStreamManager();
+  const { streamMessage } = useStreamChat();
+  // The agent is parked on this card's request for as long as it's live, so
+  // answering it resumes that turn. It won't be live for a card reloaded after
+  // a restart, or one whose turn was stopped — those fall back to handing the
+  // spec over as a fresh chat turn.
+  const userInputReadModel = useUserInputReadModel();
+  const userInputRequests = useUserInputRequests();
+  const parkedRequest = requestId
+    ? userInputRequests.get(requestId)
+    : undefined;
+  const isAgentWaiting =
+    parkedRequest !== undefined && parkedRequest.status !== "settled";
+
+  const [items, setItems] = useState<AssertionPlanItem[]>(payload.items);
+  // Held locally until the rewritten message makes it back through
+  // `syncChatFromDb`. Without it the card flips to "Generated" with "Open test
+  // file" dead until the verification stream finishes.
+  const [approvedSpecPath, setApprovedSpecPath] = useState<string | null>(null);
+  const specPath = approvedSpecPath ?? "";
+  const [isExpanded, setIsExpanded] = useState(true);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [draftText, setDraftText] = useState("");
+  const [dragId, setDragId] = useState<string | null>(null);
+  const [expandedCodeId, setExpandedCodeId] = useState<string | null>(null);
+  // The card is mounted only while the message still says the plan is up for
+  // review, so these latches are what carry it through the write: the server's
+  // rewrite unmounts it and the message's own receipt takes over.
+  const [optimisticApproved, setOptimisticApproved] = useState(false);
+  const [optimisticDiscarded, setOptimisticDiscarded] = useState(false);
+  const [isApproving, setIsApproving] = useState(false);
+  // Tracked apart from `isApproving` even though both disable the same
+  // controls: closing a plan writes no file, and reusing the approval flag made
+  // the card answer "Generating…" to a button that generates nothing.
+  const [isDiscarding, setIsDiscarding] = useState(false);
+  const [liveMessage, setLiveMessage] = useState("");
+  // Synchronous guard: state updates are async, so a fast double-click would
+  // otherwise fire two applies before the flags above re-render. Shared by both
+  // operations — either one in flight rules out the other.
+  const busyRef = useRef(false);
+  const editingIdRef = useRef<string | null>(null);
+  editingIdRef.current = editingId;
+
+  // The agent can rewrite the plan while it's up for review, so re-seed from
+  // the server's rows whenever they change — but never stomp an edit the user
+  // is mid-way through. `payload` only changes identity when the tag text
+  // does, so a restreamed message around an untouched card is a no-op.
+  useEffect(() => {
+    if (editingIdRef.current) return;
+    setItems(payload.items);
+  }, [payload]);
+
+  const isApproved = optimisticApproved;
+  // Discarding freezes the plan too: nothing was written, but there is nothing
+  // left to answer either. Persisted alongside the approval, so a reload can't
+  // hand back a plan the user already declined.
+  const discarded = optimisticDiscarded;
+  const isLocked = isApproved || discarded;
+  const assertions = items.filter(isAssertionItem);
+  const hasBlankAssertion = assertions.some((item) => !item.text.trim());
+  const checkCountLabel =
+    assertions.length === 1 ? "1 check" : `${assertions.length} checks`;
+
+  const updateAssertion = useCallback(
+    (id: string, text: string) => {
+      setItems((prev) =>
+        prev.map((item) =>
+          isAssertionItem(item) && item.id === id
+            ? // The code no longer matches the sentence, so mark it for
+              // re-synthesis on approve.
+              { ...item, text, needsCode: true, origin: "user" as const }
+            : item,
+        ),
+      );
+    },
+    [setItems],
+  );
+
+  const commitEdit = useCallback(() => {
+    if (!editingId) return;
+    updateAssertion(editingId, draftText.trim());
+    setEditingId(null);
+    setDraftText("");
+  }, [draftText, editingId, updateAssertion]);
+
+  const startEdit = (id: string, text: string) => {
+    if (isLocked) return;
+    setEditingId(id);
+    setDraftText(text);
+  };
+
+  const removeAssertion = (id: string) => {
+    if (isLocked) return;
+    if (editingId === id) setEditingId(null);
+    setItems((prev) =>
+      prev.filter((item) => !isAssertionItem(item) || item.id !== id),
+    );
+    setLiveMessage("Assertion removed");
+  };
+
+  const addAssertionAfter = (index: number) => {
+    if (isLocked) return;
+    const id = crypto.randomUUID();
+    setItems((prev) => {
+      const next = [...prev];
+      next.splice(index + 1, 0, {
+        kind: "assertion",
+        id,
+        text: "",
+        code: null,
+        needsCode: true,
+        origin: "user",
+      });
+      return next;
+    });
+    setEditingId(id);
+    setDraftText("");
+  };
+
+  const moveByOffset = (index: number, offset: number) => {
+    if (isLocked) return;
+    // Compute outside setItems: a state updater must stay pure.
+    const next = moveAssertion(items, index, index + offset);
+    if (next === items) return;
+    setItems(next);
+    setLiveMessage(
+      `Assertion moved to position ${index + offset + 1} of ${next.length}`,
+    );
+  };
+
+  const handleDrop = (targetIndex: number) => {
+    if (dragId === null) return;
+    const fromIndex = items.findIndex(
+      (item) => isAssertionItem(item) && item.id === dragId,
+    );
+    setDragId(null);
+    if (fromIndex === -1) return;
+    setItems((prev) => moveAssertion(prev, fromIndex, targetIndex));
+  };
+
+  const openSpecFile = () => {
+    if (!specPath) return;
+    setSelectedFile({ path: specPath });
+    setPreviewMode("code");
+  };
+
+  /**
+   * Ask the agent to run the spec the approval just generated. Only for a card
+   * whose turn is no longer parked on it — a reload or a stopped stream. Sent as
+   * a normal chat turn (Agent mode, where run_tests lives) so the run and any
+   * fix are visible in the conversation.
+   */
+  const requestVerificationRun = (generatedSpecPath: string) => {
+    if (chatId == null || !generatedSpecPath) return;
+    streamMessage({
+      prompt: [
+        `I approved the assertions. Dyad generated ${generatedSpecPath} from my recording.`,
+        "",
+        `Run it with run_tests to make sure it actually works. If it fails, read the failure, decide whether the test or the app is wrong, fix it, and run it again until it passes — or tell me what's blocking it.`,
+      ].join("\n"),
+      chatId,
+      requestedChatMode: "local-agent",
+    });
+  };
+
+  const handleApprove = async () => {
+    if (busyRef.current || isLocked) return;
+    if (!proposalId || chatId == null || appId == null) return;
+    busyRef.current = true;
+    setIsApproving(true);
+    setOptimisticApproved(true);
+    try {
+      const result = await ipc.tests.applyTestAssertions({
+        appId,
+        chatId,
+        proposalId,
+        items,
+      });
+      setApprovedSpecPath(result.specPath || null);
+      queryClient.invalidateQueries({ queryKey: queryKeys.appFiles.all });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.tests.list({ appId }),
+      });
+      // A warning can accompany a spec written perfectly well, so report success
+      // and the caveat separately: a red error toast over a file that exists
+      // reads as "nothing was saved".
+      if (result.specPath) {
+        showSuccess(`Generated ${result.specPath}`);
+        if (result.warning) showWarning(result.warning);
+      } else if (result.warning) {
+        showError(result.warning);
+      }
+      // A recorded test nobody has run is a guess: replay can behave differently
+      // from the hand-performed flow, so the agent gets the spec back either
+      // way. The parked turn picks it up as its tool result and carries on
+      // without a visible message; a card whose turn is gone — or whose request
+      // expired between render and click — needs a new turn instead.
+      const handedToParkedTurn =
+        isAgentWaiting &&
+        (await userInputReadModel.respond(requestId, {
+          kind: "test-assertions",
+          specPath: result.specPath || null,
+          appliedCount: result.appliedCount,
+        }));
+      if (!handedToParkedTurn) {
+        // The stream manager answers "is this chat streaming?" — without that
+        // guard the DB snapshot would overwrite the live messages of a stream
+        // that started meanwhile. The parked path skips the sync entirely: the
+        // resumed turn streams the approved card down itself.
+        syncChatFromDb(chatId, setMessagesById, "[TEST-ASSERTIONS]", (id) =>
+          chatStreamManager.getIsStreaming(id),
+        );
+        requestVerificationRun(result.specPath);
+      }
+    } catch (error) {
+      setOptimisticApproved(false);
+      setApprovedSpecPath(null);
+      showError(
+        error instanceof Error
+          ? error.message
+          : "Couldn't generate the test file.",
+      );
+    } finally {
+      busyRef.current = false;
+      setIsApproving(false);
+    }
+  };
+
+  /**
+   * Close the plan without writing anything. Only offered while the agent is
+   * parked on it: it exists so a turn waiting on this card has an exit that
+   * isn't the 30-minute deadline.
+   */
+  const handleDiscard = async () => {
+    if (busyRef.current || isLocked || !isAgentWaiting) return;
+    busyRef.current = true;
+    setIsDiscarding(true);
+    try {
+      // Latched BEFORE the parked request is answered. Answering resumes the
+      // agent's turn, which immediately re-reads this message row and keeps
+      // streaming into it — a discard written after that read is overwritten by
+      // the turn's own copy, and the closed plan comes back approvable on
+      // reload. Ordering it first means the turn resumes reading a row that
+      // already says "discarded".
+      if (chatId != null && appId != null && proposalId) {
+        try {
+          await ipc.tests.discardTestAssertions({ appId, chatId, proposalId });
+        } catch (error) {
+          // Leave the plan exactly as it was rather than answering the turn
+          // against a card that still reads as approvable.
+          console.warn("Couldn't record the discarded assertion plan", error);
+          const message =
+            error instanceof Error ? error.message : String(error);
+          showError(`Couldn't close the assertion plan: ${message}`);
+          return;
+        }
+      }
+      setOptimisticDiscarded(true);
+      const answered = await userInputReadModel.respond(requestId, {
+        kind: "test-assertions",
+        specPath: null,
+        appliedCount: 0,
+      });
+      if (!answered) {
+        // The card stays discarded rather than reverting: the latch above
+        // already succeeded, so the stored plan *is* declined and showing it as
+        // approvable again would only lead to "this plan was closed" on the
+        // next approve. `respond` has surfaced its own error, and a turn left
+        // parked converges on the same outcome at its deadline — a park that
+        // resolves to nothing is read as a close.
+        console.warn(
+          `Discarded assertion plan ${proposalId}, but couldn't notify the parked turn`,
+        );
+      }
+    } finally {
+      busyRef.current = false;
+      setIsDiscarding(false);
+    }
+  };
+
+  // Either operation locks the card's controls; only approving writes a file,
+  // so the labels below still have to tell them apart.
+  const isBusy = isApproving || isDiscarding;
+
+  // Filename only once there is one: every recorded spec lives in e2e-tests/,
+  // and in a narrow chat panel the directory eats the truncation. Before
+  // approval the title stands in.
+  const subtitle = specPath
+    ? (specPath.split("/").pop() ?? specPath)
+    : payload.testTitle;
+
+  return (
+    <div
+      className="border-b border-border bg-muted/30"
+      data-testid="dyad-test-assertions-card"
+    >
+      <button
+        type="button"
+        onClick={() => setIsExpanded((prev) => !prev)}
+        aria-expanded={isExpanded}
+        className="flex w-full items-center gap-2 px-3 py-1.5 text-left transition-colors hover:bg-muted/50"
+      >
+        <FlaskConical className={cn("size-4 shrink-0", ACCENT_TEXT)} />
+        <span className="shrink-0 text-sm">
+          {isApproved ? "Recorded test" : "Review recorded test"}
+        </span>
+        <span
+          className={cn(
+            "min-w-0 flex-1 truncate text-xs text-muted-foreground",
+            specPath && "font-mono",
+          )}
+          title={subtitle}
+        >
+          {subtitle}
+        </span>
+        <span
+          className="inline-flex shrink-0 items-center gap-1 text-xs text-muted-foreground"
+          data-testid={
+            isApproved && !isBusy
+              ? "dyad-test-assertions-approved-badge"
+              : undefined
+          }
+        >
+          {/* "Generated" only once it actually is. The approval latches
+              optimistically so the plan can't be edited or submitted twice
+              while the write is in flight, but claiming the file exists
+              before it does leaves a slow apply looking finished — and a
+              failed one silently reverting from a terminal state.
+
+              Closing gets its own label: it writes nothing, so announcing it
+              as generation promises a file that is never coming. */}
+          {isBusy ? (
+            <Loader2 size={12} className="animate-spin motion-reduce:hidden" />
+          ) : (
+            isApproved && <Check size={12} strokeWidth={2.5} />
+          )}
+          {isApproving
+            ? "Generating…"
+            : isDiscarding
+              ? "Closing…"
+              : isApproved
+                ? "Generated"
+                : checkCountLabel}
+        </span>
+        {isExpanded ? (
+          <ChevronUp className="size-4 shrink-0 text-muted-foreground" />
+        ) : (
+          <ChevronDown className="size-4 shrink-0 text-muted-foreground" />
+        )}
+      </button>
+
+      {isExpanded && (
+        <ol
+          className="max-h-44 overflow-y-auto border-t border-border/50 py-1"
+          role="list"
+        >
+          {items.map((item, index) => {
+            const isFirst = index === 0;
+            const isLast = index === items.length - 1;
+            const isDropTarget = dragId !== null && !isLocked;
+            const dropProps = isDropTarget
+              ? {
+                  onDragOver: (e: React.DragEvent) => {
+                    e.preventDefault();
+                  },
+                  onDrop: (e: React.DragEvent) => {
+                    e.preventDefault();
+                    handleDrop(index);
+                  },
+                }
+              : {};
+
+            if (item.kind === "step") {
+              return (
+                <li
+                  key={`step-${item.stepIndex}`}
+                  data-testid={`dyad-test-assertions-step-${item.stepIndex}`}
+                  className="group/row flex gap-2 pr-2 pl-3"
+                  {...dropProps}
+                >
+                  <div className="flex w-4 shrink-0 flex-col items-center">
+                    <RailSegment hidden={isFirst} lead="step" />
+                    <span
+                      aria-hidden
+                      className="size-1.5 shrink-0 rounded-full bg-muted-foreground/40"
+                    />
+                    <RailSegment hidden={isLast} grow />
+                  </div>
+                  <div className="flex min-w-0 flex-1 items-start gap-2 py-0.5">
+                    <span className="min-w-0 flex-1 truncate text-xs leading-4 text-muted-foreground">
+                      {item.text}
+                    </span>
+                    {!isLocked && (
+                      <button
+                        type="button"
+                        onClick={() => addAssertionAfter(index)}
+                        aria-label={`Add a check after step ${item.stepIndex + 1}`}
+                        title="Add a check after this step"
+                        className={cn(ICON_BUTTON, ROW_ACTION)}
+                      >
+                        <Plus size={13} />
+                      </button>
+                    )}
+                  </div>
+                </li>
+              );
+            }
+
+            const isEditing = editingId === item.id;
+            const isCodeOpen = expandedCodeId === item.id;
+            return (
+              <li
+                key={item.id}
+                data-testid={`dyad-test-assertions-assertion-${item.id}`}
+                draggable={!isLocked && !isEditing}
+                tabIndex={isLocked ? undefined : 0}
+                aria-label={
+                  isLocked
+                    ? undefined
+                    : `Assertion: ${item.text || "not described yet"}. Alt with arrow keys to reorder.`
+                }
+                onDragStart={(e) => {
+                  e.dataTransfer.effectAllowed = "move";
+                  e.dataTransfer.setData("text/plain", item.id);
+                  setDragId(item.id);
+                }}
+                onDragEnd={() => setDragId(null)}
+                onKeyDown={(e) => {
+                  // HTML5 drag is pointer-only; keep reordering reachable.
+                  if (!e.altKey) return;
+                  if (e.key === "ArrowUp") {
+                    e.preventDefault();
+                    moveByOffset(index, -1);
+                  } else if (e.key === "ArrowDown") {
+                    e.preventDefault();
+                    moveByOffset(index, 1);
+                  }
+                }}
+                className={cn(
+                  "group/row flex gap-2 pr-2 pl-3 outline-none",
+                  "focus-visible:bg-(--background-lighter)",
+                  dragId === item.id && "opacity-50",
+                )}
+                {...dropProps}
+              >
+                <div className="flex w-4 shrink-0 flex-col items-center">
+                  <RailSegment hidden={isFirst} lead="assertion" />
+                  <span
+                    aria-hidden
+                    className={cn(
+                      "flex size-4 shrink-0 items-center justify-center rounded-full",
+                      ACCENT_NODE,
+                    )}
+                  >
+                    <Check size={10} strokeWidth={3} />
+                  </span>
+                  <RailSegment hidden={isLast} grow />
+                </div>
+
+                <div className="flex min-w-0 flex-1 items-start gap-1.5 py-px">
+                  <div className="min-w-0 flex-1">
+                    {isEditing ? (
+                      <textarea
+                        autoFocus
+                        value={draftText}
+                        onChange={(e) => setDraftText(e.target.value)}
+                        onBlur={commitEdit}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" && !e.shiftKey) {
+                            e.preventDefault();
+                            commitEdit();
+                          } else if (e.key === "Escape") {
+                            e.preventDefault();
+                            setEditingId(null);
+                            setDraftText("");
+                          }
+                        }}
+                        rows={2}
+                        placeholder="Describe what this should check…"
+                        aria-label="Assertion description"
+                        data-testid={`dyad-test-assertions-edit-${item.id}`}
+                        className="w-full resize-none rounded-md border border-input bg-(--background-lighter) px-2 py-1 text-[13px] leading-5 text-foreground outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
+                      />
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={() => startEdit(item.id, item.text)}
+                        disabled={isLocked}
+                        title={isLocked ? undefined : "Click to edit"}
+                        data-testid={`dyad-test-assertions-text-${item.id}`}
+                        className={cn(
+                          "w-full rounded-sm text-left text-[13px] leading-5 text-foreground",
+                          "focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none",
+                          // Dotted underline on hover is the editable-text
+                          // convention: the sentence itself is the control.
+                          "decoration-muted-foreground decoration-dotted underline-offset-4 hover:underline",
+                          "disabled:cursor-default disabled:hover:no-underline",
+                        )}
+                      >
+                        {item.text || (
+                          <span className="text-muted-foreground italic">
+                            Describe what this should check…
+                          </span>
+                        )}
+                      </button>
+                    )}
+
+                    {(item.code || (item.needsCode && !isLocked)) && (
+                      <div className="flex flex-wrap items-center gap-x-2.5 gap-y-0.5">
+                        {item.code && (
+                          <button
+                            type="button"
+                            onClick={() =>
+                              setExpandedCodeId((prev) =>
+                                prev === item.id ? null : item.id,
+                              )
+                            }
+                            aria-expanded={isCodeOpen}
+                            className="inline-flex items-center gap-0.5 rounded-sm text-[11px] text-muted-foreground transition-colors duration-150 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                          >
+                            <ChevronRight
+                              size={11}
+                              className={cn(
+                                "transition-transform duration-150 motion-reduce:transition-none",
+                                isCodeOpen && "rotate-90",
+                              )}
+                            />
+                            {isCodeOpen ? "Hide code" : "Show code"}
+                          </button>
+                        )}
+                        {item.needsCode && !isLocked && (
+                          <span className={cn("text-[11px]", ACCENT_TEXT)}>
+                            Code written on approve
+                          </span>
+                        )}
+                      </div>
+                    )}
+
+                    {item.code && isCodeOpen && (
+                      <code className="mt-1 block overflow-x-auto rounded-md bg-(--background-darker) px-2 py-1 font-mono text-[11px] leading-relaxed whitespace-pre text-foreground">
+                        {item.code}
+                      </code>
+                    )}
+                  </div>
+
+                  {!isLocked && !isEditing && (
+                    <>
+                      <span
+                        aria-hidden
+                        title="Drag to move this check"
+                        className={cn(
+                          "shrink-0 cursor-grab p-0.5 text-muted-foreground",
+                          ROW_ACTION,
+                        )}
+                      >
+                        <GripVertical size={13} />
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() => removeAssertion(item.id)}
+                        aria-label="Remove this check"
+                        title="Remove"
+                        data-testid={`dyad-test-assertions-remove-${item.id}`}
+                        className={cn(
+                          ICON_BUTTON,
+                          ROW_ACTION,
+                          "hover:text-destructive",
+                        )}
+                      >
+                        <Trash2 size={13} />
+                      </button>
+                    </>
+                  )}
+                </div>
+              </li>
+            );
+          })}
+        </ol>
+      )}
+
+      {isExpanded && assertions.length === 0 && (
+        <p className="px-3 pb-1.5 text-xs text-muted-foreground">
+          {isApproved
+            ? "No checks were added — the test replays the recorded steps only."
+            : discarded
+              ? "No checks were added."
+              : "No checks proposed. Point at a step to add your own."}
+        </p>
+      )}
+
+      {/* Outside the collapse: folding away a long plan should hide the rows,
+          not the decision the composer is blocked on. */}
+      <div className="flex flex-wrap items-center gap-2 border-t border-border/50 px-3 py-1.5">
+        {isApproving ? (
+          // The approval is latched but the file isn't written yet. Its own row
+          // rather than the terminal one: there is nothing to open, and the
+          // wait is the whole state.
+          <span
+            className="inline-flex items-center gap-1.5 text-xs text-muted-foreground"
+            data-testid="dyad-test-assertions-generating-note"
+          >
+            <Loader2 size={12} className="animate-spin motion-reduce:hidden" />
+            Generating the test file…
+          </span>
+        ) : isDiscarding ? (
+          // Same shape, opposite promise: nothing is being written, so the row
+          // says what is actually happening rather than borrowing the approval's.
+          <span
+            className="inline-flex items-center gap-1.5 text-xs text-muted-foreground"
+            data-testid="dyad-test-assertions-closing-note"
+          >
+            <Loader2 size={12} className="animate-spin motion-reduce:hidden" />
+            Closing the plan…
+          </span>
+        ) : isApproved ? (
+          <>
+            <span className="text-xs text-muted-foreground">
+              Test generated with {checkCountLabel}.
+            </span>
+            <button
+              type="button"
+              onClick={openSpecFile}
+              disabled={!specPath}
+              data-testid="dyad-test-assertions-open-file-button"
+              className="ml-auto rounded-md px-2 py-1 text-xs font-medium text-foreground transition-colors duration-150 hover:bg-(--background-darker) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-default disabled:opacity-50"
+            >
+              Open test file
+            </button>
+          </>
+        ) : discarded ? (
+          <span
+            className="text-xs text-muted-foreground"
+            data-testid="dyad-test-assertions-discarded-note"
+          >
+            Closed without generating a test.
+          </span>
+        ) : (
+          <>
+            <span className="text-xs text-muted-foreground">
+              {hasBlankAssertion
+                ? "Describe every check before approving."
+                : isAgentWaiting
+                  ? "Dyad is waiting on this before it continues."
+                  : "Approving generates the test file and runs it."}
+            </span>
+            {/* One group, so the decision stays together on the right when the
+                composer is too narrow to keep it on the hint's line. */}
+            <div className="ml-auto flex items-center gap-2">
+              {/* Close is only offered while the turn is parked on this card:
+                  otherwise there is nothing waiting, and closing would just
+                  hide a plan that is still usable. */}
+              {isAgentWaiting && (
+                <button
+                  type="button"
+                  onClick={() => void handleDiscard()}
+                  disabled={isBusy}
+                  data-testid="dyad-test-assertions-discard-button"
+                  className="rounded-md px-2 py-1 text-xs font-medium text-muted-foreground transition-colors duration-150 hover:bg-(--background-darker) hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  Close without generating
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={() => void handleApprove()}
+                disabled={isBusy || hasBlankAssertion || !proposalId}
+                data-testid="dyad-test-assertions-approve-button"
+                className="inline-flex items-center gap-1.5 rounded-md bg-purple-600 px-2.5 py-1 text-xs font-medium text-white transition-colors duration-150 hover:bg-purple-700 focus-visible:ring-2 focus-visible:ring-purple-600 focus-visible:ring-offset-2 focus-visible:ring-offset-(--background-lighter) focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:bg-purple-600 dark:hover:bg-purple-500"
+              >
+                {isApproving && (
+                  <Loader2
+                    size={12}
+                    className="animate-spin motion-reduce:hidden"
+                  />
+                )}
+                {isApproving ? "Generating…" : "Approve & generate"}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+
+      <span className="sr-only" role="status" aria-live="polite">
+        {liveMessage}
+      </span>
+    </div>
+  );
+}

--- a/src/components/chat/TestAssertionsInput.tsx
+++ b/src/components/chat/TestAssertionsInput.tsx
@@ -25,7 +25,7 @@ import { selectedFileAtom } from "@/atoms/viewAtoms";
 import { useChatStreamManager } from "@/chat_stream/ChatStreamProvider";
 import { useChatMessages } from "@/hooks/useChatMessages";
 import { useStreamChat } from "@/hooks/useStreamChat";
-import { ipc } from "@/ipc/types";
+import { ipc, type Message } from "@/ipc/types";
 import { cn } from "@/lib/utils";
 import { queryKeys } from "@/lib/queryKeys";
 import { showError, showSuccess, showWarning } from "@/lib/toast";
@@ -80,56 +80,71 @@ const ROW_ACTION =
   "motion-reduce:transition-none";
 
 /**
- * How far back to look for a plan awaiting review.
+ * The unanswered plan in one message, cached on the message object.
  *
- * A plan is proposed by a tool that then parks on it, so a live one is all but
- * always in the last message; the slack covers a plan left unanswered when the
- * turn was stopped and the user carried on chatting. Bounded because this scan
- * re-runs on every chunk of every stream.
+ * The scan below covers the WHOLE transcript — a plan left unanswered has to
+ * stay reachable however far the conversation has moved on, because the message
+ * itself now only carries a receipt — and it re-runs on every chunk of every
+ * stream. This is what keeps that affordable: `applyStreamingPatch` rebuilds
+ * only the message being streamed into and preserves every other message's
+ * identity, so a stream re-reads one message per chunk and hits the cache for
+ * the rest.
  */
-const MAX_SCANNED_MESSAGES = 20;
+const unansweredTagCache = new WeakMap<Message, AssertionsTagSummary | null>();
 
-/**
- * The most recent plan in this chat that nobody has answered yet, as the raw
- * tag text.
- *
- * Returns the tag rather than the parsed plan so the parse can be memoized on
- * a value that only changes when the plan does: the surrounding message is
- * rewritten and restreamed while a card is open, and re-seeding the rows from
- * the server's copy on every one of those would throw away the user's edits.
- */
-function useLiveAssertionsTag(
-  chatId: number | undefined,
-): AssertionsTagSummary | null {
-  const messages = useChatMessages(chatId);
-  const raw = useMemo(() => {
-    const start = Math.max(0, messages.length - MAX_SCANNED_MESSAGES);
-    for (let i = messages.length - 1; i >= start; i--) {
-      const message = messages[i];
-      if (message.role !== "assistant") continue;
-      if (!messageMayHaveAssertionsTag(message.content)) continue;
-      const proposed = listAssertionsTags(message.content).filter(
-        (tag) => tag.status === "proposed",
-      );
-      // Last one in the message: a turn may propose twice, and the later plan
-      // is the one the agent is parked on.
-      if (proposed.length > 0) return proposed[proposed.length - 1].raw;
-    }
-    return null;
-  }, [messages]);
-
-  return useMemo(
-    () => (raw ? (listAssertionsTags(raw)[0] ?? null) : null),
-    [raw],
-  );
+function unansweredTagIn(message: Message): AssertionsTagSummary | null {
+  const cached = unansweredTagCache.get(message);
+  if (cached !== undefined) return cached;
+  let found: AssertionsTagSummary | null = null;
+  if (
+    message.role === "assistant" &&
+    messageMayHaveAssertionsTag(message.content)
+  ) {
+    const proposed = listAssertionsTags(message.content).filter(
+      (tag) => tag.status === "proposed",
+    );
+    // Last one in the message: a turn may propose twice, and the later plan is
+    // the one the agent is parked on.
+    found = proposed.at(-1) ?? null;
+  }
+  unansweredTagCache.set(message, found);
+  return found;
 }
+
+interface LiveAssertionPlans {
+  /** The one up for review: the most recent plan nobody has answered. */
+  tag: AssertionsTagSummary | null;
+  /**
+   * How many plans are unanswered in total. More than one is a queue, not a
+   * dead end — answering the one on top brings the previous one up.
+   */
+  pendingCount: number;
+}
+
+const NO_LIVE_PLANS: LiveAssertionPlans = { tag: null, pendingCount: 0 };
 
 export function TestAssertionsInput() {
   const chatId = useAtomValue(selectedChatIdAtom);
-  const tag = useLiveAssertionsTag(chatId ?? undefined);
+  const messages = useChatMessages(chatId);
+  const { tag, pendingCount } = useMemo(() => {
+    let newest: AssertionsTagSummary | null = null;
+    let pendingCount = 0;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const found = unansweredTagIn(messages[i]);
+      if (!found) continue;
+      pendingCount++;
+      newest ??= found;
+    }
+    return newest ? { tag: newest, pendingCount } : NO_LIVE_PLANS;
+  }, [messages]);
+
+  // Keyed on the tag TEXT, not the summary: the scan above re-runs whenever the
+  // transcript changes, and re-seeding the rows from a fresh parse of an
+  // unchanged plan would throw away the user's edits.
+  const raw = tag?.raw ?? null;
   const payload = useMemo(
-    () => (tag ? parseAssertionsPayloadFromMessage(tag.raw) : null),
-    [tag],
+    () => (raw ? parseAssertionsPayloadFromMessage(raw) : null),
+    [raw],
   );
 
   if (!tag || !payload) return null;
@@ -142,6 +157,7 @@ export function TestAssertionsInput() {
       proposalId={tag.proposalId}
       requestId={tag.requestId}
       payload={payload}
+      pendingCount={pendingCount}
     />
   );
 }
@@ -178,11 +194,14 @@ export function TestAssertionsPlanCard({
   proposalId,
   requestId,
   payload,
+  pendingCount = 1,
 }: {
   proposalId: string;
   /** Empty when no turn is parked on the plan — a reload, or a stopped stream. */
   requestId: string;
   payload: AssertionProposalPayload;
+  /** Unanswered plans in this chat, including this one. */
+  pendingCount?: number;
 }) {
   const chatId = useAtomValue(selectedChatIdAtom);
   const appId = useAtomValue(selectedAppIdAtom);
@@ -203,6 +222,18 @@ export function TestAssertionsPlanCard({
     : undefined;
   const isAgentWaiting =
     parkedRequest !== undefined && parkedRequest.status !== "settled";
+
+  /**
+   * Is the turn STILL parked, read live rather than from the render snapshot?
+   *
+   * `respond` answers false for two very different things: a request main has
+   * already dropped, and a transient IPC failure that left it parked. Only the
+   * first is a licence to start a new turn.
+   */
+  const isStillParked = () => {
+    const request = userInputReadModel.getSnapshot().requests.get(requestId);
+    return request !== undefined && request.status !== "settled";
+  };
 
   const [items, setItems] = useState<AssertionPlanItem[]>(payload.items);
   // Held locally until the rewritten message makes it back through
@@ -394,7 +425,12 @@ export function TestAssertionsPlanCard({
           specPath: result.specPath || null,
           appliedCount: result.appliedCount,
         }));
-      if (!handedToParkedTurn) {
+      // A hand-off that failed on a transient IPC error leaves the turn sitting
+      // on this card. Starting a fresh turn there would queue a second
+      // generation behind the parked one and hand the agent the same spec
+      // twice; `respond` has already surfaced the error, and the turn converges
+      // on its deadline. The spec is written either way, and the card says so.
+      if (!handedToParkedTurn && !isStillParked()) {
         // The stream manager answers "is this chat streaming?" — without that
         // guard the DB snapshot would overwrite the live messages of a stream
         // that started meanwhile. The parked path skips the sync entirely: the
@@ -419,12 +455,17 @@ export function TestAssertionsPlanCard({
   };
 
   /**
-   * Close the plan without writing anything. Only offered while the agent is
-   * parked on it: it exists so a turn waiting on this card has an exit that
-   * isn't the 30-minute deadline.
+   * Close the plan without writing anything.
+   *
+   * Offered for every unanswered plan, not just a parked one. While a turn is
+   * waiting this is its exit that isn't the 30-minute deadline; with no turn
+   * waiting it is the ONLY exit, since the card is pinned to the composer
+   * rather than scrolling away up the transcript — without it, a plan left over
+   * from a stopped turn or a restart could only be dismissed by approving a
+   * test the user may not want.
    */
   const handleDiscard = async () => {
-    if (busyRef.current || isLocked || !isAgentWaiting) return;
+    if (busyRef.current || isLocked) return;
     busyRef.current = true;
     setIsDiscarding(true);
     try {
@@ -448,6 +489,18 @@ export function TestAssertionsPlanCard({
         }
       }
       setOptimisticDiscarded(true);
+      if (!isAgentWaiting) {
+        // Nothing to resume: the latch above IS the close. Re-read the chat so
+        // the message picks up its "discarded" receipt — otherwise the card
+        // would stay pinned to the composer on the optimistic latch alone, and
+        // any older unanswered plan behind it would never come up.
+        if (chatId != null) {
+          syncChatFromDb(chatId, setMessagesById, "[TEST-ASSERTIONS]", (id) =>
+            chatStreamManager.getIsStreaming(id),
+          );
+        }
+        return;
+      }
       const answered = await userInputReadModel.respond(requestId, {
         kind: "test-assertions",
         specPath: null,
@@ -495,6 +548,14 @@ export function TestAssertionsPlanCard({
         <FlaskConical className={cn("size-4 shrink-0", ACCENT_TEXT)} />
         <span className="shrink-0 text-sm">
           {isApproved ? "Recorded test" : "Review recorded test"}
+          {/* A queue, not a dead end: answering this one brings the previous
+              plan up. Says so, so a receipt further up the transcript reading
+              "waiting for your review" has somewhere to point. */}
+          {pendingCount > 1 && !isLocked && (
+            <span className="ml-1.5 text-xs font-normal text-muted-foreground">
+              (1 of {pendingCount})
+            </span>
+          )}
         </span>
         <span
           className={cn(
@@ -838,20 +899,19 @@ export function TestAssertionsPlanCard({
             {/* One group, so the decision stays together on the right when the
                 composer is too narrow to keep it on the hint's line. */}
             <div className="ml-auto flex items-center gap-2">
-              {/* Close is only offered while the turn is parked on this card:
-                  otherwise there is nothing waiting, and closing would just
-                  hide a plan that is still usable. */}
-              {isAgentWaiting && (
-                <button
-                  type="button"
-                  onClick={() => void handleDiscard()}
-                  disabled={isBusy}
-                  data-testid="dyad-test-assertions-discard-button"
-                  className="rounded-md px-2 py-1 text-xs font-medium text-muted-foreground transition-colors duration-150 hover:bg-(--background-darker) hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
-                >
-                  Close without generating
-                </button>
-              )}
+              {/* Every unanswered plan gets an exit. While a turn is parked
+                  this saves it from its deadline; with none parked it is the
+                  only way to put the card down, since it no longer scrolls
+                  away up the transcript. */}
+              <button
+                type="button"
+                onClick={() => void handleDiscard()}
+                disabled={isBusy}
+                data-testid="dyad-test-assertions-discard-button"
+                className="rounded-md px-2 py-1 text-xs font-medium text-muted-foreground transition-colors duration-150 hover:bg-(--background-darker) hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Close without generating
+              </button>
               <button
                 type="button"
                 onClick={() => void handleApprove()}

--- a/src/hooks/useAttachments.test.tsx
+++ b/src/hooks/useAttachments.test.tsx
@@ -84,6 +84,35 @@ describe("useAttachments", () => {
     );
   });
 
+  it.each([
+    { what: "a file drag", types: ["Files"], armed: true },
+    {
+      what: "a row dragged inside the composer",
+      types: ["text/plain"],
+      armed: false,
+    },
+  ])("$what: overlay armed = $armed", ({ types, armed }) => {
+    // The composer hosts draggable rows of its own — reordering a recorded
+    // test's checks — and their dragover bubbles up to the container's
+    // handler. Arming on those paints "Drop files to attach" over the very
+    // rows being dragged between.
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(useAttachments, { wrapper: Wrapper });
+    const preventDefault = vi.fn();
+
+    act(() => {
+      result.current.handleDragOver({
+        preventDefault,
+        dataTransfer: { types },
+      } as unknown as React.DragEvent);
+    });
+
+    expect(result.current.isDraggingOver).toBe(armed);
+    // Still called either way: the container stays a valid drop target, so a
+    // drop landing outside a row is a no-op rather than a browser navigation.
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+  });
+
   it("clears stale draft attachments when a queued replacement is invalid", () => {
     const { store, Wrapper } = makeWrapper();
     const { result } = renderHook(useAttachments, { wrapper: Wrapper });

--- a/src/hooks/useAttachments.ts
+++ b/src/hooks/useAttachments.ts
@@ -5,6 +5,17 @@ import { attachmentsAtom } from "@/atoms/chatAtoms";
 import { showError } from "@/lib/toast";
 import { validateChatAttachmentFiles } from "@/shared/chatAttachmentLimits";
 
+/**
+ * Is this drag carrying files, rather than something dragged within the page?
+ *
+ * `dataTransfer.files` is empty until the drop, so a dragover can only be told
+ * apart by its advertised types.
+ */
+function isFileDrag(e: React.DragEvent): boolean {
+  const types = e.dataTransfer?.types;
+  return types ? Array.from(types).includes("Files") : false;
+}
+
 export function useAttachments() {
   const [attachments, setAttachments] = useAtom(attachmentsAtom);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -81,6 +92,12 @@ export function useAttachments() {
 
   const handleDragOver = (e: React.DragEvent) => {
     e.preventDefault();
+    // Only a file drag arms the overlay. The composer also hosts draggable rows
+    // of its own — reordering a recorded test's checks — and their `dragover`
+    // bubbles up here; without this guard the whole composer would paint "Drop
+    // files to attach" over the very rows being dragged between, flickering as
+    // each child boundary fires `dragleave`.
+    if (!isFileDrag(e)) return;
     if (!pendingFiles) {
       setIsDraggingOver(true);
     }

--- a/src/lib/test_recorder/assertion_tag.test.ts
+++ b/src/lib/test_recorder/assertion_tag.test.ts
@@ -4,6 +4,7 @@ import { parseFullMessage } from "../streamingMessageParser";
 import {
   ASSERTIONS_TAG,
   buildAssertionsTagContent,
+  listAssertionsTags,
   messageHasAssertionsProposal,
   parseAssertionsPayload,
   parseAssertionsPayloadFromMessage,
@@ -158,5 +159,56 @@ describe("replaceAssertionsTagInMessage", () => {
     expect(
       replaceAssertionsTagInMessage(`prose ${proposed}`, approved, "prop-9"),
     ).toBeNull();
+  });
+});
+
+describe("listAssertionsTags", () => {
+  const proposed = buildAssertionsTagContent({
+    proposalId: "prop-1",
+    requestId: "req-1",
+    status: "proposed",
+    payload: PAYLOAD,
+  });
+  const approved = buildAssertionsTagContent({
+    proposalId: "prop-2",
+    status: "approved",
+    payload: { ...PAYLOAD, specPath: "e2e-tests/second.spec.ts" },
+  });
+
+  it("reports every card in the message, in order, with its decision", () => {
+    // How the composer tells the plan it should put up for review from the ones
+    // already answered.
+    const tags = listAssertionsTags(
+      `Plan A:\n${approved}\nPlan B:\n${proposed}`,
+    );
+
+    expect(tags.map((tag) => tag.proposalId)).toEqual(["prop-2", "prop-1"]);
+    expect(tags.map((tag) => tag.status)).toEqual(["approved", "proposed"]);
+    expect(tags[0].specPath).toBe("e2e-tests/second.spec.ts");
+    // The parked request is dropped when a plan settles, so only the live one
+    // carries something to answer.
+    expect(tags[0].requestId).toBe("");
+    expect(tags[1].requestId).toBe("req-1");
+  });
+
+  it("hands back the tag verbatim so the payload parse can be memoized on it", () => {
+    const [tag] = listAssertionsTags(`prose\n${proposed}\nmore prose`);
+
+    expect(tag.raw).toBe(proposed);
+    expect(parseAssertionsPayloadFromMessage(tag.raw)).toEqual(PAYLOAD);
+  });
+
+  it("skips a card that hasn't finished streaming", () => {
+    // Offering a half-written plan for approval would generate a test from it.
+    expect(listAssertionsTags(proposed.slice(0, -20))).toEqual([]);
+  });
+
+  it("reads an unrecognized status as still up for review", () => {
+    // Only "approved" and "discarded" hide a plan, so neither may be inferred.
+    const tags = listAssertionsTags(
+      proposed.replace('status="proposed"', 'status="whatever"'),
+    );
+
+    expect(tags[0].status).toBe("proposed");
   });
 });

--- a/src/lib/test_recorder/assertion_tag.ts
+++ b/src/lib/test_recorder/assertion_tag.ts
@@ -1,4 +1,9 @@
-import { escapeXmlAttr, escapeXmlContent } from "../../../shared/xmlEscape";
+import {
+  escapeXmlAttr,
+  escapeXmlContent,
+  unescapeXmlAttr,
+  unescapeXmlContent,
+} from "../../../shared/xmlEscape";
 import {
   AssertionProposalPayloadSchema,
   type AssertionProposalPayload,
@@ -166,10 +171,72 @@ export function parseAssertionsPayloadFromMessage(
   proposalId?: string,
 ): AssertionProposalPayload | null {
   const found = findAssertionsTagBlock(messageContent, proposalId);
-  if (!found) return null;
-  const unescaped = found.body
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&amp;/g, "&");
-  return parseAssertionsPayload(unescaped);
+  return found ? parseAssertionsPayload(unescapeXmlContent(found.body)) : null;
+}
+
+export interface AssertionsTagSummary {
+  proposalId: string;
+  /** Empty once the plan settles — the rewrite drops the parked request. */
+  requestId: string;
+  status: AssertionProposalStatus;
+  /** Empty until an approval writes the spec. */
+  specPath: string;
+  /**
+   * The whole `<tag …>…</tag>` span. A stable identity for the plan: the
+   * composer memoizes the (expensive) payload parse on this string, so a plan
+   * survives the message around it being restreamed without its edits being
+   * re-seeded from the server's copy.
+   */
+  raw: string;
+}
+
+const PROPOSAL_STATUSES = new Set<string>([
+  "proposed",
+  "approved",
+  "discarded",
+] satisfies AssertionProposalStatus[]);
+
+/**
+ * Every assertions card in a message, in document order, WITHOUT parsing the
+ * payloads.
+ *
+ * This is how the composer finds the plan it should offer for review: the card
+ * lives inside an assistant message rather than in the parked user-input
+ * request, so the plan has to be read back out of the content. The scan runs
+ * on every chat re-render — which during a stream is every chunk — so it stays
+ * a regex over attributes and leaves the JSON to a memo keyed on `raw`.
+ *
+ * Only closed `<tag>…</tag>` spans match, so a card still streaming in is
+ * absent here rather than half-read: the composer waits for a whole plan
+ * before putting it up for review, and the chat message renders the
+ * "preparing…" placeholder in the meantime.
+ */
+export function listAssertionsTags(
+  messageContent: string,
+): AssertionsTagSummary[] {
+  const summaries: AssertionsTagSummary[] = [];
+  const re = assertionsTagBlockRe();
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(messageContent)) !== null) {
+    const attrs = match[1];
+    const status = unescapeXmlAttr(readAttribute(attrs, "status") ?? "");
+    summaries.push({
+      proposalId: unescapeXmlAttr(readAttribute(attrs, "proposal-id") ?? ""),
+      requestId: unescapeXmlAttr(readAttribute(attrs, "request-id") ?? ""),
+      // An unrecognized status is read as still up for review: the two settled
+      // values are the ones that must never be inferred, since either one
+      // hides a plan the user has not answered yet.
+      status: PROPOSAL_STATUSES.has(status)
+        ? (status as AssertionProposalStatus)
+        : "proposed",
+      specPath: unescapeXmlAttr(readAttribute(attrs, "spec-path") ?? ""),
+      raw: match[0],
+    });
+  }
+  return summaries;
+}
+
+/** Cheap "is there anything to scan for?" guard for the composer's hot path. */
+export function messageMayHaveAssertionsTag(messageContent: string): boolean {
+  return messageContent.includes(`<${ASSERTIONS_TAG}`);
 }


### PR DESCRIPTION
#skip-bb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large UI relocation of agent park/resume and test-generation flows, but behavior is heavily covered by moved and new unit/e2e tests rather than backend security changes.
> 
> **Overview**
> Bumps the app to **1.11.0-beta.1**.
> 
> **Recorded test assertion review** moves from the in-transcript `DyadTestAssertionsCard` to **`TestAssertionsInput`** on the chat composer (alongside questionnaires and consent). The transcript card is now a compact **receipt** (proposed / approved / discarded); approve, edit, reorder, and close live only in the composer so there is never a duplicate control surface.
> 
> The composer scans chat messages for unanswered `proposed` tags (`listAssertionsTags`, cached per message), surfaces the newest plan with a queue hint when several are pending, and keeps plans reachable after long chats. **Approve/discard** behavior is tightened: discard is always available; fallback to a new agent turn only when the parked request is truly gone (not on transient `respond` failures); non-parked discard resyncs chat to unpin the card.
> 
> **`useAttachments`** only arms the file-drop overlay when the drag carries `Files`, so reordering assertion rows in the composer no longer flashes “drop files to attach.”
> 
> Unit tests move from `DyadTestAssertionsCard` to `TestAssertionsInput`; e2e asserts the parked-plan hint text on the composer card.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 430d80779d28d12dd843e94701bd25d0bdbe60ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

