### PR TITLE
Run project pre-commit hooks before agent checkpoints

### DIFF
--- a/rules/local-agent-tools.md
+++ b/rules/local-agent-tools.md
@@ -32,6 +32,11 @@ Agent tool definitions live in `src/pro/main/ipc/handlers/local_agent/tools/`. E
 
 ## User-visible tool output
 
+- Hook availability must be based on Git's effective executable hook path, but
+  remember that Husky's tracked `.husky/pre-commit` delegates through generated
+  `.husky/_` shims. A history restore can preserve the tracked hook while dropping
+  those shims, so surface the resolved missing path and require Husky reinitialization
+  rather than claiming the repository has no hook configuration.
 - Treat model-generated code as untrusted executable input whenever its prompt
   contains app-, tool-, or user-controlled text. Model provenance plus a
   one-statement/shape check is not a security boundary: before writing or

--- a/src/ipc/git_types.ts
+++ b/src/ipc/git_types.ts
@@ -14,6 +14,8 @@ export interface GitBaseParams {
 export interface GitCommitParams extends GitBaseParams {
   message: string;
   amend?: boolean;
+  /** Bypass pre-commit and commit-msg hooks for internal checkpoint commits. */
+  noVerify?: boolean;
   /**
    * Paths (relative to the repo root) to commit. When set, git makes a partial
    * commit: it records the working-tree state of exactly these paths and leaves

--- a/src/ipc/utils/git_utils.test.ts
+++ b/src/ipc/utils/git_utils.test.ts
@@ -31,6 +31,8 @@ import {
   isGitPathClean,
   readGitIndexEntries,
   restoreGitIndexEntries,
+  gitAddAll,
+  gitCommit,
 } from "@/ipc/utils/git_utils";
 
 const execFileAsync = promisify(execFile);
@@ -87,6 +89,44 @@ async function runGitOutput(repoDir: string, args: string[]): Promise<string> {
   const { stdout } = await execFileAsync("git", args, { cwd: repoDir });
   return stdout.trim();
 }
+
+describe("gitCommit", () => {
+  let repoDir: string | undefined;
+
+  afterEach(async () => {
+    if (repoDir) {
+      await fs.promises.rm(repoDir, {
+        recursive: true,
+        force: true,
+        maxRetries: 3,
+        retryDelay: 100,
+      });
+      repoDir = undefined;
+    }
+  });
+
+  it("can create an internal checkpoint while bypassing a failing pre-commit hook", async () => {
+    repoDir = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), "git-no-verify-"),
+    );
+    await runGit(repoDir, ["init"]);
+    const hookPath = path.join(repoDir, ".git", "hooks", "pre-commit");
+    await fs.promises.writeFile(hookPath, "#!/bin/sh\nexit 1\n");
+    if (process.platform !== "win32") {
+      await fs.promises.chmod(hookPath, 0o755);
+    }
+    await fs.promises.writeFile(path.join(repoDir, "file.txt"), "content\n");
+    await gitAddAll({ path: repoDir });
+
+    const commitHash = await gitCommit({
+      path: repoDir,
+      message: "internal checkpoint",
+      noVerify: true,
+    });
+
+    expect(commitHash).toMatch(/^[0-9a-f]{40,64}$/);
+  });
+});
 
 describe("gitLog", () => {
   let repoDir: string | undefined;

--- a/src/ipc/utils/git_utils.ts
+++ b/src/ipc/utils/git_utils.ts
@@ -528,12 +528,16 @@ export async function gitCommit({
   path,
   message,
   amend,
+  noVerify,
   paths,
 }: GitCommitParams): Promise<string> {
   // Perform the commit using dugite with -c user.name/email config
   const commitArgs = ["commit", "-m", message];
   if (amend) {
     commitArgs.push("--amend");
+  }
+  if (noVerify) {
+    commitArgs.push("--no-verify");
   }
   if (paths?.length) {
     // `--` scopes the commit to these paths, so unrelated staged changes stay

--- a/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
+++ b/src/pro/main/ipc/handlers/local_agent/local_agent_handler.ts
@@ -105,6 +105,7 @@ import {
   executeSandboxScriptTool,
 } from "./tools/execute_sandbox_script";
 import { writeFileTool } from "./tools/write_file";
+import { isPreCommitHookAvailable } from "./tools/run_pre_commit";
 import {
   collectMcpToolDefs,
   estimateMcpInlineTokens,
@@ -764,6 +765,8 @@ export async function handleLocalAgentStream(
     );
     const effectiveFreeModelMode =
       freeModelMode ?? isFreeProModel(settings.selectedModel);
+    const preCommitHookAvailable =
+      !readOnly && !planModeOnly && (await isPreCommitHookAvailable(appPath));
     const ctx: AgentContext = {
       event,
       appId: chat.app.id,
@@ -784,6 +787,7 @@ export async function handleLocalAgentStream(
       todos: persistedTodos,
       dyadRequestId,
       fileEditTracker,
+      preCommitHookAvailable,
       testingEnabled: Boolean(chat.app.testingEnabled),
       testRunAttempts: new Map(),
       isDyadPro: isDyadProEnabled(settings),

--- a/src/pro/main/ipc/handlers/local_agent/processors/file_operations.test.ts
+++ b/src/pro/main/ipc/handlers/local_agent/processors/file_operations.test.ts
@@ -62,6 +62,7 @@ describe("commitAllChanges", () => {
     expect(mocks.gitCommit).toHaveBeenCalledWith({
       path: "/mock/app",
       message: "(1 files changed)",
+      noVerify: true,
     });
     expect(result).toEqual({ commitHash: "commit-hash" });
   });

--- a/src/pro/main/ipc/handlers/local_agent/processors/file_operations.ts
+++ b/src/pro/main/ipc/handlers/local_agent/processors/file_operations.ts
@@ -140,6 +140,9 @@ export async function commitAllChanges(
         commitHash = await gitCommit({
           path: ctx.appPath,
           message: message,
+          // Local Agent commits are internal turn checkpoints. Verification is
+          // owned by run_pre_commit so a failing hook cannot prevent versioning.
+          noVerify: true,
         });
       } catch (error) {
         logger.error(

--- a/src/pro/main/ipc/handlers/local_agent/tool_definitions.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tool_definitions.ts
@@ -34,6 +34,7 @@ import { generateImageTool } from "./tools/generate_image";
 import { updateTodosTool } from "./tools/update_todos";
 import { runTypeChecksTool } from "./tools/run_type_checks";
 import { runTestsTool } from "./tools/run_tests";
+import { runPreCommitTool } from "./tools/run_pre_commit";
 import { generateTestAssertionsTool } from "./tools/generate_test_assertions";
 import { rebuildAppTool, restartAppTool } from "./tools/app_lifecycle";
 import { grepTool } from "./tools/grep";
@@ -131,6 +132,7 @@ export const TOOL_DEFINITIONS: readonly ToolDefinition[] = [
   generateImageTool,
   updateTodosTool,
   runTypeChecksTool,
+  runPreCommitTool,
   runTestsTool,
   generateTestAssertionsTool,
   restartAppTool,

--- a/src/pro/main/ipc/handlers/local_agent/tools/git.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/git.ts
@@ -441,6 +441,7 @@ export const gitRestoreFileTool: ToolDefinition<
   inputSchema: gitRestoreFileSchema,
   defaultConsent: "always",
   modifiesState: true,
+  shouldTrackMutation: () => true,
   getConsentPreview: (args) =>
     `Restore ${args.path} from ${args.revision} without staging it`,
   buildXml: (args, isComplete) =>

--- a/src/pro/main/ipc/handlers/local_agent/tools/run_pre_commit.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/run_pre_commit.spec.ts
@@ -1,0 +1,269 @@
+import { chmod, mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { exec } from "dugite";
+import type { BufferedProcessOptions } from "@/ipc/utils/buffered_process";
+import type { AgentContext } from "./types";
+
+const mocks = vi.hoisted(() => ({
+  gitAddAll: vi.fn(),
+  runBufferedProcess: vi.fn(),
+}));
+
+vi.mock("@/ipc/utils/git_utils", () => ({
+  gitAddAll: mocks.gitAddAll,
+}));
+
+vi.mock("@/ipc/utils/buffered_process", () => ({
+  runBufferedProcess: mocks.runBufferedProcess,
+}));
+
+import {
+  isPreCommitHookAvailable,
+  MAX_PRE_COMMIT_RUNS_PER_TURN,
+  runPreCommitTool,
+} from "./run_pre_commit";
+
+const tempDirs: string[] = [];
+
+async function makeRepo(options?: {
+  hook?: boolean;
+  executable?: boolean;
+  hooksPath?: string;
+}): Promise<string> {
+  const repo = await mkdtemp(path.join(os.tmpdir(), "dyad-pre-commit-"));
+  tempDirs.push(repo);
+  const initialized = await exec(["init"], repo);
+  expect(initialized.exitCode).toBe(0);
+
+  if (options?.hooksPath) {
+    const configured = await exec(
+      ["config", "core.hooksPath", options.hooksPath],
+      repo,
+    );
+    expect(configured.exitCode).toBe(0);
+  }
+
+  if (options?.hook) {
+    const hookDir = options.hooksPath
+      ? path.join(repo, options.hooksPath)
+      : path.join(repo, ".git", "hooks");
+    await mkdir(hookDir, { recursive: true });
+    const hookPath = path.join(hookDir, "pre-commit");
+    await writeFile(hookPath, "#!/bin/sh\nexit 0\n");
+    if (process.platform !== "win32") {
+      await chmod(hookPath, options.executable === false ? 0o644 : 0o755);
+    }
+  }
+
+  return repo;
+}
+
+function context(appPath: string, overrides: Partial<AgentContext> = {}) {
+  return {
+    appPath,
+    fileMutationCount: 1,
+    preCommitHookAvailable: true,
+    onXmlStream: vi.fn(),
+    onXmlComplete: vi.fn(),
+    ...overrides,
+  } as AgentContext;
+}
+
+function processResult(overrides = {}) {
+  return {
+    code: 0,
+    signal: null,
+    stdout: "",
+    stderr: "",
+    stdoutTruncated: false,
+    stderrTruncated: false,
+    aborted: false,
+    timedOut: false,
+    ...overrides,
+  };
+}
+
+describe("isPreCommitHookAvailable", () => {
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.splice(0).map((dir) =>
+        rm(dir, {
+          recursive: true,
+          force: true,
+          maxRetries: 3,
+          retryDelay: 100,
+        }),
+      ),
+    );
+  });
+
+  it("returns false when Git only resolves the default missing hook path", async () => {
+    expect(await isPreCommitHookAvailable(await makeRepo())).toBe(false);
+  });
+
+  it("detects an executable hook in Git's default hooks directory", async () => {
+    expect(await isPreCommitHookAvailable(await makeRepo({ hook: true }))).toBe(
+      true,
+    );
+  });
+
+  it("respects a configured core.hooksPath", async () => {
+    const repo = await makeRepo({ hook: true, hooksPath: ".custom-hooks" });
+    expect(await isPreCommitHookAvailable(repo)).toBe(true);
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "ignores a non-executable hook",
+    async () => {
+      const repo = await makeRepo({ hook: true, executable: false });
+      expect(await isPreCommitHookAvailable(repo)).toBe(false);
+    },
+  );
+});
+
+describe("runPreCommitTool", () => {
+  let repo: string;
+  let hookRuns: number;
+  let hookChangesFiles: boolean;
+  let hookResults: ReturnType<typeof processResult>[];
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    repo = await makeRepo({ hook: true });
+    hookRuns = 0;
+    hookChangesFiles = false;
+    hookResults = [];
+    mocks.gitAddAll.mockResolvedValue(undefined);
+    mocks.runBufferedProcess.mockImplementation(
+      async (options: BufferedProcessOptions) => {
+        if (options.args?.[0] === "hook") {
+          hookRuns++;
+          return hookResults.shift() ?? processResult();
+        }
+        options.onStdout?.(
+          hookChangesFiles ? `fingerprint-${hookRuns}` : "fingerprint",
+          {} as never,
+        );
+        return processResult();
+      },
+    );
+  });
+
+  it("is registered only when hook detection enabled it for the turn", () => {
+    expect(
+      runPreCommitTool.isEnabled?.(
+        context(repo, {
+          preCommitHookAvailable: true,
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      runPreCommitTool.isEnabled?.(
+        context(repo, {
+          preCommitHookAvailable: false,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.splice(0).map((dir) =>
+        rm(dir, {
+          recursive: true,
+          force: true,
+          maxRetries: 3,
+          retryDelay: 100,
+        }),
+      ),
+    );
+  });
+
+  it("requires a successful file modification before staging or running", async () => {
+    const ctx = context(repo, { fileMutationCount: 0 });
+
+    const result = await runPreCommitTool.execute({}, ctx);
+
+    expect(result).toContain("No files have been successfully modified");
+    expect(mocks.gitAddAll).not.toHaveBeenCalled();
+    expect(hookRuns).toBe(0);
+  });
+
+  it("stages files, returns hook errors, and refuses an unchanged retry", async () => {
+    hookResults.push(processResult({ code: 1, stderr: "lint failed" }));
+    const ctx = context(repo);
+
+    const first = await runPreCommitTool.execute({}, ctx);
+    const second = await runPreCommitTool.execute({}, ctx);
+
+    expect(mocks.gitAddAll).toHaveBeenCalledWith({ path: repo });
+    expect(first).toContain("lint failed");
+    expect(second).toContain("no files have changed");
+    expect(hookRuns).toBe(1);
+  });
+
+  it("reports a clean pass and refuses an unchanged rerun", async () => {
+    hookResults.push(processResult({ stdout: "checks passed" }));
+    const ctx = context(repo);
+
+    const first = await runPreCommitTool.execute({}, ctx);
+    const second = await runPreCommitTool.execute({}, ctx);
+
+    expect(first).toContain("Pre-commit passed");
+    expect(first).toContain("checks passed");
+    expect(second).toContain("last pre-commit run passed");
+    expect(hookRuns).toBe(1);
+  });
+
+  it("allows a retry when the hook itself changes files", async () => {
+    hookChangesFiles = true;
+    hookResults.push(
+      processResult({ code: 1, stderr: "formatted files" }),
+      processResult(),
+    );
+    const ctx = context(repo);
+
+    await runPreCommitTool.execute({}, ctx);
+    const second = await runPreCommitTool.execute({}, ctx);
+
+    expect(ctx.fileMutationCount).toBe(3);
+    expect(second).toContain("passed, but the hook changed files");
+    expect(hookRuns).toBe(2);
+  });
+
+  it("counts timed-out runs and enforces the per-turn limit", async () => {
+    hookResults.push(processResult({ code: 124, timedOut: true }));
+    const ctx = context(repo, {
+      preCommitRunCount: MAX_PRE_COMMIT_RUNS_PER_TURN - 1,
+    });
+
+    const timedOut = await runPreCommitTool.execute({}, ctx);
+    ctx.fileMutationCount = (ctx.fileMutationCount ?? 0) + 1;
+    const limited = await runPreCommitTool.execute({}, ctx);
+
+    expect(timedOut).toContain("exceeded 10 minutes");
+    expect(limited).toContain("already run 4 times");
+    expect(hookRuns).toBe(1);
+  });
+
+  it("does not consume a run when the hook process cannot start", async () => {
+    mocks.runBufferedProcess.mockImplementation(
+      async (options: BufferedProcessOptions) => {
+        if (options.args?.[0] === "hook") {
+          throw new Error("spawn failed");
+        }
+        options.onStdout?.("fingerprint", {} as never);
+        return processResult();
+      },
+    );
+    const ctx = context(repo);
+
+    const result = await runPreCommitTool.execute({}, ctx);
+
+    expect(result).toContain("did not consume a run");
+    expect(ctx.preCommitRunCount).toBe(0);
+    expect(ctx.preCommitFileMutationCountAtLastRun).toBeUndefined();
+  });
+});

--- a/src/pro/main/ipc/handlers/local_agent/tools/run_pre_commit.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/run_pre_commit.ts
@@ -1,0 +1,300 @@
+import { createHash } from "node:crypto";
+import fs, { promises as fsPromises } from "node:fs";
+import { z } from "zod";
+import { exec, setupEnvironment } from "dugite";
+import { gitAddAll } from "@/ipc/utils/git_utils";
+import {
+  runBufferedProcess,
+  type BufferedProcessResult,
+} from "@/ipc/utils/buffered_process";
+import {
+  AgentContext,
+  ToolDefinition,
+  escapeXmlAttr,
+  escapeXmlContent,
+} from "./types";
+
+export const MAX_PRE_COMMIT_RUNS_PER_TURN = 4;
+export const PRE_COMMIT_TIMEOUT_MS = 10 * 60_000;
+const MAX_RESULT_OUTPUT_CHARS = 12_000;
+const FINGERPRINT_TIMEOUT_MS = 60_000;
+
+const runPreCommitSchema = z.object({});
+
+async function resolvePreCommitHookPath(
+  appPath: string,
+): Promise<string | null> {
+  try {
+    const result = await exec(
+      ["rev-parse", "--path-format=absolute", "--git-path", "hooks/pre-commit"],
+      appPath,
+      { maxBuffer: 64_000 },
+    );
+    if (result.exitCode !== 0) return null;
+    return result.stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+export async function isPreCommitHookAvailable(
+  appPath: string,
+): Promise<boolean> {
+  const hookPath = await resolvePreCommitHookPath(appPath);
+  if (!hookPath) return false;
+
+  try {
+    const stat = await fsPromises.stat(hookPath);
+    if (!stat.isFile()) return false;
+    if (process.platform === "win32") return true;
+    await fsPromises.access(hookPath, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function gitProcessEnvironment() {
+  return setupEnvironment({});
+}
+
+async function hashGitOutput(
+  appPath: string,
+  args: string[],
+  signal?: AbortSignal,
+): Promise<string> {
+  const hash = createHash("sha256");
+  const { env, gitLocation } = gitProcessEnvironment();
+  const result = await runBufferedProcess({
+    command: gitLocation,
+    args,
+    cwd: appPath,
+    env,
+    signal,
+    timeoutMs: FINGERPRINT_TIMEOUT_MS,
+    maxOutputBytes: 1_024,
+    captureOutputOnSuccess: false,
+    onStdout: (chunk) => hash.update(chunk),
+  });
+  if (result.code !== 0 || result.aborted || result.timedOut) {
+    throw new Error(`Git fingerprint command failed: git ${args.join(" ")}`);
+  }
+  return hash.digest("hex");
+}
+
+/** Fingerprint staged, tracked-worktree, and untracked-path state. */
+async function getGitStateFingerprint(
+  appPath: string,
+  signal?: AbortSignal,
+): Promise<string> {
+  const staged = await hashGitOutput(
+    appPath,
+    ["diff", "--cached", "--binary", "--no-ext-diff", "--"],
+    signal,
+  );
+  const unstaged = await hashGitOutput(
+    appPath,
+    ["diff", "--binary", "--no-ext-diff", "--"],
+    signal,
+  );
+  const status = await exec(
+    ["status", "--porcelain=v1", "-z", "--untracked-files=all"],
+    appPath,
+    { maxBuffer: 1_000_000, signal },
+  );
+  if (status.exitCode !== 0) {
+    throw new Error("Failed to fingerprint Git status");
+  }
+  return `${staged}\0${unstaged}\0${status.stdout}`;
+}
+
+function tail(value: string): string {
+  return value.length > MAX_RESULT_OUTPUT_CHARS
+    ? `[Earlier output truncated]\n${value.slice(-MAX_RESULT_OUTPUT_CHARS)}`
+    : value;
+}
+
+function formatProcessOutput(stdout: string, stderr: string): string {
+  const parts = [stdout.trim(), stderr.trim()].filter(Boolean);
+  return tail(parts.join("\n")) || "The hook produced no output.";
+}
+
+function complete(
+  ctx: AgentContext,
+  title: string,
+  body: string,
+  state: "finished" | "warning" = "finished",
+): string {
+  ctx.onXmlComplete(
+    `<dyad-status title="${escapeXmlAttr(title)}" state="${state}">\n${escapeXmlContent(body)}\n</dyad-status>`,
+  );
+  return body;
+}
+
+export const runPreCommitTool: ToolDefinition<
+  z.infer<typeof runPreCommitSchema>
+> = {
+  name: "run_pre_commit",
+  description: `Stage all current workspace changes and run the repository's configured pre-commit hook.
+
+- Call this after finishing file edits, before ending the turn.
+- If it fails, use the returned output to fix the files, then call it again.
+- A retry is allowed only after files changed. Hook-generated changes count.
+- Stop after ${MAX_PRE_COMMIT_RUNS_PER_TURN} runs in one turn and summarize any remaining failure.
+- A passing run verifies the currently staged snapshot. If files change afterward, run it again.`,
+  inputSchema: runPreCommitSchema,
+  defaultConsent: "ask",
+  modifiesState: true,
+  isEnabled: (ctx) => ctx.preCommitHookAvailable === true,
+  getConsentPreview: () => "Stage all changes and run the pre-commit hook",
+
+  execute: async (_args, ctx) => {
+    const fileMutationCount = ctx.fileMutationCount ?? 0;
+    if (fileMutationCount === 0) {
+      return complete(
+        ctx,
+        "Pre-commit not run",
+        "No files have been successfully modified this turn. Finish the file edits before running pre-commit.",
+        "warning",
+      );
+    }
+
+    if ((ctx.preCommitRunCount ?? 0) >= MAX_PRE_COMMIT_RUNS_PER_TURN) {
+      return complete(
+        ctx,
+        "Pre-commit run limit reached",
+        `The pre-commit hook has already run ${MAX_PRE_COMMIT_RUNS_PER_TURN} times this turn. Do not run it again. Stop editing and summarize what still fails and what you tried.`,
+        "warning",
+      );
+    }
+
+    if (ctx.preCommitFileMutationCountAtLastRun === fileMutationCount) {
+      const previous = ctx.preCommitLastRunPassed ? "passed" : "failed";
+      return complete(
+        ctx,
+        "Files unchanged since pre-commit",
+        `The last pre-commit run ${previous}, and no files have changed since then. Do not rerun it until you make a targeted file change.`,
+        "warning",
+      );
+    }
+
+    if (!(await isPreCommitHookAvailable(ctx.appPath))) {
+      ctx.preCommitHookAvailable = false;
+      return complete(
+        ctx,
+        "Pre-commit hook unavailable",
+        "The configured pre-commit hook is missing or is not executable, so it was not run.",
+        "warning",
+      );
+    }
+
+    await gitAddAll({ path: ctx.appPath });
+    const beforeFingerprint = await getGitStateFingerprint(
+      ctx.appPath,
+      ctx.abortSignal,
+    ).catch(() => undefined);
+    if (ctx.abortSignal?.aborted) {
+      return complete(
+        ctx,
+        "Pre-commit cancelled",
+        "The pre-commit hook was cancelled before it started.",
+        "warning",
+      );
+    }
+
+    const previousRunCount = ctx.preCommitRunCount ?? 0;
+    const previousMutationCountAtLastRun =
+      ctx.preCommitFileMutationCountAtLastRun;
+    ctx.preCommitRunCount = previousRunCount + 1;
+    ctx.preCommitFileMutationCountAtLastRun = fileMutationCount;
+    ctx.onXmlStream(
+      `<dyad-status title="${escapeXmlAttr(`Running pre-commit (${ctx.preCommitRunCount}/${MAX_PRE_COMMIT_RUNS_PER_TURN})`)}"></dyad-status>`,
+    );
+
+    const { env, gitLocation } = gitProcessEnvironment();
+    let result: BufferedProcessResult;
+    try {
+      result = await runBufferedProcess({
+        command: gitLocation,
+        args: ["hook", "run", "pre-commit"],
+        cwd: ctx.appPath,
+        env,
+        signal: ctx.abortSignal,
+        timeoutMs: PRE_COMMIT_TIMEOUT_MS,
+        maxOutputBytes: 256_000,
+      });
+    } catch (error) {
+      // A process that never spawned is not an actual hook run and should not
+      // consume the retry budget or require a file edit before retrying.
+      ctx.preCommitRunCount = previousRunCount;
+      ctx.preCommitFileMutationCountAtLastRun = previousMutationCountAtLastRun;
+      const message = error instanceof Error ? error.message : String(error);
+      return complete(
+        ctx,
+        "Pre-commit could not start",
+        `The pre-commit hook process could not be started. This did not consume a run.\n\n${message}`,
+        "warning",
+      );
+    }
+
+    const afterFingerprint = result.aborted
+      ? undefined
+      : await getGitStateFingerprint(ctx.appPath, ctx.abortSignal).catch(
+          () => undefined,
+        );
+    const hookChangedFiles =
+      beforeFingerprint !== undefined &&
+      afterFingerprint !== undefined &&
+      beforeFingerprint !== afterFingerprint;
+    if (hookChangedFiles) {
+      ctx.fileMutationCount = (ctx.fileMutationCount ?? 0) + 1;
+    }
+
+    if (result.aborted) {
+      ctx.preCommitLastRunPassed = false;
+      return complete(
+        ctx,
+        "Pre-commit cancelled",
+        "The pre-commit hook was cancelled before it completed.",
+        "warning",
+      );
+    }
+    if (result.timedOut) {
+      ctx.preCommitLastRunPassed = false;
+      return complete(
+        ctx,
+        "Pre-commit timed out",
+        `The pre-commit hook exceeded ${Math.round(PRE_COMMIT_TIMEOUT_MS / 60_000)} minutes and was stopped.\n\n${formatProcessOutput(result.stdout, result.stderr)}`,
+        "warning",
+      );
+    }
+
+    const output = formatProcessOutput(result.stdout, result.stderr);
+    if (result.code !== 0) {
+      ctx.preCommitLastRunPassed = false;
+      const remaining =
+        MAX_PRE_COMMIT_RUNS_PER_TURN - (ctx.preCommitRunCount ?? 0);
+      return complete(
+        ctx,
+        "Pre-commit failed",
+        `Pre-commit failed with exit code ${result.code ?? "unknown"}. Fix the reported errors before retrying. ${remaining} run(s) remain this turn.\n\n${output}`,
+        "warning",
+      );
+    }
+
+    ctx.preCommitLastRunPassed = true;
+    if (hookChangedFiles) {
+      return complete(
+        ctx,
+        "Pre-commit passed and changed files",
+        `Pre-commit passed, but the hook changed files. Run pre-commit again to verify the resulting files.\n\n${output}`,
+        "warning",
+      );
+    }
+    return complete(
+      ctx,
+      "Pre-commit passed",
+      `Pre-commit passed. Do not run it again unless files change.\n\n${output}`,
+    );
+  },
+};

--- a/src/pro/main/ipc/handlers/local_agent/tools/tool_invocation.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/tool_invocation.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { AgentContext, ToolDefinition } from "./types";
-import { shouldTrackToolMutation } from "./tool_invocation";
+import { shouldTrackToolMutation, trackAppMutation } from "./tool_invocation";
 
 function tool(
   name: string,
@@ -36,5 +36,26 @@ describe("shouldTrackToolMutation", () => {
     expect(
       shouldTrackToolMutation(tool("write_file"), {}, "success", ctx),
     ).toBe(true);
+  });
+});
+
+describe("trackAppMutation", () => {
+  it("tracks workspace-file mutations separately from database mutations", () => {
+    const ctx = {} as AgentContext;
+
+    trackAppMutation(ctx, "write_file");
+    trackAppMutation(ctx, "execute_sql");
+
+    expect(ctx.mutationCount).toBe(2);
+    expect(ctx.fileMutationCount).toBe(1);
+  });
+
+  it("counts restored files as workspace-file mutations", () => {
+    const ctx = {} as AgentContext;
+
+    trackAppMutation(ctx, "git_restore_file");
+
+    expect(ctx.mutationCount).toBe(1);
+    expect(ctx.fileMutationCount).toBe(1);
   });
 });

--- a/src/pro/main/ipc/handlers/local_agent/tools/tool_invocation.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/tool_invocation.ts
@@ -22,6 +22,10 @@ import {
 
 const FILE_EDIT_TOOLS: Set<FileEditToolName> = new Set(FILE_EDIT_TOOL_NAMES);
 const APP_MUTATING_TOOLS: Set<string> = new Set(APP_MUTATING_TOOL_NAMES);
+const FILE_MUTATING_TOOLS = new Set<string>([
+  ...FILE_EDIT_TOOL_NAMES,
+  ...APP_MUTATING_TOOL_NAMES.filter((name) => name !== "execute_sql"),
+]);
 
 /**
  * Track file edit tool usage for retry/fallback telemetry. This intentionally
@@ -69,6 +73,9 @@ export function trackAppMutation(
     return;
   }
   ctx.mutationCount = (ctx.mutationCount ?? 0) + 1;
+  if (FILE_MUTATING_TOOLS.has(toolName)) {
+    ctx.fileMutationCount = (ctx.fileMutationCount ?? 0) + 1;
+  }
 }
 
 /**

--- a/src/pro/main/ipc/handlers/local_agent/tools/types.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/types.ts
@@ -57,6 +57,7 @@ export const APP_MUTATING_TOOL_NAMES = [
   "add_integration",
   "enable_nitro",
   "generate_image",
+  "git_restore_file",
 ] as const;
 
 export interface AgentContext {
@@ -93,6 +94,8 @@ export interface AgentContext {
   fileEditTracker: FileEditTracker;
   /** True after a tool has successfully changed workspace contents this turn. */
   workspaceMutated?: boolean;
+  /** Successful workspace-file mutations completed during this turn. */
+  fileMutationCount?: number;
   /**
    * Turn-scoped count of successfully completed tool invocations that change
    * the app or its data: file edits (including sandbox write_file host calls)
@@ -101,6 +104,14 @@ export interface AgentContext {
    * through ANY mutating tool — not just write_file/search_replace.
    */
   mutationCount?: number;
+  /** Whether Git had an executable pre-commit hook when this turn started. */
+  preCommitHookAvailable?: boolean;
+  /** Actual pre-commit hook processes started during this turn. */
+  preCommitRunCount?: number;
+  /** File mutation count observed when the last pre-commit run started. */
+  preCommitFileMutationCountAtLastRun?: number;
+  /** Whether the last completed pre-commit run passed. */
+  preCommitLastRunPassed?: boolean;
   /**
    * If true, the user has Dyad Pro enabled.
    * Engine-dependent tools require this to access the Dyad Pro API.


### PR DESCRIPTION
## Summary

Add an opt-in local-agent verification loop that runs a repository's effective pre-commit hook after successful file edits, while keeping Dyad's turn checkpoint commits reliable even when project checks fail.

- Expose the tool only for writable turns whose Git configuration resolves to an executable `pre-commit` hook; repository hooks remain arbitrary code, so each run uses the normal agent-tool consent path.
- Stage the complete workspace before verification, cap execution at four runs and ten minutes per run, and require a real file mutation before the first run or any retry.
- Detect hook-generated Git changes and allow a follow-up verification run, while refusing unchanged reruns so a failing or nondeterministic hook cannot create an unbounded loop.
- Keep verification separate from versioning: turn-end checkpoint commits stage again and use `--no-verify`, so hook failures are reported to the agent but never prevent Dyad from preserving the turn.
- Intentionally snapshot hook availability when the turn begins. A hook installed or repaired mid-turn becomes available on the next turn, and generated Husky shims must exist at Git's effective hook path.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

