### PR TITLE
feat: prompt for a screenshot on session uploads and record the outcome

### DIFF
--- a/e2e-tests/screenshot_prompt.spec.ts
+++ b/e2e-tests/screenshot_prompt.spec.ts
@@ -3,13 +3,7 @@ import http from "node:http";
 import type { AddressInfo } from "node:net";
 import { test, Timeout } from "./helpers/test_helper";
 
-// The screenshot prompt is covered in depth by unit tests, but two things only
-// the packaged app can show: that Escape actually reaches the dismiss handler
-// (unit tests replace the dialog primitive with a stand-in), and that a capture
-// really leaves an image on the clipboard for the reporter to paste. The issue
-// URL itself is not observable here, since test builds skip opening it.
-
-test("bug report: backing out recovers, and a capture reaches the clipboard", async ({
+test("bug report: backing out of the prompt returns to help", async ({
   po,
 }) => {
   await po.setUp();
@@ -23,35 +17,6 @@ test("bug report: backing out recovers, and a capture reaches the clipboard", as
   await po.page.keyboard.press("Escape");
   await expect(po.page.getByText("Need help with Dyad?")).toBeVisible();
   await expect(po.page.getByText("Take a screenshot?")).not.toBeVisible();
-
-  await po.page.getByRole("button", { name: "Report a Bug" }).click();
-
-  // The capture targets the focused window. On macOS a window cannot take focus
-  // while its app is inactive, which is normal for an app a test launched, so
-  // activate the app as well. Both are re-asked each tick because either can be
-  // granted asynchronously or dropped while the app is still settling.
-  await expect
-    .poll(
-      () =>
-        po.electronApp.evaluate(({ app, BrowserWindow }) => {
-          app.focus({ steal: true });
-          BrowserWindow.getAllWindows()[0]?.focus();
-          return BrowserWindow.getFocusedWindow() !== null;
-        }),
-      { timeout: Timeout.MEDIUM },
-    )
-    .toBe(true);
-  await po.page.getByRole("button", { name: /recommended/ }).click();
-
-  await expect(
-    po.page.getByText(/Screenshot captured to clipboard/),
-  ).toBeVisible({ timeout: Timeout.MEDIUM });
-
-  // The reporter is told to paste an image, so one has to be on the clipboard.
-  const hasImage = await po.electronApp.evaluate(
-    ({ clipboard }) => !clipboard.readImage().isEmpty(),
-  );
-  expect(hasImage).toBe(true);
 });
 
 test("session report: backing out of the prompt keeps the uploaded session", async ({

--- a/e2e-tests/screenshot_prompt.spec.ts
+++ b/e2e-tests/screenshot_prompt.spec.ts
@@ -26,11 +26,19 @@ test("bug report: backing out recovers, and a capture reaches the clipboard", as
 
   await po.page.getByRole("button", { name: "Report a Bug" }).click();
 
-  // The capture targets the focused window, which the windowing environment
-  // running the suite may not have granted on its own.
-  await po.electronApp.evaluate(({ BrowserWindow }: any) => {
-    BrowserWindow.getAllWindows()[0]?.focus();
-  });
+  // The capture targets the focused window. focus() returns before the window
+  // manager grants it, so wait for the result. Re-asked each tick since a
+  // manager may ignore the first.
+  await expect
+    .poll(
+      () =>
+        po.electronApp.evaluate(({ BrowserWindow }: any) => {
+          BrowserWindow.getAllWindows()[0]?.focus();
+          return BrowserWindow.getFocusedWindow() !== null;
+        }),
+      { timeout: Timeout.MEDIUM },
+    )
+    .toBe(true);
   await po.page.getByRole("button", { name: /recommended/ }).click();
 
   await expect(

--- a/e2e-tests/screenshot_prompt.spec.ts
+++ b/e2e-tests/screenshot_prompt.spec.ts
@@ -1,12 +1,52 @@
-import { expect } from "@playwright/test";
+import { expect, type ElectronApplication } from "@playwright/test";
 import http from "node:http";
 import type { AddressInfo } from "node:net";
 import { test, Timeout } from "./helpers/test_helper";
 
-test("bug report: backing out of the prompt returns to help", async ({
-  po,
-}) => {
+// Both flows end in a filed report, with a back out on the way. Backing out on
+// its own only shows the dialog returned; carrying on afterwards is what shows
+// the flow still works, which is where this feature's regressions have been.
+//
+// The capture is stubbed at the IPC boundary, so these cover the flow's
+// handling of a successful capture, not that an image reaches the clipboard.
+// A real capture needs a host that grants the window OS focus, which the CI
+// runner does not.
+
+/** Makes the capture succeed without needing a focused window or a clipboard. */
+async function stubScreenshotCapture(electronApp: ElectronApplication) {
+  await electronApp.evaluate(({ ipcMain }) => {
+    ipcMain.removeHandler("take-screenshot");
+    ipcMain.handle("take-screenshot", () => {});
+  });
+}
+
+/** Test builds never open external URLs, so record what would have opened. */
+async function recordIssueUrls(electronApp: ElectronApplication) {
+  await electronApp.evaluate(({ ipcMain }) => {
+    const opened: string[] = [];
+    (globalThis as Record<string, unknown>).__openedUrls = opened;
+    ipcMain.removeHandler("open-external-url");
+    ipcMain.handle("open-external-url", (_event, url: string) => {
+      opened.push(url);
+    });
+  });
+}
+
+/** The query of the first issue URL the app tried to open. */
+async function firstIssueUrl(electronApp: ElectronApplication) {
+  const read = () =>
+    electronApp.evaluate(
+      () => (globalThis as Record<string, unknown>).__openedUrls as string[],
+    );
+  await expect
+    .poll(async () => (await read()).length, { timeout: Timeout.MEDIUM })
+    .toBeGreaterThan(0);
+  return new URL((await read())[0]).searchParams;
+}
+
+test("file a bug report without a screenshot", async ({ po }) => {
   await po.setUp();
+  await recordIssueUrls(po.electronApp);
 
   await po.page.getByRole("button", { name: "Help" }).click();
   await po.page.getByRole("button", { name: "Report a Bug" }).click();
@@ -17,13 +57,25 @@ test("bug report: backing out of the prompt returns to help", async ({
   await po.page.keyboard.press("Escape");
   await expect(po.page.getByText("Need help with Dyad?")).toBeVisible();
   await expect(po.page.getByText("Take a screenshot?")).not.toBeVisible();
+
+  // The report that follows the back out is the point: a dismissal must not
+  // leave state behind that breaks the next one.
+  await po.page.getByRole("button", { name: "Report a Bug" }).click();
+  await po.page.getByText("File bug report without screenshot").click();
+
+  const params = await firstIssueUrl(po.electronApp);
+  expect(params.get("title")).toContain("[bug]");
+  expect(params.get("labels")).toContain("bug");
+  expect(params.get("body")).toContain("Screenshot status: declined");
 });
 
-test("session report: backing out of the prompt keeps the uploaded session", async ({
+test("upload a chat session and report it with a screenshot", async ({
   po,
 }) => {
   await po.setUp();
   await po.sendPrompt("tc=write-index");
+  await recordIssueUrls(po.electronApp);
+  await stubScreenshotCapture(po.electronApp);
 
   // Stand in for the upload service on loopback, which test builds accept, so
   // the IPC handler and its upload run for real against a local endpoint.
@@ -69,6 +121,23 @@ test("session report: backing out of the prompt keeps the uploaded session", asy
     await po.page.keyboard.press("Escape");
     await expect(po.page.getByText("Upload Complete")).toBeVisible();
     await expect(po.page.getByText("v2:e2e-session")).toBeVisible();
+
+    await po.page.getByRole("button", { name: "Create GitHub Issue" }).click();
+    await po.page.getByRole("button", { name: /recommended/ }).click();
+
+    // The prompt hides itself for the capture, then confirms it succeeded.
+    await expect(
+      po.page.getByText(/Screenshot captured to clipboard/),
+    ).toBeVisible({ timeout: Timeout.MEDIUM });
+    await po.page.getByText("Create GitHub issue").click();
+
+    const params = await firstIssueUrl(po.electronApp);
+    expect(params.get("title")).toContain("[session report]");
+    expect(params.get("labels")).toContain("support");
+    const body = params.get("body") ?? "";
+    expect(body).toContain("Screenshot status: captured");
+    // The session the reporter uploaded is the one the issue points at.
+    expect(body).toContain("v2:e2e-session");
   } finally {
     await new Promise<void>((resolve) => server.close(() => resolve()));
   }

--- a/e2e-tests/screenshot_prompt.spec.ts
+++ b/e2e-tests/screenshot_prompt.spec.ts
@@ -1,0 +1,100 @@
+import { expect } from "@playwright/test";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { test, Timeout } from "./helpers/test_helper";
+
+// The screenshot prompt is covered in depth by unit tests, but two things only
+// the packaged app can show: that Escape actually reaches the dismiss handler
+// (unit tests replace the dialog primitive with a stand-in), and that a capture
+// really leaves an image on the clipboard for the reporter to paste. The issue
+// URL itself is not observable here, since test builds skip opening it.
+
+test("bug report: backing out recovers, and a capture reaches the clipboard", async ({
+  po,
+}) => {
+  await po.setUp();
+
+  await po.page.getByRole("button", { name: "Help" }).click();
+  await po.page.getByRole("button", { name: "Report a Bug" }).click();
+  await expect(po.page.getByText("Take a screenshot?")).toBeVisible({
+    timeout: Timeout.MEDIUM,
+  });
+
+  await po.page.keyboard.press("Escape");
+  await expect(po.page.getByText("Need help with Dyad?")).toBeVisible();
+  await expect(po.page.getByText("Take a screenshot?")).not.toBeVisible();
+
+  await po.page.getByRole("button", { name: "Report a Bug" }).click();
+
+  // The capture targets the focused window, which the windowing environment
+  // running the suite may not have granted on its own.
+  await po.electronApp.evaluate(({ BrowserWindow }: any) => {
+    BrowserWindow.getAllWindows()[0]?.focus();
+  });
+  await po.page.getByRole("button", { name: /recommended/ }).click();
+
+  await expect(
+    po.page.getByText(/Screenshot captured to clipboard/),
+  ).toBeVisible({ timeout: Timeout.MEDIUM });
+
+  // The reporter is told to paste an image, so one has to be on the clipboard.
+  const hasImage = await po.electronApp.evaluate(
+    ({ clipboard }: any) => !clipboard.readImage().isEmpty(),
+  );
+  expect(hasImage).toBe(true);
+});
+
+test("session report: backing out of the prompt keeps the uploaded session", async ({
+  po,
+}) => {
+  await po.setUp();
+  await po.sendPrompt("tc=write-index");
+
+  // Stand in for the upload service on loopback, which test builds accept, so
+  // the IPC handler and its upload run for real against a local endpoint.
+  const uploads: string[] = [];
+  const server = http.createServer((req, res) => {
+    uploads.push(req.url ?? "");
+    req.resume();
+    req.on("end", () => {
+      res.writeHead(200);
+      res.end();
+    });
+  });
+  await new Promise<void>((resolve) =>
+    server.listen(0, "127.0.0.1", () => resolve()),
+  );
+  const { port } = server.address() as AddressInfo;
+
+  try {
+    await po.page.route("**/generate-upload-url", async (route) => {
+      await route.fulfill({
+        json: {
+          uploadUrl: `http://127.0.0.1:${port}/signed`,
+          filename: "e2e-session.json",
+        },
+      });
+    });
+
+    await po.page.getByRole("button", { name: "Help" }).click();
+    await po.page.getByRole("button", { name: "Upload Chat Session" }).click();
+    await po.page.getByRole("button", { name: "Upload", exact: true }).click();
+
+    await expect(po.page.getByText("Upload Complete")).toBeVisible({
+      timeout: Timeout.LONG,
+    });
+    // The id shown comes from the real upload round trip.
+    await expect(po.page.getByText("v2:e2e-session")).toBeVisible();
+    expect(uploads).toEqual(["/signed"]);
+
+    await po.page.getByRole("button", { name: "Create GitHub Issue" }).click();
+    await expect(po.page.getByText("Take a screenshot?")).toBeVisible();
+
+    // Backing out must not orphan an upload that already reached the server.
+    await po.page.keyboard.press("Escape");
+    await expect(po.page.getByText("Upload Complete")).toBeVisible();
+    await expect(po.page.getByText("v2:e2e-session")).toBeVisible();
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+});

--- a/e2e-tests/screenshot_prompt.spec.ts
+++ b/e2e-tests/screenshot_prompt.spec.ts
@@ -26,13 +26,15 @@ test("bug report: backing out recovers, and a capture reaches the clipboard", as
 
   await po.page.getByRole("button", { name: "Report a Bug" }).click();
 
-  // The capture targets the focused window. focus() returns before the window
-  // manager grants it, so wait for the result. Re-asked each tick since a
-  // manager may ignore the first.
+  // The capture targets the focused window. On macOS a window cannot take focus
+  // while its app is inactive, which is normal for an app a test launched, so
+  // activate the app as well. Both are re-asked each tick because either can be
+  // granted asynchronously or dropped while the app is still settling.
   await expect
     .poll(
       () =>
-        po.electronApp.evaluate(({ BrowserWindow }: any) => {
+        po.electronApp.evaluate(({ app, BrowserWindow }) => {
+          app.focus({ steal: true });
           BrowserWindow.getAllWindows()[0]?.focus();
           return BrowserWindow.getFocusedWindow() !== null;
         }),
@@ -47,7 +49,7 @@ test("bug report: backing out recovers, and a capture reaches the clipboard", as
 
   // The reporter is told to paste an image, so one has to be on the clipboard.
   const hasImage = await po.electronApp.evaluate(
-    ({ clipboard }: any) => !clipboard.readImage().isEmpty(),
+    ({ clipboard }) => !clipboard.readImage().isEmpty(),
   );
   expect(hasImage).toBe(true);
 });

--- a/src/components/BugScreenshotDialog.test.tsx
+++ b/src/components/BugScreenshotDialog.test.tsx
@@ -288,9 +288,7 @@ describe("BugScreenshotDialog", () => {
 
     // Without this the reporter reaches GitHub expecting an image to paste.
     await waitFor(() =>
-      expect(mocks.showError).toHaveBeenCalledWith(
-        "Failed to take screenshot: no window",
-      ),
+      expect(mocks.showError).toHaveBeenCalledWith("no window"),
     );
   });
 

--- a/src/components/BugScreenshotDialog.test.tsx
+++ b/src/components/BugScreenshotDialog.test.tsx
@@ -2,17 +2,26 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { BugScreenshotDialog } from "./BugScreenshotDialog";
 
-const mocks = vi.hoisted(() => ({
-  takeScreenshot: vi.fn(),
-  posthogCapture: vi.fn(),
-}));
+const mocks = vi.hoisted(() => {
+  const posthogCapture = vi.fn();
+  return {
+    takeScreenshot: vi.fn(),
+    showError: vi.fn(),
+    posthogCapture,
+    // Stable across renders, matching the real client, so effects keyed on it
+    // do not re-run.
+    posthogClient: { capture: posthogCapture },
+  };
+});
 
 vi.mock("@/ipc/types", () => ({
   ipc: { system: { takeScreenshot: mocks.takeScreenshot } },
 }));
 
+vi.mock("@/lib/toast", () => ({ showError: mocks.showError }));
+
 vi.mock("posthog-js/react", () => ({
-  usePostHog: () => ({ capture: mocks.posthogCapture }),
+  usePostHog: () => mocks.posthogClient,
 }));
 
 vi.mock("./ui/dialog", () => ({
@@ -65,6 +74,7 @@ describe("BugScreenshotDialog", () => {
   beforeEach(() => {
     mocks.takeScreenshot.mockReset().mockResolvedValue(undefined);
     mocks.posthogCapture.mockReset();
+    mocks.showError.mockReset();
   });
 
   it("reports that the prompt was shown, with its source", () => {
@@ -78,6 +88,18 @@ describe("BugScreenshotDialog", () => {
   it("does not report a prompt that was never opened", () => {
     renderPrompt({ isOpen: false });
     expect(mocks.posthogCapture).not.toHaveBeenCalled();
+  });
+
+  it("reports the prompt as shown once per opening", async () => {
+    renderPrompt();
+    // Re-render while open, which is what capturing a screenshot does.
+    fireEvent.click(screen.getByRole("button", { name: /recommended/ }));
+    await waitFor(() => expect(mocks.takeScreenshot).toHaveBeenCalled());
+
+    const shown = mocks.posthogCapture.mock.calls.filter(
+      (call) => call[0] === "screenshot-prompt:shown",
+    );
+    expect(shown).toHaveLength(1);
   });
 
   it("reports a dismissal as backing out, not as a decline", () => {
@@ -105,7 +127,7 @@ describe("BugScreenshotDialog", () => {
 
     expect(props.onClose).toHaveBeenCalled();
     expect(mocks.posthogCapture).toHaveBeenCalledWith(
-      "screenshot-prompt:capture",
+      "screenshot-prompt:capture-attempt",
       { source: "report-bug" },
     );
 
@@ -130,6 +152,19 @@ describe("BugScreenshotDialog", () => {
     expect(mocks.posthogCapture).toHaveBeenCalledWith(
       "screenshot-prompt:capture-failed",
       { source: "upload-session", reason: "No focused window to capture" },
+    );
+  });
+
+  it("tells the reporter the capture failed", async () => {
+    mocks.takeScreenshot.mockRejectedValue(new Error("no window"));
+    renderPrompt();
+    fireEvent.click(screen.getByRole("button", { name: /recommended/ }));
+
+    // Without this the reporter reaches GitHub expecting an image to paste.
+    await waitFor(() =>
+      expect(mocks.showError).toHaveBeenCalledWith(
+        "Failed to take screenshot: no window",
+      ),
     );
   });
 

--- a/src/components/BugScreenshotDialog.test.tsx
+++ b/src/components/BugScreenshotDialog.test.tsx
@@ -61,6 +61,7 @@ function renderPrompt(
     isOpen: true,
     onClose: vi.fn(),
     onDismiss: vi.fn(),
+    onCaptureAbandon: vi.fn(),
     onContinue: vi.fn(),
     source: "report-bug" as const,
     report: { kind: "bug" } as const,
@@ -69,6 +70,11 @@ function renderPrompt(
   const view = render(<BugScreenshotDialog {...props} />);
   return { ...props, view, props };
 }
+
+const SESSION = {
+  source: "upload-session",
+  report: { kind: "session", sessionId: "v2:abc" },
+} as const;
 
 function shownEvents() {
   return mocks.posthogCapture.mock.calls.filter(
@@ -84,7 +90,7 @@ describe("BugScreenshotDialog", () => {
   });
 
   it("reports that the prompt was shown, with its source", () => {
-    renderPrompt({ source: "upload-session" });
+    renderPrompt(SESSION);
     expect(mocks.posthogCapture).toHaveBeenCalledWith(
       "screenshot-prompt:shown",
       { source: "upload-session" },
@@ -110,7 +116,7 @@ describe("BugScreenshotDialog", () => {
   });
 
   it("reports a dismissal as backing out, not as a decline", () => {
-    const props = renderPrompt({ source: "upload-session" });
+    const props = renderPrompt(SESSION);
     fireEvent.click(screen.getByText("mock-dialog-dismiss"));
 
     expect(props.onDismiss).toHaveBeenCalled();
@@ -240,7 +246,7 @@ describe("BugScreenshotDialog", () => {
   });
 
   it("reports a captured screenshot that the reporter abandons", async () => {
-    const props = renderPrompt({ source: "upload-session" });
+    const props = renderPrompt(SESSION);
     fireEvent.click(screen.getByRole("button", { name: /recommended/ }));
     await waitFor(() => expect(mocks.takeScreenshot).toHaveBeenCalled());
     await screen.findByText("Create GitHub issue");
@@ -260,13 +266,13 @@ describe("BugScreenshotDialog", () => {
     mocks.takeScreenshot.mockRejectedValue(
       new Error("No focused window to capture"),
     );
-    const props = renderPrompt({ source: "upload-session" });
+    const props = renderPrompt(SESSION);
     fireEvent.click(screen.getByRole("button", { name: /recommended/ }));
 
     await waitFor(() =>
       expect(props.onContinue).toHaveBeenCalledWith(
         { status: "capture-failed", reason: "No focused window to capture" },
-        { kind: "bug" },
+        SESSION.report,
       ),
     );
     expect(mocks.posthogCapture).toHaveBeenCalledWith(

--- a/src/components/BugScreenshotDialog.test.tsx
+++ b/src/components/BugScreenshotDialog.test.tsx
@@ -66,8 +66,14 @@ function renderPrompt(
     source: "report-bug" as const,
     ...overrides,
   };
-  render(<BugScreenshotDialog {...props} />);
-  return props;
+  const view = render(<BugScreenshotDialog {...props} />);
+  return { ...props, view, props };
+}
+
+function shownEvents() {
+  return mocks.posthogCapture.mock.calls.filter(
+    (call) => call[0] === "screenshot-prompt:shown",
+  );
 }
 
 describe("BugScreenshotDialog", () => {
@@ -91,15 +97,16 @@ describe("BugScreenshotDialog", () => {
   });
 
   it("reports the prompt as shown once per opening", async () => {
-    renderPrompt();
+    const { view, props } = renderPrompt();
     // Re-render while open, which is what capturing a screenshot does.
     fireEvent.click(screen.getByRole("button", { name: /recommended/ }));
     await waitFor(() => expect(mocks.takeScreenshot).toHaveBeenCalled());
+    expect(shownEvents()).toHaveLength(1);
 
-    const shown = mocks.posthogCapture.mock.calls.filter(
-      (call) => call[0] === "screenshot-prompt:shown",
-    );
-    expect(shown).toHaveLength(1);
+    // Closing and reopening is a second offer, so it counts again.
+    view.rerender(<BugScreenshotDialog {...props} isOpen={false} />);
+    view.rerender(<BugScreenshotDialog {...props} isOpen={true} />);
+    expect(shownEvents()).toHaveLength(2);
   });
 
   it("reports a dismissal as backing out, not as a decline", () => {
@@ -134,6 +141,35 @@ describe("BugScreenshotDialog", () => {
     await waitFor(() => expect(mocks.takeScreenshot).toHaveBeenCalled());
     fireEvent.click(await screen.findByText("Create GitHub issue"));
     expect(props.onContinue).toHaveBeenCalledWith({ status: "captured" });
+  });
+
+  it("reports a captured screenshot that the reporter files", async () => {
+    renderPrompt();
+    fireEvent.click(screen.getByRole("button", { name: /recommended/ }));
+    await waitFor(() => expect(mocks.takeScreenshot).toHaveBeenCalled());
+    fireEvent.click(await screen.findByText("Create GitHub issue"));
+
+    expect(mocks.posthogCapture).toHaveBeenCalledWith(
+      "screenshot-prompt:captured",
+      { source: "report-bug" },
+    );
+  });
+
+  it("reports a captured screenshot that the reporter abandons", async () => {
+    const props = renderPrompt({ source: "upload-session" });
+    fireEvent.click(screen.getByRole("button", { name: /recommended/ }));
+    await waitFor(() => expect(mocks.takeScreenshot).toHaveBeenCalled());
+    await screen.findByText("Create GitHub issue");
+
+    // The success dialog renders after the prompt, so its dismiss is last.
+    const dismissals = screen.getAllByText("mock-dialog-dismiss");
+    fireEvent.click(dismissals[dismissals.length - 1]);
+
+    expect(mocks.posthogCapture).toHaveBeenCalledWith(
+      "screenshot-prompt:capture-abandoned",
+      { source: "upload-session" },
+    );
+    expect(props.onContinue).not.toHaveBeenCalled();
   });
 
   it("still files the report when the capture fails, recording why", async () => {

--- a/src/components/BugScreenshotDialog.test.tsx
+++ b/src/components/BugScreenshotDialog.test.tsx
@@ -63,6 +63,7 @@ function renderPrompt(
     onDismiss: vi.fn(),
     onContinue: vi.fn(),
     source: "report-bug" as const,
+    report: { kind: "bug" } as const,
     ...overrides,
   };
   const view = render(<BugScreenshotDialog {...props} />);
@@ -147,7 +148,10 @@ describe("BugScreenshotDialog", () => {
     const props = renderPrompt();
     fireEvent.click(screen.getByText(/without screenshot/));
 
-    expect(props.onContinue).toHaveBeenCalledWith({ status: "declined" });
+    expect(props.onContinue).toHaveBeenCalledWith(
+      { status: "declined" },
+      { kind: "bug" },
+    );
     expect(mocks.posthogCapture).toHaveBeenCalledWith(
       "screenshot-prompt:decline",
       { source: "report-bug" },
@@ -166,7 +170,10 @@ describe("BugScreenshotDialog", () => {
 
     await waitFor(() => expect(mocks.takeScreenshot).toHaveBeenCalled());
     fireEvent.click(await screen.findByText("Create GitHub issue"));
-    expect(props.onContinue).toHaveBeenCalledWith({ status: "captured" });
+    expect(props.onContinue).toHaveBeenCalledWith(
+      { status: "captured" },
+      { kind: "bug" },
+    );
   });
 
   it("reports a captured screenshot that the reporter files", async () => {
@@ -178,6 +185,28 @@ describe("BugScreenshotDialog", () => {
     expect(mocks.posthogCapture).toHaveBeenCalledWith(
       "screenshot-prompt:captured",
       { source: "report-bug" },
+    );
+  });
+
+  it("files a late capture against the report that started it", async () => {
+    const props = renderPrompt({
+      report: { kind: "session", sessionId: "v2:first" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /recommended/ }));
+    await waitFor(() => expect(mocks.takeScreenshot).toHaveBeenCalled());
+
+    // Another report starts while this capture is still resolving.
+    props.view.rerender(
+      <BugScreenshotDialog {...props.props} report={{ kind: "bug" }} />,
+    );
+    fireEvent.click(await screen.findByText("Create GitHub issue"));
+
+    expect(props.onContinue).toHaveBeenCalledWith(
+      { status: "captured" },
+      {
+        kind: "session",
+        sessionId: "v2:first",
+      },
     );
   });
 
@@ -206,10 +235,10 @@ describe("BugScreenshotDialog", () => {
     fireEvent.click(screen.getByRole("button", { name: /recommended/ }));
 
     await waitFor(() =>
-      expect(props.onContinue).toHaveBeenCalledWith({
-        status: "capture-failed",
-        reason: "No focused window to capture",
-      }),
+      expect(props.onContinue).toHaveBeenCalledWith(
+        { status: "capture-failed", reason: "No focused window to capture" },
+        { kind: "bug" },
+      ),
     );
     expect(mocks.posthogCapture).toHaveBeenCalledWith(
       "screenshot-prompt:capture-failed",

--- a/src/components/BugScreenshotDialog.test.tsx
+++ b/src/components/BugScreenshotDialog.test.tsx
@@ -62,7 +62,6 @@ function renderPrompt(
     onClose: vi.fn(),
     onDismiss: vi.fn(),
     onContinue: vi.fn(),
-    isLoading: false,
     source: "report-bug" as const,
     ...overrides,
   };
@@ -115,6 +114,33 @@ describe("BugScreenshotDialog", () => {
 
     expect(props.onDismiss).toHaveBeenCalled();
     expect(props.onContinue).not.toHaveBeenCalled();
+  });
+
+  it("answers once even if clicked again while closing", () => {
+    const props = renderPrompt();
+    const decline = screen.getByText(/without screenshot/);
+    // A dialog stays clickable through its closing animation.
+    fireEvent.click(decline);
+    fireEvent.click(decline);
+
+    expect(props.onContinue).toHaveBeenCalledTimes(1);
+    expect(
+      mocks.posthogCapture.mock.calls.filter(
+        (call) => call[0] === "screenshot-prompt:decline",
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("does not report a dismissal after the prompt was already answered", () => {
+    const props = renderPrompt();
+    fireEvent.click(screen.getByText(/without screenshot/));
+    fireEvent.click(screen.getByText("mock-dialog-dismiss"));
+
+    expect(props.onDismiss).not.toHaveBeenCalled();
+    expect(mocks.posthogCapture).not.toHaveBeenCalledWith(
+      "screenshot-prompt:dismissed",
+      expect.anything(),
+    );
   });
 
   it("files the report as declined when the reporter skips the screenshot", () => {
@@ -187,7 +213,7 @@ describe("BugScreenshotDialog", () => {
     );
     expect(mocks.posthogCapture).toHaveBeenCalledWith(
       "screenshot-prompt:capture-failed",
-      { source: "upload-session", reason: "No focused window to capture" },
+      { source: "upload-session", failure: "no-focused-window" },
     );
   });
 

--- a/src/components/BugScreenshotDialog.test.tsx
+++ b/src/components/BugScreenshotDialog.test.tsx
@@ -1,0 +1,144 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { BugScreenshotDialog } from "./BugScreenshotDialog";
+
+const mocks = vi.hoisted(() => ({
+  takeScreenshot: vi.fn(),
+  posthogCapture: vi.fn(),
+}));
+
+vi.mock("@/ipc/types", () => ({
+  ipc: { system: { takeScreenshot: mocks.takeScreenshot } },
+}));
+
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => ({ capture: mocks.posthogCapture }),
+}));
+
+vi.mock("./ui/dialog", () => ({
+  Dialog: ({
+    open,
+    onOpenChange,
+    children,
+  }: {
+    open: boolean;
+    onOpenChange?: (open: boolean) => void;
+    children: React.ReactNode;
+  }) =>
+    open ? (
+      <div>
+        {/* Stands in for Esc, the overlay, and the built-in close button. */}
+        <button onClick={() => onOpenChange?.(false)}>
+          mock-dialog-dismiss
+        </button>
+        {children}
+      </div>
+    ) : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogHeader: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogTitle: ({ children }: { children: React.ReactNode }) => (
+    <h2>{children}</h2>
+  ),
+}));
+
+function renderPrompt(
+  overrides: Partial<Parameters<typeof BugScreenshotDialog>[0]> = {},
+) {
+  const props = {
+    isOpen: true,
+    onClose: vi.fn(),
+    onDismiss: vi.fn(),
+    onContinue: vi.fn(),
+    isLoading: false,
+    source: "report-bug" as const,
+    ...overrides,
+  };
+  render(<BugScreenshotDialog {...props} />);
+  return props;
+}
+
+describe("BugScreenshotDialog", () => {
+  beforeEach(() => {
+    mocks.takeScreenshot.mockReset().mockResolvedValue(undefined);
+    mocks.posthogCapture.mockReset();
+  });
+
+  it("reports that the prompt was shown, with its source", () => {
+    renderPrompt({ source: "upload-session" });
+    expect(mocks.posthogCapture).toHaveBeenCalledWith(
+      "screenshot-prompt:shown",
+      { source: "upload-session" },
+    );
+  });
+
+  it("does not report a prompt that was never opened", () => {
+    renderPrompt({ isOpen: false });
+    expect(mocks.posthogCapture).not.toHaveBeenCalled();
+  });
+
+  it("reports a dismissal as backing out, not as a decline", () => {
+    const props = renderPrompt({ source: "upload-session" });
+    fireEvent.click(screen.getByText("mock-dialog-dismiss"));
+
+    expect(props.onDismiss).toHaveBeenCalled();
+    expect(props.onContinue).not.toHaveBeenCalled();
+  });
+
+  it("files the report as declined when the reporter skips the screenshot", () => {
+    const props = renderPrompt();
+    fireEvent.click(screen.getByText(/without screenshot/));
+
+    expect(props.onContinue).toHaveBeenCalledWith({ status: "declined" });
+    expect(mocks.posthogCapture).toHaveBeenCalledWith(
+      "screenshot-prompt:decline",
+      { source: "report-bug" },
+    );
+  });
+
+  it("captures a screenshot and files the report as captured", async () => {
+    const props = renderPrompt();
+    fireEvent.click(screen.getByRole("button", { name: /recommended/ }));
+
+    expect(props.onClose).toHaveBeenCalled();
+    expect(mocks.posthogCapture).toHaveBeenCalledWith(
+      "screenshot-prompt:capture",
+      { source: "report-bug" },
+    );
+
+    await waitFor(() => expect(mocks.takeScreenshot).toHaveBeenCalled());
+    fireEvent.click(await screen.findByText("Create GitHub issue"));
+    expect(props.onContinue).toHaveBeenCalledWith({ status: "captured" });
+  });
+
+  it("still files the report when the capture fails, recording why", async () => {
+    mocks.takeScreenshot.mockRejectedValue(
+      new Error("No focused window to capture"),
+    );
+    const props = renderPrompt({ source: "upload-session" });
+    fireEvent.click(screen.getByRole("button", { name: /recommended/ }));
+
+    await waitFor(() =>
+      expect(props.onContinue).toHaveBeenCalledWith({
+        status: "capture-failed",
+        reason: "No focused window to capture",
+      }),
+    );
+    expect(mocks.posthogCapture).toHaveBeenCalledWith(
+      "screenshot-prompt:capture-failed",
+      { source: "upload-session", reason: "No focused window to capture" },
+    );
+  });
+
+  it("does not show the paste reminder when the capture fails", async () => {
+    mocks.takeScreenshot.mockRejectedValue(new Error("nope"));
+    renderPrompt();
+    fireEvent.click(screen.getByRole("button", { name: /recommended/ }));
+
+    await waitFor(() => expect(mocks.takeScreenshot).toHaveBeenCalled());
+    expect(screen.queryByText("Create GitHub issue")).toBeNull();
+  });
+});

--- a/src/components/BugScreenshotDialog.test.tsx
+++ b/src/components/BugScreenshotDialog.test.tsx
@@ -210,6 +210,35 @@ describe("BugScreenshotDialog", () => {
     );
   });
 
+  it("reports a late capture under the source that started it", async () => {
+    const props = renderPrompt({
+      source: "upload-session",
+      report: { kind: "session", sessionId: "v2:first" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /recommended/ }));
+    await waitFor(() => expect(mocks.takeScreenshot).toHaveBeenCalled());
+
+    // The other flow opens a prompt while this capture is still resolving.
+    props.view.rerender(
+      <BugScreenshotDialog
+        {...props.props}
+        source="report-bug"
+        report={{ kind: "bug" }}
+      />,
+    );
+    fireEvent.click(await screen.findByText("Create GitHub issue"));
+
+    // Both halves of one capture belong to the same flow.
+    expect(mocks.posthogCapture).toHaveBeenCalledWith(
+      "screenshot-prompt:capture-attempt",
+      { source: "upload-session" },
+    );
+    expect(mocks.posthogCapture).toHaveBeenCalledWith(
+      "screenshot-prompt:captured",
+      { source: "upload-session" },
+    );
+  });
+
   it("reports a captured screenshot that the reporter abandons", async () => {
     const props = renderPrompt({ source: "upload-session" });
     fireEvent.click(screen.getByRole("button", { name: /recommended/ }));

--- a/src/components/BugScreenshotDialog.tsx
+++ b/src/components/BugScreenshotDialog.tsx
@@ -11,16 +11,26 @@ import { type ScreenshotOutcome } from "@/lib/issueBody";
 /** Which report flow opened the prompt. Reported with every prompt event. */
 export type ScreenshotPromptSource = "report-bug" | "upload-session";
 
+/**
+ * Known capture failures, reported instead of the raw message so the event
+ * carries a fixed set of values. The raw message still reaches the issue body,
+ * which the reporter sees before submitting.
+ */
+function classifyCaptureFailure(reason: string): string {
+  if (reason.includes("No focused window")) return "no-focused-window";
+  if (reason.includes("Failed to capture screenshot")) return "empty-image";
+  if (reason.includes("IPC renderer not available")) return "ipc-unavailable";
+  return "other";
+}
+
 /** Copy that differs between the two flows, keyed by the reporting source. */
 const VARIANTS = {
   "report-bug": {
     declineLabel: "File bug report without screenshot",
-    pendingLabel: "Preparing Report...",
     icon: <BugIcon className="mr-2 h-5 w-5" />,
   },
   "upload-session": {
     declineLabel: "Create issue without screenshot",
-    pendingLabel: "Creating Issue...",
     icon: <MessageSquareIcon className="mr-2 h-5 w-5" />,
   },
 } as const;
@@ -29,11 +39,10 @@ interface BugScreenshotDialogProps {
   isOpen: boolean;
   /** Hides the prompt without ending the flow, so it stays out of the capture. */
   onClose: () => void;
-  /** The reporter backed out of the prompt without filing anything. */
+  /** The reporter backed out without filing anything. */
   onDismiss: () => void;
   /** Files the report, recording what happened with the screenshot. */
-  onContinue: (outcome: ScreenshotOutcome) => void | Promise<void>;
-  isLoading: boolean;
+  onContinue: (outcome: ScreenshotOutcome) => void;
   source: ScreenshotPromptSource;
 }
 
@@ -42,12 +51,15 @@ export function BugScreenshotDialog({
   onClose,
   onDismiss,
   onContinue,
-  isLoading,
   source,
 }: BugScreenshotDialogProps) {
-  const { declineLabel, pendingLabel, icon } = VARIANTS[source];
+  const { declineLabel, icon } = VARIANTS[source];
   const [isScreenshotSuccessOpen, setIsScreenshotSuccessOpen] = useState(false);
   const hasReportedShown = useRef(false);
+  // A dialog stays clickable through its closing animation. These keep one
+  // answer per opening, so a second click cannot file or report twice.
+  const promptAnswered = useRef(false);
+  const captureAnswered = useRef(false);
   const posthog = usePostHog();
 
   // Latched on the open edge so the count is one per prompt, whatever else
@@ -59,21 +71,30 @@ export function BugScreenshotDialog({
     }
     if (hasReportedShown.current) return;
     hasReportedShown.current = true;
+    // Reset on open rather than on close, because the prompt is still
+    // clickable while it animates out.
+    promptAnswered.current = false;
     posthog.capture("screenshot-prompt:shown", { source });
   }, [isOpen, source, posthog]);
 
   const handleCapture = () => {
+    if (promptAnswered.current) return;
+    promptAnswered.current = true;
     // An attempt, not a success: the capture can still fail below.
     posthog.capture("screenshot-prompt:capture-attempt", { source });
     onClose();
     setTimeout(async () => {
       try {
         await ipc.system.takeScreenshot();
+        captureAnswered.current = false;
         setIsScreenshotSuccessOpen(true);
       } catch (error) {
         const reason =
           error instanceof Error ? error.message : "Failed to take screenshot";
-        posthog.capture("screenshot-prompt:capture-failed", { source, reason });
+        posthog.capture("screenshot-prompt:capture-failed", {
+          source,
+          failure: classifyCaptureFailure(reason),
+        });
         // Prevents the case where the reporter reaches GitHub expecting an
         // image on the clipboard and pastes whatever is there instead.
         showError(`Failed to take screenshot: ${reason}`);
@@ -82,27 +103,25 @@ export function BugScreenshotDialog({
     }, 200); // Small delay for dialog to close
   };
 
-  const handleDecline = async () => {
+  const handleDecline = () => {
+    if (promptAnswered.current) return;
+    promptAnswered.current = true;
     posthog.capture("screenshot-prompt:decline", { source });
-    // Keeps the pending label on screen while the logs are gathered.
-    await onContinue({ status: "declined" });
     onClose();
+    onContinue({ status: "declined" });
+  };
+
+  const handlePromptDismiss = () => {
+    if (promptAnswered.current) return;
+    promptAnswered.current = true;
+    posthog.capture("screenshot-prompt:dismissed", { source });
+    onDismiss();
   };
 
   return (
     <>
-      <Dialog open={isOpen} onOpenChange={onDismiss}>
-        {/* While the report is being prepared the prompt has no working exit,
-            so don't offer one: onDismiss ignores dismissals until it lands. */}
-        <DialogContent showCloseButton={!isLoading}>
-          <span
-            className="sr-only"
-            role="status"
-            aria-live="polite"
-            aria-atomic="true"
-          >
-            {isLoading ? pendingLabel : ""}
-          </span>
+      <Dialog open={isOpen} onOpenChange={handlePromptDismiss}>
+        <DialogContent>
           <DialogHeader>
             <DialogTitle>Take a screenshot?</DialogTitle>
           </DialogHeader>
@@ -111,7 +130,6 @@ export function BugScreenshotDialog({
               <Button
                 variant="default"
                 onClick={handleCapture}
-                disabled={isLoading}
                 className="w-full py-6 border-primary/50 shadow-sm shadow-primary/10 transition-all hover:shadow-md hover:shadow-primary/15"
               >
                 <Camera className="mr-2 h-5 w-5" /> Take a screenshot
@@ -125,10 +143,9 @@ export function BugScreenshotDialog({
               <Button
                 variant="outline"
                 onClick={handleDecline}
-                disabled={isLoading}
                 className="w-full py-6 bg-(--background-lightest)"
               >
-                {icon} {isLoading ? pendingLabel : declineLabel}
+                {icon} {declineLabel}
               </Button>
               <p className="text-sm text-muted-foreground px-2">
                 We'll still try to respond but might not be able to help as
@@ -141,21 +158,20 @@ export function BugScreenshotDialog({
       <ScreenshotSuccessDialog
         isOpen={isScreenshotSuccessOpen}
         onDismiss={() => {
-          // Prevents the case where this closes and leaves nothing on screen
-          // while the report it belongs to is still being prepared.
-          if (isLoading) return;
+          if (captureAnswered.current) return;
+          captureAnswered.current = true;
           // A screenshot was taken but no report follows it.
           posthog.capture("screenshot-prompt:capture-abandoned", { source });
           setIsScreenshotSuccessOpen(false);
           onDismiss();
         }}
-        onSubmit={async () => {
+        onSubmit={() => {
+          if (captureAnswered.current) return;
+          captureAnswered.current = true;
           posthog.capture("screenshot-prompt:captured", { source });
-          await onContinue({ status: "captured" });
           setIsScreenshotSuccessOpen(false);
+          onContinue({ status: "captured" });
         }}
-        isLoading={isLoading}
-        pendingLabel={pendingLabel}
         icon={icon}
       />
     </>

--- a/src/components/BugScreenshotDialog.tsx
+++ b/src/components/BugScreenshotDialog.tsx
@@ -121,7 +121,9 @@ export function BugScreenshotDialog({
         });
         // Prevents the case where the reporter reaches GitHub expecting an
         // image on the clipboard and pastes whatever is there instead.
-        showError(`Failed to take screenshot: ${reason}`);
+        // Both known reasons already read as a screenshot failure, so a prefix
+        // here only doubles the message.
+        showError(reason);
         onContinue({ status: "capture-failed", reason }, capturedFor);
       }
     }, 200); // Small delay for dialog to close

--- a/src/components/BugScreenshotDialog.tsx
+++ b/src/components/BugScreenshotDialog.tsx
@@ -47,8 +47,10 @@ interface BugScreenshotDialogProps {
   isOpen: boolean;
   /** Hides the prompt without ending the flow, so it stays out of the capture. */
   onClose: () => void;
-  /** The reporter backed out without filing anything. */
+  /** The reporter backed out of the prompt without answering it. */
   onDismiss: () => void;
+  /** The reporter closed the captured screenshot without filing a report. */
+  onCaptureAbandon: () => void;
   /** Files the report, recording what happened with the screenshot. */
   onContinue: (outcome: ScreenshotOutcome, report: PendingReport) => void;
   source: ScreenshotPromptSource;
@@ -60,6 +62,7 @@ export function BugScreenshotDialog({
   isOpen,
   onClose,
   onDismiss,
+  onCaptureAbandon,
   onContinue,
   source,
   report,
@@ -133,7 +136,7 @@ export function BugScreenshotDialog({
   };
 
   const handlePromptDismiss = () => {
-    if (promptAnswered.current) return;
+    if (promptAnswered.current || !report) return;
     promptAnswered.current = true;
     posthog.capture("screenshot-prompt:dismissed", { source });
     onDismiss();
@@ -186,7 +189,7 @@ export function BugScreenshotDialog({
             source: capture.source,
           });
           setCapture(null);
-          onDismiss();
+          onCaptureAbandon();
         }}
         onSubmit={() => {
           if (captureAnswered.current || !capture) return;

--- a/src/components/BugScreenshotDialog.tsx
+++ b/src/components/BugScreenshotDialog.tsx
@@ -6,20 +6,28 @@ import { useEffect, useRef, useState } from "react";
 import { usePostHog } from "posthog-js/react";
 import { ScreenshotSuccessDialog } from "./ScreenshotSuccessDialog";
 import { showError } from "@/lib/toast";
+import { SCREENSHOT_ERRORS } from "@/ipc/types/system";
 import { type ScreenshotOutcome } from "@/lib/issueBody";
 
 /** Which report flow opened the prompt. Reported with every prompt event. */
 export type ScreenshotPromptSource = "report-bug" | "upload-session";
 
+/** The report a prompt was opened for, carried through to the outcome. */
+export type PendingReport =
+  | { kind: "bug" }
+  | { kind: "session"; sessionId: string };
+
 /**
  * Known capture failures, reported instead of the raw message so the event
  * carries a fixed set of values. The raw message still reaches the issue body,
- * which the reporter sees before submitting.
+ * which the reporter sees before submitting. Matching on the shared constants
+ * keeps this in step with what the handler throws.
  */
 function classifyCaptureFailure(reason: string): string {
-  if (reason.includes("No focused window")) return "no-focused-window";
-  if (reason.includes("Failed to capture screenshot")) return "empty-image";
-  if (reason.includes("IPC renderer not available")) return "ipc-unavailable";
+  if (reason.includes(SCREENSHOT_ERRORS.noFocusedWindow)) {
+    return "no-focused-window";
+  }
+  if (reason.includes(SCREENSHOT_ERRORS.emptyImage)) return "empty-image";
   return "other";
 }
 
@@ -42,8 +50,10 @@ interface BugScreenshotDialogProps {
   /** The reporter backed out without filing anything. */
   onDismiss: () => void;
   /** Files the report, recording what happened with the screenshot. */
-  onContinue: (outcome: ScreenshotOutcome) => void;
+  onContinue: (outcome: ScreenshotOutcome, report: PendingReport) => void;
   source: ScreenshotPromptSource;
+  /** The report this prompt was opened for. */
+  report: PendingReport | null;
 }
 
 export function BugScreenshotDialog({
@@ -52,9 +62,12 @@ export function BugScreenshotDialog({
   onDismiss,
   onContinue,
   source,
+  report,
 }: BugScreenshotDialogProps) {
   const { declineLabel, icon } = VARIANTS[source];
-  const [isScreenshotSuccessOpen, setIsScreenshotSuccessOpen] = useState(false);
+  const [successReport, setSuccessReport] = useState<PendingReport | null>(
+    null,
+  );
   const hasReportedShown = useRef(false);
   // A dialog stays clickable through its closing animation. These keep one
   // answer per opening, so a second click cannot file or report twice.
@@ -71,15 +84,22 @@ export function BugScreenshotDialog({
     }
     if (hasReportedShown.current) return;
     hasReportedShown.current = true;
-    // Reset on open rather than on close, because the prompt is still
-    // clickable while it animates out.
-    promptAnswered.current = false;
     posthog.capture("screenshot-prompt:shown", { source });
   }, [isOpen, source, posthog]);
 
+  // Kept separate from the event above so a change there cannot disable the
+  // guard. Reset on open rather than on close, because the prompt is still
+  // clickable while it animates out.
+  useEffect(() => {
+    if (isOpen) promptAnswered.current = false;
+  }, [isOpen]);
+
   const handleCapture = () => {
-    if (promptAnswered.current) return;
+    if (promptAnswered.current || !report) return;
     promptAnswered.current = true;
+    // Captured per invocation, so a capture that resolves after another has
+    // started still files against the report that began it.
+    const capturedFor = report;
     // An attempt, not a success: the capture can still fail below.
     posthog.capture("screenshot-prompt:capture-attempt", { source });
     onClose();
@@ -87,7 +107,7 @@ export function BugScreenshotDialog({
       try {
         await ipc.system.takeScreenshot();
         captureAnswered.current = false;
-        setIsScreenshotSuccessOpen(true);
+        setSuccessReport(capturedFor);
       } catch (error) {
         const reason =
           error instanceof Error ? error.message : "Failed to take screenshot";
@@ -98,17 +118,17 @@ export function BugScreenshotDialog({
         // Prevents the case where the reporter reaches GitHub expecting an
         // image on the clipboard and pastes whatever is there instead.
         showError(`Failed to take screenshot: ${reason}`);
-        onContinue({ status: "capture-failed", reason });
+        onContinue({ status: "capture-failed", reason }, capturedFor);
       }
     }, 200); // Small delay for dialog to close
   };
 
   const handleDecline = () => {
-    if (promptAnswered.current) return;
+    if (promptAnswered.current || !report) return;
     promptAnswered.current = true;
     posthog.capture("screenshot-prompt:decline", { source });
     onClose();
-    onContinue({ status: "declined" });
+    onContinue({ status: "declined" }, report);
   };
 
   const handlePromptDismiss = () => {
@@ -156,21 +176,21 @@ export function BugScreenshotDialog({
         </DialogContent>
       </Dialog>
       <ScreenshotSuccessDialog
-        isOpen={isScreenshotSuccessOpen}
+        isOpen={successReport !== null}
         onDismiss={() => {
           if (captureAnswered.current) return;
           captureAnswered.current = true;
           // A screenshot was taken but no report follows it.
           posthog.capture("screenshot-prompt:capture-abandoned", { source });
-          setIsScreenshotSuccessOpen(false);
+          setSuccessReport(null);
           onDismiss();
         }}
         onSubmit={() => {
-          if (captureAnswered.current) return;
+          if (captureAnswered.current || !successReport) return;
           captureAnswered.current = true;
           posthog.capture("screenshot-prompt:captured", { source });
-          setIsScreenshotSuccessOpen(false);
-          onContinue({ status: "captured" });
+          setSuccessReport(null);
+          onContinue({ status: "captured" }, successReport);
         }}
         icon={icon}
       />

--- a/src/components/BugScreenshotDialog.tsx
+++ b/src/components/BugScreenshotDialog.tsx
@@ -1,90 +1,145 @@
 import { ipc } from "@/ipc/types";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "./ui/dialog";
 import { Button } from "./ui/button";
-import { BugIcon, Camera } from "lucide-react";
-import { useState } from "react";
+import { BugIcon, Camera, MessageSquareIcon } from "lucide-react";
+import { useEffect, useState } from "react";
+import { usePostHog } from "posthog-js/react";
 import { ScreenshotSuccessDialog } from "./ScreenshotSuccessDialog";
+import { type ScreenshotOutcome } from "@/lib/issueBody";
+
+/** Which report flow opened the prompt. Reported with every prompt event. */
+export type ScreenshotPromptSource = "report-bug" | "upload-session";
+
+/**
+ * Everything that differs between the two flows, keyed by the same value the
+ * events are tagged with. Keeping it here rather than in props means the copy
+ * cannot drift out of sync with the source it describes.
+ */
+const VARIANTS = {
+  "report-bug": {
+    declineLabel: "File bug report without screenshot",
+    pendingLabel: "Preparing Report...",
+    declineIcon: <BugIcon className="mr-2 h-5 w-5" />,
+  },
+  "upload-session": {
+    declineLabel: "Create issue without screenshot",
+    pendingLabel: "Creating Issue...",
+    declineIcon: <MessageSquareIcon className="mr-2 h-5 w-5" />,
+  },
+} as const;
 
 interface BugScreenshotDialogProps {
   isOpen: boolean;
+  /** Hides the prompt without ending the flow, so it stays out of the capture. */
   onClose: () => void;
-  handleReportBug: () => Promise<void>;
+  /** The reporter backed out of the prompt without filing anything. */
+  onDismiss: () => void;
+  /** Files the report, recording what happened with the screenshot. */
+  onContinue: (outcome: ScreenshotOutcome) => void | Promise<void>;
   isLoading: boolean;
+  source: ScreenshotPromptSource;
 }
+
 export function BugScreenshotDialog({
   isOpen,
   onClose,
-  handleReportBug,
+  onDismiss,
+  onContinue,
   isLoading,
+  source,
 }: BugScreenshotDialogProps) {
+  const { declineLabel, pendingLabel, declineIcon } = VARIANTS[source];
   const [isScreenshotSuccessOpen, setIsScreenshotSuccessOpen] = useState(false);
-  const [screenshotError, setScreenshotError] = useState<string | null>(null);
+  const posthog = usePostHog();
 
-  const handleReportBugWithScreenshot = async () => {
-    setScreenshotError(null);
+  useEffect(() => {
+    if (!isOpen) return;
+    posthog.capture("screenshot-prompt:shown", { source });
+  }, [isOpen, source, posthog]);
+
+  const handleCapture = () => {
+    posthog.capture("screenshot-prompt:capture", { source });
     onClose();
     setTimeout(async () => {
       try {
         await ipc.system.takeScreenshot();
         setIsScreenshotSuccessOpen(true);
       } catch (error) {
-        setScreenshotError(
-          error instanceof Error ? error.message : "Failed to take screenshot",
-        );
+        const reason =
+          error instanceof Error ? error.message : "Failed to take screenshot";
+        posthog.capture("screenshot-prompt:capture-failed", { source, reason });
+        // Carry on to the issue. The reporter came here to file one, and the
+        // status line records why no screenshot is attached.
+        onContinue({ status: "capture-failed", reason });
       }
     }, 200); // Small delay for dialog to close
   };
 
+  const handleDecline = async () => {
+    posthog.capture("screenshot-prompt:decline", { source });
+    // Stay open, showing the pending label, until the issue is ready. Closing
+    // first leaves the reporter with no feedback while logs are gathered.
+    await onContinue({ status: "declined" });
+    onClose();
+  };
+
   return (
-    <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Take a screenshot?</DialogTitle>
-        </DialogHeader>
-        <div className="flex flex-col space-y-4 w-full">
-          <div className="flex flex-col space-y-2">
-            <Button
-              variant="default"
-              onClick={handleReportBugWithScreenshot}
-              className="w-full py-6 border-primary/50 shadow-sm shadow-primary/10 transition-all hover:shadow-md hover:shadow-primary/15"
-            >
-              <Camera className="mr-2 h-5 w-5" /> Take a screenshot
-              (recommended)
-            </Button>
-            <p className="text-sm text-muted-foreground px-2">
-              You'll get better and faster responses if you do this!
-            </p>
+    <>
+      <Dialog open={isOpen} onOpenChange={onDismiss}>
+        {/* While the report is being prepared the prompt has no working exit,
+            so don't offer one: onDismiss ignores dismissals until it lands. */}
+        <DialogContent showCloseButton={!isLoading}>
+          <DialogHeader>
+            <DialogTitle>Take a screenshot?</DialogTitle>
+          </DialogHeader>
+          <div className="flex flex-col space-y-4 w-full">
+            <div className="flex flex-col space-y-2">
+              <Button
+                variant="default"
+                onClick={handleCapture}
+                disabled={isLoading}
+                className="w-full py-6 border-primary/50 shadow-sm shadow-primary/10 transition-all hover:shadow-md hover:shadow-primary/15"
+              >
+                <Camera className="mr-2 h-5 w-5" /> Take a screenshot
+                (recommended)
+              </Button>
+              <p className="text-sm text-muted-foreground px-2">
+                You'll get better and faster responses if you do this!
+              </p>
+            </div>
+            <div className="flex flex-col space-y-2">
+              <Button
+                variant="outline"
+                onClick={handleDecline}
+                disabled={isLoading}
+                className="w-full py-6 bg-(--background-lightest)"
+              >
+                {declineIcon} {isLoading ? pendingLabel : declineLabel}
+              </Button>
+              <p className="text-sm text-muted-foreground px-2">
+                We'll still try to respond but might not be able to help as
+                much.
+              </p>
+            </div>
           </div>
-          <div className="flex flex-col space-y-2">
-            <Button
-              variant="outline"
-              onClick={() => {
-                handleReportBug();
-              }}
-              className="w-full py-6 bg-(--background-lightest)"
-            >
-              <BugIcon className="mr-2 h-5 w-5" />{" "}
-              {isLoading
-                ? "Preparing Report..."
-                : "File bug report without screenshot"}
-            </Button>
-            <p className="text-sm text-muted-foreground px-2">
-              We'll still try to respond but might not be able to help as much.
-            </p>
-          </div>
-          {screenshotError && (
-            <p className="text-sm text-destructive px-2">
-              Failed to take screenshot: {screenshotError}
-            </p>
-          )}
-        </div>
-      </DialogContent>
+        </DialogContent>
+      </Dialog>
       <ScreenshotSuccessDialog
         isOpen={isScreenshotSuccessOpen}
-        onClose={() => setIsScreenshotSuccessOpen(false)}
-        handleReportBug={handleReportBug}
+        onDismiss={() => {
+          // Matches the prompt: a report already on its way cannot be called
+          // off, so don't let this close either and leave nothing on screen.
+          if (isLoading) return;
+          setIsScreenshotSuccessOpen(false);
+          onDismiss();
+        }}
+        onSubmit={async () => {
+          await onContinue({ status: "captured" });
+          setIsScreenshotSuccessOpen(false);
+        }}
         isLoading={isLoading}
+        pendingLabel={pendingLabel}
       />
-    </Dialog>
+    </>
   );
 }

--- a/src/components/BugScreenshotDialog.tsx
+++ b/src/components/BugScreenshotDialog.tsx
@@ -16,12 +16,12 @@ const VARIANTS = {
   "report-bug": {
     declineLabel: "File bug report without screenshot",
     pendingLabel: "Preparing Report...",
-    declineIcon: <BugIcon className="mr-2 h-5 w-5" />,
+    icon: <BugIcon className="mr-2 h-5 w-5" />,
   },
   "upload-session": {
     declineLabel: "Create issue without screenshot",
     pendingLabel: "Creating Issue...",
-    declineIcon: <MessageSquareIcon className="mr-2 h-5 w-5" />,
+    icon: <MessageSquareIcon className="mr-2 h-5 w-5" />,
   },
 } as const;
 
@@ -45,7 +45,7 @@ export function BugScreenshotDialog({
   isLoading,
   source,
 }: BugScreenshotDialogProps) {
-  const { declineLabel, pendingLabel, declineIcon } = VARIANTS[source];
+  const { declineLabel, pendingLabel, icon } = VARIANTS[source];
   const [isScreenshotSuccessOpen, setIsScreenshotSuccessOpen] = useState(false);
   const hasReportedShown = useRef(false);
   const posthog = usePostHog();
@@ -128,7 +128,7 @@ export function BugScreenshotDialog({
                 disabled={isLoading}
                 className="w-full py-6 bg-(--background-lightest)"
               >
-                {declineIcon} {isLoading ? pendingLabel : declineLabel}
+                {icon} {isLoading ? pendingLabel : declineLabel}
               </Button>
               <p className="text-sm text-muted-foreground px-2">
                 We'll still try to respond but might not be able to help as
@@ -141,18 +141,22 @@ export function BugScreenshotDialog({
       <ScreenshotSuccessDialog
         isOpen={isScreenshotSuccessOpen}
         onDismiss={() => {
-          // Matches the prompt: a report already on its way cannot be called
-          // off, so don't let this close either and leave nothing on screen.
+          // Prevents the case where this closes and leaves nothing on screen
+          // while the report it belongs to is still being prepared.
           if (isLoading) return;
+          // A screenshot was taken but no report follows it.
+          posthog.capture("screenshot-prompt:capture-abandoned", { source });
           setIsScreenshotSuccessOpen(false);
           onDismiss();
         }}
         onSubmit={async () => {
+          posthog.capture("screenshot-prompt:captured", { source });
           await onContinue({ status: "captured" });
           setIsScreenshotSuccessOpen(false);
         }}
         isLoading={isLoading}
         pendingLabel={pendingLabel}
+        icon={icon}
       />
     </>
   );

--- a/src/components/BugScreenshotDialog.tsx
+++ b/src/components/BugScreenshotDialog.tsx
@@ -65,9 +65,10 @@ export function BugScreenshotDialog({
   report,
 }: BugScreenshotDialogProps) {
   const { declineLabel, icon } = VARIANTS[source];
-  const [successReport, setSuccessReport] = useState<PendingReport | null>(
-    null,
-  );
+  const [capture, setCapture] = useState<{
+    report: PendingReport;
+    source: ScreenshotPromptSource;
+  } | null>(null);
   const hasReportedShown = useRef(false);
   // A dialog stays clickable through its closing animation. These keep one
   // answer per opening, so a second click cannot file or report twice.
@@ -107,7 +108,7 @@ export function BugScreenshotDialog({
       try {
         await ipc.system.takeScreenshot();
         captureAnswered.current = false;
-        setSuccessReport(capturedFor);
+        setCapture({ report: capturedFor, source });
       } catch (error) {
         const reason =
           error instanceof Error ? error.message : "Failed to take screenshot";
@@ -176,23 +177,27 @@ export function BugScreenshotDialog({
         </DialogContent>
       </Dialog>
       <ScreenshotSuccessDialog
-        isOpen={successReport !== null}
+        isOpen={capture !== null}
         onDismiss={() => {
-          if (captureAnswered.current) return;
+          if (captureAnswered.current || !capture) return;
           captureAnswered.current = true;
           // A screenshot was taken but no report follows it.
-          posthog.capture("screenshot-prompt:capture-abandoned", { source });
-          setSuccessReport(null);
+          posthog.capture("screenshot-prompt:capture-abandoned", {
+            source: capture.source,
+          });
+          setCapture(null);
           onDismiss();
         }}
         onSubmit={() => {
-          if (captureAnswered.current || !successReport) return;
+          if (captureAnswered.current || !capture) return;
           captureAnswered.current = true;
-          posthog.capture("screenshot-prompt:captured", { source });
-          setSuccessReport(null);
-          onContinue({ status: "captured" }, successReport);
+          posthog.capture("screenshot-prompt:captured", {
+            source: capture.source,
+          });
+          setCapture(null);
+          onContinue({ status: "captured" }, capture.report);
         }}
-        icon={icon}
+        icon={VARIANTS[capture?.source ?? source].icon}
       />
     </>
   );

--- a/src/components/BugScreenshotDialog.tsx
+++ b/src/components/BugScreenshotDialog.tsx
@@ -2,19 +2,16 @@ import { ipc } from "@/ipc/types";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "./ui/dialog";
 import { Button } from "./ui/button";
 import { BugIcon, Camera, MessageSquareIcon } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { usePostHog } from "posthog-js/react";
 import { ScreenshotSuccessDialog } from "./ScreenshotSuccessDialog";
+import { showError } from "@/lib/toast";
 import { type ScreenshotOutcome } from "@/lib/issueBody";
 
 /** Which report flow opened the prompt. Reported with every prompt event. */
 export type ScreenshotPromptSource = "report-bug" | "upload-session";
 
-/**
- * Everything that differs between the two flows, keyed by the same value the
- * events are tagged with. Keeping it here rather than in props means the copy
- * cannot drift out of sync with the source it describes.
- */
+/** Copy that differs between the two flows, keyed by the reporting source. */
 const VARIANTS = {
   "report-bug": {
     declineLabel: "File bug report without screenshot",
@@ -50,15 +47,24 @@ export function BugScreenshotDialog({
 }: BugScreenshotDialogProps) {
   const { declineLabel, pendingLabel, declineIcon } = VARIANTS[source];
   const [isScreenshotSuccessOpen, setIsScreenshotSuccessOpen] = useState(false);
+  const hasReportedShown = useRef(false);
   const posthog = usePostHog();
 
+  // Latched on the open edge so the count is one per prompt, whatever else
+  // changes while it is on screen.
   useEffect(() => {
-    if (!isOpen) return;
+    if (!isOpen) {
+      hasReportedShown.current = false;
+      return;
+    }
+    if (hasReportedShown.current) return;
+    hasReportedShown.current = true;
     posthog.capture("screenshot-prompt:shown", { source });
   }, [isOpen, source, posthog]);
 
   const handleCapture = () => {
-    posthog.capture("screenshot-prompt:capture", { source });
+    // An attempt, not a success: the capture can still fail below.
+    posthog.capture("screenshot-prompt:capture-attempt", { source });
     onClose();
     setTimeout(async () => {
       try {
@@ -68,8 +74,9 @@ export function BugScreenshotDialog({
         const reason =
           error instanceof Error ? error.message : "Failed to take screenshot";
         posthog.capture("screenshot-prompt:capture-failed", { source, reason });
-        // Carry on to the issue. The reporter came here to file one, and the
-        // status line records why no screenshot is attached.
+        // Prevents the case where the reporter reaches GitHub expecting an
+        // image on the clipboard and pastes whatever is there instead.
+        showError(`Failed to take screenshot: ${reason}`);
         onContinue({ status: "capture-failed", reason });
       }
     }, 200); // Small delay for dialog to close
@@ -77,8 +84,7 @@ export function BugScreenshotDialog({
 
   const handleDecline = async () => {
     posthog.capture("screenshot-prompt:decline", { source });
-    // Stay open, showing the pending label, until the issue is ready. Closing
-    // first leaves the reporter with no feedback while logs are gathered.
+    // Keeps the pending label on screen while the logs are gathered.
     await onContinue({ status: "declined" });
     onClose();
   };
@@ -89,6 +95,14 @@ export function BugScreenshotDialog({
         {/* While the report is being prepared the prompt has no working exit,
             so don't offer one: onDismiss ignores dismissals until it lands. */}
         <DialogContent showCloseButton={!isLoading}>
+          <span
+            className="sr-only"
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            {isLoading ? pendingLabel : ""}
+          </span>
           <DialogHeader>
             <DialogTitle>Take a screenshot?</DialogTitle>
           </DialogHeader>

--- a/src/components/HelpDialog.test.tsx
+++ b/src/components/HelpDialog.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useSetAtom } from "jotai";
 import { useEffect } from "react";
 import { HelpDialog } from "./HelpDialog";
@@ -163,6 +163,10 @@ function bodyOfOpenedIssue(): string {
 }
 
 describe("HelpDialog screenshot prompt", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.getSystemDebugInfo.mockResolvedValue(debugInfo);
@@ -353,6 +357,71 @@ describe("HelpDialog screenshot prompt", () => {
 
     await waitFor(() => expect(mocks.openExternalUrl).toHaveBeenCalled());
     expect(bodyOfOpenedIssue()).toContain("Screenshot status: declined");
+  });
+
+  it("abandoning a late capture leaves a newer prompt alone", async () => {
+    let releaseCapture = () => {};
+    mocks.takeScreenshot.mockReturnValue(
+      new Promise<void>((resolve) => {
+        releaseCapture = resolve;
+      }),
+    );
+
+    await reachUploadCompleteScreen();
+    fireEvent.click(screen.getByText("Create GitHub Issue"));
+    fireEvent.click(await screen.findByRole("button", { name: /recommended/ }));
+    await waitFor(() => expect(mocks.takeScreenshot).toHaveBeenCalled());
+
+    // A second report starts while the first capture is still resolving. The
+    // reopened dialog keeps the upload-complete screen, so it starts there.
+    fireEvent.click(screen.getByText("reopen-help"));
+    fireEvent.click(await screen.findByText("Create GitHub Issue"));
+    await screen.findByText("Take a screenshot?");
+
+    // The first capture lands and stacks its success dialog on top.
+    releaseCapture();
+    const dismissals = await waitFor(() => {
+      const found = screen.getAllByText("mock-dialog-dismiss");
+      expect(found.length).toBeGreaterThan(1);
+      return found;
+    });
+
+    // Abandoning it must not take the newer prompt down with it.
+    fireEvent.click(dismissals[dismissals.length - 1]);
+    expect(screen.getByText("Take a screenshot?")).toBeTruthy();
+    expect(mocks.openExternalUrl).not.toHaveBeenCalled();
+  });
+
+  it("returns to help when an abandoned capture is the last thing on screen", async () => {
+    const releases: (() => void)[] = [];
+    mocks.takeScreenshot.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          releases.push(resolve);
+        }),
+    );
+
+    await reachUploadCompleteScreen();
+    fireEvent.click(screen.getByText("Create GitHub Issue"));
+    fireEvent.click(await screen.findByRole("button", { name: /recommended/ }));
+    await waitFor(() => expect(releases).toHaveLength(1));
+
+    // A second report is started and answered while the first still hangs.
+    fireEvent.click(screen.getByText("reopen-help"));
+    fireEvent.click(await screen.findByText("Create GitHub Issue"));
+    fireEvent.click(await screen.findByRole("button", { name: /recommended/ }));
+    await waitFor(() => expect(releases).toHaveLength(2));
+
+    // They land out of order, so the dialog on screen is not the newest report.
+    releases[1]();
+    await screen.findByText("Create GitHub issue");
+    releases[0]();
+
+    const dismissals = screen.getAllByText("mock-dialog-dismiss");
+    fireEvent.click(dismissals[dismissals.length - 1]);
+
+    // With no prompt left open, backing out has to land somewhere.
+    expect(await screen.findByText("Upload Complete")).toBeTruthy();
   });
 
   it("still offers the prompt on the bug report path", async () => {

--- a/src/components/HelpDialog.test.tsx
+++ b/src/components/HelpDialog.test.tsx
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   uploadToSignedUrl: vi.fn(),
   openExternalUrl: vi.fn(),
   takeScreenshot: vi.fn(),
+  showInfo: vi.fn(),
 }));
 
 vi.mock("@/ipc/types", () => ({
@@ -56,7 +57,10 @@ vi.mock("@/hooks/useLanguageModelsByProviders", () => ({
   useLanguageModelsByProviders: () => ({ data: undefined }),
 }));
 
-vi.mock("@/lib/toast", () => ({ showError: vi.fn() }));
+vi.mock("@/lib/toast", () => ({
+  showError: vi.fn(),
+  showInfo: mocks.showInfo,
+}));
 
 vi.mock("./HelpBotDialog", () => ({ HelpBotDialog: () => null }));
 
@@ -233,7 +237,7 @@ describe("HelpDialog screenshot prompt", () => {
     expect(bodyOfOpenedIssue()).toContain("Session ID: v2:abc");
   });
 
-  it("keeps the prompt open showing progress while the report is prepared", async () => {
+  it("reports progress outside the prompt once it is answered", async () => {
     let releaseDebugInfo = (_: unknown) => {};
     mocks.getSystemDebugInfo.mockReturnValue(
       new Promise((resolve) => {
@@ -247,21 +251,19 @@ describe("HelpDialog screenshot prompt", () => {
       await screen.findByText("File bug report without screenshot"),
     );
 
-    // Gathering logs takes a moment; the reporter should see that it is
-    // happening rather than a dialog that vanished and did nothing.
-    expect(
-      await screen.findByRole("button", { name: /Preparing Report/ }),
-    ).toBeTruthy();
+    // The prompt is finished the moment it is answered, and gathering logs
+    // takes a moment, so progress is reported outside the dialog.
+    await waitFor(() =>
+      expect(screen.queryByText("Take a screenshot?")).toBeNull(),
+    );
+    expect(mocks.showInfo).toHaveBeenCalled();
     expect(mocks.openExternalUrl).not.toHaveBeenCalled();
 
     releaseDebugInfo(debugInfo);
     await waitFor(() => expect(mocks.openExternalUrl).toHaveBeenCalled());
-    await waitFor(() =>
-      expect(screen.queryByText("Take a screenshot?")).toBeNull(),
-    );
   });
 
-  it("does not let a report in flight be dismissed or interleaved with a capture", async () => {
+  it("leaves the reporter's dialogs alone while a report is prepared", async () => {
     let releaseDebugInfo = (_: unknown) => {};
     mocks.getSystemDebugInfo.mockReturnValue(
       new Promise((resolve) => {
@@ -272,55 +274,72 @@ describe("HelpDialog screenshot prompt", () => {
     await reachUploadCompleteScreen();
     fireEvent.click(screen.getByText("Create GitHub Issue"));
     fireEvent.click(await screen.findByText("Create issue without screenshot"));
-    await screen.findByRole("button", { name: /Creating Issue/ });
-
-    // The issue is already on its way, so neither exit may take the reporter
-    // somewhere the arriving report would contradict.
-    fireEvent.click(screen.getByText("mock-dialog-dismiss"));
-    expect(screen.queryByText("Upload Complete")).toBeNull();
-    expect(screen.getByRole("button", { name: /Creating Issue/ })).toBeTruthy();
-
-    expect(
-      screen
-        .getByRole("button", { name: /recommended/ })
-        .hasAttribute("disabled"),
-    ).toBe(true);
-    expect(mocks.takeScreenshot).not.toHaveBeenCalled();
-
-    releaseDebugInfo(debugInfo);
-    await waitFor(() => expect(mocks.openExternalUrl).toHaveBeenCalledTimes(1));
-    expect(bodyOfOpenedIssue()).toContain("Session ID: v2:abc");
-  });
-
-  it("cannot open a second prompt sealed shut by an earlier report in flight", async () => {
-    let releaseDebugInfo = (_: unknown) => {};
-    mocks.getSystemDebugInfo.mockReturnValue(
-      new Promise((resolve) => {
-        releaseDebugInfo = resolve;
-      }),
-    );
-    mocks.takeScreenshot.mockRejectedValue(new Error("no window"));
-
-    await reachUploadCompleteScreen();
-    fireEvent.click(screen.getByText("Create GitHub Issue"));
-    fireEvent.click(await screen.findByRole("button", { name: /recommended/ }));
-
-    // Capture failed, so the report is in flight with no dialog on screen.
-    await waitFor(() => expect(mocks.takeScreenshot).toHaveBeenCalled());
     await waitFor(() =>
       expect(screen.queryByText("Take a screenshot?")).toBeNull(),
     );
 
-    // Reopening help restores the upload-complete screen, but its button must
-    // not mount a prompt whose every exit is held shut by the other report.
+    // The reporter goes back into help while the report is still being built.
     fireEvent.click(screen.getByText("reopen-help"));
-    expect(await screen.findByText("Upload Complete")).toBeTruthy();
-    fireEvent.click(screen.getByText("Create GitHub Issue"));
-    expect(screen.queryByText("Take a screenshot?")).toBeNull();
+    expect(await screen.findByText("Need help with Dyad?")).toBeTruthy();
 
     releaseDebugInfo(debugInfo);
-    await waitFor(() => expect(mocks.openExternalUrl).toHaveBeenCalledTimes(1));
-    expect(bodyOfOpenedIssue()).toContain("Screenshot status: capture-failed");
+    await waitFor(() => expect(mocks.openExternalUrl).toHaveBeenCalled());
+
+    // The arriving report files correctly and does not touch what is on screen.
+    expect(bodyOfOpenedIssue()).toContain("Session ID: v2:abc");
+    expect(screen.getByText("Need help with Dyad?")).toBeTruthy();
+  });
+
+  it("reports a dismissal so every opening has an outcome", async () => {
+    render(<OpenHelpDialog />);
+    fireEvent.click(await screen.findByText("Report a Bug"));
+    await screen.findByText("Take a screenshot?");
+
+    fireEvent.click(screen.getByText("mock-dialog-dismiss"));
+
+    expect(posthogClient.capture).toHaveBeenCalledWith(
+      "screenshot-prompt:dismissed",
+      { source: "report-bug" },
+    );
+  });
+
+  it("files a second report started while the first is still preparing", async () => {
+    const releases: ((value: unknown) => void)[] = [];
+    mocks.getSystemDebugInfo.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          releases.push(resolve);
+        }),
+    );
+
+    await reachUploadCompleteScreen();
+    fireEvent.click(screen.getByText("Create GitHub Issue"));
+    fireEvent.click(await screen.findByText("Create issue without screenshot"));
+    await waitFor(() =>
+      expect(screen.queryByText("Take a screenshot?")).toBeNull(),
+    );
+
+    fireEvent.click(screen.getByText("reopen-help"));
+    fireEvent.click(await screen.findByText("Report a Bug"));
+    fireEvent.click(
+      await screen.findByText("File bug report without screenshot"),
+    );
+
+    expect(releases).toHaveLength(2);
+    releases[0](debugInfo);
+    releases[1](debugInfo);
+    await waitFor(() => expect(mocks.openExternalUrl).toHaveBeenCalledTimes(2));
+
+    // Each report carries its own data rather than the other one's.
+    const bodies = mocks.openExternalUrl.mock.calls.map(
+      (call) => new URL(call[0] as string).searchParams.get("body") ?? "",
+    );
+    expect(bodies.some((body) => body.includes("Session ID: v2:abc"))).toBe(
+      true,
+    );
+    expect(
+      bodies.some((body) => body.includes("## Bug Description (required)")),
+    ).toBe(true);
   });
 
   it("keeps the screenshot status when debug info cannot be gathered", async () => {

--- a/src/components/HelpDialog.test.tsx
+++ b/src/components/HelpDialog.test.tsx
@@ -12,7 +12,6 @@ const mocks = vi.hoisted(() => ({
   uploadToSignedUrl: vi.fn(),
   openExternalUrl: vi.fn(),
   takeScreenshot: vi.fn(),
-  posthogCapture: vi.fn(),
 }));
 
 vi.mock("@/ipc/types", () => ({
@@ -27,8 +26,12 @@ vi.mock("@/ipc/types", () => ({
   },
 }));
 
+// Stable across renders, matching the real client, so effects keyed on it do
+// not re-run.
+const posthogClient = vi.hoisted(() => ({ capture: vi.fn() }));
+
 vi.mock("posthog-js/react", () => ({
-  usePostHog: () => ({ capture: mocks.posthogCapture }),
+  usePostHog: () => posthogClient,
 }));
 
 vi.mock("react-i18next", () => ({
@@ -178,7 +181,7 @@ describe("HelpDialog screenshot prompt", () => {
     fireEvent.click(screen.getByText("Create GitHub Issue"));
 
     expect(await screen.findByText("Take a screenshot?")).toBeTruthy();
-    expect(mocks.posthogCapture).toHaveBeenCalledWith(
+    expect(posthogClient.capture).toHaveBeenCalledWith(
       "screenshot-prompt:shown",
       { source: "upload-session" },
     );
@@ -246,7 +249,9 @@ describe("HelpDialog screenshot prompt", () => {
 
     // Gathering logs takes a moment; the reporter should see that it is
     // happening rather than a dialog that vanished and did nothing.
-    expect(await screen.findByText("Preparing Report...")).toBeTruthy();
+    expect(
+      await screen.findByRole("button", { name: /Preparing Report/ }),
+    ).toBeTruthy();
     expect(mocks.openExternalUrl).not.toHaveBeenCalled();
 
     releaseDebugInfo(debugInfo);
@@ -267,13 +272,13 @@ describe("HelpDialog screenshot prompt", () => {
     await reachUploadCompleteScreen();
     fireEvent.click(screen.getByText("Create GitHub Issue"));
     fireEvent.click(await screen.findByText("Create issue without screenshot"));
-    await screen.findByText("Creating Issue...");
+    await screen.findByRole("button", { name: /Creating Issue/ });
 
     // The issue is already on its way, so neither exit may take the reporter
     // somewhere the arriving report would contradict.
     fireEvent.click(screen.getByText("mock-dialog-dismiss"));
     expect(screen.queryByText("Upload Complete")).toBeNull();
-    expect(screen.getByText("Creating Issue...")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Creating Issue/ })).toBeTruthy();
 
     expect(
       screen
@@ -318,12 +323,25 @@ describe("HelpDialog screenshot prompt", () => {
     expect(bodyOfOpenedIssue()).toContain("Screenshot status: capture-failed");
   });
 
+  it("keeps the screenshot status when debug info cannot be gathered", async () => {
+    mocks.getSystemDebugInfo.mockRejectedValue(new Error("no debug info"));
+
+    render(<OpenHelpDialog />);
+    fireEvent.click(await screen.findByText("Report a Bug"));
+    fireEvent.click(
+      await screen.findByText("File bug report without screenshot"),
+    );
+
+    await waitFor(() => expect(mocks.openExternalUrl).toHaveBeenCalled());
+    expect(bodyOfOpenedIssue()).toContain("Screenshot status: declined");
+  });
+
   it("still offers the prompt on the bug report path", async () => {
     render(<OpenHelpDialog />);
     fireEvent.click(await screen.findByText("Report a Bug"));
 
     expect(await screen.findByText("Take a screenshot?")).toBeTruthy();
-    expect(mocks.posthogCapture).toHaveBeenCalledWith(
+    expect(posthogClient.capture).toHaveBeenCalledWith(
       "screenshot-prompt:shown",
       { source: "report-bug" },
     );

--- a/src/components/HelpDialog.test.tsx
+++ b/src/components/HelpDialog.test.tsx
@@ -1,0 +1,335 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useSetAtom } from "jotai";
+import { useEffect } from "react";
+import { HelpDialog } from "./HelpDialog";
+import { helpDialogAtom } from "@/atoms/helpDialogAtom";
+import { selectedChatIdAtom } from "@/atoms/chatAtoms";
+
+const mocks = vi.hoisted(() => ({
+  getSystemDebugInfo: vi.fn(),
+  getSessionDebugBundle: vi.fn(),
+  uploadToSignedUrl: vi.fn(),
+  openExternalUrl: vi.fn(),
+  takeScreenshot: vi.fn(),
+  posthogCapture: vi.fn(),
+}));
+
+vi.mock("@/ipc/types", () => ({
+  ipc: {
+    system: {
+      getSystemDebugInfo: mocks.getSystemDebugInfo,
+      openExternalUrl: mocks.openExternalUrl,
+      uploadToSignedUrl: mocks.uploadToSignedUrl,
+      takeScreenshot: mocks.takeScreenshot,
+    },
+    misc: { getSessionDebugBundle: mocks.getSessionDebugBundle },
+  },
+}));
+
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => ({ capture: mocks.posthogCapture }),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/hooks/useSettings", () => ({
+  useSettings: () => ({ settings: null }),
+}));
+
+vi.mock("@/hooks/useUserBudgetInfo", () => ({
+  useUserBudgetInfo: () => ({ userBudget: { redactedUserId: "user-abc" } }),
+}));
+
+// Both are react-query backed and only feed the "Selected Model"/"Effort Level"
+// diagnostic lines, which these tests do not assert on.
+vi.mock("@/hooks/useChatMode", () => ({
+  useChatMode: () => ({ chat: null }),
+}));
+
+vi.mock("@/hooks/useLanguageModelsByProviders", () => ({
+  useLanguageModelsByProviders: () => ({ data: undefined }),
+}));
+
+vi.mock("@/lib/toast", () => ({ showError: vi.fn() }));
+
+vi.mock("./HelpBotDialog", () => ({ HelpBotDialog: () => null }));
+
+vi.mock("framer-motion", () => ({
+  motion: {
+    div: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  },
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+vi.mock("./ui/dialog", () => ({
+  Dialog: ({
+    open,
+    onOpenChange,
+    children,
+  }: {
+    open: boolean;
+    onOpenChange?: (open: boolean) => void;
+    children: React.ReactNode;
+  }) =>
+    open ? (
+      <div>
+        {/* Stands in for Esc, the overlay, and the built-in close button. */}
+        <button onClick={() => onOpenChange?.(false)}>
+          mock-dialog-dismiss
+        </button>
+        {children}
+      </div>
+    ) : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogHeader: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogTitle: ({ children }: { children: React.ReactNode }) => (
+    <h2>{children}</h2>
+  ),
+  DialogDescription: ({ children }: { children: React.ReactNode }) => (
+    <p>{children}</p>
+  ),
+}));
+
+const debugInfo = {
+  nodeVersion: "20.0.0",
+  pnpmVersion: "9.0.0",
+  nodePath: "/usr/bin/node",
+  telemetryId: "telemetry-id",
+  telemetryConsent: "opted_in",
+  telemetryUrl: "https://example.test",
+  dyadVersion: "1.2.3",
+  platform: "linux",
+  architecture: "x64",
+  logs: "logs",
+  updaterLogs: null,
+  selectedLanguageModel: "auto",
+};
+
+const bundle = {
+  chat: { messages: [{ id: 1, role: "user", content: "hi" }] },
+  codebase: "codebase",
+  logs: "logs",
+  updaterLogs: null,
+  system: debugInfo,
+  settings: {},
+  app: {},
+  providers: [],
+  mcpServers: [],
+};
+
+function OpenHelpDialog() {
+  const setHelpDialog = useSetAtom(helpDialogAtom);
+  const setSelectedChatId = useSetAtom(selectedChatIdAtom);
+  useEffect(() => {
+    setSelectedChatId(1);
+    setHelpDialog({ open: true });
+  }, [setHelpDialog, setSelectedChatId]);
+  return (
+    <>
+      {/* Stands in for the sidebar's Help button. */}
+      <button onClick={() => setHelpDialog({ open: true })}>reopen-help</button>
+      <HelpDialog />
+    </>
+  );
+}
+
+/** Walks the upload flow up to the screen that offers to create the issue. */
+async function reachUploadCompleteScreen() {
+  render(<OpenHelpDialog />);
+  fireEvent.click(await screen.findByText("Upload Chat Session"));
+  fireEvent.click(await screen.findByRole("button", { name: /^Upload$/ }));
+  await screen.findByText("Upload Complete");
+}
+
+function bodyOfOpenedIssue(): string {
+  const url = mocks.openExternalUrl.mock.calls.at(-1)?.[0] as string;
+  return new URL(url).searchParams.get("body") ?? "";
+}
+
+describe("HelpDialog screenshot prompt", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSystemDebugInfo.mockResolvedValue(debugInfo);
+    mocks.getSessionDebugBundle.mockResolvedValue(bundle);
+    mocks.uploadToSignedUrl.mockResolvedValue(undefined);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          uploadUrl: "https://upload.test/signed",
+          filename: "abc.json",
+        }),
+      }),
+    );
+  });
+
+  it("offers the screenshot prompt before creating a session issue", async () => {
+    await reachUploadCompleteScreen();
+    fireEvent.click(screen.getByText("Create GitHub Issue"));
+
+    expect(await screen.findByText("Take a screenshot?")).toBeTruthy();
+    expect(mocks.posthogCapture).toHaveBeenCalledWith(
+      "screenshot-prompt:shown",
+      { source: "upload-session" },
+    );
+    expect(mocks.openExternalUrl).not.toHaveBeenCalled();
+  });
+
+  it("keeps the session ID after the prompt closes the help dialog", async () => {
+    await reachUploadCompleteScreen();
+    fireEvent.click(screen.getByText("Create GitHub Issue"));
+    fireEvent.click(await screen.findByText("Create issue without screenshot"));
+
+    await waitFor(() => expect(mocks.openExternalUrl).toHaveBeenCalled());
+    const body = bodyOfOpenedIssue();
+    expect(body).toContain("Session ID: v2:abc");
+    expect(body).toContain("Screenshot status: declined");
+  });
+
+  it("records a captured screenshot in the session issue", async () => {
+    mocks.takeScreenshot.mockResolvedValue(undefined);
+    await reachUploadCompleteScreen();
+    fireEvent.click(screen.getByText("Create GitHub Issue"));
+    fireEvent.click(await screen.findByRole("button", { name: /recommended/ }));
+    fireEvent.click(await screen.findByText("Create GitHub issue"));
+
+    await waitFor(() => expect(mocks.openExternalUrl).toHaveBeenCalled());
+    const body = bodyOfOpenedIssue();
+    expect(body).toContain("Session ID: v2:abc");
+    expect(body).toContain("Screenshot status: captured");
+  });
+
+  it("returns an uploaded session to the upload-complete screen when the prompt is dismissed", async () => {
+    await reachUploadCompleteScreen();
+    fireEvent.click(screen.getByText("Create GitHub Issue"));
+    await screen.findByText("Take a screenshot?");
+
+    fireEvent.click(screen.getByText("mock-dialog-dismiss"));
+
+    // Back where they were, with the session ID they just uploaded intact and
+    // one click from filing, rather than stranded with the upload orphaned.
+    expect(await screen.findByText("Upload Complete")).toBeTruthy();
+    expect(screen.getByText("v2:abc")).toBeTruthy();
+    expect(screen.queryByText("Take a screenshot?")).toBeNull();
+    expect(mocks.openExternalUrl).not.toHaveBeenCalled();
+
+    // And the recovered screen still files a complete issue.
+    fireEvent.click(screen.getByText("Create GitHub Issue"));
+    fireEvent.click(await screen.findByText("Create issue without screenshot"));
+    await waitFor(() => expect(mocks.openExternalUrl).toHaveBeenCalled());
+    expect(bodyOfOpenedIssue()).toContain("Session ID: v2:abc");
+  });
+
+  it("keeps the prompt open showing progress while the report is prepared", async () => {
+    let releaseDebugInfo = (_: unknown) => {};
+    mocks.getSystemDebugInfo.mockReturnValue(
+      new Promise((resolve) => {
+        releaseDebugInfo = resolve;
+      }),
+    );
+
+    render(<OpenHelpDialog />);
+    fireEvent.click(await screen.findByText("Report a Bug"));
+    fireEvent.click(
+      await screen.findByText("File bug report without screenshot"),
+    );
+
+    // Gathering logs takes a moment; the reporter should see that it is
+    // happening rather than a dialog that vanished and did nothing.
+    expect(await screen.findByText("Preparing Report...")).toBeTruthy();
+    expect(mocks.openExternalUrl).not.toHaveBeenCalled();
+
+    releaseDebugInfo(debugInfo);
+    await waitFor(() => expect(mocks.openExternalUrl).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(screen.queryByText("Take a screenshot?")).toBeNull(),
+    );
+  });
+
+  it("does not let a report in flight be dismissed or interleaved with a capture", async () => {
+    let releaseDebugInfo = (_: unknown) => {};
+    mocks.getSystemDebugInfo.mockReturnValue(
+      new Promise((resolve) => {
+        releaseDebugInfo = resolve;
+      }),
+    );
+
+    await reachUploadCompleteScreen();
+    fireEvent.click(screen.getByText("Create GitHub Issue"));
+    fireEvent.click(await screen.findByText("Create issue without screenshot"));
+    await screen.findByText("Creating Issue...");
+
+    // The issue is already on its way, so neither exit may take the reporter
+    // somewhere the arriving report would contradict.
+    fireEvent.click(screen.getByText("mock-dialog-dismiss"));
+    expect(screen.queryByText("Upload Complete")).toBeNull();
+    expect(screen.getByText("Creating Issue...")).toBeTruthy();
+
+    expect(
+      screen
+        .getByRole("button", { name: /recommended/ })
+        .hasAttribute("disabled"),
+    ).toBe(true);
+    expect(mocks.takeScreenshot).not.toHaveBeenCalled();
+
+    releaseDebugInfo(debugInfo);
+    await waitFor(() => expect(mocks.openExternalUrl).toHaveBeenCalledTimes(1));
+    expect(bodyOfOpenedIssue()).toContain("Session ID: v2:abc");
+  });
+
+  it("cannot open a second prompt sealed shut by an earlier report in flight", async () => {
+    let releaseDebugInfo = (_: unknown) => {};
+    mocks.getSystemDebugInfo.mockReturnValue(
+      new Promise((resolve) => {
+        releaseDebugInfo = resolve;
+      }),
+    );
+    mocks.takeScreenshot.mockRejectedValue(new Error("no window"));
+
+    await reachUploadCompleteScreen();
+    fireEvent.click(screen.getByText("Create GitHub Issue"));
+    fireEvent.click(await screen.findByRole("button", { name: /recommended/ }));
+
+    // Capture failed, so the report is in flight with no dialog on screen.
+    await waitFor(() => expect(mocks.takeScreenshot).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(screen.queryByText("Take a screenshot?")).toBeNull(),
+    );
+
+    // Reopening help restores the upload-complete screen, but its button must
+    // not mount a prompt whose every exit is held shut by the other report.
+    fireEvent.click(screen.getByText("reopen-help"));
+    expect(await screen.findByText("Upload Complete")).toBeTruthy();
+    fireEvent.click(screen.getByText("Create GitHub Issue"));
+    expect(screen.queryByText("Take a screenshot?")).toBeNull();
+
+    releaseDebugInfo(debugInfo);
+    await waitFor(() => expect(mocks.openExternalUrl).toHaveBeenCalledTimes(1));
+    expect(bodyOfOpenedIssue()).toContain("Screenshot status: capture-failed");
+  });
+
+  it("still offers the prompt on the bug report path", async () => {
+    render(<OpenHelpDialog />);
+    fireEvent.click(await screen.findByText("Report a Bug"));
+
+    expect(await screen.findByText("Take a screenshot?")).toBeTruthy();
+    expect(mocks.posthogCapture).toHaveBeenCalledWith(
+      "screenshot-prompt:shown",
+      { source: "report-bug" },
+    );
+
+    fireEvent.click(screen.getByText("File bug report without screenshot"));
+    await waitFor(() => expect(mocks.openExternalUrl).toHaveBeenCalled());
+    expect(bodyOfOpenedIssue()).toContain("Screenshot status: declined");
+  });
+});

--- a/src/components/HelpDialog.tsx
+++ b/src/components/HelpDialog.tsx
@@ -33,7 +33,7 @@ import { usePostHog } from "posthog-js/react";
 import { selectedChatIdAtom } from "@/atoms/chatAtoms";
 import { helpDialogAtom } from "@/atoms/helpDialogAtom";
 import { type SessionDebugBundle } from "@/ipc/types";
-import { showError } from "@/lib/toast";
+import { showError, showInfo } from "@/lib/toast";
 import { useTranslation } from "react-i18next";
 import { HelpBotDialog } from "./HelpBotDialog";
 import { useSettings } from "@/hooks/useSettings";
@@ -227,7 +227,6 @@ export function HelpDialog() {
   const [helpDialog, setHelpDialog] = useAtom(helpDialogAtom);
   const isOpen = helpDialog.open;
   const onClose = () => setHelpDialog({ open: false });
-  const [isLoading, setIsLoading] = useState(false);
   const [isUploading, setIsUploading] = useState(false);
   const [screen, setScreen] = useState<DialogScreen>("main");
   const [direction, setDirection] = useState(0);
@@ -237,6 +236,8 @@ export function HelpDialog() {
   const [sessionId, setSessionId] = useState("");
   const [isHelpBotOpen, setIsHelpBotOpen] = useState(false);
   const [isScreenshotPromptOpen, setIsScreenshotPromptOpen] = useState(false);
+  const [promptSource, setPromptSource] =
+    useState<ScreenshotPromptSource>("report-bug");
   // What the screenshot prompt should file once the reporter answers it.
   // Opening the prompt closes this dialog, which runs resetDialogState, so the
   // session ID is snapshotted here rather than read back from state later.
@@ -286,7 +287,6 @@ export function HelpDialog() {
   };
 
   const resetDialogState = () => {
-    setIsLoading(false);
     setIsUploading(false);
     setScreen("main");
     setDirection(0);
@@ -350,7 +350,7 @@ export function HelpDialog() {
   // ---------------------------------------------------------------------------
 
   const handleReportBug = async (screenshot: ScreenshotOutcome) => {
-    setIsLoading(true);
+    showInfo("Preparing your bug report...");
     try {
       const debugInfo = await ipc.system.getSystemDebugInfo();
       const body = buildBugReportBody({
@@ -374,8 +374,6 @@ export function HelpDialog() {
         body: buildBugReportFallbackBody({ screenshot }),
         isDyadProUser,
       });
-    } finally {
-      setIsLoading(false);
     }
   };
 
@@ -445,7 +443,7 @@ export function HelpDialog() {
     screenshot: ScreenshotOutcome,
     reportedSessionId: string,
   ) => {
-    setIsLoading(true);
+    showInfo("Preparing your session report...");
     try {
       const debugInfo = await ipc.system.getSystemDebugInfo();
       openGitHubIssue({
@@ -473,45 +471,39 @@ export function HelpDialog() {
         }),
         isDyadProUser,
       });
-    } finally {
-      setIsLoading(false);
     }
-    handleClose();
   };
 
   // Both report paths funnel through the screenshot prompt, so the issue body
   // always records whether a screenshot was taken.
   const openScreenshotPrompt = (report: PendingReport) => {
-    // A report already in flight owns isLoading, which gates every exit from
-    // the prompt. Opening a second one would mount a dialog that is sealed
-    // shut and labelled for the other report.
-    if (isLoading) return;
+    // Held separately from pendingReport, which is released as soon as the
+    // report is dispatched, while the prompt is still animating out.
+    setPromptSource(
+      report.kind === "session" ? "upload-session" : "report-bug",
+    );
     setPendingReport(report);
     handleClose();
     setIsScreenshotPromptOpen(true);
   };
 
-  const handleScreenshotPromptContinue = async (
-    screenshot: ScreenshotOutcome,
-  ) => {
+  const handleScreenshotPromptContinue = (screenshot: ScreenshotOutcome) => {
     const report = pendingReport;
     if (!report) return;
-    if (report.kind === "session") {
-      await handleOpenGitHubIssue(screenshot, report.sessionId);
-    } else {
-      await handleReportBug(screenshot);
-    }
-    // Release only the report this call filed, so a later one is never cleared
-    // out from under itself. Clearing lets the next open start fresh.
+    // The report carries its own screenshot outcome and session ID, so it
+    // needs nothing from this dialog once it starts. Release only this report,
+    // so a later one is never cleared out from under itself.
     setPendingReport((current) => (current === report ? null : current));
+    if (report.kind === "session") {
+      void handleOpenGitHubIssue(screenshot, report.sessionId);
+    } else {
+      void handleReportBug(screenshot);
+    }
   };
 
   // The prompt is a stop on the way to the issue, not a place to lose an
   // upload: backing out of it reopens the help dialog as the reporter left it.
   const handleScreenshotPromptDismiss = () => {
-    // Prevents the case where a dismissal reopens this dialog and the report
-    // already on its way closes it again a moment later.
-    if (isLoading) return;
     setIsScreenshotPromptOpen(false);
     setPendingReport(null);
     setHelpDialog({ open: true });
@@ -609,11 +601,9 @@ export function HelpDialog() {
             <Button
               variant="outline"
               onClick={() => openScreenshotPrompt({ kind: "bug" })}
-              disabled={isLoading}
               className="w-full bg-(--background-lightest)"
             >
-              <BugIcon className="mr-2 h-4 w-4" />{" "}
-              {isLoading ? "Preparing Report..." : "Report a Bug"}
+              <BugIcon className="mr-2 h-4 w-4" /> Report a Bug
             </Button>
           </div>
         </div>
@@ -742,7 +732,6 @@ export function HelpDialog() {
 
       <Button
         onClick={() => openScreenshotPrompt({ kind: "session", sessionId })}
-        disabled={isLoading}
         className="w-full py-5 text-base mt-4"
         size="lg"
       >
@@ -786,8 +775,6 @@ export function HelpDialog() {
   // ---------------------------------------------------------------------------
 
   const isCrashPreloading = helpDialog.uploadChatId != null;
-  const screenshotPromptSource: ScreenshotPromptSource =
-    pendingReport?.kind === "session" ? "upload-session" : "report-bug";
 
   return (
     <>
@@ -818,8 +805,7 @@ export function HelpDialog() {
         onClose={() => setIsScreenshotPromptOpen(false)}
         onDismiss={handleScreenshotPromptDismiss}
         onContinue={handleScreenshotPromptContinue}
-        isLoading={isLoading}
-        source={screenshotPromptSource}
+        source={promptSource}
       />
     </>
   );

--- a/src/components/HelpDialog.tsx
+++ b/src/components/HelpDialog.tsx
@@ -14,7 +14,7 @@ import {
   CheckIcon,
   XIcon,
   SparklesIcon,
-  ExternalLinkIcon,
+  Github,
   AlertCircleIcon,
   MessageSquareIcon,
   CopyIcon,
@@ -29,28 +29,37 @@ import {
   useCallback,
 } from "react";
 import { useAtom, useAtomValue } from "jotai";
+import { usePostHog } from "posthog-js/react";
 import { selectedChatIdAtom } from "@/atoms/chatAtoms";
 import { helpDialogAtom } from "@/atoms/helpDialogAtom";
-import { type SessionDebugBundle, type SystemDebugInfo } from "@/ipc/types";
+import { type SessionDebugBundle } from "@/ipc/types";
 import { showError } from "@/lib/toast";
 import { useTranslation } from "react-i18next";
 import { HelpBotDialog } from "./HelpBotDialog";
 import { useSettings } from "@/hooks/useSettings";
-import { BugScreenshotDialog } from "./BugScreenshotDialog";
+import {
+  BugScreenshotDialog,
+  type ScreenshotPromptSource,
+} from "./BugScreenshotDialog";
 import { useUserBudgetInfo } from "@/hooks/useUserBudgetInfo";
-import { type ModelSelection, type UserSettings } from "@/lib/schemas";
-import { type UserBudgetInfo } from "@/ipc/types/system";
 import { motion, AnimatePresence } from "framer-motion";
-import { formatUpdaterLogsForIssueBody } from "@/lib/debugLogFormatting";
 import { useChatMode } from "@/hooks/useChatMode";
 import { useLanguageModelsByProviders } from "@/hooks/useLanguageModelsByProviders";
 import { createModelSelection, getModelPreferenceKey } from "@/lib/modelEffort";
+import {
+  buildBugReportBody,
+  buildSessionReportBody,
+  buildSessionReportFallbackBody,
+  type ScreenshotOutcome,
+} from "@/lib/issueBody";
 
 // =============================================================================
 // Animation constants
 // =============================================================================
 
 type DialogScreen = "main" | "review" | "upload-complete";
+
+type PendingReport = { kind: "bug" } | { kind: "session"; sessionId: string };
 
 const SCREEN_ORDER: DialogScreen[] = ["main", "review", "upload-complete"];
 
@@ -77,55 +86,6 @@ const screenTransition = {
 
 const GITHUB_ISSUES_BASE =
   "https://github.com/dyad-sh/dyad/issues/new" as const;
-
-function formatSettingsLines(
-  settings: UserSettings | null,
-  selectedModel: ModelSelection | null,
-): string {
-  if (!settings) return "Settings not available";
-  const model = selectedModel ?? settings.selectedModel;
-  return [
-    `- Selected Model: ${model.provider}:${model.name}`,
-    `- Chat Mode: ${settings.selectedChatMode ?? "default"}`,
-    `- Auto Approve Changes: ${settings.autoApproveChanges ?? "n/a"}`,
-    `- Dyad Pro Enabled: ${settings.enableDyadPro ?? "n/a"}`,
-    `- Effort Level: ${selectedModel?.effortLevel ?? "medium"}`,
-    `- Runtime Mode: ${settings.runtimeMode2 ?? "n/a"}`,
-    `- Release Channel: ${settings.releaseChannel ?? "n/a"}`,
-  ].join("\n");
-}
-
-function formatSystemInfoSection(
-  debugInfo: SystemDebugInfo,
-  userBudget: UserBudgetInfo | undefined,
-): string {
-  return `## System Information
-- Dyad Version: ${debugInfo.dyadVersion}
-- Platform: ${debugInfo.platform}
-- Architecture: ${debugInfo.architecture}
-- Node Version: ${debugInfo.nodeVersion || "n/a"}
-- PNPM Version: ${debugInfo.pnpmVersion || "n/a"}
-- Node Path: ${debugInfo.nodePath || "n/a"}
-- Pro User ID: ${userBudget?.redactedUserId || "n/a"}
-- Telemetry ID: ${debugInfo.telemetryId || "n/a"}
-- Model: ${debugInfo.selectedLanguageModel || "n/a"}`;
-}
-
-function formatLogsSection(debugInfo: SystemDebugInfo): string {
-  // Keep the updater section small: the issue body travels in the GitHub URL.
-  const updaterSection = debugInfo.updaterLogs
-    ? `
-
-## Auto-Updater Logs
-\`\`\`
-${formatUpdaterLogsForIssueBody(debugInfo.updaterLogs)}
-\`\`\``
-    : "";
-  return `## Logs
-\`\`\`
-${debugInfo.logs.slice(-3_500) || "No logs available"}
-\`\`\`${updaterSection}`;
-}
 
 function openGitHubIssue(params: {
   title: string;
@@ -204,15 +164,19 @@ function ReviewDetailsSection({
 /** Copy button with animated feedback. */
 function CopyButton({ text }: { text: string }) {
   const [copied, setCopied] = useState(false);
+  const posthog = usePostHog();
 
   const handleCopy = useCallback(async () => {
     try {
       await navigator.clipboard.writeText(text);
+      // Reported so we can see copies that land after a screenshot capture and
+      // overwrite the image the reporter was about to paste.
+      posthog.capture("session-report:copy-session-id");
       setCopied(true);
     } catch (err) {
       console.error("Failed to copy:", err);
     }
-  }, [text]);
+  }, [text, posthog]);
 
   useEffect(() => {
     if (!copied) return;
@@ -271,7 +235,13 @@ export function HelpDialog() {
   );
   const [sessionId, setSessionId] = useState("");
   const [isHelpBotOpen, setIsHelpBotOpen] = useState(false);
-  const [isBugScreenshotOpen, setIsBugScreenshotOpen] = useState(false);
+  const [isScreenshotPromptOpen, setIsScreenshotPromptOpen] = useState(false);
+  // What the screenshot prompt should file once the reporter answers it.
+  // Opening the prompt closes this dialog, which runs resetDialogState, so the
+  // session ID is snapshotted here rather than read back from state later.
+  const [pendingReport, setPendingReport] = useState<PendingReport | null>(
+    null,
+  );
   const hasNavigated = useRef(false);
   // Tracks which chat (if any) we've already preloaded for the crash-triggered
   // upload flow, so the preload effect fires once per open.
@@ -325,9 +295,13 @@ export function HelpDialog() {
     preloadedChatId.current = null;
   };
 
+  // Hold this dialog's state while a report is waiting on the screenshot
+  // prompt. The prompt closes this dialog only to keep it out of the capture,
+  // and backing out of the prompt has to land the reporter where they were,
+  // with an uploaded session ID still on screen.
   useEffect(() => {
-    if (!isOpen) resetDialogState();
-  }, [isOpen]);
+    if (!isOpen && !pendingReport) resetDialogState();
+  }, [isOpen, pendingReport]);
 
   // Crash-triggered upload: when opened with a uploadChatId, skip the main
   // screen, preload that chat's debug bundle, and jump straight to review.
@@ -376,26 +350,17 @@ export function HelpDialog() {
   // Actions
   // ---------------------------------------------------------------------------
 
-  const handleReportBug = async () => {
+  const handleReportBug = async (screenshot: ScreenshotOutcome) => {
     setIsLoading(true);
     try {
       const debugInfo = await ipc.system.getSystemDebugInfo();
-      const body = `\
-<!-- Please fill in all fields in English -->
-
-## Bug Description (required)
-<!-- Please describe the issue you're experiencing and how to reproduce it -->
-
-## Screenshot (recommended)
-<!-- Screenshot of the bug -->
-
-${formatSystemInfoSection(debugInfo, userBudget ?? undefined)}
-
-## Settings
-${formatSettingsLines(settings, diagnosticModelSelection)}
-
-${formatLogsSection(debugInfo)}
-`;
+      const body = buildBugReportBody({
+        debugInfo,
+        settings,
+        selectedModel: diagnosticModelSelection,
+        userBudget: userBudget ?? undefined,
+        screenshot,
+      });
       openGitHubIssue({
         title: "[bug] <WRITE TITLE HERE>",
         labels: ["bug"],
@@ -470,36 +435,26 @@ ${formatLogsSection(debugInfo)}
     setDebugBundle(null);
   };
 
-  const handleOpenGitHubIssue = async () => {
+  // reportedSessionId is passed in rather than read from state: the screenshot
+  // prompt closes this dialog before this runs, which clears sessionId.
+  const handleOpenGitHubIssue = async (
+    screenshot: ScreenshotOutcome,
+    reportedSessionId: string,
+  ) => {
+    setIsLoading(true);
     try {
       const debugInfo = await ipc.system.getSystemDebugInfo();
-      const body = `\
-<!-- Please fill in all fields in English -->
-
-Session ID: ${sessionId}
-Session Schema: v2.0
-Pro User ID: ${userBudget?.redactedUserId || "n/a"}
-
-## Issue Description (required)
-<!-- Please describe the issue you're experiencing -->
-
-## Expected Behavior (required)
-<!-- What did you expect to happen? -->
-
-## Actual Behavior (required)
-<!-- What actually happened? -->
-
-${formatSystemInfoSection(debugInfo, userBudget ?? undefined)}
-
-## Settings
-${formatSettingsLines(settings, diagnosticModelSelection)}
-
-${formatLogsSection(debugInfo)}
-`;
       openGitHubIssue({
         title: "[session report] <add title>",
         labels: ["support"],
-        body,
+        body: buildSessionReportBody({
+          debugInfo,
+          settings,
+          selectedModel: diagnosticModelSelection,
+          userBudget: userBudget ?? undefined,
+          screenshot,
+          sessionId: reportedSessionId,
+        }),
         isDyadProUser,
       });
     } catch (error) {
@@ -507,11 +462,56 @@ ${formatLogsSection(debugInfo)}
       openGitHubIssue({
         title: "[session report] <add title>",
         labels: ["support"],
-        body: `Session ID: ${sessionId}\nSession Schema: v2.0\nPro User ID: ${userBudget?.redactedUserId || "n/a"}`,
+        body: buildSessionReportFallbackBody({
+          userBudget: userBudget ?? undefined,
+          screenshot,
+          sessionId: reportedSessionId,
+        }),
         isDyadProUser,
       });
+    } finally {
+      setIsLoading(false);
     }
     handleClose();
+  };
+
+  // Both report paths funnel through the screenshot prompt, so the issue body
+  // always records whether a screenshot was taken.
+  const openScreenshotPrompt = (report: PendingReport) => {
+    // A report already in flight owns isLoading, which gates every exit from
+    // the prompt. Opening a second one would mount a dialog that is sealed
+    // shut and labelled for the other report.
+    if (isLoading) return;
+    setPendingReport(report);
+    handleClose();
+    setIsScreenshotPromptOpen(true);
+  };
+
+  const handleScreenshotPromptContinue = async (
+    screenshot: ScreenshotOutcome,
+  ) => {
+    const report = pendingReport;
+    if (!report) return;
+    if (report.kind === "session") {
+      await handleOpenGitHubIssue(screenshot, report.sessionId);
+    } else {
+      await handleReportBug(screenshot);
+    }
+    // Release only the report this call filed, so a later one is never cleared
+    // out from under itself. Clearing lets the next open start fresh.
+    setPendingReport((current) => (current === report ? null : current));
+  };
+
+  // The prompt is a stop on the way to the issue, not a place to lose an
+  // upload: backing out of it reopens the help dialog as the reporter left it.
+  const handleScreenshotPromptDismiss = () => {
+    // A report already being prepared cannot be called off: it will open the
+    // issue regardless. Ignoring the dismissal keeps the prompt honest about
+    // that rather than reopening a dialog the report is about to close.
+    if (isLoading) return;
+    setIsScreenshotPromptOpen(false);
+    setPendingReport(null);
+    setHelpDialog({ open: true });
   };
 
   // ---------------------------------------------------------------------------
@@ -605,10 +605,7 @@ ${formatLogsSection(debugInfo)}
             </p>
             <Button
               variant="outline"
-              onClick={() => {
-                handleClose();
-                setIsBugScreenshotOpen(true);
-              }}
+              onClick={() => openScreenshotPrompt({ kind: "bug" })}
               disabled={isLoading}
               className="w-full bg-(--background-lightest)"
             >
@@ -741,11 +738,12 @@ ${formatLogsSection(debugInfo)}
       </div>
 
       <Button
-        onClick={handleOpenGitHubIssue}
+        onClick={() => openScreenshotPrompt({ kind: "session", sessionId })}
+        disabled={isLoading}
         className="w-full py-5 text-base mt-4"
         size="lg"
       >
-        <ExternalLinkIcon className="mr-2 h-5 w-5" />
+        <Github className="mr-2 h-5 w-5" />
         Create GitHub Issue
       </Button>
 
@@ -785,6 +783,8 @@ ${formatLogsSection(debugInfo)}
   // ---------------------------------------------------------------------------
 
   const isCrashPreloading = helpDialog.uploadChatId != null;
+  const screenshotPromptSource: ScreenshotPromptSource =
+    pendingReport?.kind === "session" ? "upload-session" : "report-bug";
 
   return (
     <>
@@ -811,10 +811,12 @@ ${formatLogsSection(debugInfo)}
         onClose={() => setIsHelpBotOpen(false)}
       />
       <BugScreenshotDialog
-        isOpen={isBugScreenshotOpen}
-        onClose={() => setIsBugScreenshotOpen(false)}
-        handleReportBug={handleReportBug}
+        isOpen={isScreenshotPromptOpen}
+        onClose={() => setIsScreenshotPromptOpen(false)}
+        onDismiss={handleScreenshotPromptDismiss}
+        onContinue={handleScreenshotPromptContinue}
         isLoading={isLoading}
+        source={screenshotPromptSource}
       />
     </>
   );

--- a/src/components/HelpDialog.tsx
+++ b/src/components/HelpDialog.tsx
@@ -501,6 +501,14 @@ export function HelpDialog() {
     }
   };
 
+  // A prompt on screen belongs to a newer report, so an abandoned capture
+  // leaves it in place rather than closing it.
+  const handleCaptureAbandon = () => {
+    if (isScreenshotPromptOpen) return;
+    setPendingReport(null);
+    setHelpDialog({ open: true });
+  };
+
   // The prompt is a stop on the way to the issue, not a place to lose an
   // upload: backing out of it reopens the help dialog as the reporter left it.
   const handleScreenshotPromptDismiss = () => {
@@ -804,6 +812,7 @@ export function HelpDialog() {
         isOpen={isScreenshotPromptOpen}
         onClose={() => setIsScreenshotPromptOpen(false)}
         onDismiss={handleScreenshotPromptDismiss}
+        onCaptureAbandon={handleCaptureAbandon}
         onContinue={handleScreenshotPromptContinue}
         source={promptSource}
         report={pendingReport}

--- a/src/components/HelpDialog.tsx
+++ b/src/components/HelpDialog.tsx
@@ -39,6 +39,7 @@ import { HelpBotDialog } from "./HelpBotDialog";
 import { useSettings } from "@/hooks/useSettings";
 import {
   BugScreenshotDialog,
+  type PendingReport,
   type ScreenshotPromptSource,
 } from "./BugScreenshotDialog";
 import { useUserBudgetInfo } from "@/hooks/useUserBudgetInfo";
@@ -59,8 +60,6 @@ import {
 // =============================================================================
 
 type DialogScreen = "main" | "review" | "upload-complete";
-
-type PendingReport = { kind: "bug" } | { kind: "session"; sessionId: string };
 
 const SCREEN_ORDER: DialogScreen[] = ["main", "review", "upload-complete"];
 
@@ -487,9 +486,10 @@ export function HelpDialog() {
     setIsScreenshotPromptOpen(true);
   };
 
-  const handleScreenshotPromptContinue = (screenshot: ScreenshotOutcome) => {
-    const report = pendingReport;
-    if (!report) return;
+  const handleScreenshotPromptContinue = (
+    screenshot: ScreenshotOutcome,
+    report: PendingReport,
+  ) => {
     // The report carries its own screenshot outcome and session ID, so it
     // needs nothing from this dialog once it starts. Release only this report,
     // so a later one is never cleared out from under itself.
@@ -806,6 +806,7 @@ export function HelpDialog() {
         onDismiss={handleScreenshotPromptDismiss}
         onContinue={handleScreenshotPromptContinue}
         source={promptSource}
+        report={pendingReport}
       />
     </>
   );

--- a/src/components/HelpDialog.tsx
+++ b/src/components/HelpDialog.tsx
@@ -48,6 +48,7 @@ import { useLanguageModelsByProviders } from "@/hooks/useLanguageModelsByProvide
 import { createModelSelection, getModelPreferenceKey } from "@/lib/modelEffort";
 import {
   buildBugReportBody,
+  buildBugReportFallbackBody,
   buildSessionReportBody,
   buildSessionReportFallbackBody,
   type ScreenshotOutcome,
@@ -295,10 +296,8 @@ export function HelpDialog() {
     preloadedChatId.current = null;
   };
 
-  // Hold this dialog's state while a report is waiting on the screenshot
-  // prompt. The prompt closes this dialog only to keep it out of the capture,
-  // and backing out of the prompt has to land the reporter where they were,
-  // with an uploaded session ID still on screen.
+  // Holds this dialog's state while a report waits on the screenshot prompt,
+  // so backing out of the prompt lands the reporter where they were.
   useEffect(() => {
     if (!isOpen && !pendingReport) resetDialogState();
   }, [isOpen, pendingReport]);
@@ -369,7 +368,12 @@ export function HelpDialog() {
       });
     } catch (error) {
       console.error("Failed to prepare bug report:", error);
-      ipc.system.openExternalUrl(GITHUB_ISSUES_BASE);
+      openGitHubIssue({
+        title: "[bug] <WRITE TITLE HERE>",
+        labels: ["bug"],
+        body: buildBugReportFallbackBody({ screenshot }),
+        isDyadProUser,
+      });
     } finally {
       setIsLoading(false);
     }
@@ -505,9 +509,8 @@ export function HelpDialog() {
   // The prompt is a stop on the way to the issue, not a place to lose an
   // upload: backing out of it reopens the help dialog as the reporter left it.
   const handleScreenshotPromptDismiss = () => {
-    // A report already being prepared cannot be called off: it will open the
-    // issue regardless. Ignoring the dismissal keeps the prompt honest about
-    // that rather than reopening a dialog the report is about to close.
+    // Prevents the case where a dismissal reopens this dialog and the report
+    // already on its way closes it again a moment later.
     if (isLoading) return;
     setIsScreenshotPromptOpen(false);
     setPendingReport(null);

--- a/src/components/ScreenshotSuccessDialog.tsx
+++ b/src/components/ScreenshotSuccessDialog.tsx
@@ -6,9 +6,7 @@ interface ScreenshotSuccessDialogProps {
   isOpen: boolean;
   /** The reporter backed out without filing anything. */
   onDismiss: () => void;
-  onSubmit: () => void | Promise<void>;
-  isLoading: boolean;
-  pendingLabel: string;
+  onSubmit: () => void;
   icon: ReactNode;
 }
 
@@ -16,21 +14,11 @@ export function ScreenshotSuccessDialog({
   isOpen,
   onDismiss,
   onSubmit,
-  isLoading,
-  pendingLabel,
   icon,
 }: ScreenshotSuccessDialogProps) {
   return (
     <Dialog open={isOpen} onOpenChange={onDismiss}>
-      <DialogContent showCloseButton={!isLoading}>
-        <span
-          className="sr-only"
-          role="status"
-          aria-live="polite"
-          aria-atomic="true"
-        >
-          {isLoading ? pendingLabel : ""}
-        </span>
+      <DialogContent>
         <DialogHeader>
           <DialogTitle>
             Screenshot captured to clipboard! Please paste in GitHub issue.
@@ -38,11 +26,10 @@ export function ScreenshotSuccessDialog({
         </DialogHeader>
         <Button
           variant="default"
-          onClick={() => onSubmit()}
-          disabled={isLoading}
+          onClick={onSubmit}
           className="w-full py-6 border-primary/50 shadow-sm shadow-primary/10 transition-all hover:shadow-md hover:shadow-primary/15"
         >
-          {icon} {isLoading ? pendingLabel : "Create GitHub issue"}
+          {icon} Create GitHub issue
         </Button>
       </DialogContent>
     </Dialog>

--- a/src/components/ScreenshotSuccessDialog.tsx
+++ b/src/components/ScreenshotSuccessDialog.tsx
@@ -21,6 +21,14 @@ export function ScreenshotSuccessDialog({
   return (
     <Dialog open={isOpen} onOpenChange={onDismiss}>
       <DialogContent showCloseButton={!isLoading}>
+        <span
+          className="sr-only"
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+        >
+          {isLoading ? pendingLabel : ""}
+        </span>
         <DialogHeader>
           <DialogTitle>
             Screenshot captured to clipboard! Please paste in GitHub issue.

--- a/src/components/ScreenshotSuccessDialog.tsx
+++ b/src/components/ScreenshotSuccessDialog.tsx
@@ -4,24 +4,23 @@ import { BugIcon } from "lucide-react";
 
 interface ScreenshotSuccessDialogProps {
   isOpen: boolean;
-  onClose: () => void;
-  handleReportBug: () => Promise<void>;
+  /** The reporter backed out without filing anything. */
+  onDismiss: () => void;
+  onSubmit: () => void | Promise<void>;
   isLoading: boolean;
+  pendingLabel: string;
 }
 
 export function ScreenshotSuccessDialog({
   isOpen,
-  onClose,
-  handleReportBug,
+  onDismiss,
+  onSubmit,
   isLoading,
+  pendingLabel,
 }: ScreenshotSuccessDialogProps) {
-  const handleSubmit = async () => {
-    await handleReportBug();
-    onClose();
-  };
   return (
-    <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent>
+    <Dialog open={isOpen} onOpenChange={onDismiss}>
+      <DialogContent showCloseButton={!isLoading}>
         <DialogHeader>
           <DialogTitle>
             Screenshot captured to clipboard! Please paste in GitHub issue.
@@ -29,11 +28,12 @@ export function ScreenshotSuccessDialog({
         </DialogHeader>
         <Button
           variant="default"
-          onClick={handleSubmit}
+          onClick={() => onSubmit()}
+          disabled={isLoading}
           className="w-full py-6 border-primary/50 shadow-sm shadow-primary/10 transition-all hover:shadow-md hover:shadow-primary/15"
         >
           <BugIcon className="mr-2 h-5 w-5" />{" "}
-          {isLoading ? "Preparing Report..." : "Create GitHub issue"}
+          {isLoading ? pendingLabel : "Create GitHub issue"}
         </Button>
       </DialogContent>
     </Dialog>

--- a/src/components/ScreenshotSuccessDialog.tsx
+++ b/src/components/ScreenshotSuccessDialog.tsx
@@ -1,6 +1,6 @@
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "./ui/dialog";
 import { Button } from "./ui/button";
-import { BugIcon } from "lucide-react";
+import { type ReactNode } from "react";
 
 interface ScreenshotSuccessDialogProps {
   isOpen: boolean;
@@ -9,6 +9,7 @@ interface ScreenshotSuccessDialogProps {
   onSubmit: () => void | Promise<void>;
   isLoading: boolean;
   pendingLabel: string;
+  icon: ReactNode;
 }
 
 export function ScreenshotSuccessDialog({
@@ -17,6 +18,7 @@ export function ScreenshotSuccessDialog({
   onSubmit,
   isLoading,
   pendingLabel,
+  icon,
 }: ScreenshotSuccessDialogProps) {
   return (
     <Dialog open={isOpen} onOpenChange={onDismiss}>
@@ -40,8 +42,7 @@ export function ScreenshotSuccessDialog({
           disabled={isLoading}
           className="w-full py-6 border-primary/50 shadow-sm shadow-primary/10 transition-all hover:shadow-md hover:shadow-primary/15"
         >
-          <BugIcon className="mr-2 h-5 w-5" />{" "}
-          {isLoading ? pendingLabel : "Create GitHub issue"}
+          {icon} {isLoading ? pendingLabel : "Create GitHub issue"}
         </Button>
       </DialogContent>
     </Dialog>

--- a/src/ipc/handlers/debug_handlers.ts
+++ b/src/ipc/handlers/debug_handlers.ts
@@ -2,7 +2,7 @@ import { BrowserWindow, clipboard } from "electron";
 import { platform, arch } from "os";
 import { readSettings } from "../../main/settings";
 import { createTypedHandler } from "./base";
-import { systemContracts } from "../types/system";
+import { SCREENSHOT_ERRORS, systemContracts } from "../types/system";
 import { miscContracts, SESSION_DEBUG_SCHEMA_VERSION } from "../types/misc";
 import type { SystemDebugInfo } from "../types/system";
 import type { SessionDebugBundle } from "../types/misc";
@@ -522,16 +522,13 @@ export function registerDebugHandlers() {
 
   createTypedHandler(systemContracts.takeScreenshot, async () => {
     const win = BrowserWindow.getFocusedWindow();
-    if (!win) throw new Error("No focused window to capture");
+    if (!win) throw new Error(SCREENSHOT_ERRORS.noFocusedWindow);
 
     // Capture the window's current contents as a NativeImage
     const image = await win.capturePage();
     // Validate image
     if (!image || image.isEmpty()) {
-      throw new DyadError(
-        "Failed to capture screenshot",
-        DyadErrorKind.External,
-      );
+      throw new DyadError(SCREENSHOT_ERRORS.emptyImage, DyadErrorKind.External);
     }
     // Write the image to the clipboard
     clipboard.writeImage(image);

--- a/src/ipc/handlers/debug_handlers.ts
+++ b/src/ipc/handlers/debug_handlers.ts
@@ -522,7 +522,12 @@ export function registerDebugHandlers() {
 
   createTypedHandler(systemContracts.takeScreenshot, async () => {
     const win = BrowserWindow.getFocusedWindow();
-    if (!win) throw new Error(SCREENSHOT_ERRORS.noFocusedWindow);
+    if (!win) {
+      throw new DyadError(
+        SCREENSHOT_ERRORS.noFocusedWindow,
+        DyadErrorKind.Precondition,
+      );
+    }
 
     // Capture the window's current contents as a NativeImage
     const image = await win.capturePage();

--- a/src/ipc/handlers/upload_handlers.ts
+++ b/src/ipc/handlers/upload_handlers.ts
@@ -3,6 +3,7 @@ import fetch from "node-fetch";
 import { createTypedHandler } from "./base";
 import { systemContracts } from "../types/system";
 import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
+import { IS_TEST_BUILD } from "@/ipc/utils/test_utils";
 
 const logger = log.scope("upload_handlers");
 
@@ -11,8 +12,13 @@ export function registerUploadHandlers() {
     const { url, contentType, data } = params;
     logger.debug("IPC: upload-to-signed-url called");
 
-    // Validate the signed URL
-    if (!url || typeof url !== "string" || !url.startsWith("https://")) {
+    // Validate the signed URL. E2E builds also accept a loopback address so a
+    // test can stand in for the upload service.
+    const isSignedUrl =
+      typeof url === "string" &&
+      (url.startsWith("https://") ||
+        (IS_TEST_BUILD && url.startsWith("http://127.0.0.1:")));
+    if (!url || !isSignedUrl) {
       throw new DyadError(
         "Invalid signed URL provided",
         DyadErrorKind.Validation,

--- a/src/ipc/handlers/upload_handlers.ts
+++ b/src/ipc/handlers/upload_handlers.ts
@@ -7,6 +7,21 @@ import { IS_TEST_BUILD } from "@/ipc/utils/test_utils";
 
 const logger = log.scope("upload_handlers");
 
+/**
+ * Whether a URL names the loopback fixture an E2E test stands up in place of
+ * the upload service. Parsed rather than matched as a prefix, because
+ * "http://127.0.0.1:@evil.test/x" carries the loopback prefix but resolves to
+ * evil.test. Same shape as isSecureInstanceUrl.
+ */
+function isTestUploadUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" && url.hostname === "127.0.0.1";
+  } catch {
+    return false;
+  }
+}
+
 export function registerUploadHandlers() {
   createTypedHandler(systemContracts.uploadToSignedUrl, async (_, params) => {
     const { url, contentType, data } = params;
@@ -16,9 +31,8 @@ export function registerUploadHandlers() {
     // test can stand in for the upload service.
     const isSignedUrl =
       typeof url === "string" &&
-      (url.startsWith("https://") ||
-        (IS_TEST_BUILD && url.startsWith("http://127.0.0.1:")));
-    if (!url || !isSignedUrl) {
+      (url.startsWith("https://") || (IS_TEST_BUILD && isTestUploadUrl(url)));
+    if (!isSignedUrl) {
       throw new DyadError(
         "Invalid signed URL provided",
         DyadErrorKind.Validation,

--- a/src/ipc/types/system.ts
+++ b/src/ipc/types/system.ts
@@ -182,6 +182,16 @@ export const ForceCloseDetectedPayloadSchema = z.object({
   activeChatId: z.number().optional(),
 });
 
+/**
+ * Failures takeScreenshot can raise. The renderer matches on these to bucket
+ * capture failures for telemetry, so both sides move together instead of
+ * drifting apart.
+ */
+export const SCREENSHOT_ERRORS = {
+  noFocusedWindow: "No focused window to capture",
+  emptyImage: "Failed to capture screenshot",
+} as const;
+
 // =============================================================================
 // System Contracts
 // =============================================================================

--- a/src/lib/issueBody.test.ts
+++ b/src/lib/issueBody.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildBugReportBody,
+  buildBugReportFallbackBody,
   buildSessionReportBody,
   buildSessionReportFallbackBody,
   formatScreenshotStatusLine,
@@ -118,6 +119,16 @@ describe("buildSessionReportBody", () => {
     expect(body).toContain("Session ID: v2:abc");
     expect(body).toContain("Session Schema: v2.0");
     expect(body).toContain("Pro User ID: user-abc");
+  });
+});
+
+describe("buildBugReportFallbackBody", () => {
+  it("still carries the screenshot status", () => {
+    const body = buildBugReportFallbackBody({
+      screenshot: { status: "captured" },
+    });
+    expect(body).toContain("Screenshot status: captured");
+    expect(body).toContain("## Bug Description (required)");
   });
 });
 

--- a/src/lib/issueBody.test.ts
+++ b/src/lib/issueBody.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildBugReportBody,
+  buildSessionReportBody,
+  buildSessionReportFallbackBody,
+  formatScreenshotStatusLine,
+} from "./issueBody";
+import { type SystemDebugInfo } from "@/ipc/types";
+import { type UserBudgetInfo } from "@/ipc/types/system";
+
+const debugInfo: SystemDebugInfo = {
+  nodeVersion: "20.0.0",
+  pnpmVersion: "9.0.0",
+  nodePath: "/usr/bin/node",
+  telemetryId: "telemetry-id",
+  telemetryConsent: "opted_in",
+  telemetryUrl: "https://example.test",
+  dyadVersion: "1.2.3",
+  platform: "linux",
+  architecture: "x64",
+  logs: "some logs",
+  updaterLogs: null,
+  selectedLanguageModel: "auto",
+};
+
+const userBudget: UserBudgetInfo = {
+  usedCredits: 1,
+  totalCredits: 10,
+  budgetResetDate: new Date(0),
+  redactedUserId: "user-abc",
+  isTrial: false,
+};
+
+const common = {
+  debugInfo,
+  settings: null,
+  selectedModel: null,
+  userBudget,
+};
+
+describe("formatScreenshotStatusLine", () => {
+  it("uses a stable prefix so published issues can be counted", () => {
+    expect(formatScreenshotStatusLine({ status: "captured" })).toContain(
+      "Screenshot status: captured",
+    );
+    expect(formatScreenshotStatusLine({ status: "declined" })).toBe(
+      "Screenshot status: declined",
+    );
+    expect(formatScreenshotStatusLine({ status: "capture-failed" })).toBe(
+      "Screenshot status: capture-failed",
+    );
+  });
+
+  it("tells a maintainer to ask for a screenshot the reporter already has", () => {
+    expect(formatScreenshotStatusLine({ status: "captured" })).toContain(
+      "ask them to paste it",
+    );
+  });
+
+  it("includes the failure reason when capture failed", () => {
+    expect(
+      formatScreenshotStatusLine({
+        status: "capture-failed",
+        reason: "No focused window to capture",
+      }),
+    ).toBe("Screenshot status: capture-failed (No focused window to capture)");
+  });
+});
+
+describe("buildBugReportBody", () => {
+  it("records the screenshot status under the screenshot section", () => {
+    const body = buildBugReportBody({
+      ...common,
+      screenshot: { status: "captured" },
+    });
+    expect(body).toContain(
+      "## Screenshot (recommended)\n<!-- Screenshot of the bug -->\nScreenshot status: captured",
+    );
+  });
+
+  it.each(["captured", "declined", "capture-failed"] as const)(
+    "records %s",
+    (status) => {
+      const body = buildBugReportBody({ ...common, screenshot: { status } });
+      expect(body).toContain(`Screenshot status: ${status}`);
+    },
+  );
+
+  it("keeps the existing report sections", () => {
+    const body = buildBugReportBody({
+      ...common,
+      screenshot: { status: "declined" },
+    });
+    expect(body).toContain("## Bug Description (required)");
+    expect(body).toContain("## System Information");
+    expect(body).toContain("- Dyad Version: 1.2.3");
+    expect(body).toContain("## Settings");
+    expect(body).toContain("## Logs");
+  });
+});
+
+describe("buildSessionReportBody", () => {
+  it("records the screenshot status", () => {
+    const body = buildSessionReportBody({
+      ...common,
+      sessionId: "v2:abc",
+      screenshot: { status: "captured" },
+    });
+    expect(body).toContain("Screenshot status: captured");
+  });
+
+  it("keeps the session ID that makes the report actionable", () => {
+    const body = buildSessionReportBody({
+      ...common,
+      sessionId: "v2:abc",
+      screenshot: { status: "declined" },
+    });
+    expect(body).toContain("Session ID: v2:abc");
+    expect(body).toContain("Session Schema: v2.0");
+    expect(body).toContain("Pro User ID: user-abc");
+  });
+});
+
+describe("buildSessionReportFallbackBody", () => {
+  it("still carries the session ID and screenshot status", () => {
+    const body = buildSessionReportFallbackBody({
+      userBudget,
+      sessionId: "v2:abc",
+      screenshot: { status: "capture-failed", reason: "boom" },
+    });
+    expect(body).toContain("Session ID: v2:abc");
+    expect(body).toContain("Screenshot status: capture-failed (boom)");
+  });
+});

--- a/src/lib/issueBody.ts
+++ b/src/lib/issueBody.ts
@@ -153,6 +153,24 @@ ${formatLogsSection(debugInfo)}
 `;
 }
 
+/** Used when getSystemDebugInfo fails, so the screenshot status still reaches GitHub. */
+export function buildBugReportFallbackBody({
+  screenshot,
+}: {
+  screenshot: ScreenshotOutcome;
+}): string {
+  return `\
+<!-- Please fill in all fields in English -->
+
+## Bug Description (required)
+<!-- Please describe the issue you're experiencing and how to reproduce it -->
+
+## Screenshot (recommended)
+<!-- Screenshot of the bug -->
+${formatScreenshotStatusLine(screenshot)}
+`;
+}
+
 /** Used when getSystemDebugInfo fails, so the session ID still reaches GitHub. */
 export function buildSessionReportFallbackBody({
   userBudget,

--- a/src/lib/issueBody.ts
+++ b/src/lib/issueBody.ts
@@ -1,0 +1,170 @@
+import { type SystemDebugInfo } from "@/ipc/types";
+import { type UserBudgetInfo } from "@/ipc/types/system";
+import { type ModelSelection, type UserSettings } from "@/lib/schemas";
+import { formatUpdaterLogsForIssueBody } from "@/lib/debugLogFormatting";
+
+/**
+ * What happened when we offered to take a screenshot. Recorded in the issue
+ * body so a maintainer can tell an issue with no image from a reporter who
+ * declined, and so the two cases can be counted separately after the fact.
+ */
+export type ScreenshotStatus = "captured" | "declined" | "capture-failed";
+
+export interface ScreenshotOutcome {
+  status: ScreenshotStatus;
+  /** Failure message from takeScreenshot, only set for "capture-failed". */
+  reason?: string;
+}
+
+/** Stable prefix so published issues can be counted with a GitHub search. */
+const SCREENSHOT_STATUS_PREFIX = "Screenshot status:";
+
+export function formatScreenshotStatusLine(outcome: ScreenshotOutcome): string {
+  switch (outcome.status) {
+    case "captured":
+      return `${SCREENSHOT_STATUS_PREFIX} captured (reporter captured a screenshot in Dyad; if none appears above, ask them to paste it)`;
+    case "declined":
+      return `${SCREENSHOT_STATUS_PREFIX} declined`;
+    case "capture-failed":
+      return outcome.reason
+        ? `${SCREENSHOT_STATUS_PREFIX} capture-failed (${outcome.reason})`
+        : `${SCREENSHOT_STATUS_PREFIX} capture-failed`;
+  }
+}
+
+export function formatSettingsLines(
+  settings: UserSettings | null,
+  selectedModel: ModelSelection | null,
+): string {
+  if (!settings) return "Settings not available";
+  const model = selectedModel ?? settings.selectedModel;
+  return [
+    `- Selected Model: ${model.provider}:${model.name}`,
+    `- Chat Mode: ${settings.selectedChatMode ?? "default"}`,
+    `- Auto Approve Changes: ${settings.autoApproveChanges ?? "n/a"}`,
+    `- Dyad Pro Enabled: ${settings.enableDyadPro ?? "n/a"}`,
+    `- Effort Level: ${selectedModel?.effortLevel ?? "medium"}`,
+    `- Runtime Mode: ${settings.runtimeMode2 ?? "n/a"}`,
+    `- Release Channel: ${settings.releaseChannel ?? "n/a"}`,
+  ].join("\n");
+}
+
+export function formatSystemInfoSection(
+  debugInfo: SystemDebugInfo,
+  userBudget: UserBudgetInfo | undefined,
+): string {
+  return `## System Information
+- Dyad Version: ${debugInfo.dyadVersion}
+- Platform: ${debugInfo.platform}
+- Architecture: ${debugInfo.architecture}
+- Node Version: ${debugInfo.nodeVersion || "n/a"}
+- PNPM Version: ${debugInfo.pnpmVersion || "n/a"}
+- Node Path: ${debugInfo.nodePath || "n/a"}
+- Pro User ID: ${userBudget?.redactedUserId || "n/a"}
+- Telemetry ID: ${debugInfo.telemetryId || "n/a"}
+- Model: ${debugInfo.selectedLanguageModel || "n/a"}`;
+}
+
+export function formatLogsSection(debugInfo: SystemDebugInfo): string {
+  // Keep the updater section small: the issue body travels in the GitHub URL.
+  const updaterSection = debugInfo.updaterLogs
+    ? `
+
+## Auto-Updater Logs
+\`\`\`
+${formatUpdaterLogsForIssueBody(debugInfo.updaterLogs)}
+\`\`\``
+    : "";
+  return `## Logs
+\`\`\`
+${debugInfo.logs.slice(-3_500) || "No logs available"}
+\`\`\`${updaterSection}`;
+}
+
+interface CommonBodyParams {
+  debugInfo: SystemDebugInfo;
+  settings: UserSettings | null;
+  /** Effort-aware model for this chat, falling back to the global setting. */
+  selectedModel: ModelSelection | null;
+  userBudget: UserBudgetInfo | undefined;
+  screenshot: ScreenshotOutcome;
+}
+
+export function buildBugReportBody({
+  debugInfo,
+  settings,
+  selectedModel,
+  userBudget,
+  screenshot,
+}: CommonBodyParams): string {
+  return `\
+<!-- Please fill in all fields in English -->
+
+## Bug Description (required)
+<!-- Please describe the issue you're experiencing and how to reproduce it -->
+
+## Screenshot (recommended)
+<!-- Screenshot of the bug -->
+${formatScreenshotStatusLine(screenshot)}
+
+${formatSystemInfoSection(debugInfo, userBudget)}
+
+## Settings
+${formatSettingsLines(settings, selectedModel)}
+
+${formatLogsSection(debugInfo)}
+`;
+}
+
+export function buildSessionReportBody({
+  debugInfo,
+  settings,
+  selectedModel,
+  userBudget,
+  screenshot,
+  sessionId,
+}: CommonBodyParams & { sessionId: string }): string {
+  return `\
+<!-- Please fill in all fields in English -->
+
+Session ID: ${sessionId}
+Session Schema: v2.0
+Pro User ID: ${userBudget?.redactedUserId || "n/a"}
+
+## Issue Description (required)
+<!-- Please describe the issue you're experiencing -->
+
+## Expected Behavior (required)
+<!-- What did you expect to happen? -->
+
+## Actual Behavior (required)
+<!-- What actually happened? -->
+
+## Screenshot (recommended)
+<!-- Screenshot of the issue -->
+${formatScreenshotStatusLine(screenshot)}
+
+${formatSystemInfoSection(debugInfo, userBudget)}
+
+## Settings
+${formatSettingsLines(settings, selectedModel)}
+
+${formatLogsSection(debugInfo)}
+`;
+}
+
+/** Used when getSystemDebugInfo fails, so the session ID still reaches GitHub. */
+export function buildSessionReportFallbackBody({
+  userBudget,
+  screenshot,
+  sessionId,
+}: {
+  userBudget: UserBudgetInfo | undefined;
+  screenshot: ScreenshotOutcome;
+  sessionId: string;
+}): string {
+  return `Session ID: ${sessionId}
+Session Schema: v2.0
+Pro User ID: ${userBudget?.redactedUserId || "n/a"}
+${formatScreenshotStatusLine(screenshot)}`;
+}

--- a/src/lib/issueBody.ts
+++ b/src/lib/issueBody.ts
@@ -22,7 +22,7 @@ const SCREENSHOT_STATUS_PREFIX = "Screenshot status:";
 export function formatScreenshotStatusLine(outcome: ScreenshotOutcome): string {
   switch (outcome.status) {
     case "captured":
-      return `${SCREENSHOT_STATUS_PREFIX} captured (reporter captured a screenshot in Dyad; if none appears above, ask them to paste it)`;
+      return `${SCREENSHOT_STATUS_PREFIX} captured (reporter captured a screenshot in Dyad; if no image is attached, ask them to paste it)`;
     case "declined":
       return `${SCREENSHOT_STATUS_PREFIX} declined`;
     case "capture-failed":
@@ -32,7 +32,7 @@ export function formatScreenshotStatusLine(outcome: ScreenshotOutcome): string {
   }
 }
 
-export function formatSettingsLines(
+function formatSettingsLines(
   settings: UserSettings | null,
   selectedModel: ModelSelection | null,
 ): string {
@@ -49,7 +49,7 @@ export function formatSettingsLines(
   ].join("\n");
 }
 
-export function formatSystemInfoSection(
+function formatSystemInfoSection(
   debugInfo: SystemDebugInfo,
   userBudget: UserBudgetInfo | undefined,
 ): string {
@@ -65,7 +65,7 @@ export function formatSystemInfoSection(
 - Model: ${debugInfo.selectedLanguageModel || "n/a"}`;
 }
 
-export function formatLogsSection(debugInfo: SystemDebugInfo): string {
+function formatLogsSection(debugInfo: SystemDebugInfo): string {
   // Keep the updater section small: the issue body travels in the GitHub URL.
   const updaterSection = debugInfo.updaterLogs
     ? `

--- a/src/lib/posthogTelemetry.test.ts
+++ b/src/lib/posthogTelemetry.test.ts
@@ -181,6 +181,26 @@ describe("shouldBypassNonProTelemetrySampling", () => {
     ).toBe(true);
   });
 
+  it("always sends the screenshot prompt funnel for non-Pro sampling", () => {
+    for (const event of [
+      "screenshot-prompt:shown",
+      "screenshot-prompt:capture-attempt",
+      "screenshot-prompt:captured",
+      "screenshot-prompt:capture-abandoned",
+      "screenshot-prompt:capture-failed",
+      "screenshot-prompt:decline",
+      "screenshot-prompt:dismissed",
+      "session-report:copy-session-id",
+    ]) {
+      expect(
+        shouldBypassNonProTelemetrySampling({
+          event,
+          properties: { source: "upload-session" },
+        }),
+      ).toBe(true);
+    }
+  });
+
   it("always sends app:initial-load for non-Pro sampling", () => {
     expect(
       shouldBypassNonProTelemetrySampling({

--- a/src/lib/posthogTelemetry.ts
+++ b/src/lib/posthogTelemetry.ts
@@ -107,6 +107,15 @@ export function shouldBypassNonProTelemetrySampling(
     return true;
   }
 
+  // Reporting a bug is rare enough that these add little volume, and sampling
+  // them independently would break the outcome each prompt is paired with.
+  if (
+    eventName?.startsWith("screenshot-prompt:") ||
+    eventName === "session-report:copy-session-id"
+  ) {
+    return true;
+  }
+
   return (
     eventName === "$exception" ||
     eventName?.toLowerCase().includes("error") === true ||


### PR DESCRIPTION
*Written by Claude; reviewed by me. This PR aims to improve the rate at which users submit screenshots for the "upload chat session" path, and also will hopefully give us data on whether a smoother screenshot UX will be helpful to us. See the Basecamp write-up for details on follow-ups.*

Upload Chat Session now shows the same "Take a screenshot?" prompt that Report a Bug already used. That path files a lot of issues and attaches almost nothing.

Both paths now write one line into the issue body recording what actually happened: captured, declined, or capture-failed. Today an issue with no image is ambiguous. It could mean the reporter declined the offer, or that they took a screenshot and it never made it into GitHub. Separating those cases tells a maintainer whether to go ask for an image the reporter already has, and tells us whether automatically attaching screenshots would be worth building or would only ever help a handful of people.

The same three outcomes are reported through telemetry as anonymous usage counts, which gives an additional read.

Issue-body building moves to src/lib/issueBody.ts so the recorded line can be unit tested without rendering the dialog.

Also fixes a pre-existing dead end: when a capture failed, the error was written into a dialog that had already closed, so the reporter saw nothing and no issue was filed at all. A failed capture now files the report with the reason recorded.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

