### PR TITLE
Add grace period before app sidebar collapse

### DIFF
--- a/src/components/app-sidebar-state.test.ts
+++ b/src/components/app-sidebar-state.test.ts
@@ -3,6 +3,7 @@ import {
   getRouteSidebarPanel,
   getSelectedSidebarPanel,
   isSidebarItemActive,
+  shouldExpandSidebarForHover,
   shouldShowSelectedAppChatList,
 } from "@/components/app-sidebar-state";
 
@@ -29,6 +30,23 @@ describe("app sidebar state", () => {
         pathname: "/apps",
       }),
     ).toBe("Apps");
+  });
+
+  it("does not restore a hover expansion after the pointer leaves", () => {
+    expect(
+      shouldExpandSidebarForHover({
+        hoverState: "start-hover:app",
+        sidebarState: "collapsed",
+        isPointerOverSidebar: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldExpandSidebarForHover({
+        hoverState: "start-hover:app",
+        sidebarState: "collapsed",
+        isPointerOverSidebar: false,
+      }),
+    ).toBe(false);
   });
 
   it("shows the selected app chat list only inside Apps with an app selected", () => {

--- a/src/components/app-sidebar-state.ts
+++ b/src/components/app-sidebar-state.ts
@@ -45,6 +45,22 @@ export function getHoverSidebarPanel(
   return null;
 }
 
+export function shouldExpandSidebarForHover({
+  hoverState,
+  sidebarState,
+  isPointerOverSidebar,
+}: {
+  hoverState: AppSidebarHoverState;
+  sidebarState: "expanded" | "collapsed";
+  isPointerOverSidebar: boolean;
+}) {
+  return (
+    isPointerOverSidebar &&
+    sidebarState === "collapsed" &&
+    hoverState.startsWith("start-hover")
+  );
+}
+
 export function getSelectedSidebarPanel({
   hoverState,
   sidebarState,

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -39,6 +39,7 @@ import {
   type AppSidebarItemTitle,
   getSelectedSidebarPanel,
   isSidebarItemActive,
+  shouldExpandSidebarForHover,
   shouldShowSelectedAppChatList,
 } from "./app-sidebar-state";
 
@@ -156,6 +157,7 @@ export function AppSidebar() {
   const [hoverState, setHoverState] =
     useState<AppSidebarHoverState>("no-hover");
   const expandedByHover = useRef(false);
+  const isPointerOverSidebar = useRef(false);
   const collapseTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const setHelpDialog = useSetAtom(helpDialogAtom);
   const [isDropdownOpen] = useAtom(dropdownOpenAtom);
@@ -174,9 +176,23 @@ export function AppSidebar() {
   useEffect(() => cancelPendingCollapse, [cancelPendingCollapse]);
 
   useEffect(() => {
-    if (hoverState.startsWith("start-hover") && state === "collapsed") {
+    if (
+      shouldExpandSidebarForHover({
+        hoverState,
+        sidebarState: state,
+        isPointerOverSidebar: isPointerOverSidebar.current,
+      })
+    ) {
       expandedByHover.current = true;
       toggleSidebar();
+    } else if (
+      hoverState.startsWith("start-hover") &&
+      state === "collapsed" &&
+      !isPointerOverSidebar.current
+    ) {
+      cancelPendingCollapse();
+      expandedByHover.current = false;
+      setHoverState("no-hover");
     }
     if (
       hoverState === "clear-hover" &&
@@ -188,7 +204,14 @@ export function AppSidebar() {
       expandedByHover.current = false;
       setHoverState("no-hover");
     }
-  }, [hoverState, toggleSidebar, state, setHoverState, isDropdownOpen]);
+  }, [
+    hoverState,
+    toggleSidebar,
+    state,
+    setHoverState,
+    isDropdownOpen,
+    cancelPendingCollapse,
+  ]);
 
   const routerState = useRouterState();
   const selectedItem = getSelectedSidebarPanel({
@@ -213,12 +236,14 @@ export function AppSidebar() {
       collapsible="icon"
       className="shadow-lg"
       onMouseEnter={() => {
+        isPointerOverSidebar.current = true;
         cancelPendingCollapse();
         setHoverState((current) =>
           current === "clear-hover" ? "no-hover" : current,
         );
       }}
       onMouseLeave={() => {
+        isPointerOverSidebar.current = false;
         if (!isDropdownOpen) {
           cancelPendingCollapse();
           collapseTimer.current = setTimeout(() => {

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -9,7 +9,7 @@ import {
 } from "lucide-react";
 import { Link, useNavigate, useRouterState } from "@tanstack/react-router";
 import { useSidebar } from "@/components/ui/sidebar"; // import useSidebar hook
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { ComponentType } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
@@ -41,6 +41,8 @@ import {
   isSidebarItemActive,
   shouldShowSelectedAppChatList,
 } from "./app-sidebar-state";
+
+const SIDEBAR_COLLAPSE_DELAY_MS = 300;
 
 // Menu items.
 const items = [
@@ -154,12 +156,22 @@ export function AppSidebar() {
   const [hoverState, setHoverState] =
     useState<AppSidebarHoverState>("no-hover");
   const expandedByHover = useRef(false);
+  const collapseTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const setHelpDialog = useSetAtom(helpDialogAtom);
   const [isDropdownOpen] = useAtom(dropdownOpenAtom);
   const selectedAppId = useAtomValue(selectedAppIdAtom);
   const setSelectedAppId = useSetAtom(selectedAppIdAtom);
   const setSelectedChatId = useSetAtom(selectedChatIdAtom);
   const navigate = useNavigate();
+
+  const cancelPendingCollapse = useCallback(() => {
+    if (collapseTimer.current !== null) {
+      clearTimeout(collapseTimer.current);
+      collapseTimer.current = null;
+    }
+  }, []);
+
+  useEffect(() => cancelPendingCollapse, [cancelPendingCollapse]);
 
   useEffect(() => {
     if (hoverState.startsWith("start-hover") && state === "collapsed") {
@@ -200,9 +212,19 @@ export function AppSidebar() {
     <Sidebar
       collapsible="icon"
       className="shadow-lg"
+      onMouseEnter={() => {
+        cancelPendingCollapse();
+        setHoverState((current) =>
+          current === "clear-hover" ? "no-hover" : current,
+        );
+      }}
       onMouseLeave={() => {
         if (!isDropdownOpen) {
-          setHoverState("clear-hover");
+          cancelPendingCollapse();
+          collapseTimer.current = setTimeout(() => {
+            collapseTimer.current = null;
+            setHoverState("clear-hover");
+          }, SIDEBAR_COLLAPSE_DELAY_MS);
         }
       }}
     >


### PR DESCRIPTION
## Summary

Adds a 300 ms grace period before the hover-expanded app navigation sidebar collapses, making brief pointer slips less disruptive while keeping navigation responsive.

- Applies the delay only when the pointer leaves the entire sidebar; switching among Apps, Settings, and Library previews remains immediate.
- Cancels a pending collapse when the pointer re-enters and clears the timer when the component unmounts.
- Preserves the dropdown-open guard and the existing 200 ms visual collapse animation. Reviewers should verify that the 300 ms grace period feels natural in normal navigation.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only hover/collapse timing in the app sidebar; no auth, data, or security impact.
> 
> **Overview**
> Adds a **300ms grace period** before the hover-expanded app sidebar collapses when the pointer leaves, so brief slips are less disruptive.
> 
> Collapse is delayed only when leaving the whole sidebar; switching among Apps, Settings, and Library stays immediate. Re-entering cancels the pending timer, and hover expansion is not restored after the pointer has already left (`shouldExpandSidebarForHover`). Dropdown-open still blocks collapse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41ad54dd19ff250007ae5777254076f719172157. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->