### PR TITLE
Add text annotations to chat responses

### DIFF
--- a/src/atoms/chatAnnotationAtoms.test.ts
+++ b/src/atoms/chatAnnotationAtoms.test.ts
@@ -3,6 +3,7 @@ import {
   addChatAnnotation,
   clearChatAnnotations,
   hasOverlappingChatAnnotation,
+  pruneChatAnnotations,
   removeChatAnnotation,
   updateChatAnnotation,
   type ChatAnnotation,
@@ -56,5 +57,37 @@ describe("chat annotation state", () => {
   it("detects overlapping ranges but permits adjacent ranges", () => {
     expect(hasOverlappingChatAnnotation([annotation], 20, 5)).toBe(true);
     expect(hasOverlappingChatAnnotation([annotation], 23, 5)).toBe(false);
+  });
+
+  it("normalizes comment whitespace on both the add and update paths", () => {
+    const added = addChatAnnotation(new Map(), {
+      ...annotation,
+      comment: "  Change this  ",
+    });
+    const updated = updateChatAnnotation(
+      added,
+      annotation.chatId,
+      annotation.id,
+      "  Change this  ",
+    );
+
+    expect(added.get(7)?.[0].comment).toBe("Change this");
+    expect(updated.get(7)?.[0].comment).toBe("Change this");
+  });
+
+  it("prunes annotations whose message was retried away", () => {
+    const annotations = addChatAnnotation(
+      addChatAnnotation(new Map(), annotation),
+      { ...annotation, id: "annotation-2", messageId: 12 },
+    );
+
+    const pruned = pruneChatAnnotations(annotations, 7, new Set([11]));
+
+    expect(pruned.get(7)?.map((item) => item.id)).toEqual(["annotation-1"]);
+    // Nothing to prune returns the same map so Jotai skips the re-render.
+    expect(pruneChatAnnotations(pruned, 7, new Set([11]))).toBe(pruned);
+    expect(pruneChatAnnotations(pruned, 7, new Set<number>()).has(7)).toBe(
+      false,
+    );
   });
 });

--- a/src/atoms/chatAnnotationAtoms.test.ts
+++ b/src/atoms/chatAnnotationAtoms.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import {
   addChatAnnotation,
   clearChatAnnotations,
-  hasOverlappingChatAnnotation,
   pruneChatAnnotations,
   removeChatAnnotation,
   updateChatAnnotation,
@@ -52,11 +51,6 @@ describe("chat annotation state", () => {
 
     expect(cleared.has(7)).toBe(false);
     expect(cleared.get(8)).toHaveLength(1);
-  });
-
-  it("detects overlapping ranges but permits adjacent ranges", () => {
-    expect(hasOverlappingChatAnnotation([annotation], 20, 5)).toBe(true);
-    expect(hasOverlappingChatAnnotation([annotation], 23, 5)).toBe(false);
   });
 
   it("normalizes comment whitespace on both the add and update paths", () => {

--- a/src/atoms/chatAnnotationAtoms.test.ts
+++ b/src/atoms/chatAnnotationAtoms.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  addChatAnnotation,
+  clearChatAnnotations,
+  hasOverlappingChatAnnotation,
+  removeChatAnnotation,
+  updateChatAnnotation,
+  type ChatAnnotation,
+} from "./chatAnnotationAtoms";
+
+const annotation: ChatAnnotation = {
+  id: "annotation-1",
+  chatId: 7,
+  messageId: 11,
+  selectedText: "selected text",
+  comment: "Change this",
+  createdAt: 1,
+  startOffset: 10,
+  selectionLength: 13,
+};
+
+describe("chat annotation state", () => {
+  it("adds, updates, and removes annotations without mutating prior maps", () => {
+    const initial = new Map();
+    const added = addChatAnnotation(initial, annotation);
+    const updated = updateChatAnnotation(
+      added,
+      annotation.chatId,
+      annotation.id,
+      "  Explain this  ",
+    );
+    const removed = removeChatAnnotation(
+      updated,
+      annotation.chatId,
+      annotation.id,
+    );
+
+    expect(initial.size).toBe(0);
+    expect(added.get(7)?.[0].comment).toBe("Change this");
+    expect(updated.get(7)?.[0].comment).toBe("Explain this");
+    expect(removed.has(7)).toBe(false);
+  });
+
+  it("clears only the requested chat", () => {
+    const annotations = addChatAnnotation(
+      addChatAnnotation(new Map(), annotation),
+      { ...annotation, id: "annotation-2", chatId: 8 },
+    );
+
+    const cleared = clearChatAnnotations(annotations, 7);
+
+    expect(cleared.has(7)).toBe(false);
+    expect(cleared.get(8)).toHaveLength(1);
+  });
+
+  it("detects overlapping ranges but permits adjacent ranges", () => {
+    expect(hasOverlappingChatAnnotation([annotation], 20, 5)).toBe(true);
+    expect(hasOverlappingChatAnnotation([annotation], 23, 5)).toBe(false);
+  });
+});

--- a/src/atoms/chatAnnotationAtoms.ts
+++ b/src/atoms/chatAnnotationAtoms.ts
@@ -1,0 +1,81 @@
+import { atom } from "jotai";
+
+export interface ChatAnnotation {
+  id: string;
+  chatId: number;
+  messageId: number;
+  selectedText: string;
+  comment: string;
+  createdAt: number;
+  startOffset: number;
+  selectionLength: number;
+}
+
+export type ChatAnnotationsMap = Map<number, ChatAnnotation[]>;
+
+export const chatAnnotationsAtom = atom<ChatAnnotationsMap>(new Map());
+
+export function addChatAnnotation(
+  previous: ChatAnnotationsMap,
+  annotation: ChatAnnotation,
+): ChatAnnotationsMap {
+  const next = new Map(previous);
+  next.set(annotation.chatId, [
+    ...(next.get(annotation.chatId) ?? []),
+    annotation,
+  ]);
+  return next;
+}
+
+export function updateChatAnnotation(
+  previous: ChatAnnotationsMap,
+  chatId: number,
+  annotationId: string,
+  comment: string,
+): ChatAnnotationsMap {
+  const next = new Map(previous);
+  next.set(
+    chatId,
+    (next.get(chatId) ?? []).map((annotation) =>
+      annotation.id === annotationId
+        ? { ...annotation, comment: comment.trim() }
+        : annotation,
+    ),
+  );
+  return next;
+}
+
+export function removeChatAnnotation(
+  previous: ChatAnnotationsMap,
+  chatId: number,
+  annotationId: string,
+): ChatAnnotationsMap {
+  const next = new Map(previous);
+  const remaining = (next.get(chatId) ?? []).filter(
+    (annotation) => annotation.id !== annotationId,
+  );
+  if (remaining.length === 0) next.delete(chatId);
+  else next.set(chatId, remaining);
+  return next;
+}
+
+export function clearChatAnnotations(
+  previous: ChatAnnotationsMap,
+  chatId: number,
+): ChatAnnotationsMap {
+  const next = new Map(previous);
+  next.delete(chatId);
+  return next;
+}
+
+export function hasOverlappingChatAnnotation(
+  annotations: ChatAnnotation[],
+  startOffset: number,
+  selectionLength: number,
+): boolean {
+  const endOffset = startOffset + selectionLength;
+  return annotations.some((annotation) => {
+    const annotationEnd = annotation.startOffset + annotation.selectionLength;
+    return startOffset < annotationEnd && annotation.startOffset < endOffset;
+  });
+}

--- a/src/atoms/chatAnnotationAtoms.ts
+++ b/src/atoms/chatAnnotationAtoms.ts
@@ -95,15 +95,3 @@ export function pruneChatAnnotations(
   else next.set(chatId, remaining);
   return next;
 }
-
-export function hasOverlappingChatAnnotation(
-  annotations: ChatAnnotation[],
-  startOffset: number,
-  selectionLength: number,
-): boolean {
-  const endOffset = startOffset + selectionLength;
-  return annotations.some((annotation) => {
-    const annotationEnd = annotation.startOffset + annotation.selectionLength;
-    return startOffset < annotationEnd && annotation.startOffset < endOffset;
-  });
-}

--- a/src/atoms/chatAnnotationAtoms.ts
+++ b/src/atoms/chatAnnotationAtoms.ts
@@ -22,7 +22,9 @@ export function addChatAnnotation(
   const next = new Map(previous);
   next.set(annotation.chatId, [
     ...(next.get(annotation.chatId) ?? []),
-    annotation,
+    // Trim here as well as in `updateChatAnnotation` so both reducers store
+    // the same normalized text, whatever a caller hands them.
+    { ...annotation, comment: annotation.comment.trim() },
   ]);
   return next;
 }
@@ -65,6 +67,32 @@ export function clearChatAnnotations(
 ): ChatAnnotationsMap {
   const next = new Map(previous);
   next.delete(chatId);
+  return next;
+}
+
+/**
+ * Drops annotations that point at assistant messages the chat no longer has.
+ *
+ * Retry deletes the trailing user/assistant pair server-side, so without this
+ * the tray would keep - and later submit - a comment quoting stale text and
+ * labelled with a message id that does not exist any more.
+ */
+export function pruneChatAnnotations(
+  previous: ChatAnnotationsMap,
+  chatId: number,
+  existingMessageIds: ReadonlySet<number>,
+): ChatAnnotationsMap {
+  const current = previous.get(chatId);
+  if (!current) return previous;
+
+  const remaining = current.filter((annotation) =>
+    existingMessageIds.has(annotation.messageId),
+  );
+  if (remaining.length === current.length) return previous;
+
+  const next = new Map(previous);
+  if (remaining.length === 0) next.delete(chatId);
+  else next.set(chatId, remaining);
   return next;
 }
 

--- a/src/atoms/chatAtoms.ts
+++ b/src/atoms/chatAtoms.ts
@@ -9,6 +9,10 @@ import type { ListedApp } from "@/ipc/types/app";
 import type { Getter, Setter } from "jotai";
 import { atom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
+import {
+  chatAnnotationsAtom,
+  clearChatAnnotations,
+} from "@/atoms/chatAnnotationAtoms";
 import { planAcceptInNewChatByChatIdAtom } from "@/atoms/planAtoms";
 import { createChatTabSessionStorage } from "@/window_infrastructure/chat_tab_session_storage";
 
@@ -539,6 +543,12 @@ export const removeChatIdFromAllTrackingAtom = atom(
       const next = new Map(planAcceptChoices);
       next.delete(chatId);
       set(planAcceptInNewChatByChatIdAtom, next);
+    }
+    // Clear unsent message annotations so they don't accumulate for a chat
+    // that no longer exists (or resurface if the id is ever reused)
+    const annotations = get(chatAnnotationsAtom);
+    if (annotations.has(chatId)) {
+      set(chatAnnotationsAtom, clearChatAnnotations(annotations, chatId));
     }
   },
 );

--- a/src/components/chat/ChatAnnotationsTray.test.tsx
+++ b/src/components/chat/ChatAnnotationsTray.test.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { createStore, Provider } from "jotai";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  chatAnnotationsAtom,
+  type ChatAnnotation,
+} from "@/atoms/chatAnnotationAtoms";
+import { ChatAnnotationsTray } from "./ChatAnnotationsTray";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { count?: number }) =>
+      ({
+        "annotations.commentCount": `${options?.count ?? 0} comment`,
+        "annotations.discard": "Discard",
+        "annotations.deleteComment": "Delete comment",
+      })[key] ?? key,
+  }),
+}));
+
+const annotation: ChatAnnotation = {
+  id: "annotation-1",
+  chatId: 7,
+  messageId: 11,
+  selectedText: "selected text",
+  comment: "Change this",
+  createdAt: 1,
+  startOffset: 0,
+  selectionLength: 13,
+};
+
+function renderTray() {
+  const store = createStore();
+  store.set(chatAnnotationsAtom, new Map([[annotation.chatId, [annotation]]]));
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <Provider store={store}>{children}</Provider>
+  );
+
+  return render(<ChatAnnotationsTray chatId={annotation.chatId} />, {
+    wrapper,
+  });
+}
+
+describe("ChatAnnotationsTray", () => {
+  it("uses an X to discard annotations and has no separate send action", () => {
+    renderTray();
+
+    const discardButton = screen.getByRole("button", { name: "Discard" });
+    expect(discardButton.textContent).toBe("");
+    expect(discardButton.querySelector("svg")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /send/i })).toBeNull();
+
+    fireEvent.click(discardButton);
+
+    expect(screen.queryByTestId("chat-annotations-tray")).toBeNull();
+  });
+});

--- a/src/components/chat/ChatAnnotationsTray.tsx
+++ b/src/components/chat/ChatAnnotationsTray.tsx
@@ -1,0 +1,119 @@
+import { useAtom } from "jotai";
+import { ChevronDown, ChevronUp, MessageSquare, Trash2 } from "lucide-react";
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  chatAnnotationsAtom,
+  clearChatAnnotations,
+  removeChatAnnotation,
+} from "@/atoms/chatAnnotationAtoms";
+import { Button } from "@/components/ui/button";
+import { useStreamChat } from "@/hooks/useStreamChat";
+import { serializeChatAnnotations } from "@/lib/serializeChatAnnotations";
+
+export function ChatAnnotationsTray({ chatId }: { chatId: number }) {
+  const { t } = useTranslation("chat");
+  const [allAnnotations, setAllAnnotations] = useAtom(chatAnnotationsAtom);
+  const [expanded, setExpanded] = useState(false);
+  const [isSending, setIsSending] = useState(false);
+  const { streamMessage, isStreaming } = useStreamChat();
+  const annotations = useMemo(
+    () => allAnnotations.get(chatId) ?? [],
+    [allAnnotations, chatId],
+  );
+
+  if (annotations.length === 0) return null;
+
+  const send = () => {
+    if (isSending || isStreaming) return;
+    const submittedIds = new Set(annotations.map((annotation) => annotation.id));
+    setIsSending(true);
+    streamMessage({
+      chatId,
+      prompt: serializeChatAnnotations(annotations),
+      onSettled: ({ success }) => {
+        if (success) {
+          setAllAnnotations((previous) => {
+            const next = new Map(previous);
+            const remaining = (next.get(chatId) ?? []).filter(
+              (annotation) => !submittedIds.has(annotation.id),
+            );
+            if (remaining.length === 0) next.delete(chatId);
+            else next.set(chatId, remaining);
+            return next;
+          });
+        }
+        setIsSending(false);
+      },
+    });
+  };
+
+  return (
+    <div
+      className="border-b border-border bg-yellow-500/5"
+      data-testid="chat-annotations-tray"
+    >
+      <div className="flex items-center gap-2 px-3 py-2">
+        <MessageSquare className="size-4 text-yellow-600 dark:text-yellow-400" />
+        <button
+          type="button"
+          className="flex flex-1 items-center gap-1 text-left text-sm font-medium"
+          onClick={() => setExpanded((value) => !value)}
+        >
+          {t("annotations.commentCount", { count: annotations.length })}
+          {expanded ? (
+            <ChevronUp className="size-4" />
+          ) : (
+            <ChevronDown className="size-4" />
+          )}
+        </button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() =>
+            setAllAnnotations((previous) =>
+              clearChatAnnotations(previous, chatId),
+            )
+          }
+        >
+          {t("annotations.discard")}
+        </Button>
+        <Button size="sm" disabled={isStreaming || isSending} onClick={send}>
+          {isSending
+            ? t("annotations.sending")
+            : t("annotations.send", { count: annotations.length })}
+        </Button>
+      </div>
+      {expanded && (
+        <div className="max-h-48 space-y-2 overflow-y-auto border-t px-3 py-2">
+          {annotations.map((annotation) => (
+            <div
+              key={annotation.id}
+              className="flex gap-2 rounded-md bg-background p-2 text-xs"
+            >
+              <div className="min-w-0 flex-1">
+                <blockquote className="truncate border-l-2 pl-2 italic text-muted-foreground">
+                  {annotation.selectedText}
+                </blockquote>
+                <p className="mt-1 whitespace-pre-wrap">{annotation.comment}</p>
+              </div>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-7"
+                aria-label={t("annotations.deleteComment")}
+                onClick={() =>
+                  setAllAnnotations((previous) =>
+                    removeChatAnnotation(previous, chatId, annotation.id),
+                  )
+                }
+              >
+                <Trash2 className="size-3.5" />
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/chat/ChatAnnotationsTray.tsx
+++ b/src/components/chat/ChatAnnotationsTray.tsx
@@ -1,13 +1,15 @@
 import { useAtom } from "jotai";
 import { ChevronDown, ChevronUp, MessageSquare, Trash2 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useId, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   chatAnnotationsAtom,
   clearChatAnnotations,
+  pruneChatAnnotations,
   removeChatAnnotation,
 } from "@/atoms/chatAnnotationAtoms";
 import { Button } from "@/components/ui/button";
+import { useChatMessages } from "@/hooks/useChatMessages";
 import { useStreamChat } from "@/hooks/useStreamChat";
 import { serializeChatAnnotations } from "@/lib/serializeChatAnnotations";
 
@@ -16,27 +18,47 @@ export function ChatAnnotationsTray({ chatId }: { chatId: number }) {
   const [allAnnotations, setAllAnnotations] = useAtom(chatAnnotationsAtom);
   const [expanded, setExpanded] = useState(false);
   const [isSending, setIsSending] = useState(false);
+  const listId = useId();
   const { streamMessage, isStreaming } = useStreamChat();
+  const messages = useChatMessages(chatId);
   const annotations = useMemo(
     () => allAnnotations.get(chatId) ?? [],
     [allAnnotations, chatId],
   );
 
+  // Retry deletes the trailing assistant message server-side, and so does
+  // clearing a chat's history. Reconcile against the loaded messages so the
+  // tray never submits a comment quoting a message that is gone.
+  useEffect(() => {
+    if (messages.length === 0) return;
+    const messageIds = new Set(messages.map((message) => message.id));
+    setAllAnnotations((previous) =>
+      pruneChatAnnotations(previous, chatId, messageIds),
+    );
+  }, [chatId, messages, setAllAnnotations]);
+
   if (annotations.length === 0) return null;
 
   const send = () => {
     if (isSending || isStreaming) return;
-    const submittedIds = new Set(annotations.map((annotation) => annotation.id));
+    // Snapshot the exact text submitted so an edit made while the turn is in
+    // flight survives settlement instead of being dropped by id.
+    const submitted = new Map(
+      annotations.map((annotation) => [annotation.id, annotation.comment]),
+    );
     setIsSending(true);
     streamMessage({
       chatId,
       prompt: serializeChatAnnotations(annotations),
-      onSettled: ({ success }) => {
-        if (success) {
+      onSettled: ({ success, queued }) => {
+        // A queued turn was accepted and will run; leaving the comments in the
+        // tray would invite the user to send the same prompt twice.
+        if (success || queued) {
           setAllAnnotations((previous) => {
             const next = new Map(previous);
             const remaining = (next.get(chatId) ?? []).filter(
-              (annotation) => !submittedIds.has(annotation.id),
+              (annotation) =>
+                submitted.get(annotation.id) !== annotation.comment,
             );
             if (remaining.length === 0) next.delete(chatId);
             else next.set(chatId, remaining);
@@ -58,6 +80,8 @@ export function ChatAnnotationsTray({ chatId }: { chatId: number }) {
         <button
           type="button"
           className="flex flex-1 items-center gap-1 text-left text-sm font-medium"
+          aria-expanded={expanded}
+          aria-controls={listId}
           onClick={() => setExpanded((value) => !value)}
         >
           {t("annotations.commentCount", { count: annotations.length })}
@@ -79,13 +103,18 @@ export function ChatAnnotationsTray({ chatId }: { chatId: number }) {
           {t("annotations.discard")}
         </Button>
         <Button size="sm" disabled={isStreaming || isSending} onClick={send}>
-          {isSending
-            ? t("annotations.sending")
-            : t("annotations.send", { count: annotations.length })}
+          <span role="status" aria-live="polite">
+            {isSending
+              ? t("annotations.sending")
+              : t("annotations.send", { count: annotations.length })}
+          </span>
         </Button>
       </div>
       {expanded && (
-        <div className="max-h-48 space-y-2 overflow-y-auto border-t px-3 py-2">
+        <div
+          id={listId}
+          className="max-h-48 space-y-2 overflow-y-auto border-t px-3 py-2"
+        >
           {annotations.map((annotation) => (
             <div
               key={annotation.id}

--- a/src/components/chat/ChatAnnotationsTray.tsx
+++ b/src/components/chat/ChatAnnotationsTray.tsx
@@ -1,5 +1,5 @@
 import { useAtom } from "jotai";
-import { ChevronDown, ChevronUp, MessageSquare, Trash2 } from "lucide-react";
+import { ChevronDown, ChevronUp, MessageSquare, Trash2, X } from "lucide-react";
 import { useEffect, useId, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
@@ -13,16 +13,12 @@ import {
   useChatMessages,
   useChatMessagesLoaded,
 } from "@/hooks/useChatMessages";
-import { useStreamChat } from "@/hooks/useStreamChat";
-import { serializeChatAnnotations } from "@/lib/serializeChatAnnotations";
 
 export function ChatAnnotationsTray({ chatId }: { chatId: number }) {
   const { t } = useTranslation("chat");
   const [allAnnotations, setAllAnnotations] = useAtom(chatAnnotationsAtom);
   const [expanded, setExpanded] = useState(false);
-  const [isSending, setIsSending] = useState(false);
   const listId = useId();
-  const { streamMessage, isStreaming } = useStreamChat();
   const messages = useChatMessages(chatId);
   const messagesLoaded = useChatMessagesLoaded(chatId);
   const annotations = useMemo(
@@ -44,37 +40,6 @@ export function ChatAnnotationsTray({ chatId }: { chatId: number }) {
   }, [chatId, messages, messagesLoaded, setAllAnnotations]);
 
   if (annotations.length === 0) return null;
-
-  const send = () => {
-    if (isSending || isStreaming) return;
-    // Snapshot the exact text submitted so an edit made while the turn is in
-    // flight survives settlement instead of being dropped by id.
-    const submitted = new Map(
-      annotations.map((annotation) => [annotation.id, annotation.comment]),
-    );
-    setIsSending(true);
-    streamMessage({
-      chatId,
-      prompt: serializeChatAnnotations(annotations),
-      onSettled: ({ success, queued }) => {
-        // A queued turn was accepted and will run; leaving the comments in the
-        // tray would invite the user to send the same prompt twice.
-        if (success || queued) {
-          setAllAnnotations((previous) => {
-            const next = new Map(previous);
-            const remaining = (next.get(chatId) ?? []).filter(
-              (annotation) =>
-                submitted.get(annotation.id) !== annotation.comment,
-            );
-            if (remaining.length === 0) next.delete(chatId);
-            else next.set(chatId, remaining);
-            return next;
-          });
-        }
-        setIsSending(false);
-      },
-    });
-  };
 
   return (
     <div
@@ -99,21 +64,16 @@ export function ChatAnnotationsTray({ chatId }: { chatId: number }) {
         </button>
         <Button
           variant="ghost"
-          size="sm"
+          size="icon"
+          className="size-7 text-muted-foreground hover:text-foreground"
+          aria-label={t("annotations.discard")}
           onClick={() =>
             setAllAnnotations((previous) =>
               clearChatAnnotations(previous, chatId),
             )
           }
         >
-          {t("annotations.discard")}
-        </Button>
-        <Button size="sm" disabled={isStreaming || isSending} onClick={send}>
-          <span role="status" aria-live="polite">
-            {isSending
-              ? t("annotations.sending")
-              : t("annotations.send", { count: annotations.length })}
-          </span>
+          <X className="size-4" />
         </Button>
       </div>
       {expanded && (

--- a/src/components/chat/ChatAnnotationsTray.tsx
+++ b/src/components/chat/ChatAnnotationsTray.tsx
@@ -9,7 +9,10 @@ import {
   removeChatAnnotation,
 } from "@/atoms/chatAnnotationAtoms";
 import { Button } from "@/components/ui/button";
-import { useChatMessages } from "@/hooks/useChatMessages";
+import {
+  useChatMessages,
+  useChatMessagesLoaded,
+} from "@/hooks/useChatMessages";
 import { useStreamChat } from "@/hooks/useStreamChat";
 import { serializeChatAnnotations } from "@/lib/serializeChatAnnotations";
 
@@ -21,6 +24,7 @@ export function ChatAnnotationsTray({ chatId }: { chatId: number }) {
   const listId = useId();
   const { streamMessage, isStreaming } = useStreamChat();
   const messages = useChatMessages(chatId);
+  const messagesLoaded = useChatMessagesLoaded(chatId);
   const annotations = useMemo(
     () => allAnnotations.get(chatId) ?? [],
     [allAnnotations, chatId],
@@ -28,14 +32,16 @@ export function ChatAnnotationsTray({ chatId }: { chatId: number }) {
 
   // Retry deletes the trailing assistant message server-side, and so does
   // clearing a chat's history. Reconcile against the loaded messages so the
-  // tray never submits a comment quoting a message that is gone.
+  // tray never submits a comment quoting a message that is gone. Gate on
+  // `messagesLoaded`, not on the list being non-empty: a cleared chat loads as
+  // an empty list, and that is exactly when everything needs pruning.
   useEffect(() => {
-    if (messages.length === 0) return;
+    if (!messagesLoaded) return;
     const messageIds = new Set(messages.map((message) => message.id));
     setAllAnnotations((previous) =>
       pruneChatAnnotations(previous, chatId, messageIds),
     );
-  }, [chatId, messages, setAllAnnotations]);
+  }, [chatId, messages, messagesLoaded, setAllAnnotations]);
 
   if (annotations.length === 0) return null;
 

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -121,6 +121,7 @@ import {
   CHAT_PROMPT_LENGTH_LIMIT_MESSAGE,
   MAX_CHAT_PROMPT_CHARS,
 } from "@/shared/chatAttachmentLimits";
+import { ChatAnnotationsTray } from "./ChatAnnotationsTray";
 
 const showTokenBarAtom = atom(false);
 
@@ -821,6 +822,8 @@ export function ChatInput({ chatId }: { chatId?: number }) {
         >
           {/* Show active questionnaire if exists */}
           <QuestionnaireInput />
+
+          {chatId && <ChatAnnotationsTray chatId={chatId} />}
 
           {/* Show the recorded-test plan waiting on a review, if any */}
           <TestAssertionsInput />

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -33,6 +33,7 @@ import {
   selectedChatIdAtom,
   agentTodosByChatIdAtom,
 } from "@/atoms/chatAtoms";
+import { chatAnnotationsAtom } from "@/atoms/chatAnnotationAtoms";
 import { atom, useAtom, useSetAtom, useAtomValue, useStore } from "jotai";
 import { useStreamChat } from "@/hooks/useStreamChat";
 import { selectedAppIdAtom } from "@/atoms/appAtoms";
@@ -122,6 +123,10 @@ import {
   MAX_CHAT_PROMPT_CHARS,
 } from "@/shared/chatAttachmentLimits";
 import { ChatAnnotationsTray } from "./ChatAnnotationsTray";
+import {
+  composeChatPrompt,
+  hasChatComposerPayload,
+} from "@/lib/serializeChatAnnotations";
 
 const showTokenBarAtom = atom(false);
 
@@ -144,6 +149,12 @@ export function ChatInput({ chatId }: { chatId?: number }) {
       });
     },
     [chatId, setInputValuesById],
+  );
+  const [allChatAnnotations, setAllChatAnnotations] =
+    useAtom(chatAnnotationsAtom);
+  const chatAnnotations = useMemo(
+    () => (chatId ? (allChatAnnotations.get(chatId) ?? []) : []),
+    [allChatAnnotations, chatId],
   );
   const { settings } = useSettings();
   const {
@@ -286,12 +297,19 @@ export function ChatInput({ chatId }: { chatId?: number }) {
 
   const lastMessage = messages.at(-1);
   const disableSendButton =
+    chatAnnotations.length === 0 &&
     selectedMode !== "local-agent" &&
     lastMessage?.role === "assistant" &&
     !lastMessage.approvalState &&
     !!proposal &&
     proposal.type === "code-proposal" &&
     messageId === lastMessage.id;
+  const hasComposerPayload = hasChatComposerPayload({
+    inputValue,
+    attachmentCount: attachments.length,
+    hasSuccessfulImageJobs,
+    annotationCount: chatAnnotations.length,
+  });
 
   // Extract user message history for terminal-style navigation
   const userMessageHistory = useMemo(() => {
@@ -510,15 +528,53 @@ export function ChatInput({ chatId }: { chatId?: number }) {
 
   const handleSubmit = async () => {
     if (
-      (!inputValue.trim() &&
-        attachments.length === 0 &&
-        !hasSuccessfulImageJobs) ||
+      !hasComposerPayload ||
       !chatId ||
       pendingFiles ||
       isAwaitingTurnAcceptanceRef.current
     ) {
       return;
     }
+
+    const submittedAnnotations = chatAnnotations;
+    const submittedAnnotationIds = new Set(
+      submittedAnnotations.map((annotation) => annotation.id),
+    );
+    const hideSubmittedAnnotations = () => {
+      if (submittedAnnotationIds.size === 0) return;
+      setAllChatAnnotations((previous) => {
+        const next = new Map(previous);
+        const remaining = (next.get(chatId) ?? []).filter(
+          (annotation) => !submittedAnnotationIds.has(annotation.id),
+        );
+        if (remaining.length === 0) next.delete(chatId);
+        else next.set(chatId, remaining);
+        return next;
+      });
+    };
+    let restoredSubmittedAnnotations = false;
+    const restoreSubmittedAnnotations = () => {
+      if (submittedAnnotations.length === 0 || restoredSubmittedAnnotations) {
+        return;
+      }
+      restoredSubmittedAnnotations = true;
+      setAllChatAnnotations((previous) => {
+        const current = previous.get(chatId) ?? [];
+        const currentIds = new Set(current.map((annotation) => annotation.id));
+        const missing = submittedAnnotations.filter(
+          (annotation) => !currentIds.has(annotation.id),
+        );
+        if (missing.length === 0) return previous;
+        const next = new Map(previous);
+        next.set(
+          chatId,
+          [...missing, ...current].sort(
+            (left, right) => left.createdAt - right.createdAt,
+          ),
+        );
+        return next;
+      });
+    };
 
     if (isRecording) {
       await toggleRecording();
@@ -533,13 +589,16 @@ export function ChatInput({ chatId }: { chatId?: number }) {
         ? `${inputValue} ${imageMentions}`
         : inputValue
       : imageMentions;
+    const currentInput = composeChatPrompt(
+      promptWithImages,
+      submittedAnnotations,
+    );
 
-    if (promptWithImages.length > MAX_CHAT_PROMPT_CHARS) {
+    if (currentInput.length > MAX_CHAT_PROMPT_CHARS) {
       showErrorToast(CHAT_PROMPT_LENGTH_LIMIT_MESSAGE);
       return;
     }
 
-    const currentInput = promptWithImages;
     const submittedInputValue = inputValue;
     const submittedImageJobIds = visibleSuccessfulImageJobs.map(
       (job) => job.id,
@@ -566,6 +625,7 @@ export function ChatInput({ chatId }: { chatId?: number }) {
         attachments,
         selectedComponents: componentsToSend,
       });
+      hideSubmittedAnnotations();
       dismissSubmittedImageJobs();
       resetEditingState();
       return;
@@ -582,6 +642,7 @@ export function ChatInput({ chatId }: { chatId?: number }) {
       });
       if (queued) {
         // Only clear input, attachments, and components on successful queue
+        hideSubmittedAnnotations();
         clearComposerAfterSubmit();
         clearAttachments();
         dismissSubmittedImageJobs();
@@ -622,6 +683,8 @@ export function ChatInput({ chatId }: { chatId?: number }) {
       dismissSubmittedImageJobs();
     };
     isAwaitingTurnAcceptanceRef.current = true;
+    hideSubmittedAnnotations();
+    let wasAccepted = false;
     await streamMessage({
       prompt: currentInput,
       chatId,
@@ -630,15 +693,20 @@ export function ChatInput({ chatId }: { chatId?: number }) {
       selectedComponents: componentsToSend,
       requestedChatMode: isChatModeLoading ? null : storedChatMode,
       onAccepted: () => {
+        wasAccepted = true;
         isAwaitingTurnAcceptanceRef.current = false;
         clearAcceptedPayload();
       },
       onAcceptanceRejected: () => {
         isAwaitingTurnAcceptanceRef.current = false;
+        restoreSubmittedAnnotations();
       },
-      onSettled: ({ queued }) => {
+      onSettled: ({ success, queued }) => {
         isAwaitingTurnAcceptanceRef.current = false;
         if (queued) clearAcceptedPayload();
+        if (!success && !queued && !wasAccepted) {
+          restoreSubmittedAnnotations();
+        }
       },
     });
     posthog.capture("chat:submit", { chatMode });
@@ -1083,12 +1151,7 @@ export function ChatInput({ chatId }: { chatId?: number }) {
                   render={
                     <button
                       onClick={handleSubmit}
-                      disabled={
-                        (!inputValue.trim() &&
-                          attachments.length === 0 &&
-                          !hasSuccessfulImageJobs) ||
-                        disableSendButton
-                      }
+                      disabled={!hasComposerPayload || disableSendButton}
                       aria-label={t("sendMessage")}
                       className="px-2 py-2 mb-0.5 mr-1 text-muted-foreground hover:text-primary rounded-lg transition-colors duration-150 disabled:opacity-30 disabled:hover:text-muted-foreground cursor-pointer disabled:cursor-default"
                     />

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -297,7 +297,6 @@ export function ChatInput({ chatId }: { chatId?: number }) {
 
   const lastMessage = messages.at(-1);
   const disableSendButton =
-    chatAnnotations.length === 0 &&
     selectedMode !== "local-agent" &&
     lastMessage?.role === "assistant" &&
     !lastMessage.approvalState &&

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -53,6 +53,7 @@ import {
   getVisibleMessageApprovalState,
   shouldShowMessageFooter,
 } from "./messageApprovalStatus";
+import { ChatMessageAnnotationLayer } from "./ChatMessageAnnotationLayer";
 
 /** Extract <dyad-attachment> tags from message content and return parsed attachment data. */
 function extractAttachments(content: string): {
@@ -129,6 +130,7 @@ const ChatMessage = ({
   const selectedChatId = useAtomValue(selectedChatIdAtom);
   const hasPreviewForChat = useChatStreamHasPreview(selectedChatId);
   const [showRestoreConfirm, setShowRestoreConfirm] = useState(false);
+  const assistantContentRef = useRef<HTMLDivElement>(null);
   const hasStreamingPreview =
     message.role === "assistant" &&
     isLastMessage &&
@@ -344,6 +346,7 @@ const ChatMessage = ({
               </div>
             ) : (
               <div
+                ref={message.role === "assistant" ? assistantContentRef : undefined}
                 className="prose dark:prose-invert prose-headings:mb-2 prose-p:my-1 prose-pre:my-0 max-w-none break-words text-[15px]"
                 suppressHydrationWarning
               >
@@ -363,6 +366,16 @@ const ChatMessage = ({
                 )}
               </div>
             )}
+            {message.role === "assistant" &&
+              selectedChatId != null &&
+              !isCancelled &&
+              !(isLastMessage && isStreaming) && (
+                <ChatMessageAnnotationLayer
+                  containerRef={assistantContentRef}
+                  chatId={selectedChatId}
+                  messageId={message.id}
+                />
+              )}
             {showMessageFooter ? (
               <div
                 className={`mt-2 flex items-center ${

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -54,6 +54,7 @@ import {
   shouldShowMessageFooter,
 } from "./messageApprovalStatus";
 import { ChatMessageAnnotationLayer } from "./ChatMessageAnnotationLayer";
+import { isChatMessageAnnotatable } from "./chatAnnotationEligibility";
 
 /** Extract <dyad-attachment> tags from message content and return parsed attachment data. */
 function extractAttachments(content: string): {
@@ -368,10 +369,13 @@ const ChatMessage = ({
                 )}
               </div>
             )}
-            {message.role === "assistant" &&
-              selectedChatId != null &&
-              !isCancelled &&
-              !(isLastMessage && isStreaming) && (
+            {selectedChatId != null &&
+              isChatMessageAnnotatable({
+                role: message.role,
+                isLastMessage,
+                isCancelled,
+                isStreaming,
+              }) && (
                 <ChatMessageAnnotationLayer
                   containerRef={assistantContentRef}
                   chatId={selectedChatId}

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -346,7 +346,9 @@ const ChatMessage = ({
               </div>
             ) : (
               <div
-                ref={message.role === "assistant" ? assistantContentRef : undefined}
+                ref={
+                  message.role === "assistant" ? assistantContentRef : undefined
+                }
                 className="prose dark:prose-invert prose-headings:mb-2 prose-p:my-1 prose-pre:my-0 max-w-none break-words text-[15px]"
                 suppressHydrationWarning
               >

--- a/src/components/chat/ChatMessageAnnotationLayer.tsx
+++ b/src/components/chat/ChatMessageAnnotationLayer.tsx
@@ -6,9 +6,9 @@ import { useTranslation } from "react-i18next";
 import {
   addChatAnnotation,
   chatAnnotationsAtom,
-  hasOverlappingChatAnnotation,
   removeChatAnnotation,
   updateChatAnnotation,
+  type ChatAnnotation,
 } from "@/atoms/chatAnnotationAtoms";
 import { Button } from "@/components/ui/button";
 import {
@@ -16,8 +16,12 @@ import {
   CHAT_ANNOTATION_ID_ATTRIBUTE,
   CHAT_ANNOTATION_MARK_SELECTOR,
   clearChatAnnotationHighlights,
+  findOverlappingChatAnnotation,
   getChatSelectionSnapshot,
 } from "./chatAnnotationDom";
+
+const POPOVER_WIDTH = 296;
+const POPOVER_HEIGHT = 180;
 
 interface FloatingSelection {
   x: number;
@@ -25,6 +29,28 @@ interface FloatingSelection {
   selectedText: string;
   startOffset: number;
   selectionLength: number;
+}
+
+/** Where the popover is pinned, so it can be repositioned as the page moves. */
+type FloatingAnchor = { kind: "mark"; id: string } | { kind: "range" };
+
+/** First `<mark>` fragment of an annotation, which carries its popover anchor. */
+function findAnnotationMark(container: HTMLElement, annotationId: string) {
+  return [
+    ...container.querySelectorAll<HTMLElement>(CHAT_ANNOTATION_MARK_SELECTOR),
+  ].find(
+    (mark) => mark.getAttribute(CHAT_ANNOTATION_ID_ATTRIBUTE) === annotationId,
+  );
+}
+
+function clampToViewport(rect: DOMRect): { x: number; y: number } {
+  return {
+    x: Math.max(
+      8,
+      Math.min(rect.right + 6, window.innerWidth - POPOVER_WIDTH - 8),
+    ),
+    y: Math.max(8, Math.min(rect.top, window.innerHeight - POPOVER_HEIGHT - 8)),
+  };
 }
 
 export function ChatMessageAnnotationLayer({
@@ -38,23 +64,44 @@ export function ChatMessageAnnotationLayer({
 }) {
   const { t } = useTranslation("chat");
   const [allAnnotations, setAllAnnotations] = useAtom(chatAnnotationsAtom);
-  const annotations = useMemo(
-    () =>
-      (allAnnotations.get(chatId) ?? []).filter(
-        (annotation) => annotation.messageId === messageId,
-      ),
-    [allAnnotations, chatId, messageId],
-  );
+  // Returning the previous array when this message's annotations are unchanged
+  // keeps the highlight effect from clearing and re-applying every message's
+  // marks whenever any annotation anywhere in the chat changes.
+  const stableAnnotationsRef = useRef<ChatAnnotation[]>([]);
+  const annotations = useMemo(() => {
+    const next = (allAnnotations.get(chatId) ?? []).filter(
+      (annotation) => annotation.messageId === messageId,
+    );
+    const previous = stableAnnotationsRef.current;
+    if (
+      previous.length === next.length &&
+      previous.every((annotation, index) => annotation === next[index])
+    ) {
+      return previous;
+    }
+    stableAnnotationsRef.current = next;
+    return next;
+  }, [allAnnotations, chatId, messageId]);
   const [floating, setFloating] = useState<FloatingSelection | null>(null);
   const [activeId, setActiveId] = useState<string | null>(null);
   const [comment, setComment] = useState("");
   const [showEditor, setShowEditor] = useState(false);
   const popoverRef = useRef<HTMLElement | null>(null);
+  const anchorRef = useRef<FloatingAnchor | null>(null);
   const setPopoverRef = useCallback((node: HTMLElement | null) => {
     popoverRef.current = node;
   }, []);
 
+  const markLabel = useCallback(
+    (selectedText: string) =>
+      selectedText.length === 0
+        ? t("annotations.viewComment")
+        : t("annotations.viewCommentFor", { text: selectedText }),
+    [t],
+  );
+
   const dismiss = useCallback(() => {
+    anchorRef.current = null;
     setFloating(null);
     setActiveId(null);
     setComment("");
@@ -64,23 +111,65 @@ export function ChatMessageAnnotationLayer({
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
-    clearChatAnnotationHighlights(container);
-    applyChatAnnotationHighlights(container, annotations);
-    return () => clearChatAnnotationHighlights(container);
-  }, [annotations, containerRef]);
+
+    let frameId: number | null = null;
+    let isApplyingHighlights = false;
+
+    // Markdown content is re-rendered outside this effect's control (React
+    // reconciles the subtree, CodeHighlight swaps its fallback `<pre>` for
+    // Shiki once the highlighter loads), and either wipes the marks out. Watch
+    // the container and re-apply instead of highlighting exactly once.
+    const observer = new MutationObserver(() => {
+      if (isApplyingHighlights) return;
+      scheduleRefresh();
+    });
+
+    const refresh = () => {
+      observer.disconnect();
+      isApplyingHighlights = true;
+      try {
+        clearChatAnnotationHighlights(container);
+        applyChatAnnotationHighlights(container, annotations, markLabel);
+      } finally {
+        isApplyingHighlights = false;
+        observer.observe(container, {
+          childList: true,
+          subtree: true,
+          characterData: true,
+        });
+      }
+    };
+
+    const scheduleRefresh = () => {
+      if (frameId !== null) cancelAnimationFrame(frameId);
+      frameId = requestAnimationFrame(() => {
+        frameId = null;
+        refresh();
+      });
+    };
+
+    scheduleRefresh();
+    observer.observe(container, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    });
+
+    return () => {
+      observer.disconnect();
+      if (frameId !== null) cancelAnimationFrame(frameId);
+      clearChatAnnotationHighlights(container);
+    };
+  }, [annotations, containerRef, markLabel]);
 
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
 
-    const openMark = (mark: HTMLElement) => {
-      const id = mark.getAttribute(CHAT_ANNOTATION_ID_ATTRIBUTE);
-      const annotation = annotations.find((item) => item.id === id);
-      if (!annotation) return;
-      const rect = mark.getBoundingClientRect();
+    const openAnnotation = (annotation: ChatAnnotation, rect: DOMRect) => {
+      anchorRef.current = { kind: "mark", id: annotation.id };
       setFloating({
-        x: Math.min(rect.right + 6, window.innerWidth - 304),
-        y: Math.max(8, rect.top),
+        ...clampToViewport(rect),
         selectedText: annotation.selectedText,
         startOffset: annotation.startOffset,
         selectionLength: annotation.selectionLength,
@@ -90,65 +179,171 @@ export function ChatMessageAnnotationLayer({
       setShowEditor(true);
     };
 
-    const handleMouseUp = (event: MouseEvent) => {
+    const openMark = (mark: HTMLElement) => {
+      const id = mark.getAttribute(CHAT_ANNOTATION_ID_ATTRIBUTE);
+      const annotation = annotations.find((item) => item.id === id);
+      if (!annotation) return;
+      openAnnotation(annotation, mark.getBoundingClientRect());
+    };
+
+    const markFromEvent = (event: Event) => {
       const target = event.target instanceof HTMLElement ? event.target : null;
-      const mark = target?.closest(
-        CHAT_ANNOTATION_MARK_SELECTOR,
-      ) as HTMLElement | null;
-      if (mark) {
-        openMark(mark);
+      return (target?.closest(CHAT_ANNOTATION_MARK_SELECTOR) ??
+        null) as HTMLElement | null;
+    };
+
+    const findMark = (annotationId: string) =>
+      findAnnotationMark(container, annotationId);
+
+    // Capture the click on the way down so a highlight sitting inside a
+    // markdown link or a tool-card button opens the comment instead of also
+    // following the link / running the card action.
+    const handleClickCapture = (event: MouseEvent) => {
+      const mark = markFromEvent(event);
+      if (!mark) return;
+      event.preventDefault();
+      event.stopPropagation();
+      openMark(mark);
+    };
+
+    const processSelection = () => {
+      const selection = window.getSelection();
+      if (!selection || selection.rangeCount === 0 || selection.isCollapsed) {
+        return;
+      }
+      const range = selection.getRangeAt(0);
+      const snapshot = getChatSelectionSnapshot(container, range);
+      if (!snapshot) return;
+
+      const overlapping = findOverlappingChatAnnotation(
+        annotations,
+        snapshot.startOffset,
+        snapshot.selectionLength,
+      );
+      if (overlapping) {
+        // Silently doing nothing here read as "the feature is broken". Open the
+        // comment the selection collides with so the overlap is explained by
+        // what appears on screen.
+        const mark = findMark(overlapping.id);
+        openAnnotation(overlapping, (mark ?? range).getBoundingClientRect());
         return;
       }
 
-      requestAnimationFrame(() => {
-        const selection = window.getSelection();
-        if (!selection || selection.rangeCount === 0 || selection.isCollapsed) {
-          return;
-        }
-        const range = selection.getRangeAt(0);
-        const snapshot = getChatSelectionSnapshot(container, range);
-        if (
-          !snapshot ||
-          hasOverlappingChatAnnotation(
-            annotations,
-            snapshot.startOffset,
-            snapshot.selectionLength,
-          )
-        ) {
-          return;
-        }
-        const rects = range.getClientRects();
-        const rect =
-          rects.item(rects.length - 1) ?? range.getBoundingClientRect();
-        setFloating({
-          x: Math.max(8, Math.min(rect.right + 6, window.innerWidth - 304)),
-          y: Math.max(8, Math.min(rect.top, window.innerHeight - 180)),
-          ...snapshot,
-        });
-        setActiveId(null);
-        setComment("");
-        setShowEditor(false);
+      const rects = range.getClientRects();
+      const rect =
+        rects.item(rects.length - 1) ?? range.getBoundingClientRect();
+      anchorRef.current = { kind: "range" };
+      setFloating({ ...clampToViewport(rect), ...snapshot });
+      setActiveId(null);
+      setComment("");
+      setShowEditor(false);
+    };
+
+    let frameId: number | null = null;
+    const scheduleProcessSelection = () => {
+      if (frameId !== null) cancelAnimationFrame(frameId);
+      frameId = requestAnimationFrame(() => {
+        frameId = null;
+        processSelection();
       });
     };
 
+    const handleSelectionEnd = (event: Event) => {
+      if (markFromEvent(event)) return;
+      scheduleProcessSelection();
+    };
+
     const handleKeyDown = (event: KeyboardEvent) => {
-      const target = event.target instanceof HTMLElement ? event.target : null;
-      const mark = target?.closest(
-        CHAT_ANNOTATION_MARK_SELECTOR,
-      ) as HTMLElement | null;
+      const mark = markFromEvent(event);
       if (mark && (event.key === "Enter" || event.key === " ")) {
         event.preventDefault();
         openMark(mark);
       }
     };
 
-    container.addEventListener("mouseup", handleMouseUp);
+    // Keyboard (shift+arrow) and touch selections never fire `mouseup`, so
+    // without this they could never reach the comment affordance. One layer is
+    // mounted per assistant message, so bail on someone else's selection before
+    // arming the debounce rather than after.
+    let selectionChangeTimer: ReturnType<typeof setTimeout> | null = null;
+    const handleSelectionChange = () => {
+      const selection = window.getSelection();
+      if (
+        !selection ||
+        selection.rangeCount === 0 ||
+        selection.isCollapsed ||
+        !container.contains(selection.getRangeAt(0).commonAncestorContainer)
+      ) {
+        return;
+      }
+      if (selectionChangeTimer !== null) clearTimeout(selectionChangeTimer);
+      selectionChangeTimer = setTimeout(() => {
+        selectionChangeTimer = null;
+        scheduleProcessSelection();
+      }, 200);
+    };
+
+    container.addEventListener("click", handleClickCapture, true);
+    container.addEventListener("mouseup", handleSelectionEnd);
     container.addEventListener("keydown", handleKeyDown);
+    container.addEventListener("touchend", handleSelectionEnd);
+    document.addEventListener("selectionchange", handleSelectionChange);
     return () => {
-      container.removeEventListener("mouseup", handleMouseUp);
+      container.removeEventListener("click", handleClickCapture, true);
+      container.removeEventListener("mouseup", handleSelectionEnd);
       container.removeEventListener("keydown", handleKeyDown);
+      container.removeEventListener("touchend", handleSelectionEnd);
+      document.removeEventListener("selectionchange", handleSelectionChange);
+      if (frameId !== null) cancelAnimationFrame(frameId);
+      if (selectionChangeTimer !== null) clearTimeout(selectionChangeTimer);
     };
   }, [annotations, containerRef]);
+
+  // The popover is `position: fixed`, so it has to be re-pinned to its anchor
+  // whenever the transcript scrolls or the window resizes - otherwise it stays
+  // at stale viewport coordinates, floating over unrelated messages or landing
+  // off-screen.
+  useEffect(() => {
+    if (!floating) return;
+    const container = containerRef.current;
+
+    const reposition = () => {
+      const anchor = anchorRef.current;
+      if (!anchor || !container) return;
+
+      let rect: DOMRect | null = null;
+      if (anchor.kind === "mark") {
+        rect =
+          findAnnotationMark(container, anchor.id)?.getBoundingClientRect() ??
+          null;
+      } else {
+        const selection = window.getSelection();
+        rect =
+          selection && selection.rangeCount > 0
+            ? selection.getRangeAt(0).getBoundingClientRect()
+            : null;
+      }
+
+      if (!rect || (rect.width === 0 && rect.height === 0)) {
+        dismiss();
+        return;
+      }
+
+      const { x, y } = clampToViewport(rect);
+      setFloating((previous) =>
+        previous && (previous.x !== x || previous.y !== y)
+          ? { ...previous, x, y }
+          : previous,
+      );
+    };
+
+    window.addEventListener("scroll", reposition, true);
+    window.addEventListener("resize", reposition);
+    return () => {
+      window.removeEventListener("scroll", reposition, true);
+      window.removeEventListener("resize", reposition);
+    };
+  }, [containerRef, dismiss, floating]);
 
   useEffect(() => {
     if (!floating) return;

--- a/src/components/chat/ChatMessageAnnotationLayer.tsx
+++ b/src/components/chat/ChatMessageAnnotationLayer.tsx
@@ -31,8 +31,36 @@ interface FloatingSelection {
   selectionLength: number;
 }
 
-/** Where the popover is pinned, so it can be repositioned as the page moves. */
-type FloatingAnchor = { kind: "mark"; id: string } | { kind: "range" };
+/**
+ * Where the popover is pinned, so it can be repositioned as the page moves.
+ *
+ * The range case holds a cloned Range rather than re-reading the live
+ * selection: focusing the editor collapses the selection, and re-deriving from
+ * it would lose the anchor (and with it whatever the user had typed).
+ */
+type FloatingAnchor =
+  | { kind: "mark"; id: string }
+  | { kind: "range"; range: Range };
+
+/**
+ * The rect the popover hangs off: the last line box, so a multi-line selection
+ * anchors at the end of its final line rather than at the union box's far
+ * right edge.
+ */
+function anchorRect(source: Element | Range): DOMRect | null {
+  const rects = source.getClientRects();
+  const rect = rects.item(rects.length - 1) ?? source.getBoundingClientRect();
+  return rect.width === 0 && rect.height === 0 ? null : rect;
+}
+
+function isOutsideViewport(rect: DOMRect): boolean {
+  return (
+    rect.bottom < 0 ||
+    rect.right < 0 ||
+    rect.top > window.innerHeight ||
+    rect.left > window.innerWidth
+  );
+}
 
 /** First `<mark>` fragment of an annotation, which carries its popover anchor. */
 function findAnnotationMark(container: HTMLElement, annotationId: string) {
@@ -112,6 +140,14 @@ export function ChatMessageAnnotationLayer({
     const container = containerRef.current;
     if (!container) return;
 
+    // Most messages in a transcript carry no comments. Clear once and stop,
+    // rather than installing a subtree observer and walking the whole message
+    // on every render for marks that can never exist.
+    if (annotations.length === 0) {
+      clearChatAnnotationHighlights(container);
+      return;
+    }
+
     let frameId: number | null = null;
     let isApplyingHighlights = false;
 
@@ -166,7 +202,12 @@ export function ChatMessageAnnotationLayer({
     const container = containerRef.current;
     if (!container) return;
 
-    const openAnnotation = (annotation: ChatAnnotation, rect: DOMRect) => {
+    const openAnnotation = (
+      annotation: ChatAnnotation,
+      source: Element | Range,
+    ) => {
+      const rect = anchorRect(source);
+      if (!rect) return;
       anchorRef.current = { kind: "mark", id: annotation.id };
       setFloating({
         ...clampToViewport(rect),
@@ -183,7 +224,7 @@ export function ChatMessageAnnotationLayer({
       const id = mark.getAttribute(CHAT_ANNOTATION_ID_ATTRIBUTE);
       const annotation = annotations.find((item) => item.id === id);
       if (!annotation) return;
-      openAnnotation(annotation, mark.getBoundingClientRect());
+      openAnnotation(annotation, mark);
     };
 
     const markFromEvent = (event: Event) => {
@@ -224,15 +265,13 @@ export function ChatMessageAnnotationLayer({
         // Silently doing nothing here read as "the feature is broken". Open the
         // comment the selection collides with so the overlap is explained by
         // what appears on screen.
-        const mark = findMark(overlapping.id);
-        openAnnotation(overlapping, (mark ?? range).getBoundingClientRect());
+        openAnnotation(overlapping, findMark(overlapping.id) ?? range);
         return;
       }
 
-      const rects = range.getClientRects();
-      const rect =
-        rects.item(rects.length - 1) ?? range.getBoundingClientRect();
-      anchorRef.current = { kind: "range" };
+      const rect = anchorRect(range);
+      if (!rect) return;
+      anchorRef.current = { kind: "range", range: range.cloneRange() };
       setFloating({ ...clampToViewport(rect), ...snapshot });
       setActiveId(null);
       setComment("");
@@ -311,20 +350,17 @@ export function ChatMessageAnnotationLayer({
       const anchor = anchorRef.current;
       if (!anchor || !container) return;
 
-      let rect: DOMRect | null = null;
-      if (anchor.kind === "mark") {
-        rect =
-          findAnnotationMark(container, anchor.id)?.getBoundingClientRect() ??
-          null;
-      } else {
-        const selection = window.getSelection();
-        rect =
-          selection && selection.rangeCount > 0
-            ? selection.getRangeAt(0).getBoundingClientRect()
-            : null;
-      }
+      const source =
+        anchor.kind === "mark"
+          ? findAnnotationMark(container, anchor.id)
+          : anchor.range;
+      const rect = source ? anchorRect(source) : null;
 
-      if (!rect || (rect.width === 0 && rect.height === 0)) {
+      // An anchor with no box left (its node was replaced out from under us)
+      // keeps its current position: dropping the popover here would throw away
+      // a comment the user is still typing.
+      if (!rect) return;
+      if (isOutsideViewport(rect)) {
         dismiss();
         return;
       }
@@ -395,6 +431,9 @@ export function ChatMessageAnnotationLayer({
         aria-label={t("annotations.commentOnSelection")}
         className="fixed z-50 flex size-8 animate-in items-center justify-center rounded-full bg-primary text-primary-foreground shadow-md ring-offset-background transition duration-150 ease-out fade-in-0 zoom-in-95 hover:bg-primary/90 hover:shadow-lg active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 motion-reduce:animate-none motion-reduce:transition-none"
         style={{ left: floating.x, top: floating.y }}
+        // Keep the browser from collapsing the selection on mousedown, so the
+        // text stays visibly highlighted while the comment is being written.
+        onMouseDown={(event) => event.preventDefault()}
         onClick={() => setShowEditor(true)}
       >
         <MessageSquare className="size-4" />

--- a/src/components/chat/ChatMessageAnnotationLayer.tsx
+++ b/src/components/chat/ChatMessageAnnotationLayer.tsx
@@ -1,0 +1,272 @@
+import { useAtom } from "jotai";
+import { MessageSquare, Trash2 } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { RefObject } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  addChatAnnotation,
+  chatAnnotationsAtom,
+  hasOverlappingChatAnnotation,
+  removeChatAnnotation,
+  updateChatAnnotation,
+} from "@/atoms/chatAnnotationAtoms";
+import { Button } from "@/components/ui/button";
+import {
+  applyChatAnnotationHighlights,
+  CHAT_ANNOTATION_ID_ATTRIBUTE,
+  CHAT_ANNOTATION_MARK_SELECTOR,
+  clearChatAnnotationHighlights,
+  getChatSelectionSnapshot,
+} from "./chatAnnotationDom";
+
+interface FloatingSelection {
+  x: number;
+  y: number;
+  selectedText: string;
+  startOffset: number;
+  selectionLength: number;
+}
+
+export function ChatMessageAnnotationLayer({
+  containerRef,
+  chatId,
+  messageId,
+}: {
+  containerRef: RefObject<HTMLDivElement | null>;
+  chatId: number;
+  messageId: number;
+}) {
+  const { t } = useTranslation("chat");
+  const [allAnnotations, setAllAnnotations] = useAtom(chatAnnotationsAtom);
+  const annotations = useMemo(
+    () =>
+      (allAnnotations.get(chatId) ?? []).filter(
+        (annotation) => annotation.messageId === messageId,
+      ),
+    [allAnnotations, chatId, messageId],
+  );
+  const [floating, setFloating] = useState<FloatingSelection | null>(null);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [comment, setComment] = useState("");
+  const [showEditor, setShowEditor] = useState(false);
+  const popoverRef = useRef<HTMLElement | null>(null);
+  const setPopoverRef = useCallback((node: HTMLElement | null) => {
+    popoverRef.current = node;
+  }, []);
+
+  const dismiss = useCallback(() => {
+    setFloating(null);
+    setActiveId(null);
+    setComment("");
+    setShowEditor(false);
+  }, []);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    clearChatAnnotationHighlights(container);
+    applyChatAnnotationHighlights(container, annotations);
+    return () => clearChatAnnotationHighlights(container);
+  }, [annotations, containerRef]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const openMark = (mark: HTMLElement) => {
+      const id = mark.getAttribute(CHAT_ANNOTATION_ID_ATTRIBUTE);
+      const annotation = annotations.find((item) => item.id === id);
+      if (!annotation) return;
+      const rect = mark.getBoundingClientRect();
+      setFloating({
+        x: Math.min(rect.right + 6, window.innerWidth - 304),
+        y: Math.max(8, rect.top),
+        selectedText: annotation.selectedText,
+        startOffset: annotation.startOffset,
+        selectionLength: annotation.selectionLength,
+      });
+      setActiveId(annotation.id);
+      setComment(annotation.comment);
+      setShowEditor(true);
+    };
+
+    const handleMouseUp = (event: MouseEvent) => {
+      const target = event.target instanceof HTMLElement ? event.target : null;
+      const mark = target?.closest(
+        CHAT_ANNOTATION_MARK_SELECTOR,
+      ) as HTMLElement | null;
+      if (mark) {
+        openMark(mark);
+        return;
+      }
+
+      requestAnimationFrame(() => {
+        const selection = window.getSelection();
+        if (!selection || selection.rangeCount === 0 || selection.isCollapsed) {
+          return;
+        }
+        const range = selection.getRangeAt(0);
+        const snapshot = getChatSelectionSnapshot(container, range);
+        if (
+          !snapshot ||
+          hasOverlappingChatAnnotation(
+            annotations,
+            snapshot.startOffset,
+            snapshot.selectionLength,
+          )
+        ) {
+          return;
+        }
+        const rects = range.getClientRects();
+        const rect =
+          rects.item(rects.length - 1) ?? range.getBoundingClientRect();
+        setFloating({
+          x: Math.max(8, Math.min(rect.right + 6, window.innerWidth - 304)),
+          y: Math.max(8, Math.min(rect.top, window.innerHeight - 180)),
+          ...snapshot,
+        });
+        setActiveId(null);
+        setComment("");
+        setShowEditor(false);
+      });
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const target = event.target instanceof HTMLElement ? event.target : null;
+      const mark = target?.closest(
+        CHAT_ANNOTATION_MARK_SELECTOR,
+      ) as HTMLElement | null;
+      if (mark && (event.key === "Enter" || event.key === " ")) {
+        event.preventDefault();
+        openMark(mark);
+      }
+    };
+
+    container.addEventListener("mouseup", handleMouseUp);
+    container.addEventListener("keydown", handleKeyDown);
+    return () => {
+      container.removeEventListener("mouseup", handleMouseUp);
+      container.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [annotations, containerRef]);
+
+  useEffect(() => {
+    if (!floating) return;
+    const handleMouseDown = (event: MouseEvent) => {
+      if (!popoverRef.current?.contains(event.target as Node)) dismiss();
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") dismiss();
+    };
+    document.addEventListener("mousedown", handleMouseDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handleMouseDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [dismiss, floating]);
+
+  if (!floating) return null;
+
+  const save = () => {
+    if (!comment.trim()) return;
+    if (activeId) {
+      setAllAnnotations((previous) =>
+        updateChatAnnotation(previous, chatId, activeId, comment),
+      );
+    } else {
+      setAllAnnotations((previous) =>
+        addChatAnnotation(previous, {
+          id: crypto.randomUUID(),
+          chatId,
+          messageId,
+          selectedText: floating.selectedText,
+          comment: comment.trim(),
+          createdAt: Date.now(),
+          startOffset: floating.startOffset,
+          selectionLength: floating.selectionLength,
+        }),
+      );
+    }
+    window.getSelection()?.removeAllRanges();
+    dismiss();
+  };
+
+  if (!showEditor) {
+    return (
+      <button
+        ref={setPopoverRef}
+        type="button"
+        aria-label={t("annotations.commentOnSelection")}
+        className="fixed z-50 flex size-8 animate-in items-center justify-center rounded-full bg-primary text-primary-foreground shadow-md ring-offset-background transition duration-150 ease-out fade-in-0 zoom-in-95 hover:bg-primary/90 hover:shadow-lg active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 motion-reduce:animate-none motion-reduce:transition-none"
+        style={{ left: floating.x, top: floating.y }}
+        onClick={() => setShowEditor(true)}
+      >
+        <MessageSquare className="size-4" />
+      </button>
+    );
+  }
+
+  return (
+    <div
+      ref={setPopoverRef}
+      role="dialog"
+      aria-label={
+        activeId
+          ? t("annotations.editComment")
+          : t("annotations.commentOnSelection")
+      }
+      className="fixed z-50 flex w-72 animate-in flex-col gap-1 rounded-2xl border border-border/70 bg-popover p-1.5 text-popover-foreground shadow-xl duration-150 ease-out fade-in-0 zoom-in-95 focus-within:ring-2 focus-within:ring-ring/30 motion-reduce:animate-none"
+      style={{ left: floating.x, top: floating.y }}
+    >
+      <textarea
+        autoFocus
+        value={comment}
+        onChange={(event) => setComment(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) save();
+        }}
+        placeholder={t("annotations.addCommentPlaceholder")}
+        className="min-h-16 w-full resize-none rounded-xl bg-transparent px-2.5 py-2 text-sm leading-relaxed outline-none placeholder:text-muted-foreground"
+      />
+      <div className="flex items-center justify-between gap-2">
+        {activeId ? (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-8 rounded-full text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+            aria-label={t("annotations.deleteComment")}
+            onClick={() => {
+              setAllAnnotations((previous) =>
+                removeChatAnnotation(previous, chatId, activeId),
+              );
+              dismiss();
+            }}
+          >
+            <Trash2 className="size-4" />
+          </Button>
+        ) : (
+          <span />
+        )}
+        <div className="flex items-center gap-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="rounded-full text-muted-foreground hover:text-foreground"
+            onClick={dismiss}
+          >
+            {t("annotations.cancel")}
+          </Button>
+          <Button
+            size="sm"
+            className="rounded-full px-4"
+            disabled={!comment.trim()}
+            onClick={save}
+          >
+            {activeId ? t("annotations.save") : t("annotations.addComment")}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/chat/DyadCardPrimitives.tsx
+++ b/src/components/chat/DyadCardPrimitives.tsx
@@ -6,6 +6,7 @@ import {
   CircleX,
   CheckCircle2,
 } from "lucide-react";
+import { ANNOTATION_IGNORE_ATTRIBUTE } from "@/lib/annotationDom";
 import { CustomTagState } from "./stateTypes";
 
 /**
@@ -141,6 +142,10 @@ export function DyadCard({
         ${onClick ? "cursor-pointer" : ""}
         ${className}
       `}
+      // Card bodies expand and collapse independently of the message content,
+      // so their text stays out of the annotation offset space - otherwise
+      // toggling a card shifts the offsets of every annotation after it.
+      {...{ [ANNOTATION_IGNORE_ATTRIBUTE]: true }}
       onClick={onClick}
       role={onClick ? "button" : undefined}
       tabIndex={onClick ? 0 : undefined}

--- a/src/components/chat/DyadThink.tsx
+++ b/src/components/chat/DyadThink.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { ChevronRight } from "lucide-react";
+import { ANNOTATION_IGNORE_ATTRIBUTE } from "@/lib/annotationDom";
 import { VanillaMarkdownParser } from "./DyadMarkdownParser";
 import { CustomTagState } from "./stateTypes";
 import { DyadTokenSavings } from "./DyadTokenSavings";
@@ -60,7 +61,10 @@ export const DyadThink: React.FC<DyadThinkProps> = ({ children, node }) => {
       : "";
 
   return (
-    <div className="my-1">
+    // Collapsed reasoning is mounted lazily, so its text appears and
+    // disappears without the message changing. Keep it out of the annotation
+    // offset space or expanding it shifts every later annotation.
+    <div className="my-1" {...{ [ANNOTATION_IGNORE_ATTRIBUTE]: true }}>
       {/* Toggle header */}
       <button
         type="button"

--- a/src/components/chat/chatAnnotationDom.test.ts
+++ b/src/components/chat/chatAnnotationDom.test.ts
@@ -1,0 +1,193 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { ChatAnnotation } from "@/atoms/chatAnnotationAtoms";
+import {
+  applyChatAnnotationHighlights,
+  clearChatAnnotationHighlights,
+  getChatSelectionSnapshot,
+} from "@/components/chat/chatAnnotationDom";
+
+function createAnnotation(overrides: Partial<ChatAnnotation>): ChatAnnotation {
+  return {
+    id: "annotation-1",
+    chatId: 1,
+    messageId: 2,
+    selectedText: "",
+    comment: "comment",
+    createdAt: 1,
+    startOffset: 0,
+    selectionLength: 0,
+    ...overrides,
+  };
+}
+
+function renderContainer(html: string): HTMLDivElement {
+  const container = document.createElement("div");
+  container.innerHTML = html;
+  document.body.appendChild(container);
+  return container;
+}
+
+function marks(container: HTMLElement): HTMLElement[] {
+  return [
+    ...container.querySelectorAll<HTMLElement>("mark[data-chat-annotation-id]"),
+  ];
+}
+
+describe("chatAnnotationDom", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("computes offsets across inline markup", () => {
+    const container = renderContainer(
+      "<p>Hello <strong>bold</strong> world</p>",
+    );
+    const boldText = container.querySelector("strong")!.firstChild!;
+    const trailingText = container.querySelector("p")!.lastChild!;
+
+    const range = document.createRange();
+    range.setStart(boldText, 0);
+    range.setEnd(trailingText, 6);
+
+    expect(getChatSelectionSnapshot(container, range)).toEqual({
+      selectedText: "bold world",
+      startOffset: 6,
+      selectionLength: 10,
+    });
+  });
+
+  it("trims leading and trailing whitespace out of the saved offsets", () => {
+    const container = renderContainer("<p>  Hello world  </p>");
+    const textNode = container.querySelector("p")!.firstChild!;
+
+    const range = document.createRange();
+    range.setStart(textNode, 0);
+    range.setEnd(textNode, textNode.textContent!.length);
+
+    expect(getChatSelectionSnapshot(container, range)).toEqual({
+      selectedText: "Hello world",
+      startOffset: 2,
+      selectionLength: 11,
+    });
+  });
+
+  it("keeps chat and plan UI chrome out of the offset space", () => {
+    const container = renderContainer(
+      "<p>Intro</p>" +
+        "<div data-plan-annotation-ignore>Copy</div>" +
+        "<div data-annotation-ignore>Thought</div>" +
+        "<p>Hello world</p>",
+    );
+    const textNode = container.querySelectorAll("p")[1]!.firstChild!;
+
+    const range = document.createRange();
+    range.setStart(textNode, 0);
+    range.setEnd(textNode, 5);
+
+    expect(getChatSelectionSnapshot(container, range)).toEqual({
+      selectedText: "Hello",
+      startOffset: 5,
+      selectionLength: 5,
+    });
+  });
+
+  it("applies one mark per text node a selection spans", () => {
+    const container = renderContainer(
+      "<p>Hello <strong>bold</strong> world</p>",
+    );
+
+    applyChatAnnotationHighlights(container, [
+      createAnnotation({
+        selectedText: "bold world",
+        startOffset: 6,
+        selectionLength: 10,
+      }),
+    ]);
+
+    const applied = marks(container);
+    expect(applied).toHaveLength(2);
+    expect(applied.map((mark) => mark.textContent).join("")).toBe("bold world");
+    expect(applied[0].getAttribute("role")).toBe("button");
+    expect(applied[0].getAttribute("tabindex")).toBe("0");
+    // Continuation fragments hold real message text, so they must stay in the
+    // accessibility tree.
+    expect(applied[1].getAttribute("aria-hidden")).toBeNull();
+    expect(applied[1].getAttribute("tabindex")).toBe("-1");
+  });
+
+  it("uses the supplied label for the accessible name", () => {
+    const container = renderContainer("<p>Hello world</p>");
+
+    applyChatAnnotationHighlights(
+      container,
+      [
+        createAnnotation({
+          selectedText: "Hello",
+          startOffset: 0,
+          selectionLength: 5,
+        }),
+      ],
+      (text) => `Ver comentario sobre ${text}`,
+    );
+
+    expect(marks(container)[0].getAttribute("aria-label")).toBe(
+      "Ver comentario sobre Hello",
+    );
+  });
+
+  it("round-trips clear and re-apply without corrupting the text", () => {
+    const container = renderContainer(
+      "<p>Hello <strong>bold</strong> world</p>",
+    );
+    const annotation = createAnnotation({
+      selectedText: "bold world",
+      startOffset: 6,
+      selectionLength: 10,
+    });
+
+    for (let cycle = 0; cycle < 3; cycle++) {
+      clearChatAnnotationHighlights(container);
+      applyChatAnnotationHighlights(container, [annotation]);
+      expect(container.textContent).toBe("Hello bold world");
+      expect(
+        marks(container)
+          .map((mark) => mark.textContent)
+          .join(""),
+      ).toBe("bold world");
+    }
+
+    clearChatAnnotationHighlights(container);
+    expect(marks(container)).toHaveLength(0);
+    expect(container.textContent).toBe("Hello bold world");
+  });
+
+  it("skips stale and overlapping annotations instead of corrupting the DOM", () => {
+    const container = renderContainer("<p>Hello brave new world</p>");
+
+    applyChatAnnotationHighlights(container, [
+      createAnnotation({
+        id: "valid",
+        selectedText: "brave",
+        startOffset: 6,
+        selectionLength: 5,
+      }),
+      createAnnotation({
+        id: "stale",
+        selectedText: "planet",
+        startOffset: 12,
+        selectionLength: 6,
+      }),
+      createAnnotation({
+        id: "overlap",
+        selectedText: "ave new",
+        startOffset: 8,
+        selectionLength: 7,
+      }),
+    ]);
+
+    const applied = marks(container);
+    expect(applied).toHaveLength(1);
+    expect(applied[0].getAttribute("data-chat-annotation-id")).toBe("valid");
+    expect(applied[0].textContent).toBe("brave");
+  });
+});

--- a/src/components/chat/chatAnnotationDom.test.ts
+++ b/src/components/chat/chatAnnotationDom.test.ts
@@ -3,6 +3,7 @@ import type { ChatAnnotation } from "@/atoms/chatAnnotationAtoms";
 import {
   applyChatAnnotationHighlights,
   clearChatAnnotationHighlights,
+  findOverlappingChatAnnotation,
   getChatSelectionSnapshot,
 } from "@/components/chat/chatAnnotationDom";
 
@@ -159,6 +160,17 @@ describe("chatAnnotationDom", () => {
     clearChatAnnotationHighlights(container);
     expect(marks(container)).toHaveLength(0);
     expect(container.textContent).toBe("Hello bold world");
+  });
+
+  it("returns the colliding annotation for an overlapping range, but not an adjacent one", () => {
+    const existing = createAnnotation({
+      selectedText: "selected text",
+      startOffset: 10,
+      selectionLength: 13,
+    });
+
+    expect(findOverlappingChatAnnotation([existing], 20, 5)).toBe(existing);
+    expect(findOverlappingChatAnnotation([existing], 23, 5)).toBeUndefined();
   });
 
   it("skips stale and overlapping annotations instead of corrupting the DOM", () => {

--- a/src/components/chat/chatAnnotationDom.ts
+++ b/src/components/chat/chatAnnotationDom.ts
@@ -1,168 +1,64 @@
 import type { ChatAnnotation } from "@/atoms/chatAnnotationAtoms";
+import {
+  ANNOTATION_IGNORE_ATTRIBUTE,
+  createAnnotationDom,
+  findOverlappingAnnotation,
+  hasOverlappingAnnotation,
+  type AnnotationSelectionSnapshot,
+} from "@/lib/annotationDom";
+import { PLAN_ANNOTATION_IGNORE_ATTRIBUTE } from "../preview_panel/plan/planAnnotationDom";
 
 export const CHAT_ANNOTATION_ID_ATTRIBUTE = "data-chat-annotation-id";
-export const CHAT_ANNOTATION_MARK_SELECTOR = `mark[${CHAT_ANNOTATION_ID_ATTRIBUTE}]`;
-const IGNORE_SELECTOR = "[data-chat-annotation-ignore]";
 
-interface TextSegment {
-  node: Text;
-  start: number;
-  end: number;
-}
+const chatAnnotationDom = createAnnotationDom({
+  idAttribute: CHAT_ANNOTATION_ID_ATTRIBUTE,
+  // `data-plan-annotation-ignore` predates the shared attribute and is still
+  // what CodeHighlight stamps on the language/Copy toolbar, so honour both or
+  // that chrome lands in the offset space and can be highlighted.
+  ignoreSelector: `[${ANNOTATION_IGNORE_ATTRIBUTE}], [${PLAN_ANNOTATION_IGNORE_ATTRIBUTE}]`,
+  markClassName:
+    "bg-yellow-400/25 text-inherit cursor-pointer rounded-sm border-b border-yellow-400/60",
+  defaultLabel: (selectedText) =>
+    selectedText.length === 0
+      ? "View comment"
+      : `View comment for ${selectedText}`,
+});
 
-export interface ChatSelectionSnapshot {
-  selectedText: string;
-  startOffset: number;
-  selectionLength: number;
-}
+export const CHAT_ANNOTATION_MARK_SELECTOR = chatAnnotationDom.markSelector;
 
-function collectSegments(container: HTMLElement): TextSegment[] {
-  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT, {
-    acceptNode: (node) => {
-      const parent = (node as Text).parentElement;
-      return parent && node.textContent && !parent.closest(IGNORE_SELECTOR)
-        ? NodeFilter.FILTER_ACCEPT
-        : NodeFilter.FILTER_REJECT;
-    },
-  });
-  const segments: TextSegment[] = [];
-  let offset = 0;
-  let node: Text | null;
-  while ((node = walker.nextNode() as Text | null)) {
-    const length = node.data.length;
-    segments.push({ node, start: offset, end: offset + length });
-    offset += length;
-  }
-  return segments;
-}
-
-function boundaryOffset(
-  container: HTMLElement,
-  boundaryNode: Node,
-  boundaryNodeOffset: number,
-  segments: TextSegment[],
-): number | null {
-  if (!container.contains(boundaryNode)) return null;
-  const range = document.createRange();
-  range.selectNodeContents(container);
-  try {
-    range.setEnd(boundaryNode, boundaryNodeOffset);
-  } catch {
-    return null;
-  }
-  let offset = 0;
-  for (const segment of segments) {
-    if (!range.intersectsNode(segment.node)) continue;
-    if (range.endContainer === segment.node) {
-      return segment.start + range.endOffset;
-    }
-    offset = segment.end;
-  }
-  return offset;
-}
-
-function readText(
-  segments: TextSegment[],
-  startOffset: number,
-  selectionLength: number,
-): string | null {
-  if (startOffset < 0 || selectionLength <= 0) return null;
-  const endOffset = startOffset + selectionLength;
-  let result = "";
-  for (const segment of segments) {
-    if (segment.end <= startOffset) continue;
-    if (segment.start >= endOffset) break;
-    result += segment.node.data.slice(
-      Math.max(0, startOffset - segment.start),
-      Math.min(segment.node.data.length, endOffset - segment.start),
-    );
-  }
-  return result.length === selectionLength ? result : null;
-}
+export type ChatSelectionSnapshot = AnnotationSelectionSnapshot;
 
 export function getChatSelectionSnapshot(
   container: HTMLElement,
   range: Range,
 ): ChatSelectionSnapshot | null {
-  if (range.collapsed || !container.contains(range.commonAncestorContainer)) {
-    return null;
-  }
-  const segments = collectSegments(container);
-  const start = boundaryOffset(
-    container,
-    range.startContainer,
-    range.startOffset,
-    segments,
-  );
-  const end = boundaryOffset(
-    container,
-    range.endContainer,
-    range.endOffset,
-    segments,
-  );
-  if (start === null || end === null || end <= start) return null;
-  const rawText = readText(segments, start, end - start);
-  if (!rawText?.trim()) return null;
-  const leading = rawText.length - rawText.trimStart().length;
-  const trailing = rawText.length - rawText.trimEnd().length;
-  return {
-    selectedText: rawText.trim(),
-    startOffset: start + leading,
-    selectionLength: end - start - leading - trailing,
-  };
+  return chatAnnotationDom.getSelectionSnapshot(container, range);
+}
+
+export function hasOverlappingChatAnnotation(
+  annotations: ChatAnnotation[],
+  startOffset: number,
+  selectionLength: number,
+): boolean {
+  return hasOverlappingAnnotation(annotations, startOffset, selectionLength);
+}
+
+export function findOverlappingChatAnnotation(
+  annotations: ChatAnnotation[],
+  startOffset: number,
+  selectionLength: number,
+): ChatAnnotation | undefined {
+  return findOverlappingAnnotation(annotations, startOffset, selectionLength);
 }
 
 export function clearChatAnnotationHighlights(container: HTMLElement) {
-  container.querySelectorAll(CHAT_ANNOTATION_MARK_SELECTOR).forEach((mark) => {
-    const parent = mark.parentNode;
-    if (!parent) return;
-    parent.replaceChild(document.createTextNode(mark.textContent ?? ""), mark);
-    parent.normalize();
-  });
+  chatAnnotationDom.clearHighlights(container);
 }
 
 export function applyChatAnnotationHighlights(
   container: HTMLElement,
   annotations: ChatAnnotation[],
+  label?: (selectedText: string) => string,
 ) {
-  const segments = collectSegments(container);
-  const valid = [...annotations]
-    .filter(
-      (annotation) =>
-        readText(
-          segments,
-          annotation.startOffset,
-          annotation.selectionLength,
-        ) === annotation.selectedText,
-    )
-    .sort((left, right) => right.startOffset - left.startOffset);
-
-  for (const annotation of valid) {
-    const endOffset = annotation.startOffset + annotation.selectionLength;
-    const overlapping = segments.filter(
-      (segment) =>
-        segment.start < endOffset && segment.end > annotation.startOffset,
-    );
-    for (let index = overlapping.length - 1; index >= 0; index--) {
-      const segment = overlapping[index];
-      const start = Math.max(0, annotation.startOffset - segment.start);
-      const end = Math.min(segment.node.data.length, endOffset - segment.start);
-      const highlighted = segment.node.splitText(start);
-      highlighted.splitText(end - start);
-      const mark = document.createElement("mark");
-      mark.setAttribute(CHAT_ANNOTATION_ID_ATTRIBUTE, annotation.id);
-      mark.className =
-        "bg-yellow-400/25 text-inherit cursor-pointer rounded-sm border-b border-yellow-400/60";
-      mark.textContent = highlighted.textContent;
-      if (index === 0) {
-        mark.tabIndex = 0;
-        mark.setAttribute("role", "button");
-        mark.setAttribute("aria-label", `View comment for ${annotation.selectedText}`);
-      } else {
-        mark.tabIndex = -1;
-        mark.setAttribute("aria-hidden", "true");
-      }
-      highlighted.parentNode?.replaceChild(mark, highlighted);
-    }
-  }
+  chatAnnotationDom.applyHighlights(container, annotations, { label });
 }

--- a/src/components/chat/chatAnnotationDom.ts
+++ b/src/components/chat/chatAnnotationDom.ts
@@ -1,0 +1,168 @@
+import type { ChatAnnotation } from "@/atoms/chatAnnotationAtoms";
+
+export const CHAT_ANNOTATION_ID_ATTRIBUTE = "data-chat-annotation-id";
+export const CHAT_ANNOTATION_MARK_SELECTOR = `mark[${CHAT_ANNOTATION_ID_ATTRIBUTE}]`;
+const IGNORE_SELECTOR = "[data-chat-annotation-ignore]";
+
+interface TextSegment {
+  node: Text;
+  start: number;
+  end: number;
+}
+
+export interface ChatSelectionSnapshot {
+  selectedText: string;
+  startOffset: number;
+  selectionLength: number;
+}
+
+function collectSegments(container: HTMLElement): TextSegment[] {
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT, {
+    acceptNode: (node) => {
+      const parent = (node as Text).parentElement;
+      return parent && node.textContent && !parent.closest(IGNORE_SELECTOR)
+        ? NodeFilter.FILTER_ACCEPT
+        : NodeFilter.FILTER_REJECT;
+    },
+  });
+  const segments: TextSegment[] = [];
+  let offset = 0;
+  let node: Text | null;
+  while ((node = walker.nextNode() as Text | null)) {
+    const length = node.data.length;
+    segments.push({ node, start: offset, end: offset + length });
+    offset += length;
+  }
+  return segments;
+}
+
+function boundaryOffset(
+  container: HTMLElement,
+  boundaryNode: Node,
+  boundaryNodeOffset: number,
+  segments: TextSegment[],
+): number | null {
+  if (!container.contains(boundaryNode)) return null;
+  const range = document.createRange();
+  range.selectNodeContents(container);
+  try {
+    range.setEnd(boundaryNode, boundaryNodeOffset);
+  } catch {
+    return null;
+  }
+  let offset = 0;
+  for (const segment of segments) {
+    if (!range.intersectsNode(segment.node)) continue;
+    if (range.endContainer === segment.node) {
+      return segment.start + range.endOffset;
+    }
+    offset = segment.end;
+  }
+  return offset;
+}
+
+function readText(
+  segments: TextSegment[],
+  startOffset: number,
+  selectionLength: number,
+): string | null {
+  if (startOffset < 0 || selectionLength <= 0) return null;
+  const endOffset = startOffset + selectionLength;
+  let result = "";
+  for (const segment of segments) {
+    if (segment.end <= startOffset) continue;
+    if (segment.start >= endOffset) break;
+    result += segment.node.data.slice(
+      Math.max(0, startOffset - segment.start),
+      Math.min(segment.node.data.length, endOffset - segment.start),
+    );
+  }
+  return result.length === selectionLength ? result : null;
+}
+
+export function getChatSelectionSnapshot(
+  container: HTMLElement,
+  range: Range,
+): ChatSelectionSnapshot | null {
+  if (range.collapsed || !container.contains(range.commonAncestorContainer)) {
+    return null;
+  }
+  const segments = collectSegments(container);
+  const start = boundaryOffset(
+    container,
+    range.startContainer,
+    range.startOffset,
+    segments,
+  );
+  const end = boundaryOffset(
+    container,
+    range.endContainer,
+    range.endOffset,
+    segments,
+  );
+  if (start === null || end === null || end <= start) return null;
+  const rawText = readText(segments, start, end - start);
+  if (!rawText?.trim()) return null;
+  const leading = rawText.length - rawText.trimStart().length;
+  const trailing = rawText.length - rawText.trimEnd().length;
+  return {
+    selectedText: rawText.trim(),
+    startOffset: start + leading,
+    selectionLength: end - start - leading - trailing,
+  };
+}
+
+export function clearChatAnnotationHighlights(container: HTMLElement) {
+  container.querySelectorAll(CHAT_ANNOTATION_MARK_SELECTOR).forEach((mark) => {
+    const parent = mark.parentNode;
+    if (!parent) return;
+    parent.replaceChild(document.createTextNode(mark.textContent ?? ""), mark);
+    parent.normalize();
+  });
+}
+
+export function applyChatAnnotationHighlights(
+  container: HTMLElement,
+  annotations: ChatAnnotation[],
+) {
+  const segments = collectSegments(container);
+  const valid = [...annotations]
+    .filter(
+      (annotation) =>
+        readText(
+          segments,
+          annotation.startOffset,
+          annotation.selectionLength,
+        ) === annotation.selectedText,
+    )
+    .sort((left, right) => right.startOffset - left.startOffset);
+
+  for (const annotation of valid) {
+    const endOffset = annotation.startOffset + annotation.selectionLength;
+    const overlapping = segments.filter(
+      (segment) =>
+        segment.start < endOffset && segment.end > annotation.startOffset,
+    );
+    for (let index = overlapping.length - 1; index >= 0; index--) {
+      const segment = overlapping[index];
+      const start = Math.max(0, annotation.startOffset - segment.start);
+      const end = Math.min(segment.node.data.length, endOffset - segment.start);
+      const highlighted = segment.node.splitText(start);
+      highlighted.splitText(end - start);
+      const mark = document.createElement("mark");
+      mark.setAttribute(CHAT_ANNOTATION_ID_ATTRIBUTE, annotation.id);
+      mark.className =
+        "bg-yellow-400/25 text-inherit cursor-pointer rounded-sm border-b border-yellow-400/60";
+      mark.textContent = highlighted.textContent;
+      if (index === 0) {
+        mark.tabIndex = 0;
+        mark.setAttribute("role", "button");
+        mark.setAttribute("aria-label", `View comment for ${annotation.selectedText}`);
+      } else {
+        mark.tabIndex = -1;
+        mark.setAttribute("aria-hidden", "true");
+      }
+      highlighted.parentNode?.replaceChild(mark, highlighted);
+    }
+  }
+}

--- a/src/components/chat/chatAnnotationDom.ts
+++ b/src/components/chat/chatAnnotationDom.ts
@@ -3,7 +3,6 @@ import {
   ANNOTATION_IGNORE_ATTRIBUTE,
   createAnnotationDom,
   findOverlappingAnnotation,
-  hasOverlappingAnnotation,
   type AnnotationSelectionSnapshot,
 } from "@/lib/annotationDom";
 import { PLAN_ANNOTATION_IGNORE_ATTRIBUTE } from "../preview_panel/plan/planAnnotationDom";
@@ -33,14 +32,6 @@ export function getChatSelectionSnapshot(
   range: Range,
 ): ChatSelectionSnapshot | null {
   return chatAnnotationDom.getSelectionSnapshot(container, range);
-}
-
-export function hasOverlappingChatAnnotation(
-  annotations: ChatAnnotation[],
-  startOffset: number,
-  selectionLength: number,
-): boolean {
-  return hasOverlappingAnnotation(annotations, startOffset, selectionLength);
 }
 
 export function findOverlappingChatAnnotation(

--- a/src/components/chat/chatAnnotationEligibility.test.ts
+++ b/src/components/chat/chatAnnotationEligibility.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { isChatMessageAnnotatable } from "./chatAnnotationEligibility";
+
+describe("isChatMessageAnnotatable", () => {
+  it("only allows the latest completed assistant response", () => {
+    expect(
+      isChatMessageAnnotatable({
+        role: "assistant",
+        isLastMessage: true,
+        isCancelled: false,
+        isStreaming: false,
+      }),
+    ).toBe(true);
+    expect(
+      isChatMessageAnnotatable({
+        role: "assistant",
+        isLastMessage: false,
+        isCancelled: false,
+        isStreaming: false,
+      }),
+    ).toBe(false);
+    expect(
+      isChatMessageAnnotatable({
+        role: "assistant",
+        isLastMessage: true,
+        isCancelled: false,
+        isStreaming: true,
+      }),
+    ).toBe(false);
+    expect(
+      isChatMessageAnnotatable({
+        role: "user",
+        isLastMessage: true,
+        isCancelled: false,
+        isStreaming: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/components/chat/chatAnnotationEligibility.ts
+++ b/src/components/chat/chatAnnotationEligibility.ts
@@ -1,0 +1,15 @@
+import type { Message } from "@/ipc/types";
+
+export function isChatMessageAnnotatable({
+  role,
+  isLastMessage,
+  isCancelled,
+  isStreaming,
+}: {
+  role: Message["role"];
+  isLastMessage: boolean;
+  isCancelled: boolean;
+  isStreaming: boolean;
+}): boolean {
+  return role === "assistant" && isLastMessage && !isCancelled && !isStreaming;
+}

--- a/src/components/preview_panel/plan/planAnnotationDom.ts
+++ b/src/components/preview_panel/plan/planAnnotationDom.ts
@@ -1,271 +1,34 @@
 import type { PlanAnnotation } from "@/atoms/planAtoms";
+import {
+  ANNOTATION_IGNORE_ATTRIBUTE,
+  createAnnotationDom,
+  hasOverlappingAnnotation,
+  type AnnotationSelectionSnapshot,
+} from "@/lib/annotationDom";
 
 export const PLAN_ANNOTATION_IGNORE_ATTRIBUTE = "data-plan-annotation-ignore";
 export const ANNOTATION_ID_ATTRIBUTE = "data-annotation-id";
-export const ANNOTATION_MARK_SELECTOR = `mark[${ANNOTATION_ID_ATTRIBUTE}]`;
 
-const PLAN_ANNOTATION_IGNORE_SELECTOR = `[${PLAN_ANNOTATION_IGNORE_ATTRIBUTE}]`;
+const planAnnotationDom = createAnnotationDom({
+  idAttribute: ANNOTATION_ID_ATTRIBUTE,
+  ignoreSelector: `[${PLAN_ANNOTATION_IGNORE_ATTRIBUTE}], [${ANNOTATION_IGNORE_ATTRIBUTE}]`,
+  markClassName:
+    "bg-yellow-400/25 text-inherit cursor-pointer rounded-sm px-0.5 border-b border-yellow-400/50",
+  defaultLabel: (selectedText) =>
+    selectedText.length === 0
+      ? "View comment"
+      : `View comment for ${selectedText}`,
+});
 
-interface PlanTextSegment {
-  node: Text;
-  startOffset: number;
-  endOffset: number;
-}
+export const ANNOTATION_MARK_SELECTOR = planAnnotationDom.markSelector;
 
-export interface PlanSelectionSnapshot {
-  selectedText: string;
-  startOffset: number;
-  selectionLength: number;
-}
-
-function collectPlanTextSegments(container: HTMLElement): PlanTextSegment[] {
-  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT, {
-    acceptNode: (node) => {
-      const textNode = node as Text;
-      const text = textNode.textContent ?? "";
-      const parent = textNode.parentElement;
-
-      if (!parent || text.length === 0) {
-        return NodeFilter.FILTER_REJECT;
-      }
-
-      if (parent.closest(PLAN_ANNOTATION_IGNORE_SELECTOR)) {
-        return NodeFilter.FILTER_REJECT;
-      }
-
-      return NodeFilter.FILTER_ACCEPT;
-    },
-  });
-
-  const segments: PlanTextSegment[] = [];
-  let currentOffset = 0;
-  let node: Text | null;
-
-  while ((node = walker.nextNode() as Text | null)) {
-    const textLength = node.textContent?.length ?? 0;
-    segments.push({
-      node,
-      startOffset: currentOffset,
-      endOffset: currentOffset + textLength,
-    });
-    currentOffset += textLength;
-  }
-
-  return segments;
-}
-
-/**
- * Maps a DOM selection boundary (node + offset) to a flat character offset
- * within the plan's concatenated text content.
- *
- * Creates a temporary Range from the container start to the boundary point,
- * then walks the pre-collected text segments to find which segment contains
- * the boundary. This Range-based approach correctly handles boundaries that
- * land inside element nodes (not just text nodes) and accounts for ignored
- * regions (e.g. annotation marks) that are excluded from the segment list.
- */
-function getBoundaryTextOffset(
-  container: HTMLElement,
-  boundaryNode: Node,
-  boundaryOffset: number,
-  segments: PlanTextSegment[],
-): number | null {
-  if (!container.contains(boundaryNode)) {
-    return null;
-  }
-
-  const boundaryRange = document.createRange();
-  boundaryRange.selectNodeContents(container);
-
-  try {
-    boundaryRange.setEnd(boundaryNode, boundaryOffset);
-  } catch {
-    return null;
-  }
-
-  let offset = 0;
-
-  for (const segment of segments) {
-    if (!boundaryRange.intersectsNode(segment.node)) {
-      continue;
-    }
-
-    if (boundaryRange.endContainer === segment.node) {
-      return segment.startOffset + boundaryRange.endOffset;
-    }
-
-    offset = segment.endOffset;
-  }
-
-  return offset;
-}
-
-function readPlanTextFromSegments(
-  segments: PlanTextSegment[],
-  startOffset: number,
-  selectionLength: number,
-): string | null {
-  if (selectionLength <= 0 || startOffset < 0) {
-    return null;
-  }
-
-  const endOffset = startOffset + selectionLength;
-  let text = "";
-
-  for (const segment of segments) {
-    if (segment.endOffset <= startOffset) {
-      continue;
-    }
-
-    if (segment.startOffset >= endOffset) {
-      break;
-    }
-
-    const startInNode = Math.max(0, startOffset - segment.startOffset);
-    const endInNode = Math.min(
-      segment.node.textContent?.length ?? 0,
-      endOffset - segment.startOffset,
-    );
-
-    if (startInNode >= endInNode) {
-      continue;
-    }
-
-    text += segment.node.data.slice(startInNode, endInNode);
-  }
-
-  return text.length === selectionLength ? text : null;
-}
-
-function highlightAtOffset(
-  segments: PlanTextSegment[],
-  startOffset: number,
-  selectionLength: number,
-  annotationId: string,
-  selectedText: string,
-) {
-  if (selectionLength <= 0) {
-    return;
-  }
-
-  const endOffset = startOffset + selectionLength;
-  const overlappingSegments = segments.filter(
-    ({ startOffset: segmentStart, endOffset: segmentEnd }) =>
-      segmentStart < endOffset && segmentEnd > startOffset,
-  );
-
-  // Iterate in reverse so that splitText mutations don't shift offsets
-  // of earlier (not-yet-processed) segments.
-  for (let index = overlappingSegments.length - 1; index >= 0; index--) {
-    const segment = overlappingSegments[index];
-    const { node: textNode } = segment;
-    const startInNode = Math.max(0, startOffset - segment.startOffset);
-    const endInNode = Math.min(
-      textNode.textContent?.length ?? 0,
-      endOffset - segment.startOffset,
-    );
-    const charsToHighlight = endInNode - startInNode;
-
-    if (charsToHighlight <= 0 || !textNode.parentNode) {
-      continue;
-    }
-
-    const highlightNode = textNode.splitText(startInNode);
-    highlightNode.splitText(charsToHighlight);
-
-    const mark = document.createElement("mark");
-    const isFirstFragment = index === 0;
-    mark.setAttribute(ANNOTATION_ID_ATTRIBUTE, annotationId);
-
-    if (isFirstFragment) {
-      const normalizedSelectedText = selectedText.replace(/\s+/g, " ").trim();
-      mark.setAttribute("role", "button");
-      mark.setAttribute("tabindex", "0");
-      mark.setAttribute("aria-haspopup", "dialog");
-      mark.setAttribute(
-        "aria-label",
-        normalizedSelectedText.length === 0
-          ? "View comment"
-          : `View comment for ${normalizedSelectedText}`,
-      );
-    } else {
-      mark.setAttribute("tabindex", "-1");
-      mark.setAttribute("aria-hidden", "true");
-    }
-
-    mark.className =
-      "bg-yellow-400/25 text-inherit cursor-pointer rounded-sm px-0.5 border-b border-yellow-400/50";
-    mark.textContent = highlightNode.textContent;
-
-    const parent = highlightNode.parentNode;
-    if (!parent) {
-      continue;
-    }
-
-    parent.replaceChild(mark, highlightNode);
-  }
-}
+export type PlanSelectionSnapshot = AnnotationSelectionSnapshot;
 
 export function getPlanSelectionSnapshot(
   container: HTMLElement,
   range: Range,
 ): PlanSelectionSnapshot | null {
-  if (range.collapsed || !container.contains(range.commonAncestorContainer)) {
-    return null;
-  }
-
-  const segments = collectPlanTextSegments(container);
-  if (segments.length === 0) {
-    return null;
-  }
-
-  const rawStartOffset = getBoundaryTextOffset(
-    container,
-    range.startContainer,
-    range.startOffset,
-    segments,
-  );
-  const rawEndOffset = getBoundaryTextOffset(
-    container,
-    range.endContainer,
-    range.endOffset,
-    segments,
-  );
-
-  if (rawStartOffset === null || rawEndOffset === null) {
-    return null;
-  }
-
-  const rawSelectionLength = rawEndOffset - rawStartOffset;
-  if (rawSelectionLength <= 0) {
-    return null;
-  }
-
-  const rawSelectedText = readPlanTextFromSegments(
-    segments,
-    rawStartOffset,
-    rawSelectionLength,
-  );
-  if (!rawSelectedText) {
-    return null;
-  }
-
-  const leadingWhitespace =
-    rawSelectedText.length - rawSelectedText.trimStart().length;
-  const trailingWhitespace =
-    rawSelectedText.length - rawSelectedText.trimEnd().length;
-  const selectedText = rawSelectedText.trim();
-
-  if (selectedText.length === 0) {
-    return null;
-  }
-
-  return {
-    selectedText,
-    startOffset: rawStartOffset + leadingWhitespace,
-    selectionLength:
-      rawSelectionLength - leadingWhitespace - trailingWhitespace,
-  };
+  return planAnnotationDom.getSelectionSnapshot(container, range);
 }
 
 export function hasOverlappingPlanAnnotation(
@@ -273,86 +36,16 @@ export function hasOverlappingPlanAnnotation(
   startOffset: number,
   selectionLength: number,
 ): boolean {
-  const endOffset = startOffset + selectionLength;
-
-  return annotations.some((annotation) => {
-    const annotationEnd = annotation.startOffset + annotation.selectionLength;
-    return startOffset < annotationEnd && annotation.startOffset < endOffset;
-  });
+  return hasOverlappingAnnotation(annotations, startOffset, selectionLength);
 }
 
 export function clearPlanAnnotationHighlights(container: HTMLElement) {
-  container.querySelectorAll(ANNOTATION_MARK_SELECTOR).forEach((mark) => {
-    const parent = mark.parentNode;
-    if (!parent) {
-      return;
-    }
-
-    parent.replaceChild(document.createTextNode(mark.textContent ?? ""), mark);
-    parent.normalize();
-  });
+  planAnnotationDom.clearHighlights(container);
 }
 
 export function applyPlanAnnotationHighlights(
   container: HTMLElement,
   annotations: PlanAnnotation[],
 ) {
-  const segments = collectPlanTextSegments(container);
-  if (segments.length === 0) {
-    return;
-  }
-
-  const totalTextLength = segments[segments.length - 1]?.endOffset ?? 0;
-
-  const renderableAnnotations = [...annotations]
-    .filter((annotation) => {
-      if (annotation.selectionLength <= 0 || annotation.startOffset < 0) {
-        return false;
-      }
-
-      if (
-        annotation.startOffset + annotation.selectionLength >
-        totalTextLength
-      ) {
-        return false;
-      }
-
-      const actualText = readPlanTextFromSegments(
-        segments,
-        annotation.startOffset,
-        annotation.selectionLength,
-      );
-
-      return actualText === annotation.selectedText;
-    })
-    .sort(
-      (left, right) =>
-        left.startOffset - right.startOffset ||
-        right.selectionLength - left.selectionLength,
-    );
-
-  const nonOverlappingAnnotations: PlanAnnotation[] = [];
-  let previousEndOffset = -1;
-
-  for (const annotation of renderableAnnotations) {
-    if (annotation.startOffset < previousEndOffset) {
-      continue;
-    }
-
-    nonOverlappingAnnotations.push(annotation);
-    previousEndOffset = annotation.startOffset + annotation.selectionLength;
-  }
-
-  // Iterate in reverse so that DOM mutations from highlightAtOffset don't
-  // invalidate offsets of earlier (not-yet-processed) annotations.
-  for (let index = nonOverlappingAnnotations.length - 1; index >= 0; index--) {
-    const annotation = nonOverlappingAnnotations[index];
-    highlightAtOffset(
-      segments,
-      annotation.startOffset,
-      annotation.selectionLength,
-      annotation.id,
-      annotation.selectedText,
-    );
-  }
+  planAnnotationDom.applyHighlights(container, annotations);
 }

--- a/src/components/preview_panel/plan/planAnnotationDom.ts
+++ b/src/components/preview_panel/plan/planAnnotationDom.ts
@@ -2,7 +2,7 @@ import type { PlanAnnotation } from "@/atoms/planAtoms";
 import {
   ANNOTATION_IGNORE_ATTRIBUTE,
   createAnnotationDom,
-  hasOverlappingAnnotation,
+  findOverlappingAnnotation,
   type AnnotationSelectionSnapshot,
 } from "@/lib/annotationDom";
 
@@ -36,7 +36,10 @@ export function hasOverlappingPlanAnnotation(
   startOffset: number,
   selectionLength: number,
 ): boolean {
-  return hasOverlappingAnnotation(annotations, startOffset, selectionLength);
+  return (
+    findOverlappingAnnotation(annotations, startOffset, selectionLength) !==
+    undefined
+  );
 }
 
 export function clearPlanAnnotationHighlights(container: HTMLElement) {

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -377,6 +377,8 @@
   "annotations": {
     "commentOnSelection": "Comment on selected text",
     "editComment": "Edit comment",
+    "viewComment": "View comment",
+    "viewCommentFor": "View comment for {{text}}",
     "addCommentPlaceholder": "Add your comment...",
     "deleteComment": "Delete comment",
     "cancel": "Cancel",

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -373,5 +373,19 @@
   "guide": "Guide",
   "agentModeActivated": "Agent Mode Activated",
   "agentModeTip": "Tip: Create a new chat to give the agent a clean context for better results.",
-  "neverShowAgain": "Never show again"
+  "neverShowAgain": "Never show again",
+  "annotations": {
+    "commentOnSelection": "Comment on selected text",
+    "editComment": "Edit comment",
+    "addCommentPlaceholder": "Add your comment...",
+    "deleteComment": "Delete comment",
+    "cancel": "Cancel",
+    "save": "Save",
+    "addComment": "Add comment",
+    "commentCount_one": "{{count}} comment",
+    "commentCount_other": "{{count}} comments",
+    "discard": "Discard",
+    "sending": "Sending...",
+    "send": "Send {{count}}"
+  }
 }

--- a/src/i18n/locales/es/chat.json
+++ b/src/i18n/locales/es/chat.json
@@ -371,5 +371,19 @@
   "guide": "Guía",
   "agentModeActivated": "Modo Agente Activado",
   "agentModeTip": "Consejo: Crea un nuevo chat para darle al agente un contexto limpio para obtener mejores resultados.",
-  "neverShowAgain": "No volver a mostrar"
+  "neverShowAgain": "No volver a mostrar",
+  "annotations": {
+    "commentOnSelection": "Comentar el texto seleccionado",
+    "editComment": "Editar comentario",
+    "addCommentPlaceholder": "Añade tu comentario...",
+    "deleteComment": "Eliminar comentario",
+    "cancel": "Cancelar",
+    "save": "Guardar",
+    "addComment": "Añadir comentario",
+    "commentCount_one": "{{count}} comentario",
+    "commentCount_other": "{{count}} comentarios",
+    "discard": "Descartar",
+    "sending": "Enviando...",
+    "send": "Enviar {{count}}"
+  }
 }

--- a/src/i18n/locales/es/chat.json
+++ b/src/i18n/locales/es/chat.json
@@ -375,6 +375,8 @@
   "annotations": {
     "commentOnSelection": "Comentar el texto seleccionado",
     "editComment": "Editar comentario",
+    "viewComment": "Ver comentario",
+    "viewCommentFor": "Ver comentario sobre {{text}}",
     "addCommentPlaceholder": "Añade tu comentario...",
     "deleteComment": "Eliminar comentario",
     "cancel": "Cancelar",

--- a/src/i18n/locales/ko/chat.json
+++ b/src/i18n/locales/ko/chat.json
@@ -377,6 +377,8 @@
   "annotations": {
     "commentOnSelection": "선택한 텍스트에 댓글 달기",
     "editComment": "댓글 수정",
+    "viewComment": "댓글 보기",
+    "viewCommentFor": "{{text}}에 대한 댓글 보기",
     "addCommentPlaceholder": "댓글을 추가하세요...",
     "deleteComment": "댓글 삭제",
     "cancel": "취소",

--- a/src/i18n/locales/ko/chat.json
+++ b/src/i18n/locales/ko/chat.json
@@ -373,5 +373,19 @@
   "guide": "가이드",
   "agentModeActivated": "에이전트 모드 활성화됨",
   "agentModeTip": "팁: 새 채팅을 만들면 에이전트에게 더 나은 결과를 위한 깨끗한 컨텍스트를 제공할 수 있습니다.",
-  "neverShowAgain": "다시 표시 안 함"
+  "neverShowAgain": "다시 표시 안 함",
+  "annotations": {
+    "commentOnSelection": "선택한 텍스트에 댓글 달기",
+    "editComment": "댓글 수정",
+    "addCommentPlaceholder": "댓글을 추가하세요...",
+    "deleteComment": "댓글 삭제",
+    "cancel": "취소",
+    "save": "저장",
+    "addComment": "댓글 추가",
+    "commentCount_one": "댓글 {{count}}개",
+    "commentCount_other": "댓글 {{count}}개",
+    "discard": "버리기",
+    "sending": "전송 중...",
+    "send": "{{count}}개 전송"
+  }
 }

--- a/src/i18n/locales/pt-BR/chat.json
+++ b/src/i18n/locales/pt-BR/chat.json
@@ -370,5 +370,19 @@
   "guide": "Guia",
   "agentModeActivated": "Modo Agente Ativado",
   "agentModeTip": "Dica: Crie um novo chat para dar ao agente um contexto limpo para melhores resultados.",
-  "neverShowAgain": "Não mostrar novamente"
+  "neverShowAgain": "Não mostrar novamente",
+  "annotations": {
+    "commentOnSelection": "Comentar o texto selecionado",
+    "editComment": "Editar comentário",
+    "addCommentPlaceholder": "Adicione seu comentário...",
+    "deleteComment": "Excluir comentário",
+    "cancel": "Cancelar",
+    "save": "Salvar",
+    "addComment": "Adicionar comentário",
+    "commentCount_one": "{{count}} comentário",
+    "commentCount_other": "{{count}} comentários",
+    "discard": "Descartar",
+    "sending": "Enviando...",
+    "send": "Enviar {{count}}"
+  }
 }

--- a/src/i18n/locales/pt-BR/chat.json
+++ b/src/i18n/locales/pt-BR/chat.json
@@ -374,6 +374,8 @@
   "annotations": {
     "commentOnSelection": "Comentar o texto selecionado",
     "editComment": "Editar comentário",
+    "viewComment": "Ver comentário",
+    "viewCommentFor": "Ver comentário sobre {{text}}",
     "addCommentPlaceholder": "Adicione seu comentário...",
     "deleteComment": "Excluir comentário",
     "cancel": "Cancelar",

--- a/src/i18n/locales/zh-CN/chat.json
+++ b/src/i18n/locales/zh-CN/chat.json
@@ -370,5 +370,19 @@
   "guide": "指南",
   "agentModeActivated": "Agent 模式已激活",
   "agentModeTip": "提示：创建新聊天以给 Agent 一个干净的上下文，获得更好的结果。",
-  "neverShowAgain": "不再显示"
+  "neverShowAgain": "不再显示",
+  "annotations": {
+    "commentOnSelection": "评论所选文本",
+    "editComment": "编辑评论",
+    "addCommentPlaceholder": "添加评论...",
+    "deleteComment": "删除评论",
+    "cancel": "取消",
+    "save": "保存",
+    "addComment": "添加评论",
+    "commentCount_one": "{{count}} 条评论",
+    "commentCount_other": "{{count}} 条评论",
+    "discard": "丢弃",
+    "sending": "正在发送...",
+    "send": "发送 {{count}} 条"
+  }
 }

--- a/src/i18n/locales/zh-CN/chat.json
+++ b/src/i18n/locales/zh-CN/chat.json
@@ -374,6 +374,8 @@
   "annotations": {
     "commentOnSelection": "评论所选文本",
     "editComment": "编辑评论",
+    "viewComment": "查看评论",
+    "viewCommentFor": "查看关于 {{text}} 的评论",
     "addCommentPlaceholder": "添加评论...",
     "deleteComment": "删除评论",
     "cancel": "取消",

--- a/src/ipc/handlers/__tests__/chat_annotations.integration.test.tsx
+++ b/src/ipc/handlers/__tests__/chat_annotations.integration.test.tsx
@@ -1,0 +1,99 @@
+import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
+import { eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import { messages } from "@/db/schema";
+import {
+  setupHybridChatHarness,
+  type HybridChatHarness,
+} from "@/testing/hybrid_chat_harness";
+import { h } from "@/testing/hybrid.setup";
+
+describe("chat annotations (integration)", () => {
+  let harness: HybridChatHarness;
+
+  beforeAll(async () => {
+    harness = await setupHybridChatHarness({
+      electronMock: h,
+      settings: { isTestMode: true },
+    });
+  }, 60_000);
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  afterAll(async () => {
+    await harness?.dispose();
+  });
+
+  it("submits annotations without composer text through the real chat flow", async () => {
+    const [assistantMessage] = await harness.db
+      .insert(messages)
+      .values({
+        chatId: harness.chatId,
+        role: "assistant",
+        content: "The dashboard title should stay descriptive.",
+      })
+      .returning({ id: messages.id });
+
+    harness.mount();
+    await screen.findByText("The dashboard title should stay descriptive.");
+
+    harness.setChatAnnotations(harness.chatId, [
+      {
+        id: "annotation-1",
+        chatId: harness.chatId,
+        messageId: assistantMessage.id,
+        selectedText: "dashboard title",
+        comment: "[dump] Make this heading concise.",
+        createdAt: 1,
+        startOffset: 4,
+        selectionLength: 15,
+      },
+    ]);
+
+    expect(screen.getByTestId("chat-annotations-tray")).toBeTruthy();
+    expect(harness.getChatInputValue(harness.chatId)).toBe("");
+
+    const sendButton = await screen.findByLabelText(
+      /^(sendMessage|Send message)$/,
+    );
+    await waitFor(() => {
+      expect((sendButton as HTMLButtonElement).disabled).toBe(false);
+    });
+
+    const streamEnd = harness.waitForNextStreamEnd(harness.chatId);
+    fireEvent.click(sendButton);
+    await streamEnd;
+
+    expect(
+      harness.bridge.sentEvents.filter(
+        (event) => event.channel === "chat:response:error",
+      ),
+    ).toHaveLength(0);
+    expect(harness.getChatAnnotations(harness.chatId)).toEqual([]);
+    expect(screen.queryByTestId("chat-annotations-tray")).toBeNull();
+
+    const chatMessages = await harness.db.query.messages.findMany({
+      where: eq(messages.chatId, harness.chatId),
+    });
+    const submittedMessage = chatMessages.find(
+      (message) => message.role === "user",
+    );
+    expect(submittedMessage?.content).toBe(
+      `I have comments on your latest response. Address every comment below.\n\n## Comment 1\n\nFrom assistant message ${assistantMessage.id}:\n\n> dashboard title\n\n[dump] Make this heading concise.`,
+    );
+
+    const dump = harness.getServerDump({ type: "last-message" });
+    expect(dump.text).toContain(
+      "I have comments on your latest response. Address every comment below.",
+    );
+    expect(dump.text).toContain(
+      `From assistant message ${assistantMessage.id}:`,
+    );
+    expect(dump.text).toContain("> dashboard title");
+    expect(dump.text).toContain("[dump] Make this heading concise.");
+    expect([...harness.bridge.missingChannels]).toEqual([]);
+  }, 60_000);
+});

--- a/src/ipc/handlers/__tests__/chat_annotations.integration.test.tsx
+++ b/src/ipc/handlers/__tests__/chat_annotations.integration.test.tsx
@@ -27,6 +27,57 @@ describe("chat annotations (integration)", () => {
     await harness?.dispose();
   });
 
+  it("blocks annotated follow-ups while the latest code proposal is unapproved", async () => {
+    const [assistantMessage] = await harness.db
+      .insert(messages)
+      .values({
+        chatId: harness.chatId,
+        role: "assistant",
+        content:
+          '<dyad-write path="src/pending.tsx" description="Pending change">export const pending = true;</dyad-write>',
+      })
+      .returning({ id: messages.id });
+
+    harness.mount();
+    await screen.findByTestId("chat-input-container");
+
+    harness.setChatAnnotations(harness.chatId, [
+      {
+        id: "pending-proposal-annotation",
+        chatId: harness.chatId,
+        messageId: assistantMessage.id,
+        selectedText: "export const pending = true;",
+        comment: "Please rename this before applying it.",
+        createdAt: 1,
+        startOffset: 0,
+        selectionLength: 28,
+      },
+    ]);
+
+    await screen.findByTestId("chat-annotations-tray");
+    const sendButton = await screen.findByLabelText(
+      /^(sendMessage|Send message)$/,
+    );
+    await waitFor(() => {
+      expect((sendButton as HTMLButtonElement).disabled).toBe(true);
+    });
+
+    const streamInvokeCount = harness.bridge.invokeLog.filter(
+      (entry) => entry.channel === "chat:stream",
+    ).length;
+
+    fireEvent.click(sendButton);
+    await harness.pressEnterInChat("");
+    await harness.bridge.settleInFlight();
+
+    expect(
+      harness.bridge.invokeLog.filter(
+        (entry) => entry.channel === "chat:stream",
+      ),
+    ).toHaveLength(streamInvokeCount);
+    expect(harness.getChatAnnotations(harness.chatId)).toHaveLength(1);
+  });
+
   it("submits annotations without composer text through the real chat flow", async () => {
     const [assistantMessage] = await harness.db
       .insert(messages)

--- a/src/lib/annotationDom.ts
+++ b/src/lib/annotationDom.ts
@@ -1,0 +1,424 @@
+/**
+ * Shared DOM engine for text annotations (plan documents and chat messages).
+ *
+ * Both surfaces need the same three primitives: map a DOM selection to a flat
+ * character offset in the rendered text, read the text back at a saved offset
+ * to detect stale annotations, and wrap the matching text nodes in `<mark>`
+ * elements. Keeping one implementation means offset-math fixes land on both
+ * callers instead of drifting between two near-identical copies.
+ */
+
+/**
+ * Marks a subtree as UI chrome that must stay out of the annotation offset
+ * space (toolbars, collapsible tool cards, anything whose text can appear or
+ * disappear without the message content changing).
+ */
+export const ANNOTATION_IGNORE_ATTRIBUTE = "data-annotation-ignore";
+
+interface AnnotationTextSegment {
+  node: Text;
+  startOffset: number;
+  endOffset: number;
+}
+
+export interface AnnotationSelectionSnapshot {
+  selectedText: string;
+  startOffset: number;
+  selectionLength: number;
+}
+
+/** The subset of an annotation this module needs to render a highlight. */
+export interface AnnotationRange {
+  id: string;
+  selectedText: string;
+  startOffset: number;
+  selectionLength: number;
+}
+
+export interface AnnotationDomConfig {
+  /** Attribute stamped on each `<mark>` with the annotation id. */
+  idAttribute: string;
+  /** CSS selector matching subtrees excluded from the offset space. */
+  ignoreSelector: string;
+  /** Tailwind classes applied to each `<mark>`. */
+  markClassName: string;
+  /** Builds the accessible name of the first `<mark>` of an annotation. */
+  defaultLabel: (selectedText: string) => string;
+}
+
+export interface ApplyHighlightsOptions {
+  /**
+   * Overrides `defaultLabel` for this call, so callers with access to i18n can
+   * pass a translated accessible name instead of the module's fallback.
+   */
+  label?: (selectedText: string) => string;
+}
+
+export function hasOverlappingAnnotation(
+  annotations: AnnotationRange[],
+  startOffset: number,
+  selectionLength: number,
+): boolean {
+  const endOffset = startOffset + selectionLength;
+
+  return annotations.some((annotation) => {
+    const annotationEnd = annotation.startOffset + annotation.selectionLength;
+    return startOffset < annotationEnd && annotation.startOffset < endOffset;
+  });
+}
+
+export function findOverlappingAnnotation<T extends AnnotationRange>(
+  annotations: T[],
+  startOffset: number,
+  selectionLength: number,
+): T | undefined {
+  const endOffset = startOffset + selectionLength;
+
+  return annotations.find((annotation) => {
+    const annotationEnd = annotation.startOffset + annotation.selectionLength;
+    return startOffset < annotationEnd && annotation.startOffset < endOffset;
+  });
+}
+
+export function createAnnotationDom(config: AnnotationDomConfig) {
+  const { idAttribute, ignoreSelector, markClassName, defaultLabel } = config;
+  const markSelector = `mark[${idAttribute}]`;
+
+  function collectTextSegments(
+    container: HTMLElement,
+  ): AnnotationTextSegment[] {
+    const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT, {
+      acceptNode: (node) => {
+        const textNode = node as Text;
+        const parent = textNode.parentElement;
+
+        if (!parent || textNode.data.length === 0) {
+          return NodeFilter.FILTER_REJECT;
+        }
+
+        if (parent.closest(ignoreSelector)) {
+          return NodeFilter.FILTER_REJECT;
+        }
+
+        return NodeFilter.FILTER_ACCEPT;
+      },
+    });
+
+    const segments: AnnotationTextSegment[] = [];
+    let currentOffset = 0;
+    let node: Text | null;
+
+    while ((node = walker.nextNode() as Text | null)) {
+      const textLength = node.data.length;
+      segments.push({
+        node,
+        startOffset: currentOffset,
+        endOffset: currentOffset + textLength,
+      });
+      currentOffset += textLength;
+    }
+
+    return segments;
+  }
+
+  /**
+   * Maps a DOM selection boundary (node + offset) to a flat character offset
+   * within the container's concatenated text content.
+   *
+   * Creates a temporary Range from the container start to the boundary point,
+   * then walks the pre-collected text segments to find which segment contains
+   * the boundary. This Range-based approach correctly handles boundaries that
+   * land inside element nodes (not just text nodes) and accounts for ignored
+   * regions (e.g. annotation marks) that are excluded from the segment list.
+   */
+  function getBoundaryTextOffset(
+    container: HTMLElement,
+    boundaryNode: Node,
+    boundaryOffset: number,
+    segments: AnnotationTextSegment[],
+  ): number | null {
+    if (!container.contains(boundaryNode)) {
+      return null;
+    }
+
+    const boundaryRange = document.createRange();
+    boundaryRange.selectNodeContents(container);
+
+    try {
+      boundaryRange.setEnd(boundaryNode, boundaryOffset);
+    } catch {
+      return null;
+    }
+
+    let offset = 0;
+
+    for (const segment of segments) {
+      if (!boundaryRange.intersectsNode(segment.node)) {
+        continue;
+      }
+
+      if (boundaryRange.endContainer === segment.node) {
+        return segment.startOffset + boundaryRange.endOffset;
+      }
+
+      offset = segment.endOffset;
+    }
+
+    return offset;
+  }
+
+  function readTextFromSegments(
+    segments: AnnotationTextSegment[],
+    startOffset: number,
+    selectionLength: number,
+  ): string | null {
+    if (selectionLength <= 0 || startOffset < 0) {
+      return null;
+    }
+
+    const endOffset = startOffset + selectionLength;
+    let text = "";
+
+    for (const segment of segments) {
+      if (segment.endOffset <= startOffset) {
+        continue;
+      }
+
+      if (segment.startOffset >= endOffset) {
+        break;
+      }
+
+      const startInNode = Math.max(0, startOffset - segment.startOffset);
+      const endInNode = Math.min(
+        segment.node.data.length,
+        endOffset - segment.startOffset,
+      );
+
+      if (startInNode >= endInNode) {
+        continue;
+      }
+
+      text += segment.node.data.slice(startInNode, endInNode);
+    }
+
+    return text.length === selectionLength ? text : null;
+  }
+
+  function highlightAtOffset(
+    segments: AnnotationTextSegment[],
+    annotation: AnnotationRange,
+    label: (selectedText: string) => string,
+  ) {
+    if (annotation.selectionLength <= 0) {
+      return;
+    }
+
+    const endOffset = annotation.startOffset + annotation.selectionLength;
+    const overlappingSegments = segments.filter(
+      ({ startOffset: segmentStart, endOffset: segmentEnd }) =>
+        segmentStart < endOffset && segmentEnd > annotation.startOffset,
+    );
+
+    // Iterate in reverse so that splitText mutations don't shift offsets
+    // of earlier (not-yet-processed) segments.
+    for (let index = overlappingSegments.length - 1; index >= 0; index--) {
+      const segment = overlappingSegments[index];
+      const { node: textNode } = segment;
+      const startInNode = Math.max(
+        0,
+        annotation.startOffset - segment.startOffset,
+      );
+      const endInNode = Math.min(
+        textNode.data.length,
+        endOffset - segment.startOffset,
+      );
+      const charsToHighlight = endInNode - startInNode;
+
+      if (charsToHighlight <= 0 || !textNode.parentNode) {
+        continue;
+      }
+
+      const highlightNode = textNode.splitText(startInNode);
+      highlightNode.splitText(charsToHighlight);
+
+      const mark = document.createElement("mark");
+      mark.setAttribute(idAttribute, annotation.id);
+      mark.className = markClassName;
+      mark.textContent = highlightNode.data;
+
+      if (index === 0) {
+        const normalizedSelectedText = annotation.selectedText
+          .replace(/\s+/g, " ")
+          .trim();
+        mark.setAttribute("role", "button");
+        mark.setAttribute("tabindex", "0");
+        mark.setAttribute("aria-haspopup", "dialog");
+        mark.setAttribute("aria-label", label(normalizedSelectedText));
+      } else {
+        // Continuation fragments stay in the accessibility tree: they hold
+        // real message text, and hiding them would drop part of the message
+        // for screen reader users just because it was annotated.
+        mark.setAttribute("tabindex", "-1");
+      }
+
+      const parent = highlightNode.parentNode;
+      if (!parent) {
+        continue;
+      }
+
+      parent.replaceChild(mark, highlightNode);
+    }
+  }
+
+  function getSelectionSnapshot(
+    container: HTMLElement,
+    range: Range,
+  ): AnnotationSelectionSnapshot | null {
+    if (range.collapsed || !container.contains(range.commonAncestorContainer)) {
+      return null;
+    }
+
+    const segments = collectTextSegments(container);
+    if (segments.length === 0) {
+      return null;
+    }
+
+    const rawStartOffset = getBoundaryTextOffset(
+      container,
+      range.startContainer,
+      range.startOffset,
+      segments,
+    );
+    const rawEndOffset = getBoundaryTextOffset(
+      container,
+      range.endContainer,
+      range.endOffset,
+      segments,
+    );
+
+    if (rawStartOffset === null || rawEndOffset === null) {
+      return null;
+    }
+
+    const rawSelectionLength = rawEndOffset - rawStartOffset;
+    if (rawSelectionLength <= 0) {
+      return null;
+    }
+
+    const rawSelectedText = readTextFromSegments(
+      segments,
+      rawStartOffset,
+      rawSelectionLength,
+    );
+    if (!rawSelectedText) {
+      return null;
+    }
+
+    const leadingWhitespace =
+      rawSelectedText.length - rawSelectedText.trimStart().length;
+    const trailingWhitespace =
+      rawSelectedText.length - rawSelectedText.trimEnd().length;
+    const selectedText = rawSelectedText.trim();
+
+    if (selectedText.length === 0) {
+      return null;
+    }
+
+    return {
+      selectedText,
+      startOffset: rawStartOffset + leadingWhitespace,
+      selectionLength:
+        rawSelectionLength - leadingWhitespace - trailingWhitespace,
+    };
+  }
+
+  function clearHighlights(container: HTMLElement) {
+    container.querySelectorAll(markSelector).forEach((mark) => {
+      const parent = mark.parentNode;
+      if (!parent) {
+        return;
+      }
+
+      // Restore only the node this module created. `parent.normalize()` would
+      // also merge adjacent text nodes the annotation never touched, and React
+      // still holds references to those nodes for the markdown subtree it
+      // rendered - merging them away makes a later update throw
+      // NotFoundError on removeChild or write text into the wrong node.
+      parent.replaceChild(
+        document.createTextNode(mark.textContent ?? ""),
+        mark,
+      );
+    });
+  }
+
+  function applyHighlights(
+    container: HTMLElement,
+    annotations: AnnotationRange[],
+    options: ApplyHighlightsOptions = {},
+  ) {
+    const segments = collectTextSegments(container);
+    if (segments.length === 0) {
+      return;
+    }
+
+    const label = options.label ?? defaultLabel;
+    const totalTextLength = segments[segments.length - 1]?.endOffset ?? 0;
+
+    const renderableAnnotations = annotations
+      .filter((annotation) => {
+        if (annotation.selectionLength <= 0 || annotation.startOffset < 0) {
+          return false;
+        }
+
+        if (
+          annotation.startOffset + annotation.selectionLength >
+          totalTextLength
+        ) {
+          return false;
+        }
+
+        return (
+          readTextFromSegments(
+            segments,
+            annotation.startOffset,
+            annotation.selectionLength,
+          ) === annotation.selectedText
+        );
+      })
+      .sort(
+        (left, right) =>
+          left.startOffset - right.startOffset ||
+          right.selectionLength - left.selectionLength,
+      );
+
+    const nonOverlappingAnnotations: AnnotationRange[] = [];
+    let previousEndOffset = -1;
+
+    for (const annotation of renderableAnnotations) {
+      if (annotation.startOffset < previousEndOffset) {
+        continue;
+      }
+
+      nonOverlappingAnnotations.push(annotation);
+      previousEndOffset = annotation.startOffset + annotation.selectionLength;
+    }
+
+    // Iterate in reverse so that DOM mutations from highlightAtOffset don't
+    // invalidate offsets of earlier (not-yet-processed) annotations.
+    for (
+      let index = nonOverlappingAnnotations.length - 1;
+      index >= 0;
+      index--
+    ) {
+      highlightAtOffset(segments, nonOverlappingAnnotations[index], label);
+    }
+  }
+
+  return {
+    idAttribute,
+    markSelector,
+    getSelectionSnapshot,
+    clearHighlights,
+    applyHighlights,
+  };
+}

--- a/src/lib/annotationDom.ts
+++ b/src/lib/annotationDom.ts
@@ -54,19 +54,7 @@ export interface ApplyHighlightsOptions {
   label?: (selectedText: string) => string;
 }
 
-export function hasOverlappingAnnotation(
-  annotations: AnnotationRange[],
-  startOffset: number,
-  selectionLength: number,
-): boolean {
-  const endOffset = startOffset + selectionLength;
-
-  return annotations.some((annotation) => {
-    const annotationEnd = annotation.startOffset + annotation.selectionLength;
-    return startOffset < annotationEnd && annotation.startOffset < endOffset;
-  });
-}
-
+/** The single overlap primitive; callers that only need a boolean compare to undefined. */
 export function findOverlappingAnnotation<T extends AnnotationRange>(
   annotations: T[],
   startOffset: number,

--- a/src/lib/serializeChatAnnotations.test.ts
+++ b/src/lib/serializeChatAnnotations.test.ts
@@ -33,7 +33,8 @@ describe("serializeChatAnnotations", () => {
 
   it("keeps chat syntax inside the quoted assistant text inert", () => {
     const zeroWidthSpace = String.fromCharCode(0x200b);
-    const quoted = "Run /webapp-testing and see @prompt:12 or @media:a.png";
+    const quoted =
+      "Run /webapp-testing and see @prompt:12, @media:a.png or @app:other.app.com";
     const prompt = serializeChatAnnotations([
       annotation({ selectedText: quoted, comment: "Please fix." }),
     ]);
@@ -42,8 +43,20 @@ describe("serializeChatAnnotations", () => {
     expect(prompt).not.toMatch(/(^|\s)\/[a-zA-Z0-9-]+(?=\s|$)/);
     expect(prompt).not.toMatch(/@prompt:\d+/);
     expect(prompt).not.toMatch(/@media:[\w.%\-!~*'()]/);
+    expect(prompt).not.toMatch(/@app:[\w.-]/);
     // ...but the quote still reads the same, since the breaks are zero-width.
     expect(prompt.split(zeroWidthSpace).join("")).toContain(`> ${quoted}`);
+  });
+
+  it("leaves quoted paths that were never expandable byte-for-byte intact", () => {
+    // `replaceSlashSkillReference` only expands a whole slug token terminated
+    // by whitespace or end-of-string, so these must not be touched at all.
+    const quoted = "Check /usr/bin and /dev/null, then read ./src/main.ts";
+    const prompt = serializeChatAnnotations([
+      annotation({ selectedText: quoted, comment: "Please fix." }),
+    ]);
+
+    expect(prompt).toContain(`> ${quoted}`);
   });
 
   it("leaves the user's own comment text untouched", () => {

--- a/src/lib/serializeChatAnnotations.test.ts
+++ b/src/lib/serializeChatAnnotations.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { ChatAnnotation } from "@/atoms/chatAnnotationAtoms";
-import { serializeChatAnnotations } from "./serializeChatAnnotations";
+import {
+  composeChatPrompt,
+  hasChatComposerPayload,
+  serializeChatAnnotations,
+} from "./serializeChatAnnotations";
 
 function annotation(overrides: Partial<ChatAnnotation> = {}): ChatAnnotation {
   return {
@@ -68,5 +72,41 @@ describe("serializeChatAnnotations", () => {
     ]);
 
     expect(prompt).toContain("Use /webapp-testing on this.");
+  });
+
+  it("uses annotations as a complete prompt when the composer is empty", () => {
+    const prompt = composeChatPrompt("", [annotation()]);
+
+    expect(prompt).toContain("comments on your latest response");
+    expect(prompt).toContain("Make this clearer.");
+  });
+
+  it("appends annotations to typed composer text", () => {
+    const prompt = composeChatPrompt("Please also simplify the example.", [
+      annotation(),
+    ]);
+
+    expect(prompt).toMatch(
+      /^Please also simplify the example\.\n\nI have comments on your latest response\./,
+    );
+  });
+
+  it("treats annotations as submittable composer content", () => {
+    expect(
+      hasChatComposerPayload({
+        inputValue: "",
+        attachmentCount: 0,
+        hasSuccessfulImageJobs: false,
+        annotationCount: 1,
+      }),
+    ).toBe(true);
+    expect(
+      hasChatComposerPayload({
+        inputValue: "",
+        attachmentCount: 0,
+        hasSuccessfulImageJobs: false,
+        annotationCount: 0,
+      }),
+    ).toBe(false);
   });
 });

--- a/src/lib/serializeChatAnnotations.test.ts
+++ b/src/lib/serializeChatAnnotations.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import type { ChatAnnotation } from "@/atoms/chatAnnotationAtoms";
+import { serializeChatAnnotations } from "./serializeChatAnnotations";
+
+function annotation(
+  overrides: Partial<ChatAnnotation> = {},
+): ChatAnnotation {
+  return {
+    id: "one",
+    chatId: 1,
+    messageId: 10,
+    selectedText: "first line\nsecond line",
+    comment: "Make this clearer.",
+    createdAt: 1,
+    startOffset: 0,
+    selectionLength: 22,
+    ...overrides,
+  };
+}
+
+describe("serializeChatAnnotations", () => {
+  it("orders annotations and preserves multiline selections as blockquotes", () => {
+    const prompt = serializeChatAnnotations([
+      annotation({ id: "two", messageId: 20, createdAt: 2 }),
+      annotation(),
+    ]);
+
+    expect(prompt).toContain("Address every comment below");
+    expect(prompt).toContain("> first line\n> second line");
+    expect(prompt.indexOf("message 10")).toBeLessThan(
+      prompt.indexOf("message 20"),
+    );
+    expect(prompt).toContain("Make this clearer.");
+  });
+});

--- a/src/lib/serializeChatAnnotations.test.ts
+++ b/src/lib/serializeChatAnnotations.test.ts
@@ -2,9 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { ChatAnnotation } from "@/atoms/chatAnnotationAtoms";
 import { serializeChatAnnotations } from "./serializeChatAnnotations";
 
-function annotation(
-  overrides: Partial<ChatAnnotation> = {},
-): ChatAnnotation {
+function annotation(overrides: Partial<ChatAnnotation> = {}): ChatAnnotation {
   return {
     id: "one",
     chatId: 1,
@@ -31,5 +29,31 @@ describe("serializeChatAnnotations", () => {
       prompt.indexOf("message 20"),
     );
     expect(prompt).toContain("Make this clearer.");
+  });
+
+  it("keeps chat syntax inside the quoted assistant text inert", () => {
+    const zeroWidthSpace = String.fromCharCode(0x200b);
+    const quoted = "Run /webapp-testing and see @prompt:12 or @media:a.png";
+    const prompt = serializeChatAnnotations([
+      annotation({ selectedText: quoted, comment: "Please fix." }),
+    ]);
+
+    // None of the main process's expansion patterns still match the quote.
+    expect(prompt).not.toMatch(/(^|\s)\/[a-zA-Z0-9-]+(?=\s|$)/);
+    expect(prompt).not.toMatch(/@prompt:\d+/);
+    expect(prompt).not.toMatch(/@media:[\w.%\-!~*'()]/);
+    // ...but the quote still reads the same, since the breaks are zero-width.
+    expect(prompt.split(zeroWidthSpace).join("")).toContain(`> ${quoted}`);
+  });
+
+  it("leaves the user's own comment text untouched", () => {
+    const prompt = serializeChatAnnotations([
+      annotation({
+        selectedText: "plain text",
+        comment: "Use /webapp-testing on this.",
+      }),
+    ]);
+
+    expect(prompt).toContain("Use /webapp-testing on this.");
   });
 });

--- a/src/lib/serializeChatAnnotations.ts
+++ b/src/lib/serializeChatAnnotations.ts
@@ -1,0 +1,22 @@
+import type { ChatAnnotation } from "@/atoms/chatAnnotationAtoms";
+
+function quoteSelectedText(text: string): string {
+  return text
+    .split("\n")
+    .map((line) => `> ${line}`)
+    .join("\n");
+}
+
+export function serializeChatAnnotations(
+  annotations: ChatAnnotation[],
+): string {
+  const comments = [...annotations]
+    .sort((left, right) => left.createdAt - right.createdAt)
+    .map(
+      (annotation, index) =>
+        `## Comment ${index + 1}\n\nFrom assistant message ${annotation.messageId}:\n\n${quoteSelectedText(annotation.selectedText)}\n\n${annotation.comment}`,
+    )
+    .join("\n\n---\n\n");
+
+  return `I have comments on earlier assistant responses. Address every comment below.\n\n${comments}`;
+}

--- a/src/lib/serializeChatAnnotations.ts
+++ b/src/lib/serializeChatAnnotations.ts
@@ -7,17 +7,23 @@ const ZERO_WIDTH_SPACE = String.fromCharCode(0x200b);
 /**
  * Quoted assistant output is context, not a command.
  *
- * The main process expands `@prompt:<id>`, `@media:<name>` and `/slug` over the
- * whole prompt string before the turn runs, so a response that happened to
- * contain one of those tokens would silently inline a stored prompt, expand a
- * skill, or resolve a local file just because the user commented on it. Break
- * the trigger so the text stays inert; the user's own comment is left alone so
- * chat syntax they type themselves still works.
+ * The main process expands `@app:<name>`, `@prompt:<id>`, `@media:<name>` and
+ * `/slug` over the whole prompt string before the turn runs, so a response that
+ * happened to contain one of those tokens would silently pull in another app's
+ * codebase, inline a stored prompt, expand a skill, or resolve a local file
+ * just because the user commented on it. Break the trigger so the text stays
+ * inert; the user's own comment is left alone so chat syntax they type
+ * themselves still works.
  */
 function neutralizeChatSyntax(text: string): string {
-  return text
-    .replace(/@(prompt|media)(?=:)/g, `@$1${ZERO_WIDTH_SPACE}`)
-    .replace(/(^|\s)\/(?=[a-zA-Z0-9-])/g, `$1/${ZERO_WIDTH_SPACE}`);
+  return (
+    text
+      .replace(/@(app|prompt|media)(?=:)/g, `@$1${ZERO_WIDTH_SPACE}`)
+      // Mirror `replaceSlashSkillReference`'s pattern exactly: only a whole
+      // slug token terminated by whitespace or end-of-string ever expands, so
+      // quoted paths like `/usr/bin` must stay byte-for-byte intact.
+      .replace(/(^|\s)\/([a-zA-Z0-9-]+)(?=\s|$)/g, `$1/${ZERO_WIDTH_SPACE}$2`)
+  );
 }
 
 function quoteSelectedText(text: string): string {

--- a/src/lib/serializeChatAnnotations.ts
+++ b/src/lib/serializeChatAnnotations.ts
@@ -1,7 +1,27 @@
 import type { ChatAnnotation } from "@/atoms/chatAnnotationAtoms";
 
-function quoteSelectedText(text: string): string {
+// Zero-width space. Invisible in the rendered message and in the model's view
+// of the quote, but enough to break the mention/skill patterns below.
+const ZERO_WIDTH_SPACE = String.fromCharCode(0x200b);
+
+/**
+ * Quoted assistant output is context, not a command.
+ *
+ * The main process expands `@prompt:<id>`, `@media:<name>` and `/slug` over the
+ * whole prompt string before the turn runs, so a response that happened to
+ * contain one of those tokens would silently inline a stored prompt, expand a
+ * skill, or resolve a local file just because the user commented on it. Break
+ * the trigger so the text stays inert; the user's own comment is left alone so
+ * chat syntax they type themselves still works.
+ */
+function neutralizeChatSyntax(text: string): string {
   return text
+    .replace(/@(prompt|media)(?=:)/g, `@$1${ZERO_WIDTH_SPACE}`)
+    .replace(/(^|\s)\/(?=[a-zA-Z0-9-])/g, `$1/${ZERO_WIDTH_SPACE}`);
+}
+
+function quoteSelectedText(text: string): string {
+  return neutralizeChatSyntax(text)
     .split("\n")
     .map((line) => `> ${line}`)
     .join("\n");

--- a/src/lib/serializeChatAnnotations.ts
+++ b/src/lib/serializeChatAnnotations.ts
@@ -44,5 +44,36 @@ export function serializeChatAnnotations(
     )
     .join("\n\n---\n\n");
 
-  return `I have comments on earlier assistant responses. Address every comment below.\n\n${comments}`;
+  return `I have comments on your latest response. Address every comment below.\n\n${comments}`;
+}
+
+export function composeChatPrompt(
+  prompt: string,
+  annotations: ChatAnnotation[],
+): string {
+  if (annotations.length === 0) return prompt;
+
+  const annotationPrompt = serializeChatAnnotations(annotations);
+  return prompt.trim()
+    ? `${prompt.trim()}\n\n${annotationPrompt}`
+    : annotationPrompt;
+}
+
+export function hasChatComposerPayload({
+  inputValue,
+  attachmentCount,
+  hasSuccessfulImageJobs,
+  annotationCount,
+}: {
+  inputValue: string;
+  attachmentCount: number;
+  hasSuccessfulImageJobs: boolean;
+  annotationCount: number;
+}): boolean {
+  return (
+    inputValue.trim().length > 0 ||
+    attachmentCount > 0 ||
+    hasSuccessfulImageJobs ||
+    annotationCount > 0
+  );
 }

--- a/src/testing/hybrid_chat_harness.tsx
+++ b/src/testing/hybrid_chat_harness.tsx
@@ -69,6 +69,10 @@ import {
 import type { RendererEvent } from "./electron_mock";
 import { selectedAppIdAtom } from "@/atoms/appAtoms";
 import {
+  chatAnnotationsAtom,
+  type ChatAnnotation,
+} from "@/atoms/chatAnnotationAtoms";
+import {
   attachmentsAtom,
   chatInputValuesByIdAtom,
   selectedChatIdAtom,
@@ -366,6 +370,10 @@ export interface HybridChatHarness extends ChatFlowHarness {
    */
   setChatInputValue: (text: string, opts?: MountOptions) => void;
   getChatInputValue: (chatId: number) => string;
+
+  /** Seed/read a chat's transient assistant-message annotations. */
+  setChatAnnotations: (chatId: number, annotations: ChatAnnotation[]) => void;
+  getChatAnnotations: (chatId: number) => ChatAnnotation[];
 
   /**
    * Seed the real ChatInput attachment atom with browser File objects, matching
@@ -1195,6 +1203,21 @@ export async function setupHybridChatHarness(
     const getChatInputValue = (chatId: number) =>
       getActiveStore().get(chatInputValuesByIdAtom).get(chatId) ?? "";
 
+    const setChatAnnotations = (
+      chatId: number,
+      annotations: ChatAnnotation[],
+    ): void => {
+      const store = getActiveStore();
+      const next = new Map(store.get(chatAnnotationsAtom));
+      if (annotations.length === 0) next.delete(chatId);
+      else next.set(chatId, annotations);
+      act(() => {
+        store.set(chatAnnotationsAtom, next);
+      });
+    };
+    const getChatAnnotations = (chatId: number): ChatAnnotation[] =>
+      getActiveStore().get(chatAnnotationsAtom).get(chatId) ?? [];
+
     const typeInChat = async (
       text: string,
       opts: MountOptions = {},
@@ -1668,6 +1691,8 @@ export async function setupHybridChatHarness(
       setSwitch,
       setChatInputValue: seedChatInput,
       getChatInputValue,
+      setChatAnnotations,
+      getChatAnnotations,
       setChatAttachments,
       setSelectedComponents,
       typeInChat,


### PR DESCRIPTION
## Summary

Adds inline text annotations to assistant replies and makes annotated feedback flow through the normal chat composer as one coherent follow-up action.

- Restricts new annotations to the latest completed assistant response, while pruning comments whose source message disappears after Retry or history clearing.
- Treats annotations as composer content: the primary Send action is enabled with comments alone, combines them with any typed prompt, and hides the tray immediately. Comments are restored if turn admission is rejected so feedback is not lost.
- Keeps one primary action in the annotation banner by removing its duplicate Send button and replacing the visible Discard label with an accessible X control.
- Neutralizes app, prompt, media, and skill syntax inside quoted assistant text so annotating a response cannot accidentally expand references; syntax intentionally typed by the user remains active.
- Keeps annotation state renderer-local and scoped per chat; this change does not add persistence across app restarts.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
