### PR TITLE
fix(search-replace): stop writing stray blank lines into edited files

### DIFF
--- a/src/pro/main/ipc/handlers/local_agent/tools/search_replace.spec.ts
+++ b/src/pro/main/ipc/handlers/local_agent/tools/search_replace.spec.ts
@@ -341,9 +341,12 @@ describe("searchReplaceTool", () => {
       );
 
       expect(result).toContain("Successfully");
+      // Asserted exactly, not with stringContaining: the point of these cases
+      // is what the stray newline does to the OUTPUT, and a substring check
+      // passes just as happily on a file with extra blank lines in it.
       expect(fs.promises.writeFile).toHaveBeenCalledWith(
         "/test/app/test.ts",
-        expect.stringContaining("const y = 2"),
+        "function test() {\n  const y = 2;\n  return y;\n}",
       );
     });
 
@@ -371,7 +374,7 @@ describe("searchReplaceTool", () => {
       expect(result).toContain("Successfully");
       expect(fs.promises.writeFile).toHaveBeenCalledWith(
         "/test/app/test.ts",
-        expect.stringContaining("const y = 2"),
+        "function test() {\n  const y = 2;\n  return y;\n}",
       );
     });
 
@@ -399,7 +402,64 @@ describe("searchReplaceTool", () => {
       expect(result).toContain("Successfully");
       expect(fs.promises.writeFile).toHaveBeenCalledWith(
         "/test/app/test.ts",
-        expect.stringContaining("const y = 2"),
+        "function test() {\n  const y = 2;\n  return y;\n}",
+      );
+    });
+
+    // The shape observed in production traffic: GPT 5.6 Sol terminates both
+    // args together because it copies a contiguous region of the file, and the
+    // trailing empty line matches nothing when the boundary has no blank line.
+    it("does not add a blank line when both args are newline-terminated and the file has none", async () => {
+      const originalContent = [
+        "function test() {",
+        "  if (!ok) {",
+        "    rollback();",
+        "  }",
+        "}",
+      ].join("\n");
+
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.promises.readFile).mockResolvedValue(originalContent);
+
+      const result = await searchReplaceTool.execute(
+        {
+          file_path: "test.ts",
+          old_string: "  if (!ok) {\n",
+          new_string: "  if (!found) {\n",
+        },
+        mockContext,
+      );
+
+      expect(result).toContain("Successfully");
+      expect(fs.promises.writeFile).toHaveBeenCalledWith(
+        "/test/app/test.ts",
+        "function test() {\n  if (!found) {\n    rollback();\n  }\n}",
+      );
+    });
+
+    it("preserves a blank line the terminated args genuinely matched", async () => {
+      const originalContent = [
+        "const a = 1;",
+        "const b = 2;",
+        "",
+        "const c = 3;",
+      ].join("\n");
+
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.promises.readFile).mockResolvedValue(originalContent);
+
+      await searchReplaceTool.execute(
+        {
+          file_path: "test.ts",
+          old_string: "const b = 2;\n",
+          new_string: "const b = 22;\n",
+        },
+        mockContext,
+      );
+
+      expect(fs.promises.writeFile).toHaveBeenCalledWith(
+        "/test/app/test.ts",
+        "const a = 1;\nconst b = 22;\n\nconst c = 3;",
       );
     });
   });

--- a/src/pro/main/ipc/processors/search_replace_passes.txt
+++ b/src/pro/main/ipc/processors/search_replace_passes.txt
@@ -1043,3 +1043,87 @@ step4
 <output_file>
 step4
 </output_file>
+
+--- Test case name: spurious trailing blank line in both blocks does not add a blank line ---
+<original_file>
+function f() {
+  if (!ok) {
+    rollback();
+  }
+}
+</original_file>
+<<<<<<< SEARCH
+  if (!ok) {
+
+=======
+  if (!found) {
+
+>>>>>>> REPLACE
+<output_file>
+function f() {
+  if (!found) {
+    rollback();
+  }
+}
+</output_file>
+
+--- Test case name: real trailing blank line in both blocks is preserved ---
+<original_file>
+const a = 1;
+const b = 2;
+
+const c = 3;
+</original_file>
+<<<<<<< SEARCH
+const b = 2;
+
+=======
+const b = 22;
+
+>>>>>>> REPLACE
+<output_file>
+const a = 1;
+const b = 22;
+
+const c = 3;
+</output_file>
+
+--- Test case name: spurious leading blank line in both blocks does not add a blank line ---
+<original_file>
+const a = 1;
+const b = 2;
+const c = 3;
+</original_file>
+<<<<<<< SEARCH
+
+const b = 2;
+=======
+
+const b = 22;
+>>>>>>> REPLACE
+<output_file>
+const a = 1;
+const b = 22;
+const c = 3;
+</output_file>
+
+--- Test case name: replace block keeps its own blank lines when search has none to trim ---
+<original_file>
+const a = 1;
+const b = 2;
+const c = 3;
+</original_file>
+<<<<<<< SEARCH
+const b = 2;
+=======
+const b = 22;
+
+const b2 = 3;
+>>>>>>> REPLACE
+<output_file>
+const a = 1;
+const b = 22;
+
+const b2 = 3;
+const c = 3;
+</output_file>

--- a/src/pro/main/ipc/processors/search_replace_processor.ts
+++ b/src/pro/main/ipc/processors/search_replace_processor.ts
@@ -90,6 +90,43 @@ function trimEmptyLines(lines: string[]): string[] {
 }
 
 /**
+ * Mirror onto the replace block whatever edge empty lines the fallback had to
+ * strip from the search block, capped at the replace block's own edge empty
+ * lines. Never removes a non-empty line.
+ */
+function trimReplaceEdgesLike(
+  replaceLines: string[],
+  originalSearchLines: string[],
+  trimmedSearchLines: string[],
+): string[] {
+  let leadingTrimmed = 0;
+  while (
+    leadingTrimmed < originalSearchLines.length &&
+    originalSearchLines[leadingTrimmed] === ""
+  ) {
+    leadingTrimmed++;
+  }
+  const trailingTrimmed =
+    originalSearchLines.length - trimmedSearchLines.length - leadingTrimmed;
+
+  const result = [...replaceLines];
+  for (let i = 0; i < trailingTrimmed; i++) {
+    if (result.length === 0 || result[result.length - 1] !== "") break;
+    result.pop();
+  }
+  // Unreachable through the current parser: parseSearchReplaceBlocks consumes
+  // leading blank lines in the `\s*\n` after the SEARCH marker, so a search
+  // block never arrives with one and leadingTrimmed is always 0. Kept for
+  // symmetry with the trailing case, and because leadingTrimmed itself stays
+  // load-bearing above - trailingTrimmed is derived from it.
+  for (let i = 0; i < leadingTrimmed; i++) {
+    if (result.length === 0 || result[0] !== "") break;
+    result.shift();
+  }
+  return result;
+}
+
+/**
  * Find all positions where searchLines match against resultLines using the given comparator
  */
 function findMatchPositions(
@@ -324,6 +361,15 @@ export function applySearchReplace(
         const trimmedResult = cascadingMatch(resultLines, trimmedSearchLines);
         if (!trimmedResult.error) {
           matchResult = trimmedResult;
+          // The search block's edge empty lines were spurious - they matched
+          // nothing in the file. The replace block's edge empty lines came from
+          // the same off-by-one, so drop them too or they land in the file as
+          // stray blank lines.
+          replaceLines = trimReplaceEdgesLike(
+            replaceLines,
+            searchLines,
+            trimmedSearchLines,
+          );
           searchLines = trimmedSearchLines;
           logger.debug(
             "Matched after trimming leading/trailing empty lines from search content",


### PR DESCRIPTION
Theoretically closes #4286. This might benefit from some more testing/evaluation on search_replace, but I think this fixes the problem that was at the heart of the issue. I'll open a different PR with the extension of the eval suite I used to test this.

The rest of this description was generated by Claude:

search_replace inserted stray blank lines into the files it edited. It hit roughly 1 in 12 edits and accumulated across a session when tested with GPT 5.6 Sol.

The tool joins the model's args with newline delimiters, so a newline that only terminates an arg becomes a trailing empty line in the parsed block. The search side's copy matches nothing and the trimEmptyLines fallback strips it, but nothing stripped the replace side, so the phantom line reached the file. Mirror the fallback's trim onto the replace block, capped at its own edge blanks so a non-empty line is never removed.

Measured on GPT 5.6 Sol across the 16-case search_replace eval suite:

  | metric                                       | count |
  | -------------------------------------------- | ----- |
  | search_replace calls that applied            |    82 |
  | ...where both args ended in a newline        |    18 |
  | ...where that newline matched no blank line  |     7 |
  | ...that wrote a stray blank line             |     7 |


Replaying those calls against the fix: 7 -> 0, byte-identical on the other 75. Matching is untouched — only replaceLines is mutated, after the match index is decided.

Trade-off: a single terminator on new_string meant as "add a blank line", paired with an old_string that mis-terminates a boundary having no blank line, now loses that blank. In 18/18 symmetric calls the replace block ended on the same line as the search block — copied context, not authored blanks — and new_string ending "\n\n" still yields one.

Caveats:
- The asymmetric shape (new_string terminated, old_string not) is unfixed; the fallback never fires for it. Leaving it is justified by the pattern likely being uncommon among models - it was not seen once in 82 calls made by GPT 5.6 Sol.
- applySearchReplace is shared with the <dyad-search-replace> tag path. The new DSL cases cover that path's input shape, but no real tag-path traffic was measured.
- Evaluated with one model, 82 calls.

Also tightens three old_string newline tests from stringContaining to exact output — they passed just as happily on corrupted output, which is why this went unnoticed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

