### PR TITLE
Graduate home chat app selector

### DIFF
--- a/e2e-tests/helpers/page-objects/PageObject.ts
+++ b/e2e-tests/helpers/page-objects/PageObject.ts
@@ -347,19 +347,14 @@ export class PageObject {
   async setUp({
     autoApprove = false,
     enableBasicAgent = false,
-    enableSelectAppFromHomeChatInput = false,
   }: {
     autoApprove?: boolean;
     enableBasicAgent?: boolean;
-    enableSelectAppFromHomeChatInput?: boolean;
   } = {}) {
     await this.baseSetup();
     await this.navigation.goToSettingsTab();
     if (autoApprove) {
       await this.settings.toggleAutoApprove();
-    }
-    if (enableSelectAppFromHomeChatInput) {
-      await this.settings.toggleEnableSelectAppFromHomeChatInput();
     }
     await this.settings.setUpTestProvider();
     await this.settings.setUpTestModel();

--- a/e2e-tests/helpers/page-objects/components/Settings.ts
+++ b/e2e-tests/helpers/page-objects/components/Settings.ts
@@ -34,14 +34,6 @@ export class Settings {
       .click();
   }
 
-  async toggleEnableSelectAppFromHomeChatInput() {
-    await this.page
-      .getByRole("switch", {
-        name: "Enable Select App from Home Chat Input",
-      })
-      .click();
-  }
-
   async toggleAutoUpdate() {
     await this.page.getByRole("switch", { name: "Auto-update" }).click();
   }

--- a/e2e-tests/home_chat_existing_app.spec.ts
+++ b/e2e-tests/home_chat_existing_app.spec.ts
@@ -4,7 +4,6 @@ import { expect } from "@playwright/test";
 test("home chat - start new chat in existing app", async ({ po }) => {
   await po.setUp({
     autoApprove: true,
-    enableSelectAppFromHomeChatInput: true,
   });
 
   // Create an app first
@@ -53,7 +52,6 @@ test("home chat - start new chat in existing app", async ({ po }) => {
 test("home chat - clear selected app", async ({ po }) => {
   await po.setUp({
     autoApprove: true,
-    enableSelectAppFromHomeChatInput: true,
   });
 
   // Create an app first

--- a/src/components/chat/HomeChatInput.test.tsx
+++ b/src/components/chat/HomeChatInput.test.tsx
@@ -21,7 +21,6 @@ vi.mock("@/hooks/useSettings", () => ({
   useSettings: () => ({
     settings: {
       enableDyadPro: true,
-      enableSelectAppFromHomeChatInput: true,
     },
   }),
 }));

--- a/src/components/chat/HomeChatInput.test.tsx
+++ b/src/components/chat/HomeChatInput.test.tsx
@@ -4,6 +4,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { HomeChatInput } from "./HomeChatInput";
 
 const mocks = vi.hoisted(() => ({
+  apps: [{ id: 1, name: "Existing" }],
+  appsLoading: false,
   setInputValue: vi.fn(),
   setSelectedApp: vi.fn(),
   transcription: null as null | ((text: string) => void),
@@ -37,7 +39,10 @@ vi.mock("@/hooks/useTypingPlaceholder", () => ({
   useTypingPlaceholder: () => "something",
 }));
 vi.mock("@/hooks/useLoadApps", () => ({
-  useLoadApps: () => ({ apps: [{ id: 1, name: "Existing" }] }),
+  useLoadApps: () => ({
+    apps: mocks.apps,
+    loading: mocks.appsLoading,
+  }),
 }));
 vi.mock("@/hooks/useAttachments", () => ({
   useAttachments: () => ({
@@ -105,8 +110,10 @@ vi.mock("@/ipc/types", () => ({
   ipc: { system: { openExternalUrl: vi.fn() } },
 }));
 
-describe("HomeChatInput disabled state", () => {
+describe("HomeChatInput", () => {
   beforeEach(() => {
+    mocks.apps = [{ id: 1, name: "Existing" }];
+    mocks.appsLoading = false;
     mocks.setInputValue.mockReset();
     mocks.setSelectedApp.mockReset();
     mocks.transcription = null;
@@ -147,5 +154,20 @@ describe("HomeChatInput disabled state", () => {
     act(() => mocks.transcription?.("late transcript"));
 
     expect(mocks.setInputValue).not.toHaveBeenCalled();
+  });
+
+  it("shows the app selector only when the loaded list contains an app", () => {
+    mocks.appsLoading = true;
+    const view = render(<HomeChatInput onSubmit={vi.fn()} />);
+
+    expect(screen.queryByTestId("home-app-selector")).toBeNull();
+
+    mocks.appsLoading = false;
+    view.rerender(<HomeChatInput onSubmit={vi.fn()} />);
+    expect(screen.getByTestId("home-app-selector")).toBeTruthy();
+
+    mocks.apps = [];
+    view.rerender(<HomeChatInput onSubmit={vi.fn()} />);
+    expect(screen.queryByTestId("home-app-selector")).toBeNull();
   });
 });

--- a/src/components/chat/HomeChatInput.tsx
+++ b/src/components/chat/HomeChatInput.tsx
@@ -17,7 +17,7 @@ import {
 import { useSettings } from "@/hooks/useSettings";
 import { homeChatInputValueAtom, homeSelectedAppAtom } from "@/atoms/chatAtoms";
 import { useAtom } from "jotai";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { useStreamChat } from "@/hooks/useStreamChat";
 import { useAttachments } from "@/hooks/useAttachments";
 import { AttachmentsList } from "./AttachmentsList";
@@ -70,13 +70,6 @@ export function HomeChatInput({
 
   const [appSearchOpen, setAppSearchOpen] = useState(false);
   const { apps } = useLoadApps();
-
-  // Clear selected app when the experiment flag is disabled
-  useEffect(() => {
-    if (!settings?.enableSelectAppFromHomeChatInput) {
-      setSelectedApp(null);
-    }
-  }, [settings?.enableSelectAppFromHomeChatInput, setSelectedApp]);
 
   const typingText = useTypingPlaceholder([
     "an ecommerce store...",
@@ -290,52 +283,50 @@ export function HomeChatInput({
           <div className="px-2 flex items-center justify-between pb-0.5 pt-0.5">
             <div className="flex items-center">
               <ChatInputControls showContextFilesPicker={false} />
-              {settings?.enableSelectAppFromHomeChatInput && (
-                <Tooltip>
-                  <TooltipTrigger
-                    render={
-                      <button
-                        onClick={() => {
-                          if (!disabled) setAppSearchOpen(true);
-                        }}
-                        disabled={disabled}
-                        className={cn(
-                          "cursor-pointer px-2 py-1 ml-1.5 text-xs font-medium rounded-lg transition-colors flex items-center gap-1",
-                          selectedApp
-                            ? "bg-primary/10 text-primary hover:bg-primary/15"
-                            : "text-foreground/80 hover:text-foreground hover:bg-muted/60",
-                        )}
-                        data-testid="home-app-selector"
-                      />
-                    }
-                  >
-                    <FolderOpenIcon size={14} />
-                    <span className="truncate max-w-[150px]">
-                      {selectedApp ? selectedApp.name : "No app selected"}
-                    </span>
-                    {selectedApp && (
-                      <button
-                        type="button"
-                        disabled={disabled}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setSelectedApp(null);
-                        }}
-                        className="hover:bg-primary/20 rounded-sm p-0.5 transition-colors"
-                        aria-label="Deselect app"
-                        data-testid="home-app-selector-clear"
-                      >
-                        <XIcon size={12} />
-                      </button>
-                    )}
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    {selectedApp
-                      ? "Change selected app"
-                      : "Select an existing app"}
-                  </TooltipContent>
-                </Tooltip>
-              )}
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <button
+                      onClick={() => {
+                        if (!disabled) setAppSearchOpen(true);
+                      }}
+                      disabled={disabled}
+                      className={cn(
+                        "cursor-pointer px-2 py-1 ml-1.5 text-xs font-medium rounded-lg transition-colors flex items-center gap-1",
+                        selectedApp
+                          ? "bg-primary/10 text-primary hover:bg-primary/15"
+                          : "text-foreground/80 hover:text-foreground hover:bg-muted/60",
+                      )}
+                      data-testid="home-app-selector"
+                    />
+                  }
+                >
+                  <FolderOpenIcon size={14} />
+                  <span className="truncate max-w-[150px]">
+                    {selectedApp ? selectedApp.name : "No app selected"}
+                  </span>
+                  {selectedApp && (
+                    <button
+                      type="button"
+                      disabled={disabled}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setSelectedApp(null);
+                      }}
+                      className="hover:bg-primary/20 rounded-sm p-0.5 transition-colors"
+                      aria-label="Deselect app"
+                      data-testid="home-app-selector-clear"
+                    >
+                      <XIcon size={12} />
+                    </button>
+                  )}
+                </TooltipTrigger>
+                <TooltipContent>
+                  {selectedApp
+                    ? "Change selected app"
+                    : "Select an existing app"}
+                </TooltipContent>
+              </Tooltip>
             </div>
 
             <AuxiliaryActionsMenu

--- a/src/components/chat/HomeChatInput.tsx
+++ b/src/components/chat/HomeChatInput.tsx
@@ -69,7 +69,8 @@ export function HomeChatInput({
   });
 
   const [appSearchOpen, setAppSearchOpen] = useState(false);
-  const { apps } = useLoadApps();
+  const { apps, loading: appsLoading } = useLoadApps();
+  const canSelectApp = !appsLoading && apps.length > 0;
 
   const typingText = useTypingPlaceholder([
     "an ecommerce store...",
@@ -283,50 +284,52 @@ export function HomeChatInput({
           <div className="px-2 flex items-center justify-between pb-0.5 pt-0.5">
             <div className="flex items-center">
               <ChatInputControls showContextFilesPicker={false} />
-              <Tooltip>
-                <TooltipTrigger
-                  render={
-                    <button
-                      onClick={() => {
-                        if (!disabled) setAppSearchOpen(true);
-                      }}
-                      disabled={disabled}
-                      className={cn(
-                        "cursor-pointer px-2 py-1 ml-1.5 text-xs font-medium rounded-lg transition-colors flex items-center gap-1",
-                        selectedApp
-                          ? "bg-primary/10 text-primary hover:bg-primary/15"
-                          : "text-foreground/80 hover:text-foreground hover:bg-muted/60",
-                      )}
-                      data-testid="home-app-selector"
-                    />
-                  }
-                >
-                  <FolderOpenIcon size={14} />
-                  <span className="truncate max-w-[150px]">
-                    {selectedApp ? selectedApp.name : "No app selected"}
-                  </span>
-                  {selectedApp && (
-                    <button
-                      type="button"
-                      disabled={disabled}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setSelectedApp(null);
-                      }}
-                      className="hover:bg-primary/20 rounded-sm p-0.5 transition-colors"
-                      aria-label="Deselect app"
-                      data-testid="home-app-selector-clear"
-                    >
-                      <XIcon size={12} />
-                    </button>
-                  )}
-                </TooltipTrigger>
-                <TooltipContent>
-                  {selectedApp
-                    ? "Change selected app"
-                    : "Select an existing app"}
-                </TooltipContent>
-              </Tooltip>
+              {canSelectApp && (
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <button
+                        onClick={() => {
+                          if (!disabled) setAppSearchOpen(true);
+                        }}
+                        disabled={disabled}
+                        className={cn(
+                          "cursor-pointer px-2 py-1 ml-1.5 text-xs font-medium rounded-lg transition-colors flex items-center gap-1",
+                          selectedApp
+                            ? "bg-primary/10 text-primary hover:bg-primary/15"
+                            : "text-foreground/80 hover:text-foreground hover:bg-muted/60",
+                        )}
+                        data-testid="home-app-selector"
+                      />
+                    }
+                  >
+                    <FolderOpenIcon size={14} />
+                    <span className="truncate max-w-[150px]">
+                      {selectedApp ? selectedApp.name : "No app selected"}
+                    </span>
+                    {selectedApp && (
+                      <button
+                        type="button"
+                        disabled={disabled}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setSelectedApp(null);
+                        }}
+                        className="hover:bg-primary/20 rounded-sm p-0.5 transition-colors"
+                        aria-label="Deselect app"
+                        data-testid="home-app-selector-clear"
+                      >
+                        <XIcon size={12} />
+                      </button>
+                    )}
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    {selectedApp
+                      ? "Change selected app"
+                      : "Select an existing app"}
+                  </TooltipContent>
+                </Tooltip>
+              )}
             </div>
 
             <AuxiliaryActionsMenu
@@ -337,7 +340,7 @@ export function HomeChatInput({
         </div>
       </div>
 
-      {appSearchOpen && (
+      {appSearchOpen && canSelectApp && (
         <AppSearchDialog
           open={appSearchOpen}
           onOpenChange={setAppSearchOpen}

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -467,7 +467,6 @@ const BaseUserSettingsFields = {
   hideLocalAgentNewChatToast: z.boolean().optional(),
   enableContextCompaction: z.boolean().optional(),
   skipNotificationBanner: z.boolean().optional(),
-  enableSelectAppFromHomeChatInput: z.boolean().optional(),
   previewIdleTimeoutPolicy: z.enum(["default", "never"]).optional(),
 };
 

--- a/src/lib/settingsSearchIndex.ts
+++ b/src/lib/settingsSearchIndex.ts
@@ -52,8 +52,6 @@ export const SETTING_IDS = {
   enableAdvancedSubagents: "setting-enable-advanced-subagents",
   autoFixReviewIssues: "setting-auto-fix-review-issues",
   enableOwnServerDeployment: "setting-enable-own-server-deployment",
-  enableSelectAppFromHomeChatInput:
-    "setting-enable-select-app-from-home-chat-input",
   reset: "setting-reset",
 } as const;
 
@@ -609,16 +607,6 @@ export const SETTINGS_SEARCH_INDEX: SearchableSettingItem[] = [
       "publish",
       "experiment",
     ],
-    sectionId: SECTION_IDS.experiments,
-    sectionLabel: "Experiments",
-  },
-
-  {
-    id: SETTING_IDS.enableSelectAppFromHomeChatInput,
-    label: "Enable Select App from Home Chat Input",
-    description:
-      "Show an app selector in the home chat input to start a chat referencing an existing app",
-    keywords: ["app", "select", "home", "chat", "experiment", "input"],
     sectionId: SECTION_IDS.experiments,
     sectionLabel: "Experiments",
   },

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -327,31 +327,6 @@ export default function SettingsPage() {
               </p>
             </div>
 
-            <div
-              id={SETTING_IDS.enableSelectAppFromHomeChatInput}
-              className="space-y-1.5"
-            >
-              <div className="flex items-center gap-2">
-                <Switch
-                  id="enable-select-app-from-home-chat-input"
-                  aria-label="Enable Select App from Home Chat Input"
-                  checked={!!settings?.enableSelectAppFromHomeChatInput}
-                  onCheckedChange={(checked) => {
-                    updateSettings({
-                      enableSelectAppFromHomeChatInput: checked,
-                    });
-                  }}
-                />
-                <Label htmlFor="enable-select-app-from-home-chat-input">
-                  Enable Select App from Home Chat Input
-                </Label>
-              </div>
-              <p className={hint}>
-                Show an app selector in the home chat input to start a chat
-                referencing an existing app.
-              </p>
-            </div>
-
             <div id={SETTING_IDS.enableCodeExplorer} className="space-y-1.5">
               <div className="flex items-center gap-2">
                 <Switch


### PR DESCRIPTION
## Summary

Make the existing-app selector a standard home-chat capability instead of an opt-in experiment. Users can now start a new chat in an existing app directly from Home without changing Settings.

- Keep new-app creation as the default when no app is selected.
- Remove the obsolete experiment setting, schema field, search entry, and E2E setup plumbing.
- Preserve the existing selected-app submission flow and update its E2E coverage to exercise the default product experience.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

