### PR TITLE
test(evals): add newline probe suite and recorded search_replace calls

### DIFF
--- a/src/__tests__/evals/README.md
+++ b/src/__tests__/evals/README.md
@@ -1,8 +1,8 @@
 # Evals
 
-LLM eval suite for tool-use quality. Five suites run the same 16 cases and
-the same three models (Claude Sonnet 4.6, GPT 5.4, Gemini 3 Flash) but with
-different tool sets and system prompts:
+LLM eval suite for tool-use quality. Five suites run the same 16 cases across
+the model matrix (Claude Sonnet 4.6, GPT 5.4, Gemini 3 Flash, GPT 5.6 Sol,
+GPT 5.6 Luna) but with different tool sets and system prompts:
 
 | Suite name               | Tools available                | System prompt                                |
 | ------------------------ | ------------------------------ | -------------------------------------------- |
@@ -11,6 +11,10 @@ different tool sets and system prompts:
 | `basic_agent`            | `search_replace`, `write_file` | Production `LOCAL_AGENT_BASIC_SYSTEM_PROMPT` |
 | `pro_agent`              | `search_replace`, `write_file` | Production `LOCAL_AGENT_SYSTEM_PROMPT` (Pro) |
 | `pro_agent_experimental` | `search_replace`, `write_file` | Editable copy of the Pro prompt for tweaking |
+
+The `newline_probe` suite is separate: it runs its own four cases (not the
+shared 16), skips the LLM judge, and measures `search_replace` serialization
+mechanics rather than edit quality. See [Newline probe](#newline-probe).
 
 Each case gives the model a real source file plus an editing instruction,
 runs the model with the suite's tools wired up, applies the produced edits,
@@ -60,7 +64,7 @@ EVAL_SUITE=all EVAL_MODEL=all DYAD_PRO_API_KEY="..." npm run eval
 
 **Heads up — this is expensive.** A full `all`/`all` run issues one
 generation per (suite × model × case) triple plus one judge call per case,
-across 5 suites, 3 models, and 16 cases. Expect dozens of LLM requests,
+across 5 suites, 5 models, and 16 cases. Expect dozens of LLM requests,
 some of which run reasoning models on 300+ line fixtures. Use sparingly;
 prefer narrow filters during development.
 
@@ -246,3 +250,129 @@ call. The split view contains the raw pieces as standalone files:
   JSON blobs. So a `search_replace` call produces `old_string.ts` and
   `new_string.ts`; a `write_file` call produces `content.ts` and
   `description.ts`.
+
+## Newline probe
+
+`search_replace` builds its operations string by joining the model's raw args
+with newline delimiters:
+
+```
+<<<<<<< SEARCH\n${old_string}\n=======\n${new_string}\n>>>>>>> REPLACE
+```
+
+A newline that merely _terminates_ an arg therefore becomes a trailing empty
+line in the parsed block. On the search side that empty line matches nothing,
+the processor's `trimEmptyLines` fallback rescues the match, and — before the
+fix — nothing trimmed the replace side, so the phantom line was written into
+the file as a stray blank line.
+
+This suite measures how often real models send the triggering arg shape.
+Every `search_replace` call is applied twice: once with the current
+serialization and once with a counterfactual that trims the terminator.
+Divergence marks a call the defect fires on.
+
+```bash
+DYAD_PRO_API_KEY="..." EVAL_SUITE=newline_probe EVAL_MODEL="GPT 5.6 Sol" npm run eval
+```
+
+`EVAL_SKIP_JUDGE=1` skips the judge round-trip on any suite, which halves the
+spend when you only care about serialization mechanics.
+
+### What the first run found
+
+Across 82 applied `search_replace` calls from GPT 5.6 Sol (the shared 16-case
+`search_replace` suite):
+
+|                                           | count        |
+| ----------------------------------------- | ------------ |
+| applied calls                             | 82           |
+| both args newline-terminated (symmetric)  | 18           |
+| `new_string`-only terminated (asymmetric) | 0            |
+| `trimEmptyLines` fallback fired           | 7            |
+| **corrupted**                             | **7 (8.5%)** |
+
+All 7 were the symmetric shape. The model terminates both args because it
+copies a contiguous region of the file — in 18 of 18 symmetric calls the
+replace block ended on the same line the search block ended on, i.e. copied
+context rather than an authored blank line. Corruption followed in exactly the
+7 cases where the file had no real blank line at that boundary.
+
+Reading a report:
+
+- **Non-zero divergence** — the defect reproduced. The summary prints a
+  `current` vs `fixed` unified diff per affected call, and the offending args
+  sit in that run's `tool_calls/NN/` folder as ready-made fixtures.
+- **Zero divergence** — the defect did not fire for that model on those cases.
+
+### Known gap
+
+The processor fix covers the symmetric shape only, because it lives inside the
+`trimEmptyLines` fallback and an unterminated `old_string` matches as-is, so
+the fallback never fires. The asymmetric shape (`new_string` terminated,
+`old_string` not) still writes a stray blank line. It was not observed once in
+82 calls, so it is unfixed by choice rather than oversight — the probe stays
+live for it, and `helpers/newline_probe.spec.ts` pins the behavior.
+
+Output goes to `eval-results/newline_probe/` (`samples.json` plus
+`summary.txt`), accumulated across runs, in addition to the per-case records.
+
+The probe's own detector is unit-tested in `helpers/newline_probe.spec.ts`,
+which runs in the normal `vitest` suite with no API key. That test matters: the
+first version of this probe compared against an asymmetric-only counterfactual,
+which by construction leaves symmetric calls untouched — so it reported "0
+corrupted" while 7 real corruptions sat in the data. The spec now pins that
+blind spot explicitly.
+
+## Recorded calls
+
+`recorded_calls/<model>/` holds real `search_replace` tool calls captured from
+eval runs, stored as the operations strings the tool builds from the model's
+arguments. `recorded_calls.spec.ts` replays them against the current processor.
+
+Each case starts from a fixture already in `fixtures/`, so replaying the calls
+in order reconstructs the edit session. That keeps the evidence behind the
+newline findings reviewable without an API key and without `eval-results/`,
+which is gitignored and gets wiped.
+
+The assertion is that an applied call produces exactly what replacing the first
+verbatim occurrence of `old_string` with `new_string` produces — the tool's
+whole contract, and the thing a trailing newline in the arguments breaks.
+
+To add cases, copy `old_string` / `new_string` out of a run's `tool_calls/NN/`
+folder into `<model>/<case>/NN.txt` in the marker format, and list the case
+under that model in `manifest.json` with the fixture it starts from.
+
+### Replaying against the pre-fix processor
+
+The current processor no longer writes stray blank lines, so replaying these
+calls against it shows none. `helpers/legacy_search_replace.ts` is a frozen
+copy of the processor as it stood at `67c9ee7c`, the commit before
+[#4338](https://github.com/dyad-sh/dyad/pull/4338), kept so the recordings can
+still be replayed against the behavior they were captured from.
+
+The spec replays both by default and asserts each model's totals, so the
+measurement is pinned in CI rather than described in prose:
+
+| model        | processor    | applied | did not match | stray blank lines |
+| ------------ | ------------ | ------- | ------------- | ----------------- |
+| GPT 5.6 Sol  | before #4338 | 9       | 7             | 7                 |
+| GPT 5.6 Sol  | current      | 11      | 5             | 0                 |
+| GPT 5.6 Luna | before #4338 | 5       | 0             | 2                 |
+| GPT 5.6 Luna | current      | 5       | 0             | 0                 |
+
+Sol's applied count goes up because two calls that could not match were being
+blocked by a stray blank line an earlier call had introduced.
+
+Both models produce the defect, at different rates. Over the full runs these
+recordings were drawn from, Sol corrupted 7 of 82 applied calls and Luna 2 of
+116, so the recorded set is the corrupting subset rather than a sample.
+
+To replay only one implementation:
+
+```bash
+SEARCH_REPLACE_IMPL=legacy npx vitest run src/__tests__/evals/recorded_calls.spec.ts
+SEARCH_REPLACE_IMPL=current npx vitest run src/__tests__/evals/recorded_calls.spec.ts
+```
+
+`legacy_search_replace.ts` is a historical snapshot. It should not be updated
+to track the real processor - its only job is to keep producing the old output.

--- a/src/__tests__/evals/helpers/legacy_search_replace.ts
+++ b/src/__tests__/evals/helpers/legacy_search_replace.ts
@@ -1,0 +1,409 @@
+/* eslint-disable no-irregular-whitespace */
+/**
+ * Frozen copy of the search_replace processor as it stood at 67c9ee7c, the
+ * commit before https://github.com/dyad-sh/dyad/pull/4338.
+ *
+ * It exists so the recorded calls in `recorded_calls/` can be replayed against
+ * the behavior they were captured from. Replaying them against the current
+ * processor shows no stray blank lines, which is the point of the fix but also
+ * means the recordings alone no longer demonstrate what they caught.
+ *
+ * Do not update this file to track the real processor. It is a historical
+ * snapshot, and its only job is to keep producing the old output. The only
+ * deviation from 67c9ee7c is the logger scope name, so its output is
+ * distinguishable from the real processor's.
+ */
+
+import { parseSearchReplaceBlocks } from "@/pro/shared/search_replace_parser";
+import { normalizeString } from "@/utils/text_normalization";
+import log from "electron-log";
+
+const logger = log.scope("legacy_search_replace");
+
+// ============================================================================
+// Options Interface
+// ============================================================================
+
+function unescapeMarkers(content: string): string {
+  return content
+    .replace(/^\\<<<<<<</gm, "<<<<<<<")
+    .replace(/^\\=======/gm, "=======")
+    .replace(/^\\>>>>>>>/gm, ">>>>>>>");
+}
+
+// ============================================================================
+// Cascading Fuzzy Matching
+// ============================================================================
+// The tool locates where to apply changes by matching context lines against the file.
+// Implements cascading fuzzy matching with decreasing strictness:
+//
+// Pass 1: Exact Match
+// Pass 2: Trailing Whitespace Ignored
+// Pass 3: All Edge Whitespace Ignored
+// Pass 4: Unicode Normalization
+// ============================================================================
+
+type LineComparator = (fileLine: string, patternLine: string) => boolean;
+
+/**
+ * Pass 1: Exact Match
+ * file_line == pattern_line
+ */
+const exactMatch: LineComparator = (fileLine, patternLine) =>
+  fileLine === patternLine;
+
+/**
+ * Pass 2: Trailing Whitespace Ignored
+ * file_line.trimEnd() == pattern_line.trimEnd()
+ */
+const trailingWhitespaceIgnored: LineComparator = (fileLine, patternLine) =>
+  fileLine.trimEnd() === patternLine.trimEnd();
+
+/**
+ * Pass 3: All Edge Whitespace Ignored
+ * file_line.trim() == pattern_line.trim()
+ */
+const allEdgeWhitespaceIgnored: LineComparator = (fileLine, patternLine) =>
+  fileLine.trim() === patternLine.trim();
+
+/**
+ * Pass 4: Unicode Normalization
+ * Normalize common Unicode variants to ASCII before comparing:
+ * - En-dash, em-dash, etc. → -
+ * - Smart quotes → " '
+ * - Non-breaking space → regular space
+ */
+const unicodeNormalized: LineComparator = (fileLine, patternLine) =>
+  normalizeString(fileLine.trim()) === normalizeString(patternLine.trim());
+
+/**
+ * All matching passes in order of decreasing strictness
+ */
+const MATCHING_PASSES: Array<{ name: string; comparator: LineComparator }> = [
+  { name: "exact", comparator: exactMatch },
+  {
+    name: "trailing-whitespace-ignored",
+    comparator: trailingWhitespaceIgnored,
+  },
+  { name: "all-edge-whitespace-ignored", comparator: allEdgeWhitespaceIgnored },
+  { name: "unicode-normalized", comparator: unicodeNormalized },
+];
+
+/**
+ * Trim leading and trailing empty lines from an array of lines
+ */
+function trimEmptyLines(lines: string[]): string[] {
+  const result = [...lines];
+  while (result.length > 0 && result[0] === "") {
+    result.shift();
+  }
+  while (result.length > 0 && result[result.length - 1] === "") {
+    result.pop();
+  }
+  return result;
+}
+
+/**
+ * Find all positions where searchLines match against resultLines using the given comparator
+ */
+function findMatchPositions(
+  resultLines: string[],
+  searchLines: string[],
+  comparator: LineComparator,
+): number[] {
+  const positions: number[] = [];
+
+  for (let i = 0; i <= resultLines.length - searchLines.length; i++) {
+    let allMatch = true;
+    for (let j = 0; j < searchLines.length; j++) {
+      if (!comparator(resultLines[i + j], searchLines[j])) {
+        allMatch = false;
+        break;
+      }
+    }
+    if (allMatch) {
+      positions.push(i);
+      // For ambiguity detection, we only need to know if there's more than one
+      if (positions.length > 1) break;
+    }
+  }
+
+  return positions;
+}
+
+/**
+ * Find the best partial match - the position in resultLines where the most
+ * consecutive lines from searchLines match (using unicode-normalized comparison)
+ */
+function findBestPartialMatch(
+  resultLines: string[],
+  searchLines: string[],
+): { startIndex: number; matchingLines: number; firstMismatchIndex: number } {
+  let bestStartIndex = 0;
+  let bestMatchingLines = 0;
+  let bestFirstMismatchIndex = 0;
+
+  for (let i = 0; i < resultLines.length; i++) {
+    let matchingLines = 0;
+    let firstMismatchIndex = -1;
+
+    for (let j = 0; j < searchLines.length && i + j < resultLines.length; j++) {
+      if (unicodeNormalized(resultLines[i + j], searchLines[j])) {
+        matchingLines++;
+      } else {
+        if (firstMismatchIndex === -1) {
+          firstMismatchIndex = j;
+        }
+        // Continue counting to find total matching lines, not just consecutive
+      }
+    }
+
+    if (matchingLines > bestMatchingLines) {
+      bestMatchingLines = matchingLines;
+      bestStartIndex = i;
+      bestFirstMismatchIndex =
+        firstMismatchIndex === -1 ? searchLines.length : firstMismatchIndex;
+    }
+  }
+
+  return {
+    startIndex: bestStartIndex,
+    matchingLines: bestMatchingLines,
+    firstMismatchIndex: bestFirstMismatchIndex,
+  };
+}
+
+/**
+ * Log detailed information about a failed match to help diagnose issues
+ */
+function logMatchFailure(
+  resultLines: string[],
+  searchLines: string[],
+  blockIndex: number,
+): void {
+  logger.error(
+    `=== SEARCH/REPLACE MATCH FAILURE (Block ${blockIndex + 1}) ===`,
+  );
+
+  // Log search content
+  logger.error(`\n--- SEARCH CONTENT (${searchLines.length} lines) ---`);
+  searchLines.forEach((line, i) => {
+    logger.error(`  ${String(i + 1).padStart(3)}: ${JSON.stringify(line)}`);
+  });
+
+  // Find best partial match
+  const bestMatch = findBestPartialMatch(resultLines, searchLines);
+
+  logger.error(
+    `\n--- BEST PARTIAL MATCH: ${bestMatch.matchingLines}/${searchLines.length} lines match ---`,
+  );
+  logger.error(
+    `    Location: lines ${bestMatch.startIndex + 1}-${bestMatch.startIndex + searchLines.length} of original file`,
+  );
+  logger.error(
+    `    First mismatch at search line: ${bestMatch.firstMismatchIndex + 1}`,
+  );
+
+  // Show the relevant section of the original file with context
+  const contextLines = 5;
+  const startLine = Math.max(0, bestMatch.startIndex - contextLines);
+  const endLine = Math.min(
+    resultLines.length,
+    bestMatch.startIndex + searchLines.length + contextLines,
+  );
+
+  logger.error(
+    `\n--- ORIGINAL FILE (lines ${startLine + 1}-${endLine}, match region marked with >) ---`,
+  );
+  for (let i = startLine; i < endLine; i++) {
+    const isInMatchRegion =
+      i >= bestMatch.startIndex &&
+      i < bestMatch.startIndex + searchLines.length;
+    const searchLineIndex = i - bestMatch.startIndex;
+    const matchesSearch =
+      isInMatchRegion &&
+      searchLineIndex < searchLines.length &&
+      unicodeNormalized(resultLines[i], searchLines[searchLineIndex]);
+
+    const marker = isInMatchRegion ? (matchesSearch ? ">" : "X") : " ";
+    logger.error(
+      `  ${marker} ${String(i + 1).padStart(4)}: ${JSON.stringify(resultLines[i])}`,
+    );
+  }
+
+  // If there's a mismatch, show the specific comparison
+  if (bestMatch.firstMismatchIndex < searchLines.length) {
+    const mismatchFileIndex =
+      bestMatch.startIndex + bestMatch.firstMismatchIndex;
+    if (mismatchFileIndex < resultLines.length) {
+      logger.error(`\n--- FIRST MISMATCH DETAILS ---`);
+      logger.error(
+        `  Search line ${bestMatch.firstMismatchIndex + 1}: ${JSON.stringify(searchLines[bestMatch.firstMismatchIndex])}`,
+      );
+      logger.error(
+        `  File line ${mismatchFileIndex + 1}:   ${JSON.stringify(resultLines[mismatchFileIndex])}`,
+      );
+    }
+  }
+
+  logger.error(`\n=== END MATCH FAILURE ===\n`);
+}
+
+/**
+ * Cascading fuzzy matching: try each pass in order until we find a match
+ * Returns the match index or -1 if no match found, along with any error
+ */
+function cascadingMatch(
+  resultLines: string[],
+  searchLines: string[],
+): { matchIndex: number; error?: string; passName?: string } {
+  const passesToTry = MATCHING_PASSES;
+
+  for (const pass of passesToTry) {
+    const positions = findMatchPositions(
+      resultLines,
+      searchLines,
+      pass.comparator,
+    );
+
+    if (positions.length > 1) {
+      return {
+        matchIndex: -1,
+        error: `Search block matched multiple locations in the target file (ambiguous, detected in ${pass.name} pass)`,
+      };
+    }
+
+    if (positions.length === 1) {
+      return { matchIndex: positions[0], passName: pass.name };
+    }
+  }
+
+  return {
+    matchIndex: -1,
+    error: "Search block did not match any content in the target file.",
+  };
+}
+
+export function applySearchReplace(
+  originalContent: string,
+  diffContent: string,
+): {
+  success: boolean;
+  content?: string;
+  error?: string;
+} {
+  const blocks = parseSearchReplaceBlocks(diffContent);
+  if (blocks.length === 0) {
+    return {
+      success: false,
+      error:
+        "Invalid diff format - missing required sections. Expected <<<<<<< SEARCH / ======= / >>>>>>> REPLACE",
+    };
+  }
+
+  const lineEnding = originalContent.includes("\r\n") ? "\r\n" : "\n";
+  let resultLines = originalContent.split(/\r?\n/);
+  let appliedCount = 0;
+
+  for (const block of blocks) {
+    let { searchContent, replaceContent } = block;
+
+    // Normalize markers and strip line numbers if present on all lines
+    searchContent = unescapeMarkers(searchContent);
+    replaceContent = unescapeMarkers(replaceContent);
+
+    let searchLines = searchContent === "" ? [] : searchContent.split(/\r?\n/);
+    let replaceLines =
+      replaceContent === "" ? [] : replaceContent.split(/\r?\n/);
+
+    if (searchLines.length === 0) {
+      return {
+        success: false,
+        error: "Invalid diff format - empty SEARCH block is not allowed",
+      };
+    }
+
+    // If search and replace are identical, it's either an error or a no-op warning
+    if (searchLines.join("\n") === replaceLines.join("\n")) {
+      logger.warn("Search and replace blocks are identical");
+    }
+
+    // Use cascading fuzzy matching to find the match
+    let matchResult = cascadingMatch(resultLines, searchLines);
+
+    // If no match found, try with trimmed leading/trailing empty lines as a fallback
+    if (matchResult.error && !matchResult.error.includes("ambiguous")) {
+      const trimmedSearchLines = trimEmptyLines(searchLines);
+      if (trimmedSearchLines.length !== searchLines.length) {
+        const trimmedResult = cascadingMatch(resultLines, trimmedSearchLines);
+        if (!trimmedResult.error) {
+          matchResult = trimmedResult;
+          searchLines = trimmedSearchLines;
+          logger.debug(
+            "Matched after trimming leading/trailing empty lines from search content",
+          );
+        }
+      }
+    }
+
+    if (matchResult.error) {
+      // Log detailed diagnostic information for debugging
+      logMatchFailure(resultLines, searchLines, appliedCount);
+      return {
+        success: false,
+        error: matchResult.error,
+      };
+    }
+
+    const matchIndex = matchResult.matchIndex;
+
+    const matchedLines = resultLines.slice(
+      matchIndex,
+      matchIndex + searchLines.length,
+    );
+
+    // Preserve indentation relative to first matched line
+    const originalIndents = matchedLines.map((line) => {
+      const m = line.match(/^[\t ]*/);
+      return m ? m[0] : "";
+    });
+    const searchIndents = searchLines.map((line) => {
+      const m = line.match(/^[\t ]*/);
+      return m ? m[0] : "";
+    });
+
+    const indentedReplaceLines = replaceLines.map((line) => {
+      const matchedIndent = originalIndents[0] || "";
+      const currentIndentMatch = line.match(/^[\t ]*/);
+      const currentIndent = currentIndentMatch ? currentIndentMatch[0] : "";
+      const searchBaseIndent = searchIndents[0] || "";
+
+      const searchBaseLevel = searchBaseIndent.length;
+      const currentLevel = currentIndent.length;
+      const relativeLevel = currentLevel - searchBaseLevel;
+
+      const finalIndent =
+        relativeLevel < 0
+          ? matchedIndent.slice(
+              0,
+              Math.max(0, matchedIndent.length + relativeLevel),
+            )
+          : matchedIndent + currentIndent.slice(searchBaseLevel);
+
+      return finalIndent + line.trim();
+    });
+
+    const beforeMatch = resultLines.slice(0, matchIndex);
+    const afterMatch = resultLines.slice(matchIndex + searchLines.length);
+    resultLines = [...beforeMatch, ...indentedReplaceLines, ...afterMatch];
+    appliedCount++;
+  }
+
+  if (appliedCount === 0) {
+    return {
+      success: false,
+      error: "No search/replace blocks could be applied",
+    };
+  }
+  return { success: true, content: resultLines.join(lineEnding) };
+}

--- a/src/__tests__/evals/helpers/newline_probe.spec.ts
+++ b/src/__tests__/evals/helpers/newline_probe.spec.ts
@@ -1,0 +1,185 @@
+/**
+ * Self-check for the newline probe.
+ *
+ * The probe's job is to flag search_replace calls where the current
+ * serialization writes a stray blank line. If the probe itself were broken, a
+ * clean eval run would be indistinguishable from "the defect never fired" —
+ * so these tests pin both directions: it flags known-corrupting args, and
+ * stays silent on clean ones.
+ *
+ * Runs in the normal unit suite; needs no API key.
+ */
+
+import { describe, it, expect } from "vitest";
+import { applySearchReplace } from "@/pro/main/ipc/processors/search_replace_processor";
+import {
+  serializeCurrent,
+  serializeFixed,
+  serializeFixedFull,
+} from "./newline_probe";
+
+const FILE_NO_BLANK = "const a = 1;\nconst b = 2;\nconst c = 3;\n";
+const FILE_WITH_BLANK = "const a = 1;\nconst b = 2;\n\nconst c = 3;\n";
+
+function apply(
+  serialize: (o: string, n: string) => string,
+  file: string,
+  oldString: string,
+  newString: string,
+): string {
+  const result = applySearchReplace(file, serialize(oldString, newString));
+  expect(result.success).toBe(true);
+  return result.content!;
+}
+
+function detects(file: string, oldString: string, newString: string): boolean {
+  return (
+    apply(serializeCurrent, file, oldString, newString) !==
+    apply(serializeFixed, file, oldString, newString)
+  );
+}
+
+describe("newline probe detector", () => {
+  it("flags a trailing newline on new_string as corrupting", () => {
+    expect(detects(FILE_NO_BLANK, "const b = 2;", "const b = 22;\n")).toBe(
+      true,
+    );
+
+    // And the corruption is specifically a stray blank line.
+    expect(
+      apply(serializeCurrent, FILE_NO_BLANK, "const b = 2;", "const b = 22;\n"),
+    ).toBe("const a = 1;\nconst b = 22;\n\nconst c = 3;\n");
+    expect(
+      apply(serializeFixed, FILE_NO_BLANK, "const b = 2;", "const b = 22;\n"),
+    ).toBe("const a = 1;\nconst b = 22;\nconst c = 3;\n");
+  });
+
+  it("flags a multi-line replacement carrying a terminator", () => {
+    expect(
+      detects(FILE_NO_BLANK, "const b = 2;", "const b = 22;\nconst b2 = 3;\n"),
+    ).toBe(true);
+  });
+
+  it("stays silent when neither arg has a trailing newline", () => {
+    expect(detects(FILE_NO_BLANK, "const b = 2;", "const b = 22;")).toBe(false);
+  });
+
+  it("stays silent when both args are newline-terminated", () => {
+    // The trailing blank is load-bearing here: it consumes and re-emits the
+    // real blank line in the file, so the fix must leave it alone.
+    expect(detects(FILE_WITH_BLANK, "const b = 2;\n", "const b = 22;\n")).toBe(
+      false,
+    );
+    expect(
+      apply(
+        serializeFixed,
+        FILE_WITH_BLANK,
+        "const b = 2;\n",
+        "const b = 22;\n",
+      ),
+    ).toBe("const a = 1;\nconst b = 22;\n\nconst c = 3;\n");
+  });
+
+  it("flags an explicit blank-line request as over-applied", () => {
+    // A model asking for ONE blank line (new_string ending "\n\n") currently
+    // gets TWO. The off-by-one is unconditional: whenever the replace block is
+    // newline-terminated, the current serialization adds exactly one blank line
+    // more than the model asked for. There is no input where a terminated
+    // new_string produces what was requested.
+    expect(detects(FILE_NO_BLANK, "const b = 2;", "const b = 22;\n\n")).toBe(
+      true,
+    );
+    expect(
+      apply(
+        serializeCurrent,
+        FILE_NO_BLANK,
+        "const b = 2;",
+        "const b = 22;\n\n",
+      ),
+    ).toBe("const a = 1;\nconst b = 22;\n\n\nconst c = 3;\n");
+    expect(
+      apply(serializeFixed, FILE_NO_BLANK, "const b = 2;", "const b = 22;\n\n"),
+    ).toBe("const a = 1;\nconst b = 22;\n\nconst c = 3;\n");
+  });
+
+  // The symmetric case is the one that fired on real model output: GPT 5.6 Sol
+  // terminates both args together because it copies a contiguous region, and
+  // corruption followed whenever the file had no real blank line at that
+  // boundary. The processor fix (mirroring the trimEmptyLines fallback onto the
+  // replace side) closes it, so these are now regression guards: if the probe
+  // starts reporting divergence here again, the fix has been undone.
+  describe("symmetric case (the shape observed in production traffic)", () => {
+    it("no longer corrupts when the file has no blank line there", () => {
+      const cur = apply(
+        serializeCurrent,
+        FILE_NO_BLANK,
+        "const b = 2;\n",
+        "const b = 22;\n",
+      );
+      const full = apply(
+        serializeFixedFull,
+        FILE_NO_BLANK,
+        "const b = 2;\n",
+        "const b = 22;\n",
+      );
+      expect(cur).toBe("const a = 1;\nconst b = 22;\nconst c = 3;\n");
+      expect(cur).toBe(full);
+    });
+
+    it("stays silent when the blank line is real", () => {
+      const cur = apply(
+        serializeCurrent,
+        FILE_WITH_BLANK,
+        "const b = 2;\n",
+        "const b = 22;\n",
+      );
+      const full = apply(
+        serializeFixedFull,
+        FILE_WITH_BLANK,
+        "const b = 2;\n",
+        "const b = 22;\n",
+      );
+      expect(cur).toBe(full);
+      expect(full).toBe("const a = 1;\nconst b = 22;\n\nconst c = 3;\n");
+    });
+
+    it("is invisible to the asymmetric-only counterfactual", () => {
+      // Documents the blind spot that hid this defect during measurement:
+      // serializeFixed leaves symmetric calls untouched, so it reported clean
+      // on genuinely corrupted calls. serializeFixedFull is the detector.
+      expect(detects(FILE_NO_BLANK, "const b = 2;\n", "const b = 22;\n")).toBe(
+        false,
+      );
+    });
+  });
+
+  it("still flags the asymmetric shape, which the processor fix does not cover", () => {
+    // Part A only runs inside the trimEmptyLines fallback, and an
+    // unterminated old_string matches as-is so the fallback never fires. This
+    // shape was never observed in 82 recorded GPT 5.6 Sol calls, but the probe
+    // stays live for it.
+    expect(detects(FILE_NO_BLANK, "const b = 2;", "const b = 22;\n")).toBe(
+      true,
+    );
+    expect(
+      apply(serializeCurrent, FILE_NO_BLANK, "const b = 2;", "const b = 22;\n"),
+    ).toBe("const a = 1;\nconst b = 22;\n\nconst c = 3;\n");
+  });
+
+  it("never alters old_string, so matching behavior cannot move", () => {
+    // Two identical candidates; only the trailing blank line disambiguates.
+    const ambiguous =
+      "const b = 2;\nconst x = 0;\nconst b = 2;\n\nconst c = 3;\n";
+    const current = applySearchReplace(
+      ambiguous,
+      serializeCurrent("const b = 2;\n", "const b = 22;\n"),
+    );
+    const fixed = applySearchReplace(
+      ambiguous,
+      serializeFixed("const b = 2;\n", "const b = 22;\n"),
+    );
+    expect(current.success).toBe(true);
+    expect(fixed.success).toBe(true);
+    expect(fixed.content).toBe(current.content);
+  });
+});

--- a/src/__tests__/evals/helpers/newline_probe.ts
+++ b/src/__tests__/evals/helpers/newline_probe.ts
@@ -1,0 +1,308 @@
+/**
+ * Newline probe for the search_replace tool.
+ *
+ * Question this answers: do real models send `new_string` (or `old_string`)
+ * with a trailing newline, and when they do, does the current serialization
+ * write a stray blank line into the file?
+ *
+ * Background: the tool builds its operations string by joining the raw args
+ * with newline delimiters —
+ *
+ *     `<<<<<<< SEARCH\n${old}\n=======\n${new}\n>>>>>>> REPLACE`
+ *
+ * so a newline that merely *terminates* `new_string` becomes a trailing empty
+ * line in the parsed replace block, and that empty line is written to the file.
+ *
+ * Rather than assert a guess about how often this happens, every search_replace
+ * call is applied twice: once with the current serialization and once with a
+ * candidate fix. Calls where the two disagree are exactly the calls the bug
+ * fires on — and, equivalently, exactly the calls the fix would change. A run
+ * with zero disagreements means the defect is unreachable for that model on
+ * those cases AND that the fix is a no-op on real traffic.
+ */
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { applySearchReplace } from "@/pro/main/ipc/processors/search_replace_processor";
+import { escapeSearchReplaceMarkers } from "@/pro/shared/search_replace_markers";
+import { createUnifiedDiff } from "./unified_diff";
+
+const RESULTS_ROOT = resolve(__dirname, "../../../../eval-results");
+
+export interface NewlineProbeSample {
+  suite: string;
+  model: string;
+  caseName: string;
+  callIndex: number;
+  filePath: string;
+  oldEndsWithNewline: boolean;
+  newEndsWithNewline: boolean;
+  /** Blank lines in the file after the edit, minus blank lines before it. */
+  blankLineDelta: number;
+  /** True when current and fixed serialization produce different files. */
+  differsUnderFix: boolean;
+  /** True when the counterfactual could not be applied, so nothing is proven. */
+  undetermined: boolean;
+  /** Unified diff of current-vs-fixed output. Empty when identical. */
+  currentVsFixedDiff: string;
+  oldString: string;
+  newString: string;
+}
+
+const samples: NewlineProbeSample[] = [];
+
+/**
+ * Calls that never applied (bad match, ambiguous search, wrong file). They
+ * wrote nothing, so they cannot be corrupted — but they are counted so the
+ * summary reconciles with the tool-call totals in the run log instead of
+ * looking like the probe silently dropped data.
+ */
+const failures: Array<{ model: string; caseName: string; error: string }> = [];
+
+export function recordFailedSearchReplaceCall(input: {
+  model: string;
+  caseName: string;
+  error: string;
+}): void {
+  failures.push(input);
+}
+
+/** Current production serialization (search_replace.ts). */
+export function serializeCurrent(oldString: string, newString: string): string {
+  const escapedOld = escapeSearchReplaceMarkers(oldString);
+  const escapedNew = escapeSearchReplaceMarkers(newString);
+  return `<<<<<<< SEARCH\n${escapedOld}\n=======\n${escapedNew}\n>>>>>>> REPLACE`;
+}
+
+const trimOneNewline = (s: string) => s.replace(/\r?\n$/, "");
+
+/**
+ * Candidate fix, ASYMMETRIC case only: drop a newline that merely terminates
+ * `new_string` when `old_string` is not itself newline-terminated. Matching
+ * input is never modified.
+ *
+ * NOTE: by construction this leaves symmetric calls (both args terminated)
+ * completely unchanged, so on its own it CANNOT detect the symmetric
+ * corruption case. Use `serializeFixedFull` for detection; this is kept
+ * because it is the exact shape of the tool-level fix.
+ */
+export function serializeFixed(oldString: string, newString: string): string {
+  const normalizedNew = oldString.endsWith("\n")
+    ? newString
+    : trimOneNewline(newString);
+  const escapedOld = escapeSearchReplaceMarkers(oldString);
+  const escapedNew = escapeSearchReplaceMarkers(normalizedNew);
+  return `<<<<<<< SEARCH\n${escapedOld}\n=======\n${escapedNew}\n>>>>>>> REPLACE`;
+}
+
+/**
+ * Candidate fix covering BOTH corrupting shapes.
+ *
+ * - Asymmetric (`new_string` terminated, `old_string` not): drop the
+ *   terminator from the replace side.
+ * - Symmetric (both terminated): trim the terminator from both. When the file
+ *   really does have a blank line there, this is a no-op — the current form
+ *   consumes and re-emits it, this form never touches it, and both produce
+ *   identical output. When the file does NOT, the current form emits a stray
+ *   blank line (the processor's trimEmptyLines fallback rescues the search
+ *   side but nothing trims the replace side) and the two diverge.
+ *
+ * This is the detector. It is deliberately more aggressive than the shipped
+ * fix would be: trimming `old_string` can in principle turn a unique match
+ * ambiguous, which is why a failure to apply is reported as *undetermined*
+ * rather than silently counted as "not corrupted".
+ */
+export function serializeFixedFull(
+  oldString: string,
+  newString: string,
+): string {
+  const o = oldString.endsWith("\n") ? trimOneNewline(oldString) : oldString;
+  const n = trimOneNewline(newString);
+  const escapedOld = escapeSearchReplaceMarkers(o);
+  const escapedNew = escapeSearchReplaceMarkers(n);
+  return `<<<<<<< SEARCH\n${escapedOld}\n=======\n${escapedNew}\n>>>>>>> REPLACE`;
+}
+
+function countBlankLines(text: string): number {
+  return text.split(/\r?\n/).filter((line) => line.trim() === "").length;
+}
+
+/**
+ * Record one search_replace call. Never throws — a probe failure must not fail
+ * the eval it is observing.
+ */
+export function recordSearchReplaceCall(input: {
+  suite: string;
+  model: string;
+  caseName: string;
+  callIndex: number;
+  filePath: string;
+  oldString: string;
+  newString: string;
+  fileBefore: string;
+  fileAfter: string;
+}): void {
+  try {
+    const fixed = applySearchReplace(
+      input.fileBefore,
+      serializeFixedFull(input.oldString, input.newString),
+    );
+    const fixedContent = fixed.success ? (fixed.content ?? null) : null;
+    // A counterfactual that fails to apply proves nothing either way; count it
+    // as undetermined rather than folding it into the clean bucket.
+    const undetermined = fixedContent === null;
+    const differsUnderFix = !undetermined && fixedContent !== input.fileAfter;
+
+    samples.push({
+      suite: input.suite,
+      model: input.model,
+      caseName: input.caseName,
+      callIndex: input.callIndex,
+      filePath: input.filePath,
+      oldEndsWithNewline: input.oldString.endsWith("\n"),
+      newEndsWithNewline: input.newString.endsWith("\n"),
+      blankLineDelta:
+        countBlankLines(input.fileAfter) - countBlankLines(input.fileBefore),
+      undetermined,
+      differsUnderFix,
+      currentVsFixedDiff: differsUnderFix
+        ? createUnifiedDiff(input.fileAfter, fixedContent!, {
+            oldLabel: "current",
+            newLabel: "fixed",
+          })
+        : "",
+      oldString: input.oldString,
+      newString: input.newString,
+    });
+  } catch {
+    // Probe is observational only.
+  }
+}
+
+export function getNewlineProbeSamples(): NewlineProbeSample[] {
+  return samples;
+}
+
+export function renderNewlineProbeSummary(): string {
+  if (samples.length === 0) {
+    return "Newline probe: no search_replace calls recorded.";
+  }
+
+  const lines: string[] = [];
+  lines.push("");
+  lines.push("=".repeat(72));
+  lines.push("NEWLINE PROBE — search_replace trailing-newline behavior");
+  lines.push("=".repeat(72));
+
+  const byModel = new Map<string, NewlineProbeSample[]>();
+  for (const s of samples) {
+    const list = byModel.get(s.model) ?? [];
+    list.push(s);
+    byModel.set(s.model, list);
+  }
+
+  for (const [model, list] of byModel) {
+    const newTrailing = list.filter((s) => s.newEndsWithNewline);
+    const oldTrailing = list.filter((s) => s.oldEndsWithNewline);
+    const differing = list.filter((s) => s.differsUnderFix);
+
+    const failedForModel = failures.filter((f) => f.model === model);
+
+    lines.push("");
+    lines.push(
+      `${model} — ${list.length} applied search_replace calls` +
+        (failedForModel.length > 0
+          ? `, plus ${failedForModel.length} that never applied (not analyzable)`
+          : ""),
+    );
+    const symmetric = list.filter(
+      (s) => s.oldEndsWithNewline && s.newEndsWithNewline,
+    );
+    const newOnly = list.filter(
+      (s) => s.newEndsWithNewline && !s.oldEndsWithNewline,
+    );
+    const undet = list.filter((s) => s.undetermined);
+
+    lines.push(
+      `  new_string ends with newline: ${newTrailing.length} (${pct(newTrailing.length, list.length)})`,
+    );
+    lines.push(
+      `  old_string ends with newline: ${oldTrailing.length} (${pct(oldTrailing.length, list.length)})`,
+    );
+    lines.push(
+      `    of which symmetric (both):  ${symmetric.length}   new-only: ${newOnly.length}`,
+    );
+    lines.push(
+      `  CORRUPTED (current output != fixed output): ${differing.length} (${pct(differing.length, list.length)})`,
+    );
+    lines.push(
+      `    corrupted symmetric: ${differing.filter((s) => s.oldEndsWithNewline).length}` +
+        `   corrupted new-only: ${differing.filter((s) => !s.oldEndsWithNewline).length}`,
+    );
+    if (undet.length > 0) {
+      lines.push(
+        `  UNDETERMINED (counterfactual would not apply): ${undet.length}`,
+      );
+    }
+
+    for (const s of differing) {
+      lines.push("");
+      lines.push(`  --- ${s.caseName} / ${s.suite} / call #${s.callIndex + 1}`);
+      lines.push(
+        `      old ends with \\n: ${s.oldEndsWithNewline}   new ends with \\n: ${s.newEndsWithNewline}`,
+      );
+      lines.push(
+        s.currentVsFixedDiff
+          .split("\n")
+          .map((l) => `      ${l}`)
+          .join("\n"),
+      );
+    }
+  }
+
+  const totalDiffering = samples.filter((s) => s.differsUnderFix).length;
+  lines.push("");
+  lines.push("-".repeat(72));
+  lines.push(
+    totalDiffering === 0
+      ? "VERDICT: no divergence. Either the triggering arg shape did not occur " +
+          "on this traffic, or the shipped processor already handles it - which " +
+          "is the expected result now that the fallback trims the replace side. " +
+          "A non-zero count on a later run means that handling regressed."
+      : `VERDICT: ${totalDiffering} of ${samples.length} calls diverge from the ` +
+          `counterfactual. Each diff above is a stray blank line reaching a real file.`,
+  );
+  lines.push("-".repeat(72));
+  lines.push("");
+  return lines.join("\n");
+}
+
+function pct(n: number, total: number): string {
+  if (total === 0) return "0%";
+  return `${((n / total) * 100).toFixed(1)}%`;
+}
+
+export async function writeNewlineProbeReport(): Promise<string | null> {
+  if (samples.length === 0) return null;
+  const dir = resolve(RESULTS_ROOT, "newline_probe");
+  await mkdir(dir, { recursive: true });
+
+  // Accumulate across runs. Each `npm run eval` is a fresh process, so without
+  // merging, a second run silently discards the first run's evidence — and
+  // this defect needs a sample built up over several runs to say anything.
+  const samplesPath = resolve(dir, "samples.json");
+  let previous: NewlineProbeSample[] = [];
+  try {
+    previous = JSON.parse(await readFile(samplesPath, "utf8"));
+    if (!Array.isArray(previous)) previous = [];
+  } catch {
+    previous = [];
+  }
+
+  await writeFile(
+    samplesPath,
+    JSON.stringify([...previous, ...samples], null, 2),
+  );
+  await writeFile(resolve(dir, "summary.txt"), renderNewlineProbeSummary());
+  return dir;
+}

--- a/src/__tests__/evals/recorded_calls.spec.ts
+++ b/src/__tests__/evals/recorded_calls.spec.ts
@@ -1,0 +1,193 @@
+/**
+ * Replays real search_replace tool calls recorded from eval runs.
+ *
+ * The calls in `recorded_calls/<model>/` are the operations strings the tool
+ * builds from the model's raw arguments, captured verbatim. Each case starts
+ * from a fixture that already lives in `fixtures/`, so replaying the calls in
+ * order reconstructs the edit session without needing an API key or the
+ * (gitignored) eval-results directory.
+ *
+ * Every applied call should produce exactly what replacing the first verbatim
+ * occurrence of old_string with new_string produces. That is the whole contract
+ * of the tool, and it is what a trailing newline in the model's arguments used
+ * to break: the phantom empty line showed up in the file as a stray blank line,
+ * so the output no longer matched a plain text replacement.
+ *
+ * Both the current processor and the frozen pre-fix copy are replayed, which
+ * pins the measurement in CI rather than leaving it as a claim. Set
+ * SEARCH_REPLACE_IMPL=current or =legacy to replay only one of them.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { applySearchReplace } from "@/pro/main/ipc/processors/search_replace_processor";
+import { applySearchReplace as legacyApplySearchReplace } from "./helpers/legacy_search_replace";
+import { parseSearchReplaceBlocks } from "@/pro/shared/search_replace_parser";
+
+const CALLS_DIR = resolve(__dirname, "recorded_calls");
+const FIXTURES_DIR = resolve(__dirname, "fixtures");
+
+interface RecordedCase {
+  case: string;
+  fixture: string;
+  calls: string[];
+}
+
+interface RecordedModel {
+  label: string;
+  cases: RecordedCase[];
+}
+
+const manifest: Record<string, RecordedModel> = JSON.parse(
+  readFileSync(resolve(CALLS_DIR, "manifest.json"), "utf8"),
+);
+
+/** Replace the first verbatim occurrence, or null if old_string is not present. */
+function literalReplace(
+  content: string,
+  oldString: string,
+  newString: string,
+): string | null {
+  const index = content.indexOf(oldString);
+  if (index < 0) return null;
+  return (
+    content.slice(0, index) +
+    newString +
+    content.slice(index + oldString.length)
+  );
+}
+
+interface ReplayTotals {
+  applied: number;
+  didNotMatch: number;
+  strayBlankLines: number;
+  newlineTerminated: number;
+}
+
+function replayModel(
+  modelDir: string,
+  apply: typeof applySearchReplace,
+  onApplied?: (label: string, actual: string, expected: string | null) => void,
+): ReplayTotals {
+  const totals: ReplayTotals = {
+    applied: 0,
+    didNotMatch: 0,
+    strayBlankLines: 0,
+    newlineTerminated: 0,
+  };
+
+  for (const entry of manifest[modelDir].cases) {
+    let content = readFileSync(resolve(FIXTURES_DIR, entry.fixture), "utf8");
+
+    for (const callFile of entry.calls) {
+      const operations = readFileSync(
+        resolve(CALLS_DIR, modelDir, entry.case, callFile),
+        "utf8",
+      );
+      const [block] = parseSearchReplaceBlocks(operations);
+      expect(block, `${callFile} should parse into one block`).toBeDefined();
+
+      const result = apply(content, operations);
+      if (!result.success || typeof result.content !== "string") {
+        // The model retried these; they change nothing, so the replay moves on.
+        totals.didNotMatch++;
+        continue;
+      }
+
+      totals.applied++;
+      if (block.searchContent.endsWith("\n")) totals.newlineTerminated++;
+
+      const expected = literalReplace(
+        content,
+        block.searchContent,
+        block.replaceContent,
+      );
+      if (expected !== null && result.content !== expected) {
+        totals.strayBlankLines++;
+      }
+      onApplied?.(
+        `${modelDir}/${entry.case}/${callFile}`,
+        result.content,
+        expected,
+      );
+
+      content = result.content;
+    }
+  }
+
+  return totals;
+}
+
+/**
+ * Totals each model's recordings produce. The legacy column is what the
+ * recordings originally caught; the current column is what the fix leaves.
+ * The applied count rises under the fix because some calls could not match
+ * while a stray blank line from an earlier call was shifting their context.
+ */
+const EXPECTED = {
+  sol: {
+    current: { applied: 11, didNotMatch: 5, strayBlankLines: 0 },
+    legacy: { applied: 9, didNotMatch: 7, strayBlankLines: 7 },
+    minNewlineTerminated: 7,
+  },
+  luna: {
+    current: { applied: 5, didNotMatch: 0, strayBlankLines: 0 },
+    legacy: { applied: 5, didNotMatch: 0, strayBlankLines: 2 },
+    minNewlineTerminated: 3,
+  },
+};
+
+const only = process.env.SEARCH_REPLACE_IMPL;
+const runCurrent = only !== "legacy";
+const runLegacy = only !== "current";
+
+describe("recorded search_replace calls", () => {
+  for (const [modelDir, expected] of Object.entries(EXPECTED)) {
+    const label = manifest[modelDir].label;
+
+    describe(label, () => {
+      it.runIf(runCurrent)(
+        "current processor matches a plain text replacement",
+        () => {
+          const totals = replayModel(
+            modelDir,
+            applySearchReplace,
+            (name, actual, expectedContent) => {
+              expect(
+                expectedContent,
+                `${name}: old_string should appear verbatim`,
+              ).not.toBeNull();
+              expect(
+                actual,
+                `${name} should match a plain text replacement`,
+              ).toBe(expectedContent);
+            },
+          );
+
+          expect(totals.applied).toBe(expected.current.applied);
+          expect(totals.didNotMatch).toBe(expected.current.didNotMatch);
+          expect(totals.strayBlankLines).toBe(expected.current.strayBlankLines);
+        },
+      );
+
+      it.runIf(runLegacy)("pre-fix processor wrote stray blank lines", () => {
+        const totals = replayModel(modelDir, legacyApplySearchReplace);
+
+        expect(totals.applied).toBe(expected.legacy.applied);
+        expect(totals.didNotMatch).toBe(expected.legacy.didNotMatch);
+        expect(totals.strayBlankLines).toBe(expected.legacy.strayBlankLines);
+      });
+
+      it("recordings still carry newline-terminated arguments", () => {
+        // Guards the fixtures: if a future edit strips the trailing newlines
+        // out of these recordings they stop covering the case they exist for,
+        // and the assertions above would pass without testing anything.
+        const totals = replayModel(modelDir, applySearchReplace);
+        expect(totals.newlineTerminated).toBeGreaterThanOrEqual(
+          expected.minNewlineTerminated,
+        );
+      });
+    });
+  }
+});

--- a/src/__tests__/evals/recorded_calls/luna/add-error-handling/01.txt
+++ b/src/__tests__/evals/recorded_calls/luna/add-error-handling/01.txt
@@ -1,0 +1,12 @@
+<<<<<<< SEARCH
+import { getAuthToken } from "./auth";
+
+const BASE_URL =
+
+=======
+import { getAuthToken } from "./auth";
+import { logger } from "./logger";
+
+const BASE_URL =
+
+>>>>>>> REPLACE

--- a/src/__tests__/evals/recorded_calls/luna/add-error-handling/02.txt
+++ b/src/__tests__/evals/recorded_calls/luna/add-error-handling/02.txt
@@ -1,0 +1,52 @@
+<<<<<<< SEARCH
+export async function getResource<T>(
+  path: string,
+  headers?: Record<string, string>,
+): Promise<T> {
+  const data = await serviceRequest<T>(path, { method: "GET", headers });
+  return data;
+}
+
+export async function postResource<T>(path: string, body: unknown): Promise<T> {
+  const data = await serviceRequest<T>(path, { method: "POST", body });
+  return data;
+}
+
+export async function putResource<T>(path: string, body: unknown): Promise<T> {
+  const data = await serviceRequest<T>(path, { method: "PUT", body });
+  return data;
+}
+=======
+export async function getResource<T>(
+  path: string,
+  headers?: Record<string, string>,
+): Promise<T> {
+  try {
+    const data = await serviceRequest<T>(path, { method: "GET", headers });
+    return data;
+  } catch (err) {
+    logger.error(`GET ${path} failed`, err);
+    throw err;
+  }
+}
+
+export async function postResource<T>(path: string, body: unknown): Promise<T> {
+  try {
+    const data = await serviceRequest<T>(path, { method: "POST", body });
+    return data;
+  } catch (err) {
+    logger.error(`POST ${path} failed`, err);
+    throw err;
+  }
+}
+
+export async function putResource<T>(path: string, body: unknown): Promise<T> {
+  try {
+    const data = await serviceRequest<T>(path, { method: "PUT", body });
+    return data;
+  } catch (err) {
+    logger.error(`PUT ${path} failed`, err);
+    throw err;
+  }
+}
+>>>>>>> REPLACE

--- a/src/__tests__/evals/recorded_calls/luna/add-error-handling/03.txt
+++ b/src/__tests__/evals/recorded_calls/luna/add-error-handling/03.txt
@@ -1,0 +1,41 @@
+<<<<<<< SEARCH
+export async function patchResource<T>(
+  path: string,
+  body: unknown,
+): Promise<T> {
+  const data = await serviceRequest<T>(path, { method: "PATCH", body });
+  return data;
+}
+
+export async function deleteResource(path: string): Promise<void> {
+  const data = await serviceRequest<void>(path, { method: "DELETE" });
+  return data;
+}
+
+// ── User resources ─────────────────────────────────────────────────────────
+=======
+export async function patchResource<T>(
+  path: string,
+  body: unknown,
+): Promise<T> {
+  try {
+    const data = await serviceRequest<T>(path, { method: "PATCH", body });
+    return data;
+  } catch (err) {
+    logger.error(`PATCH ${path} failed`, err);
+    throw err;
+  }
+}
+
+export async function deleteResource(path: string): Promise<void> {
+  try {
+    const data = await serviceRequest<void>(path, { method: "DELETE" });
+    return data;
+  } catch (err) {
+    logger.error(`DELETE ${path} failed`, err);
+    throw err;
+  }
+}
+
+// ── User resources ─────────────────────────────────────────────────────────
+>>>>>>> REPLACE

--- a/src/__tests__/evals/recorded_calls/luna/add-zod-validation/01.txt
+++ b/src/__tests__/evals/recorded_calls/luna/add-zod-validation/01.txt
@@ -1,0 +1,27 @@
+<<<<<<< SEARCH
+import type { Request, Response } from "express";
+import { db } from "./db";
+import { logger } from "./logger";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+type UserRole = "admin" | "member" | "guest";
+
+=======
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { db } from "./db";
+import { logger } from "./logger";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+type UserRole = "admin" | "member" | "guest";
+
+const createUserBodySchema = z.object({
+  email: z.string().email(),
+  name: z.string().min(1),
+  age: z.number().int().nonnegative(),
+  role: z.enum(["admin", "member", "guest"]),
+});
+
+>>>>>>> REPLACE

--- a/src/__tests__/evals/recorded_calls/luna/add-zod-validation/02.txt
+++ b/src/__tests__/evals/recorded_calls/luna/add-zod-validation/02.txt
@@ -1,0 +1,37 @@
+<<<<<<< SEARCH
+export async function createUserHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const email = req.body.email as string;
+  const name = req.body.name as string;
+  const age = req.body.age as number;
+  const role = req.body.role as "admin" | "member" | "guest";
+
+  const existing = await db.query("SELECT id FROM users WHERE email = ?", [
+    email,
+  ]);
+
+=======
+export async function createUserHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  let parsedBody: z.infer<typeof createUserBodySchema>;
+  try {
+    parsedBody = createUserBodySchema.parse(req.body);
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      res.status(400).json({ error: "invalid body", details: err.issues });
+      return;
+    }
+    throw err;
+  }
+
+  const { email, name, age, role } = parsedBody;
+
+  const existing = await db.query("SELECT id FROM users WHERE email = ?", [
+    email,
+  ]);
+
+>>>>>>> REPLACE

--- a/src/__tests__/evals/recorded_calls/manifest.json
+++ b/src/__tests__/evals/recorded_calls/manifest.json
@@ -1,0 +1,63 @@
+{
+  "sol": {
+    "label": "GPT 5.6 Sol",
+    "cases": [
+      {
+        "case": "extract-a-helper-function",
+        "fixture": "order_processor.ts",
+        "calls": [
+          "01.txt"
+        ]
+      },
+      {
+        "case": "add-zod-validation",
+        "fixture": "user_handler.ts",
+        "calls": [
+          "01.txt",
+          "02.txt",
+          "03.txt"
+        ]
+      },
+      {
+        "case": "refactor-giant-component",
+        "fixture": "UserProfileFull.tsx",
+        "calls": [
+          "01.txt",
+          "02.txt",
+          "03.txt",
+          "04.txt",
+          "05.txt",
+          "06.txt",
+          "07.txt",
+          "08.txt",
+          "09.txt",
+          "10.txt",
+          "11.txt",
+          "12.txt"
+        ]
+      }
+    ]
+  },
+  "luna": {
+    "label": "GPT 5.6 Luna",
+    "cases": [
+      {
+        "case": "add-error-handling",
+        "fixture": "fetch_client.ts",
+        "calls": [
+          "01.txt",
+          "02.txt",
+          "03.txt"
+        ]
+      },
+      {
+        "case": "add-zod-validation",
+        "fixture": "user_handler.ts",
+        "calls": [
+          "01.txt",
+          "02.txt"
+        ]
+      }
+    ]
+  }
+}

--- a/src/__tests__/evals/recorded_calls/sol/add-zod-validation/01.txt
+++ b/src/__tests__/evals/recorded_calls/sol/add-zod-validation/01.txt
@@ -1,0 +1,16 @@
+<<<<<<< SEARCH
+import type { Request, Response } from "express";
+import { db } from "./db";
+import { logger } from "./logger";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+=======
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { db } from "./db";
+import { logger } from "./logger";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+>>>>>>> REPLACE

--- a/src/__tests__/evals/recorded_calls/sol/add-zod-validation/02.txt
+++ b/src/__tests__/evals/recorded_calls/sol/add-zod-validation/02.txt
@@ -1,0 +1,34 @@
+<<<<<<< SEARCH
+interface PaginatedResponse<T> {
+  items: T[];
+  total: number;
+  page: number;
+  limit: number;
+  hasMore: boolean;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function parseIntParam(value: string | undefined, defaultVal: number): number {
+
+=======
+interface PaginatedResponse<T> {
+  items: T[];
+  total: number;
+  page: number;
+  limit: number;
+  hasMore: boolean;
+}
+
+const createUserBodySchema = z.object({
+  email: z.string().email(),
+  name: z.string().min(1),
+  age: z.number().int().nonnegative(),
+  role: z.enum(["admin", "member", "guest"]),
+});
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function parseIntParam(value: string | undefined, defaultVal: number): number {
+
+>>>>>>> REPLACE

--- a/src/__tests__/evals/recorded_calls/sol/add-zod-validation/03.txt
+++ b/src/__tests__/evals/recorded_calls/sol/add-zod-validation/03.txt
@@ -1,0 +1,39 @@
+<<<<<<< SEARCH
+export async function createUserHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const email = req.body.email as string;
+  const name = req.body.name as string;
+  const age = req.body.age as number;
+  const role = req.body.role as "admin" | "member" | "guest";
+
+  const existing = await db.query("SELECT id FROM users WHERE email = ?", [
+    email,
+  ]);
+  if (existing.length > 0) {
+
+=======
+export async function createUserHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  let body: z.infer<typeof createUserBodySchema>;
+  try {
+    body = createUserBodySchema.parse(req.body);
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      res.status(400).json({ error: "invalid body", details: err.issues });
+      return;
+    }
+    throw err;
+  }
+
+  const { email, name, age, role } = body;
+
+  const existing = await db.query("SELECT id FROM users WHERE email = ?", [
+    email,
+  ]);
+  if (existing.length > 0) {
+
+>>>>>>> REPLACE

--- a/src/__tests__/evals/recorded_calls/sol/extract-a-helper-function/01.txt
+++ b/src/__tests__/evals/recorded_calls/sol/extract-a-helper-function/01.txt
@@ -1,0 +1,128 @@
+<<<<<<< SEARCH
+async function notifyOrderConfirmed(
+  _orderId: string,
+  _email: string,
+): Promise<void> {
+  // Implementation elided — sends confirmation email
+}
+
+/**
+ * Processes an order end-to-end.
+ * Validation, payment, shipment creation, and persistence are all inlined here.
+ * TODO: Extract the validation block into a separate `validateOrder` function.
+ */
+export async function processOrder(order: Order): Promise<ProcessResult> {
+  logger.info(`Processing order for ${order.items.length} item(s)`);
+
+  // ── Validation block (extract this into validateOrder) ────────────────────
+  // Check inventory for each item
+  for (const item of order.items) {
+    const inventory = await getInventory(item.productId);
+    if (!inventory) {
+      logger.warn(`Product ${item.productId} not found in inventory`);
+      return { success: false, error: `Product ${item.productId} not found` };
+    }
+    if (inventory.quantity < item.quantity) {
+      logger.warn(
+        `Insufficient stock for ${item.productId}: need ${item.quantity}, have ${inventory.quantity}`,
+      );
+      return {
+        success: false,
+        error: `Insufficient stock for ${item.productId}`,
+      };
+    }
+  }
+
+  // Validate payment method
+  if (
+    !order.payment.method ||
+    !["card", "paypal", "bank"].includes(order.payment.method)
+  ) {
+    return { success: false, error: "Invalid payment method" };
+  }
+  if (!order.payment.amount || order.payment.amount <= 0) {
+    return { success: false, error: "Invalid payment amount" };
+  }
+
+  // Validate shipping address
+  if (!order.shipping.address.street || !order.shipping.address.city) {
+    return { success: false, error: "Incomplete shipping address" };
+  }
+  if (!order.shipping.address.postalCode.match(/^\d{5}(-\d{4})?$/)) {
+    return { success: false, error: "Invalid postal code" };
+  }
+  // ── End of validation block ───────────────────────────────────────────────
+
+  // Reserve inventory
+  const reservations: Array<{ productId: string; quantity: number }> = [];
+  for (const item of order.items) {
+    const ok = await reserveInventory(item.productId, item.quantity);
+    if (!ok) {
+
+=======
+async function notifyOrderConfirmed(
+  _orderId: string,
+  _email: string,
+): Promise<void> {
+  // Implementation elided — sends confirmation email
+}
+
+async function validateOrder(order: Order): Promise<ProcessResult | null> {
+  // Check inventory for each item
+  for (const item of order.items) {
+    const inventory = await getInventory(item.productId);
+    if (!inventory) {
+      logger.warn(`Product ${item.productId} not found in inventory`);
+      return { success: false, error: `Product ${item.productId} not found` };
+    }
+    if (inventory.quantity < item.quantity) {
+      logger.warn(
+        `Insufficient stock for ${item.productId}: need ${item.quantity}, have ${inventory.quantity}`,
+      );
+      return {
+        success: false,
+        error: `Insufficient stock for ${item.productId}`,
+      };
+    }
+  }
+
+  // Validate payment method
+  if (
+    !order.payment.method ||
+    !["card", "paypal", "bank"].includes(order.payment.method)
+  ) {
+    return { success: false, error: "Invalid payment method" };
+  }
+  if (!order.payment.amount || order.payment.amount <= 0) {
+    return { success: false, error: "Invalid payment amount" };
+  }
+
+  // Validate shipping address
+  if (!order.shipping.address.street || !order.shipping.address.city) {
+    return { success: false, error: "Incomplete shipping address" };
+  }
+  if (!order.shipping.address.postalCode.match(/^\d{5}(-\d{4})?$/)) {
+    return { success: false, error: "Invalid postal code" };
+  }
+
+  return null;
+}
+
+/**
+ * Processes an order end-to-end.
+ */
+export async function processOrder(order: Order): Promise<ProcessResult> {
+  logger.info(`Processing order for ${order.items.length} item(s)`);
+
+  const validationFailure = await validateOrder(order);
+  if (validationFailure) {
+    return validationFailure;
+  }
+
+  // Reserve inventory
+  const reservations: Array<{ productId: string; quantity: number }> = [];
+  for (const item of order.items) {
+    const ok = await reserveInventory(item.productId, item.quantity);
+    if (!ok) {
+
+>>>>>>> REPLACE

--- a/src/__tests__/evals/recorded_calls/sol/refactor-giant-component/01.txt
+++ b/src/__tests__/evals/recorded_calls/sol/refactor-giant-component/01.txt
@@ -1,0 +1,393 @@
+<<<<<<< SEARCH
+function getActivityIcon(type: string): string {
+  switch (type) {
+    case "commit":
+      return "📝";
+    case "review":
+      return "👀";
+    case "merge":
+      return "🔀";
+    case "comment":
+      return "💬";
+    case "deploy":
+      return "🚀";
+    default:
+      return "📌";
+  }
+}
+
+// ── Main component ────────────────────────────────────────────
+
+=======
+function getActivityIcon(type: string): string {
+  switch (type) {
+    case "commit":
+      return "📝";
+    case "review":
+      return "👀";
+    case "merge":
+      return "🔀";
+    case "comment":
+      return "💬";
+    case "deploy":
+      return "🚀";
+    default:
+      return "📌";
+  }
+}
+
+interface AvatarSectionProps {
+  user: User;
+  userId: string;
+}
+
+function AvatarSection({ user, userId }: AvatarSectionProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [avatar, setAvatar] = useState<AvatarState>({
+    url: user.avatarUrl ?? null,
+    uploading: false,
+    error: null,
+    previewUrl: null,
+  });
+
+  useEffect(() => {
+    setAvatar((prev) => ({ ...prev, url: user.avatarUrl ?? null }));
+  }, [user.avatarUrl]);
+
+  const handleAvatarClick = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
+  const handleAvatarSelect = useCallback(
+    async (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      if (!file) return;
+
+      if (!file.type.startsWith("image/")) {
+        setAvatar((prev) => ({
+          ...prev,
+          error: "Please select an image file",
+        }));
+        return;
+      }
+
+      if (file.size > 5 * 1024 * 1024) {
+        setAvatar((prev) => ({ ...prev, error: "Image must be under 5MB" }));
+        return;
+      }
+
+      const previewUrl = URL.createObjectURL(file);
+      setAvatar((prev) => ({
+        ...prev,
+        previewUrl,
+        uploading: true,
+        error: null,
+      }));
+
+      try {
+        const result = await uploadAvatar(userId, file);
+        setAvatar({
+          url: result.url,
+          uploading: false,
+          error: null,
+          previewUrl: null,
+        });
+        URL.revokeObjectURL(previewUrl);
+      } catch (err) {
+        setAvatar((prev) => ({
+          ...prev,
+          uploading: false,
+          error: err instanceof Error ? err.message : "Upload failed",
+        }));
+        URL.revokeObjectURL(previewUrl);
+      }
+    },
+    [userId],
+  );
+
+  const handleAvatarRemove = useCallback(() => {
+    setAvatar({ url: null, uploading: false, error: null, previewUrl: null });
+  }, []);
+
+  const avatarDisplayUrl =
+    avatar.previewUrl ?? avatar.url ?? "/default-avatar.png";
+
+  const renderAvatarBadge = () => {
+    if (avatar.uploading) {
+      return <span className="avatar-badge avatar-badge--uploading">⏳</span>;
+    }
+    if (avatar.error) {
+      return <span className="avatar-badge avatar-badge--error">⚠️</span>;
+    }
+    return null;
+  };
+
+  return (
+    <section className="avatar-section">
+      <div className="avatar-container" onClick={handleAvatarClick}>
+        <img
+          src={avatarDisplayUrl}
+          alt={`${user.name}'s avatar`}
+          className={`avatar-image ${avatar.uploading ? "avatar-image--uploading" : ""}`}
+        />
+        {renderAvatarBadge()}
+        <div className="avatar-overlay">
+          <span>Change Photo</span>
+        </div>
+      </div>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        className="avatar-input"
+        onChange={handleAvatarSelect}
+      />
+      {avatar.url && (
+        <button className="avatar-remove-btn" onClick={handleAvatarRemove}>
+          Remove Photo
+        </button>
+      )}
+      {avatar.error && <p className="avatar-error">{avatar.error}</p>}
+      <div className="avatar-info">
+        <h2>{user.name}</h2>
+        <p className="avatar-info__role">{user.role}</p>
+        <p className="avatar-info__email">{user.email}</p>
+        <p className="avatar-info__joined">
+          Member since {new Date(user.createdAt).toLocaleDateString()}
+        </p>
+      </div>
+    </section>
+  );
+}
+
+interface StatsPanelProps {
+  userId: string;
+}
+
+function StatsPanel({ userId }: StatsPanelProps) {
+  const initialPeriod: "week" | "month" | "year" = "month";
+  const [stats, setStats] = useState<StatsState>({
+    cards: [],
+    loading: true,
+    error: null,
+    period: initialPeriod,
+  });
+
+  const loadStats = useCallback(async (period: "week" | "month" | "year") => {
+    setStats((prev) => ({ ...prev, loading: true, error: null, period }));
+    try {
+      await new Promise((r) => setTimeout(r, 100));
+      const mockCards: StatCard[] = [
+        { label: "Commits", value: period === "week" ? 23 : period === "month" ? 87 : 1042, change: 12.5 },
+        { label: "PRs Merged", value: period === "week" ? 5 : period === "month" ? 18 : 203, change: -3.2 },
+        { label: "Reviews", value: period === "week" ? 11 : period === "month" ? 42 : 498, change: 8.1 },
+        { label: "Lines Changed", value: period === "week" ? 1250 : period === "month" ? 4800 : 58000, unit: "lines", change: 15.7 },
+        { label: "Issues Closed", value: period === "week" ? 7 : period === "month" ? 25 : 312, change: 0 },
+        { label: "Build Success", value: "98.2%", change: 1.1 },
+      ];
+      setStats({ cards: mockCards, loading: false, error: null, period });
+    } catch (err) {
+      setStats((prev) => ({
+        ...prev,
+        loading: false,
+        error: err instanceof Error ? err.message : "Failed to load stats",
+      }));
+    }
+  }, []);
+
+  useEffect(() => {
+    if (userId) loadStats(initialPeriod);
+  }, [userId, loadStats]);
+
+  const statsGridColumns = useMemo(
+    () => (stats.cards.length <= 3 ? "stats-grid--2col" : "stats-grid--3col"),
+    [stats.cards.length],
+  );
+  const totalCommits = useMemo(() => {
+    const commitCard = stats.cards.find((card) => card.label === "Commits");
+    return typeof commitCard?.value === "number" ? commitCard.value : 0;
+  }, [stats.cards]);
+  const periods: Array<"week" | "month" | "year"> = ["week", "month", "year"];
+
+  return (
+    <section className="stats-panel">
+      <div className="stats-header">
+        <h2 className="stats-header__title">Performance Stats</h2>
+        <div className="stats-header__periods">
+          {periods.map((period) => (
+            <button
+              key={period}
+              className={`period-btn ${stats.period === period ? "period-btn--active" : ""}`}
+              onClick={() => loadStats(period)}
+            >
+              {period.charAt(0).toUpperCase() + period.slice(1)}
+            </button>
+          ))}
+        </div>
+      </div>
+      {stats.loading ? (
+        <div className="stats-loading">
+          <div className="spinner spinner--small" />
+          <p>Loading stats…</p>
+        </div>
+      ) : stats.error ? (
+        <div className="stats-error">
+          <p>{stats.error}</p>
+          <button onClick={() => loadStats(stats.period)}>Retry</button>
+        </div>
+      ) : (
+        <>
+          <div className={`stats-grid ${statsGridColumns}`}>
+            {stats.cards.map((card, index) => (
+              <div key={index} className="stat-card">
+                <div className="stat-card__label">{card.label}</div>
+                <div className="stat-card__value">
+                  {formatStatValue(card.value, card.unit)}
+                </div>
+                <div className={`stat-card__change ${getChangeClass(card.change)}`}>
+                  {formatChangePercent(card.change)}
+                </div>
+              </div>
+            ))}
+          </div>
+          {totalCommits !== 0 && (
+            <div className="stats-summary">
+              <p>
+                Total activity: <strong>{totalCommits}</strong> commits this{" "}
+                {stats.period}.
+              </p>
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  );
+}
+
+interface ActivityFeedProps {
+  userId: string;
+}
+
+function ActivityFeed({ userId }: ActivityFeedProps) {
+  const navigate = useNavigate();
+  const [activityState, setActivityState] = useState<ActivityState>({
+    items: [],
+    loading: true,
+    error: null,
+    page: 1,
+    hasMore: true,
+  });
+
+  const loadActivity = useCallback(
+    async (page: number, append = false) => {
+      setActivityState((prev) => ({ ...prev, loading: true, error: null }));
+      try {
+        const items = await fetchUserActivity(userId, page);
+        setActivityState((prev) => ({
+          items: append ? [...prev.items, ...items] : items,
+          loading: false,
+          error: null,
+          page,
+          hasMore: items.length >= 20,
+        }));
+      } catch (err) {
+        setActivityState((prev) => ({
+          ...prev,
+          loading: false,
+          error: err instanceof Error ? err.message : "Failed to load activity",
+        }));
+      }
+    },
+    [userId],
+  );
+
+  useEffect(() => {
+    if (userId) loadActivity(1);
+  }, [userId, loadActivity]);
+
+  const groupedActivity = useMemo(() => {
+    const groups: Record<string, ActivityItem[]> = {};
+    for (const item of activityState.items) {
+      const dateKey = new Date(item.timestamp).toLocaleDateString();
+      if (!groups[dateKey]) groups[dateKey] = [];
+      groups[dateKey].push(item);
+    }
+    return groups;
+  }, [activityState.items]);
+
+  const renderActivityItem = (item: ActivityItem) => (
+    <div key={item.id} className="activity-item">
+      <span className="activity-item__icon">{getActivityIcon(item.type)}</span>
+      <div className="activity-item__content">
+        <p className="activity-item__description">{item.description}</p>
+        <span className="activity-item__time">
+          {formatActivityDate(item.timestamp)}
+        </span>
+        {item.metadata?.pr && (
+          <a
+            className="activity-item__link"
+            href={`/pr/${item.metadata.pr}`}
+            onClick={(event) => {
+              event.preventDefault();
+              navigate(`/pr/${item.metadata!.pr}`);
+            }}
+          >
+            PR #{item.metadata.pr}
+          </a>
+        )}
+      </div>
+    </div>
+  );
+
+  return (
+    <section className="activity-feed">
+      <h2 className="activity-feed__title">Recent Activity</h2>
+      {activityState.loading && activityState.items.length === 0 ? (
+        <div className="activity-loading">
+          <div className="spinner spinner--small" />
+          <p>Loading activity…</p>
+        </div>
+      ) : activityState.error && activityState.items.length === 0 ? (
+        <div className="activity-error">
+          <p>{activityState.error}</p>
+          <button onClick={() => loadActivity(1)}>Retry</button>
+        </div>
+      ) : activityState.items.length === 0 ? (
+        <div className="activity-empty">
+          <p>No recent activity to show.</p>
+        </div>
+      ) : (
+        <>
+          {Object.entries(groupedActivity).map(([dateKey, items]) => (
+            <div key={dateKey} className="activity-group">
+              <h3 className="activity-group__date">{dateKey}</h3>
+              <div className="activity-group__items">
+                {items.map(renderActivityItem)}
+              </div>
+            </div>
+          ))}
+          {activityState.hasMore && (
+            <div className="activity-load-more">
+              <button
+                onClick={() => loadActivity(activityState.page + 1, true)}
+                disabled={activityState.loading}
+                className="btn btn--secondary"
+              >
+                {activityState.loading ? "Loading…" : "Load More"}
+              </button>
+            </div>
+          )}
+          {activityState.error && (
+            <div className="activity-inline-error">
+              <p>Failed to load more: {activityState.error}</p>
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────
+
+>>>>>>> REPLACE

--- a/src/__tests__/evals/recorded_calls/sol/refactor-giant-component/02.txt
+++ b/src/__tests__/evals/recorded_calls/sol/refactor-giant-component/02.txt
@@ -1,0 +1,109 @@
+<<<<<<< SEARCH
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  // ── Avatar state and logic ──────────────────────────────────
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [avatar, setAvatar] = useState<AvatarState>({
+    url: null,
+    uploading: false,
+    error: null,
+    previewUrl: null,
+  });
+
+  const handleAvatarClick = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
+  const handleAvatarSelect = useCallback(
+    async (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      if (!file) return;
+
+      if (!file.type.startsWith("image/")) {
+        setAvatar((prev) => ({
+          ...prev,
+          error: "Please select an image file",
+        }));
+        return;
+      }
+
+      if (file.size > 5 * 1024 * 1024) {
+        setAvatar((prev) => ({ ...prev, error: "Image must be under 5MB" }));
+        return;
+      }
+
+      const previewUrl = URL.createObjectURL(file);
+      setAvatar((prev) => ({
+        ...prev,
+        previewUrl,
+        uploading: true,
+        error: null,
+      }));
+
+      try {
+        const result = await uploadAvatar(resolvedUserId, file);
+        setAvatar({
+          url: result.url,
+          uploading: false,
+          error: null,
+          previewUrl: null,
+        });
+        URL.revokeObjectURL(previewUrl);
+      } catch (err) {
+        setAvatar((prev) => ({
+          ...prev,
+          uploading: false,
+          error: err instanceof Error ? err.message : "Upload failed",
+        }));
+        URL.revokeObjectURL(previewUrl);
+      }
+    },
+    [resolvedUserId],
+  );
+
+  const handleAvatarRemove = useCallback(() => {
+    setAvatar({ url: null, uploading: false, error: null, previewUrl: null });
+  }, []);
+
+  const avatarDisplayUrl =
+    avatar.previewUrl ?? avatar.url ?? "/default-avatar.png";
+
+  const renderAvatarBadge = useCallback(() => {
+    if (avatar.uploading) {
+      return <span className="avatar-badge avatar-badge--uploading">⏳</span>;
+    }
+    if (avatar.error) {
+      return <span className="avatar-badge avatar-badge--error">⚠️</span>;
+    }
+    return null;
+  }, [avatar.uploading, avatar.error]);
+
+  // ── Load user data ──────────────────────────────────────────
+
+  const loadUser = useCallback(async () => {
+    if (!resolvedUserId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const userData = await fetchUser(resolvedUserId);
+      setUser(userData);
+      setAvatar((prev) => ({ ...prev, url: userData.avatarUrl ?? null }));
+    } catch (err) {
+
+=======
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  // ── Load user data ──────────────────────────────────────────
+
+  const loadUser = useCallback(async () => {
+    if (!resolvedUserId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const userData = await fetchUser(resolvedUserId);
+      setUser(userData);
+    } catch (err) {
+
+>>>>>>> REPLACE

--- a/src/__tests__/evals/recorded_calls/sol/refactor-giant-component/03.txt
+++ b/src/__tests__/evals/recorded_calls/sol/refactor-giant-component/03.txt
@@ -1,0 +1,158 @@
+<<<<<<< SEARCH
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const updated = await updateUser(resolvedUserId, draft);
+      setUser(updated);
+      setEditing(false);
+      setDraft({});
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  }, [resolvedUserId, draft]);
+
+  // ── Stats state and logic ───────────────────────────────────
+  const INITIAL_STATS_PERIOD: "week" | "month" | "year" = "month";
+  const [stats, setStats] = useState<StatsState>({
+    cards: [],
+    loading: true,
+    error: null,
+    period: INITIAL_STATS_PERIOD,
+  });
+
+  const loadStats = useCallback(async (period: "week" | "month" | "year") => {
+    setStats((prev) => ({ ...prev, loading: true, error: null, period }));
+    try {
+      // Simulate loading stats — in production this hits the analytics API
+      await new Promise((r) => setTimeout(r, 100));
+      const mockCards: StatCard[] = [
+        {
+          label: "Commits",
+          value: period === "week" ? 23 : period === "month" ? 87 : 1042,
+          change: 12.5,
+        },
+        {
+          label: "PRs Merged",
+          value: period === "week" ? 5 : period === "month" ? 18 : 203,
+          change: -3.2,
+        },
+        {
+          label: "Reviews",
+          value: period === "week" ? 11 : period === "month" ? 42 : 498,
+          change: 8.1,
+        },
+        {
+          label: "Lines Changed",
+          value: period === "week" ? 1250 : period === "month" ? 4800 : 58000,
+          unit: "lines",
+          change: 15.7,
+        },
+        {
+          label: "Issues Closed",
+          value: period === "week" ? 7 : period === "month" ? 25 : 312,
+          change: 0,
+        },
+        { label: "Build Success", value: "98.2%", change: 1.1 },
+      ];
+      setStats({ cards: mockCards, loading: false, error: null, period });
+    } catch (err) {
+      setStats((prev) => ({
+        ...prev,
+        loading: false,
+        error: err instanceof Error ? err.message : "Failed to load stats",
+      }));
+    }
+  }, []);
+
+  useEffect(() => {
+    if (showStats && resolvedUserId) {
+      loadStats(INITIAL_STATS_PERIOD);
+    }
+  }, [showStats, resolvedUserId, loadStats]);
+
+  const handlePeriodChange = useCallback(
+    (period: "week" | "month" | "year") => {
+      loadStats(period);
+    },
+    [loadStats],
+  );
+
+  const statsGridColumns = useMemo(() => {
+    return stats.cards.length <= 3 ? "stats-grid--2col" : "stats-grid--3col";
+  }, [stats.cards.length]);
+
+  const totalCommits = useMemo(() => {
+    const commitCard = stats.cards.find((c) => c.label === "Commits");
+    return typeof commitCard?.value === "number" ? commitCard.value : 0;
+  }, [stats.cards]);
+
+  const renderStatCard = useCallback((card: StatCard, index: number) => {
+    return (
+      <div key={index} className="stat-card">
+        <div className="stat-card__label">{card.label}</div>
+        <div className="stat-card__value">
+          {formatStatValue(card.value, card.unit)}
+        </div>
+        <div className={`stat-card__change ${getChangeClass(card.change)}`}>
+          {formatChangePercent(card.change)}
+        </div>
+      </div>
+    );
+  }, []);
+
+  const renderStatsHeader = useCallback(() => {
+    const periods: Array<"week" | "month" | "year"> = ["week", "month", "year"];
+    return (
+      <div className="stats-header">
+        <h2 className="stats-header__title">Performance Stats</h2>
+        <div className="stats-header__periods">
+          {periods.map((p) => (
+            <button
+              key={p}
+              className={`period-btn ${stats.period === p ? "period-btn--active" : ""}`}
+              onClick={() => handlePeriodChange(p)}
+            >
+              {p.charAt(0).toUpperCase() + p.slice(1)}
+            </button>
+          ))}
+        </div>
+      </div>
+    );
+  }, [stats.period, handlePeriodChange]);
+
+  const renderStatsSummary = useCallback(() => {
+    if (totalCommits === 0) return null;
+    return (
+      <div className="stats-summary">
+        <p>
+          Total activity: <strong>{totalCommits}</strong> commits this{" "}
+          {stats.period}.
+        </p>
+      </div>
+    );
+  }, [totalCommits, stats.period]);
+
+  // ── Activity feed state and logic ───────────────────────────
+
+=======
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const updated = await updateUser(resolvedUserId, draft);
+      setUser(updated);
+      setEditing(false);
+      setDraft({});
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  }, [resolvedUserId, draft]);
+
+  // ── Activity feed state and logic ───────────────────────────
+
+>>>>>>> REPLACE

--- a/src/__tests__/evals/recorded_calls/sol/refactor-giant-component/04.txt
+++ b/src/__tests__/evals/recorded_calls/sol/refactor-giant-component/04.txt
@@ -1,0 +1,125 @@
+<<<<<<< SEARCH
+  // ── Activity feed state and logic ───────────────────────────
+  const [activityState, setActivityState] = useState<ActivityState>({
+    items: [],
+    loading: true,
+    error: null,
+    page: 1,
+    hasMore: true,
+  });
+
+  const loadActivity = useCallback(
+    async (page: number, append = false) => {
+      setActivityState((prev) => ({ ...prev, loading: true, error: null }));
+      try {
+        const items = await fetchUserActivity(resolvedUserId, page);
+        setActivityState((prev) => ({
+          items: append ? [...prev.items, ...items] : items,
+          loading: false,
+          error: null,
+          page,
+          hasMore: items.length >= 20,
+        }));
+      } catch (err) {
+        setActivityState((prev) => ({
+          ...prev,
+          loading: false,
+          error: err instanceof Error ? err.message : "Failed to load activity",
+        }));
+      }
+    },
+    [resolvedUserId],
+  );
+
+  useEffect(() => {
+    if (showActivity && resolvedUserId) {
+      loadActivity(1);
+    }
+  }, [showActivity, resolvedUserId, loadActivity]);
+
+  const handleLoadMore = useCallback(() => {
+    loadActivity(activityState.page + 1, true);
+  }, [loadActivity, activityState.page]);
+
+  const groupedActivity = useMemo(() => {
+    const groups: Record<string, ActivityItem[]> = {};
+    for (const item of activityState.items) {
+      const dateKey = new Date(item.timestamp).toLocaleDateString();
+      if (!groups[dateKey]) groups[dateKey] = [];
+      groups[dateKey].push(item);
+    }
+    return groups;
+  }, [activityState.items]);
+
+  const renderActivityItem = useCallback(
+    (item: ActivityItem) => {
+      return (
+        <div key={item.id} className="activity-item">
+          <span className="activity-item__icon">
+            {getActivityIcon(item.type)}
+          </span>
+          <div className="activity-item__content">
+            <p className="activity-item__description">{item.description}</p>
+            <span className="activity-item__time">
+              {formatActivityDate(item.timestamp)}
+            </span>
+            {item.metadata?.pr && (
+              <a
+                className="activity-item__link"
+                href={`/pr/${item.metadata.pr}`}
+                onClick={(e) => {
+                  e.preventDefault();
+                  navigate(`/pr/${item.metadata!.pr}`);
+                }}
+              >
+                PR #{item.metadata.pr}
+              </a>
+            )}
+          </div>
+        </div>
+      );
+    },
+    [navigate],
+  );
+
+  const renderActivityGroup = useCallback(
+    (dateKey: string, items: ActivityItem[]) => {
+      return (
+        <div key={dateKey} className="activity-group">
+          <h3 className="activity-group__date">{dateKey}</h3>
+          <div className="activity-group__items">
+            {items.map((item) => renderActivityItem(item))}
+          </div>
+        </div>
+      );
+    },
+    [renderActivityItem],
+  );
+
+  const renderActivityEmpty = useCallback(() => {
+    return (
+      <div className="activity-empty">
+        <p>No recent activity to show.</p>
+      </div>
+    );
+  }, []);
+
+  const renderActivityError = useCallback(() => {
+    return (
+      <div className="activity-error">
+        <p>{activityState.error}</p>
+        <button onClick={() => loadActivity(1)}>Retry</button>
+      </div>
+    );
+  }, [activityState.error, loadActivity]);
+
+  // ── Loading / error states ──────────────────────────────────
+
+  if (loading) {
+
+=======
+  // ── Loading / error states ──────────────────────────────────
+
+  if (loading) {
+
+>>>>>>> REPLACE

--- a/src/__tests__/evals/recorded_calls/sol/refactor-giant-component/05.txt
+++ b/src/__tests__/evals/recorded_calls/sol/refactor-giant-component/05.txt
@@ -1,0 +1,125 @@
+<<<<<<< SEARCH
+  // ── Activity feed state and logic ───────────────────────────
+  const [activityState, setActivityState] = useState<ActivityState>({
+    items: [],
+    loading: true,
+    error: null,
+    page: 1,
+    hasMore: true,
+  });
+
+  const loadActivity = useCallback(
+    async (page: number, append = false) => {
+      setActivityState((prev) => ({ ...prev, loading: true, error: null }));
+      try {
+        const items = await fetchUserActivity(resolvedUserId, page);
+        setActivityState((prev) => ({
+          items: append ? [...prev.items, ...items] : items,
+          loading: false,
+          error: null,
+          page,
+          hasMore: items.length >= 20,
+        }));
+      } catch (err) {
+        setActivityState((prev) => ({
+          ...prev,
+          loading: false,
+          error: err instanceof Error ? err.message : "Failed to load activity",
+        }));
+      }
+    },
+    [resolvedUserId],
+  );
+
+  useEffect(() => {
+    if (showActivity && resolvedUserId) {
+      loadActivity(1);
+    }
+  }, [showActivity, resolvedUserId, loadActivity]);
+
+  const handleLoadMore = useCallback(() => {
+    loadActivity(activityState.page + 1, true);
+  }, [loadActivity, activityState.page]);
+
+  const groupedActivity = useMemo(() => {
+    const groups: Record<string, ActivityItem[]> = {};
+    for (const item of activityState.items) {
+      const dateKey = new Date(item.timestamp).toLocaleDateString();
+      if (!groups[dateKey]) groups[dateKey] = [];
+      groups[dateKey].push(item);
+    }
+    return groups;
+  }, [activityState.items]);
+
+  const renderActivityItem = useCallback(
+    (item: ActivityItem) => {
+      return (
+        <div key={item.id} className="activity-item">
+          <span className="activity-item__icon">
+            {getActivityIcon(item.type)}
+          </span>
+          <div className="activity-item__content">
+            <p className="activity-item__description">{item.description}</p>
+            <span className="activity-item__time">
+              {formatActivityDate(item.timestamp)}
+            </span>
+            {item.metadata?.pr && (
+              <a
+                className="activity-item__link"
+                href={`/pr/${item.metadata.pr}`}
+                onClick={(e) => {
+                  e.preventDefault();
+                  navigate(`/pr/${item.metadata!.pr}`);
+                }}
+              >
+                PR #{item.metadata.pr}
+              </a>
+            )}
+          </div>
+        </div>
+      );
+    },
+    [navigate],
+  );
+
+  const renderActivityGroup = useCallback(
+    (dateKey: string, items: ActivityItem[]) => {
+      return (
+        <div key={dateKey} className="activity-group">
+          <h3 className="activity-group__date">{dateKey}</h3>
+          <div className="activity-group__items">
+            {items.map((item) => renderActivityItem(item))}
+          </div>
+        </div>
+      );
+    },
+    [renderActivityItem],
+  );
+
+  const renderActivityEmpty = useCallback(() => {
+    return (
+      <div className="activity-empty">
+        <p>No recent activity to show.</p>
+      </div>
+    );
+  }, []);
+
+  const renderActivityError = useCallback(() => {
+    return (
+      <div className="activity-error">
+        <p>{activityState.error}</p>
+        <button onClick={() => loadActivity(1)}>Retry</button>
+      </div>
+    );
+  }, [activityState.error, loadActivity]);
+
+  // ── Loading / error states ──────────────────────────────────
+
+  if (loading) {
+
+=======
+  // ── Loading / error states ──────────────────────────────────
+
+  if (loading) {
+
+>>>>>>> REPLACE

--- a/src/__tests__/evals/recorded_calls/sol/refactor-giant-component/06.txt
+++ b/src/__tests__/evals/recorded_calls/sol/refactor-giant-component/06.txt
@@ -1,0 +1,50 @@
+<<<<<<< SEARCH
+  // ── Activity feed state and logic ───────────────────────────
+  const [activityState, setActivityState] = useState<ActivityState>({
+    items: [],
+    loading: true,
+    error: null,
+    page: 1,
+    hasMore: true,
+  });
+
+  const loadActivity = useCallback(
+    async (page: number, append = false) => {
+      setActivityState((prev) => ({ ...prev, loading: true, error: null }));
+      try {
+        const items = await fetchUserActivity(resolvedUserId, page);
+        setActivityState((prev) => ({
+          items: append ? [...prev.items, ...items] : items,
+          loading: false,
+          error: null,
+          page,
+          hasMore: items.length >= 20,
+        }));
+      } catch (err) {
+        setActivityState((prev) => ({
+          ...prev,
+          loading: false,
+          error: err instanceof Error ? err.message : "Failed to load activity",
+        }));
+      }
+    },
+    [resolvedUserId],
+  );
+
+  useEffect(() => {
+    if (showActivity && resolvedUserId) {
+      loadActivity(1);
+    }
+  }, [showActivity, resolvedUserId, loadActivity]);
+
+  const handleLoadMore = useCallback(() => {
+    loadActivity(activityState.page + 1, true);
+  }, [loadActivity, activityState.page]);
+
+  const groupedActivity = useMemo(() => {
+
+=======
+  // ── Activity feed state and logic ───────────────────────────
+  const groupedActivity = useMemo(() => {
+
+>>>>>>> REPLACE

--- a/src/__tests__/evals/recorded_calls/sol/refactor-giant-component/07.txt
+++ b/src/__tests__/evals/recorded_calls/sol/refactor-giant-component/07.txt
@@ -1,0 +1,46 @@
+<<<<<<< SEARCH
+      {/* ── Avatar section ────────────────────────────────── */}
+      <section className="avatar-section">
+        <div className="avatar-container" onClick={handleAvatarClick}>
+          <img
+            src={avatarDisplayUrl}
+            alt={`${user.name}'s avatar`}
+            className={`avatar-image ${avatar.uploading ? "avatar-image--uploading" : ""}`}
+          />
+          {renderAvatarBadge()}
+          <div className="avatar-overlay">
+            <span>Change Photo</span>
+          </div>
+        </div>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          className="avatar-input"
+          onChange={handleAvatarSelect}
+        />
+        {avatar.url && (
+          <button className="avatar-remove-btn" onClick={handleAvatarRemove}>
+            Remove Photo
+          </button>
+        )}
+        {avatar.error && <p className="avatar-error">{avatar.error}</p>}
+        <div className="avatar-info">
+          <h2>{user.name}</h2>
+          <p className="avatar-info__role">{user.role}</p>
+          <p className="avatar-info__email">{user.email}</p>
+          <p className="avatar-info__joined">
+            Member since {new Date(user.createdAt).toLocaleDateString()}
+          </p>
+        </div>
+      </section>
+
+      {/* ── Profile edit form ─────────────────────────────── */}
+
+=======
+      {/* ── Avatar section ────────────────────────────────── */}
+      <AvatarSection user={user} userId={resolvedUserId} />
+
+      {/* ── Profile edit form ─────────────────────────────── */}
+
+>>>>>>> REPLACE

--- a/src/__tests__/evals/recorded_calls/sol/refactor-giant-component/08.txt
+++ b/src/__tests__/evals/recorded_calls/sol/refactor-giant-component/08.txt
@@ -1,0 +1,35 @@
+<<<<<<< SEARCH
+      {/* ── Stats panel ───────────────────────────────────── */}
+      {showStats && (
+        <section className="stats-panel">
+          {renderStatsHeader()}
+          {stats.loading ? (
+            <div className="stats-loading">
+              <div className="spinner spinner--small" />
+              <p>Loading stats…</p>
+            </div>
+          ) : stats.error ? (
+            <div className="stats-error">
+              <p>{stats.error}</p>
+              <button onClick={() => loadStats(stats.period)}>Retry</button>
+            </div>
+          ) : (
+            <>
+              <div className={`stats-grid ${statsGridColumns}`}>
+                {stats.cards.map((card, i) => renderStatCard(card, i))}
+              </div>
+              {renderStatsSummary()}
+            </>
+          )}
+        </section>
+      )}
+
+      {/* ── Activity feed ─────────────────────────────────── */}
+
+=======
+      {/* ── Stats panel ───────────────────────────────────── */}
+      {showStats && <StatsPanel userId={resolvedUserId} />}
+
+      {/* ── Activity feed ─────────────────────────────────── */}
+
+>>>>>>> REPLACE

--- a/src/__tests__/evals/recorded_calls/sol/refactor-giant-component/09.txt
+++ b/src/__tests__/evals/recorded_calls/sol/refactor-giant-component/09.txt
@@ -1,0 +1,49 @@
+<<<<<<< SEARCH
+      {/* ── Activity feed ─────────────────────────────────── */}
+      {showActivity && (
+        <section className="activity-feed">
+          <h2 className="activity-feed__title">Recent Activity</h2>
+          {activityState.loading && activityState.items.length === 0 ? (
+            <div className="activity-loading">
+              <div className="spinner spinner--small" />
+              <p>Loading activity…</p>
+            </div>
+          ) : activityState.error && activityState.items.length === 0 ? (
+            renderActivityError()
+          ) : activityState.items.length === 0 ? (
+            renderActivityEmpty()
+          ) : (
+            <>
+              {Object.entries(groupedActivity).map(([dateKey, items]) =>
+                renderActivityGroup(dateKey, items),
+              )}
+              {activityState.hasMore && (
+                <div className="activity-load-more">
+                  <button
+                    onClick={handleLoadMore}
+                    disabled={activityState.loading}
+                    className="btn btn--secondary"
+                  >
+                    {activityState.loading ? "Loading…" : "Load More"}
+                  </button>
+                </div>
+              )}
+              {activityState.error && (
+                <div className="activity-inline-error">
+                  <p>Failed to load more: {activityState.error}</p>
+                </div>
+              )}
+            </>
+          )}
+        </section>
+      )}
+
+      {/* ── Footer ────────────────────────────────────────── */}
+
+=======
+      {/* ── Activity feed ─────────────────────────────────── */}
+      {showActivity && <ActivityFeed userId={resolvedUserId} />}
+
+      {/* ── Footer ────────────────────────────────────────── */}
+
+>>>>>>> REPLACE

--- a/src/__tests__/evals/recorded_calls/sol/refactor-giant-component/10.txt
+++ b/src/__tests__/evals/recorded_calls/sol/refactor-giant-component/10.txt
@@ -1,0 +1,51 @@
+<<<<<<< SEARCH
+      {/* ── Activity feed ─────────────────────────────────── */}
+      {showActivity && (
+        <section className="activity-feed">
+          <h2 className="activity-feed__title">Recent Activity</h2>
+          {activityState.loading && activityState.items.length === 0 ? (
+            <div className="activity-loading">
+              <div className="spinner spinner--small" />
+              <p>Loading activity…</p>
+            </div>
+          ) : activityState.error && activityState.items.length === 0 ? (
+            renderActivityError()
+          ) : activityState.items.length === 0 ? (
+            renderActivityEmpty()
+          ) : (
+            <>
+              {Object.entries(groupedActivity).map(([dateKey, items]) =>
+                renderActivityGroup(dateKey, items),
+              )}
+              {activityState.hasMore && (
+                <div className="activity-load-more">
+                  <button
+                    onClick={handleLoadMore}
+                    disabled={activityState.loading}
+                    className="btn btn--secondary"
+                  >
+                    {activityState.loading ? "Loading…" : "Load More"}
+                  </button>
+                </div>
+              )}
+              {activityState.error && (
+                <div className="activity-inline-error">
+                  <p>Failed to load more: {activityState.error}</p>
+                </div>
+              )}
+            </>
+          )}
+        </section>
+      )}
+
+      {/* ── Footer ────────────────────────────────────────── */}
+      <footer className="user-profile__footer">
+
+=======
+      {/* ── Activity feed ─────────────────────────────────── */}
+      {showActivity && <ActivityFeed userId={resolvedUserId} />}
+
+      {/* ── Footer ────────────────────────────────────────── */}
+      <footer className="user-profile__footer">
+
+>>>>>>> REPLACE

--- a/src/__tests__/evals/recorded_calls/sol/refactor-giant-component/11.txt
+++ b/src/__tests__/evals/recorded_calls/sol/refactor-giant-component/11.txt
@@ -1,0 +1,16 @@
+<<<<<<< SEARCH
+      {/* ── Activity feed ─────────────────────────────────── */}
+      {showActivity && (
+        <section className="activity-feed">
+          <h2 className="activity-feed__title">Recent Activity</h2>
+          {activityState.loading && activityState.items.length === 0 ? (
+            <div className="activity-loading">
+              <div className="spinner spinner--small" />
+              <p>Loading activity…</p>
+            </div>
+
+=======
+      {/* ── Activity feed ─────────────────────────────────── */}
+      {showActivity && <ActivityFeed userId={resolvedUserId} />}
+
+>>>>>>> REPLACE

--- a/src/__tests__/evals/recorded_calls/sol/refactor-giant-component/12.txt
+++ b/src/__tests__/evals/recorded_calls/sol/refactor-giant-component/12.txt
@@ -1,0 +1,61 @@
+<<<<<<< SEARCH
+    } finally {
+      setSaving(false);
+    }
+  }, [resolvedUserId, draft]);
+
+  // ── Activity feed state and logic ───────────────────────────
+  const [activityState, setActivityState] = useState<ActivityState>({
+    items: [],
+    loading: true,
+    error: null,
+    page: 1,
+    hasMore: true,
+  });
+
+  const loadActivity = useCallback(
+    async (page: number, append = false) => {
+      setActivityState((prev) => ({ ...prev, loading: true, error: null }));
+      try {
+        const items = await fetchUserActivity(resolvedUserId, page);
+        setActivityState((prev) => ({
+          items: append ? [...prev.items, ...items] : items,
+          loading: false,
+          error: null,
+          page,
+          hasMore: items.length >= 20,
+        }));
+      } catch (err) {
+        setActivityState((prev) => ({
+          ...prev,
+          loading: false,
+          error: err instanceof Error ? err.message : "Failed to load activity",
+        }));
+      }
+    },
+    [resolvedUserId],
+  );
+
+  useEffect(() => {
+    if (showActivity && resolvedUserId) {
+      loadActivity(1);
+    }
+  }, [showActivity, resolvedUserId, loadActivity]);
+
+  const handleLoadMore = useCallback(() => {
+    loadActivity(activityState.page + 1, true);
+  }, [loadActivity, activityState.page]);
+
+  const groupedActivity = useMemo(() => {
+    const groups: Record<string, ActivityItem[]> = {};
+
+=======
+    } finally {
+      setSaving(false);
+    }
+  }, [resolvedUserId, draft]);
+
+  const groupedActivity = useMemo(() => {
+    const groups: Record<string, ActivityItem[]> = {};
+
+>>>>>>> REPLACE

--- a/src/__tests__/evals/tool_use.eval.ts
+++ b/src/__tests__/evals/tool_use.eval.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "vitest";
+import { afterAll, describe, it } from "vitest";
 import { generateText, stepCountIs, type Tool } from "ai";
 import { readFileSync } from "node:fs";
 import { basename, resolve } from "node:path";
@@ -10,7 +10,15 @@ import { constructLocalAgentPrompt } from "@/prompts/local_agent_prompt";
 import {
   SONNET_4_6,
   GEMINI_3_FLASH,
+  GPT_5_6_SOL_MODEL_NAME,
+  GPT_5_6_LUNA_MODEL_NAME,
 } from "@/ipc/shared/language_model_constants";
+import {
+  recordFailedSearchReplaceCall,
+  recordSearchReplaceCall,
+  renderNewlineProbeSummary,
+  writeNewlineProbeReport,
+} from "./helpers/newline_probe";
 import {
   GPT_5_4,
   getEvalModel,
@@ -442,6 +450,8 @@ interface ToolRunState {
   content: string;
   toolCalls: ToolCallRecord[];
   abortSignal?: AbortSignal;
+  /** Suite name, carried so the newline probe can label its samples. */
+  suiteName: string;
 }
 
 function makeRecord(
@@ -494,6 +504,17 @@ function searchReplaceHarnessTool(
           );
         }
         state.content = applySearchReplaceEdit(state.content, args);
+        recordSearchReplaceCall({
+          suite: state.suiteName,
+          model: label,
+          caseName: c.name,
+          callIndex: state.toolCalls.length,
+          filePath: args.file_path,
+          oldString: args.old_string,
+          newString: args.new_string,
+          fileBefore,
+          fileAfter: state.content,
+        });
         state.toolCalls.push(
           makeRecord(
             "search_replace",
@@ -507,6 +528,11 @@ function searchReplaceHarnessTool(
         return `Successfully applied edits to ${args.file_path}`;
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
+        recordFailedSearchReplaceCall({
+          model: label,
+          caseName: c.name,
+          error: message,
+        });
         state.toolCalls.push(
           makeRecord(
             "search_replace",
@@ -588,9 +614,74 @@ interface SuiteConfig {
     c: EvalCase,
     label: string,
   ) => Record<string, Tool>;
+  /** Cases to run. Defaults to the shared CASES list. */
+  cases?: EvalCase[];
+  /** Skip the LLM judge round-trip (for suites measuring mechanics, not quality). */
+  skipJudge?: boolean;
 }
 
+// Cases for the newline probe. Deliberately shaped to maximize exposure to
+// the trailing-newline defect rather than to measure edit quality:
+//
+//  - Each asks for SEVERAL small independent changes, so the model makes many
+//    separate search_replace calls instead of one block rewrite. A stray blank
+//    line per call is the accumulating symptom users report.
+//  - Every edit site sits between non-blank lines. A trailing newline only
+//    corrupts when it has no real blank line to cancel against, so edits next
+//    to blank lines mask the defect.
+//  - One case edits the last function in the file, since a file's final
+//    newline is a common place for a model to carry a terminator along.
+const NEWLINE_PROBE_CASES: EvalCase[] = [
+  {
+    name: "Flip three permission methods",
+    fileName: "permissions.ts",
+    fileContent: loadFixture("permissions.ts"),
+    prompt:
+      "In `AdminPolicy` only, change `canDeleteContent`, `canManageUsers`, and " +
+      "`canManageRoles` to return `false` instead of `true`. Leave every other " +
+      "method and every other class exactly as it is.",
+  },
+  {
+    name: "Change three guard-clause return values",
+    fileName: "stat_utils.ts",
+    fileContent: loadFixture("stat_utils.ts"),
+    prompt:
+      "In `mean`, `variance`, and `populationVariance`, change the early-return " +
+      "value for the empty/too-short input guard from `0` to `NaN`. Do not touch " +
+      "any other function and do not change any other behavior.",
+  },
+  {
+    name: "Insert a guard line into three methods",
+    fileName: "permissions.ts",
+    fileContent: loadFixture("permissions.ts"),
+    prompt:
+      "In `AdminPolicy` only, add the line `// audited` as the first line inside " +
+      "the bodies of `canViewContent`, `canViewUsers`, and `canViewAuditLog`. " +
+      "Change nothing else.",
+  },
+  {
+    name: "Edit the last function in the file",
+    fileName: "stat_utils.ts",
+    fileContent: loadFixture("stat_utils.ts"),
+    prompt:
+      "In the final function in the file, `correlation`, return `NaN` instead of " +
+      "`0` when either standard deviation is zero. Change nothing else.",
+  },
+];
+
 const SUITES: SuiteConfig[] = [
+  {
+    // Measures search_replace serialization mechanics, not edit quality.
+    // Judge is skipped; the verdict comes from the newline probe report.
+    name: "newline_probe",
+    displayName: "newline_probe (trailing-newline measurement)",
+    systemPrompt: SIMPLE_SEARCH_REPLACE_SYSTEM_PROMPT,
+    cases: NEWLINE_PROBE_CASES,
+    skipJudge: true,
+    buildTools: (state, c, label) => ({
+      search_replace: searchReplaceHarnessTool(state, c, label),
+    }),
+  },
   {
     name: "search_replace",
     displayName: "search_replace",
@@ -667,6 +758,18 @@ const ALL_MODELS: Array<{
     label: "Gemini 3 Flash",
     temperature: 1,
   },
+  {
+    provider: "openai",
+    modelName: GPT_5_6_SOL_MODEL_NAME,
+    label: "GPT 5.6 Sol",
+    temperature: 1,
+  },
+  {
+    provider: "openai",
+    modelName: GPT_5_6_LUNA_MODEL_NAME,
+    label: "GPT 5.6 Luna",
+    temperature: 1,
+  },
 ];
 
 // ── Case runner ────────────────────────────────────────────────
@@ -705,6 +808,7 @@ async function runCase(
     content: c.fileContent,
     toolCalls: [],
     abortSignal: abortController.signal,
+    suiteName: suite.name,
   };
   const timeoutHandle = setTimeout(() => {
     abortController.abort(
@@ -783,23 +887,33 @@ async function runCase(
         `  Full record will be written to: ${recordDir}`,
     );
 
-    console.log(`\n[${suite.name} / ${label}] ${c.name} — calling judge...`);
-    judgeRecord = await judgeResult(
-      c.fileContent,
-      c.prompt,
-      state.content,
-      abortController.signal,
-    );
-    console.log(
-      `\n[${suite.name} / ${label}] ${c.name} — judge verdict: ${judgeRecord.pass ? "PASS" : "FAIL"}\n${judgeRecord.explanation}`,
-    );
-
-    if (!judgeRecord.pass) {
-      throw new Error(
-        `Judge (${JUDGE_LABEL}) said FAIL for ${label}:\n${judgeRecord.explanation}`,
+    // The newline probe measures serialization behavior, not edit quality, so
+    // it skips the judge call: the verdict is irrelevant to it and the judge
+    // is a second paid model round-trip per case.
+    if (suite.skipJudge || process.env.EVAL_SKIP_JUDGE === "1") {
+      console.log(
+        `\n[${suite.name} / ${label}] ${c.name} — judge skipped (probe suite)`,
       );
+      passed = true;
+    } else {
+      console.log(`\n[${suite.name} / ${label}] ${c.name} — calling judge...`);
+      judgeRecord = await judgeResult(
+        c.fileContent,
+        c.prompt,
+        state.content,
+        abortController.signal,
+      );
+      console.log(
+        `\n[${suite.name} / ${label}] ${c.name} — judge verdict: ${judgeRecord.pass ? "PASS" : "FAIL"}\n${judgeRecord.explanation}`,
+      );
+
+      if (!judgeRecord.pass) {
+        throw new Error(
+          `Judge (${JUDGE_LABEL}) said FAIL for ${label}:\n${judgeRecord.explanation}`,
+        );
+      }
+      passed = true;
     }
-    passed = true;
   } catch (err) {
     errorMessage = err instanceof Error ? err.message : String(err);
     if (totalDurationMs === 0) totalDurationMs = Date.now() - llmStartMs;
@@ -948,12 +1062,21 @@ if (!SUITE_FILTER_RAW || !MODEL_FILTER_RAW) {
       }
     });
   } else {
+    afterAll(async () => {
+      const summary = renderNewlineProbeSummary();
+      console.log(summary);
+      const dir = await writeNewlineProbeReport();
+      if (dir) {
+        console.log(`Newline probe report written to: ${dir}`);
+      }
+    });
+
     for (const suite of ACTIVE_SUITES) {
       for (const { provider, modelName, label, temperature } of MODELS) {
         describe.skipIf(!hasDyadProKey())(
           `${suite.displayName} — ${label}`,
           () => {
-            for (const c of CASES) {
+            for (const c of suite.cases ?? CASES) {
               it.concurrent(c.name, async () => {
                 try {
                   await runCase(


### PR DESCRIPTION
*This is a bit of a slop PR; there's no production code and merging is optional. Description written by Claude.*

Adds the eval harness used to measure how often real models send search_replace arguments in the shape that produced the stray blank lines fixed in #4338, and checks in the recorded calls from that investigation as a regression test.

The probe applies every model search_replace call twice - once with the current serialization, once with a counterfactual that trims a terminating newline - and reports where the two diverge.

recorded_calls/\<model\>/ holds real GPT 5.6 Sol and Luna calls as the operations strings the tool builds from the model's arguments. recorded_calls.spec.ts replays them from fixtures already in the repo and asserts each applied call produces exactly what replacing the first verbatim occurrence of old_string produces. It runs in the normal unit suite, so the evidence behind #4338 stays auditable without an API key and without eval-results/, which is gitignored.

The current processor no longer writes stray blank lines, so the recordings on their own no longer show what they caught. helpers/legacy_search_replace.ts is a frozen copy of the processor from before #4338, and the spec replays both implementations and asserts each model's totals:

  Sol,  before #4338:  9 applied, 7 did not match, 7 stray blank lines
  Sol,  current:      11 applied, 5 did not match, 0 stray blank lines
  Luna, before #4338:  5 applied, 0 did not match, 2 stray blank lines
  Luna, current:       5 applied, 0 did not match, 0 stray blank lines

SEARCH_REPLACE_IMPL=legacy or =current replays just one of them. Sol's applied count goes up because two calls that could not match were blocked by a stray blank line an earlier call had introduced.

Both models produce the defect at different rates - over the full runs these recordings were drawn from, Sol corrupted 7 of 82 applied calls and Luna 2 of 116.

Also adds GPT 5.6 Sol and Luna to the model matrix and EVAL_SKIP_JUDGE=1 for skipping the judge round-trip when only serialization mechanics matter.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

