### PR TITLE
Fix Monaco diff editor model disposal errors

### DIFF
--- a/src/components/preview_panel/FileDiffEditor.test.tsx
+++ b/src/components/preview_panel/FileDiffEditor.test.tsx
@@ -1,0 +1,103 @@
+import { render } from "@testing-library/react";
+import { useEffect, useRef } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FileDiffEditor } from "./FileDiffEditor";
+
+// Records dispose calls so the test can assert both *that* the models are
+// disposed and *when* they are disposed relative to the diff widget.
+const mocks = vi.hoisted(() => {
+  const disposeOrder: string[] = [];
+
+  function createModel(name: string) {
+    let disposed = false;
+    return {
+      isDisposed: () => disposed,
+      dispose: () => {
+        disposed = true;
+        disposeOrder.push(name);
+      },
+    };
+  }
+
+  function createEditor() {
+    const models = {
+      original: createModel("original-model"),
+      modified: createModel("modified-model"),
+    };
+    return {
+      getModel: () => models,
+      dispose: () => disposeOrder.push("widget"),
+    };
+  }
+
+  return { disposeOrder, createEditor };
+});
+
+vi.mock("@monaco-editor/react", () => ({
+  loader: { init: vi.fn(() => Promise.resolve({})) },
+  // Faithfully mirrors @monaco-editor/react@4.7.0's DiffEditor teardown: its
+  // `disposeEditor` disposes the models first and the widget last, unless it is
+  // told to keep them. Disposing an attached model is what makes Monaco raise
+  // "TextModel got disposed before DiffEditorWidget model got reset".
+  DiffEditor: (props: {
+    onMount?: (editor: ReturnType<typeof mocks.createEditor>) => void;
+    keepCurrentOriginalModel?: boolean;
+    keepCurrentModifiedModel?: boolean;
+  }) => {
+    // The library creates and tears the editor down once (`useMount`), so the
+    // props are read through a ref rather than re-running the effect.
+    const propsRef = useRef(props);
+    propsRef.current = props;
+
+    useEffect(() => {
+      const editor = mocks.createEditor();
+      propsRef.current.onMount?.(editor);
+      return () => {
+        const { keepCurrentOriginalModel, keepCurrentModifiedModel } =
+          propsRef.current;
+        const models = editor.getModel();
+        if (!keepCurrentOriginalModel) {
+          models.original.dispose();
+        }
+        if (!keepCurrentModifiedModel) {
+          models.modified.dispose();
+        }
+        editor.dispose();
+      };
+    }, []);
+    return <div data-testid="mock-diff-editor" />;
+  },
+}));
+
+vi.mock("@/contexts/ThemeContext", () => ({
+  useTheme: () => ({ theme: "light", isDarkMode: false }),
+}));
+
+describe("FileDiffEditor model disposal", () => {
+  beforeEach(() => {
+    mocks.disposeOrder.length = 0;
+  });
+
+  it("disposes the diff models after the widget, not before", async () => {
+    const view = render(
+      <FileDiffEditor
+        filePath="src/index.ts"
+        oldContent="const a = 1;"
+        newContent="const a = 2;"
+      />,
+    );
+
+    view.unmount();
+
+    // Nothing but the widget is torn down inside the unmount commit itself.
+    expect(mocks.disposeOrder).toEqual(["widget"]);
+
+    // The models are released right afterwards, so no model leaks.
+    await Promise.resolve();
+    expect(mocks.disposeOrder).toEqual([
+      "widget",
+      "original-model",
+      "modified-model",
+    ]);
+  });
+});

--- a/src/components/preview_panel/FileDiffEditor.tsx
+++ b/src/components/preview_panel/FileDiffEditor.tsx
@@ -1,4 +1,6 @@
-import { DiffEditor } from "@monaco-editor/react";
+import { DiffEditor, type DiffOnMount } from "@monaco-editor/react";
+import type { editor as MonacoEditor } from "monaco-editor";
+import { useEffect, useRef } from "react";
 import "@/components/chat/monaco";
 import { useTheme } from "@/contexts/ThemeContext";
 import { getLanguage } from "@/utils/get_language";
@@ -20,6 +22,39 @@ export function FileDiffEditor({
 }: FileDiffEditorProps) {
   const { isDarkMode } = useTheme();
   const editorTheme = isDarkMode ? "dyad-dark" : "dyad-light";
+  const modelsRef = useRef<MonacoEditor.ITextModel[]>([]);
+
+  const handleMount: DiffOnMount = (editor) => {
+    const models = editor.getModel();
+    modelsRef.current = models ? [models.original, models.modified] : [];
+  };
+
+  // On unmount, @monaco-editor/react@4.7.0 disposes the two text models *before*
+  // it disposes the diff widget that still holds them. Monaco reacts to that
+  // with a BugIndicatingError ("TextModel got disposed before DiffEditorWidget
+  // model got reset") whose default handler rethrows asynchronously, so every
+  // closed/switched diff view produced an uncaught error in the renderer.
+  //
+  // `keepCurrent*Model` stops the library from touching the models, leaving it
+  // to only dispose the widget. We then dispose the models ourselves in a
+  // microtask, which runs after React has finished the unmount commit (and thus
+  // after the widget is gone), so the order is correct and nothing leaks.
+  useEffect(() => {
+    return () => {
+      const models = modelsRef.current;
+      modelsRef.current = [];
+      if (models.length === 0) {
+        return;
+      }
+      queueMicrotask(() => {
+        for (const model of models) {
+          if (!model.isDisposed()) {
+            model.dispose();
+          }
+        }
+      });
+    };
+  }, []);
 
   return (
     <div className="h-full w-full" data-testid="version-diff-editor">
@@ -29,6 +64,9 @@ export function FileDiffEditor({
         original={oldContent}
         modified={newContent}
         theme={editorTheme}
+        keepCurrentOriginalModel
+        keepCurrentModifiedModel
+        onMount={handleMount}
         options={{
           readOnly: true,
           renderSideBySide: false,


### PR DESCRIPTION
close #4251 
## Summary

Prevent the Monaco diff viewer from raising an uncaught `TextModel got disposed before DiffEditorWidget model got reset` error whenever users switch files or close a diff view. The diff widget is now released before its original and modified text models, while still cleaning up both models to avoid leaks.

- Keep the wrapper-created models alive during `@monaco-editor/react` teardown, then dispose them in a microtask after React finishes the unmount commit and the diff widget is gone.
- Scope the workaround to Dyad's read-only `FileDiffEditor` instead of downgrading Monaco or patching the dependency globally; the upstream wrapper still disposes models before its widget.
- Add a focused regression test that mirrors the wrapper teardown and verifies the widget-to-model disposal order.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

