### PR TITLE
Track meaningful visual editor usage

### DIFF
--- a/src/components/preview_panel/VisualEditingChangesDialog.test.tsx
+++ b/src/components/preview_panel/VisualEditingChangesDialog.test.tsx
@@ -14,6 +14,7 @@ import { VisualEditingChangesDialog } from "./VisualEditingChangesDialog";
 
 const mocks = vi.hoisted(() => ({
   applyChanges: vi.fn(),
+  posthogCapture: vi.fn(),
   showError: vi.fn(),
   showSuccess: vi.fn(),
 }));
@@ -31,11 +32,52 @@ vi.mock("@/lib/toast", () => ({
   showSuccess: mocks.showSuccess,
 }));
 
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => ({ capture: mocks.posthogCapture }),
+}));
+
+const firstChange = {
+  componentId: "src/pages/Index.tsx:7",
+  componentName: "h1",
+  relativePath: "src/pages/Index.tsx",
+  lineNumber: 7,
+  styles: {
+    margin: { left: "20px", right: "20px" },
+  },
+};
+
 describe("VisualEditingChangesDialog", () => {
   beforeEach(() => {
     mocks.applyChanges.mockReset();
+    mocks.posthogCapture.mockReset();
     mocks.showError.mockReset();
     mocks.showSuccess.mockReset();
+  });
+
+  it("tracks an edit only after a component is modified", async () => {
+    const store = createStore();
+    store.set(selectedAppIdAtom, 1);
+    const Wrapper = ({ children }: PropsWithChildren) => (
+      <Provider store={store}>{children}</Provider>
+    );
+
+    render(<VisualEditingChangesDialog />, {
+      wrapper: Wrapper,
+      reactStrictMode: true,
+    });
+
+    expect(mocks.posthogCapture).not.toHaveBeenCalled();
+
+    act(() => {
+      store.set(
+        pendingVisualChangesAtom,
+        new Map([[firstChange.componentId, firstChange]]),
+      );
+    });
+
+    await waitFor(() => {
+      expect(mocks.posthogCapture).toHaveBeenCalledWith("visual-editor:edit");
+    });
   });
 
   it("applies pending changes once when the component rerenders during save", async () => {
@@ -51,20 +93,7 @@ describe("VisualEditingChangesDialog", () => {
     store.set(selectedAppIdAtom, 1);
     store.set(
       pendingVisualChangesAtom,
-      new Map([
-        [
-          "src/pages/Index.tsx:7",
-          {
-            componentId: "src/pages/Index.tsx:7",
-            componentName: "h1",
-            relativePath: "src/pages/Index.tsx",
-            lineNumber: 7,
-            styles: {
-              margin: { left: "20px", right: "20px" },
-            },
-          },
-        ],
-      ]),
+      new Map([[firstChange.componentId, firstChange]]),
     );
 
     const iframe = document.createElement("iframe");
@@ -117,6 +146,7 @@ describe("VisualEditingChangesDialog", () => {
       expect(screen.queryByRole("button", { name: "Save Changes" })).toBeNull();
     });
     expect(mocks.showSuccess).toHaveBeenCalledTimes(1);
+    expect(mocks.posthogCapture).toHaveBeenCalledWith("visual-editor:save");
     iframe.remove();
   });
 });

--- a/src/components/preview_panel/VisualEditingChangesDialog.tsx
+++ b/src/components/preview_panel/VisualEditingChangesDialog.tsx
@@ -6,6 +6,7 @@ import { Check, X } from "lucide-react";
 import { useState, useEffect, useRef } from "react";
 import { showError, showSuccess } from "@/lib/toast";
 import { selectedAppIdAtom } from "@/atoms/appAtoms";
+import { usePostHog } from "posthog-js/react";
 
 interface VisualEditingChangesDialogProps {
   onReset?: () => void;
@@ -18,12 +19,26 @@ export function VisualEditingChangesDialog({
 }: VisualEditingChangesDialogProps) {
   const [pendingChanges, setPendingChanges] = useAtom(pendingVisualChangesAtom);
   const selectedAppId = useAtomValue(selectedAppIdAtom);
+  const posthog = usePostHog();
   const [isSaving, setIsSaving] = useState(false);
   const textContentCache = useRef<Map<string, string>>(new Map());
   const [allResponsesReceived, setAllResponsesReceived] = useState(false);
   const expectedResponsesRef = useRef<Set<string>>(new Set());
   const isWaitingForResponses = useRef(false);
   const isApplyingChanges = useRef(false);
+  const previouslyHadPendingChanges = useRef(false);
+
+  // Count an editing attempt once per unsaved batch. Activating or using the
+  // component selector alone never creates a pending change.
+  useEffect(() => {
+    const hasPendingChanges = pendingChanges.size > 0;
+
+    if (hasPendingChanges && !previouslyHadPendingChanges.current) {
+      posthog.capture("visual-editor:edit");
+    }
+
+    previouslyHadPendingChanges.current = hasPendingChanges;
+  }, [pendingChanges.size, posthog]);
 
   // Listen for text content responses
   useEffect(() => {
@@ -73,6 +88,7 @@ export function VisualEditingChangesDialog({
             changes: updatedChanges,
           });
 
+          posthog.capture("visual-editor:save");
           setPendingChanges(new Map());
           textContentCache.current.clear();
           showSuccess("Visual changes saved to source files");
@@ -96,6 +112,7 @@ export function VisualEditingChangesDialog({
     pendingChanges,
     selectedAppId,
     onReset,
+    posthog,
     setPendingChanges,
   ]);
 
@@ -138,6 +155,7 @@ export function VisualEditingChangesDialog({
           changes: changesToSave,
         });
 
+        posthog.capture("visual-editor:save");
         setPendingChanges(new Map());
         textContentCache.current.clear();
         showSuccess("Visual changes saved to source files");


### PR DESCRIPTION
## Summary

Track meaningful visual editor adoption and edit-to-save conversion in PostHog without counting users who only open the component selector.

- Emit `visual-editor:edit` once when an unsaved editing batch gains its first component change.
- Emit `visual-editor:save` only after the source-file update succeeds, so failed save attempts do not inflate completion counts.
- Keep the events intentionally property-free because the product question only needs user and event counts.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

