### PR TITLE
Improve interrupted version restore recovery

### DIFF
--- a/drizzle/0049_high_sersi.sql
+++ b/drizzle/0049_high_sersi.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `chat_turn_intents` ADD `terminal_outcome` text;

--- a/drizzle/meta/0049_snapshot.json
+++ b/drizzle/meta/0049_snapshot.json
@@ -1,0 +1,2106 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "7926d785-3275-4294-a939-483799596730",
+  "prevId": "ba672ad0-808c-426e-942c-528cbdbbf5e2",
+  "tables": {
+    "agent_activities": {
+      "name": "agent_activities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "presentation_xml": {
+          "name": "presentation_xml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_json": {
+          "name": "input_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_text": {
+          "name": "output_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_activities_thread_tool_call_unique": {
+          "name": "agent_activities_thread_tool_call_unique",
+          "columns": [
+            "thread_id",
+            "tool_call_id"
+          ],
+          "isUnique": true
+        },
+        "agent_activities_thread_sequence_unique": {
+          "name": "agent_activities_thread_sequence_unique",
+          "columns": [
+            "thread_id",
+            "sequence"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_activities_thread_id_agent_threads_id_fk": {
+          "name": "agent_activities_thread_id_agent_threads_id_fk",
+          "tableFrom": "agent_activities",
+          "tableTo": "agent_threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_messages": {
+      "name": "agent_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed": {
+          "name": "consumed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "agent_messages_thread_sequence_unique": {
+          "name": "agent_messages_thread_sequence_unique",
+          "columns": [
+            "thread_id",
+            "sequence"
+          ],
+          "isUnique": true
+        },
+        "agent_messages_thread_message_unique": {
+          "name": "agent_messages_thread_message_unique",
+          "columns": [
+            "thread_id",
+            "message_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_messages_thread_id_agent_threads_id_fk": {
+          "name": "agent_messages_thread_id_agent_threads_id_fk",
+          "tableFrom": "agent_messages",
+          "tableTo": "agent_threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_threads": {
+      "name": "agent_threads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "persona": {
+          "name": "persona",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_name": {
+          "name": "task_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assignment": {
+          "name": "assignment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reasoning_effort": {
+          "name": "reasoning_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_json": {
+          "name": "context_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "result_json": {
+          "name": "result_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_base_commit": {
+          "name": "review_base_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_target_commit": {
+          "name": "review_target_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_diff_hash": {
+          "name": "review_diff_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "invocation_source": {
+          "name": "invocation_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remediation_source": {
+          "name": "remediation_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_fix_at": {
+          "name": "auto_fix_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tool_call_count": {
+          "name": "tool_call_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "agent_threads_chat_id_idx": {
+          "name": "agent_threads_chat_id_idx",
+          "columns": [
+            "chat_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_threads_chat_id_chats_id_fk": {
+          "name": "agent_threads_chat_id_chats_id_fk",
+          "tableFrom": "agent_threads",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_collections": {
+      "name": "app_collections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "app_collections_name_unique": {
+          "name": "app_collections_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apps": {
+      "name": "apps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "github_org": {
+          "name": "github_org",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_repo": {
+          "name": "github_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_branch": {
+          "name": "github_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supabase_project_id": {
+          "name": "supabase_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supabase_parent_project_id": {
+          "name": "supabase_parent_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supabase_organization_slug": {
+          "name": "supabase_organization_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supabase_test_user_id": {
+          "name": "supabase_test_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_project_id": {
+          "name": "neon_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_development_branch_id": {
+          "name": "neon_development_branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_preview_branch_id": {
+          "name": "neon_preview_branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_active_branch_id": {
+          "name": "neon_active_branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_test_branch_id": {
+          "name": "neon_test_branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_production_auth_cookie_secret": {
+          "name": "neon_production_auth_cookie_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_development_auth_cookie_secret": {
+          "name": "neon_development_auth_cookie_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selected_database_branch_type": {
+          "name": "selected_database_branch_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vercel_project_id": {
+          "name": "vercel_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vercel_project_name": {
+          "name": "vercel_project_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vercel_team_id": {
+          "name": "vercel_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vercel_deployment_url": {
+          "name": "vercel_deployment_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "install_command": {
+          "name": "install_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_command": {
+          "name": "start_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chat_context": {
+          "name": "chat_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "theme_id": {
+          "name": "theme_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "needs_app_blueprint": {
+          "name": "needs_app_blueprint",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "testing_enabled": {
+          "name": "testing_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apps_collection_id_app_collections_id_fk": {
+          "name": "apps_collection_id_app_collections_id_fk",
+          "tableFrom": "apps",
+          "tableTo": "app_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_queue_entries": {
+      "name": "chat_queue_entries",
+      "columns": {
+        "intent_id": {
+          "name": "intent_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_queue_entries_intent_id_chat_turn_intents_intent_id_fk": {
+          "name": "chat_queue_entries_intent_id_chat_turn_intents_intent_id_fk",
+          "tableFrom": "chat_queue_entries",
+          "tableTo": "chat_turn_intents",
+          "columnsFrom": [
+            "intent_id"
+          ],
+          "columnsTo": [
+            "intent_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_queue_states": {
+      "name": "chat_queue_states",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "paused": {
+          "name": "paused",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "pause_reason": {
+          "name": "pause_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_queue_states_chat_id_chats_id_fk": {
+          "name": "chat_queue_states_chat_id_chats_id_fk",
+          "tableFrom": "chat_queue_states",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_search_dirty_chats": {
+      "name": "chat_search_dirty_chats",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_search_dirty_messages": {
+      "name": "chat_search_dirty_messages",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_search_meta": {
+      "name": "chat_search_meta",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_turn_intents": {
+      "name": "chat_turn_intents",
+      "columns": {
+        "intent_id": {
+          "name": "intent_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "intent": {
+          "name": "intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "acceptance": {
+          "name": "acceptance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "recovery": {
+          "name": "recovery",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'not-started'"
+        },
+        "terminal_outcome": {
+          "name": "terminal_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_message_id": {
+          "name": "accepted_message_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "chat_turn_intents_chat_idx": {
+          "name": "chat_turn_intents_chat_idx",
+          "columns": [
+            "chat_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "chat_turn_intents_chat_id_chats_id_fk": {
+          "name": "chat_turn_intents_chat_id_chats_id_fk",
+          "tableFrom": "chat_turn_intents",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chats": {
+      "name": "chats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "initial_commit_hash": {
+          "name": "initial_commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "compacted_at": {
+          "name": "compacted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "compaction_backup_path": {
+          "name": "compaction_backup_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pending_compaction": {
+          "name": "pending_compaction",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chat_mode": {
+          "name": "chat_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_selection": {
+          "name": "model_selection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "referenced_app_ids": {
+          "name": "referenced_app_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chats_app_id_apps_id_fk": {
+          "name": "chats_app_id_apps_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "coolify_app_connections": {
+      "name": "coolify_app_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_uuid": {
+          "name": "server_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_uuid": {
+          "name": "project_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment_name": {
+          "name": "environment_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'production'"
+        },
+        "application_uuid": {
+          "name": "application_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "app_url": {
+          "name": "app_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_deployed_at": {
+          "name": "last_deployed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "coolify_app_connections_target_unique": {
+          "name": "coolify_app_connections_target_unique",
+          "columns": [
+            "app_id",
+            "server_uuid",
+            "project_uuid",
+            "environment_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "coolify_app_connections_app_id_apps_id_fk": {
+          "name": "coolify_app_connections_app_id_apps_id_fk",
+          "tableFrom": "coolify_app_connections",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_themes": {
+      "name": "custom_themes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "language_model_providers": {
+      "name": "language_model_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_base_url": {
+          "name": "api_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "env_var_name": {
+          "name": "env_var_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "language_models": {
+      "name": "language_models",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_name": {
+          "name": "api_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "builtin_provider_id": {
+          "name": "builtin_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "custom_provider_id": {
+          "name": "custom_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_output_tokens": {
+          "name": "max_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "language_models_custom_provider_id_language_model_providers_id_fk": {
+          "name": "language_models_custom_provider_id_language_model_providers_id_fk",
+          "tableFrom": "language_models",
+          "tableTo": "language_model_providers",
+          "columnsFrom": [
+            "custom_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "env_json": {
+          "name": "env_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "headers_json": {
+          "name": "headers_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "env_encrypted": {
+          "name": "env_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "headers_encrypted": {
+          "name": "headers_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "oauth_enabled": {
+          "name": "oauth_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "oauth_state": {
+          "name": "oauth_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client_secret": {
+          "name": "oauth_client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_scope": {
+          "name": "oauth_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_callback_port": {
+          "name": "oauth_callback_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "catalog_slug": {
+          "name": "catalog_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "uniq_mcp_catalog_slug": {
+          "name": "uniq_mcp_catalog_slug",
+          "columns": [
+            "catalog_slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_tool_consents": {
+      "name": "mcp_tool_consents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consent": {
+          "name": "consent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ask'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "uniq_mcp_consent": {
+          "name": "uniq_mcp_consent",
+          "columns": [
+            "server_id",
+            "tool_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "mcp_tool_consents_server_id_mcp_servers_id_fk": {
+          "name": "mcp_tool_consents_server_id_mcp_servers_id_fk",
+          "tableFrom": "mcp_tool_consents",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "approval_state": {
+          "name": "approval_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_commit_hash": {
+          "name": "source_commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "commit_hash": {
+          "name": "commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_input_request_id": {
+          "name": "user_input_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chat_turn_intent_id": {
+          "name": "chat_turn_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_tokens_used": {
+          "name": "max_tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ai_messages_json": {
+          "name": "ai_messages_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "using_free_agent_mode_quota": {
+          "name": "using_free_agent_mode_quota",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_compaction_summary": {
+          "name": "is_compaction_summary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "messages_chat_user_input_request_unique": {
+          "name": "messages_chat_user_input_request_unique",
+          "columns": [
+            "chat_id",
+            "user_input_request_id"
+          ],
+          "isUnique": true
+        },
+        "messages_chat_turn_intent_unique": {
+          "name": "messages_chat_turn_intent_unique",
+          "columns": [
+            "chat_id",
+            "chat_turn_intent_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "messages_chat_id_chats_id_fk": {
+          "name": "messages_chat_id_chats_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompts": {
+      "name": "prompts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "prompts_slug_unique": {
+          "name": "prompts_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "security_fix_chats": {
+      "name": "security_fix_chats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "review_chat_id": {
+          "name": "review_chat_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finding_key": {
+          "name": "finding_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fix_chat_id": {
+          "name": "fix_chat_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "security_fix_chats_review_chat_id_idx": {
+          "name": "security_fix_chats_review_chat_id_idx",
+          "columns": [
+            "review_chat_id"
+          ],
+          "isUnique": false
+        },
+        "security_fix_chats_fix_chat_id_idx": {
+          "name": "security_fix_chats_fix_chat_id_idx",
+          "columns": [
+            "fix_chat_id"
+          ],
+          "isUnique": false
+        },
+        "security_fix_chats_unique": {
+          "name": "security_fix_chats_unique",
+          "columns": [
+            "app_id",
+            "review_chat_id",
+            "finding_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "security_fix_chats_app_id_apps_id_fk": {
+          "name": "security_fix_chats_app_id_apps_id_fk",
+          "tableFrom": "security_fix_chats",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "security_fix_chats_review_chat_id_chats_id_fk": {
+          "name": "security_fix_chats_review_chat_id_chats_id_fk",
+          "tableFrom": "security_fix_chats",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "review_chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "security_fix_chats_fix_chat_id_chats_id_fk": {
+          "name": "security_fix_chats_fix_chat_id_chats_id_fk",
+          "tableFrom": "security_fix_chats",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "fix_chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "versions": {
+      "name": "versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "commit_hash": {
+          "name": "commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "neon_db_timestamp": {
+          "name": "neon_db_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "versions_app_commit_unique": {
+          "name": "versions_app_commit_unique",
+          "columns": [
+            "app_id",
+            "commit_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "versions_app_id_apps_id_fk": {
+          "name": "versions_app_id_apps_id_fk",
+          "tableFrom": "versions",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -344,6 +344,13 @@
       "when": 1786721941438,
       "tag": "0048_familiar_mystique",
       "breakpoints": true
+    },
+    {
+      "idx": 49,
+      "version": "6",
+      "when": 1787112815219,
+      "tag": "0049_high_sersi",
+      "breakpoints": true
     }
   ]
 }

--- a/e2e-tests/fixtures/engine/local-agent/cancel-after-write.ts
+++ b/e2e-tests/fixtures/engine/local-agent/cancel-after-write.ts
@@ -1,0 +1,29 @@
+import type { LocalAgentFixture } from "../../../../testing/fake-llm-server/localAgentTypes";
+
+/**
+ * Write a file, then keep the generation open so the real Stop control can
+ * interrupt the turn after a user-visible mutation but before finalization.
+ */
+export const fixture: LocalAgentFixture = {
+  description: "Write a partial file, then stall until the turn is cancelled",
+  turns: [
+    {
+      text: "I'll start creating the requested file.",
+      toolCalls: [
+        {
+          name: "write_file",
+          args: {
+            path: "src/stopped-generation.ts",
+            content: `export const stoppedGeneration = "partial";
+`,
+            description: "Create the partial generation file",
+          },
+        },
+      ],
+    },
+    {
+      delayMs: 30_000,
+      text: "Finishing the remaining work...",
+    },
+  ],
+};

--- a/plans/better-version-recovery.md
+++ b/plans/better-version-recovery.md
@@ -1,0 +1,544 @@
+# Better Version Recovery
+
+> Implementation plan created 2026-08-18
+
+## Summary
+
+Fix the `Stop generation -> Undo` workflow so Dyad durably remembers that the target turn was cancelled, preserves its partial working-tree changes in a recoverable checkpoint commit, and completes Undo without losing work. Also narrow `restore-recovery-required` to genuinely ambiguous Git states and add validated **Use current version** and **Save changes & use current version** paths for stale recovery checkpoints.
+
+Ship all three changes in one PR because they form one recovery contract: prevent the common false-positive, classify failures correctly, and provide an escape hatch for checkpoints that still cannot be reconciled automatically.
+
+## Problem Statement
+
+The reproduced failure has this sequence:
+
+1. An agent turn modifies files but has not committed them.
+2. The user presses Stop.
+3. Chat finalization durably records only `recovery = "terminal"`; it does not preserve whether the turn completed, was cancelled, or errored.
+4. The user clicks the footer Undo action for that generation (or chooses **Restore code & fork chat** at the same target message).
+5. The footer Undo path calls `revertVersionHandler` with `currentChatMessageId`; the fork action calls `restoreToMessageHandler`. Neither path sees a currently active stream after Stop has settled.
+6. The working tree is dirty, but Undo no longer knows that the dirt came from the cancelled target turn. `gitStageToRevert` therefore throws `Cannot revert: working tree has uncommitted changes.`
+7. The restore has already checkpointed `nextStep = "checkout-branch"`, so the command adapter escalates the ordinary conflict to `restore-recovery-required` based only on the checkpoint label.
+8. Version History becomes permanently disabled. The persistent toast has no action even when the repository is on a valid branch and commit.
+
+The Git dirty-tree refusal is a valid data-loss guard. The bugs are losing the cancelled-turn provenance, classifying a pre-destructive refusal as ambiguous recovery, and providing no supported acknowledgement path for a genuinely stale checkpoint.
+
+## Goals
+
+- Make Stop followed by Undo work without losing partial generation output or unrelated working-tree changes.
+- Persist the terminal outcome of each accepted chat turn so correctness does not depend on in-memory cancellation timing.
+- Keep ordinary dirty-tree conflicts out of `restore-recovery-required` when no destructive reset may have started and Git remains at the pre-restore branch and HEAD.
+- Preserve conservative recovery for failures after a hard reset, soft reset, restore commit, or partial Git/database handoff.
+- Let a user explicitly accept a healthy current repository and clear a stale recovery checkpoint without changing Git.
+- Give a user with an otherwise healthy but dirty repository a lossless, in-product path to checkpoint those changes and continue.
+- Keep all repository inspection and mutation in the main process under app operation coordination.
+- Preserve existing behavior for ordinary Version History restores, manual edits, recordings, app deletion, and renderer reloads.
+
+## Non-goals
+
+- Automatically discard dirty files.
+- Attribute individual dirty files to the agent with certainty; Dyad already cannot distinguish partial generation writes from simultaneous manual edits.
+- Add general Git repair tooling, conflict resolution, reset, or force-checkout actions.
+- Add a guided conflict-resolution panel, automatically continue/abort an in-progress Git operation, or create special backups for those operations.
+- Redesign Version History beyond the recovery toast/action.
+- Make Git mutations cancellable.
+- Backfill an authoritative outcome for every historical turn when the old schema did not store one.
+
+## Product and Safety Decisions
+
+### Preserve rather than discard
+
+When the target user message belongs to a durably cancelled turn, Undo may commit the whole dirty tree before restoring. This matches the existing active-cancellation behavior and is lossless: unrelated manual edits may be included in the checkpoint, but nothing is silently overwritten. The success/warning copy must disclose that partial changes were saved.
+
+The checkpoint is an ordinary commit on the app's reachable branch history, so it appears in Version History and supports the same preview and restore actions as every other version. Use the canonical commit message **`[Interrupted] Saved partial changes before restoring to an earlier version`**. The `[Interrupted]` prefix is the user-visible label; do not add a second checkpoint model or a special Version History row type in this PR.
+
+### A durable outcome, not a timing heuristic
+
+Extend the existing `chat_turn_intents` record rather than creating a second cancellation registry. The user message already carries `chatTurnIntentId`, and `chat_turn_intents.accepted_message_id` points back to that message.
+
+Add a nullable terminal outcome with values:
+
+- `completed`
+- `cancelled`
+- `errored`
+
+`null` means a legacy or non-terminal row whose outcome is unknown. Unknown must remain conservative; it must not be treated as cancelled merely because the tree is dirty.
+
+Persist the outcome in the same SQLite transaction that marks `recovery = "terminal"` and removes the queue entry. Update the in-memory `IntentRecord` at the same linearization point so live and restarted behavior agree.
+
+For compatibility with turns created before the migration, allow a narrowly scoped fallback only when the target user message is immediately followed by an assistant message recognized by `isCancelledResponseContent`, with no successful `commitHash`. Keep this fallback in one helper and test it; do not infer cancellation from an absent commit alone.
+
+### Recovery means ambiguity, not merely dirtiness
+
+A dirty tree is an ordinary Git conflict unless a destructive restore step may already have crossed its checkpoint. Move the non-preserving dirty-tree preflight before branch checkout and before any destructive checkpoint.
+
+The failure disposition must be based on both the last effect boundary and a repository probe, not only `restoreProgress.nextStep`:
+
+- `preparing` or preflight failure: ordinary `RESTORE_FAILED`.
+- `checkout-branch`, with the repository still at the recorded pre-restore branch and HEAD and no destructive step started: ordinary `RESTORE_FAILED`, regardless of dirtiness.
+- `checkout-branch`, with branch or HEAD divergence: recovery required.
+- `preserve-dirty-tree`, `hard-reset`, `soft-reset`, or `commit`: recovery required unless a stronger, explicitly tested postcondition proves a terminal state.
+- `chat-mutation`: recovery required because Git may be complete while the chat fork is not.
+- `completed`: reconcile against the recorded completed HEAD as today.
+
+Skip `git checkout` entirely when `revertRef` is already the current branch. Only write a `checkout-branch` checkpoint when a checkout will actually execute.
+
+Classify the failure while the restore still owns its repository operation claim. Do not release the coordinator lock and then race a new chat turn while probing Git.
+
+### “Use current version” is acknowledgement, not dismissal
+
+Do not add a cosmetic Dismiss action. Add a state-machine intent that means: “validate the repository as it exists now, abandon the unfinished restore checkpoint, and resume from current HEAD.”
+
+The action must not modify Git. Before accepting, main must verify under a coordinated repository read that:
+
+- the app and repository still exist;
+- HEAD resolves to a commit;
+- HEAD is attached to a named branch;
+- the index has no unmerged entries;
+- no merge, rebase, cherry-pick, revert, or bisect operation is in progress; and
+- the working tree is clean.
+
+On success, return authoritative `appId`, branch, accepted HEAD, and optional saved-version ID; transition to `closed`; remove the checkpoint through the existing persistence observer; reset historical-preview presentation; refresh repository, version, file, and chat data; dismiss the recovery toast; and restore normal Version History capabilities. On failure, remain in `restore-recovery-required` and replace the description with an actionable `DyadErrorKind.Conflict` or `Precondition` message.
+
+#### Dirty-tree recovery
+
+A dirty tree is recoverable without asking the user to understand Git. If read-only validation finds an otherwise healthy repository whose only blocker is uncommitted changes, keep recovery active and change the primary action to **Save changes & use current version**.
+
+This is a separate, explicitly mutating action. Under a coordinated repository write claim it must:
+
+1. revalidate that HEAD is attached, the index has no unresolved entries, and no Git operation is in progress;
+2. stage the same user-visible files covered by Dyad's existing whole-tree checkpoint behavior;
+3. create the canonical checkpoint commit **`[Recovery] Saved current changes before continuing Version History`** so this distinct, user-initiated recovery save is also recognizable as an ordinary version;
+4. re-run the repository-health probe and require a clean attached HEAD; and
+5. only then transition to `closed` and remove the stale restore checkpoint.
+
+If staging, committing, or final validation fails, leave `restore-recovery-required` in place and show the specific error. Never reset, discard, force-checkout, or clear recovery on a partial failure. If Dyad crashes after the commit but before acknowledgement, restart reconciliation sees a clean repository and the user can safely choose **Use current version**.
+
+Detached HEAD, unresolved index entries, missing repositories, and active merge/rebase/cherry-pick/revert/bisect operations do not offer the save action. Dyad does not attempt to repair, continue, abort, reset, or back up these states in this feature. The toast explains the detected blocker in plain language and offers only the read-only **Check again** action after the user resolves it outside Dyad.
+
+## User Experience
+
+### Stop followed by Undo
+
+1. The user stops a generation after it has edited files.
+2. The cancelled outcome is persisted before the turn is considered settled.
+3. The user clicks Undo on that user message.
+4. Dyad recognizes the target turn as cancelled.
+5. If the tree is dirty, Dyad creates `[Interrupted] Saved partial changes before restoring to an earlier version` and then completes the requested Undo or restore/fork flow.
+6. The result toast explains that partial changes were saved as an **Interrupted** entry in Version History and that the prompt can be resubmitted if desired.
+
+No additional confirmation is required because the operation is lossless and the user already confirmed Undo. If checkpoint creation fails, leave the tree untouched and show the ordinary Git conflict; do not continue to reset.
+
+### Ordinary dirty repository
+
+If the target turn is completed/unknown and the tree is dirty, Undo fails with the existing conflict message. Version History stays usable because the failure occurred before any destructive restore boundary.
+
+### Stale recovery checkpoint
+
+Show the existing persistent toast with one primary action:
+
+> **Version restore needs attention**  
+> Dyad could not verify an earlier restore. If this project is clean, you can continue from its current version.  
+> **Use current version**
+
+While validation runs, update the toast description to “Checking the current repository…” and suppress duplicate clicks. If validation fails, retain the toast and render the next action from the authoritative blocker classification.
+
+If the only validation failure is a dirty working tree, do not tell the user to open a terminal, commit, or stash. Update the same toast in place:
+
+> **Your current changes need to be saved**  
+> Dyad found changes that are not part of a saved version. Save them as the current version to continue using Version History.  
+> **Save changes & use current version**
+
+While saving, show “Saving the current version…” and disable duplicate activation. On success, dismiss the toast and restore Version History. On failure, keep the toast open with the concrete error and a retry action.
+
+### Successful recovery landing
+
+Acceptance returns the user to the live project without navigating or reopening Version History automatically. It must clear any historical version selection and diff, refresh the current branch/HEAD and Version History, refresh file/change data, and re-read chats/messages so the renderer reflects whatever durable chat mutation did or did not complete before recovery. Keep the currently selected chat if it still exists; otherwise select the app's latest surviving chat. Acceptance itself never forks, deletes, trims, or rewrites chat.
+
+Show passive confirmation with no action button:
+
+For read-only acceptance:
+
+> **Version History is ready**  
+> Continuing from the current code version.
+
+For checkpoint-and-accept:
+
+> **Current changes saved**  
+> Your changes were saved as `[Recovery] Saved current changes before continuing Version History`. Version History is ready.
+
+Both success toasts use the normal finite duration. Do not include **Open Version History**, **View saved version**, or any other action, and do not force navigation. The `[Recovery]` commit is available the next time the user opens Version History.
+
+For unresolved file conflicts, use blocker-specific copy:
+
+> **Version History is unavailable**  
+> This project has unresolved file conflicts. Resolve them outside Dyad, then check again.  
+> **Check again**
+
+For an in-progress Git operation, name the operation when known:
+
+> **Version History is unavailable**  
+> A Git rebase is still in progress. Finish or cancel it outside Dyad, then check again.  
+> **Check again**
+
+Use the same pattern for merge, cherry-pick, revert, and bisect. **Check again** only reruns the read-only repository-health probe; it never continues, aborts, resets, commits, or otherwise changes Git. If the blocker remains, keep the toast and recovery checkpoint unchanged. Do not add a recovery panel for these states in this PR.
+
+The close affordance may hide the toast for the current renderer session, but it must not clear recovery or unlock mutations. While recovery remains unresolved, opening the Version History pane shows an inline blocked state instead of an empty list or disabled controls:
+
+> **Version History is temporarily unavailable**  
+> Resolve the version recovery notice to continue.
+
+The pane must not open automatically solely because recovery was detected. Preserve whether it was already open; allow it to close normally; and show the blocked state whenever the user opens it during recovery. Opening the pane should also resurface the persistent recovery toast if it was dismissed. The inline state is explanatory only and contains no duplicate repair actions.
+
+## Technical Design
+
+### 1. Persist terminal chat-turn outcome
+
+Affected areas:
+
+- `src/db/schema.ts`
+- generated `drizzle/` migration and migration metadata
+- `src/chat_stream/persistence.ts`
+- `src/chat_stream/definition.ts`
+- chat-stream persistence and actor tests
+
+Changes:
+
+1. Add nullable `terminal_outcome` to `chat_turn_intents` with the three values above.
+2. Extend `IntentRecord` and persisted queue hydration to carry it.
+3. Replace the boolean-style finalization input with an explicit outcome derived from the authoritative terminal event:
+   - `STREAM_ENDED` + `wasCancelled` -> `cancelled`
+   - normal `STREAM_ENDED` -> `completed`
+   - `STREAM_ERRORED` -> `errored`
+4. Persist `terminalOutcome`, `recovery = "terminal"`, queue removal, and pause state atomically.
+5. Keep rejected-before-acceptance intents outcome-null; they never produced a turn whose working tree should be attributed to cancellation.
+6. Ensure restart reconciliation and intent hydration preserve the terminal outcome even after the serialized intent payload is released.
+
+No new standalone IPC endpoint is needed.
+
+### 2. Resolve interrupted-turn provenance during Undo
+
+Affected areas:
+
+- `src/ipc/handlers/version_handlers.ts`
+- a focused helper near chat/version persistence queries
+- `src/shared/chatCancellation.ts` only if the legacy fallback is centralized there
+
+Add a helper such as `getRestoreTargetTurnOutcome(chat, messageId)` that:
+
+1. verifies the target message is the requested user message;
+2. reads its `chatTurnIntentId` and matching `chat_turn_intents` row;
+3. returns `cancelled`, `completed`, `errored`, or `unknown`;
+4. applies the narrowly tested legacy cancelled-response fallback; and
+5. is evaluated under the coordinated repository/chat claim immediately before Git mutation. The multi-phase restore/fork path re-evaluates fresh rows inside phase 3 after stream cancellation; footer Undo performs the same check in its single coordinated mutation.
+
+Set:
+
+```ts
+preserveDirtyTree =
+  didCancelActor ||
+  didCancelTransport ||
+  latestTargetTurnOutcome === "cancelled";
+```
+
+For footer Undo, `currentChatMessageId` identifies the same target user turn; pass `preserveDirtyTree = true` only when that fresh durable outcome resolves to `cancelled`. This ensures Stop -> footer Undo and Stop -> Restore code & fork chat share the same preservation contract.
+
+Do not trust the phase-1 result across cancellation awaits. The phase-3 query under `chat-content` and `repository` ownership is authoritative.
+
+Continue using the existing whole-tree checkpoint behavior because it preserves all user-visible changes. Update logging to identify why preservation was enabled (`cancelled-now` versus `previously-cancelled-turn`) without logging file contents.
+
+Keep the interrupted checkpoint on reachable branch history. Do not store it only in the reflog or behind an internal-only reference. Because `listVersions` is backed by the branch's Git log, the canonical commit automatically becomes a normal, numbered, selectable, previewable, and restorable Version History entry without requiring a `messages.commitHash` association or dedicated `versions` metadata row.
+
+### 3. Preflight and classify restore failures correctly
+
+Affected areas:
+
+- `src/ipc/handlers/version_handlers.ts`
+- `src/ipc/utils/git_utils.ts`
+- `src/ipc/services/version_preview_service.ts`
+- `src/ipc/services/version_preview_definition.ts`
+- `src/version_preview/state.ts`
+- recovery/reconciliation tests
+
+Changes:
+
+1. Add a read-only dirty-tree preflight before `checkpointGitStep("checkout-branch")` whenever `preserveDirtyTree` is false. Reuse the same user-visible-path rules as `gitStageToRevert`; do not create two subtly different definitions of “dirty.”
+2. Skip a no-op branch checkout.
+3. Track whether any destructive reset boundary was checkpointed.
+4. On error, inspect branch and HEAD while the repository claim is still held and produce a structured internal failure disposition:
+   - ordinary conflict; or
+   - recovery required with durable recovery facts.
+5. Preserve `DyadError` classification and original user-facing messages. A dirty tree remains `DyadErrorKind.Conflict` and should be filtered from exception telemetry.
+6. Make the command runner emit `RESTORE_FAILED` or `RESTORE_RECOVERY_REQUIRED` from that disposition. Remove the current heuristic that treats every progress value other than `preparing`/`completed` as recovery-required.
+7. Keep restart reconciliation conservative for hard-reset-and-later checkpoints.
+
+The structured disposition is internal to the main-process bridge; it should not weaken the typed renderer transport or expose raw errors over IPC.
+
+### 4. Add validated acceptance of current repository
+
+Affected areas:
+
+- `src/version_preview/state.ts`
+- `src/version_preview/transition.ts`
+- `src/version_preview/projection.ts`
+- `src/version_preview/transport.ts`
+- `src/ipc/services/version_preview_definition.ts`
+- `src/ipc/services/version_preview_service.ts`
+- `src/ipc/services/version_preview_persistence.ts`
+- `src/version_preview/VersionPreviewProvider.tsx`
+- `src/components/chat/VersionPane.tsx`
+- scoped query-invalidation and chat-selection integration points
+
+State-machine additions:
+
+- Renderer intent: `ACCEPT_CURRENT_REPOSITORY` with a stable `operationId`.
+- Renderer intent: `CHECKPOINT_AND_ACCEPT_CURRENT_REPOSITORY` with a stable `operationId`, exposed only after validation reports a dirty-tree-only blocker.
+- Transient state: `validating-current-repository`, retaining the prior recovery session/error.
+- Transient state: `checkpointing-current-repository`, also retaining the prior recovery session/error.
+- Command: `validate-current-repository`.
+- Command: `checkpoint-and-validate-current-repository`.
+- Host events: `CURRENT_REPOSITORY_ACCEPTED` carrying authoritative `appId`, `branch`, `acceptedHead`, and optional `savedVersionId`; `CURRENT_REPOSITORY_DIRTY`; and `CURRENT_REPOSITORY_REJECTED`.
+- Capability: `canAcceptCurrentRepository`, true only in `restore-recovery-required` while transport is ready.
+- Capability: `canCheckpointAndAcceptCurrentRepository`, true only when the latest authoritative validation classified the sole blocker as a dirty working tree.
+
+Transition behavior:
+
+- `restore-recovery-required + ACCEPT_CURRENT_REPOSITORY` -> validating state + one command.
+- Dirty validation -> recovery-required with a typed dirty-tree assessment and `canCheckpointAndAcceptCurrentRepository`.
+- `restore-recovery-required + CHECKPOINT_AND_ACCEPT_CURRENT_REPOSITORY` -> checkpointing state + one command, only for that assessment.
+- Conflict or in-progress-operation validation -> recovery-required with a typed blocker and `canAcceptCurrentRepository` still available as **Check again**; redispatch uses a fresh `operationId` and reruns only read-only validation.
+- Duplicate/mutation intents while validating are ignored with explicit reasons.
+- Duplicate/mutation intents while checkpointing are ignored with explicit reasons.
+- Accepted -> `closed`, clearing the recovery session's selected version/diff presentation.
+- Rejected -> the original recovery state with the new actionable error.
+- Renderer/app disposal does not cancel authoritative validation or checkpointing; settlement remains main-owned.
+- Track whether the Version History pane is open while recovery is unresolved as presentation-only state: `OPEN` shows the blocked pane and resurfaces the toast, while `CLOSE` hides the pane without clearing recovery. Do not persist this visibility bit; after restart it defaults closed until the user opens Version History.
+
+Persistence behavior:
+
+- Do not persist either transient state as successful acknowledgement.
+- While validation or checkpointing is in flight, persist/retain the original `restore-recovery-required` snapshot so the safety latch survives restart.
+- Successful transition to `closed` removes the checkpoint through the existing adapter.
+- Checkpoint removal and the accepted terminal event remain ordered so the renderer never observes an unlocked recovery state before authoritative acceptance succeeds.
+
+Command behavior:
+
+- Acquire `readAppResource("app-path")` and a repository read claim through `appOperationCoordinator`.
+- Run one shared `inspectRepositoryHealth` probe returning structured branch, HEAD, cleanliness, unmerged-index, and operation-in-progress facts; use it for restore classification, reconciliation, and acceptance rather than duplicating Git sentinel logic.
+- Return only typed domain facts/errors to the machine.
+- Revalidate actor/invocation identity before applying the terminal event through the existing distributed-machine runner.
+- For checkpoint-and-accept, acquire the repository write claim, revalidate before staging, reuse the existing whole-tree checkpoint primitive, validate again after committing, and settle through the same runner.
+- Publish scoped invalidations for Version History, current branch/HEAD, version changes/files, and chats/messages from the authoritative accepted settlement. Do not infer success or accepted HEAD in the renderer.
+
+Renderer behavior:
+
+- Add **Use current version** to the persistent recovery toast.
+- Replace it with **Save changes & use current version** only after an authoritative dirty-tree-only assessment.
+- Relabel the read-only validation action as **Check again** after a conflict or active-operation assessment; do not expose repair controls.
+- Dispatch through `useVersionPreview`/the existing remote intent path, not a direct IPC client.
+- Represent validation and saving progress in the toast from authoritative machine state.
+- Do not optimistically dismiss the toast or enable Version History before acceptance settles.
+- On accepted settlement, clear stale preview/diff presentation, retain the selected chat if it survives (otherwise fall back to the latest chat), keep the current app/screen, and show the appropriate finite success toast without an action.
+- Render the exact inline blocked state in the Version History pane whenever recovery is unresolved and the pane is open. Do not duplicate the toast's recovery buttons in the pane.
+
+### 5. Settled persistence and typing decisions
+
+- Define one `CHAT_TURN_TERMINAL_OUTCOMES` const tuple, derive the shared schema/string union from it, and pass the same tuple to Drizzle's text-enum declaration. The generated migration is the database representation; do not maintain a second handwritten application value list.
+- Use one focused `inspectRepositoryHealth` helper for restore failure classification, restart reconciliation, and both acceptance commands. Existing Git helpers may be refactored behind it, but branch, HEAD, cleanliness, unmerged-index, and Git-operation semantics have one source of truth.
+- Do not persist `validating-current-repository` or `checkpointing-current-repository`. Keep the durable snapshot in `restore-recovery-required` until an accepted terminal event transitions to `closed`. A restart during either command therefore hydrates back into recovery-required.
+- Keep the dirty-tree assessment in authoritative in-memory state, but do not add it to the persisted recovery schema. After a process restart the user starts from **Use current version**, which re-runs the health probe and can reveal the save action again. No version-preview persistence schema bump is required for this work.
+
+## Implementation Sequence
+
+### Phase 1: Durable cancelled-turn provenance
+
+- [ ] Add and generate the `chat_turn_intents.terminal_outcome` migration.
+- [ ] Thread explicit terminal outcomes through chat-stream transition, command, persistence, and hydration.
+- [ ] Add legacy cancelled-response fallback for pre-migration turns.
+- [ ] Add persistence and restart tests.
+
+### Phase 2: Stop -> Undo preservation
+
+- [ ] Resolve target-turn outcome in restore preparation and authoritative phase 3.
+- [ ] Enable whole-tree checkpoint preservation for a previously cancelled target turn.
+- [ ] Use the canonical `[Interrupted]` commit message and verify the checkpoint appears as an ordinary Version History entry.
+- [ ] Log the preservation reason and retain existing user warning copy.
+- [ ] Add a Git/SQLite integration test proving partial work remains reachable and the restored tree is clean.
+
+### Phase 3: Correct recovery classification
+
+- [ ] Move dirty-tree validation before branch checkout for non-preserving restores.
+- [ ] Skip no-op branch checkouts.
+- [ ] Introduce structured ordinary-versus-recovery failure disposition.
+- [ ] Replace the command runner’s `nextStep` heuristic.
+- [ ] Extend restart reconciliation tests for dirty pre-state, branch divergence, and destructive checkpoints.
+
+### Phase 4: Use current version
+
+- [ ] Add state, events, commands, transport schemas, mutual type assertions, and capabilities.
+- [ ] Add coordinated repository-health validation.
+- [ ] Add the dirty-tree assessment and coordinated whole-tree checkpoint-and-accept command.
+- [ ] Use the canonical `[Recovery]` commit message and verify that checkpoint also appears as an ordinary Version History entry.
+- [ ] Preserve recovery durably while validation is pending; clear only on accepted settlement.
+- [ ] Add both persistent toast actions and their validation, saving, and blocker copy.
+- [ ] Add authoritative accepted-result invalidations, presentation reset, passive success toasts, and surviving-chat fallback.
+- [ ] Add the inline Version History blocked state and presentation-only open/close behavior.
+- [ ] Add transition-matrix, main-actor, persistence, and provider tests.
+
+### Phase 5: Verification and documentation
+
+- [ ] Run targeted tests during implementation.
+- [ ] Run `npm run fmt`, `npm run lint`, and `npm run ts` before commit.
+- [ ] Manually verify the packaged/dev flow: edit -> Stop -> Undo -> partial checkpoint -> restored chat; seed a stale clean checkpoint and choose **Use current version**; then seed a stale dirty checkpoint and choose **Save changes & use current version**.
+- [ ] Check the final diff for generated migration correctness and unrelated formatter changes.
+
+The phases may be separate commits but should ship in one PR.
+
+## Testing Strategy
+
+### Chat-turn persistence unit tests
+
+- A completed terminal event persists `completed`.
+- Stop persists `cancelled` atomically with `recovery = "terminal"` and queue pause state.
+- Stream error persists `errored`.
+- Restart hydration retains the outcome after intent payload release.
+- Rejected-before-acceptance intent remains outcome-null.
+- Legacy rows with a null outcome hydrate safely.
+
+### Restore integration tests with a real temporary Git repository and SQLite
+
+- Cancelled target turn + dirty tracked file:
+  - creates a partial-work checkpoint commit,
+  - creates/restores the target tree through the normal revert commit,
+  - leaves the repository clean,
+  - creates the forked chat once,
+  - keeps the partial commit reachable in history,
+  - returns it from `listVersions` with the exact `[Interrupted]` label so it can be selected, previewed, and restored, and
+  - reports the interrupted-generation warning.
+- Cancelled target turn + untracked file preserves that file in the checkpoint.
+- Completed/unknown target turn + dirty tree returns `DyadErrorKind.Conflict`, leaves branch/HEAD/index/tree unchanged, and does not create a fork chat.
+- Active generation cancelled by Undo retains the existing behavior.
+- Phase-1 and phase-3 outcome disagreement uses the fresh phase-3 result.
+- A recording refusal occurs before cancellation/preservation work.
+
+### Recovery classification tests
+
+- Dirty preflight at the recorded branch/HEAD emits ordinary `RESTORE_FAILED`.
+- Failed/no-op checkout at the recorded branch/HEAD emits ordinary failure even if dirty.
+- Checkout ending on a different branch or HEAD requires recovery.
+- Hard-reset, soft-reset, commit, and chat-mutation checkpoints remain recovery-required unless their existing terminal postcondition matches.
+- Ordinary failure does not persist a recovery checkpoint or disable `canSelectVersion` after reopening the pane.
+
+### State-machine and transport tests
+
+- Extend the full state x event matrix for the new intent and terminal events.
+- Ignored events retain exact state identity.
+- Only `restore-recovery-required` exposes `canAcceptCurrentRepository`.
+- Validation prevents selection/restore/branch switching until it settles.
+- Transport schemas reject malformed events and error objects.
+- Accepted-event transport requires `appId`, branch, and accepted HEAD, accepts only a valid optional saved-version ID, and rejects malformed settlement facts.
+- Persistence reload during validation returns to recovery-required, never closed.
+- Recovery pane visibility is not persisted; reload retains recovery while defaulting the pane closed.
+
+### Repository acceptance tests
+
+- Clean named branch + readable HEAD succeeds and removes the checkpoint.
+- Dirty tree is classified separately and offers checkpoint-and-accept rather than a generic rejection.
+- Checkpoint-and-accept stages and commits the whole user-visible tree, leaves a clean attached HEAD, then removes the recovery checkpoint.
+- The checkpoint-and-accept commit is returned by `listVersions` with the exact `[Recovery]` label and supports normal preview/restore behavior.
+- A checkpoint commit failure retains the recovery checkpoint and does not reset or discard files.
+- A crash after the checkpoint commit but before acknowledgement restarts in recovery-required and can pass read-only acceptance.
+- Unmerged index, detached HEAD, missing repository, and each in-progress Git operation reject without changing Git or the checkpoint and never offer checkpoint-and-accept.
+- After an externally resolved conflict or completed/aborted Git operation, **Check again** accepts the now-healthy repository and removes the checkpoint.
+- Concurrent app deletion or repository mutation is serialized/refused by coordinator ownership.
+- Repeated/stale action dispatches do not run validation twice or clear a newer recovery state.
+
+### Renderer tests
+
+- Recovery toast includes **Use current version**.
+- Clicking it dispatches the stable intent and does not dismiss optimistically.
+- Pending validation presents progress and suppresses duplicate activation.
+- Dirty-tree validation replaces the primary action with **Save changes & use current version** and plain-language copy.
+- Pending checkpointing presents saving progress and suppresses duplicate activation.
+- Conflict and in-progress-operation results show **Check again**, never the save action.
+- **Check again** repeats the health probe, keeps the toast/checkpoint unchanged while blocked, and dismisses recovery only after the repository independently becomes healthy.
+- Success dismisses the toast when the remote state becomes closed.
+- Read-only success shows **Version History is ready** with no toast action.
+- Checkpoint success shows **Current changes saved**, names the `[Recovery]` version, and has no toast action.
+- Accepted settlement clears stale selected-version/diff presentation and invalidates versions, branch/HEAD, files/changes, and chats/messages.
+- Acceptance keeps the selected surviving chat and falls back to the latest chat only when the prior selection no longer exists.
+- Recovery does not force the Version History pane open; opening it shows the inline blocked copy and resurfaces a dismissed recovery toast; closing it does not clear recovery.
+- The inline blocked state contains no duplicate recovery controls.
+- Failure retains the toast with actionable text.
+- Keyboard activation and accessible action naming work through the existing toast component.
+
+Prefer Vitest integration tests over Playwright because the behavior can be proven with real Git, SQLite, handlers, and the renderer/IPC harness. Use one final manual Electron sanity check for the toast interaction and packaged lifecycle.
+
+## Acceptance Criteria
+
+- Stop a generation after a file write, then click Undo: Dyad saves partial work and successfully restores/forks without a dirty-tree error.
+- The saved partial work is a reachable, ordinary Version History entry labeled `[Interrupted]`; it can be selected, previewed, and restored without Git knowledge, and no user-visible file is lost.
+- A dirty tree unrelated to a cancelled target turn is never silently committed or discarded.
+- A pre-destructive dirty-tree conflict does not enter `restore-recovery-required` and does not permanently disable Version History.
+- Failures after a potentially destructive reset remain fail-closed.
+- A user with a stale recovery checkpoint can choose **Use current version** when the repository is healthy.
+- Read-only acceptance never mutates Git.
+- A user whose only blocker is a dirty tree can choose **Save changes & use current version** without opening a terminal; Dyad creates a recoverable commit before clearing recovery.
+- Neither acceptance path can clear recovery for a detached, conflicted, missing, or mid-operation repository.
+- Conflicted and mid-operation repositories receive a state-specific error plus read-only **Check again**; this PR provides no guided repair, continue, abort, reset, or backup action for them.
+- Recovery state survives reload/shutdown until authoritative acceptance succeeds.
+- Successful acceptance returns to the live current HEAD, clears stale historical preview/diff state, refreshes repository/version/file/chat data, and does not navigate or reopen Version History automatically.
+- Success feedback is finite and passive, with no action button.
+- Whenever the user opens Version History during unresolved recovery, the pane explains that Version History is temporarily unavailable and directs them to the recovery notice; dismissing either surface never clears the safety latch.
+- Existing version checkout, branch switch, restore, recording refusal, app deletion, and multi-window behavior remain covered and passing.
+
+## Risks and Mitigations
+
+| Risk                                                                  | Impact                                                 | Mitigation                                                                                                                                                       |
+| --------------------------------------------------------------------- | ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A cancelled marker is applied to unrelated later manual edits         | Extra checkpoint content                               | Commit the whole tree losslessly, disclose it, and require an explicit Undo targeting that cancelled turn.                                                       |
+| Internal checkpoints clutter Version History                          | Extra versions in the normal timeline                  | Keep them recoverable and visible, but distinguish them with the canonical `[Interrupted]` and `[Recovery]` prefixes instead of adding a parallel checkpoint UI. |
+| Terminal outcome persistence diverges from actor completion           | Incorrect provenance after restart                     | Persist outcome atomically with terminal recovery/queue mutation and test live plus hydrated paths.                                                              |
+| Failure classification clears a genuinely partial restore             | Data loss or misleading state                          | Preflight before checkout, classify under the repository claim, and keep hard-reset-and-later phases conservative.                                               |
+| “Use current version” becomes a disguised force-clear                 | Unsafe future Git mutations                            | Require clean attached HEAD, no unmerged entries, and no in-progress Git operation; never modify Git in this command.                                            |
+| Dirty-tree users reach another dead end                               | Version History remains unusable without Git knowledge | After read-only validation, offer an explicit whole-tree checkpoint action with plain-language copy and no discard/reset behavior.                               |
+| Checkpoint commit succeeds but acknowledgement crashes                | User sees recovery again despite a healthy repository  | Persist recovery until settlement; on restart the now-clean repository passes **Use current version** safely.                                                    |
+| Renderer disappears during acceptance                                 | Lost or optimistic acknowledgement                     | Main owns settlement; persist recovery until success and treat renderer delivery as best-effort.                                                                 |
+| Recovery clears but the renderer still shows historical or stale data | User cannot tell which code/chat is authoritative      | Return accepted branch/HEAD facts, clear preview presentation, publish scoped invalidations, and preserve only a surviving chat selection.                       |
+| Dismissing the toast hides the reason Version History is locked       | Disabled controls appear broken                        | Show an inline blocked state whenever the pane is opened during unresolved recovery and resurface the persistent notice.                                         |
+| Migration cannot identify old cancelled turns                         | Old Stop -> Undo remains conservative                  | Nullable outcome plus narrowly validated cancelled-response fallback; stale recovery still has the validated acceptance action.                                  |
+| New event expands the distributed-machine boundary incorrectly        | Transport or lifecycle regression                      | Use existing remote intent/command runner, update exact inventories only if production call sites genuinely change, and run conformance tests.                   |
+
+## Observability
+
+Add structured, non-content logs for:
+
+- restore preservation reason (`active-cancel`, `durable-cancelled-turn`, or none);
+- restore failure disposition and last checkpoint phase;
+- repository acceptance success/rejection reason; and
+- checkpoint removal after acceptance.
+
+Never log prompts, file contents, tokens, or remote URLs. Expected dirty-tree and repository-health refusals remain classified `DyadError`s rather than exception telemetry.
+
+## Decision Log
+
+- **One PR:** all three fixes define one safe recovery workflow.
+- **Existing turn-intent storage:** extend `chat_turn_intents`; do not create another cancellation database.
+- **Explicit terminal outcome:** `recovery = "terminal"` alone is insufficient provenance.
+- **Whole-tree checkpoint:** prefer recoverability over guessing which files belong to the agent.
+- **Visible ordinary versions:** keep both checkpoint commits on reachable branch history and identify them with canonical `[Interrupted]` or `[Recovery]` commit-message prefixes; no new version type or hidden recovery store.
+- **Preflight before checkout:** ordinary dirtiness must be detected before a mutation checkpoint.
+- **Structured failure disposition:** remove the `nextStep !== preparing` heuristic.
+- **Validated acknowledgement:** “Use current version” is a main-owned state-machine operation, not a toast dismissal or direct IPC shortcut.
+- **Guided dirty-tree recovery:** read-only validation can reveal **Save changes & use current version**, a separate explicit checkpointing action; users are not sent to Git for an otherwise healthy dirty tree.
+- **Error-only complex Git states:** conflicts and active Git operations remain fail-closed with specific copy and read-only **Check again**; automated repair and a conflict-resolution UI are out of scope.
+- **Fail closed after destructive boundaries:** convenience never overrides ambiguous Git state.
+- **Shared outcome type:** define `terminal_outcome` once as a shared schema/string union and reuse it across persistence and domain code.
+- **One health probe:** centralize repository health in `inspectRepositoryHealth` rather than growing divergent status checks.
+- **Transient states stay transient:** persist the recovery-required fallback during validation/checkpointing; only accepted settlement clears it.
+- **Deterministic successful landing:** accepted settlement returns authoritative branch/HEAD facts, resets historical presentation, refreshes repository/version/file/chat data, preserves a surviving chat selection, and shows passive success feedback without navigation or actions.
+- **Visible safety latch:** unresolved recovery never relies on a toast alone; an opened Version History pane shows a small inline blocked explanation and can resurface the notice without duplicating its actions.
+
+---
+
+_Plan created directly at the user’s request; no swarm session was used._

--- a/rules/database-drizzle.md
+++ b/rules/database-drizzle.md
@@ -2,6 +2,12 @@
 
 This app uses SQLite and drizzle ORM.
 
+When logic depends on conversation insertion adjacency (for example, finding
+the assistant response immediately after a user message), order messages by
+`messages.id`, not `createdAt`. Compaction summaries may be inserted later with
+an older logical timestamp, so timestamp ordering can move them ahead of the
+response they followed in storage.
+
 Generate SQL migrations by running this:
 
 ```sh

--- a/src/chat_stream/definition.ts
+++ b/src/chat_stream/definition.ts
@@ -476,6 +476,11 @@ function createCommandRunner(
             command.error !== undefined ||
               command.response?.wasCancelled === true,
             pauseForStop ? "stop" : pauseForStepLimit ? "step-limit" : "manual",
+            command.response?.wasCancelled === true
+              ? "cancelled"
+              : command.error !== undefined
+                ? "errored"
+                : "completed",
           );
           publishChatInvalidations(context.key.chatId, active.targetAppId);
           emit({

--- a/src/chat_stream/main_actor.test.ts
+++ b/src/chat_stream/main_actor.test.ts
@@ -1146,6 +1146,7 @@ describe("main-hosted chat stream actor", () => {
       true,
       false,
       "manual",
+      "completed",
     );
 
     const reloaded = new ChatStreamRemoteManager(
@@ -1634,6 +1635,7 @@ describe("main-hosted chat stream actor", () => {
         true,
         true,
         "stop",
+        "cancelled",
       ),
     );
     resolveCancel(true);

--- a/src/chat_stream/persistence.test.ts
+++ b/src/chat_stream/persistence.test.ts
@@ -251,9 +251,16 @@ describe("chat stream persistence", () => {
     );
 
     markIntentAccepted(turn.intentId, 42);
-    markIntentTerminal(database, turn, false);
+    markIntentTerminal(database, turn, false, false, "manual", "cancelled");
 
     expect(getRetainedIntentPayloadBytes(turn.intentId)).toBe(0);
+    expect(
+      database
+        .select({ terminalOutcome: chatTurnIntents.terminalOutcome })
+        .from(chatTurnIntents)
+        .where(eq(chatTurnIntents.intentId, turn.intentId))
+        .get(),
+    ).toEqual({ terminalOutcome: "cancelled" });
     expect(persistQueuedIntent(database, turn)).toEqual({
       kind: "replayed",
       acceptance: "message-accepted",
@@ -404,13 +411,27 @@ describe("chat stream persistence", () => {
     const turn = intent("failed-turn");
     persistQueuedIntent(database, turn);
 
-    const queue = markIntentTerminal(database, turn, false, true);
+    const queue = markIntentTerminal(
+      database,
+      turn,
+      false,
+      true,
+      "manual",
+      "errored",
+    );
 
     expect(queue).toMatchObject({ queueRevision: 2, queue: [] });
     expect(persistQueuedIntent(database, turn)).toEqual({
       kind: "replayed",
       acceptance: "rejected",
     });
+    expect(
+      database
+        .select({ terminalOutcome: chatTurnIntents.terminalOutcome })
+        .from(chatTurnIntents)
+        .where(eq(chatTurnIntents.intentId, turn.intentId))
+        .get(),
+    ).toEqual({ terminalOutcome: null });
   });
 
   it("restores durable queued work paused after process-lifetime disposal", () => {

--- a/src/chat_stream/persistence.ts
+++ b/src/chat_stream/persistence.ts
@@ -13,6 +13,7 @@ import {
   rejectDueFollowUp,
 } from "@/ipc/services/user_input_followup_service";
 import { computeChatTurnPayloadHash } from "@/ipc/utils/chat_turn_intent_hash";
+import type { ChatTurnTerminalOutcome } from "@/shared/chat_turn_outcome";
 import {
   CHAT_STREAM_MAX_QUEUE_BYTES,
   SerializableChatTurnIntentSchema,
@@ -34,6 +35,7 @@ interface IntentRecord {
   payloadHash: string;
   acceptance: "queued" | "message-accepted" | "rejected";
   recovery: "not-started" | "started" | "terminal";
+  terminalOutcome: ChatTurnTerminalOutcome | null;
   acceptedMessageId?: number;
   durable: boolean;
 }
@@ -185,6 +187,7 @@ export function hydrateChatStreamPersistence(
         intent: chatTurnIntents.intent,
         acceptance: chatTurnIntents.acceptance,
         recovery: chatTurnIntents.recovery,
+        terminalOutcome: chatTurnIntents.terminalOutcome,
         acceptedMessageId: chatTurnIntents.acceptedMessageId,
       })
       .from(chatQueueEntries)
@@ -246,6 +249,7 @@ export function hydrateChatStreamPersistence(
         payloadHash: entry.payloadHash,
         acceptance: entry.acceptance,
         recovery: entry.recovery,
+        terminalOutcome: entry.terminalOutcome,
         acceptedMessageId: entry.acceptedMessageId ?? undefined,
         durable: true,
       });
@@ -413,6 +417,7 @@ function persistIntentInQueue(
         payloadHash: persisted.payloadHash,
         acceptance: persisted.acceptance,
         recovery: persisted.recovery,
+        terminalOutcome: persisted.terminalOutcome,
         acceptedMessageId: persisted.acceptedMessageId ?? undefined,
         durable: true,
       };
@@ -493,6 +498,7 @@ function persistIntentInQueue(
     payloadHash: intent.payloadHash,
     acceptance: "queued",
     recovery: "not-started",
+    terminalOutcome: null,
     durable,
   });
   aggregate.intentIds.push(intent.intentId);
@@ -552,6 +558,7 @@ export function stageActiveIntent(
     payloadHash: intent.payloadHash,
     acceptance: "queued",
     recovery: "not-started",
+    terminalOutcome: null,
     durable: false,
   });
   return null;
@@ -570,6 +577,7 @@ export function ensureIntentRecord(intent: SerializableChatTurnIntent): void {
     payloadHash: intent.payloadHash,
     acceptance: "queued",
     recovery: "not-started",
+    terminalOutcome: null,
     durable: false,
   });
 }
@@ -612,6 +620,7 @@ export function persistAcceptedChatTurn(
         payloadHash: existing.payloadHash,
         acceptance: existing.acceptance,
         recovery: existing.recovery,
+        terminalOutcome: existing.terminalOutcome,
         acceptedMessageId: existing.acceptedMessageId ?? undefined,
         durable: true,
       },
@@ -1020,6 +1029,7 @@ export function markIntentTerminal(
   pauseQueue: boolean,
   rejectBeforeAcceptance = false,
   pauseReason: QueueAggregate["pauseReason"] = "manual",
+  terminalOutcome: ChatTurnTerminalOutcome | null = null,
 ): ReturnType<typeof loadChatQueue> {
   const record = recordFor(intent.intentId);
   if (!record) {
@@ -1039,6 +1049,7 @@ export function markIntentTerminal(
     intent: record.intent,
     acceptance: record.acceptance,
     recovery: record.recovery,
+    terminalOutcome: record.terminalOutcome,
   };
   let changed = false;
   if (rejectBeforeAcceptance && record.acceptance === "queued") {
@@ -1048,8 +1059,10 @@ export function markIntentTerminal(
       changed = true;
     }
     record.acceptance = "rejected";
+    terminalOutcome = null;
   }
   record.recovery = "terminal";
+  record.terminalOutcome = terminalOutcome;
   if (
     pauseQueue &&
     (!aggregate.paused ||
@@ -1070,6 +1083,7 @@ export function markIntentTerminal(
           .set({
             acceptance: record.acceptance,
             recovery: "terminal",
+            terminalOutcome: record.terminalOutcome,
             intent: null,
             updatedAt: new Date(),
           })
@@ -1093,6 +1107,7 @@ export function markIntentTerminal(
       record.intent = originalRecord.intent;
       record.acceptance = originalRecord.acceptance;
       record.recovery = originalRecord.recovery;
+      record.terminalOutcome = originalRecord.terminalOutcome;
       throw error;
     }
   }

--- a/src/components/chat/VersionPane.test.tsx
+++ b/src/components/chat/VersionPane.test.tsx
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   send: vi.fn(),
   versions: [] as Version[],
   state: { type: "closed" } as PreviewState,
+  paneVisible: false,
 }));
 
 vi.mock("react-virtuoso", () => ({
@@ -62,7 +63,7 @@ vi.mock("@/hooks/useVersionPreview", () => ({
   useVersionPreview: () => ({
     state: mocks.state,
     projection: projectVersionPreview(mocks.state),
-    isPaneVisible: isPaneVisibleState(mocks.state),
+    isPaneVisible: mocks.paneVisible || isPaneVisibleState(mocks.state),
     send: mocks.send,
     sendAndWaitForMutation: vi.fn(),
   }),
@@ -113,6 +114,7 @@ describe("VersionPane", () => {
     vi.clearAllMocks();
     mocks.versions.length = 0;
     mocks.state = { type: "closed" };
+    mocks.paneVisible = false;
     mocks.listAppScreenshots.mockResolvedValue({ screenshots: [] });
     mocks.refreshVersions.mockResolvedValue({ data: mocks.versions });
   });
@@ -158,5 +160,26 @@ describe("VersionPane", () => {
     expect(projectVersionPreview(mocks.state).capabilities.canRestore).toBe(
       false,
     );
+  });
+
+  it("shows an inline blocked state while restore recovery is unresolved", async () => {
+    const browsing = browsingState();
+    if (browsing.type !== "browsing") throw new Error("invalid fixture");
+    mocks.state = {
+      type: "restore-recovery-required",
+      session: browsing.session,
+      error: { message: "restore interrupted" },
+    };
+    mocks.paneVisible = true;
+
+    render(<VersionPane />, { wrapper });
+
+    expect(
+      await screen.findByText("Version History is temporarily unavailable"),
+    ).toBeDefined();
+    expect(
+      screen.getByText("Resolve the version recovery notice to continue."),
+    ).toBeDefined();
+    expect(screen.queryByTestId("virtualized-version-list")).toBeNull();
   });
 });

--- a/src/components/chat/VersionPane.tsx
+++ b/src/components/chat/VersionPane.tsx
@@ -536,6 +536,37 @@ export function VersionPane() {
     return null;
   }
 
+  if (
+    previewState.type === "restore-recovery-required" ||
+    previewState.type === "validating-current-repository" ||
+    previewState.type === "checkpointing-current-repository"
+  ) {
+    return (
+      <div className="h-full border-t border-2 border-border w-full flex flex-col">
+        <div className="p-2 border-b border-border flex items-center justify-between">
+          <h2 className="text-base font-medium pl-2">Version History</h2>
+          <button
+            onClick={() => send({ type: "CLOSE" })}
+            className="p-1 hover:bg-(--background-lightest) rounded-md"
+            aria-label="Close version pane"
+          >
+            <X size={20} />
+          </button>
+        </div>
+        <div className="flex-1 flex items-center justify-center p-6">
+          <div className="max-w-sm text-center">
+            <h3 className="text-sm font-medium">
+              Version History is temporarily unavailable
+            </h3>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Resolve the version recovery notice to continue.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   const handleVersionClick = (version: Version) => {
     send({
       type: "SELECT_VERSION",

--- a/src/components/chat/VersionPane.tsx
+++ b/src/components/chat/VersionPane.tsx
@@ -26,7 +26,10 @@ import {
 import { Virtuoso } from "react-virtuoso";
 
 import { useVersionPreview } from "@/hooks/useVersionPreview";
-import { diffVersionIdForState } from "@/version_preview/state";
+import {
+  diffVersionIdForState,
+  isRestoreRecoveryFlowState,
+} from "@/version_preview/state";
 
 function HighlightMatch({
   text,
@@ -536,11 +539,7 @@ export function VersionPane() {
     return null;
   }
 
-  if (
-    previewState.type === "restore-recovery-required" ||
-    previewState.type === "validating-current-repository" ||
-    previewState.type === "checkpointing-current-repository"
-  ) {
+  if (isRestoreRecoveryFlowState(previewState)) {
     return (
       <div className="h-full border-t border-2 border-border w-full flex flex-col">
         <div className="p-2 border-b border-border flex items-center justify-between">

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -11,6 +11,10 @@ import { relations } from "drizzle-orm";
 import type { ModelMessage } from "ai";
 import type { ModelSelection, StoredChatMode } from "@/lib/schemas";
 import type { SerializableChatTurnIntent } from "@/chat_stream/transport";
+import {
+  CHAT_TURN_TERMINAL_OUTCOMES,
+  type ChatTurnTerminalOutcome,
+} from "@/shared/chat_turn_outcome";
 
 export const AI_MESSAGES_SDK_VERSION = "ai@v6" as const;
 
@@ -231,6 +235,9 @@ export const chatTurnIntents = sqliteTable(
     })
       .notNull()
       .default("not-started"),
+    terminalOutcome: text("terminal_outcome", {
+      enum: CHAT_TURN_TERMINAL_OUTCOMES,
+    }).$type<ChatTurnTerminalOutcome | null>(),
     acceptedMessageId: integer("accepted_message_id"),
     createdAt: integer("created_at", { mode: "timestamp" })
       .notNull()

--- a/src/distributed_machines/boundaries.test.ts
+++ b/src/distributed_machines/boundaries.test.ts
@@ -85,6 +85,7 @@ describe("distributed machine boundaries", () => {
       "plan_handoff/transport.ts",
       "version_preview/VersionPreviewProvider.tsx",
       "version_preview/client_definition.ts",
+      "version_preview/remote_intent_contract.ts",
     ]);
   });
 });

--- a/src/hooks/useVersionPreview.ts
+++ b/src/hooks/useVersionPreview.ts
@@ -160,6 +160,7 @@ export function useVersionPreview(appId: number | null): {
         event.type === "CLOSE" &&
         isRestoreRecoveryFlowState(actor.getView().state.state)
       ) {
+        await releaseSelectionInterest(operationId());
         presentationStore.send(appId, event);
         return;
       }
@@ -306,8 +307,6 @@ export function useVersionPreview(appId: number | null): {
         canRestore: false,
         canSelectVersion: false,
         canSwitchBranch: false,
-        canAcceptCurrentRepository: false,
-        canCheckpointAndAcceptCurrentRepository: false,
       },
     };
   }, [remote.connection, state]);

--- a/src/hooks/useVersionPreview.ts
+++ b/src/hooks/useVersionPreview.ts
@@ -6,6 +6,7 @@ import {
 import { showError } from "@/lib/toast";
 import {
   CLOSED_STATE,
+  isRestoreRecoveryFlowState,
   type PreviewEvent,
   type PreviewState,
 } from "@/version_preview/state";
@@ -142,20 +143,22 @@ export function useVersionPreview(appId: number | null): {
         await windowInterest.acquire(appId);
         presentationStore.send(appId, event);
         if (actor.getView().state.state.type === "restore-recovery-required") {
-          await dispatchActorIntent({
-            type: "SHOW_RECOVERY_NOTICE",
-            operationId: operationId(),
-          });
+          try {
+            await dispatchActorIntent({
+              type: "SHOW_RECOVERY_NOTICE",
+              operationId: operationId(),
+            });
+          } catch {
+            // Recovery is already projected by the provider. Startup
+            // reconciliation may temporarily refuse this best-effort resurface
+            // request, but pane opening itself succeeded.
+          }
         }
         return;
       }
       if (
         event.type === "CLOSE" &&
-        (actor.getView().state.state.type === "restore-recovery-required" ||
-          actor.getView().state.state.type ===
-            "validating-current-repository" ||
-          actor.getView().state.state.type ===
-            "checkpointing-current-repository")
+        isRestoreRecoveryFlowState(actor.getView().state.state)
       ) {
         presentationStore.send(appId, event);
         return;

--- a/src/hooks/useVersionPreview.ts
+++ b/src/hooks/useVersionPreview.ts
@@ -35,6 +35,8 @@ function toIntent(
   switch (event.type) {
     case "CLOSE":
     case "RETRY_RETURN":
+    case "ACCEPT_CURRENT_REPOSITORY":
+    case "CHECKPOINT_AND_ACCEPT_CURRENT_REPOSITORY":
       return { type: event.type, operationId: id };
     case "APP_CHANGED":
       return { ...event, operationId: id };
@@ -70,6 +72,9 @@ function toIntent(
     case "RESTORE_SUCCEEDED":
     case "RESTORE_FAILED":
     case "RESTORE_RECOVERY_REQUIRED":
+    case "CURRENT_REPOSITORY_ACCEPTED":
+    case "CURRENT_REPOSITORY_DIRTY":
+    case "CURRENT_REPOSITORY_REJECTED":
     case "RETURN_SUCCEEDED":
     case "RETURN_FAILED":
     case "SWITCH_BRANCH_SUCCEEDED":
@@ -110,6 +115,10 @@ export function useVersionPreview(appId: number | null): {
       : combineVersionPreviewState(appId, remote.state.state, presentation);
   const isPaneVisible =
     appId !== null && presentationStore.isPaneVisible(appId);
+  const dispatchActorIntent = useCallback(
+    (intent: VersionPreviewIntentEvent) => actor.dispatch(intent),
+    [actor],
+  );
 
   const dispatchNow = useCallback(
     async (
@@ -131,6 +140,23 @@ export function useVersionPreview(appId: number | null): {
       };
       if (event.type === "OPEN") {
         await windowInterest.acquire(appId);
+        presentationStore.send(appId, event);
+        if (actor.getView().state.state.type === "restore-recovery-required") {
+          await dispatchActorIntent({
+            type: "SHOW_RECOVERY_NOTICE",
+            operationId: operationId(),
+          });
+        }
+        return;
+      }
+      if (
+        event.type === "CLOSE" &&
+        (actor.getView().state.state.type === "restore-recovery-required" ||
+          actor.getView().state.state.type ===
+            "validating-current-repository" ||
+          actor.getView().state.state.type ===
+            "checkpointing-current-repository")
+      ) {
         presentationStore.send(appId, event);
         return;
       }
@@ -194,7 +220,7 @@ export function useVersionPreview(appId: number | null): {
           await settlement;
           return;
         }
-        const receipt = await actor.dispatch(intent);
+        const receipt = await dispatchActorIntent(intent);
         if (receipt.kind === "applied") {
           if (event.type === "SELECT_VERSION") {
             selectionAccepted = true;
@@ -216,7 +242,7 @@ export function useVersionPreview(appId: number | null): {
         throw error;
       }
     },
-    [actor, appId, presentationStore, windowInterest],
+    [actor, appId, dispatchActorIntent, presentationStore, windowInterest],
   );
   const dispatch = useCallback(
     (event: PreviewEvent, waitForSettlement: boolean): Promise<void> => {
@@ -277,6 +303,8 @@ export function useVersionPreview(appId: number | null): {
         canRestore: false,
         canSelectVersion: false,
         canSwitchBranch: false,
+        canAcceptCurrentRepository: false,
+        canCheckpointAndAcceptCurrentRepository: false,
       },
     };
   }, [remote.connection, state]);

--- a/src/ipc/handlers/__tests__/context_compaction.integration.test.ts
+++ b/src/ipc/handlers/__tests__/context_compaction.integration.test.ts
@@ -19,6 +19,7 @@
 // of a stream error. Dyad Engine calls are routed to the harness fake server
 // via `engine: true`.
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -41,6 +42,22 @@ import {
   gitLog,
 } from "@/ipc/utils/git_utils";
 import type { RestoreRecovery } from "@/version_preview/state";
+
+function gitCommand(appDir: string, args: string[], input?: string): string {
+  return execFileSync(
+    "git",
+    [
+      "-c",
+      "user.email=test@example.com",
+      "-c",
+      "user.name=Test User",
+      "-c",
+      "commit.gpgsign=false",
+      ...args,
+    ],
+    { cwd: appDir, input, stdio: ["pipe", "pipe", "pipe"] },
+  ).toString();
+}
 
 describe("context compaction (integration)", () => {
   let harness: HybridChatHarness;
@@ -384,6 +401,121 @@ describe("context compaction (integration)", () => {
       ).toBe(true);
     } finally {
       await fs.promises.unlink(partialFile).catch(() => undefined);
+    }
+  });
+
+  it("does not checkpoint a stopped generation over an unresolved Git merge", async () => {
+    const targetCommitHash = await getCurrentCommitHash({
+      path: harness.appDir,
+    });
+    const [chatRow] = await harness.db
+      .insert(chats)
+      .values({
+        appId: harness.appId,
+        chatMode: "local-agent",
+        initialCommitHash: targetCommitHash,
+      })
+      .returning();
+    const intentId = `stopped-during-merge-${chatRow.id}`;
+    await harness.db.insert(chatTurnIntents).values({
+      intentId,
+      chatId: chatRow.id,
+      payloadHash: "stopped-during-merge",
+      acceptance: "message-accepted",
+      recovery: "terminal",
+      terminalOutcome: "cancelled",
+    });
+    const [targetMessage] = await harness.db
+      .insert(messages)
+      .values({
+        chatId: chatRow.id,
+        role: "user",
+        content: "Stopped generation with a conflicted merge",
+        chatTurnIntentId: intentId,
+      })
+      .returning();
+    await harness.db.insert(messages).values({
+      chatId: chatRow.id,
+      role: "assistant",
+      content: "Generation stopped before completion.",
+      sourceCommitHash: targetCommitHash,
+    });
+
+    const conflictPath = "stopped-merge-conflict.txt";
+    const conflictFile = path.join(harness.appDir, conflictPath);
+    const gitDir = path.resolve(
+      harness.appDir,
+      gitCommand(harness.appDir, ["rev-parse", "--git-dir"]).trim(),
+    );
+    const mergeHeadPath = path.join(gitDir, "MERGE_HEAD");
+    const writeBlob = (content: string) =>
+      gitCommand(
+        harness.appDir,
+        ["hash-object", "-w", "--stdin"],
+        content,
+      ).trim();
+    const baseBlob = writeBlob("base\n");
+    const oursBlob = writeBlob("ours\n");
+    const theirsBlob = writeBlob("theirs\n");
+
+    gitCommand(harness.appDir, [
+      "update-index",
+      "--force-remove",
+      "--",
+      conflictPath,
+    ]);
+    gitCommand(
+      harness.appDir,
+      ["update-index", "--index-info"],
+      [
+        `100644 ${baseBlob} 1\t${conflictPath}`,
+        `100644 ${oursBlob} 2\t${conflictPath}`,
+        `100644 ${theirsBlob} 3\t${conflictPath}`,
+        "",
+      ].join("\n"),
+    );
+    fs.writeFileSync(
+      conflictFile,
+      "<<<<<<< ours\nours\n=======\ntheirs\n>>>>>>> theirs\n",
+    );
+    fs.writeFileSync(mergeHeadPath, `${targetCommitHash}\n`);
+
+    const headBeforeRestore = await getCurrentCommitHash({
+      path: harness.appDir,
+    });
+    const indexBeforeRestore = gitCommand(harness.appDir, [
+      "ls-files",
+      "--stage",
+      "--",
+      conflictPath,
+    ]);
+    const mergeHeadBeforeRestore = fs.readFileSync(mergeHeadPath, "utf8");
+
+    try {
+      await expect(
+        versionPreviewHandlerService.restoreToMessage({
+          appId: harness.appId,
+          chatId: chatRow.id,
+          messageId: targetMessage.id,
+          restoreCodebase: true,
+        }),
+      ).rejects.toThrow(
+        "Cannot revert: repository has unresolved file conflicts.",
+      );
+
+      await expect(
+        getCurrentCommitHash({ path: harness.appDir }),
+      ).resolves.toBe(headBeforeRestore);
+      expect(
+        gitCommand(harness.appDir, ["ls-files", "--stage", "--", conflictPath]),
+      ).toBe(indexBeforeRestore);
+      expect(fs.readFileSync(mergeHeadPath, "utf8")).toBe(
+        mergeHeadBeforeRestore,
+      );
+    } finally {
+      fs.rmSync(mergeHeadPath, { force: true });
+      gitCommand(harness.appDir, ["reset", "--hard", "HEAD"]);
+      fs.rmSync(conflictFile, { force: true });
     }
   });
 

--- a/src/ipc/handlers/__tests__/context_compaction.integration.test.ts
+++ b/src/ipc/handlers/__tests__/context_compaction.integration.test.ts
@@ -356,31 +356,35 @@ describe("context compaction (integration)", () => {
     const partialFile = path.join(harness.appDir, "stopped-partial.txt");
     await fs.promises.writeFile(partialFile, "partial generation output\n");
 
-    const result = await versionPreviewHandlerService.restoreToMessage({
-      appId: harness.appId,
-      chatId: chatRow.id,
-      messageId: targetMessage.id,
-      restoreCodebase: true,
-    });
+    try {
+      const result = await versionPreviewHandlerService.restoreToMessage({
+        appId: harness.appId,
+        chatId: chatRow.id,
+        messageId: targetMessage.id,
+        restoreCodebase: true,
+      });
 
-    expect(result.repositoryOutcome).toBe("target-applied");
-    expect(result.notification).toMatchObject({
-      kind: "success",
-      message: expect.stringContaining(
-        "saved as an [Interrupted] version in Version History",
-      ),
-    });
-    await expect(fs.promises.stat(partialFile)).rejects.toThrow();
-    const versions = await gitLog({ path: harness.appDir });
-    expect(
-      versions.some(
-        (version) =>
-          version.commit.message.startsWith("[Interrupted]") &&
-          version.commit.message.includes(
-            "Saved partial changes before restoring to an earlier version",
-          ),
-      ),
-    ).toBe(true);
+      expect(result.repositoryOutcome).toBe("target-applied");
+      expect(result.notification).toMatchObject({
+        kind: "success",
+        message: expect.stringContaining(
+          "saved as an [Interrupted] version in Version History",
+        ),
+      });
+      await expect(fs.promises.stat(partialFile)).rejects.toThrow();
+      const versions = await gitLog({ path: harness.appDir });
+      expect(
+        versions.some(
+          (version) =>
+            version.commit.message.startsWith("[Interrupted]") &&
+            version.commit.message.includes(
+              "Saved partial changes before restoring to an earlier version",
+            ),
+        ),
+      ).toBe(true);
+    } finally {
+      await fs.promises.unlink(partialFile).catch(() => undefined);
+    }
   });
 
   it("keeps a preflight dirty-tree refusal outside restore recovery", async () => {

--- a/src/ipc/handlers/__tests__/context_compaction.integration.test.ts
+++ b/src/ipc/handlers/__tests__/context_compaction.integration.test.ts
@@ -404,6 +404,95 @@ describe("context compaction (integration)", () => {
     }
   });
 
+  it("does not create an interrupted version for Dyad-managed-only churn", async () => {
+    const targetCommitHash = await getCurrentCommitHash({
+      path: harness.appDir,
+    });
+    const targetBranch = await gitCurrentBranch({ path: harness.appDir });
+    const [chatRow] = await harness.db
+      .insert(chats)
+      .values({
+        appId: harness.appId,
+        chatMode: "local-agent",
+        initialCommitHash: targetCommitHash,
+      })
+      .returning();
+    const intentId = `managed-only-stopped-${chatRow.id}`;
+    await harness.db.insert(chatTurnIntents).values({
+      intentId,
+      chatId: chatRow.id,
+      payloadHash: "managed-only-stopped",
+      acceptance: "message-accepted",
+      recovery: "terminal",
+      terminalOutcome: "cancelled",
+    });
+    const [targetMessage] = await harness.db
+      .insert(messages)
+      .values({
+        chatId: chatRow.id,
+        role: "user",
+        content: "Stopped generation with managed-only churn",
+        chatTurnIntentId: intentId,
+      })
+      .returning();
+    await harness.db.insert(messages).values({
+      chatId: chatRow.id,
+      role: "assistant",
+      content: "Generation stopped before completion.",
+      sourceCommitHash: targetCommitHash,
+    });
+
+    const managedRelativePath = "pnpm-workspace.yaml";
+    const managedPath = path.join(harness.appDir, managedRelativePath);
+    const managedPathExisted = fs.existsSync(managedPath);
+    const originalManagedContent = managedPathExisted
+      ? await fs.promises.readFile(managedPath, "utf8")
+      : null;
+    await fs.promises.writeFile(
+      managedPath,
+      `packages:\n  - managed-only-${chatRow.id}\n`,
+    );
+    expect(
+      gitCommand(harness.appDir, [
+        "status",
+        "--porcelain",
+        "--",
+        managedRelativePath,
+      ]),
+    ).not.toBe("");
+
+    try {
+      const result = await versionPreviewHandlerService.revertVersion({
+        appId: harness.appId,
+        previousVersionId: targetCommitHash,
+        targetBranchName: targetBranch ?? undefined,
+        currentChatMessageId: {
+          chatId: chatRow.id,
+          messageId: targetMessage.id,
+        },
+      });
+
+      expect(result.notification?.message).not.toContain("[Interrupted]");
+      await expect(
+        getCurrentCommitHash({ path: harness.appDir }),
+      ).resolves.toBe(targetCommitHash);
+      expect(
+        gitCommand(harness.appDir, [
+          "status",
+          "--porcelain",
+          "--",
+          managedRelativePath,
+        ]),
+      ).not.toBe("");
+    } finally {
+      if (originalManagedContent === null) {
+        await fs.promises.rm(managedPath, { force: true });
+      } else {
+        await fs.promises.writeFile(managedPath, originalManagedContent);
+      }
+    }
+  });
+
   it("does not checkpoint a stopped generation over an unresolved Git merge", async () => {
     const targetCommitHash = await getCurrentCommitHash({
       path: harness.appDir,
@@ -586,6 +675,65 @@ describe("context compaction (integration)", () => {
           }),
         ]),
       );
+    } finally {
+      await fs.promises.unlink(partialFile).catch(() => undefined);
+    }
+  });
+
+  it("restores and forks a legacy cancelled turn before a later compaction summary", async () => {
+    const targetCommitHash = await getCurrentCommitHash({
+      path: harness.appDir,
+    });
+    const [chatRow] = await harness.db
+      .insert(chats)
+      .values({
+        appId: harness.appId,
+        chatMode: "local-agent",
+        initialCommitHash: targetCommitHash,
+      })
+      .returning();
+    const [targetMessage] = await harness.db
+      .insert(messages)
+      .values({
+        chatId: chatRow.id,
+        role: "user",
+        content: "Legacy stopped generation restored through fork",
+      })
+      .returning();
+    await harness.db.insert(messages).values({
+      chatId: chatRow.id,
+      role: "assistant",
+      content: "Partial response\n\n[Response cancelled by user]",
+      sourceCommitHash: targetCommitHash,
+      createdAt: new Date(10_000),
+    });
+    await harness.db.insert(messages).values({
+      chatId: chatRow.id,
+      role: "assistant",
+      content: "Earlier conversation summary",
+      isCompactionSummary: true,
+      createdAt: new Date(0),
+    });
+    const partialFile = path.join(
+      harness.appDir,
+      "legacy-stopped-fork-partial.txt",
+    );
+    await fs.promises.writeFile(partialFile, "legacy fork partial output\n");
+
+    try {
+      const result = await versionPreviewHandlerService.restoreToMessage({
+        appId: harness.appId,
+        chatId: chatRow.id,
+        messageId: targetMessage.id,
+        restoreCodebase: true,
+      });
+
+      expect(result.repositoryOutcome).toBe("target-applied");
+      expect(result.notification?.message).toContain(
+        "saved as an [Interrupted] version in Version History",
+      );
+      expect(result.createdChatId).not.toBeNull();
+      await expect(fs.promises.stat(partialFile)).rejects.toThrow();
     } finally {
       await fs.promises.unlink(partialFile).catch(() => undefined);
     }

--- a/src/ipc/handlers/__tests__/context_compaction.integration.test.ts
+++ b/src/ipc/handlers/__tests__/context_compaction.integration.test.ts
@@ -575,6 +575,70 @@ describe("context compaction (integration)", () => {
     }
   });
 
+  it("keeps a refused detached checkout outside restore recovery when Git is unchanged", async () => {
+    const targetBranchName = await gitCurrentBranch({ path: harness.appDir });
+    expect(targetBranchName).toBeTruthy();
+    const detachedHead = await getCurrentCommitHash({ path: harness.appDir });
+    const managedCollision = path.join(harness.appDir, "pnpm-workspace.yaml");
+    await fs.promises.writeFile(managedCollision, "packages:\n  - branch\n");
+    await gitAddAll({ path: harness.appDir });
+    await gitCommit({
+      path: harness.appDir,
+      message: "Add managed checkout collision fixture",
+    });
+    const [chatRow] = await harness.db
+      .insert(chats)
+      .values({
+        appId: harness.appId,
+        chatMode: "local-agent",
+        initialCommitHash: detachedHead,
+      })
+      .returning();
+    const [targetMessage] = await harness.db
+      .insert(messages)
+      .values({
+        chatId: chatRow.id,
+        role: "user",
+        content: "Restore across a refused detached checkout",
+      })
+      .returning();
+
+    await gitCheckout({ path: harness.appDir, ref: detachedHead });
+    await fs.promises.writeFile(managedCollision, "packages:\n  - detached\n");
+    const progress: RestoreRecovery[] = [];
+    try {
+      await expect(
+        versionPreviewHandlerService.restoreToMessage(
+          {
+            appId: harness.appId,
+            chatId: chatRow.id,
+            messageId: targetMessage.id,
+            restoreCodebase: true,
+            targetBranchName: targetBranchName!,
+          },
+          undefined,
+          (checkpoint) => progress.push(checkpoint),
+        ),
+      ).rejects.toThrow(/checkout|overwritten/i);
+
+      await expect(
+        gitCurrentBranch({ path: harness.appDir }),
+      ).resolves.toBeNull();
+      await expect(
+        getCurrentCommitHash({ path: harness.appDir }),
+      ).resolves.toBe(detachedHead);
+      expect(progress.at(-1)).toEqual({
+        repositoryOutcome: "unchanged",
+        nextStep: "completed",
+      });
+    } finally {
+      await fs.promises.rm(managedCollision, { force: true });
+      await gitCheckout({ path: harness.appDir, ref: targetBranchName! }).catch(
+        () => {},
+      );
+    }
+  });
+
   it("anchors a fork-only chat to the detached preview commit", async () => {
     const targetBranchName = await gitCurrentBranch({ path: harness.appDir });
     expect(targetBranchName).toBeTruthy();

--- a/src/ipc/handlers/__tests__/context_compaction.integration.test.ts
+++ b/src/ipc/handlers/__tests__/context_compaction.integration.test.ts
@@ -387,6 +387,78 @@ describe("context compaction (integration)", () => {
     }
   });
 
+  it("finds the legacy cancelled response before a later compaction summary", async () => {
+    const targetCommitHash = await getCurrentCommitHash({
+      path: harness.appDir,
+    });
+    const targetBranch = await gitCurrentBranch({ path: harness.appDir });
+    const [chatRow] = await harness.db
+      .insert(chats)
+      .values({
+        appId: harness.appId,
+        chatMode: "local-agent",
+        initialCommitHash: targetCommitHash,
+      })
+      .returning();
+    const [targetMessage] = await harness.db
+      .insert(messages)
+      .values({
+        chatId: chatRow.id,
+        role: "user",
+        content: "Legacy stopped generation",
+      })
+      .returning();
+    await harness.db.insert(messages).values({
+      chatId: chatRow.id,
+      role: "assistant",
+      content: "Partial response\n\n[Response cancelled by user]",
+      sourceCommitHash: targetCommitHash,
+      createdAt: new Date(10_000),
+    });
+    // Compaction summaries can preserve an old logical timestamp even though
+    // they are inserted later. The legacy fallback must follow insertion
+    // order so this summary cannot displace the cancelled assistant response.
+    await harness.db.insert(messages).values({
+      chatId: chatRow.id,
+      role: "assistant",
+      content: "Earlier conversation summary",
+      isCompactionSummary: true,
+      createdAt: new Date(0),
+    });
+    const partialFile = path.join(harness.appDir, "legacy-stopped-partial.txt");
+    await fs.promises.writeFile(partialFile, "legacy partial output\n");
+
+    try {
+      const result = await versionPreviewHandlerService.revertVersion({
+        appId: harness.appId,
+        previousVersionId: targetCommitHash,
+        targetBranchName: targetBranch ?? undefined,
+        currentChatMessageId: {
+          chatId: chatRow.id,
+          messageId: targetMessage.id,
+        },
+      });
+
+      expect(result.notification).toMatchObject({
+        message: expect.stringContaining(
+          "saved as an [Interrupted] version in Version History",
+        ),
+      });
+      await expect(fs.promises.stat(partialFile)).rejects.toThrow();
+      await expect(gitLog({ path: harness.appDir })).resolves.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            commit: expect.objectContaining({
+              message: expect.stringMatching(/^\[Interrupted\]/),
+            }),
+          }),
+        ]),
+      );
+    } finally {
+      await fs.promises.unlink(partialFile).catch(() => undefined);
+    }
+  });
+
   it("keeps a preflight dirty-tree refusal outside restore recovery", async () => {
     const headBeforeRestore = await getCurrentCommitHash({
       path: harness.appDir,

--- a/src/ipc/handlers/__tests__/context_compaction.integration.test.ts
+++ b/src/ipc/handlers/__tests__/context_compaction.integration.test.ts
@@ -31,7 +31,7 @@ import {
 import { h } from "@/testing/hybrid.setup";
 import { ipc } from "@/ipc/types";
 import { versionPreviewHandlerService } from "@/ipc/handlers/version_handlers";
-import { chats, messages } from "@/db/schema";
+import { chatTurnIntents, chats, messages } from "@/db/schema";
 import {
   getCurrentCommitHash,
   gitAddAll,
@@ -315,6 +315,131 @@ describe("context compaction (integration)", () => {
       appId: harness.appId,
       initialCommitHash,
     });
+  });
+
+  it("checkpoints partial files when restoring to an already-stopped generation", async () => {
+    const targetCommitHash = await getCurrentCommitHash({
+      path: harness.appDir,
+    });
+    const [chatRow] = await harness.db
+      .insert(chats)
+      .values({
+        appId: harness.appId,
+        chatMode: "local-agent",
+        initialCommitHash: targetCommitHash,
+      })
+      .returning();
+    const intentId = `stopped-before-undo-${chatRow.id}`;
+    await harness.db.insert(chatTurnIntents).values({
+      intentId,
+      chatId: chatRow.id,
+      payloadHash: "stopped-before-undo",
+      acceptance: "message-accepted",
+      recovery: "terminal",
+      terminalOutcome: "cancelled",
+    });
+    const [targetMessage] = await harness.db
+      .insert(messages)
+      .values({
+        chatId: chatRow.id,
+        role: "user",
+        content: "Stopped generation with partial files",
+        chatTurnIntentId: intentId,
+      })
+      .returning();
+    await harness.db.insert(messages).values({
+      chatId: chatRow.id,
+      role: "assistant",
+      content: "Generation stopped before completion.",
+      sourceCommitHash: targetCommitHash,
+    });
+    const partialFile = path.join(harness.appDir, "stopped-partial.txt");
+    await fs.promises.writeFile(partialFile, "partial generation output\n");
+
+    const result = await versionPreviewHandlerService.restoreToMessage({
+      appId: harness.appId,
+      chatId: chatRow.id,
+      messageId: targetMessage.id,
+      restoreCodebase: true,
+    });
+
+    expect(result.repositoryOutcome).toBe("target-applied");
+    expect(result.notification).toMatchObject({
+      kind: "success",
+      message: expect.stringContaining(
+        "saved as an [Interrupted] version in Version History",
+      ),
+    });
+    await expect(fs.promises.stat(partialFile)).rejects.toThrow();
+    const versions = await gitLog({ path: harness.appDir });
+    expect(
+      versions.some(
+        (version) =>
+          version.commit.message.startsWith("[Interrupted]") &&
+          version.commit.message.includes(
+            "Saved partial changes before restoring to an earlier version",
+          ),
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps a preflight dirty-tree refusal outside restore recovery", async () => {
+    const headBeforeRestore = await getCurrentCommitHash({
+      path: harness.appDir,
+    });
+    const branchBeforeRestore = await gitCurrentBranch({
+      path: harness.appDir,
+    });
+    const [chatRow] = await harness.db
+      .insert(chats)
+      .values({
+        appId: harness.appId,
+        chatMode: "local-agent",
+        initialCommitHash: headBeforeRestore,
+      })
+      .returning();
+    const [targetMessage] = await harness.db
+      .insert(messages)
+      .values({
+        chatId: chatRow.id,
+        role: "user",
+        content: "Completed generation followed by manual edits",
+      })
+      .returning();
+    await harness.db.insert(messages).values({
+      chatId: chatRow.id,
+      role: "assistant",
+      content: "Completed normally.",
+      sourceCommitHash: headBeforeRestore,
+      commitHash: headBeforeRestore,
+    });
+    const manualFile = path.join(harness.appDir, "manual-uncommitted.txt");
+    await fs.promises.writeFile(manualFile, "manual work\n");
+    const progress: RestoreRecovery[] = [];
+
+    try {
+      await expect(
+        versionPreviewHandlerService.restoreToMessage(
+          {
+            appId: harness.appId,
+            chatId: chatRow.id,
+            messageId: targetMessage.id,
+            restoreCodebase: true,
+          },
+          undefined,
+          (checkpoint) => progress.push(checkpoint),
+        ),
+      ).rejects.toThrow("Cannot revert: working tree has uncommitted changes.");
+      expect(progress).toEqual([]);
+      await expect(
+        getCurrentCommitHash({ path: harness.appDir }),
+      ).resolves.toBe(headBeforeRestore);
+      await expect(gitCurrentBranch({ path: harness.appDir })).resolves.toBe(
+        branchBeforeRestore,
+      );
+    } finally {
+      await fs.promises.unlink(manualFile).catch(() => {});
+    }
   });
 
   it("carries sticky referenced apps into the forked chat", async () => {

--- a/src/ipc/handlers/__tests__/stopped_generation_undo.integration.test.tsx
+++ b/src/ipc/handlers/__tests__/stopped_generation_undo.integration.test.tsx
@@ -4,7 +4,10 @@ import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
 import { asc, eq } from "drizzle-orm";
 
 import { chatTurnIntents, messages } from "@/db/schema";
-import { getGitUncommittedFilesWithStatus } from "@/ipc/utils/git_utils";
+import {
+  getGitUncommittedFilesWithStatus,
+  gitCurrentBranch,
+} from "@/ipc/utils/git_utils";
 import {
   setupHybridChatHarness,
   type HybridChatHarness,
@@ -50,6 +53,8 @@ describe("stopped generation undo (integration)", () => {
       { timeout: 15_000 },
     );
     await harness.selectChatMode("local-agent");
+    const initialBranch = await gitCurrentBranch({ path: harness.appDir });
+    expect(initialBranch).not.toBeNull();
 
     const streamStarted = harness.waitForEvent(
       "chat:stream:start",
@@ -134,6 +139,7 @@ describe("stopped generation undo (integration)", () => {
       {},
       { timeout: 20_000 },
     );
+    await harness.bridge.settleInFlight();
     await waitFor(
       () => {
         expect(screen.queryByText(PROMPT)).toBeNull();
@@ -143,6 +149,9 @@ describe("stopped generation undo (integration)", () => {
     );
     await waitFor(
       async () => {
+        expect(await gitCurrentBranch({ path: harness.appDir })).toBe(
+          initialBranch,
+        );
         expect(
           await getGitUncommittedFilesWithStatus({ path: harness.appDir }),
         ).toHaveLength(0);

--- a/src/ipc/handlers/__tests__/stopped_generation_undo.integration.test.tsx
+++ b/src/ipc/handlers/__tests__/stopped_generation_undo.integration.test.tsx
@@ -1,0 +1,163 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
+import { asc, eq } from "drizzle-orm";
+
+import { chatTurnIntents, messages } from "@/db/schema";
+import { getGitUncommittedFilesWithStatus } from "@/ipc/utils/git_utils";
+import {
+  setupHybridChatHarness,
+  type HybridChatHarness,
+} from "@/testing/hybrid_chat_harness";
+import { h } from "@/testing/hybrid.setup";
+
+const PARTIAL_FILE = "src/stopped-generation.ts";
+const PROMPT = "tc=local-agent/cancel-after-write";
+
+describe("stopped generation undo (integration)", () => {
+  let harness: HybridChatHarness;
+
+  beforeAll(async () => {
+    harness = await setupHybridChatHarness({
+      electronMock: h,
+      engine: true,
+      chatMode: "local-agent",
+      autoApprove: true,
+      settings: {
+        isTestMode: true,
+        enableDyadPro: true,
+        providerSettings: { auto: { apiKey: { value: "testdyadkey" } } },
+        enableCodeExplorer: false,
+      },
+    });
+  }, 60_000);
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  afterAll(async () => {
+    await harness?.dispose();
+  });
+
+  it("preserves an interrupted version and restores cleanly after Stop then Undo", async () => {
+    harness.mount();
+    await waitFor(
+      () => {
+        expect(screen.getByTestId("messages-list")).toBeTruthy();
+        expect(screen.getByTestId("chat-input-container")).toBeTruthy();
+      },
+      { timeout: 15_000 },
+    );
+    await harness.selectChatMode("local-agent");
+
+    const streamStarted = harness.waitForEvent(
+      "chat:stream:start",
+      (payload) =>
+        !!payload &&
+        typeof payload === "object" &&
+        (payload as { chatId?: number }).chatId === harness.chatId,
+      60_000,
+    );
+    const { send } = await harness.typeInChat(PROMPT);
+    send();
+    await streamStarted;
+
+    await waitFor(
+      () => {
+        expect(harness.appFileExists(PARTIAL_FILE)).toBe(true);
+        expect(harness.readAppFile(PARTIAL_FILE)).toContain(
+          'stoppedGeneration = "partial"',
+        );
+      },
+      { timeout: 20_000 },
+    );
+    await waitFor(
+      async () => {
+        const dirtyFiles = await getGitUncommittedFilesWithStatus({
+          path: harness.appDir,
+        });
+        expect(dirtyFiles.map(({ path }) => path)).toContain(PARTIAL_FILE);
+      },
+      { timeout: 15_000 },
+    );
+
+    const streamEnded = harness.waitForEvent(
+      "chat:response:end",
+      (payload) =>
+        !!payload &&
+        typeof payload === "object" &&
+        (payload as { chatId?: number }).chatId === harness.chatId &&
+        (payload as { wasCancelled?: boolean }).wasCancelled === true,
+      60_000,
+    );
+    const cancelButton = await screen.findByLabelText(
+      /^(cancelGeneration|Cancel generation)$/,
+      {},
+      { timeout: 60_000 },
+    );
+    fireEvent.click(cancelButton);
+    await streamEnded;
+
+    await waitFor(
+      async () => {
+        const chatMessages = await harness.db.query.messages.findMany({
+          where: eq(messages.chatId, harness.chatId),
+          orderBy: [asc(messages.id)],
+        });
+        const userMessage = chatMessages.find(
+          (message) => message.role === "user",
+        );
+        expect(userMessage?.chatTurnIntentId).toBeTruthy();
+        const intent = await harness.db.query.chatTurnIntents.findFirst({
+          where: eq(
+            chatTurnIntents.intentId,
+            userMessage?.chatTurnIntentId ?? "",
+          ),
+        });
+        expect(intent?.terminalOutcome).toBe("cancelled");
+      },
+      { timeout: 15_000 },
+    );
+
+    await waitFor(
+      () => {
+        const undo = screen.getByRole("button", { name: /Undo/ });
+        expect(undo.hasAttribute("disabled")).toBe(false);
+      },
+      { timeout: 15_000 },
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Undo/ }));
+
+    await screen.findByText(
+      /saved as an \[Interrupted\] version in Version History/,
+      {},
+      { timeout: 20_000 },
+    );
+    await waitFor(
+      () => {
+        expect(screen.queryByText(PROMPT)).toBeNull();
+        expect(harness.appFileExists(PARTIAL_FILE)).toBe(false);
+      },
+      { timeout: 20_000 },
+    );
+    await waitFor(
+      async () => {
+        expect(
+          await getGitUncommittedFilesWithStatus({ path: harness.appDir }),
+        ).toHaveLength(0);
+      },
+      { timeout: 15_000 },
+    );
+    expect(
+      harness
+        .gitLog()
+        .some((entry) =>
+          entry.includes(
+            "[Interrupted] Saved partial changes before restoring to an earlier version",
+          ),
+        ),
+    ).toBe(true);
+    expect(screen.queryByText("Version restore needs attention.")).toBeNull();
+  }, 90_000);
+});

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -721,6 +721,23 @@ export async function cancelActiveStreamsForApp(
   );
 }
 
+/** Read-only active-stream probe used while an app-wide admission block is held. */
+export async function hasActiveStreamsForApp(appId: number): Promise<boolean> {
+  const inFlightChatIds = [
+    ...new Set([...activeStreams.keys(), ...streamCompletions.keys()]),
+  ].filter(
+    (chatId) =>
+      (activeStreams.get(chatId)?.size ?? 0) > 0 ||
+      (streamCompletions.get(chatId)?.size ?? 0) > 0,
+  );
+  if (inFlightChatIds.length === 0) return false;
+  const matchingChat = await db.query.chats.findFirst({
+    columns: { id: true },
+    where: and(eq(chats.appId, appId), inArray(chats.id, inFlightChatIds)),
+  });
+  return matchingChat !== undefined;
+}
+
 // Use escapeXmlAttr from shared/xmlEscape for XML escaping
 
 // Safely parse an MCP tool key that combines server and tool names.

--- a/src/ipc/handlers/version_handlers.ts
+++ b/src/ipc/handlers/version_handlers.ts
@@ -1513,7 +1513,7 @@ export function registerVersionHandlers() {
                 kind: "warning",
                 message: appendInterruptedGenerationWarning(
                   "Could not determine a version to restore to for this message.",
-                  preserveDirtyTree,
+                  preservedByActiveCancellation,
                 ),
               },
             });
@@ -1535,7 +1535,7 @@ export function registerVersionHandlers() {
                     kind: "warning",
                     message: appendInterruptedGenerationWarning(
                       "Could not restore the codebase because the target version no longer exists in the repository.",
-                      preserveDirtyTree,
+                      preservedByActiveCancellation,
                     ),
                   },
                 });

--- a/src/ipc/handlers/version_handlers.ts
+++ b/src/ipc/handlers/version_handlers.ts
@@ -40,7 +40,6 @@ import {
   gitCurrentBranch,
   gitLog,
   inspectRepositoryHealth,
-  isGitStatusClean,
   getChangedFilesForCommit,
   getFileAtCommit,
   getOldFileContent,
@@ -575,7 +574,7 @@ async function revertCodebaseToVersion({
   // manual edits.
   let detachedCheckpointCommit: string | null = null;
   let preservedInterruptedChanges = false;
-  if (preserveDirtyTree && !(await isGitStatusClean({ path: appPath }))) {
+  if (preserveDirtyTree && !repositoryHealth.isClean) {
     // Stage everything first so untracked files (e.g. a newly added
     // pnpm-workspace.yaml) are included. With native git, `git commit` only
     // commits staged changes, so without this the commit would fail with
@@ -1268,10 +1267,7 @@ export function registerVersionHandlers() {
           where: eq(chats.id, chatId),
           with: {
             messages: {
-              orderBy: (messages, { asc }) => [
-                asc(messages.createdAt),
-                asc(messages.id),
-              ],
+              orderBy: (messages, { asc }) => [asc(messages.id)],
             },
           },
         });
@@ -1473,10 +1469,7 @@ export function registerVersionHandlers() {
             where: eq(chats.id, chatId),
             with: {
               messages: {
-                orderBy: (messages, { asc }) => [
-                  asc(messages.createdAt),
-                  asc(messages.id),
-                ],
+                orderBy: (messages, { asc }) => [asc(messages.id)],
               },
             },
           });

--- a/src/ipc/handlers/version_handlers.ts
+++ b/src/ipc/handlers/version_handlers.ts
@@ -303,7 +303,7 @@ async function getRestoreTargetTurnOutcomeForMessage({
   const nextMessage = await db.query.messages.findFirst({
     columns,
     where: and(eq(messages.chatId, chatId), gt(messages.id, messageId)),
-    orderBy: (messages, { asc }) => [asc(messages.createdAt), asc(messages.id)],
+    orderBy: (messages, { asc }) => [asc(messages.id)],
   });
   return getStoredTurnOutcome(target, nextMessage);
 }

--- a/src/ipc/handlers/version_handlers.ts
+++ b/src/ipc/handlers/version_handlers.ts
@@ -255,6 +255,13 @@ async function getRestoreTargetTurnOutcome({
   const target = chatMessages[targetIndex];
   if (!target || target.role !== "user") return "unknown";
 
+  return getStoredTurnOutcome(target, chatMessages[targetIndex + 1]);
+}
+
+async function getStoredTurnOutcome(
+  target: RestoreMessageCommitMetadata,
+  nextMessage?: RestoreMessageCommitMetadata,
+): Promise<RestoreTargetTurnOutcome> {
   if (target.chatTurnIntentId) {
     const intent = await db.query.chatTurnIntents.findFirst({
       columns: { terminalOutcome: true },
@@ -263,7 +270,6 @@ async function getRestoreTargetTurnOutcome({
     if (intent?.terminalOutcome) return intent.terminalOutcome;
   }
 
-  const nextMessage = chatMessages[targetIndex + 1];
   if (
     nextMessage?.role === "assistant" &&
     !nextMessage.commitHash &&
@@ -273,6 +279,33 @@ async function getRestoreTargetTurnOutcome({
   }
 
   return "unknown";
+}
+
+async function getRestoreTargetTurnOutcomeForMessage({
+  chatId,
+  messageId,
+}: {
+  chatId: number;
+  messageId: number;
+}): Promise<RestoreTargetTurnOutcome> {
+  const columns = {
+    role: true,
+    content: true,
+    sourceCommitHash: true,
+    commitHash: true,
+    chatTurnIntentId: true,
+  } as const;
+  const target = await db.query.messages.findFirst({
+    columns,
+    where: and(eq(messages.chatId, chatId), eq(messages.id, messageId)),
+  });
+  if (!target || target.role !== "user") return "unknown";
+  const nextMessage = await db.query.messages.findFirst({
+    columns,
+    where: and(eq(messages.chatId, chatId), gt(messages.id, messageId)),
+    orderBy: (messages, { asc }) => [asc(messages.createdAt), asc(messages.id)],
+  });
+  return getStoredTurnOutcome(target, nextMessage);
 }
 
 function resolveTargetCommitHash({
@@ -573,6 +606,10 @@ async function revertCodebaseToVersion({
   }
 
   if (currentBranch !== revertRef) {
+    const [checkoutStartBranch, checkoutStartHead] = await Promise.all([
+      gitCurrentBranch({ path: appPath }),
+      getCurrentCommitHash({ path: appPath }),
+    ]);
     checkpointGitStep("checkout-branch");
     try {
       await gitCheckout({
@@ -580,18 +617,26 @@ async function revertCodebaseToVersion({
         ref: revertRef,
       });
     } catch (error) {
-      const [branchAfterFailure, headAfterFailure] = await Promise.all([
-        gitCurrentBranch({ path: appPath }),
-        getCurrentCommitHash({ path: appPath }),
-      ]);
-      if (
-        branchAfterFailure === restoreFacts.preRestoreBranch &&
-        headAfterFailure === restoreFacts.preRestoreHead
-      ) {
-        onRestoreProgress?.({
-          repositoryOutcome: "unchanged",
-          nextStep: "completed",
-        });
+      try {
+        const [branchAfterFailure, headAfterFailure] = await Promise.all([
+          gitCurrentBranch({ path: appPath }),
+          getCurrentCommitHash({ path: appPath }),
+        ]);
+        if (
+          !preservedInterruptedChanges &&
+          branchAfterFailure === checkoutStartBranch &&
+          headAfterFailure === checkoutStartHead
+        ) {
+          onRestoreProgress?.({
+            repositoryOutcome: "unchanged",
+            nextStep: "completed",
+          });
+        }
+      } catch (probeError) {
+        logger.warn(
+          `Could not inspect repository state after checkout failed for app ${appId}; preserving the original checkout error.`,
+          probeError,
+        );
       }
       throw error;
     }
@@ -1030,26 +1075,14 @@ export function registerVersionHandlers() {
         let preserveDirtyTree = false;
         if (currentChatMessageId) {
           const targetChat = await db.query.chats.findFirst({
+            columns: { appId: true },
             where: eq(chats.id, currentChatMessageId.chatId),
-            with: {
-              messages: {
-                orderBy: (messages, { asc }) => [
-                  asc(messages.createdAt),
-                  asc(messages.id),
-                ],
-              },
-            },
           });
-          const targetIndex =
-            targetChat?.messages.findIndex(
-              (message) => message.id === currentChatMessageId.messageId,
-            ) ?? -1;
           preserveDirtyTree =
             targetChat?.appId === appId &&
-            targetIndex >= 0 &&
-            (await getRestoreTargetTurnOutcome({
-              chatMessages: targetChat.messages,
-              targetIndex,
+            (await getRestoreTargetTurnOutcomeForMessage({
+              chatId: currentChatMessageId.chatId,
+              messageId: currentChatMessageId.messageId,
             })) === "cancelled";
         }
 

--- a/src/ipc/handlers/version_handlers.ts
+++ b/src/ipc/handlers/version_handlers.ts
@@ -39,6 +39,7 @@ import {
   gitCommitExists,
   gitCurrentBranch,
   gitLog,
+  inspectRepositoryHealth,
   isGitStatusClean,
   getChangedFilesForCommit,
   getFileAtCommit,
@@ -531,6 +532,26 @@ async function revertCodebaseToVersion({
     preRestoreBranch: targetBranchName ?? currentBranch,
     targetHead: previousVersionId,
   } as const;
+
+  // Restores rewrite the index and working tree. In particular, preserving an
+  // interrupted turn stages and commits the entire tree, which Git can treat as
+  // resolving conflicts or completing an unrelated merge/cherry-pick. Refuse
+  // every restore while Git owns the repository for another operation, before
+  // emitting progress or making any mutation.
+  const repositoryHealth = await inspectRepositoryHealth({ path: appPath });
+  if (repositoryHealth.unmergedFiles.length > 0) {
+    throw new DyadError(
+      "Cannot revert: repository has unresolved file conflicts.",
+      DyadErrorKind.Conflict,
+    );
+  }
+  if (repositoryHealth.operationInProgress) {
+    throw new DyadError(
+      `Cannot revert: a Git ${repositoryHealth.operationInProgress} is in progress. Finish or cancel it outside Dyad, then try again.`,
+      DyadErrorKind.Conflict,
+    );
+  }
+
   const checkpointGitStep = (
     nextStep:
       | "preparing"

--- a/src/ipc/handlers/version_handlers.ts
+++ b/src/ipc/handlers/version_handlers.ts
@@ -1,5 +1,11 @@
 import { db } from "../../db";
-import { apps, chats, messages, versions } from "../../db/schema";
+import {
+  apps,
+  chats,
+  chatTurnIntents,
+  messages,
+  versions,
+} from "../../db/schema";
 import { desc, eq, and, gt, gte } from "drizzle-orm";
 import type { GitCommit } from "../git_types";
 import fs from "node:fs";
@@ -70,6 +76,8 @@ import {
 import type { RestoreRecovery } from "@/version_preview/state";
 import { readStoredReferencedAppIds } from "../utils/mention_apps";
 import { blockRecordingStart } from "../services/recording_registry";
+import { isCancelledResponseContent } from "@/shared/chatCancellation";
+import type { ChatTurnTerminalOutcome } from "@/shared/chat_turn_outcome";
 
 const logger = log.scope("version_handlers");
 
@@ -183,6 +191,8 @@ function appendWarning(existing: string, addition: string): string {
 
 const INTERRUPTED_GENERATION_WARNING =
   "An in-progress generation was cancelled during this restore attempt. Re-submit its prompt to continue.";
+const INTERRUPTED_CHECKPOINT_NOTICE =
+  "Partial changes from the interrupted generation were saved as an [Interrupted] version in Version History.";
 
 function versionRuntimeAction(
   app: typeof apps.$inferSelect,
@@ -230,8 +240,40 @@ function appendInterruptedGenerationWarning(
 
 type RestoreMessageCommitMetadata = Pick<
   typeof messages.$inferSelect,
-  "role" | "sourceCommitHash" | "commitHash"
+  "role" | "content" | "sourceCommitHash" | "commitHash" | "chatTurnIntentId"
 >;
+
+type RestoreTargetTurnOutcome = ChatTurnTerminalOutcome | "unknown";
+
+async function getRestoreTargetTurnOutcome({
+  chatMessages,
+  targetIndex,
+}: {
+  chatMessages: RestoreMessageCommitMetadata[];
+  targetIndex: number;
+}): Promise<RestoreTargetTurnOutcome> {
+  const target = chatMessages[targetIndex];
+  if (!target || target.role !== "user") return "unknown";
+
+  if (target.chatTurnIntentId) {
+    const intent = await db.query.chatTurnIntents.findFirst({
+      columns: { terminalOutcome: true },
+      where: eq(chatTurnIntents.intentId, target.chatTurnIntentId),
+    });
+    if (intent?.terminalOutcome) return intent.terminalOutcome;
+  }
+
+  const nextMessage = chatMessages[targetIndex + 1];
+  if (
+    nextMessage?.role === "assistant" &&
+    !nextMessage.commitHash &&
+    isCancelledResponseContent(nextMessage.content)
+  ) {
+    return "cancelled";
+  }
+
+  return "unknown";
+}
 
 function resolveTargetCommitHash({
   chatMessages,
@@ -441,6 +483,7 @@ async function revertCodebaseToVersion({
     RestoreRecovery,
     { repositoryOutcome: "target-applied" }
   > & { nextStep: "chat-mutation" };
+  preservedInterruptedChanges: boolean;
 }> {
   let successMessage = "Restored version";
   let warningMessage = "";
@@ -471,11 +514,13 @@ async function revertCodebaseToVersion({
   // revert commit would be created on the detached HEAD and then abandoned when
   // the saved branch is checked out again, silently discarding the restore. Bail
   // out with a clear message instead of doing the work only to throw it away.
-  // A stream cancelled specifically for restore-to-message may leave partial
-  // writes behind. Preserve that interrupted turn before reverting. Existing
-  // Restore, Undo, Retry, and checkout paths intentionally keep their prior
-  // dirty-tree conflict behavior instead of silently committing manual edits.
+  // A cancelled stream may leave partial writes behind. Preserve that
+  // interrupted turn before reverting when the caller can prove the dirty tree
+  // belongs to a durably cancelled turn. Other restore and checkout paths keep
+  // their prior dirty-tree conflict behavior instead of silently committing
+  // manual edits.
   let detachedCheckpointCommit: string | null = null;
+  let preservedInterruptedChanges = false;
   if (preserveDirtyTree && !(await isGitStatusClean({ path: appPath }))) {
     // Stage everything first so untracked files (e.g. a newly added
     // pnpm-workspace.yaml) are included. With native git, `git commit` only
@@ -507,18 +552,50 @@ async function revertCodebaseToVersion({
     const checkpointCommit = await gitCommit({
       path: appPath,
       message:
-        "Saved partial changes (from an interrupted generation) before restoring to an earlier version",
+        "[Interrupted] Saved partial changes before restoring to an earlier version",
     });
+    preservedInterruptedChanges = true;
     if (!currentBranch) {
       detachedCheckpointCommit = checkpointCommit;
     }
   }
 
-  checkpointGitStep("checkout-branch");
-  await gitCheckout({
-    path: appPath,
-    ref: revertRef,
-  });
+  if (!preserveDirtyTree) {
+    const userVisibleChanges = await getGitUncommittedFilesWithStatus({
+      path: appPath,
+    });
+    if (userVisibleChanges.length > 0) {
+      throw new DyadError(
+        "Cannot revert: working tree has uncommitted changes.",
+        DyadErrorKind.Conflict,
+      );
+    }
+  }
+
+  if (currentBranch !== revertRef) {
+    checkpointGitStep("checkout-branch");
+    try {
+      await gitCheckout({
+        path: appPath,
+        ref: revertRef,
+      });
+    } catch (error) {
+      const [branchAfterFailure, headAfterFailure] = await Promise.all([
+        gitCurrentBranch({ path: appPath }),
+        getCurrentCommitHash({ path: appPath }),
+      ]);
+      if (
+        branchAfterFailure === restoreFacts.preRestoreBranch &&
+        headAfterFailure === restoreFacts.preRestoreHead
+      ) {
+        onRestoreProgress?.({
+          repositoryOutcome: "unchanged",
+          nextStep: "completed",
+        });
+      }
+      throw error;
+    }
+  }
 
   // When the interrupted writes were checkpointed from a detached historical
   // preview, carry that exact tree onto the live branch before restoring. This
@@ -535,7 +612,7 @@ async function revertCodebaseToVersion({
       await gitCommit({
         path: appPath,
         message:
-          "Saved partial changes (from an interrupted generation) before restoring to an earlier version",
+          "[Interrupted] Saved partial changes before restoring to an earlier version",
       });
     }
   }
@@ -714,7 +791,12 @@ async function revertCodebaseToVersion({
   } as const;
   onRestoreProgress?.(restoreCompletion);
 
-  return { successMessage, warningMessage, restoreCompletion };
+  return {
+    successMessage,
+    warningMessage,
+    restoreCompletion,
+    preservedInterruptedChanges,
+  };
 }
 
 export function registerVersionHandlers() {
@@ -945,15 +1027,52 @@ export function registerVersionHandlers() {
           }
         }
 
-        const { successMessage, warningMessage, restoreCompletion } =
-          await revertCodebaseToVersion({
-            appId,
-            app,
-            appPath,
-            previousVersionId,
-            targetBranchName,
-            onRestoreProgress,
+        let preserveDirtyTree = false;
+        if (currentChatMessageId) {
+          const targetChat = await db.query.chats.findFirst({
+            where: eq(chats.id, currentChatMessageId.chatId),
+            with: {
+              messages: {
+                orderBy: (messages, { asc }) => [
+                  asc(messages.createdAt),
+                  asc(messages.id),
+                ],
+              },
+            },
           });
+          const targetIndex =
+            targetChat?.messages.findIndex(
+              (message) => message.id === currentChatMessageId.messageId,
+            ) ?? -1;
+          preserveDirtyTree =
+            targetChat?.appId === appId &&
+            targetIndex >= 0 &&
+            (await getRestoreTargetTurnOutcome({
+              chatMessages: targetChat.messages,
+              targetIndex,
+            })) === "cancelled";
+        }
+
+        const revertResult = await revertCodebaseToVersion({
+          appId,
+          app,
+          appPath,
+          previousVersionId,
+          targetBranchName,
+          preserveDirtyTree,
+          onRestoreProgress,
+        });
+        let { successMessage, warningMessage, restoreCompletion } =
+          revertResult;
+        if (revertResult.preservedInterruptedChanges) {
+          successMessage = `${successMessage} ${INTERRUPTED_CHECKPOINT_NOTICE}`;
+          if (warningMessage) {
+            warningMessage = appendWarning(
+              warningMessage,
+              INTERRUPTED_CHECKPOINT_NOTICE,
+            );
+          }
+        }
 
         let affectedChatId: number | null = null;
 
@@ -1247,7 +1366,8 @@ export function registerVersionHandlers() {
       const didCancelTransport = restoreCodebase
         ? await cancelActiveStreamsForApp(appId, event.sender)
         : false;
-      const preserveDirtyTree = didCancelActor || didCancelTransport;
+      const preservedByActiveCancellation =
+        didCancelActor || didCancelTransport;
 
       // No recording recheck here: the block taken above is what rules one out
       // for the rest of this operation, and it was taken while a refusal was
@@ -1322,6 +1442,23 @@ export function registerVersionHandlers() {
           if (latestTargetIndex === -1) {
             throw new DyadError("Message not found", DyadErrorKind.NotFound);
           }
+
+          const latestTargetTurnOutcome = await getRestoreTargetTurnOutcome({
+            chatMessages: latestChat.messages,
+            targetIndex: latestTargetIndex,
+          });
+          const preserveDirtyTree =
+            preservedByActiveCancellation ||
+            latestTargetTurnOutcome === "cancelled";
+          logger.info(
+            `Restore-to-message dirty-tree preservation for app ${appId}: ${
+              preservedByActiveCancellation
+                ? "active-cancel"
+                : latestTargetTurnOutcome === "cancelled"
+                  ? "durable-cancelled-turn"
+                  : "none"
+            }`,
+          );
 
           const latestMessagesBefore = latestChat.messages
             .slice(0, latestTargetIndex)
@@ -1402,6 +1539,15 @@ export function registerVersionHandlers() {
             });
             successMessage = result.successMessage;
             warningMessage = result.warningMessage;
+            if (result.preservedInterruptedChanges) {
+              successMessage = `${successMessage} ${INTERRUPTED_CHECKPOINT_NOTICE}`;
+              if (warningMessage) {
+                warningMessage = appendWarning(
+                  warningMessage,
+                  INTERRUPTED_CHECKPOINT_NOTICE,
+                );
+              }
+            }
             restoreCompletion = result.restoreCompletion;
           }
 

--- a/src/ipc/services/chat_actor_service.test.ts
+++ b/src/ipc/services/chat_actor_service.test.ts
@@ -12,6 +12,9 @@ const actor = vi.hoisted(() => {
       lastCompletion = null;
       listener = undefined;
     },
+    setPhase: (nextPhase: string) => {
+      phase = nextPhase;
+    },
     completeOnSend: (intentId: string) => {
       settleDuringSubscribe = false;
       actor.send.mockImplementationOnce(() => {
@@ -125,6 +128,7 @@ import {
   beginAppChatActorMutation,
   deleteOwnedChatAfterSettlingActors,
   dispatchChatIntentAndWait,
+  hasActiveAppChatActors,
   observeChatSubmissionStopPolicy,
   waitForAppChatActorsIdle,
   waitForChatActorIdle,
@@ -227,6 +231,16 @@ describe("waitForChatActorIdle", () => {
       expect.objectContaining({ chatId: 8 }),
     );
   });
+
+  it.each(["admitting", "streaming", "cancelling", "finalizing"])(
+    "treats the %s actor phase as active for repository recovery",
+    async (phase) => {
+      cleanup.findChats.mockResolvedValue([{ id: 7 }]);
+      actor.setPhase(phase);
+
+      await expect(hasActiveAppChatActors(3)).resolves.toBe(true);
+    },
+  );
 
   it("holds app creation and existing actor admission fences for a mutation", async () => {
     cleanup.findChats.mockResolvedValue([{ id: 7 }, { id: 8 }]);

--- a/src/ipc/services/chat_actor_service.ts
+++ b/src/ipc/services/chat_actor_service.ts
@@ -2,6 +2,7 @@ import { remoteMachineHost } from "@/ipc/services/distributed_machine_actor_host
 import { computeChatTurnPayloadHash } from "@/ipc/utils/chat_turn_intent_hash";
 import { chatStreamDefinition } from "@/chat_stream/definition";
 import { getIntentAcceptance } from "@/chat_stream/persistence";
+import { canCancelChatStreamPhase } from "@/chat_stream/transition";
 import {
   chatStreamKey,
   type ChatStreamWireEvent,
@@ -163,7 +164,7 @@ export async function hasActiveAppChatActors(appId: number): Promise<boolean> {
       ChatStreamHostIgnoreReason
     >(chatStreamDefinition.id, chatStreamKey(id));
     const phase = actor?.getSnapshot().phase;
-    return phase === "admitting" || phase === "streaming";
+    return phase !== undefined && canCancelChatStreamPhase(phase);
   });
 }
 

--- a/src/ipc/services/chat_actor_service.ts
+++ b/src/ipc/services/chat_actor_service.ts
@@ -150,6 +150,23 @@ export async function waitForAppChatActorsIdle(
   return cancellationResults.some(Boolean);
 }
 
+/** Read-only active actor probe used while app/chat admission is fenced. */
+export async function hasActiveAppChatActors(appId: number): Promise<boolean> {
+  const appChats = await db.query.chats.findMany({
+    columns: { id: true },
+    where: eq(chats.appId, appId),
+  });
+  return appChats.some(({ id }) => {
+    const actor = remoteMachineHost.peek<
+      ChatStreamHostState,
+      ChatStreamWireEvent,
+      ChatStreamHostIgnoreReason
+    >(chatStreamDefinition.id, chatStreamKey(id));
+    const phase = actor?.getSnapshot().phase;
+    return phase === "admitting" || phase === "streaming";
+  });
+}
+
 export async function beginAppChatActorMutation(
   appId: number,
 ): Promise<() => void> {

--- a/src/ipc/services/version_preview_definition.ts
+++ b/src/ipc/services/version_preview_definition.ts
@@ -82,7 +82,9 @@ function isMutationCommand(command: PreviewCommand): boolean {
     command.type === "return" ||
     command.type === "switch-branch" ||
     command.type === "restore" ||
-    command.type === "restore-to-message"
+    command.type === "restore-to-message" ||
+    command.type === "validate-current-repository" ||
+    command.type === "checkpoint-current-repository"
   );
 }
 
@@ -92,6 +94,7 @@ function isFailureEvent(event: VersionPreviewWireEvent): boolean {
     event.type === "CHECKOUT_FAILED" ||
     event.type === "RESTORE_FAILED" ||
     event.type === "RESTORE_RECOVERY_REQUIRED" ||
+    event.type === "CURRENT_REPOSITORY_REJECTED" ||
     event.type === "RETURN_FAILED" ||
     event.type === "SWITCH_BRANCH_FAILED"
   );
@@ -538,6 +541,91 @@ function createCommandRunner(
               `Version preview completion failed: ${errorInfo(error).message}`,
             );
           });
+        return;
+      }
+      case "validate-current-repository":
+      case "checkpoint-current-repository": {
+        if (!invocationRef) return;
+        const operation =
+          command.type === "validate-current-repository"
+            ? versionPreviewService.validateCurrentRepository(appId)
+            : versionPreviewService.checkpointCurrentRepository(appId);
+        const lifecycle = operation.then(
+          (result) => {
+            if (result.kind === "dirty") {
+              emit({ type: "CURRENT_REPOSITORY_DIRTY", invocationRef });
+              return;
+            }
+            if (result.kind === "blocked") {
+              emit({
+                type: "CURRENT_REPOSITORY_REJECTED",
+                error: { message: result.message },
+                assessment: result.assessment,
+                invocationRef,
+              });
+              return;
+            }
+
+            const originHandledScopes = [
+              { family: "branches", appId },
+              { family: "versions", appId },
+              { family: "app", appId },
+              { family: "problems", appId },
+            ] as const;
+            const scopes = [
+              ...originHandledScopes,
+              { family: "chats" },
+            ] as const;
+            queryInvalidationBus.publish(scopes, {
+              originEndpoint:
+                versionPreviewPresentationService.originEndpointFor(
+                  invocationRef.operationId,
+                ),
+              originHandledScopes,
+            });
+            versionPreviewPresentationService.publishResult(
+              appId,
+              invocationRef.operationId,
+              {
+                repositoryOutcome: "unchanged",
+                notification: result.savedVersionId
+                  ? {
+                      kind: "success",
+                      message:
+                        "Current changes saved as a recovery version. Version History is ready.",
+                    }
+                  : {
+                      kind: "success",
+                      message:
+                        "Version History is ready. Continuing from the current code version.",
+                    },
+                runtimeAction: "none",
+                affectedChatId: null,
+                createdChatId: null,
+              },
+            );
+            emit({
+              type: "CURRENT_REPOSITORY_ACCEPTED",
+              appId,
+              branch: result.branch,
+              acceptedHead: result.headOid,
+              savedVersionId: result.savedVersionId,
+              invocationRef,
+            });
+          },
+          (error) => {
+            emit({
+              type: "CURRENT_REPOSITORY_REJECTED",
+              error: errorInfo(error),
+              assessment: {
+                type: "blocked",
+                blocker: "repository-error",
+              },
+              invocationRef,
+            });
+          },
+        );
+        void versionPreviewService.trackLifecycle(appId, lifecycle);
         return;
       }
       case "notify-error":

--- a/src/ipc/services/version_preview_definition.ts
+++ b/src/ipc/services/version_preview_definition.ts
@@ -12,6 +12,7 @@ import { queryInvalidationBus } from "@/window_infrastructure/main/query_invalid
 import { ignore } from "@/state_machines/types";
 import {
   CLOSED_STATE,
+  isRestoreRecoveryFlowState,
   type PreviewCommand,
   type PreviewState,
   type RestoreRecovery,
@@ -410,12 +411,16 @@ function createCommandRunner(
                 command,
                 invocationRef.operationId,
                 (progress) => {
+                  const recovery =
+                    command.type === "restore-to-message"
+                      ? { ...progress, affectedChatId: command.chatId }
+                      : progress;
                   versionPreviewPersistence.checkpointRestore(
                     appId,
                     context.getSnapshot().state,
-                    progress,
+                    recovery,
                   );
-                  restoreProgress = progress;
+                  restoreProgress = recovery;
                 },
               )
             : versionPreviewService.run(command, invocationRef.operationId);
@@ -569,6 +574,10 @@ function createCommandRunner(
             }
 
             try {
+              const recoveryState = context.getSnapshot().state;
+              const affectedChatId = isRestoreRecoveryFlowState(recoveryState)
+                ? (recoveryState.restoreRecovery?.affectedChatId ?? null)
+                : null;
               const originHandledScopes = [
                 { family: "branches", appId },
                 { family: "versions", appId },
@@ -578,6 +587,9 @@ function createCommandRunner(
               const scopes = [
                 ...originHandledScopes,
                 { family: "chats" },
+                ...(affectedChatId
+                  ? ([{ family: "chat", chatId: affectedChatId }] as const)
+                  : []),
               ] as const;
               queryInvalidationBus.publish(scopes, {
                 originEndpoint:
@@ -603,7 +615,7 @@ function createCommandRunner(
                           "Version History is ready. Continuing from the current code version.",
                       },
                   runtimeAction: "none",
-                  affectedChatId: null,
+                  affectedChatId,
                   createdChatId: null,
                 },
               );

--- a/src/ipc/services/version_preview_definition.ts
+++ b/src/ipc/services/version_preview_definition.ts
@@ -38,6 +38,7 @@ import { versionPreviewPresentationService } from "./version_preview_presentatio
 import { versionPreviewService } from "./version_preview_service";
 import { versionPreviewPersistence } from "./version_preview_persistence";
 import { versionPreviewWindowInterestService } from "./version_preview_window_interest";
+import { versionPreviewRemoteIntentContract } from "@/version_preview/remote_intent_contract";
 
 interface VersionPreviewActorCommand {
   readonly command: PreviewCommand | { readonly type: "reconcile" };
@@ -94,6 +95,7 @@ function isFailureEvent(event: VersionPreviewWireEvent): boolean {
     event.type === "CHECKOUT_FAILED" ||
     event.type === "RESTORE_FAILED" ||
     event.type === "RESTORE_RECOVERY_REQUIRED" ||
+    event.type === "CURRENT_REPOSITORY_DIRTY" ||
     event.type === "CURRENT_REPOSITORY_REJECTED" ||
     event.type === "RETURN_FAILED" ||
     event.type === "SWITCH_BRANCH_FAILED"
@@ -566,52 +568,55 @@ function createCommandRunner(
               return;
             }
 
-            const originHandledScopes = [
-              { family: "branches", appId },
-              { family: "versions", appId },
-              { family: "app", appId },
-              { family: "problems", appId },
-            ] as const;
-            const scopes = [
-              ...originHandledScopes,
-              { family: "chats" },
-            ] as const;
-            queryInvalidationBus.publish(scopes, {
-              originEndpoint:
-                versionPreviewPresentationService.originEndpointFor(
-                  invocationRef.operationId,
-                ),
-              originHandledScopes,
-            });
-            versionPreviewPresentationService.publishResult(
-              appId,
-              invocationRef.operationId,
-              {
-                repositoryOutcome: "unchanged",
-                notification: result.savedVersionId
-                  ? {
-                      kind: "success",
-                      message:
-                        "Current changes saved as a recovery version. Version History is ready.",
-                    }
-                  : {
-                      kind: "success",
-                      message:
-                        "Version History is ready. Continuing from the current code version.",
-                    },
-                runtimeAction: "none",
-                affectedChatId: null,
-                createdChatId: null,
-              },
-            );
-            emit({
-              type: "CURRENT_REPOSITORY_ACCEPTED",
-              appId,
-              branch: result.branch,
-              acceptedHead: result.headOid,
-              savedVersionId: result.savedVersionId,
-              invocationRef,
-            });
+            try {
+              const originHandledScopes = [
+                { family: "branches", appId },
+                { family: "versions", appId },
+                { family: "app", appId },
+                { family: "problems", appId },
+              ] as const;
+              const scopes = [
+                ...originHandledScopes,
+                { family: "chats" },
+              ] as const;
+              queryInvalidationBus.publish(scopes, {
+                originEndpoint:
+                  versionPreviewPresentationService.originEndpointFor(
+                    invocationRef.operationId,
+                  ),
+                originHandledScopes,
+              });
+              versionPreviewPresentationService.publishResult(
+                appId,
+                invocationRef.operationId,
+                {
+                  repositoryOutcome: "unchanged",
+                  notification: result.savedVersionId
+                    ? {
+                        kind: "success",
+                        message:
+                          "Current changes saved as a recovery version. Version History is ready.",
+                      }
+                    : {
+                        kind: "success",
+                        message:
+                          "Version History is ready. Continuing from the current code version.",
+                      },
+                  runtimeAction: "none",
+                  affectedChatId: null,
+                  createdChatId: null,
+                },
+              );
+            } finally {
+              emit({
+                type: "CURRENT_REPOSITORY_ACCEPTED",
+                appId,
+                branch: result.branch,
+                acceptedHead: result.headOid,
+                savedVersionId: result.savedVersionId,
+                invocationRef,
+              });
+            }
           },
           (error) => {
             emit({
@@ -625,7 +630,15 @@ function createCommandRunner(
             });
           },
         );
-        void versionPreviewService.trackLifecycle(appId, lifecycle);
+        void versionPreviewService
+          .trackLifecycle(appId, lifecycle)
+          .catch((error) => {
+            versionPreviewPresentationService.publishError(
+              appId,
+              invocationRef.operationId,
+              `Version recovery completion failed: ${errorInfo(error).message}`,
+            );
+          });
         return;
       }
       case "notify-error":
@@ -670,7 +683,9 @@ type Definition = DistributedMachineDefinition<
   VersionPreviewActorState,
   VersionPreviewWireEvent,
   VersionPreviewActorCommand,
-  import("@/version_preview/transition").PreviewIgnoreReason | "stale-operation"
+  | import("@/version_preview/transition").PreviewIgnoreReason
+  | "stale-operation",
+  VersionPreviewIntentEvent
 > & {
   readonly host: "main";
   readonly remote: NonNullable<
@@ -681,7 +696,8 @@ type Definition = DistributedMachineDefinition<
       VersionPreviewWireEvent,
       VersionPreviewActorCommand,
       | import("@/version_preview/transition").PreviewIgnoreReason
-      | "stale-operation"
+      | "stale-operation",
+      VersionPreviewIntentEvent
     >["remote"]
   >;
 };
@@ -807,4 +823,5 @@ export const versionPreviewDefinition: Definition = {
       );
     },
   },
+  remoteIntentDeclaration: versionPreviewRemoteIntentContract,
 };

--- a/src/ipc/services/version_preview_persistence.ts
+++ b/src/ipc/services/version_preview_persistence.ts
@@ -197,6 +197,21 @@ function toPersistedState(state: PreviewState): PersistedState | null {
         ...state,
         fallback: persistedFallback(state.fallback),
       };
+    case "restore-recovery-required":
+      return {
+        type: state.type,
+        session: persistedSession(state.session),
+        error: state.error,
+        restoreRecovery: state.restoreRecovery,
+      };
+    case "validating-current-repository":
+    case "checkpointing-current-repository":
+      return {
+        type: "restore-recovery-required",
+        session: persistedSession(state.session),
+        error: state.error,
+        restoreRecovery: state.restoreRecovery,
+      };
     default:
       return {
         ...state,

--- a/src/ipc/services/version_preview_persistence.ts
+++ b/src/ipc/services/version_preview_persistence.ts
@@ -59,6 +59,7 @@ const restoreRecoverySchema = z.union([
       preRestoreHead: z.string().min(1),
       preRestoreBranch: z.string().min(1).nullable(),
       targetHead: z.string().min(1).nullable(),
+      affectedChatId: z.number().int().positive().optional(),
       nextStep: z.enum([
         "preparing",
         "preserve-dirty-tree",
@@ -76,12 +77,14 @@ const restoreRecoverySchema = z.union([
       targetHead: z.string().min(1),
       completedHead: z.string().min(1),
       repositoryOutcome: z.literal("target-applied"),
+      affectedChatId: z.number().int().positive().optional(),
       nextStep: z.enum(["chat-mutation", "completed"]),
     })
     .strict(),
   z
     .object({
       repositoryOutcome: z.literal("unchanged"),
+      affectedChatId: z.number().int().positive().optional(),
       nextStep: z.enum(["chat-mutation", "completed"]),
     })
     .strict(),

--- a/src/ipc/services/version_preview_persistence.ts
+++ b/src/ipc/services/version_preview_persistence.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { getUserDataPath } from "@/paths/paths";
 import {
   CLOSED_STATE,
+  isRestoreRecoveryFlowState,
   type BranchSwitchFallback,
   type PreviewSession,
   type PreviewState,
@@ -186,6 +187,14 @@ function hydratedFallback(fallback: PersistedFallback): BranchSwitchFallback {
 }
 
 function toPersistedState(state: PreviewState): PersistedState | null {
+  if (isRestoreRecoveryFlowState(state)) {
+    return {
+      type: "restore-recovery-required",
+      session: persistedSession(state.session),
+      error: state.error,
+      restoreRecovery: state.restoreRecovery,
+    };
+  }
   switch (state.type) {
     case "closed":
     case "viewing-diff":
@@ -196,21 +205,6 @@ function toPersistedState(state: PreviewState): PersistedState | null {
       return {
         ...state,
         fallback: persistedFallback(state.fallback),
-      };
-    case "restore-recovery-required":
-      return {
-        type: state.type,
-        session: persistedSession(state.session),
-        error: state.error,
-        restoreRecovery: state.restoreRecovery,
-      };
-    case "validating-current-repository":
-    case "checkpointing-current-repository":
-      return {
-        type: "restore-recovery-required",
-        session: persistedSession(state.session),
-        error: state.error,
-        restoreRecovery: state.restoreRecovery,
       };
     default:
       return {

--- a/src/ipc/services/version_preview_service.test.ts
+++ b/src/ipc/services/version_preview_service.test.ts
@@ -6,7 +6,22 @@ const database = vi.hoisted(() => ({
 const git = vi.hoisted(() => ({
   getCurrentCommitHash: vi.fn(async () => "live-head"),
   getGitUncommittedFilesWithStatus: vi.fn(async () => []),
+  gitAddAll: vi.fn(async () => undefined),
+  gitCommit: vi.fn(async () => "saved-head"),
   gitCurrentBranch: vi.fn(async () => "main"),
+  inspectRepositoryHealth: vi.fn(async () => ({
+    branch: "main" as string | null,
+    headOid: "live-head",
+    isClean: true,
+    unmergedFiles: [] as string[],
+    operationInProgress: null as
+      | "merge"
+      | "rebase"
+      | "cherry-pick"
+      | "revert"
+      | "bisect"
+      | null,
+  })),
 }));
 const handlers = vi.hoisted(() => ({
   revertVersion: vi.fn(),
@@ -19,7 +34,16 @@ vi.mock("@/db", () => ({
 }));
 vi.mock("@/db/schema", () => ({ apps: { id: "id" } }));
 vi.mock("@/paths/paths", () => ({ getDyadAppPath: () => "/test/app" }));
+vi.mock("node:fs", () => ({
+  default: { existsSync: vi.fn(() => true) },
+}));
 vi.mock("../utils/git_utils", () => git);
+vi.mock("./app_operation_coordinator", () => ({
+  readAppResource: (resource: string) => `read:${resource}`,
+  appOperationCoordinator: {
+    run: (_request: unknown, operation: () => Promise<unknown>) => operation(),
+  },
+}));
 vi.mock("../handlers/version_handlers", () => ({
   versionPreviewHandlerService: handlers,
 }));
@@ -36,6 +60,14 @@ describe("VersionPreviewService reconciliation admission", () => {
     git.getCurrentCommitHash.mockResolvedValue("live-head");
     git.gitCurrentBranch.mockResolvedValue("main");
     git.getGitUncommittedFilesWithStatus.mockResolvedValue([]);
+    git.gitCommit.mockResolvedValue("saved-head");
+    git.inspectRepositoryHealth.mockResolvedValue({
+      branch: "main",
+      headOid: "live-head",
+      isClean: true,
+      unmergedFiles: [],
+      operationInProgress: null,
+    });
   });
 
   it("blocks renderer intents until startup reconciliation settles", () => {
@@ -110,5 +142,79 @@ describe("VersionPreviewService reconciliation admission", () => {
     expect(progress).toEqual([]);
     expect(git.getCurrentCommitHash).not.toHaveBeenCalled();
     expect(handlers.restoreToMessage).toHaveBeenCalledOnce();
+  });
+
+  it("accepts only a clean repository on a named branch", async () => {
+    const service = new VersionPreviewService();
+
+    await expect(service.validateCurrentRepository(7)).resolves.toEqual({
+      kind: "healthy",
+      branch: "main",
+      headOid: "live-head",
+    });
+
+    git.inspectRepositoryHealth.mockResolvedValueOnce({
+      branch: null,
+      headOid: "live-head",
+      isClean: true,
+      unmergedFiles: [],
+      operationInProgress: null,
+    });
+    await expect(service.validateCurrentRepository(7)).resolves.toMatchObject({
+      kind: "blocked",
+      assessment: { type: "blocked", blocker: "detached-head" },
+    });
+  });
+
+  it("checkpoints a dirty repository with a visible recovery version", async () => {
+    git.inspectRepositoryHealth
+      .mockResolvedValueOnce({
+        branch: "main",
+        headOid: "live-head",
+        isClean: false,
+        unmergedFiles: [],
+        operationInProgress: null,
+      })
+      .mockResolvedValueOnce({
+        branch: "main",
+        headOid: "saved-head",
+        isClean: true,
+        unmergedFiles: [],
+        operationInProgress: null,
+      });
+    const service = new VersionPreviewService();
+
+    await expect(service.checkpointCurrentRepository(7)).resolves.toEqual({
+      kind: "healthy",
+      branch: "main",
+      headOid: "saved-head",
+      savedVersionId: "saved-head",
+    });
+    expect(git.gitAddAll).toHaveBeenCalledWith({ path: "/test/app" });
+    expect(git.gitCommit).toHaveBeenCalledWith({
+      path: "/test/app",
+      message:
+        "[Recovery] Saved current changes before continuing Version History",
+    });
+  });
+
+  it("does not mutate a conflicted repository", async () => {
+    git.inspectRepositoryHealth.mockResolvedValueOnce({
+      branch: "main",
+      headOid: "live-head",
+      isClean: false,
+      unmergedFiles: ["src/conflicted.ts"],
+      operationInProgress: "merge",
+    });
+    const service = new VersionPreviewService();
+
+    await expect(service.checkpointCurrentRepository(7)).resolves.toMatchObject(
+      {
+        kind: "blocked",
+        assessment: { type: "blocked", blocker: "conflicted" },
+      },
+    );
+    expect(git.gitAddAll).not.toHaveBeenCalled();
+    expect(git.gitCommit).not.toHaveBeenCalled();
   });
 });

--- a/src/ipc/services/version_preview_service.test.ts
+++ b/src/ipc/services/version_preview_service.test.ts
@@ -28,6 +28,13 @@ const handlers = vi.hoisted(() => ({
   restoreToMessage: vi.fn(),
   checkoutVersion: vi.fn(),
 }));
+const coordination = vi.hoisted(() => ({
+  requests: [] as Array<Record<string, unknown>>,
+  hasActiveActor: vi.fn(async () => false),
+  hasActiveLegacy: vi.fn(async () => false),
+  releaseActor: vi.fn(),
+  releaseStreams: vi.fn(),
+}));
 
 vi.mock("@/db", () => ({
   db: { query: { apps: { findFirst: database.findFirst } } },
@@ -41,8 +48,22 @@ vi.mock("../utils/git_utils", () => git);
 vi.mock("./app_operation_coordinator", () => ({
   readAppResource: (resource: string) => `read:${resource}`,
   appOperationCoordinator: {
-    run: (_request: unknown, operation: () => Promise<unknown>) => operation(),
+    run: (
+      request: Record<string, unknown>,
+      operation: () => Promise<unknown>,
+    ) => {
+      coordination.requests.push(request);
+      return operation();
+    },
   },
+}));
+vi.mock("./chat_actor_service", () => ({
+  beginAppChatActorMutation: vi.fn(async () => coordination.releaseActor),
+  hasActiveAppChatActors: coordination.hasActiveActor,
+}));
+vi.mock("../handlers/chat_stream_handlers", () => ({
+  blockNewStreamsForApp: vi.fn(() => coordination.releaseStreams),
+  hasActiveStreamsForApp: coordination.hasActiveLegacy,
 }));
 vi.mock("../handlers/version_handlers", () => ({
   versionPreviewHandlerService: handlers,
@@ -56,6 +77,7 @@ import { VersionPreviewService } from "./version_preview_service";
 describe("VersionPreviewService reconciliation admission", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    coordination.requests.length = 0;
     database.findFirst.mockResolvedValue({ path: "app" });
     git.getCurrentCommitHash.mockResolvedValue("live-head");
     git.gitCurrentBranch.mockResolvedValue("main");
@@ -164,6 +186,37 @@ describe("VersionPreviewService reconciliation admission", () => {
       kind: "blocked",
       assessment: { type: "blocked", blocker: "detached-head" },
     });
+  });
+
+  it("refuses recovery actions during recording instead of queueing silently", async () => {
+    const service = new VersionPreviewService();
+
+    await service.validateCurrentRepository(7);
+    await service.checkpointCurrentRepository(7);
+
+    expect(coordination.requests).toEqual([
+      expect.objectContaining({
+        operation: "validate-current-version",
+        refuseWhenRecording: "use the current version",
+      }),
+      expect.objectContaining({
+        operation: "checkpoint-current-version",
+        refuseWhenRecording: "save the current version",
+      }),
+    ]);
+  });
+
+  it("refuses repository recovery while a generation is active", async () => {
+    coordination.hasActiveActor.mockResolvedValueOnce(true);
+    const service = new VersionPreviewService();
+
+    await expect(service.checkpointCurrentRepository(7)).rejects.toThrow(
+      "Stop the active generation",
+    );
+    expect(coordination.requests).toHaveLength(0);
+    expect(coordination.releaseActor).toHaveBeenCalledOnce();
+    expect(coordination.releaseStreams).toHaveBeenCalledOnce();
+    expect(git.gitAddAll).not.toHaveBeenCalled();
   });
 
   it("checkpoints a dirty repository with a visible recovery version", async () => {

--- a/src/ipc/services/version_preview_service.ts
+++ b/src/ipc/services/version_preview_service.ts
@@ -22,6 +22,14 @@ import {
 } from "./app_operation_coordinator";
 import { versionPreviewHandlerService } from "../handlers/version_handlers";
 import { versionPreviewPresentationService } from "./version_preview_presentation_service";
+import {
+  beginAppChatActorMutation,
+  hasActiveAppChatActors,
+} from "./chat_actor_service";
+import {
+  blockNewStreamsForApp,
+  hasActiveStreamsForApp,
+} from "../handlers/chat_stream_handlers";
 
 const NO_BRANCH = "<no-branch>";
 
@@ -183,17 +191,13 @@ export class VersionPreviewService {
   ): Promise<CurrentRepositoryValidation> {
     return this.track(
       appId,
-      appOperationCoordinator.run(
-        {
-          appId,
-          operation: "validate-current-version",
-          resources: [
-            readAppResource("app-path"),
-            readAppResource("repository"),
-          ],
-        },
-        () => this.inspectCurrentRepository(appId),
-      ),
+      this.runRepositoryRecoveryOperation({
+        appId,
+        operation: "validate-current-version",
+        refuseWhenRecording: "use the current version",
+        resources: [readAppResource("app-path"), readAppResource("repository")],
+        execute: () => this.inspectCurrentRepository(appId),
+      }),
     );
   }
 
@@ -202,13 +206,12 @@ export class VersionPreviewService {
   ): Promise<CurrentRepositoryValidation> {
     return this.track(
       appId,
-      appOperationCoordinator.run(
-        {
-          appId,
-          operation: "checkpoint-current-version",
-          resources: [readAppResource("app-path"), "repository"],
-        },
-        async () => {
+      this.runRepositoryRecoveryOperation({
+        appId,
+        operation: "checkpoint-current-version",
+        refuseWhenRecording: "save the current version",
+        resources: [readAppResource("app-path"), "repository"],
+        execute: async () => {
           const before = await this.inspectCurrentRepository(appId);
           if (before.kind === "blocked" || before.kind === "healthy") {
             return before;
@@ -244,8 +247,50 @@ export class VersionPreviewService {
           }
           return { ...after, savedVersionId };
         },
-      ),
+      }),
     );
+  }
+
+  private async runRepositoryRecoveryOperation<Result>({
+    appId,
+    operation,
+    refuseWhenRecording,
+    resources,
+    execute,
+  }: {
+    appId: number;
+    operation: string;
+    refuseWhenRecording: string;
+    resources: Parameters<typeof appOperationCoordinator.run>[0]["resources"];
+    execute: () => Promise<Result>;
+  }): Promise<Result> {
+    const releaseStreamAdmission = blockNewStreamsForApp(appId);
+    let releaseActorAdmission: (() => void) | undefined;
+    try {
+      releaseActorAdmission = await beginAppChatActorMutation(appId);
+      const [hasActorStream, hasLegacyStream] = await Promise.all([
+        hasActiveAppChatActors(appId),
+        hasActiveStreamsForApp(appId),
+      ]);
+      if (hasActorStream || hasLegacyStream) {
+        throw new DyadError(
+          "Stop the active generation before continuing Version History.",
+          DyadErrorKind.Precondition,
+        );
+      }
+      return await appOperationCoordinator.run(
+        {
+          appId,
+          operation,
+          resources,
+          refuseWhenRecording,
+        },
+        execute,
+      );
+    } finally {
+      releaseActorAdmission?.();
+      releaseStreamAdmission();
+    }
   }
 
   beginAppDeletion(appId: number): void {

--- a/src/ipc/services/version_preview_service.ts
+++ b/src/ipc/services/version_preview_service.ts
@@ -7,15 +7,37 @@ import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
 import type { VersionCommandResult } from "@/ipc/types";
 import { getDyadAppPath } from "@/paths/paths";
 import type { PreviewCommand, RestoreRecovery } from "@/version_preview/state";
+import type { CurrentRepositoryAssessment } from "@/version_preview/state";
 import {
   getCurrentCommitHash,
   getGitUncommittedFilesWithStatus,
+  gitAddAll,
+  gitCommit,
   gitCurrentBranch,
+  inspectRepositoryHealth,
 } from "../utils/git_utils";
+import {
+  appOperationCoordinator,
+  readAppResource,
+} from "./app_operation_coordinator";
 import { versionPreviewHandlerService } from "../handlers/version_handlers";
 import { versionPreviewPresentationService } from "./version_preview_presentation_service";
 
 const NO_BRANCH = "<no-branch>";
+
+export type CurrentRepositoryValidation =
+  | {
+      kind: "healthy";
+      branch: string;
+      headOid: string;
+      savedVersionId?: string;
+    }
+  | { kind: "dirty" }
+  | {
+      kind: "blocked";
+      assessment: Exclude<CurrentRepositoryAssessment, { type: "dirty" }>;
+      message: string;
+    };
 
 export class VersionPreviewService {
   private readonly deletionFences = new Map<number, number>();
@@ -156,6 +178,76 @@ export class VersionPreviewService {
     );
   }
 
+  validateCurrentRepository(
+    appId: number,
+  ): Promise<CurrentRepositoryValidation> {
+    return this.track(
+      appId,
+      appOperationCoordinator.run(
+        {
+          appId,
+          operation: "validate-current-version",
+          resources: [
+            readAppResource("app-path"),
+            readAppResource("repository"),
+          ],
+        },
+        () => this.inspectCurrentRepository(appId),
+      ),
+    );
+  }
+
+  checkpointCurrentRepository(
+    appId: number,
+  ): Promise<CurrentRepositoryValidation> {
+    return this.track(
+      appId,
+      appOperationCoordinator.run(
+        {
+          appId,
+          operation: "checkpoint-current-version",
+          resources: [readAppResource("app-path"), "repository"],
+        },
+        async () => {
+          const before = await this.inspectCurrentRepository(appId);
+          if (before.kind === "blocked" || before.kind === "healthy") {
+            return before;
+          }
+
+          const app = await db.query.apps.findFirst({
+            columns: { path: true },
+            where: eq(apps.id, appId),
+          });
+          if (!app) {
+            return this.missingRepository("App not found");
+          }
+          const appPath = getDyadAppPath(app.path);
+          await gitAddAll({ path: appPath });
+          const savedVersionId = await gitCommit({
+            path: appPath,
+            message:
+              "[Recovery] Saved current changes before continuing Version History",
+          });
+          const after = await this.inspectCurrentRepository(appId);
+          if (after.kind !== "healthy") {
+            return after.kind === "dirty"
+              ? {
+                  kind: "blocked",
+                  assessment: {
+                    type: "blocked",
+                    blocker: "repository-error",
+                  },
+                  message:
+                    "The current changes were saved, but the repository is still not clean. Check the project and try again.",
+                }
+              : after;
+          }
+          return { ...after, savedVersionId };
+        },
+      ),
+    );
+  }
+
   beginAppDeletion(appId: number): void {
     this.deletionFences.set(appId, (this.deletionFences.get(appId) ?? 0) + 1);
   }
@@ -244,6 +336,65 @@ export class VersionPreviewService {
       targetHead: command.type === "restore" ? command.versionId : null,
       nextStep: "preparing",
     });
+  }
+
+  private missingRepository(message: string): CurrentRepositoryValidation {
+    return {
+      kind: "blocked",
+      assessment: { type: "blocked", blocker: "missing-repository" },
+      message,
+    };
+  }
+
+  private async inspectCurrentRepository(
+    appId: number,
+  ): Promise<CurrentRepositoryValidation> {
+    const app = await db.query.apps.findFirst({
+      columns: { path: true },
+      where: eq(apps.id, appId),
+    });
+    if (!app) return this.missingRepository("App not found");
+    const appPath = getDyadAppPath(app.path);
+    if (!fs.existsSync(path.join(appPath, ".git"))) {
+      return this.missingRepository(
+        "The project repository could not be found.",
+      );
+    }
+
+    const health = await inspectRepositoryHealth({ path: appPath });
+    if (health.unmergedFiles.length > 0) {
+      return {
+        kind: "blocked",
+        assessment: { type: "blocked", blocker: "conflicted" },
+        message:
+          "This project has unresolved file conflicts. Resolve them outside Dyad, then check again.",
+      };
+    }
+    if (health.operationInProgress) {
+      return {
+        kind: "blocked",
+        assessment: {
+          type: "blocked",
+          blocker: "git-operation",
+          operation: health.operationInProgress,
+        },
+        message: `A Git ${health.operationInProgress} is still in progress. Finish or cancel it outside Dyad, then check again.`,
+      };
+    }
+    if (!health.branch) {
+      return {
+        kind: "blocked",
+        assessment: { type: "blocked", blocker: "detached-head" },
+        message:
+          "This project is not on a named branch. Return it to a branch outside Dyad, then check again.",
+      };
+    }
+    if (!health.isClean) return { kind: "dirty" };
+    return {
+      kind: "healthy",
+      branch: health.branch,
+      headOid: health.headOid,
+    };
   }
 
   trackLifecycle<Result>(

--- a/src/ipc/utils/git_utils.test.ts
+++ b/src/ipc/utils/git_utils.test.ts
@@ -227,12 +227,22 @@ describe("inspectRepositoryHealth", () => {
 
     await expect(
       inspectRepositoryHealth({ path: repoDir }),
-    ).resolves.toMatchObject({ branch: "main", isClean: true });
+    ).resolves.toMatchObject({
+      branch: "main",
+      isClean: true,
+      operationInProgress: null,
+    });
 
+    await runGit(repoDir, ["config", "status.showUntrackedFiles", "no"]);
+    await runGit(repoDir, ["update-ref", "REBASE_HEAD", "HEAD"]);
     await fs.promises.writeFile(path.join(repoDir, "visible.txt"), "dirty\n");
     await expect(
       inspectRepositoryHealth({ path: repoDir }),
-    ).resolves.toMatchObject({ branch: "main", isClean: false });
+    ).resolves.toMatchObject({
+      branch: "main",
+      isClean: false,
+      operationInProgress: null,
+    });
   });
 });
 

--- a/src/ipc/utils/git_utils.test.ts
+++ b/src/ipc/utils/git_utils.test.ts
@@ -29,6 +29,7 @@ import {
   countChangedLines,
   unquoteGitPath,
   isGitPathClean,
+  inspectRepositoryHealth,
   readGitIndexEntries,
   restoreGitIndexEntries,
 } from "@/ipc/utils/git_utils";
@@ -198,6 +199,40 @@ describe("ensureGitLineEndingPolicy", () => {
     await expect(
       runGitOutput(repoDir, ["config", "--local", "core.eol"]),
     ).resolves.toBe("crlf");
+  });
+});
+
+describe("inspectRepositoryHealth", () => {
+  let repoDir: string | undefined;
+
+  afterEach(async () => {
+    if (repoDir) {
+      await fs.promises.rm(repoDir, { recursive: true, force: true });
+      repoDir = undefined;
+    }
+  });
+
+  it("ignores Dyad-managed working-tree churn when assessing cleanliness", async () => {
+    repoDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "git-health-"));
+    await runGit(repoDir, ["init", "-b", "main"]);
+    await fs.promises.writeFile(
+      path.join(repoDir, "pnpm-workspace.yaml"),
+      "packages: []\n",
+    );
+    await commitAll(repoDir, "initial");
+    await fs.promises.writeFile(
+      path.join(repoDir, "pnpm-workspace.yaml"),
+      "packages:\n  - app\n",
+    );
+
+    await expect(
+      inspectRepositoryHealth({ path: repoDir }),
+    ).resolves.toMatchObject({ branch: "main", isClean: true });
+
+    await fs.promises.writeFile(path.join(repoDir, "visible.txt"), "dirty\n");
+    await expect(
+      inspectRepositoryHealth({ path: repoDir }),
+    ).resolves.toMatchObject({ branch: "main", isClean: false });
   });
 });
 

--- a/src/ipc/utils/git_utils.ts
+++ b/src/ipc/utils/git_utils.ts
@@ -469,6 +469,97 @@ export async function isGitStatusClean({
   return isClean;
 }
 
+export type GitOperationInProgress =
+  | "merge"
+  | "rebase"
+  | "cherry-pick"
+  | "revert"
+  | "bisect";
+
+export interface RepositoryHealth {
+  branch: string | null;
+  headOid: string;
+  isClean: boolean;
+  unmergedFiles: string[];
+  operationInProgress: GitOperationInProgress | null;
+}
+
+async function gitInternalPath(
+  repositoryPath: string,
+  marker: string,
+): Promise<string> {
+  const result = await execGit(
+    ["rev-parse", "--git-path", marker],
+    repositoryPath,
+  );
+  if (result.exitCode !== 0) {
+    throw new DyadError(
+      `Failed to inspect Git state: ${result.stderr.trim() || result.stdout.trim()}`,
+      DyadErrorKind.Conflict,
+    );
+  }
+  const markerPath = result.stdout.trim();
+  return pathModule.isAbsolute(markerPath)
+    ? markerPath
+    : pathModule.resolve(repositoryPath, markerPath);
+}
+
+/** One source of truth for whether a repository is safe to accept as current. */
+export async function inspectRepositoryHealth({
+  path,
+}: GitBaseParams): Promise<RepositoryHealth> {
+  const [branch, headOid, isClean, unmergedFiles, markerPaths] =
+    await Promise.all([
+      gitCurrentBranch({ path }),
+      getCurrentCommitHash({ path }),
+      isGitStatusClean({ path }),
+      gitGetMergeConflicts({ path }),
+      Promise.all(
+        [
+          "MERGE_HEAD",
+          "REBASE_HEAD",
+          "rebase-apply",
+          "rebase-merge",
+          "CHERRY_PICK_HEAD",
+          "REVERT_HEAD",
+          "BISECT_START",
+        ].map((marker) => gitInternalPath(path, marker)),
+      ),
+    ]);
+  const [
+    mergeHead,
+    rebaseHead,
+    rebaseApply,
+    rebaseMerge,
+    cherryPickHead,
+    revertHead,
+    bisectStart,
+  ] = markerPaths;
+  const operationInProgress: GitOperationInProgress | null = fs.existsSync(
+    mergeHead,
+  )
+    ? "merge"
+    : fs.existsSync(rebaseHead) ||
+        fs.existsSync(rebaseApply) ||
+        fs.existsSync(rebaseMerge)
+      ? "rebase"
+      : fs.existsSync(cherryPickHead)
+        ? "cherry-pick"
+        : fs.existsSync(revertHead)
+          ? "revert"
+          : fs.existsSync(bisectStart)
+            ? "bisect"
+            : null;
+
+  return {
+    branch: branch && branch !== "<no-branch>" ? branch : null,
+    headOid,
+    isClean,
+    unmergedFiles,
+    operationInProgress,
+  };
+}
+
 /**
  * Whether one path has no staged or unstaged changes (and is not untracked).
  *

--- a/src/ipc/utils/git_utils.ts
+++ b/src/ipc/utils/git_utils.ts
@@ -455,7 +455,10 @@ export async function isGitStatusClean({
 }: {
   path: string;
 }): Promise<boolean> {
-  const result = await execGit(["status", "--porcelain"], path);
+  const result = await execGit(
+    ["status", "--porcelain", "--untracked-files=all"],
+    path,
+  );
 
   if (result.exitCode !== 0) {
     throw new DyadError(
@@ -477,7 +480,10 @@ export async function isGitStatusClean({
 export async function isUserVisibleGitStatusClean({
   path,
 }: GitBaseParams): Promise<boolean> {
-  const result = await execGit(["status", "--porcelain"], path);
+  const result = await execGit(
+    ["status", "--porcelain", "--untracked-files=all"],
+    path,
+  );
   if (result.exitCode !== 0) {
     throw new DyadError(
       `Failed to get status: ${result.stderr.trim() || result.stdout.trim()}`,
@@ -539,7 +545,6 @@ export async function inspectRepositoryHealth({
       Promise.all(
         [
           "MERGE_HEAD",
-          "REBASE_HEAD",
           "rebase-apply",
           "rebase-merge",
           "CHERRY_PICK_HEAD",
@@ -550,7 +555,6 @@ export async function inspectRepositoryHealth({
     ]);
   const [
     mergeHead,
-    rebaseHead,
     rebaseApply,
     rebaseMerge,
     cherryPickHead,
@@ -561,9 +565,7 @@ export async function inspectRepositoryHealth({
     mergeHead,
   )
     ? "merge"
-    : fs.existsSync(rebaseHead) ||
-        fs.existsSync(rebaseApply) ||
-        fs.existsSync(rebaseMerge)
+    : fs.existsSync(rebaseApply) || fs.existsSync(rebaseMerge)
       ? "rebase"
       : fs.existsSync(cherryPickHead)
         ? "cherry-pick"

--- a/src/ipc/utils/git_utils.ts
+++ b/src/ipc/utils/git_utils.ts
@@ -469,6 +469,28 @@ export async function isGitStatusClean({
   return isClean;
 }
 
+/**
+ * Returns whether the user-visible working tree is clean. Dyad-managed runtime
+ * paths are deliberately ignored so every restore/recovery guard uses the
+ * same definition of work that needs user acknowledgement.
+ */
+export async function isUserVisibleGitStatusClean({
+  path,
+}: GitBaseParams): Promise<boolean> {
+  const result = await execGit(["status", "--porcelain"], path);
+  if (result.exitCode !== 0) {
+    throw new DyadError(
+      `Failed to get status: ${result.stderr.trim() || result.stdout.trim()}`,
+      DyadErrorKind.Conflict,
+    );
+  }
+  return !result.stdout
+    .split("\n")
+    .filter((line) => line.trim() !== "")
+    .flatMap(getPorcelainPaths)
+    .some(isUserVisibleGitPath);
+}
+
 export type GitOperationInProgress =
   | "merge"
   | "rebase"
@@ -512,7 +534,7 @@ export async function inspectRepositoryHealth({
     await Promise.all([
       gitCurrentBranch({ path }),
       getCurrentCommitHash({ path }),
-      isGitStatusClean({ path }),
+      isUserVisibleGitStatusClean({ path }),
       gitGetMergeConflicts({ path }),
       Promise.all(
         [

--- a/src/shared/chat_turn_outcome.ts
+++ b/src/shared/chat_turn_outcome.ts
@@ -1,0 +1,8 @@
+export const CHAT_TURN_TERMINAL_OUTCOMES = [
+  "completed",
+  "cancelled",
+  "errored",
+] as const;
+
+export type ChatTurnTerminalOutcome =
+  (typeof CHAT_TURN_TERMINAL_OUTCOMES)[number];

--- a/src/version_preview/VersionPreviewProvider.test.tsx
+++ b/src/version_preview/VersionPreviewProvider.test.tsx
@@ -460,14 +460,21 @@ describe("VersionPreviewProvider", () => {
       },
       error: { message: "Return failed" },
     };
+    const recoverySession = remoteState.session;
     actor.dispatch
       .mockResolvedValueOnce({
         kind: "rejected",
         reason: "revision-conflict",
       })
-      .mockResolvedValueOnce({
-        kind: "ignored",
-        reason: "invalid-transition",
+      .mockImplementationOnce(async () => {
+        remoteState = {
+          type: "returning",
+          session: recoverySession,
+        };
+        return {
+          kind: "ignored" as const,
+          reason: "invalid-transition" as const,
+        };
       });
     const queryClient = new QueryClient();
     render(
@@ -490,6 +497,47 @@ describe("VersionPreviewProvider", () => {
     expect(actor.resync).toHaveBeenCalled();
     expect(toastError).not.toHaveBeenCalledWith(
       "Version recovery could not be started. Please try again.",
+    );
+  });
+
+  it("reports an ignored recovery action when recovery did not advance", async () => {
+    getDefaultStore().set(selectedAppIdAtom, 1);
+    remoteState = {
+      type: "recovery-required",
+      session: {
+        appId: 1,
+        originBranch: "main",
+        targetVersionId: "abc123",
+        checkedOutVersionId: "abc123",
+        exitIntent: { type: "none" },
+        selectedDiffFile: null,
+        isDiffVisible: false,
+      },
+      error: { message: "Return failed" },
+    };
+    actor.dispatch.mockResolvedValueOnce({
+      kind: "ignored",
+      reason: "invalid-transition",
+    });
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <VersionPreviewProvider>
+          <div>content</div>
+        </VersionPreviewProvider>
+      </QueryClientProvider>,
+    );
+
+    const recoveryToast = toastError.mock.calls.find(
+      ([message]) =>
+        message ===
+        "Unable to return to the branch that was active before previewing this version.",
+    );
+    act(() => recoveryToast?.[1]?.action?.onClick());
+
+    await waitFor(() =>
+      expect(toastError).toHaveBeenCalledWith(
+        "Version recovery could not be started. Please try again.",
+      ),
     );
   });
 
@@ -626,6 +674,59 @@ describe("VersionPreviewProvider", () => {
       1,
       expect.stringMatching(/^version-preview:/),
       { type: "close" },
+    );
+  });
+
+  it("retries window cleanup after current repository acceptance", async () => {
+    getDefaultStore().set(selectedAppIdAtom, 1);
+    const session = {
+      appId: 1,
+      originBranch: "main",
+      targetVersionId: "abc123",
+      checkedOutVersionId: null,
+      exitIntent: { type: "none" } as const,
+      selectedDiffFile: null,
+      isDiffVisible: false,
+    };
+    remoteState = {
+      type: "restore-recovery-required",
+      session,
+      error: { message: "Recovery is unresolved." },
+    };
+    windowInterest.release
+      .mockRejectedValueOnce(new Error("transport unavailable"))
+      .mockResolvedValueOnce({ cleanupStarted: false });
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <VersionPreviewProvider>
+          <Probe />
+        </VersionPreviewProvider>
+      </QueryClientProvider>,
+    );
+
+    fireEvent.click(screen.getByTestId("probe"));
+    act(() => {
+      remoteState = {
+        type: "validating-current-repository",
+        session,
+        error: { message: "Recovery is unresolved." },
+      };
+      actorListeners.forEach((listener) => listener());
+    });
+    act(() => {
+      remoteState = CLOSED_STATE;
+      actorListeners.forEach((listener) => listener());
+    });
+
+    await waitFor(() =>
+      expect(windowInterest.release).toHaveBeenCalledTimes(2),
+    );
+    expect(actor.resync).toHaveBeenCalled();
+    expect(windowInterest.release.mock.calls[0]?.[1]).toBe(
+      windowInterest.release.mock.calls[1]?.[1],
+    );
+    expect(toastError).not.toHaveBeenCalledWith(
+      "Version History closed, but its window cleanup did not finish. Reopen the app and try again.",
     );
   });
 

--- a/src/version_preview/VersionPreviewProvider.test.tsx
+++ b/src/version_preview/VersionPreviewProvider.test.tsx
@@ -37,6 +37,7 @@ const actor = {
 
 const toastError = vi.hoisted(() => vi.fn());
 const toastLoading = vi.hoisted(() => vi.fn());
+const showError = vi.hoisted(() => vi.fn());
 const windowInterest = vi.hoisted(() => ({
   acquire: vi.fn(async () => ({ acquired: true })),
   restoreIfOrphaned: vi.fn(async () => ({ acquired: false })),
@@ -61,6 +62,10 @@ vi.mock("sonner", () => ({
     success: vi.fn(),
     warning: vi.fn(),
   },
+}));
+vi.mock("@/lib/toast", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/toast")>()),
+  showError,
 }));
 vi.mock("./window_interest_client", () => ({
   VersionPreviewWindowInterestClient: class {
@@ -118,6 +123,7 @@ describe("VersionPreviewProvider", () => {
     remoteState = CLOSED_STATE;
     toastError.mockClear();
     toastLoading.mockClear();
+    showError.mockClear();
     windowInterest.acquire.mockReset().mockResolvedValue({ acquired: true });
     windowInterest.restoreIfOrphaned
       .mockReset()
@@ -519,7 +525,7 @@ describe("VersionPreviewProvider", () => {
         "true",
       ),
     );
-    expect(toastError).not.toHaveBeenCalledWith(
+    expect(showError).not.toHaveBeenCalledWith(
       "Version controls are temporarily unavailable. Please try again.",
     );
   });
@@ -565,6 +571,61 @@ describe("VersionPreviewProvider", () => {
         expect.stringMatching(/^version-preview:/),
         { type: "close" },
       ),
+    );
+  });
+
+  it("closes and releases the pane after current repository acceptance", async () => {
+    getDefaultStore().set(selectedAppIdAtom, 1);
+    const session = {
+      appId: 1,
+      originBranch: "main",
+      targetVersionId: "abc123",
+      checkedOutVersionId: null,
+      exitIntent: { type: "none" } as const,
+      selectedDiffFile: null,
+      isDiffVisible: false,
+    };
+    remoteState = {
+      type: "restore-recovery-required",
+      session,
+      error: { message: "Recovery is unresolved." },
+    };
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <VersionPreviewProvider>
+          <Probe />
+        </VersionPreviewProvider>
+      </QueryClientProvider>,
+    );
+
+    fireEvent.click(screen.getByTestId("probe"));
+    await waitFor(() =>
+      expect(screen.getByTestId("probe").getAttribute("data-visible")).toBe(
+        "true",
+      ),
+    );
+    act(() => {
+      remoteState = {
+        type: "validating-current-repository",
+        session,
+        error: { message: "Recovery is unresolved." },
+      };
+      actorListeners.forEach((listener) => listener());
+    });
+    act(() => {
+      remoteState = CLOSED_STATE;
+      actorListeners.forEach((listener) => listener());
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId("probe").getAttribute("data-visible")).toBe(
+        "false",
+      ),
+    );
+    expect(windowInterest.release).toHaveBeenCalledWith(
+      1,
+      expect.stringMatching(/^version-preview:/),
+      { type: "close" },
     );
   });
 

--- a/src/version_preview/VersionPreviewProvider.test.tsx
+++ b/src/version_preview/VersionPreviewProvider.test.tsx
@@ -36,6 +36,7 @@ const actor = {
 };
 
 const toastError = vi.hoisted(() => vi.fn());
+const toastLoading = vi.hoisted(() => vi.fn());
 const windowInterest = vi.hoisted(() => ({
   acquire: vi.fn(async () => ({ acquired: true })),
   restoreIfOrphaned: vi.fn(async () => ({ acquired: false })),
@@ -56,6 +57,7 @@ vi.mock("sonner", () => ({
     custom: vi.fn(),
     dismiss: vi.fn(),
     error: toastError,
+    loading: toastLoading,
     success: vi.fn(),
     warning: vi.fn(),
   },
@@ -115,6 +117,7 @@ describe("VersionPreviewProvider", () => {
     actorListeners.clear();
     remoteState = CLOSED_STATE;
     toastError.mockClear();
+    toastLoading.mockClear();
     windowInterest.acquire.mockReset().mockResolvedValue({ acquired: true });
     windowInterest.restoreIfOrphaned
       .mockReset()
@@ -518,6 +521,85 @@ describe("VersionPreviewProvider", () => {
     );
     expect(toastError).not.toHaveBeenCalledWith(
       "Version controls are temporarily unavailable. Please try again.",
+    );
+  });
+
+  it("releases pane ownership when recovery is closed", async () => {
+    getDefaultStore().set(selectedAppIdAtom, 1);
+    remoteState = {
+      type: "restore-recovery-required",
+      session: {
+        appId: 1,
+        originBranch: "main",
+        targetVersionId: "abc123",
+        checkedOutVersionId: null,
+        exitIntent: { type: "none" },
+        selectedDiffFile: null,
+        isDiffVisible: false,
+      },
+      error: { message: "Recovery is unresolved." },
+    };
+    function RecoveryCloseProbe() {
+      const { isPaneVisible, send } = useVersionPreview(1);
+      return (
+        <div data-visible={isPaneVisible}>
+          <button onClick={() => send({ type: "OPEN", appId: 1 })}>Open</button>
+          <button onClick={() => send({ type: "CLOSE" })}>Close</button>
+        </div>
+      );
+    }
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <VersionPreviewProvider>
+          <RecoveryCloseProbe />
+        </VersionPreviewProvider>
+      </QueryClientProvider>,
+    );
+
+    fireEvent.click(screen.getByText("Open"));
+    await waitFor(() => expect(windowInterest.acquire).toHaveBeenCalledWith(1));
+    fireEvent.click(screen.getByText("Close"));
+    await waitFor(() =>
+      expect(windowInterest.release).toHaveBeenCalledWith(
+        1,
+        expect.stringMatching(/^version-preview:/),
+        { type: "close" },
+      ),
+    );
+  });
+
+  it("uses a neutral progress toast while repository recovery is running", async () => {
+    getDefaultStore().set(selectedAppIdAtom, 1);
+    remoteState = {
+      type: "validating-current-repository",
+      session: {
+        appId: 1,
+        originBranch: "main",
+        targetVersionId: "abc123",
+        checkedOutVersionId: null,
+        exitIntent: { type: "none" },
+        selectedDiffFile: null,
+        isDiffVisible: false,
+      },
+      error: { message: "Recovery is unresolved." },
+    };
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <VersionPreviewProvider>
+          <div>content</div>
+        </VersionPreviewProvider>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() =>
+      expect(toastLoading).toHaveBeenCalledWith(
+        "Checking the current version…",
+        expect.objectContaining({ duration: Infinity }),
+      ),
+    );
+    expect(toastError).not.toHaveBeenCalledWith(
+      "Version restore needs attention.",
+      expect.anything(),
     );
   });
 

--- a/src/version_preview/VersionPreviewProvider.test.tsx
+++ b/src/version_preview/VersionPreviewProvider.test.tsx
@@ -436,7 +436,7 @@ describe("VersionPreviewProvider", () => {
     );
   });
 
-  it("resyncs a rejected recovery retry and surfaces terminal rejection", async () => {
+  it("resyncs a duplicate recovery action without showing a false error", async () => {
     getDefaultStore().set(selectedAppIdAtom, 1);
     remoteState = {
       type: "recovery-required",
@@ -479,10 +479,45 @@ describe("VersionPreviewProvider", () => {
 
     await waitFor(() => expect(actor.dispatch).toHaveBeenCalledTimes(2));
     expect(actor.resync).toHaveBeenCalled();
+    expect(toastError).not.toHaveBeenCalledWith(
+      "Version recovery could not be started. Please try again.",
+    );
+  });
+
+  it("opens the pane without a false error while recovery notice dispatch is refused", async () => {
+    getDefaultStore().set(selectedAppIdAtom, 1);
+    remoteState = {
+      type: "restore-recovery-required",
+      session: {
+        appId: 1,
+        originBranch: "main",
+        targetVersionId: "abc123",
+        checkedOutVersionId: null,
+        exitIntent: { type: "none" },
+        selectedDiffFile: null,
+        isDiffVisible: false,
+      },
+      error: { message: "Recovery is reconciling." },
+    };
+    actor.dispatch.mockRejectedValueOnce(
+      new Error("Version preview is reconciling after restart"),
+    );
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <VersionPreviewProvider>
+          <Probe />
+        </VersionPreviewProvider>
+      </QueryClientProvider>,
+    );
+
+    fireEvent.click(await screen.findByTestId("probe"));
     await waitFor(() =>
-      expect(toastError).toHaveBeenCalledWith(
-        "Version recovery could not be started. Please try again.",
+      expect(screen.getByTestId("probe").getAttribute("data-visible")).toBe(
+        "true",
       ),
+    );
+    expect(toastError).not.toHaveBeenCalledWith(
+      "Version controls are temporarily unavailable. Please try again.",
     );
   });
 

--- a/src/version_preview/VersionPreviewProvider.test.tsx
+++ b/src/version_preview/VersionPreviewProvider.test.tsx
@@ -486,7 +486,7 @@ describe("VersionPreviewProvider", () => {
     );
   });
 
-  it("surfaces interrupted restore recovery without offering an unsafe retry", async () => {
+  it("offers validated acceptance for interrupted restore recovery", async () => {
     getDefaultStore().set(selectedAppIdAtom, 1);
     remoteState = {
       type: "restore-recovery-required",
@@ -518,7 +518,89 @@ describe("VersionPreviewProvider", () => {
         }),
       ),
     );
-    expect(toastError.mock.calls.at(-1)?.[1]).not.toHaveProperty("action");
+    const action = toastError.mock.calls.at(-1)?.[1]?.action;
+    expect(action?.label).toBe("Use current version");
+    act(() => action?.onClick());
+    await waitFor(() =>
+      expect(actor.dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "ACCEPT_CURRENT_REPOSITORY" }),
+      ),
+    );
+  });
+
+  it("offers to checkpoint a dirty tree before accepting it", async () => {
+    getDefaultStore().set(selectedAppIdAtom, 1);
+    remoteState = {
+      type: "restore-recovery-required",
+      session: {
+        appId: 1,
+        originBranch: "main",
+        targetVersionId: "abc123",
+        checkedOutVersionId: null,
+        exitIntent: { type: "none" },
+        selectedDiffFile: null,
+        isDiffVisible: false,
+      },
+      error: { message: "dirty repository" },
+      currentRepositoryAssessment: { type: "dirty" },
+    };
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <VersionPreviewProvider>
+          <div>content</div>
+        </VersionPreviewProvider>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+    const action = toastError.mock.calls.at(-1)?.[1]?.action;
+    expect(action?.label).toBe("Save changes & use current version");
+    act(() => action?.onClick());
+    await waitFor(() =>
+      expect(actor.dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "CHECKPOINT_AND_ACCEPT_CURRENT_REPOSITORY",
+        }),
+      ),
+    );
+  });
+
+  it("only offers a read-only recheck for conflicted repositories", async () => {
+    getDefaultStore().set(selectedAppIdAtom, 1);
+    remoteState = {
+      type: "restore-recovery-required",
+      session: {
+        appId: 1,
+        originBranch: "main",
+        targetVersionId: "abc123",
+        checkedOutVersionId: null,
+        exitIntent: { type: "none" },
+        selectedDiffFile: null,
+        isDiffVisible: false,
+      },
+      error: { message: "Resolve conflicts outside Dyad." },
+      currentRepositoryAssessment: {
+        type: "blocked",
+        blocker: "conflicted",
+      },
+    };
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <VersionPreviewProvider>
+          <div>content</div>
+        </VersionPreviewProvider>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+    const action = toastError.mock.calls.at(-1)?.[1]?.action;
+    expect(action?.label).toBe("Check again");
+    act(() => action?.onClick());
+    await waitFor(() =>
+      expect(actor.dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "ACCEPT_CURRENT_REPOSITORY" }),
+      ),
+    );
   });
 
   it("serializes rapid selections so an accepted version stays visible", async () => {

--- a/src/version_preview/VersionPreviewProvider.tsx
+++ b/src/version_preview/VersionPreviewProvider.tsx
@@ -269,10 +269,23 @@ export function VersionPreviewProvider({ children }: PropsWithChildren) {
           state.type === "closed" &&
           (previousStateType === "restoring" ||
             previousStateType === "switching-branch" ||
+            previousStateType === "validating-current-repository" ||
+            previousStateType === "checkpointing-current-repository" ||
             restoredPresentation)
         ) {
           presentation.send(appId, { type: "CLOSE" });
           restoredPresentation = false;
+          void windowInterest
+            .release(
+              appId,
+              `version-preview:${globalThis.crypto.randomUUID()}`,
+              { type: "close" },
+            )
+            .catch(() => {
+              toast.error(
+                "Version History closed, but its window cleanup did not finish. Reopen the app and try again.",
+              );
+            });
         }
         previousStateType = state.type;
         const toastId = `version-preview-recovery-${appId}`;

--- a/src/version_preview/VersionPreviewProvider.tsx
+++ b/src/version_preview/VersionPreviewProvider.tsx
@@ -17,7 +17,7 @@ import { useRemoteMachineClient } from "@/distributed_machines/react";
 import { useRegisterEntityDisposer } from "@/state_machines/react";
 import { versionPreviewClientDefinition } from "./client_definition";
 import { VersionPreviewPresentationStore } from "./presentation_store";
-import { ownsHistoricalCheckout } from "./state";
+import { ownsHistoricalCheckout, type PreviewState } from "./state";
 import { versionPreviewKey } from "./transport";
 import { VersionPreviewWindowInterestClient } from "./window_interest_client";
 
@@ -25,6 +25,48 @@ const PresentationStoreContext =
   createContext<VersionPreviewPresentationStore | null>(null);
 const WindowInterestContext =
   createContext<VersionPreviewWindowInterestClient | null>(null);
+
+type WindowInterestExit = Parameters<
+  VersionPreviewWindowInterestClient["release"]
+>[2];
+
+async function releaseWindowInterestWithRetry({
+  windowInterest,
+  appId,
+  operationId,
+  exit,
+  resync,
+}: {
+  windowInterest: VersionPreviewWindowInterestClient;
+  appId: number;
+  operationId: string;
+  exit: WindowInterestExit;
+  resync: () => Promise<void>;
+}) {
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      return await windowInterest.release(appId, operationId, exit);
+    } catch (error) {
+      if (attempt === 2) throw error;
+      try {
+        await resync();
+      } catch {
+        // The stable release operation remains safe to retry even when the
+        // actor transport cannot resync yet.
+      }
+    }
+  }
+  throw new Error("Version preview window release exhausted its retries");
+}
+
+function recoveryIntentAlreadyAdvanced(state: PreviewState): boolean {
+  return (
+    state.type === "returning" ||
+    state.type === "validating-current-repository" ||
+    state.type === "checkpointing-current-repository" ||
+    state.type === "closed"
+  );
+}
 
 export function useVersionPreviewPresentationStore() {
   const store = useContext(PresentationStoreContext);
@@ -65,38 +107,30 @@ export function VersionPreviewProvider({ children }: PropsWithChildren) {
       if (previousAppId !== null && previousAppId !== nextAppId) {
         const releasedAppId = previousAppId;
         const operationId = `version-preview:${globalThis.crypto.randomUUID()}`;
-        void (async () => {
-          for (let attempt = 0; attempt < 3; attempt += 1) {
-            try {
-              await windowInterest.release(releasedAppId, operationId, {
-                type: "switch-app",
-                nextAppId,
-              });
-              presentation.send(releasedAppId, {
-                type: "APP_CHANGED",
-                nextAppId,
-              });
-              return;
-            } catch (error) {
-              if (attempt === 2) throw error;
-              try {
-                await client
-                  .actor(
-                    versionPreviewClientDefinition,
-                    versionPreviewKey(releasedAppId),
-                  )
-                  .resync();
-              } catch {
-                // The stable release operation remains safe to retry even when
-                // the actor transport cannot resync yet.
-              }
-            }
-          }
-        })().catch(() => {
-          toast.error(
-            "Version preview could not finish switching apps. Reopen the app and try again.",
-          );
-        });
+        void releaseWindowInterestWithRetry({
+          windowInterest,
+          appId: releasedAppId,
+          operationId,
+          exit: { type: "switch-app", nextAppId },
+          resync: () =>
+            client
+              .actor(
+                versionPreviewClientDefinition,
+                versionPreviewKey(releasedAppId),
+              )
+              .resync(),
+        })
+          .then(() => {
+            presentation.send(releasedAppId, {
+              type: "APP_CHANGED",
+              nextAppId,
+            });
+          })
+          .catch(() => {
+            toast.error(
+              "Version preview could not finish switching apps. Reopen the app and try again.",
+            );
+          });
       }
       previousAppId = nextAppId;
     });
@@ -187,8 +221,14 @@ export function VersionPreviewProvider({ children }: PropsWithChildren) {
             // advances the actor into its in-flight recovery state. The
             // original operation remains authoritative, so this is not a user
             // failure and must not produce a contradictory error toast.
-            if (receipt.kind === "applied" || receipt.kind === "ignored") {
+            if (receipt.kind === "applied") {
               return;
+            }
+            if (receipt.kind === "ignored") {
+              if (recoveryIntentAlreadyAdvanced(actor.getView().state.state)) {
+                return;
+              }
+              throw new Error("Version recovery intent was ignored");
             }
             if (
               receipt.kind === "rejected" &&
@@ -275,17 +315,18 @@ export function VersionPreviewProvider({ children }: PropsWithChildren) {
         ) {
           presentation.send(appId, { type: "CLOSE" });
           restoredPresentation = false;
-          void windowInterest
-            .release(
-              appId,
-              `version-preview:${globalThis.crypto.randomUUID()}`,
-              { type: "close" },
-            )
-            .catch(() => {
-              toast.error(
-                "Version History closed, but its window cleanup did not finish. Reopen the app and try again.",
-              );
-            });
+          const operationId = `version-preview:${globalThis.crypto.randomUUID()}`;
+          void releaseWindowInterestWithRetry({
+            windowInterest,
+            appId,
+            operationId,
+            exit: { type: "close" },
+            resync: () => actor.resync(),
+          }).catch(() => {
+            toast.error(
+              "Version History closed, but its window cleanup did not finish. Reopen the app and try again.",
+            );
+          });
         }
         previousStateType = state.type;
         const toastId = `version-preview-recovery-${appId}`;

--- a/src/version_preview/VersionPreviewProvider.tsx
+++ b/src/version_preview/VersionPreviewProvider.tsx
@@ -324,13 +324,14 @@ export function VersionPreviewProvider({ children }: PropsWithChildren) {
             );
           }
         } else if (state.type === "validating-current-repository") {
-          toast.error("Version restore needs attention.", {
+          toast.loading("Checking the current version…", {
             id: toastId,
-            description: "Checking the current repository…",
+            description:
+              "Dyad is verifying that Version History can continue safely.",
             duration: Infinity,
           });
         } else if (state.type === "checkpointing-current-repository") {
-          toast.error("Saving the current version…", {
+          toast.loading("Saving the current version…", {
             id: toastId,
             description:
               "Dyad is saving your current changes before continuing.",

--- a/src/version_preview/VersionPreviewProvider.tsx
+++ b/src/version_preview/VersionPreviewProvider.tsx
@@ -183,7 +183,13 @@ export function VersionPreviewProvider({ children }: PropsWithChildren) {
           for (let attempt = 0; attempt < 3; attempt += 1) {
             if (actor.getStatus() !== "ready") await actor.resync();
             const receipt = await actor.dispatch(event);
-            if (receipt.kind === "applied") return;
+            // A rapid duplicate can become ignored after the first dispatch
+            // advances the actor into its in-flight recovery state. The
+            // original operation remains authoritative, so this is not a user
+            // failure and must not produce a contradictory error toast.
+            if (receipt.kind === "applied" || receipt.kind === "ignored") {
+              return;
+            }
             if (
               receipt.kind === "rejected" &&
               (receipt.reason === "revision-conflict" ||

--- a/src/version_preview/VersionPreviewProvider.tsx
+++ b/src/version_preview/VersionPreviewProvider.tsx
@@ -169,6 +169,38 @@ export function VersionPreviewProvider({ children }: PropsWithChildren) {
         versionPreviewClientDefinition,
         versionPreviewKey(appId),
       );
+      const dispatchRecoveryIntent = (
+        type:
+          | "RETRY_RETURN"
+          | "ACCEPT_CURRENT_REPOSITORY"
+          | "CHECKPOINT_AND_ACCEPT_CURRENT_REPOSITORY",
+      ) => {
+        const event = {
+          type,
+          operationId: `version-preview:${globalThis.crypto.randomUUID()}`,
+        } as const;
+        void (async () => {
+          for (let attempt = 0; attempt < 3; attempt += 1) {
+            if (actor.getStatus() !== "ready") await actor.resync();
+            const receipt = await actor.dispatch(event);
+            if (receipt.kind === "applied") return;
+            if (
+              receipt.kind === "rejected" &&
+              (receipt.reason === "revision-conflict" ||
+                receipt.reason === "stale-actor")
+            ) {
+              await actor.resync();
+              continue;
+            }
+            throw new Error("Version recovery was not accepted");
+          }
+          throw new Error("Version recovery remained stale");
+        })().catch(() => {
+          toast.error(
+            "Version recovery could not be started. Please try again.",
+          );
+        });
+      };
       let previousStateType = actor.getView().state.state.type;
       let restorationStarted = false;
       let restoredPresentation = false;
@@ -247,44 +279,55 @@ export function VersionPreviewProvider({ children }: PropsWithChildren) {
               duration: Infinity,
               action: {
                 label: "Retry",
-                onClick: () => {
-                  const event = {
-                    type: "RETRY_RETURN" as const,
-                    operationId: `version-preview:${globalThis.crypto.randomUUID()}`,
-                  };
-                  void (async () => {
-                    for (let attempt = 0; attempt < 3; attempt += 1) {
-                      if (actor.getStatus() !== "ready") await actor.resync();
-                      const receipt = await actor.dispatch(event);
-                      if (receipt.kind === "applied") return;
-                      if (
-                        receipt.kind === "rejected" &&
-                        (receipt.reason === "revision-conflict" ||
-                          receipt.reason === "stale-actor")
-                      ) {
-                        await actor.resync();
-                        continue;
-                      }
-                      throw new Error(
-                        "The version recovery retry was not accepted",
-                      );
-                    }
-                    throw new Error(
-                      "The version recovery retry remained stale",
-                    );
-                  })().catch(() => {
-                    toast.error(
-                      "Version recovery could not be started. Please try again.",
-                    );
-                  });
-                },
+                onClick: () => dispatchRecoveryIntent("RETRY_RETURN"),
               },
             },
           );
         } else if (state.type === "restore-recovery-required") {
+          if (state.currentRepositoryAssessment?.type === "dirty") {
+            toast.error("Your current changes need to be saved", {
+              id: toastId,
+              description:
+                "Dyad found changes that are not part of a saved version. Save them as the current version to continue using Version History.",
+              duration: Infinity,
+              action: {
+                label: "Save changes & use current version",
+                onClick: () =>
+                  dispatchRecoveryIntent(
+                    "CHECKPOINT_AND_ACCEPT_CURRENT_REPOSITORY",
+                  ),
+              },
+            });
+          } else {
+            const isBlocked =
+              state.currentRepositoryAssessment?.type === "blocked";
+            toast.error(
+              isBlocked
+                ? "Version History is unavailable"
+                : "Version restore needs attention.",
+              {
+                id: toastId,
+                description: state.error.message,
+                duration: Infinity,
+                action: {
+                  label: isBlocked ? "Check again" : "Use current version",
+                  onClick: () =>
+                    dispatchRecoveryIntent("ACCEPT_CURRENT_REPOSITORY"),
+                },
+              },
+            );
+          }
+        } else if (state.type === "validating-current-repository") {
           toast.error("Version restore needs attention.", {
             id: toastId,
-            description: state.error.message,
+            description: "Checking the current repository…",
+            duration: Infinity,
+          });
+        } else if (state.type === "checkpointing-current-repository") {
+          toast.error("Saving the current version…", {
+            id: toastId,
+            description:
+              "Dyad is saving your current changes before continuing.",
             duration: Infinity,
           });
         } else {

--- a/src/version_preview/main_actor.test.ts
+++ b/src/version_preview/main_actor.test.ts
@@ -18,6 +18,8 @@ const service = vi.hoisted(() => ({
   resolveOriginBranch: vi.fn(),
   run: vi.fn(),
   reconcile: vi.fn(),
+  validateCurrentRepository: vi.fn(),
+  checkpointCurrentRepository: vi.fn(),
   settle: vi.fn(async () => undefined),
   assertAcceptingOperations: vi.fn(),
   assertReadyForIntent: vi.fn(),
@@ -162,6 +164,108 @@ describe("version_preview main actor", () => {
     persistence.load.mockReturnValue({ type: "closed" });
     persistence.checkpoint.mockImplementation(() => undefined);
     persistence.checkpointRestore.mockImplementation(() => undefined);
+    invalidations.publish.mockImplementation(() => undefined);
+  });
+
+  it("settles dirty repository acceptance as failed while keeping recovery actionable", async () => {
+    persistence.load.mockReturnValue({
+      type: "restore-recovery-required",
+      session: {
+        appId: 7,
+        originBranch: "main",
+        targetVersionId: "abc123",
+        checkedOutVersionId: null,
+        exitIntent: { type: "none" },
+        selectedDiffFile: null,
+        isDiffVisible: false,
+      },
+      error: { message: "restore interrupted" },
+    });
+    service.reconcile.mockResolvedValue({
+      branch: null,
+      headOid: "preview-head",
+      isClean: true,
+    });
+    service.validateCurrentRepository.mockResolvedValue({ kind: "dirty" });
+    const harness = createHarness();
+    await harness.actorA.resync();
+    await flush();
+
+    await harness.actorA.dispatch({
+      type: "ACCEPT_CURRENT_REPOSITORY",
+      operationId: "accept-dirty",
+    });
+    await flush();
+
+    expect(harness.actorA.getSnapshot().state).toMatchObject({
+      type: "restore-recovery-required",
+      currentRepositoryAssessment: { type: "dirty" },
+    });
+    expect(harness.actorA.getSnapshot().lastSettlement).toMatchObject({
+      operationId: "accept-dirty",
+      outcome: "failed",
+    });
+
+    harness.releaseA();
+    harness.releaseB();
+    harness.clientA.dispose();
+    harness.clientB.dispose();
+    harness.transport.dispose();
+  });
+
+  it("settles repository acceptance even when result presentation throws", async () => {
+    persistence.load.mockReturnValue({
+      type: "restore-recovery-required",
+      session: {
+        appId: 7,
+        originBranch: "main",
+        targetVersionId: "abc123",
+        checkedOutVersionId: null,
+        exitIntent: { type: "none" },
+        selectedDiffFile: null,
+        isDiffVisible: false,
+      },
+      error: { message: "restore interrupted" },
+    });
+    service.reconcile.mockResolvedValue({
+      branch: null,
+      headOid: "preview-head",
+      isClean: true,
+    });
+    service.validateCurrentRepository.mockResolvedValue({
+      kind: "healthy",
+      branch: "main",
+      headOid: "live-head",
+    });
+    invalidations.publish.mockImplementationOnce(() => {
+      throw new Error("invalidation failed");
+    });
+    const harness = createHarness();
+    await harness.actorA.resync();
+    await flush();
+
+    await harness.actorA.dispatch({
+      type: "ACCEPT_CURRENT_REPOSITORY",
+      operationId: "accept-presentation-failure",
+    });
+    await flush();
+
+    expect(harness.actorA.getSnapshot().state.type).toBe("closed");
+    expect(harness.actorA.getSnapshot().lastSettlement).toMatchObject({
+      operationId: "accept-presentation-failure",
+      outcome: "succeeded",
+    });
+    expect(presentation.publishError).toHaveBeenCalledWith(
+      7,
+      "accept-presentation-failure",
+      expect.stringContaining("invalidation failed"),
+    );
+
+    harness.releaseA();
+    harness.releaseB();
+    harness.clientA.dispose();
+    harness.clientB.dispose();
+    harness.transport.dispose();
   });
 
   it("continues checkout after the initiating window closes and reattaches", async () => {

--- a/src/version_preview/main_actor.test.ts
+++ b/src/version_preview/main_actor.test.ts
@@ -226,6 +226,15 @@ describe("version_preview main actor", () => {
         isDiffVisible: false,
       },
       error: { message: "restore interrupted" },
+      restoreRecovery: {
+        repositoryOutcome: "target-applied",
+        nextStep: "chat-mutation",
+        preRestoreHead: "old-head",
+        preRestoreBranch: "main",
+        targetHead: "target-head",
+        completedHead: "target-head",
+        affectedChatId: 23,
+      },
     });
     service.reconcile.mockResolvedValue({
       branch: null,
@@ -237,8 +246,8 @@ describe("version_preview main actor", () => {
       branch: "main",
       headOid: "live-head",
     });
-    invalidations.publish.mockImplementationOnce(() => {
-      throw new Error("invalidation failed");
+    presentation.publishResult.mockImplementationOnce(() => {
+      throw new Error("presentation failed");
     });
     const harness = createHarness();
     await harness.actorA.resync();
@@ -255,10 +264,15 @@ describe("version_preview main actor", () => {
       operationId: "accept-presentation-failure",
       outcome: "succeeded",
     });
+    expect(presentation.publishResult).toHaveBeenCalledWith(
+      7,
+      "accept-presentation-failure",
+      expect.objectContaining({ affectedChatId: 23 }),
+    );
     expect(presentation.publishError).toHaveBeenCalledWith(
       7,
       "accept-presentation-failure",
-      expect.stringContaining("invalidation failed"),
+      expect.stringContaining("presentation failed"),
     );
 
     harness.releaseA();
@@ -1117,8 +1131,10 @@ describe("version_preview main actor", () => {
     await harness.actorA.resync();
 
     await harness.actorA.dispatch({
-      type: "RESTORE",
-      versionId: "abc123",
+      type: "RESTORE_TO_MESSAGE",
+      chatId: 23,
+      messageId: 42,
+      restoreCodebase: true,
       operationId: "restore-checkout-failure",
     });
     await flush();
@@ -1132,7 +1148,7 @@ describe("version_preview main actor", () => {
       ).getSnapshot().state,
     ).toMatchObject({
       type: "restore-recovery-required",
-      restoreRecovery: { nextStep: "checkout-branch" },
+      restoreRecovery: { nextStep: "checkout-branch", affectedChatId: 23 },
     });
 
     harness.releaseA();

--- a/src/version_preview/presentation_store.ts
+++ b/src/version_preview/presentation_store.ts
@@ -127,7 +127,9 @@ export function combineVersionPreviewState(
     remote.type === "returning" ||
     remote.type === "switching-branch" ||
     remote.type === "recovery-required" ||
-    remote.type === "restore-recovery-required"
+    remote.type === "restore-recovery-required" ||
+    remote.type === "validating-current-repository" ||
+    remote.type === "checkpointing-current-repository"
   ) {
     return remote;
   }

--- a/src/version_preview/presentation_store.ts
+++ b/src/version_preview/presentation_store.ts
@@ -1,6 +1,7 @@
 import { SnapshotStore } from "@/state_machines/snapshot_store";
 import {
   CLOSED_STATE,
+  isRestoreRecoveryFlowState,
   type PreviewEvent,
   type PreviewSession,
   type PreviewState,
@@ -127,9 +128,7 @@ export function combineVersionPreviewState(
     remote.type === "returning" ||
     remote.type === "switching-branch" ||
     remote.type === "recovery-required" ||
-    remote.type === "restore-recovery-required" ||
-    remote.type === "validating-current-repository" ||
-    remote.type === "checkpointing-current-repository"
+    isRestoreRecoveryFlowState(remote)
   ) {
     return remote;
   }

--- a/src/version_preview/projection.test.ts
+++ b/src/version_preview/projection.test.ts
@@ -123,26 +123,6 @@ describe("version_preview capabilities", () => {
             }),
             disabledReason: "invalid-in-current-state",
           },
-          canAcceptCurrentRepository: {
-            representativeEvents: () => ({
-              valid: [
-                {
-                  type: "ACCEPT_CURRENT_REPOSITORY",
-                } satisfies PreviewEvent,
-              ],
-            }),
-            disabledReason: "invalid-in-current-state",
-          },
-          canCheckpointAndAcceptCurrentRepository: {
-            representativeEvents: () => ({
-              valid: [
-                {
-                  type: "CHECKPOINT_AND_ACCEPT_CURRENT_REPOSITORY",
-                } satisfies PreviewEvent,
-              ],
-            }),
-            disabledReason: "invalid-in-current-state",
-          },
         },
       }),
     ).not.toThrow();
@@ -156,8 +136,6 @@ describe("version_preview capabilities", () => {
       canRestore: false,
       canSelectVersion: false,
       canSwitchBranch: true,
-      canAcceptCurrentRepository: false,
-      canCheckpointAndAcceptCurrentRepository: false,
     });
   });
 });

--- a/src/version_preview/projection.test.ts
+++ b/src/version_preview/projection.test.ts
@@ -47,6 +47,22 @@ const states: PreviewState[] = [
     session: { ...session(), originBranch: null, checkedOutVersionId: null },
     error: { message: "restore interrupted" },
   },
+  {
+    type: "restore-recovery-required",
+    session: { ...session(), originBranch: null, checkedOutVersionId: null },
+    error: { message: "dirty repository" },
+    currentRepositoryAssessment: { type: "dirty" },
+  },
+  {
+    type: "validating-current-repository",
+    session: { ...session(), originBranch: null, checkedOutVersionId: null },
+    error: { message: "restore interrupted" },
+  },
+  {
+    type: "checkpointing-current-repository",
+    session: { ...session(), originBranch: null, checkedOutVersionId: null },
+    error: { message: "dirty repository" },
+  },
 ];
 
 describe("version_preview capabilities", () => {
@@ -107,6 +123,26 @@ describe("version_preview capabilities", () => {
             }),
             disabledReason: "invalid-in-current-state",
           },
+          canAcceptCurrentRepository: {
+            representativeEvents: () => ({
+              valid: [
+                {
+                  type: "ACCEPT_CURRENT_REPOSITORY",
+                } satisfies PreviewEvent,
+              ],
+            }),
+            disabledReason: "invalid-in-current-state",
+          },
+          canCheckpointAndAcceptCurrentRepository: {
+            representativeEvents: () => ({
+              valid: [
+                {
+                  type: "CHECKPOINT_AND_ACCEPT_CURRENT_REPOSITORY",
+                } satisfies PreviewEvent,
+              ],
+            }),
+            disabledReason: "invalid-in-current-state",
+          },
         },
       }),
     ).not.toThrow();
@@ -120,6 +156,8 @@ describe("version_preview capabilities", () => {
       canRestore: false,
       canSelectVersion: false,
       canSwitchBranch: true,
+      canAcceptCurrentRepository: false,
+      canCheckpointAndAcceptCurrentRepository: false,
     });
   });
 });

--- a/src/version_preview/projection.ts
+++ b/src/version_preview/projection.ts
@@ -4,6 +4,8 @@ export interface VersionPreviewCapabilities {
   readonly canRestore: boolean;
   readonly canSelectVersion: boolean;
   readonly canSwitchBranch: boolean;
+  readonly canAcceptCurrentRepository: boolean;
+  readonly canCheckpointAndAcceptCurrentRepository: boolean;
 }
 
 export interface VersionPreviewProjection {
@@ -25,39 +27,54 @@ export function selectVersionPreviewCapabilities(
         canRestore: true,
         canSelectVersion: true,
         canSwitchBranch: true,
+        canAcceptCurrentRepository: false,
+        canCheckpointAndAcceptCurrentRepository: false,
       };
     case "closed":
       return {
         canRestore: true,
         canSelectVersion: false,
         canSwitchBranch: true,
+        canAcceptCurrentRepository: false,
+        canCheckpointAndAcceptCurrentRepository: false,
       };
     case "resolving-origin":
       return {
         canRestore: false,
         canSelectVersion: true,
         canSwitchBranch: false,
+        canAcceptCurrentRepository: false,
+        canCheckpointAndAcceptCurrentRepository: false,
       };
     case "recovery-required":
       return {
         canRestore: false,
         canSelectVersion: false,
         canSwitchBranch: true,
+        canAcceptCurrentRepository: false,
+        canCheckpointAndAcceptCurrentRepository: false,
       };
     case "restore-recovery-required":
       return {
         canRestore: false,
         canSelectVersion: false,
         canSwitchBranch: false,
+        canAcceptCurrentRepository: true,
+        canCheckpointAndAcceptCurrentRepository:
+          state.currentRepositoryAssessment?.type === "dirty",
       };
     case "checking-out":
     case "restoring":
     case "returning":
     case "switching-branch":
+    case "validating-current-repository":
+    case "checkpointing-current-repository":
       return {
         canRestore: false,
         canSelectVersion: false,
         canSwitchBranch: false,
+        canAcceptCurrentRepository: false,
+        canCheckpointAndAcceptCurrentRepository: false,
       };
   }
 }

--- a/src/version_preview/projection.ts
+++ b/src/version_preview/projection.ts
@@ -4,8 +4,6 @@ export interface VersionPreviewCapabilities {
   readonly canRestore: boolean;
   readonly canSelectVersion: boolean;
   readonly canSwitchBranch: boolean;
-  readonly canAcceptCurrentRepository: boolean;
-  readonly canCheckpointAndAcceptCurrentRepository: boolean;
 }
 
 export interface VersionPreviewProjection {
@@ -27,41 +25,30 @@ export function selectVersionPreviewCapabilities(
         canRestore: true,
         canSelectVersion: true,
         canSwitchBranch: true,
-        canAcceptCurrentRepository: false,
-        canCheckpointAndAcceptCurrentRepository: false,
       };
     case "closed":
       return {
         canRestore: true,
         canSelectVersion: false,
         canSwitchBranch: true,
-        canAcceptCurrentRepository: false,
-        canCheckpointAndAcceptCurrentRepository: false,
       };
     case "resolving-origin":
       return {
         canRestore: false,
         canSelectVersion: true,
         canSwitchBranch: false,
-        canAcceptCurrentRepository: false,
-        canCheckpointAndAcceptCurrentRepository: false,
       };
     case "recovery-required":
       return {
         canRestore: false,
         canSelectVersion: false,
         canSwitchBranch: true,
-        canAcceptCurrentRepository: false,
-        canCheckpointAndAcceptCurrentRepository: false,
       };
     case "restore-recovery-required":
       return {
         canRestore: false,
         canSelectVersion: false,
         canSwitchBranch: false,
-        canAcceptCurrentRepository: true,
-        canCheckpointAndAcceptCurrentRepository:
-          state.currentRepositoryAssessment?.type === "dirty",
       };
     case "checking-out":
     case "restoring":
@@ -73,8 +60,6 @@ export function selectVersionPreviewCapabilities(
         canRestore: false,
         canSelectVersion: false,
         canSwitchBranch: false,
-        canAcceptCurrentRepository: false,
-        canCheckpointAndAcceptCurrentRepository: false,
       };
   }
 }

--- a/src/version_preview/remote_intent_contract.ts
+++ b/src/version_preview/remote_intent_contract.ts
@@ -1,0 +1,60 @@
+import {
+  DEFAULT_REMOTE_INTENT_ENVELOPE_BYTES,
+  DEFAULT_REMOTE_SNAPSHOT_ENVELOPE_BYTES,
+  PROTOCOL_V1_REFUSAL_MAP,
+  defineRemoteIntentContract,
+} from "@/distributed_machines/remote_intent_contract";
+import {
+  VersionPreviewIntentEventSchema,
+  VersionPreviewKeySchema,
+  VersionPreviewRemoteSnapshotSchema,
+  type VersionPreviewIntentEvent,
+  type VersionPreviewKey,
+  type VersionPreviewRemoteSnapshot,
+  type VersionPreviewWireEvent,
+} from "./transport";
+
+const admissionOnly = {
+  completion: "admission-only",
+  observedRevision: { kind: "actor", required: true },
+  retry: { kind: "none" },
+  acceptance: "admission",
+  inputDisposition: "preserve",
+} as const;
+
+/**
+ * Declarative policy for the protocol-v1 version-preview boundary. Completion
+ * remains projected through the actor's operation-correlated settlement state;
+ * the remote transport itself acknowledges admission only.
+ */
+export const versionPreviewRemoteIntentContract = defineRemoteIntentContract<
+  VersionPreviewKey,
+  VersionPreviewIntentEvent,
+  VersionPreviewWireEvent,
+  VersionPreviewRemoteSnapshot
+>({
+  keyCodec: VersionPreviewKeySchema,
+  encodeKey: (key) => key,
+  rendererIntentCodec: VersionPreviewIntentEventSchema,
+  snapshotCodec: VersionPreviewRemoteSnapshotSchema,
+  toTrustedEvent: ({ intent }) => Object.freeze(structuredClone(intent)),
+  authorization: { subscribe: "required", dispatch: "required" },
+  keyIntentRelationship: { kind: "entity-relative" },
+  intents: {
+    CLOSE: admissionOnly,
+    APP_CHANGED: admissionOnly,
+    SELECT_VERSION: admissionOnly,
+    SWITCH_BRANCH: admissionOnly,
+    RESTORE: admissionOnly,
+    RESTORE_TO_MESSAGE: admissionOnly,
+    RETRY_RETURN: admissionOnly,
+    ACCEPT_CURRENT_REPOSITORY: admissionOnly,
+    CHECKPOINT_AND_ACCEPT_CURRENT_REPOSITORY: admissionOnly,
+    SHOW_RECOVERY_NOTICE: admissionOnly,
+  },
+  refusalMap: PROTOCOL_V1_REFUSAL_MAP,
+  budgets: {
+    intentBytes: DEFAULT_REMOTE_INTENT_ENVELOPE_BYTES,
+    snapshotBytes: DEFAULT_REMOTE_SNAPSHOT_ENVELOPE_BYTES,
+  },
+});

--- a/src/version_preview/state.ts
+++ b/src/version_preview/state.ts
@@ -131,6 +131,26 @@ export type PreviewState =
     }
   | { type: "recovery-required"; session: PreviewSession; error: PreviewError };
 
+export type RestoreRecoveryFlowState = Extract<
+  PreviewState,
+  {
+    type:
+      | "restore-recovery-required"
+      | "validating-current-repository"
+      | "checkpointing-current-repository";
+  }
+>;
+
+export function isRestoreRecoveryFlowState(
+  state: PreviewState,
+): state is RestoreRecoveryFlowState {
+  return (
+    state.type === "restore-recovery-required" ||
+    state.type === "validating-current-repository" ||
+    state.type === "checkpointing-current-repository"
+  );
+}
+
 export function ownsHistoricalCheckout(state: PreviewState): boolean {
   if (state.type === "switching-branch") {
     return (
@@ -312,9 +332,7 @@ function canShowDiff(state: PreviewState): state is Exclude<
     state.type !== "returning" &&
     state.type !== "switching-branch" &&
     state.type !== "recovery-required" &&
-    state.type !== "restore-recovery-required" &&
-    state.type !== "validating-current-repository" &&
-    state.type !== "checkpointing-current-repository"
+    !isRestoreRecoveryFlowState(state)
   );
 }
 

--- a/src/version_preview/state.ts
+++ b/src/version_preview/state.ts
@@ -33,7 +33,7 @@ export type CurrentRepositoryAssessment =
         | "bisect";
     };
 
-export type RestoreRecovery =
+export type RestoreRecovery = (
   | {
       readonly preRestoreHead: string;
       readonly preRestoreBranch: string | null;
@@ -57,7 +57,8 @@ export type RestoreRecovery =
   | {
       readonly repositoryOutcome: "unchanged";
       readonly nextStep: "chat-mutation" | "completed";
-    };
+    }
+) & { readonly affectedChatId?: number };
 
 export interface PreviewSession {
   /** The app that owns this session. Never substituted after creation. */

--- a/src/version_preview/state.ts
+++ b/src/version_preview/state.ts
@@ -15,6 +15,24 @@ export interface PreviewError {
   message: string;
 }
 
+export type CurrentRepositoryAssessment =
+  | { readonly type: "dirty" }
+  | {
+      readonly type: "blocked";
+      readonly blocker:
+        | "conflicted"
+        | "detached-head"
+        | "missing-repository"
+        | "git-operation"
+        | "repository-error";
+      readonly operation?:
+        | "merge"
+        | "rebase"
+        | "cherry-pick"
+        | "revert"
+        | "bisect";
+    };
+
 export type RestoreRecovery =
   | {
       readonly preRestoreHead: string;
@@ -91,6 +109,19 @@ export type PreviewState =
       session: PreviewSession;
       error: PreviewError;
       restoreRecovery?: RestoreRecovery;
+      currentRepositoryAssessment?: CurrentRepositoryAssessment;
+    }
+  | {
+      type: "validating-current-repository";
+      session: PreviewSession;
+      error: PreviewError;
+      restoreRecovery?: RestoreRecovery;
+    }
+  | {
+      type: "checkpointing-current-repository";
+      session: PreviewSession;
+      error: PreviewError;
+      restoreRecovery?: RestoreRecovery;
     }
   | {
       type: "switching-branch";
@@ -143,6 +174,8 @@ export type PreviewEvent =
       restoreCodebase: boolean;
     }
   | { type: "RETRY_RETURN" }
+  | { type: "ACCEPT_CURRENT_REPOSITORY" }
+  | { type: "CHECKPOINT_AND_ACCEPT_CURRENT_REPOSITORY" }
   // Command completions (dispatched only by the controller)
   | { type: "ORIGIN_RESOLVED"; branch: string }
   | { type: "ORIGIN_RESOLUTION_FAILED" }
@@ -157,6 +190,19 @@ export type PreviewEvent =
       type: "RESTORE_RECOVERY_REQUIRED";
       error: PreviewError;
       restoreRecovery: RestoreRecovery;
+    }
+  | {
+      type: "CURRENT_REPOSITORY_ACCEPTED";
+      appId: number;
+      branch: string;
+      acceptedHead: string;
+      savedVersionId?: string;
+    }
+  | { type: "CURRENT_REPOSITORY_DIRTY" }
+  | {
+      type: "CURRENT_REPOSITORY_REJECTED";
+      error: PreviewError;
+      assessment: Exclude<CurrentRepositoryAssessment, { type: "dirty" }>;
     }
   | { type: "RETURN_SUCCEEDED" }
   | { type: "RETURN_FAILED"; error: PreviewError }
@@ -189,6 +235,8 @@ export type PreviewCommand =
       targetBranch: string | null;
     }
   | { type: "notify-error"; message: string }
+  | { type: "validate-current-repository"; appId: number }
+  | { type: "checkpoint-current-repository"; appId: number }
   | { type: "notify-recovery"; appId: number; error: PreviewError }
   | { type: "dismiss-recovery"; appId: number };
 
@@ -210,6 +258,8 @@ export function isPaneVisibleState(state: PreviewState): boolean {
     case "switching-branch":
     case "recovery-required":
     case "restore-recovery-required":
+    case "validating-current-repository":
+    case "checkpointing-current-repository":
       return false;
   }
 }
@@ -221,6 +271,7 @@ export function isMutatingState(state: PreviewState): boolean {
     case "restoring":
     case "returning":
     case "switching-branch":
+    case "checkpointing-current-repository":
       return true;
     case "closed":
     case "viewing-diff":
@@ -229,6 +280,7 @@ export function isMutatingState(state: PreviewState): boolean {
     case "previewing":
     case "recovery-required":
     case "restore-recovery-required":
+    case "validating-current-repository":
       return false;
   }
 }
@@ -244,13 +296,25 @@ function canShowDiff(state: PreviewState): state is Exclude<
       session: PreviewSession;
       error: PreviewError;
     }
+  | {
+      type: "validating-current-repository";
+      session: PreviewSession;
+      error: PreviewError;
+    }
+  | {
+      type: "checkpointing-current-repository";
+      session: PreviewSession;
+      error: PreviewError;
+    }
 > {
   return (
     state.type !== "closed" &&
     state.type !== "returning" &&
     state.type !== "switching-branch" &&
     state.type !== "recovery-required" &&
-    state.type !== "restore-recovery-required"
+    state.type !== "restore-recovery-required" &&
+    state.type !== "validating-current-repository" &&
+    state.type !== "checkpointing-current-repository"
   );
 }
 

--- a/src/version_preview/transition.test.ts
+++ b/src/version_preview/transition.test.ts
@@ -66,6 +66,8 @@ const EVENT_SAMPLES: PreviewEvent[] = [
     restoreCodebase: true,
   },
   { type: "RETRY_RETURN" },
+  { type: "ACCEPT_CURRENT_REPOSITORY" },
+  { type: "CHECKPOINT_AND_ACCEPT_CURRENT_REPOSITORY" },
   { type: "ORIGIN_RESOLVED", branch: "feature/origin" },
   { type: "ORIGIN_RESOLUTION_FAILED" },
   { type: "CHECKOUT_SUCCEEDED" },
@@ -81,6 +83,18 @@ const EVENT_SAMPLES: PreviewEvent[] = [
       targetHead: "v1",
       nextStep: "soft-reset",
     },
+  },
+  {
+    type: "CURRENT_REPOSITORY_ACCEPTED",
+    appId: APP_ID,
+    branch: "main",
+    acceptedHead: "accepted-head",
+  },
+  { type: "CURRENT_REPOSITORY_DIRTY" },
+  {
+    type: "CURRENT_REPOSITORY_REJECTED",
+    error: { message: "repository blocked" },
+    assessment: { type: "blocked", blocker: "conflicted" },
   },
   { type: "RETURN_SUCCEEDED" },
   { type: "RETURN_FAILED", error: { message: "return failed" } },
@@ -99,6 +113,8 @@ const STATE_KINDS = [
   "switching-branch",
   "recovery-required",
   "restore-recovery-required",
+  "validating-current-repository",
+  "checkpointing-current-repository",
 ] as const satisfies readonly PreviewState["type"][];
 const COMMAND_KINDS = [
   "resolve-origin",
@@ -107,6 +123,8 @@ const COMMAND_KINDS = [
   "switch-branch",
   "restore",
   "restore-to-message",
+  "validate-current-repository",
+  "checkpoint-current-repository",
   "notify-error",
   "notify-recovery",
   "dismiss-recovery",
@@ -190,6 +208,16 @@ const STATE_SAMPLES: PreviewState[] = [
     error: { message: "restore interrupted" },
   },
   {
+    type: "validating-current-repository",
+    session: session(),
+    error: { message: "restore interrupted" },
+  },
+  {
+    type: "checkpointing-current-repository",
+    session: session(),
+    error: { message: "dirty repository" },
+  },
+  {
     type: "switching-branch",
     appId: APP_ID,
     branch: "main",
@@ -203,6 +231,7 @@ const MUTATING_COMMAND_TYPES = new Set([
   "switch-branch",
   "restore",
   "restore-to-message",
+  "checkpoint-current-repository",
 ]);
 
 /**
@@ -933,6 +962,80 @@ describe("return failure and recovery", () => {
         error: { message: "return failed" },
       },
     ]);
+  });
+});
+
+describe("restore recovery acceptance", () => {
+  const recovery: PreviewState = {
+    type: "restore-recovery-required",
+    session: session({ originBranch: "main", targetVersionId: "v1" }),
+    error: { message: "restore interrupted" },
+  };
+
+  it("validates before accepting the current repository", () => {
+    const result = step(recovery, { type: "ACCEPT_CURRENT_REPOSITORY" });
+    expect(result.state.type).toBe("validating-current-repository");
+    expect(commandsOf(result)).toEqual([
+      { type: "validate-current-repository", appId: APP_ID },
+    ]);
+  });
+
+  it("offers checkpointing only after validation finds a dirty tree", () => {
+    const validated = run(
+      [
+        { type: "ACCEPT_CURRENT_REPOSITORY" },
+        { type: "CURRENT_REPOSITORY_DIRTY" },
+      ],
+      recovery,
+    );
+    expect(validated.state).toMatchObject({
+      type: "restore-recovery-required",
+      currentRepositoryAssessment: { type: "dirty" },
+    });
+
+    const checkpoint = step(validated.state, {
+      type: "CHECKPOINT_AND_ACCEPT_CURRENT_REPOSITORY",
+    });
+    expect(checkpoint.state.type).toBe("checkpointing-current-repository");
+    expect(commandsOf(checkpoint)).toEqual([
+      { type: "checkpoint-current-repository", appId: APP_ID },
+    ]);
+  });
+
+  it("keeps blocked repositories latched until a later recheck succeeds", () => {
+    const blocked = run(
+      [
+        { type: "ACCEPT_CURRENT_REPOSITORY" },
+        {
+          type: "CURRENT_REPOSITORY_REJECTED",
+          error: { message: "resolve conflicts" },
+          assessment: { type: "blocked", blocker: "conflicted" },
+        },
+      ],
+      recovery,
+    );
+    expect(blocked.state).toMatchObject({
+      type: "restore-recovery-required",
+      error: { message: "resolve conflicts" },
+      currentRepositoryAssessment: {
+        type: "blocked",
+        blocker: "conflicted",
+      },
+    });
+
+    const accepted = run(
+      [
+        { type: "ACCEPT_CURRENT_REPOSITORY" },
+        {
+          type: "CURRENT_REPOSITORY_ACCEPTED",
+          appId: APP_ID,
+          branch: "main",
+          acceptedHead: "live-head",
+        },
+      ],
+      blocked.state,
+    );
+    expect(accepted.state.type).toBe("closed");
   });
 });
 

--- a/src/version_preview/transition.ts
+++ b/src/version_preview/transition.ts
@@ -63,6 +63,8 @@ function ignoreEvent(
     case "RESTORE":
     case "RESTORE_TO_MESSAGE":
     case "RETRY_RETURN":
+    case "ACCEPT_CURRENT_REPOSITORY":
+    case "CHECKPOINT_AND_ACCEPT_CURRENT_REPOSITORY":
     case "ORIGIN_RESOLVED":
     case "ORIGIN_RESOLUTION_FAILED":
     case "CHECKOUT_SUCCEEDED":
@@ -70,6 +72,9 @@ function ignoreEvent(
     case "RESTORE_SUCCEEDED":
     case "RESTORE_FAILED":
     case "RESTORE_RECOVERY_REQUIRED":
+    case "CURRENT_REPOSITORY_ACCEPTED":
+    case "CURRENT_REPOSITORY_DIRTY":
+    case "CURRENT_REPOSITORY_REJECTED":
     case "RETURN_SUCCEEDED":
     case "RETURN_FAILED":
     case "SWITCH_BRANCH_SUCCEEDED":
@@ -759,6 +764,43 @@ export function transition(
     }
 
     case "restore-recovery-required": {
+      if (event.type === "ACCEPT_CURRENT_REPOSITORY") {
+        return {
+          kind: "applied",
+          state: {
+            type: "validating-current-repository",
+            session: state.session,
+            error: state.error,
+            restoreRecovery: state.restoreRecovery,
+          },
+          commands: [
+            {
+              type: "validate-current-repository",
+              appId: state.session.appId,
+            },
+          ],
+        };
+      }
+      if (
+        event.type === "CHECKPOINT_AND_ACCEPT_CURRENT_REPOSITORY" &&
+        state.currentRepositoryAssessment?.type === "dirty"
+      ) {
+        return {
+          kind: "applied",
+          state: {
+            type: "checkpointing-current-repository",
+            session: state.session,
+            error: state.error,
+            restoreRecovery: state.restoreRecovery,
+          },
+          commands: [
+            {
+              type: "checkpoint-current-repository",
+              appId: state.session.appId,
+            },
+          ],
+        };
+      }
       if (event.type === "OPEN") {
         return {
           kind: "applied",
@@ -770,6 +812,62 @@ export function transition(
               error: state.error,
             },
           ],
+        };
+      }
+      return ignoreEvent(state, event);
+    }
+
+    case "validating-current-repository": {
+      if (event.type === "CURRENT_REPOSITORY_ACCEPTED") {
+        return { kind: "applied", state: CLOSED_STATE, commands: [] };
+      }
+      if (event.type === "CURRENT_REPOSITORY_DIRTY") {
+        return {
+          kind: "applied",
+          state: {
+            type: "restore-recovery-required",
+            session: state.session,
+            error: {
+              message:
+                "Dyad found changes that are not part of a saved version.",
+            },
+            restoreRecovery: state.restoreRecovery,
+            currentRepositoryAssessment: { type: "dirty" },
+          },
+          commands: [],
+        };
+      }
+      if (event.type === "CURRENT_REPOSITORY_REJECTED") {
+        return {
+          kind: "applied",
+          state: {
+            type: "restore-recovery-required",
+            session: state.session,
+            error: event.error,
+            restoreRecovery: state.restoreRecovery,
+            currentRepositoryAssessment: event.assessment,
+          },
+          commands: [],
+        };
+      }
+      return ignoreEvent(state, event);
+    }
+
+    case "checkpointing-current-repository": {
+      if (event.type === "CURRENT_REPOSITORY_ACCEPTED") {
+        return { kind: "applied", state: CLOSED_STATE, commands: [] };
+      }
+      if (event.type === "CURRENT_REPOSITORY_REJECTED") {
+        return {
+          kind: "applied",
+          state: {
+            type: "restore-recovery-required",
+            session: state.session,
+            error: event.error,
+            restoreRecovery: state.restoreRecovery,
+            currentRepositoryAssessment: event.assessment,
+          },
+          commands: [],
         };
       }
       return ignoreEvent(state, event);

--- a/src/version_preview/transport.ts
+++ b/src/version_preview/transport.ts
@@ -3,6 +3,7 @@ import type { InvocationRef } from "@/state_machines/invocation_ref";
 import { SafeGitRefSchema } from "@/shared/git_refs";
 import type {
   BranchSwitchFallback,
+  CurrentRepositoryAssessment,
   PreviewError,
   PreviewEvent,
   PreviewSession,
@@ -44,6 +45,8 @@ type SafeRemotePreviewState =
         | "switching-branch"
         | "recovery-required"
         | "restore-recovery-required"
+        | "validating-current-repository"
+        | "checkpointing-current-repository"
       >]: {
         readonly type: Kind;
         readonly session: SafeRemoteSession;
@@ -55,6 +58,8 @@ type SafeRemotePreviewState =
       | "switching-branch"
       | "recovery-required"
       | "restore-recovery-required"
+      | "validating-current-repository"
+      | "checkpointing-current-repository"
     >]
   | {
       readonly type: "restoring";
@@ -74,6 +79,14 @@ type SafeRemotePreviewState =
     }
   | {
       readonly type: "restore-recovery-required";
+      readonly session: SafeRemoteSession;
+      readonly error: PreviewError;
+      readonly currentRepositoryAssessment?: CurrentRepositoryAssessment;
+    }
+  | {
+      readonly type:
+        | "validating-current-repository"
+        | "checkpointing-current-repository";
       readonly session: SafeRemoteSession;
       readonly error: PreviewError;
     };
@@ -177,6 +190,24 @@ export const VersionPreviewIntentEventSchema = z.discriminatedUnion("type", [
       operationId: z.string().min(1),
     })
     .strict(),
+  z
+    .object({
+      type: z.literal("ACCEPT_CURRENT_REPOSITORY"),
+      operationId: z.string().min(1),
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal("CHECKPOINT_AND_ACCEPT_CURRENT_REPOSITORY"),
+      operationId: z.string().min(1),
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal("SHOW_RECOVERY_NOTICE"),
+      operationId: z.string().min(1),
+    })
+    .strict(),
 ]);
 export type VersionPreviewIntentEvent = z.infer<
   typeof VersionPreviewIntentEventSchema
@@ -225,6 +256,24 @@ export type VersionPreviewProducerEvent =
       invocationRef: VersionPreviewInvocationRef;
     }
   | {
+      type: "CURRENT_REPOSITORY_ACCEPTED";
+      appId: number;
+      branch: string;
+      acceptedHead: string;
+      savedVersionId?: string;
+      invocationRef: VersionPreviewInvocationRef;
+    }
+  | {
+      type: "CURRENT_REPOSITORY_DIRTY";
+      invocationRef: VersionPreviewInvocationRef;
+    }
+  | {
+      type: "CURRENT_REPOSITORY_REJECTED";
+      error: PreviewError;
+      assessment: Exclude<CurrentRepositoryAssessment, { type: "dirty" }>;
+      invocationRef: VersionPreviewInvocationRef;
+    }
+  | {
       type: "RETURN_SUCCEEDED";
       invocationRef: VersionPreviewInvocationRef;
     }
@@ -260,6 +309,24 @@ export interface VersionPreviewActorState {
 }
 
 const previewErrorSchema = z.object({ message: z.string() }).strict();
+const currentRepositoryAssessmentSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("dirty") }).strict(),
+  z
+    .object({
+      type: z.literal("blocked"),
+      blocker: z.enum([
+        "conflicted",
+        "detached-head",
+        "missing-repository",
+        "git-operation",
+        "repository-error",
+      ]),
+      operation: z
+        .enum(["merge", "rebase", "cherry-pick", "revert", "bisect"])
+        .optional(),
+    })
+    .strict(),
+]);
 const exitIntentSchema = z.discriminatedUnion("type", [
   z.object({ type: z.literal("none") }).strict(),
   z.object({ type: z.literal("close") }).strict(),
@@ -335,6 +402,21 @@ export const PreviewStateSchema = z.discriminatedUnion("type", [
   z
     .object({
       type: z.literal("restore-recovery-required"),
+      session: sessionSchema,
+      error: previewErrorSchema,
+      currentRepositoryAssessment: currentRepositoryAssessmentSchema.optional(),
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal("validating-current-repository"),
+      session: sessionSchema,
+      error: previewErrorSchema,
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal("checkpointing-current-repository"),
       session: sessionSchema,
       error: previewErrorSchema,
     })
@@ -426,6 +508,14 @@ function stripWindowPresentation(state: PreviewState): SafeRemotePreviewState {
         session: stripSessionPresentation(state.session),
       };
     }
+    case "validating-current-repository":
+    case "checkpointing-current-repository": {
+      const { restoreRecovery: _restoreRecovery, ...safeState } = state;
+      return {
+        ...safeState,
+        session: stripSessionPresentation(state.session),
+      };
+    }
     default:
       return {
         ...state,
@@ -444,7 +534,11 @@ export function toPreviewDomainEvent(
       throw new Error(`${event.type} is handled by the hosted actor`);
     case "CLOSE":
     case "RETRY_RETURN":
+    case "ACCEPT_CURRENT_REPOSITORY":
+    case "CHECKPOINT_AND_ACCEPT_CURRENT_REPOSITORY":
       return { type: event.type };
+    case "SHOW_RECOVERY_NOTICE":
+      return { type: "OPEN", appId };
     case "APP_CHANGED":
       return { type: event.type, nextAppId: event.nextAppId };
     case "SELECT_VERSION":
@@ -484,6 +578,22 @@ export function toPreviewDomainEvent(
         type: event.type,
         error: event.error,
         restoreRecovery: event.restoreRecovery,
+      };
+    case "CURRENT_REPOSITORY_ACCEPTED":
+      return {
+        type: event.type,
+        appId: event.appId,
+        branch: event.branch,
+        acceptedHead: event.acceptedHead,
+        savedVersionId: event.savedVersionId,
+      };
+    case "CURRENT_REPOSITORY_DIRTY":
+      return { type: event.type };
+    case "CURRENT_REPOSITORY_REJECTED":
+      return {
+        type: event.type,
+        error: event.error,
+        assessment: event.assessment,
       };
     case "RESTORE_SUCCEEDED":
       return {


### PR DESCRIPTION
## Summary

Make Stop generation followed by Undo recover partial code safely, without incorrectly latching Version History in recovery mode. Dyad now persists why a turn ended, saves cancelled-generation edits as a visible `[Interrupted]` version, and provides validated paths out of genuinely stale restore recovery.

- Persist `completed`, `cancelled`, or `errored` on accepted chat-turn intents so Undo does not depend on whether the stream is still active when restore begins. Legacy cancelled assistant messages remain a narrow compatibility fallback.
- Preserve a cancelled turn's dirty tree in `[Interrupted] Saved partial changes before restoring to an earlier version`; this intentionally captures the whole tree because agent edits cannot be separated reliably from concurrent manual edits, favoring recoverability over attribution.
- Preflight ordinary dirty trees before checkout/reset and skip no-op checkouts. A failure that leaves the original branch and HEAD intact is an ordinary restore conflict, not evidence of a partially applied restore.
- Add `Use current version` as a read-only acknowledgement that requires a clean, attached, conflict-free repository with no Git operation underway.
- If the only blocker is a dirty tree, offer `Save changes & use current version`, creating `[Recovery] Saved current changes before continuing Version History` before clearing recovery. Conflicted, detached, missing, or mid-operation repositories remain blocked with a read-only `Check again`; this PR intentionally does not attempt Git repair.
- Keep the recovery success passive: no forced navigation or toast actions. When the Version History pane is opened while recovery remains unresolved, show an inline blocked explanation and resurface the recovery notice.
- Add a hybrid renderer/IPC regression test that drives the real local-agent file write, Stop control, and footer Undo control, then verifies the interrupted version remains reachable and the restored repository is clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches Git restore/mutation, SQLite migrations, and version-preview state machines; incorrect classification could lock Version History or commit unintended working-tree changes.
> 
> **Overview**
> Fixes **Stop → Undo** and stale **Version History** recovery by persisting how each chat turn ended and tightening restore/Git classification.
> 
> Adds nullable `terminal_outcome` on `chat_turn_intents` (`completed` / `cancelled` / `errored`), written when a turn reaches terminal recovery. Footer Undo and restore-to-message can then treat a **durably cancelled** turn like an active cancel: whole-tree checkpoint with **`[Interrupted]`** commit message, then normal revert/fork. Legacy turns without the column still fall back to the cancelled-assistant-message heuristic (message order by `id`, not `createdAt`).
> 
> Restore preflight now runs **before** checkout: blocks merges/conflicts in progress, rejects ordinary dirty trees when preservation is off, skips no-op branch checkout, and avoids latching **`restore-recovery-required`** when checkout fails without moving branch/HEAD.
> 
> Version preview gains **`Use current version`** (read-only health check) and **`Save changes & use current version`** (dirty-tree-only **`[Recovery]`** checkpoint), plus inline blocked state in the Version History pane while recovery is unresolved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c66d05aa1b09d0cc9c03c877cbdb744deb593ad2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

