### PR TITLE
Fix issue triage artifact permission

### DIFF
--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -62,7 +62,7 @@ jobs:
           claude_args: |
             --model claude-opus-5
             --setting-sources user
-            --allowedTools "Bash(echo:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Write(tmp/issue-triage/**)"
+            --allowedTools "Bash(echo:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Edit(/tmp/issue-triage/**)"
 
       - name: Verify issue triage output
         run: |


### PR DESCRIPTION
## Summary

Restore automated issue triage by granting Claude Code the path-scoped edit permission used for file creation under the triage handoff directory.

- Keep the existing read-only GitHub token boundary and narrow local filesystem scope.
- Preserve hidden Claude output; this does not enable `show_full_output`.
- Continue failing at the producer boundary if the required JSON handoff is missing.

#skip-bugbot

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line change to Claude Code tool allowlisting in an isolated workflow; no production app or auth logic touched.
> 
> **Overview**
> **Restores the issue-triage workflow** by updating Claude Code’s `--allowedTools` so the agent can write the required triage JSON handoff.
> 
> The triage step switches from **`Write(tmp/issue-triage/**)`** to **`Edit(/tmp/issue-triage/**)`**, aligning filesystem permissions with how Claude Code creates the output file while keeping the same narrow Bash/`gh` allowlist and read-only issue token boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 094496e5ad4e518950ec5b9e96f0131e4469f500. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

