### PR TITLE
Avoid Ubuntu mirror hangs in Linux release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,11 @@ jobs:
           gpg --dearmor /tmp/llvm-snapshot.gpg.key
           sudo install -m 0644 /tmp/llvm-snapshot.gpg.key.gpg /etc/apt/keyrings/apt.llvm.org.gpg
           echo "deb [signed-by=/etc/apt/keyrings/apt.llvm.org.gpg] https://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main" | sudo tee /etc/apt/sources.list.d/llvm-toolchain-jammy-18.list
-          sudo apt-get update
+          # Preserve the runner's package indexes and avoid refreshing unrelated Ubuntu mirrors.
+          sudo apt-get update \
+            -o Dir::Etc::sourcelist="sources.list.d/llvm-toolchain-jammy-18.list" \
+            -o Dir::Etc::sourceparts="-" \
+            -o APT::Get::List-Cleanup="0"
           sudo apt-get install -y clang-18
           echo "CC=clang-18" >> "$GITHUB_ENV"
           echo "CXX=clang++-18" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary

Prevent the Linux release build from hanging on unrelated Ubuntu package mirrors while retaining clang 18 and the Ubuntu 22.04 glibc baseline.

- Restrict `apt-get update` to the newly added LLVM Jammy repository instead of refreshing every configured runner repository.
- Preserve the runner's existing package indexes so `apt-get install clang-18` can resolve any Ubuntu-provided dependencies without changing the existing installation behavior.
- Keep the compiler selection and all non-Linux release jobs unchanged.

#skip-bugbot

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to apt update flags on Linux release builds; no application runtime or release artifact logic changes.
> 
> **Overview**
> Linux release jobs were hanging when `apt-get update` refreshed every Ubuntu mirror on the runner. The **Use clang 18 for Linux native rebuilds** step now runs a **scoped** `apt-get update` that only refreshes the added `llvm-toolchain-jammy-18` source list, with `Dir::Etc::sourceparts="-"` and `APT::Get::List-Cleanup="0"` so existing runner package indexes stay intact.
> 
> `clang-18` install and `CC`/`CXX` env setup are unchanged; other matrix platforms are untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81c8ba68f8673db97471e168f7a6fbe8981e13b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

