### PR TITLE
feat(logging): mark session boundaries in the app log

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -23,10 +23,8 @@ import {
   tryWriteSettings,
   readSettings,
   readEffectiveSettings,
-  writeCrashSentinel,
+  claimCrashSentinel,
   clearCrashSentinel,
-  crashSentinelExists,
-  readCrashSentinel,
   recordRendererCrash,
   readRendererCrashRecord,
   clearRendererCrashRecord,
@@ -156,10 +154,56 @@ import {
   type WindowSessionDescriptor,
 } from "./window_infrastructure/main/window_session";
 import { DyadError, DyadErrorKind, isDyadError } from "./errors/dyad_error";
+import {
+  formatErrorBanner,
+  formatExitBanner,
+  formatPreviousSessionBanner,
+  formatStartBanner,
+} from "./main/session_banner";
 
-log.errorHandler.startCatching();
+const LAUNCH_TIME = Date.now();
+
+// Above the dev block so a failure there is still reported. Only registers
+// process handlers; it writes nothing, so it can't fix the log directory early.
+log.errorHandler.startCatching({
+  // Runs before electron-log logs the error itself. Must not return false:
+  // that suppresses both the stack trace and the error dialog.
+  onError: ({ errorName }) => {
+    const kind =
+      errorName === "Unhandled rejection"
+        ? "unhandledRejection"
+        : "uncaughtException";
+    log.error(formatErrorBanner(process.pid, kind, Date.now() - LAUNCH_TIME));
+  },
+});
+
+// In dev, keep minidumps and logs under the project's ./userData, not the OS
+// one. Must run before crashReporter.start and before the first log call, when
+// electron-log caches its dir. macOS logs ignore userData: ~/Library/Logs/dyad.
+if (process.env.NODE_ENV === "development") {
+  const devUserData = getUserDataPath();
+  fs.mkdirSync(devUserData, { recursive: true });
+  app.setPath("userData", devUserData);
+
+  const devCrashDumps = path.join(devUserData, "Crashpad");
+  fs.mkdirSync(devCrashDumps, { recursive: true });
+  app.setPath("crashDumps", devCrashDumps);
+}
+
 log.eventLogger.startLogging();
 log.scope.labelPadding = false;
+
+// First line of every session. See session_banner.ts.
+log.info(
+  formatStartBanner({
+    pid: process.pid,
+    version: app.getVersion(),
+    platform: process.platform,
+    arch: process.arch,
+    electron: process.versions.electron ?? "unknown",
+    node: process.versions.node ?? "unknown",
+  }),
+);
 const execFileAsync = promisify(execFile);
 
 // Prefer the Dyad-managed pnpm (if installed) for everything spawned from the
@@ -199,7 +243,10 @@ async function logStartupExecutablePaths(): Promise<void> {
     resolveStartupExecutablePath("pnpm"),
   ]);
 
+  // Resolves after module evaluation, so in a short-lived second instance this
+  // lands after that process's exit banner. The pid keeps it attributable.
   log.info("Startup executable paths", {
+    pid: process.pid,
     node,
     npm,
     pnpm,
@@ -209,19 +256,6 @@ async function logStartupExecutablePaths(): Promise<void> {
 }
 
 void logStartupExecutablePaths();
-
-// In dev, keep minidumps under the project's ./userData (matching where Dyad
-// writes its other dev files) instead of the OS userData dir, so they don't
-// mingle with a prod install's dumps. Must run before crashReporter.start.
-if (process.env.NODE_ENV === "development") {
-  const devUserData = getUserDataPath();
-  fs.mkdirSync(devUserData, { recursive: true });
-  app.setPath("userData", devUserData);
-
-  const devCrashDumps = path.join(devUserData, "Crashpad");
-  fs.mkdirSync(devCrashDumps, { recursive: true });
-  app.setPath("crashDumps", devCrashDumps);
-}
 
 // Capture native crashes (main/renderer/GPU/utility) as local minidumps. Not
 // uploaded; parsed on the next launch into a summary we send as telemetry.
@@ -373,6 +407,11 @@ if (process.defaultApp) {
 }
 
 export async function onReady() {
+  // Take over the sentinel before any startup work that can crash. Migrations,
+  // the keychain and git all run below; if one of them kills us, a sentinel
+  // still naming the previous session would report this crash as that one.
+  const previousSession = claimCrashSentinel(LAUNCH_TIME);
+
   // Linux: claim the dyad:// scheme for this build (best-effort, see module).
   // setAsDefaultProtocolClient above is unreliable on Linux. Pass this instance's
   // userData so a browser-launched deep link forwards here, not a second window.
@@ -453,8 +492,19 @@ export async function onReady() {
   // settings.isRunning may still be true. Honour it once, then clear it so
   // subsequent runs rely solely on the sentinel.
   const legacyIsRunningCrash = settings.isRunning === true;
-  if (crashSentinelExists() || legacyIsRunningCrash) {
-    logger.warn("App was force-closed on previous run");
+  // previousSession.previous is null for the legacy bare-timestamp sentinel,
+  // which still counts as existing.
+  if (previousSession.existed || legacyIsRunningCrash) {
+    // Scoped and at warn, unlike this session's own banners. Deliberate: warn is
+    // the only level that survives the filtered log tail users paste into bug
+    // reports (see readAppLogs in debug_handlers), and this is the line that
+    // tells us their last session crashed.
+    logger.warn(
+      formatPreviousSessionBanner(
+        previousSession.previous?.ts,
+        settings.lastKnownPerformance?.timestamp,
+      ),
+    );
     pendingCrashDetected = true;
 
     // Store performance data to send after window is created
@@ -465,7 +515,7 @@ export async function onReady() {
 
     // The chat that was streaming when the crash happened, if any, so the
     // dialog can offer a one-click upload of it.
-    pendingActiveChatId = readCrashSentinel()?.activeChatId ?? null;
+    pendingActiveChatId = previousSession.previous?.activeChatId ?? null;
   }
 
   // TODO: Remove legacyIsRunningCrash migration path after a few releases
@@ -476,8 +526,6 @@ export async function onReady() {
       "clearing the legacy isRunning crash flag",
     );
   }
-
-  writeCrashSentinel();
 
   // Record the GPU's feature status (is compositing / WebGL hardware-accelerated)
   // on every dump written from here on. It's useful context when reading a dump,
@@ -1305,6 +1353,8 @@ if (IS_TEST_BUILD) {
   const gotTheLock = app.requestSingleInstanceLock();
 
   if (!gotTheLock) {
+    // This instance already logged a start banner above, so terminate it.
+    log.info(formatExitBanner(process.pid, "duplicate instance"));
     app.quit();
   } else {
     app.on("second-instance", (_event, commandLine, _workingDirectory) => {
@@ -1639,6 +1689,15 @@ app.on("will-quit", () => {
 
 app.on("quit", (_event, exitCode) => {
   logLifecycle("app:quit", { exitCode });
+  // Unscoped and at info, matching this session's start banner. The
+  // previous-session banner is deliberately scoped and at warn; see onReady.
+  log.info(
+    formatExitBanner(
+      process.pid,
+      `exitCode=${exitCode}`,
+      Date.now() - LAUNCH_TIME,
+    ),
+  );
 });
 
 app.on("activate", () => {

--- a/src/main/session_banner.test.ts
+++ b/src/main/session_banner.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatErrorBanner,
+  formatExitBanner,
+  formatPreviousSessionBanner,
+  formatStartBanner,
+  formatTimestamp,
+  formatUptime,
+} from "./session_banner";
+
+describe("formatUptime", () => {
+  it("shows seconds under a minute", () => {
+    expect(formatUptime(0)).toBe("0s");
+    expect(formatUptime(999)).toBe("0s");
+    expect(formatUptime(1000)).toBe("1s");
+    expect(formatUptime(59_000)).toBe("59s");
+  });
+
+  it("shows minutes and seconds under an hour", () => {
+    expect(formatUptime(60_000)).toBe("1m0s");
+    expect(formatUptime(252_000)).toBe("4m12s");
+    expect(formatUptime(3_599_000)).toBe("59m59s");
+  });
+
+  it("drops seconds once past an hour", () => {
+    expect(formatUptime(3_600_000)).toBe("1h0m");
+    expect(formatUptime(28_560_000)).toBe("7h56m");
+  });
+
+  it("shows days for long sessions", () => {
+    expect(formatUptime(86_400_000)).toBe("1d0h0m");
+    expect(formatUptime(273_600_000)).toBe("3d4h0m");
+  });
+
+  it("returns unknown rather than nonsense for bad input", () => {
+    expect(formatUptime(-1)).toBe("unknown");
+    expect(formatUptime(Number.NaN)).toBe("unknown");
+    expect(formatUptime(Number.POSITIVE_INFINITY)).toBe("unknown");
+  });
+});
+
+describe("formatTimestamp", () => {
+  it("matches electron-log's prefix format in local time", () => {
+    const local = new Date(2026, 7, 17, 0, 39, 48, 628);
+    expect(formatTimestamp(local.getTime())).toBe("2026-08-17 00:39:48.628");
+  });
+
+  it("pads every field", () => {
+    const local = new Date(2026, 0, 2, 3, 4, 5, 6);
+    expect(formatTimestamp(local.getTime())).toBe("2026-01-02 03:04:05.006");
+  });
+});
+
+describe("banners", () => {
+  it("are all found by a single grep for the marker", () => {
+    const lines = [
+      formatStartBanner({
+        pid: 4821,
+        version: "1.11.0-beta.1",
+        platform: "linux",
+        arch: "x64",
+        electron: "38.0.0",
+        node: "20.19.0",
+      }),
+      formatExitBanner(4821, "exitCode=0", 28_560_000),
+      formatExitBanner(4821, "duplicate instance"),
+      formatErrorBanner(4821, "uncaughtException", 252_000),
+      formatPreviousSessionBanner(
+        new Date(2026, 7, 17, 0, 39, 48, 628).getTime(),
+      ),
+    ];
+    for (const line of lines) {
+      expect(line).toContain("===== Dyad ");
+      expect(line.split("\n")).toHaveLength(1);
+    }
+  });
+
+  it("includes the launch details in the start banner", () => {
+    expect(
+      formatStartBanner({
+        pid: 4821,
+        version: "1.11.0-beta.1",
+        platform: "linux",
+        arch: "x64",
+        electron: "38.0.0",
+        node: "20.19.0",
+      }),
+    ).toBe(
+      "===== Dyad started | pid 4821 | 1.11.0-beta.1 | linux x64 | electron 38.0.0 | node 20.19.0 =====",
+    );
+  });
+
+  it("omits uptime when it isn't known", () => {
+    expect(formatExitBanner(4821, "duplicate instance")).toBe(
+      "===== Dyad exiting | pid 4821 | duplicate instance =====",
+    );
+    expect(formatExitBanner(4821, "exitCode=0", 28_560_000)).toBe(
+      "===== Dyad exiting | pid 4821 | exitCode=0 | uptime 7h56m =====",
+    );
+  });
+
+  it("pairs a second instance's banners by pid, not by position", () => {
+    // A duplicate launch writes its pair into the running session's log.
+    const live = formatStartBanner({
+      pid: 3310,
+      version: "1.11.0-beta.1",
+      platform: "linux",
+      arch: "x64",
+      electron: "38.0.0",
+      node: "20.19.0",
+    });
+    const intruder = formatExitBanner(4821, "duplicate instance");
+    expect(live).toContain("pid 3310");
+    expect(intruder).toContain("pid 4821");
+  });
+
+  it("names the error kind and how long the session had been up", () => {
+    expect(formatErrorBanner(4821, "uncaughtException", 252_000)).toBe(
+      "===== Dyad main-process error | pid 4821 | uncaughtException | uptime 4m12s =====",
+    );
+  });
+
+  it("says so when the lost session's start time is unavailable", () => {
+    expect(formatPreviousSessionBanner(undefined)).toBe(
+      "===== Dyad previous session ended unexpectedly | start time unknown =====",
+    );
+  });
+
+  it("approximates the lost session's uptime from its last sample", () => {
+    const started = new Date(2026, 7, 17, 0, 39, 48, 628).getTime();
+    expect(formatPreviousSessionBanner(started, started + 28_560_000)).toBe(
+      "===== Dyad previous session ended unexpectedly | started 2026-08-17 00:39:48.628 | ran ~7h56m =====",
+    );
+  });
+
+  it("does not claim a bound when the sample predates the session", () => {
+    const started = new Date(2026, 7, 17, 0, 39, 48, 628).getTime();
+    // Left over from an earlier run, so this session never sampled.
+    expect(formatPreviousSessionBanner(started, started - 5_000)).toBe(
+      "===== Dyad previous session ended unexpectedly | started 2026-08-17 00:39:48.628 | uptime unknown (ended before its first sample) =====",
+    );
+    expect(formatPreviousSessionBanner(started, started)).toContain(
+      "uptime unknown",
+    );
+  });
+
+  it("omits uptime when either end of the interval is missing", () => {
+    const started = new Date(2026, 7, 17, 0, 39, 48, 628).getTime();
+    expect(formatPreviousSessionBanner(started)).toBe(
+      "===== Dyad previous session ended unexpectedly | started 2026-08-17 00:39:48.628 =====",
+    );
+    expect(formatPreviousSessionBanner(undefined, started)).not.toContain(
+      "ran",
+    );
+  });
+});

--- a/src/main/session_banner.ts
+++ b/src/main/session_banner.ts
@@ -1,0 +1,109 @@
+// Single-line markers delimiting each run of the app in the log file. The log
+// is appended across launches, so without these it's ambiguous where one
+// session ends and the next begins. Grep for "===== Dyad " to find them all.
+//
+// Lines written by the running process carry its pid, because a second instance
+// (a deep link, or a duplicate launch) writes into the same log before quitting.
+// Without the pid its lines look like they belong to the live session.
+
+const MARKER = "=====";
+
+export interface StartBannerInfo {
+  pid: number;
+  version: string;
+  platform: string;
+  arch: string;
+  electron: string;
+  node: string;
+}
+
+export function formatStartBanner({
+  pid,
+  version,
+  platform,
+  arch,
+  electron,
+  node,
+}: StartBannerInfo): string {
+  return `${MARKER} Dyad started | pid ${pid} | ${version} | ${platform} ${arch} | electron ${electron} | node ${node} ${MARKER}`;
+}
+
+export function formatExitBanner(
+  pid: number,
+  reason: string,
+  uptimeMs?: number,
+): string {
+  const uptime =
+    uptimeMs === undefined ? "" : ` | uptime ${formatUptime(uptimeMs)}`;
+  return `${MARKER} Dyad exiting | pid ${pid} | ${reason}${uptime} ${MARKER}`;
+}
+
+// Not a session boundary: these errors are caught and logged, and the app keeps
+// running. A crash that really ends the session writes nothing — the next
+// launch reports it via formatPreviousSessionBanner.
+export function formatErrorBanner(
+  pid: number,
+  kind: string,
+  uptimeMs: number,
+): string {
+  return `${MARKER} Dyad main-process error | pid ${pid} | ${kind} | uptime ${formatUptime(uptimeMs)} ${MARKER}`;
+}
+
+// lastSeenAt is the crashed session's final performance sample. It lags the
+// crash by up to one heartbeat, so the uptime is approximate and always low.
+export function formatPreviousSessionBanner(
+  startedAt: number | undefined,
+  lastSeenAt?: number,
+): string {
+  const started =
+    startedAt === undefined
+      ? "start time unknown"
+      : `started ${formatTimestamp(startedAt)}`;
+  return `${MARKER} Dyad previous session ended unexpectedly | ${started}${formatPreviousUptime(startedAt, lastSeenAt)} ${MARKER}`;
+}
+
+function formatPreviousUptime(
+  startedAt: number | undefined,
+  lastSeenAt: number | undefined,
+): string {
+  if (startedAt === undefined || lastSeenAt === undefined) {
+    return "";
+  }
+  // A sample older than the session means it never took one, so it died early.
+  // How early depends on how long startup took, so don't name a number.
+  if (lastSeenAt <= startedAt) {
+    return " | uptime unknown (ended before its first sample)";
+  }
+  return ` | ran ~${formatUptime(lastSeenAt - startedAt)}`;
+}
+
+// Matches electron-log's own line prefix format so the printed time can be
+// compared directly against surrounding log lines. Local time, like theirs.
+// Exported, like formatUptime, only so the tests can table-test it directly.
+export function formatTimestamp(ms: number): string {
+  const d = new Date(ms);
+  const pad = (value: number, width = 2) => String(value).padStart(width, "0");
+  return (
+    `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ` +
+    `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}.${pad(d.getMilliseconds(), 3)}`
+  );
+}
+
+// Compact by design: this goes in a log column, not a sentence — "7h56m", not
+// "7 hours". formatDuration in ipc/utils/pty_command_runner is the prose
+// variant for user-facing text; they are deliberately separate.
+export function formatUptime(ms: number): string {
+  if (ms < 0 || !Number.isFinite(ms)) {
+    return "unknown";
+  }
+  const totalSeconds = Math.floor(ms / 1000);
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (days > 0) return `${days}d${hours}h${minutes}m`;
+  if (hours > 0) return `${hours}h${minutes}m`;
+  if (minutes > 0) return `${minutes}m${seconds}s`;
+  return `${seconds}s`;
+}

--- a/src/main/settings.test.ts
+++ b/src/main/settings.test.ts
@@ -15,6 +15,7 @@ import {
   decrypt,
   notifyRendererErrorToastListenerReady,
   writeCrashSentinel,
+  claimCrashSentinel,
   setSentinelActiveChat,
   readCrashSentinel,
   rewriteRecoveredSafeStorageSecretsAfterKeychainUnlock,
@@ -1363,6 +1364,9 @@ describe("crash sentinel", () => {
     mockGetUserDataPath.mockReturnValue(mockUserDataPath);
     mockPath.join.mockImplementation((...args: string[]) => args.join("/"));
     store = {};
+    mockFs.existsSync.mockImplementation(
+      (p) => store[p as string] !== undefined,
+    );
     mockFs.writeFileSync.mockImplementation((p, data) => {
       store[p as string] = data as string;
     });
@@ -1377,20 +1381,52 @@ describe("crash sentinel", () => {
     });
   });
 
-  it("writeCrashSentinel writes JSON with a timestamp and no active chat", () => {
-    writeCrashSentinel();
+  it("writeCrashSentinel persists the launch time with no active chat", () => {
+    writeCrashSentinel(1700000000000);
     const data = readCrashSentinel();
-    expect(typeof data?.ts).toBe("number");
+    expect(data?.ts).toBe(1700000000000);
     expect(data?.activeChatId).toBeUndefined();
   });
 
+  it("claimCrashSentinel reports the previous session and takes over the file", () => {
+    store[sentinelPath] = JSON.stringify({
+      ts: 1600000000000,
+      activeChatId: 5,
+    });
+
+    const previousSession = claimCrashSentinel(1700000000000);
+
+    expect(previousSession.existed).toBe(true);
+    expect(previousSession.previous?.ts).toBe(1600000000000);
+    expect(previousSession.previous?.activeChatId).toBe(5);
+    // The file now belongs to this session, so a crash below is attributed here.
+    expect(readCrashSentinel()?.ts).toBe(1700000000000);
+    expect(readCrashSentinel()?.activeChatId).toBeUndefined();
+  });
+
+  it("claimCrashSentinel reports no previous session after a clean exit", () => {
+    const previousSession = claimCrashSentinel(1700000000000);
+
+    expect(previousSession.existed).toBe(false);
+    expect(previousSession.previous).toBeNull();
+    expect(readCrashSentinel()?.ts).toBe(1700000000000);
+  });
+
+  it("claimCrashSentinel flags a legacy sentinel as existing but unparseable", () => {
+    store[sentinelPath] = "1600000000000";
+
+    const previousSession = claimCrashSentinel(1700000000000);
+
+    expect(previousSession.existed).toBe(true);
+    expect(previousSession.previous).toBeNull();
+  });
+
   it("setSentinelActiveChat records the chat id, preserving the timestamp", () => {
-    writeCrashSentinel();
-    const ts = readCrashSentinel()?.ts;
+    writeCrashSentinel(1700000000000);
     setSentinelActiveChat(42);
     const data = readCrashSentinel();
     expect(data?.activeChatId).toBe(42);
-    expect(data?.ts).toBe(ts);
+    expect(data?.ts).toBe(1700000000000);
   });
 
   it("readCrashSentinel returns null for the legacy bare-timestamp format", () => {

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -125,13 +125,29 @@ interface CrashSentinelData {
   activeChatId?: number;
 }
 
-export function writeCrashSentinel(): void {
+// startedAt should be the launch time, so a crash reported on the next run can
+// point at the start banner of the lost session. It's captured a moment before
+// that banner is written, so the printed time is near it, not identical.
+export function writeCrashSentinel(startedAt: number): void {
   try {
-    const data: CrashSentinelData = { ts: Date.now() };
+    const data: CrashSentinelData = { ts: startedAt };
     fs.writeFileSync(getCrashSentinelPath(), JSON.stringify(data));
   } catch (error) {
     logger.error("Error writing crash sentinel:", error);
   }
+}
+
+// Takes over the sentinel for this session, returning what the previous one
+// held. Read and write are paired here so the write can't accidentally be
+// ordered before the read, which would make every launch look like a crash.
+export function claimCrashSentinel(startedAt: number): {
+  previous: CrashSentinelData | null;
+  existed: boolean;
+} {
+  const existed = crashSentinelExists();
+  const previous = readCrashSentinel();
+  writeCrashSentinel(startedAt);
+  return { previous, existed };
 }
 
 // Records the chat that just started streaming into the existing sentinel,
@@ -158,8 +174,10 @@ function readLegacyCrashSentinelTimestamp(sentinelPath: string): number {
       return legacyTimestamp;
     }
   } catch {
-    // Missing or malformed legacy sentinels can be replaced with a fresh timestamp.
+    // Nothing readable to recover a start time from.
   }
+  // Only reached when this session never wrote a sentinel, so it's a stand-in,
+  // not a launch time. The next run's log banner will report it as one.
   return Date.now();
 }
 
@@ -173,14 +191,14 @@ export function clearCrashSentinel(): void {
   }
 }
 
-export function crashSentinelExists(): boolean {
+function crashSentinelExists(): boolean {
   return fs.existsSync(getCrashSentinelPath());
 }
 
 // Reads and parses the sentinel. Returns null if missing or not a JSON object
 // (e.g. the legacy bare-timestamp format from older builds). That's harmless:
-// crash detection is existence-based, and only activeChatId is consumed, so a
-// null here just means no chat to offer for upload.
+// crash detection is existence-based, so a null here just means no chat to
+// offer for upload and no start time for the previous-session log banner.
 export function readCrashSentinel(): CrashSentinelData | null {
   try {
     const parsed = JSON.parse(fs.readFileSync(getCrashSentinelPath(), "utf-8"));


### PR DESCRIPTION
_Description written by Claude._

`main.log` is appended across every launch and only rotates at 1 MB, so a log tail submitted with a bug report gives no indication of where one run of the app ends and the next begins. Nothing logged a startup marker, and the existing `App is quitting` line only fired on a clean exit.

Adds single-line markers, all containing the literal `===== Dyad ` so one grep finds every boundary:

- `Dyad started` — pid, version, platform/arch, Electron and Node versions. Emitted at the top of module evaluation, so it is the session's first line.
- `Dyad exiting` — pid, reason and uptime, from the `quit` handler and the duplicate-instance branch.
- `Dyad main-process error` — an uncaught exception or unhandled rejection, via electron-log's existing `errorHandler`. Not a boundary; the app keeps running.
- `Dyad previous session ended unexpectedly` — reported on the next launch from the crash sentinel, with the lost session's start time and an approximate uptime taken from `lastKnownPerformance`.

The pid is included because a second instance — a `dyad://` deep link, or a duplicate launch — writes its own banners into the running session's log before quitting, where they would otherwise read as a session boundary.

Supporting changes:

- Moves the dev-only `app.setPath("userData", ...)` block above the electron-log setup. electron-log resolves its log directory on the first write and caches it for the session, and the start banner is now that first write, so without this the entire dev session's log lands in the OS userData directory instead of the project's `./userData`. Affects Linux and Windows; macOS logs never follow userData.
- `writeCrashSentinel` now takes the launch time, and a new `claimCrashSentinel` pairs the sentinel read and write so the ordering cannot be inverted. `onReady` calls it before any startup work — ahead of database migrations, keychain access and git work — so a startup crash is attributed to the session that actually crashed rather than to the previous one.
- Adds unit coverage for the banner formatters and the sentinel handover.

Known limitations, all deliberate:

- A crash before `onReady` claims the sentinel, or a failed sentinel write, still leaves the previous session's sentinel, so that banner can name the wrong session's timestamps.
- A legacy bare-timestamp sentinel yields `start time unknown`.
- Banners are info-level, so the 20-line warn-filtered debug view drops them. The previous-session banner is warn and does appear there.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

