### PR TITLE
Migrate Supabase Edge Function logs from `logs.all` to `logs`

### DIFF
--- a/src/ipc/handlers/supabase_handlers.ts
+++ b/src/ipc/handlers/supabase_handlers.ts
@@ -197,20 +197,14 @@ export function registerSupabaseHandlers() {
 
     // Transform to ConsoleEntry format
     return rawLogs.map((logEntry: SupabaseProjectLog) => {
-      const metadata = logEntry.metadata?.[0] || {};
-      const level = metadata.level || "info";
       const eventMessage = logEntry.event_message || "";
       const functionName = extractFunctionName(eventMessage);
 
       return {
-        level: (level === "error"
-          ? "error"
-          : level === "warn"
-            ? "warn"
-            : "info") as "info" | "warn" | "error",
+        level: logEntry.level,
         type: "edge-function" as const,
         message: eventMessage,
-        timestamp: logEntry.timestamp / 1000, // Convert from microseconds to milliseconds
+        timestamp: logEntry.timestamp,
         sourceName: functionName,
         appId,
       };

--- a/src/supabase_admin/supabase_management_client.test.ts
+++ b/src/supabase_admin/supabase_management_client.test.ts
@@ -3,6 +3,7 @@ import { SupabaseManagementAPIError } from "@dyad-sh/supabase-management-js";
 import {
   classifyManagementApiError,
   getProjectApiKeys,
+  getSupabaseProjectLogs,
   listSupabaseOrganizations,
   refreshSupabaseToken,
 } from "./supabase_management_client";
@@ -237,6 +238,77 @@ describe("getProjectApiKeys", () => {
     ).resolves.toEqual([
       { name: "default", type: "something-new", api_key: "sb_x" },
     ]);
+  });
+});
+
+describe("getSupabaseProjectLogs", () => {
+  beforeEach(() => {
+    vi.mocked(readSettings).mockReturnValue({
+      supabase: {
+        organizations: {
+          "org-1": {
+            accessToken: { value: "org-token" },
+            expiresIn: 3600,
+            tokenTimestamp: Math.floor(Date.now() / 1000),
+          },
+        },
+      },
+    } as unknown as ReturnType<typeof readSettings>);
+  });
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("queries and maps the unified ClickHouse logs endpoint", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              result: [
+                {
+                  timestamp: "2026-08-22T00:01:02.345000",
+                  event_message: "warning from function",
+                  severity_text: "warning",
+                },
+              ],
+            }),
+            { status: 200 },
+          ),
+      ),
+    );
+
+    const timestampStart = Date.UTC(2026, 7, 22, 0, 0, 0);
+    const response = await getSupabaseProjectLogs(
+      "proj-1",
+      timestampStart,
+      "org-1",
+    );
+
+    const requestUrl = new URL(String(vi.mocked(fetch).mock.calls[0][0]));
+    expect(requestUrl.pathname).toBe(
+      "/v1/projects/proj-1/analytics/endpoints/logs",
+    );
+    const sql = requestUrl.searchParams.get("sql");
+    expect(sql).toContain("FROM logs");
+    expect(sql).toContain("WHERE source = 'function_logs'");
+    expect(sql).not.toContain("FROM function_logs");
+    expect(sql).not.toContain("metadata");
+    expect(sql).not.toContain("TIMESTAMP_MICROS");
+    expect(requestUrl.searchParams.get("iso_timestamp_start")).toBe(
+      "2026-08-22T00:00:00.000Z",
+    );
+    expect(requestUrl.searchParams.has("iso_timestamp_end")).toBe(true);
+    expect(response).toEqual({
+      result: [
+        {
+          timestamp: Date.UTC(2026, 7, 22, 0, 1, 2, 345),
+          event_message: "warning from function",
+          level: "warn",
+        },
+      ],
+      error: undefined,
+    });
   });
 });
 

--- a/src/supabase_admin/supabase_management_client.ts
+++ b/src/supabase_admin/supabase_management_client.ts
@@ -73,12 +73,53 @@ export interface DeployedFunctionResponse {
 export interface SupabaseProjectLog {
   timestamp: number;
   event_message: string;
-  metadata: any;
+  level: "info" | "warn" | "error";
 }
 
 export interface SupabaseProjectLogsResponse {
   result: SupabaseProjectLog[];
-  error?: any;
+  error?: unknown;
+}
+
+const SupabaseProjectLogApiSchema = z.object({
+  timestamp: z.union([z.string(), z.number()]),
+  event_message: z.string(),
+  severity_text: z.string().nullish(),
+});
+
+const SupabaseProjectLogsApiResponseSchema = z.object({
+  result: z.array(SupabaseProjectLogApiSchema).optional(),
+  error: z.unknown().optional(),
+});
+
+function parseSupabaseLogTimestamp(timestamp: string | number): number {
+  if (typeof timestamp === "number") {
+    return timestamp;
+  }
+
+  // ClickHouse returns UTC DateTime64 values without always including a zone.
+  // Date.parse treats a zone-less timestamp as local time, so make UTC explicit.
+  const hasTimeZone = /(?:Z|[+-]\d{2}:?\d{2})$/i.test(timestamp);
+  return Date.parse(hasTimeZone ? timestamp : `${timestamp}Z`);
+}
+
+function normalizeSupabaseLogLevel(
+  severityText: string | null | undefined,
+): SupabaseProjectLog["level"] {
+  switch (severityText?.toLowerCase()) {
+    case "warn":
+    case "warning":
+      return "warn";
+    case "alert":
+    case "critical":
+    case "emergency":
+    case "error":
+    case "fatal":
+    case "panic":
+      return "error";
+    default:
+      return "info";
+  }
 }
 
 export interface SupabaseProjectBranch {
@@ -665,20 +706,17 @@ export async function getSupabaseProjectLogs(
 ): Promise<SupabaseProjectLogsResponse> {
   const supabase = await getSupabaseClient({ organizationSlug });
 
-  // Build SQL query with optional timestamp filter
-  let sqlQuery = `
+  // The unified endpoint is ClickHouse-backed. The time range is applied by
+  // the API parameters below, while the SQL scopes the unified stream to Edge
+  // Function runtime logs.
+  const sqlQuery = `
 SELECT 
   timestamp,
   event_message,
-  metadata
-FROM function_logs`;
-
-  if (timestampStart) {
-    // Convert milliseconds to microseconds and wrap in TIMESTAMP_MICROS for BigQuery
-    sqlQuery += `\nWHERE timestamp > TIMESTAMP_MICROS(${timestampStart * 1000})`;
-  }
-
-  sqlQuery += `\nORDER BY timestamp ASC
+  severity_text
+FROM logs
+WHERE source = 'function_logs'
+ORDER BY timestamp ASC
 LIMIT 1000`;
 
   // Calculate time range for API parameters
@@ -692,7 +730,7 @@ LIMIT 1000`;
   // Encode SQL query for URL
   const encodedSql = encodeURIComponent(sqlQuery);
 
-  const url = `https://api.supabase.com/v1/projects/${projectId}/analytics/endpoints/logs.all?sql=${encodedSql}&iso_timestamp_start=${isoTimestampStart}&iso_timestamp_end=${isoTimestampEnd}`;
+  const url = `https://api.supabase.com/v1/projects/${projectId}/analytics/endpoints/logs?sql=${encodedSql}&iso_timestamp_start=${isoTimestampStart}&iso_timestamp_end=${isoTimestampEnd}`;
 
   logger.info(`Fetching logs from: ${url}`);
 
@@ -716,10 +754,35 @@ LIMIT 1000`;
     );
   }
 
-  const jsonResponse: SupabaseProjectLogsResponse = await response.json();
-  logger.info(`Received ${jsonResponse.result?.length || 0} logs`);
+  const parsed = SupabaseProjectLogsApiResponseSchema.safeParse(
+    await response.json(),
+  );
+  if (!parsed.success) {
+    throw new DyadError(
+      `Supabase returned an unexpected logs response for project ${projectId}: ${parsed.error.message}`,
+      DyadErrorKind.External,
+    );
+  }
 
-  return jsonResponse;
+  const result = (parsed.data.result ?? []).map((logEntry) => {
+    const timestamp = parseSupabaseLogTimestamp(logEntry.timestamp);
+    if (!Number.isFinite(timestamp)) {
+      throw new DyadError(
+        `Supabase returned an invalid log timestamp for project ${projectId}`,
+        DyadErrorKind.External,
+      );
+    }
+
+    return {
+      timestamp,
+      event_message: logEntry.event_message,
+      level: normalizeSupabaseLogLevel(logEntry.severity_text),
+    };
+  });
+
+  logger.info(`Received ${result.length} logs`);
+
+  return { result, error: parsed.data.error };
 }
 
 export async function executeSupabaseSql({


### PR DESCRIPTION
closes #4342 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

