### PR TITLE
feat: add one-click temporary previews with temp.md

### DIFF
--- a/src/components/preview_panel/PublishPanel.tsx
+++ b/src/components/preview_panel/PublishPanel.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { GithubCollaboratorManager } from "@/components/GithubCollaboratorManager";
 import { DatabaseSection } from "@/components/preview_panel/DatabaseSection";
 import { DeploymentSection } from "@/components/preview_panel/DeploymentSection";
+import { TemporaryPreviewCard } from "@/components/preview_panel/TemporaryPreviewCard";
 
 export const PublishPanel = () => {
   const selectedAppId = useAtomValue(selectedAppIdAtom);
@@ -121,6 +122,8 @@ export const PublishPanel = () => {
             )}
           </CardContent>
         </Card>
+
+        <TemporaryPreviewCard appId={selectedAppId} />
 
         <DeploymentSection appId={selectedAppId} app={app} />
       </div>

--- a/src/components/preview_panel/TemporaryPreviewCard.test.tsx
+++ b/src/components/preview_panel/TemporaryPreviewCard.test.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { PropsWithChildren } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { TempPreviewStatus } from "@/ipc/types/temp_preview";
+import { queryKeys } from "@/lib/queryKeys";
 import { TemporaryPreviewCard } from "./TemporaryPreviewCard";
 
 const mocks = vi.hoisted(() => ({
@@ -11,6 +12,8 @@ const mocks = vi.hoisted(() => ({
   publish: vi.fn(),
   revoke: vi.fn(),
   openExternalUrl: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
 }));
 
 vi.mock("@/ipc/types", () => ({
@@ -25,7 +28,7 @@ vi.mock("@/ipc/types", () => ({
 }));
 
 vi.mock("sonner", () => ({
-  toast: { success: vi.fn(), error: vi.fn() },
+  toast: { success: mocks.toastSuccess, error: mocks.toastError },
 }));
 
 const none: TempPreviewStatus = {
@@ -42,14 +45,17 @@ const active: TempPreviewStatus = {
   lastPublishedAt: "2026-08-23T12:00:00.000Z",
 };
 
-function renderCard() {
+function renderCard(appId = 42) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
   const Wrapper = ({ children }: PropsWithChildren) => (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );
-  return render(<TemporaryPreviewCard appId={42} />, { wrapper: Wrapper });
+  return {
+    ...render(<TemporaryPreviewCard appId={appId} />, { wrapper: Wrapper }),
+    queryClient,
+  };
 }
 
 describe("TemporaryPreviewCard", () => {
@@ -58,6 +64,7 @@ describe("TemporaryPreviewCard", () => {
     mocks.getStatus.mockResolvedValue(none);
     mocks.publish.mockResolvedValue(active);
     mocks.revoke.mockResolvedValue({ ...active, state: "revoked" });
+    mocks.openExternalUrl.mockResolvedValue(undefined);
   });
 
   it("creates a preview and replaces the create action with its public URL", async () => {
@@ -70,6 +77,7 @@ describe("TemporaryPreviewCard", () => {
 
     expect(mocks.publish).toHaveBeenCalledWith({ appId: 42 });
     expect(await screen.findByText(active.canonicalUrl!)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Create preview" })).toBeNull();
     expect(screen.getByRole("button", { name: "Update preview" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Revoke" })).toBeTruthy();
   });
@@ -86,6 +94,82 @@ describe("TemporaryPreviewCard", () => {
     );
 
     expect(mocks.openExternalUrl).toHaveBeenCalledWith(active.canonicalUrl);
+  });
+
+  it("reports a failure to open an existing preview", async () => {
+    mocks.getStatus.mockResolvedValue(active);
+    mocks.openExternalUrl.mockRejectedValue(new Error("Could not open URL"));
+    const user = userEvent.setup();
+    renderCard();
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "Open temporary preview",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mocks.toastError).toHaveBeenCalledWith("Could not open URL");
+    });
+  });
+
+  it("keeps a pending publish result scoped to its originating app", async () => {
+    let resolvePublish!: (status: TempPreviewStatus) => void;
+    mocks.publish.mockReturnValue(
+      new Promise((resolve) => {
+        resolvePublish = resolve;
+      }),
+    );
+    const user = userEvent.setup();
+    const { rerender, queryClient } = renderCard(42);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Create preview" }),
+    );
+    rerender(<TemporaryPreviewCard appId={43} />);
+    resolvePublish(active);
+
+    await waitFor(() => {
+      expect(
+        queryClient.getQueryData(queryKeys.tempPreviews.status({ appId: 42 })),
+      ).toEqual(active);
+    });
+    expect(
+      queryClient.getQueryData(queryKeys.tempPreviews.status({ appId: 43 })),
+    ).toEqual(none);
+  });
+
+  it("keeps a pending revoke result scoped to its originating app", async () => {
+    const otherActive = {
+      ...active,
+      canonicalUrl: "https://other.temp.md",
+    };
+    const revoked = { ...active, state: "revoked" as const };
+    mocks.getStatus.mockImplementation(({ appId }: { appId: number }) =>
+      Promise.resolve(appId === 42 ? active : otherActive),
+    );
+    let resolveRevoke!: (status: TempPreviewStatus) => void;
+    mocks.revoke.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRevoke = resolve;
+      }),
+    );
+    const user = userEvent.setup();
+    const { rerender, queryClient } = renderCard(42);
+
+    await user.click(await screen.findByRole("button", { name: "Revoke" }));
+    await user.click(screen.getByRole("button", { name: "Revoke preview" }));
+    rerender(<TemporaryPreviewCard appId={43} />);
+    resolveRevoke(revoked);
+
+    await waitFor(() => {
+      expect(
+        queryClient.getQueryData(queryKeys.tempPreviews.status({ appId: 42 })),
+      ).toEqual(revoked);
+    });
+    expect(
+      queryClient.getQueryData(queryKeys.tempPreviews.status({ appId: 43 })),
+    ).toEqual(otherActive);
   });
 
   it("requires confirmation before revoking the public link", async () => {

--- a/src/components/preview_panel/TemporaryPreviewCard.test.tsx
+++ b/src/components/preview_panel/TemporaryPreviewCard.test.tsx
@@ -127,6 +127,13 @@ describe("TemporaryPreviewCard", () => {
       await screen.findByRole("button", { name: "Create preview" }),
     );
     rerender(<TemporaryPreviewCard appId={43} />);
+    const otherAppCreate = await screen.findByRole("button", {
+      name: "Create preview",
+    });
+    expect((otherAppCreate as HTMLButtonElement).disabled).toBe(false);
+    expect(screen.getByRole("status").textContent).toBe(
+      "Temporary preview is not published",
+    );
     resolvePublish(active);
 
     await waitFor(() => {
@@ -160,6 +167,13 @@ describe("TemporaryPreviewCard", () => {
     await user.click(await screen.findByRole("button", { name: "Revoke" }));
     await user.click(screen.getByRole("button", { name: "Revoke preview" }));
     rerender(<TemporaryPreviewCard appId={43} />);
+    const otherAppRevoke = await screen.findByRole("button", {
+      name: "Revoke",
+    });
+    expect((otherAppRevoke as HTMLButtonElement).disabled).toBe(false);
+    expect(screen.getByRole("status").textContent).toBe(
+      "Temporary preview is active",
+    );
     resolveRevoke(revoked);
 
     await waitFor(() => {

--- a/src/components/preview_panel/TemporaryPreviewCard.test.tsx
+++ b/src/components/preview_panel/TemporaryPreviewCard.test.tsx
@@ -75,6 +75,10 @@ describe("TemporaryPreviewCard", () => {
     const user = userEvent.setup();
     renderCard();
 
+    expect(
+      screen.getByText(/Every file generated in dist becomes public/),
+    ).toBeTruthy();
+
     await user.click(
       await screen.findByRole("button", { name: "Create preview" }),
     );

--- a/src/components/preview_panel/TemporaryPreviewCard.test.tsx
+++ b/src/components/preview_panel/TemporaryPreviewCard.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { PropsWithChildren } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { TempPreviewStatus } from "@/ipc/types/temp_preview";
+import { TemporaryPreviewCard } from "./TemporaryPreviewCard";
+
+const mocks = vi.hoisted(() => ({
+  getStatus: vi.fn(),
+  publish: vi.fn(),
+  revoke: vi.fn(),
+  openExternalUrl: vi.fn(),
+}));
+
+vi.mock("@/ipc/types", () => ({
+  ipc: {
+    tempPreview: {
+      getStatus: mocks.getStatus,
+      publish: mocks.publish,
+      revoke: mocks.revoke,
+    },
+    system: { openExternalUrl: mocks.openExternalUrl },
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const none: TempPreviewStatus = {
+  state: "none",
+  canonicalUrl: null,
+  expiresAt: null,
+  lastPublishedAt: null,
+};
+
+const active: TempPreviewStatus = {
+  state: "active",
+  canonicalUrl: "https://friendly-name.temp.md",
+  expiresAt: "2026-08-30T12:00:00.000Z",
+  lastPublishedAt: "2026-08-23T12:00:00.000Z",
+};
+
+function renderCard() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const Wrapper = ({ children }: PropsWithChildren) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return render(<TemporaryPreviewCard appId={42} />, { wrapper: Wrapper });
+}
+
+describe("TemporaryPreviewCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getStatus.mockResolvedValue(none);
+    mocks.publish.mockResolvedValue(active);
+    mocks.revoke.mockResolvedValue({ ...active, state: "revoked" });
+  });
+
+  it("creates a preview and replaces the create action with its public URL", async () => {
+    const user = userEvent.setup();
+    renderCard();
+
+    await user.click(
+      await screen.findByRole("button", { name: "Create preview" }),
+    );
+
+    expect(mocks.publish).toHaveBeenCalledWith({ appId: 42 });
+    expect(await screen.findByText(active.canonicalUrl!)).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Update preview" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Revoke" })).toBeTruthy();
+  });
+
+  it("opens an existing preview through the main process", async () => {
+    mocks.getStatus.mockResolvedValue(active);
+    const user = userEvent.setup();
+    renderCard();
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "Open temporary preview",
+      }),
+    );
+
+    expect(mocks.openExternalUrl).toHaveBeenCalledWith(active.canonicalUrl);
+  });
+
+  it("requires confirmation before revoking the public link", async () => {
+    mocks.getStatus.mockResolvedValue(active);
+    const user = userEvent.setup();
+    renderCard();
+
+    await user.click(await screen.findByRole("button", { name: "Revoke" }));
+    expect(mocks.revoke).not.toHaveBeenCalled();
+    await user.click(screen.getByRole("button", { name: "Revoke preview" }));
+
+    await waitFor(() => {
+      expect(mocks.revoke).toHaveBeenCalledWith({ appId: 42 });
+    });
+  });
+});

--- a/src/components/preview_panel/TemporaryPreviewCard.test.tsx
+++ b/src/components/preview_panel/TemporaryPreviewCard.test.tsx
@@ -1,8 +1,8 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { PropsWithChildren } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { TempPreviewStatus } from "@/ipc/types/temp_preview";
 import { queryKeys } from "@/lib/queryKeys";
 import { TemporaryPreviewCard } from "./TemporaryPreviewCard";
@@ -67,6 +67,10 @@ describe("TemporaryPreviewCard", () => {
     mocks.openExternalUrl.mockResolvedValue(undefined);
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("creates a preview and replaces the create action with its public URL", async () => {
     const user = userEvent.setup();
     renderCard();
@@ -94,6 +98,35 @@ describe("TemporaryPreviewCard", () => {
     );
 
     expect(mocks.openExternalUrl).toHaveBeenCalledWith(active.canonicalUrl);
+  });
+
+  it("stops presenting an active preview when its expiry passes", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-23T12:00:00.000Z"));
+    const expiresAt = new Date(Date.now() + 60_000).toISOString();
+    mocks.getStatus.mockReturnValue(new Promise(() => undefined));
+    const { queryClient } = renderCard();
+
+    await act(async () => {
+      queryClient.setQueryData(queryKeys.tempPreviews.status({ appId: 42 }), {
+        ...active,
+        expiresAt,
+      });
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(screen.getByText(active.canonicalUrl!)).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Update preview" })).toBeTruthy();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+
+    expect(screen.getByText(/Your previous preview expired/)).toBeTruthy();
+    expect(screen.queryByText(active.canonicalUrl!)).toBeNull();
+    expect(screen.queryByRole("button", { name: "Update preview" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Revoke" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Create preview" })).toBeTruthy();
   });
 
   it("reports a failure to open an existing preview", async () => {

--- a/src/components/preview_panel/TemporaryPreviewCard.test.tsx
+++ b/src/components/preview_panel/TemporaryPreviewCard.test.tsx
@@ -185,4 +185,18 @@ describe("TemporaryPreviewCard", () => {
       expect(mocks.revoke).toHaveBeenCalledWith({ appId: 42 });
     });
   });
+
+  it("binds revoke confirmation to the app that opened the dialog", async () => {
+    mocks.getStatus.mockResolvedValue(active);
+    const user = userEvent.setup();
+    const { rerender } = renderCard(42);
+
+    await user.click(await screen.findByRole("button", { name: "Revoke" }));
+    rerender(<TemporaryPreviewCard appId={43} />);
+    await user.click(screen.getByRole("button", { name: "Revoke preview" }));
+
+    await waitFor(() => {
+      expect(mocks.revoke).toHaveBeenCalledWith({ appId: 42 });
+    });
+  });
 });

--- a/src/components/preview_panel/TemporaryPreviewCard.tsx
+++ b/src/components/preview_panel/TemporaryPreviewCard.tsx
@@ -1,0 +1,272 @@
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  Check,
+  Copy,
+  ExternalLink,
+  Loader2,
+  RefreshCw,
+  Timer,
+  Trash2,
+} from "lucide-react";
+import { toast } from "sonner";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ipc, type TempPreviewStatus } from "@/ipc/types";
+import { getErrorMessage } from "@/lib/errors";
+import { queryKeys } from "@/lib/queryKeys";
+
+interface TemporaryPreviewCardProps {
+  appId: number;
+}
+
+export function TemporaryPreviewCard({ appId }: TemporaryPreviewCardProps) {
+  const queryClient = useQueryClient();
+  const [copied, setCopied] = useState(false);
+  const [revokeOpen, setRevokeOpen] = useState(false);
+  const queryKey = queryKeys.tempPreviews.status({ appId });
+  const statusQuery = useQuery({
+    queryKey,
+    queryFn: () => ipc.tempPreview.getStatus({ appId }),
+  });
+
+  const publishMutation = useMutation({
+    mutationFn: () => ipc.tempPreview.publish({ appId }),
+    onSuccess: (status) => {
+      queryClient.setQueryData(queryKey, status);
+      toast.success(
+        statusQuery.data?.state === "active"
+          ? "Temporary preview updated"
+          : "Temporary preview is live",
+      );
+    },
+    onError: (error) => toast.error(getErrorMessage(error)),
+  });
+
+  const revokeMutation = useMutation({
+    mutationFn: () => ipc.tempPreview.revoke({ appId }),
+    onSuccess: (status) => {
+      queryClient.setQueryData(queryKey, status);
+      toast.success("Temporary preview revoked");
+    },
+    onError: (error) => toast.error(getErrorMessage(error)),
+  });
+
+  const copyUrl = async (url: string) => {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2_000);
+    } catch {
+      toast.error("Could not copy the preview URL");
+    }
+  };
+
+  const status = statusQuery.data;
+  const activeStatus =
+    status?.state === "active" && status.canonicalUrl
+      ? { ...status, canonicalUrl: status.canonicalUrl }
+      : null;
+  const isPublishing = publishMutation.isPending;
+
+  return (
+    <>
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="flex items-center gap-2">
+            <Timer className="size-5" />
+            Temporary preview
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-1">
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              Share a public, static preview without connecting GitHub or a
+              deployment provider. It expires automatically after 7 days.
+            </p>
+            <p className="text-xs text-amber-700 dark:text-amber-300">
+              Anyone with the link can view it. Server-side features and secrets
+              are not included.
+            </p>
+          </div>
+
+          {statusQuery.isPending ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="size-4 animate-spin" />
+              Checking preview status…
+            </div>
+          ) : statusQuery.isError ? (
+            <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm">
+              <p className="text-destructive">
+                {getErrorMessage(statusQuery.error)}
+              </p>
+              <Button
+                className="mt-3"
+                size="sm"
+                variant="outline"
+                onClick={() => statusQuery.refetch()}
+              >
+                Try again
+              </Button>
+            </div>
+          ) : activeStatus ? (
+            <ActivePreview
+              status={activeStatus}
+              copied={copied}
+              isPublishing={isPublishing}
+              isRevoking={revokeMutation.isPending}
+              onCopy={copyUrl}
+              onOpen={(url) => ipc.system.openExternalUrl(url)}
+              onUpdate={() => publishMutation.mutate()}
+              onRevoke={() => setRevokeOpen(true)}
+            />
+          ) : (
+            <div className="space-y-3">
+              {status?.state === "expired" && (
+                <p className="text-sm text-muted-foreground">
+                  Your previous preview expired. Create a new one to get a fresh
+                  link.
+                </p>
+              )}
+              {status?.state === "revoked" && (
+                <p className="text-sm text-muted-foreground">
+                  Your previous preview was revoked.
+                </p>
+              )}
+              <Button
+                onClick={() => publishMutation.mutate()}
+                disabled={isPublishing}
+              >
+                {isPublishing ? (
+                  <Loader2 className="animate-spin" />
+                ) : (
+                  <Timer />
+                )}
+                {isPublishing ? "Building and publishing…" : "Create preview"}
+              </Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <AlertDialog open={revokeOpen} onOpenChange={setRevokeOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Revoke this temporary preview?</AlertDialogTitle>
+            <AlertDialogDescription>
+              The public link will stop working immediately. You can create a
+              new preview later.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={revokeMutation.isPending}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-white hover:bg-destructive/90"
+              disabled={revokeMutation.isPending}
+              onClick={() => revokeMutation.mutate()}
+            >
+              {revokeMutation.isPending ? (
+                <Loader2 className="animate-spin" />
+              ) : (
+                <Trash2 />
+              )}
+              Revoke preview
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}
+
+function ActivePreview({
+  status,
+  copied,
+  isPublishing,
+  isRevoking,
+  onCopy,
+  onOpen,
+  onUpdate,
+  onRevoke,
+}: {
+  status: TempPreviewStatus & { canonicalUrl: string };
+  copied: boolean;
+  isPublishing: boolean;
+  isRevoking: boolean;
+  onCopy: (url: string) => void;
+  onOpen: (url: string) => void;
+  onUpdate: () => void;
+  onRevoke: () => void;
+}) {
+  return (
+    <div className="space-y-3">
+      <div className="rounded-lg border bg-muted/30 p-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <p
+              className="truncate text-sm font-medium"
+              title={status.canonicalUrl}
+            >
+              {status.canonicalUrl}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {formatExpiry(status.expiresAt)}
+            </p>
+          </div>
+          <div className="flex shrink-0 gap-1">
+            <Button
+              aria-label="Copy preview URL"
+              size="icon"
+              variant="ghost"
+              onClick={() => onCopy(status.canonicalUrl)}
+            >
+              {copied ? <Check /> : <Copy />}
+            </Button>
+            <Button
+              aria-label="Open temporary preview"
+              size="icon"
+              variant="ghost"
+              onClick={() => onOpen(status.canonicalUrl)}
+            >
+              <ExternalLink />
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <Button onClick={onUpdate} disabled={isPublishing || isRevoking}>
+          {isPublishing ? <Loader2 className="animate-spin" /> : <RefreshCw />}
+          {isPublishing ? "Building and updating…" : "Update preview"}
+        </Button>
+        <Button
+          variant="outline"
+          onClick={onRevoke}
+          disabled={isPublishing || isRevoking}
+        >
+          <Trash2 />
+          Revoke
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function formatExpiry(expiresAt: string | null): string {
+  if (!expiresAt) return "Expires automatically";
+  const parsed = new Date(expiresAt);
+  if (Number.isNaN(parsed.getTime())) return "Expires automatically";
+  return `Expires ${parsed.toLocaleString()}`;
+}

--- a/src/components/preview_panel/TemporaryPreviewCard.tsx
+++ b/src/components/preview_panel/TemporaryPreviewCard.tsx
@@ -1,5 +1,10 @@
 import { useState } from "react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  useIsMutating,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import {
   Check,
   Copy,
@@ -30,6 +35,9 @@ interface TemporaryPreviewCardProps {
   appId: number;
 }
 
+const TEMP_PREVIEW_PUBLISH_MUTATION_KEY = ["temp-preview", "publish"];
+const TEMP_PREVIEW_REVOKE_MUTATION_KEY = ["temp-preview", "revoke"];
+
 export function TemporaryPreviewCard({ appId }: TemporaryPreviewCardProps) {
   const queryClient = useQueryClient();
   const [copied, setCopied] = useState(false);
@@ -41,6 +49,7 @@ export function TemporaryPreviewCard({ appId }: TemporaryPreviewCardProps) {
   });
 
   const publishMutation = useMutation({
+    mutationKey: TEMP_PREVIEW_PUBLISH_MUTATION_KEY,
     mutationFn: (originAppId: number) =>
       ipc.tempPreview.publish({ appId: originAppId }),
     onSuccess: (status, originAppId) => {
@@ -60,6 +69,7 @@ export function TemporaryPreviewCard({ appId }: TemporaryPreviewCardProps) {
   });
 
   const revokeMutation = useMutation({
+    mutationKey: TEMP_PREVIEW_REVOKE_MUTATION_KEY,
     mutationFn: (originAppId: number) =>
       ipc.tempPreview.revoke({ appId: originAppId }),
     onSuccess: (status, originAppId) => {
@@ -87,13 +97,27 @@ export function TemporaryPreviewCard({ appId }: TemporaryPreviewCardProps) {
     status?.state === "active" && status.canonicalUrl
       ? { ...status, canonicalUrl: status.canonicalUrl }
       : null;
-  const isPublishing = publishMutation.isPending;
+  const isPublishing =
+    useIsMutating({
+      mutationKey: TEMP_PREVIEW_PUBLISH_MUTATION_KEY,
+      predicate: (mutation) => mutation.state.variables === appId,
+    }) > 0;
+  const isRevoking =
+    useIsMutating({
+      mutationKey: TEMP_PREVIEW_REVOKE_MUTATION_KEY,
+      predicate: (mutation) => mutation.state.variables === appId,
+    }) > 0;
+  const isRevokeDialogPending =
+    useIsMutating({
+      mutationKey: TEMP_PREVIEW_REVOKE_MUTATION_KEY,
+      predicate: (mutation) => mutation.state.variables === revokeAppId,
+    }) > 0;
   const statusAnnouncement = getStatusAnnouncement({
     status,
     error: statusQuery.error,
     isChecking: statusQuery.isPending,
-    isPublishing: publishMutation.isPending,
-    isRevoking: revokeMutation.isPending,
+    isPublishing,
+    isRevoking,
   });
 
   return (
@@ -144,7 +168,7 @@ export function TemporaryPreviewCard({ appId }: TemporaryPreviewCardProps) {
               status={activeStatus}
               copied={copied}
               isPublishing={isPublishing}
-              isRevoking={revokeMutation.isPending}
+              isRevoking={isRevoking}
               onCopy={copyUrl}
               onOpen={(url) => {
                 void ipc.system
@@ -198,19 +222,19 @@ export function TemporaryPreviewCard({ appId }: TemporaryPreviewCardProps) {
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel disabled={revokeMutation.isPending}>
+            <AlertDialogCancel disabled={isRevokeDialogPending}>
               Cancel
             </AlertDialogCancel>
             <AlertDialogAction
               className="bg-destructive text-white hover:bg-destructive/90"
-              disabled={revokeMutation.isPending}
+              disabled={isRevokeDialogPending}
               onClick={() => {
                 if (revokeAppId !== null) {
                   revokeMutation.mutate(revokeAppId);
                 }
               }}
             >
-              {revokeMutation.isPending ? (
+              {isRevokeDialogPending ? (
                 <Loader2 className="animate-spin" />
               ) : (
                 <Trash2 />

--- a/src/components/preview_panel/TemporaryPreviewCard.tsx
+++ b/src/components/preview_panel/TemporaryPreviewCard.tsx
@@ -41,11 +41,17 @@ export function TemporaryPreviewCard({ appId }: TemporaryPreviewCardProps) {
   });
 
   const publishMutation = useMutation({
-    mutationFn: () => ipc.tempPreview.publish({ appId }),
-    onSuccess: (status) => {
-      queryClient.setQueryData(queryKey, status);
+    mutationFn: (originAppId: number) =>
+      ipc.tempPreview.publish({ appId: originAppId }),
+    onSuccess: (status, originAppId) => {
+      const originQueryKey = queryKeys.tempPreviews.status({
+        appId: originAppId,
+      });
+      const previousStatus =
+        queryClient.getQueryData<TempPreviewStatus>(originQueryKey);
+      queryClient.setQueryData(originQueryKey, status);
       toast.success(
-        statusQuery.data?.state === "active"
+        previousStatus?.state === "active"
           ? "Temporary preview updated"
           : "Temporary preview is live",
       );
@@ -54,9 +60,13 @@ export function TemporaryPreviewCard({ appId }: TemporaryPreviewCardProps) {
   });
 
   const revokeMutation = useMutation({
-    mutationFn: () => ipc.tempPreview.revoke({ appId }),
-    onSuccess: (status) => {
-      queryClient.setQueryData(queryKey, status);
+    mutationFn: (originAppId: number) =>
+      ipc.tempPreview.revoke({ appId: originAppId }),
+    onSuccess: (status, originAppId) => {
+      queryClient.setQueryData(
+        queryKeys.tempPreviews.status({ appId: originAppId }),
+        status,
+      );
       toast.success("Temporary preview revoked");
     },
     onError: (error) => toast.error(getErrorMessage(error)),
@@ -78,6 +88,23 @@ export function TemporaryPreviewCard({ appId }: TemporaryPreviewCardProps) {
       ? { ...status, canonicalUrl: status.canonicalUrl }
       : null;
   const isPublishing = publishMutation.isPending;
+  const statusAnnouncement = statusQuery.isPending
+    ? "Checking preview status"
+    : statusQuery.isError
+      ? `Preview status error: ${getErrorMessage(statusQuery.error)}`
+      : publishMutation.isPending
+        ? activeStatus
+          ? "Building and updating temporary preview"
+          : "Building and publishing temporary preview"
+        : revokeMutation.isPending
+          ? "Revoking temporary preview"
+          : activeStatus
+            ? "Temporary preview is active"
+            : status?.state === "expired"
+              ? "Temporary preview expired"
+              : status?.state === "revoked"
+                ? "Temporary preview revoked"
+                : "Temporary preview is not published";
 
   return (
     <>
@@ -89,6 +116,9 @@ export function TemporaryPreviewCard({ appId }: TemporaryPreviewCardProps) {
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
+          <p className="sr-only" role="status" aria-live="polite">
+            {statusAnnouncement}
+          </p>
           <div className="space-y-1">
             <p className="text-sm text-gray-600 dark:text-gray-400">
               Share a public, static preview without connecting GitHub or a
@@ -126,8 +156,12 @@ export function TemporaryPreviewCard({ appId }: TemporaryPreviewCardProps) {
               isPublishing={isPublishing}
               isRevoking={revokeMutation.isPending}
               onCopy={copyUrl}
-              onOpen={(url) => ipc.system.openExternalUrl(url)}
-              onUpdate={() => publishMutation.mutate()}
+              onOpen={(url) => {
+                void ipc.system
+                  .openExternalUrl(url)
+                  .catch((error) => toast.error(getErrorMessage(error)));
+              }}
+              onUpdate={() => publishMutation.mutate(appId)}
               onRevoke={() => setRevokeOpen(true)}
             />
           ) : (
@@ -144,7 +178,7 @@ export function TemporaryPreviewCard({ appId }: TemporaryPreviewCardProps) {
                 </p>
               )}
               <Button
-                onClick={() => publishMutation.mutate()}
+                onClick={() => publishMutation.mutate(appId)}
                 disabled={isPublishing}
               >
                 {isPublishing ? (
@@ -175,7 +209,7 @@ export function TemporaryPreviewCard({ appId }: TemporaryPreviewCardProps) {
             <AlertDialogAction
               className="bg-destructive text-white hover:bg-destructive/90"
               disabled={revokeMutation.isPending}
-              onClick={() => revokeMutation.mutate()}
+              onClick={() => revokeMutation.mutate(appId)}
             >
               {revokeMutation.isPending ? (
                 <Loader2 className="animate-spin" />

--- a/src/components/preview_panel/TemporaryPreviewCard.tsx
+++ b/src/components/preview_panel/TemporaryPreviewCard.tsx
@@ -33,7 +33,7 @@ interface TemporaryPreviewCardProps {
 export function TemporaryPreviewCard({ appId }: TemporaryPreviewCardProps) {
   const queryClient = useQueryClient();
   const [copied, setCopied] = useState(false);
-  const [revokeOpen, setRevokeOpen] = useState(false);
+  const [revokeAppId, setRevokeAppId] = useState<number | null>(null);
   const queryKey = queryKeys.tempPreviews.status({ appId });
   const statusQuery = useQuery({
     queryKey,
@@ -88,23 +88,13 @@ export function TemporaryPreviewCard({ appId }: TemporaryPreviewCardProps) {
       ? { ...status, canonicalUrl: status.canonicalUrl }
       : null;
   const isPublishing = publishMutation.isPending;
-  const statusAnnouncement = statusQuery.isPending
-    ? "Checking preview status"
-    : statusQuery.isError
-      ? `Preview status error: ${getErrorMessage(statusQuery.error)}`
-      : publishMutation.isPending
-        ? activeStatus
-          ? "Building and updating temporary preview"
-          : "Building and publishing temporary preview"
-        : revokeMutation.isPending
-          ? "Revoking temporary preview"
-          : activeStatus
-            ? "Temporary preview is active"
-            : status?.state === "expired"
-              ? "Temporary preview expired"
-              : status?.state === "revoked"
-                ? "Temporary preview revoked"
-                : "Temporary preview is not published";
+  const statusAnnouncement = getStatusAnnouncement({
+    status,
+    error: statusQuery.error,
+    isChecking: statusQuery.isPending,
+    isPublishing: publishMutation.isPending,
+    isRevoking: revokeMutation.isPending,
+  });
 
   return (
     <>
@@ -162,7 +152,7 @@ export function TemporaryPreviewCard({ appId }: TemporaryPreviewCardProps) {
                   .catch((error) => toast.error(getErrorMessage(error)));
               }}
               onUpdate={() => publishMutation.mutate(appId)}
-              onRevoke={() => setRevokeOpen(true)}
+              onRevoke={() => setRevokeAppId(appId)}
             />
           ) : (
             <div className="space-y-3">
@@ -193,7 +183,12 @@ export function TemporaryPreviewCard({ appId }: TemporaryPreviewCardProps) {
         </CardContent>
       </Card>
 
-      <AlertDialog open={revokeOpen} onOpenChange={setRevokeOpen}>
+      <AlertDialog
+        open={revokeAppId !== null}
+        onOpenChange={(open) => {
+          if (!open) setRevokeAppId(null);
+        }}
+      >
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>Revoke this temporary preview?</AlertDialogTitle>
@@ -209,7 +204,11 @@ export function TemporaryPreviewCard({ appId }: TemporaryPreviewCardProps) {
             <AlertDialogAction
               className="bg-destructive text-white hover:bg-destructive/90"
               disabled={revokeMutation.isPending}
-              onClick={() => revokeMutation.mutate(appId)}
+              onClick={() => {
+                if (revokeAppId !== null) {
+                  revokeMutation.mutate(revokeAppId);
+                }
+              }}
             >
               {revokeMutation.isPending ? (
                 <Loader2 className="animate-spin" />
@@ -223,6 +222,40 @@ export function TemporaryPreviewCard({ appId }: TemporaryPreviewCardProps) {
       </AlertDialog>
     </>
   );
+}
+
+function getStatusAnnouncement({
+  status,
+  error,
+  isChecking,
+  isPublishing,
+  isRevoking,
+}: {
+  status: TempPreviewStatus | undefined;
+  error: Error | null;
+  isChecking: boolean;
+  isPublishing: boolean;
+  isRevoking: boolean;
+}): string {
+  if (isChecking) return "Checking preview status";
+  if (error) return `Preview status error: ${getErrorMessage(error)}`;
+  if (isPublishing) {
+    return status?.state === "active"
+      ? "Building and updating temporary preview"
+      : "Building and publishing temporary preview";
+  }
+  if (isRevoking) return "Revoking temporary preview";
+
+  switch (status?.state) {
+    case "active":
+      return "Temporary preview is active";
+    case "expired":
+      return "Temporary preview expired";
+    case "revoked":
+      return "Temporary preview revoked";
+    default:
+      return "Temporary preview is not published";
+  }
 }
 
 function ActivePreview({

--- a/src/components/preview_panel/TemporaryPreviewCard.tsx
+++ b/src/components/preview_panel/TemporaryPreviewCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   useIsMutating,
   useMutation,
@@ -60,7 +60,7 @@ export function TemporaryPreviewCard({ appId }: TemporaryPreviewCardProps) {
         queryClient.getQueryData<TempPreviewStatus>(originQueryKey);
       queryClient.setQueryData(originQueryKey, status);
       toast.success(
-        previousStatus?.state === "active"
+        getCurrentTempPreviewStatus(previousStatus)?.state === "active"
           ? "Temporary preview updated"
           : "Temporary preview is live",
       );
@@ -92,7 +92,11 @@ export function TemporaryPreviewCard({ appId }: TemporaryPreviewCardProps) {
     }
   };
 
-  const status = statusQuery.data;
+  const storedStatus = statusQuery.data;
+  useExpiryRerender(
+    storedStatus?.state === "active" ? storedStatus.expiresAt : null,
+  );
+  const status = getCurrentTempPreviewStatus(storedStatus);
   const activeStatus =
     status?.state === "active" && status.canonicalUrl
       ? { ...status, canonicalUrl: status.canonicalUrl }
@@ -246,6 +250,35 @@ export function TemporaryPreviewCard({ appId }: TemporaryPreviewCardProps) {
       </AlertDialog>
     </>
   );
+}
+
+function useExpiryRerender(expiresAt: string | null): void {
+  const [expiryTick, setExpiryTick] = useState(0);
+
+  useEffect(() => {
+    const expiresAtMs = expiresAt ? new Date(expiresAt).getTime() : Number.NaN;
+    if (!Number.isFinite(expiresAtMs)) return;
+
+    const remainingMs = expiresAtMs - Date.now();
+    if (remainingMs <= 0) return;
+
+    // Browsers clamp longer timeouts. Rechecking after the clamp keeps this
+    // correct if a provider ever returns an expiry more than ~24 days away.
+    const timeout = window.setTimeout(
+      () => setExpiryTick((tick) => tick + 1),
+      Math.min(remainingMs, 2_147_483_647),
+    );
+    return () => window.clearTimeout(timeout);
+  }, [expiresAt, expiryTick]);
+}
+
+function getCurrentTempPreviewStatus(
+  status: TempPreviewStatus | undefined,
+): TempPreviewStatus | undefined {
+  if (status?.state !== "active" || !status.expiresAt) return status;
+  const expiresAtMs = new Date(status.expiresAt).getTime();
+  if (!Number.isFinite(expiresAtMs) || expiresAtMs > Date.now()) return status;
+  return { ...status, state: "expired" };
 }
 
 function getStatusAnnouncement({

--- a/src/components/preview_panel/TemporaryPreviewCard.tsx
+++ b/src/components/preview_panel/TemporaryPreviewCard.tsx
@@ -143,8 +143,9 @@ export function TemporaryPreviewCard({ appId }: TemporaryPreviewCardProps) {
               deployment provider. It expires automatically after 7 days.
             </p>
             <p className="text-xs text-amber-700 dark:text-amber-300">
-              Anyone with the link can view it. Server-side features and secrets
-              are not included.
+              Anyone with the link can view it. Every file generated in dist
+              becomes public—remove credentials and sensitive data before
+              publishing. Server-side features are not included.
             </p>
           </div>
 

--- a/src/ipc/handlers/app_handlers.ts
+++ b/src/ipc/handlers/app_handlers.ts
@@ -656,6 +656,7 @@ async function deleteAppByIdExclusive(
 
         if (!app) {
           if (options.allowMissing && options.knownAppPath) {
+            await deleteTempPreviewForApp(appId);
             await appRunDeletion.seal();
             appRunDeletion.commit();
             deletionCommitted = true;
@@ -685,6 +686,7 @@ async function deleteAppByIdExclusive(
         const doomedRow = await db.query.apps.findFirst({
           where: eq(apps.id, appId),
         });
+        await deleteTempPreviewForApp(appId);
         try {
           // `doomedRow` for the same reason it is re-read above: the test-user
           // id can land on the row after the first read, and deleting from the
@@ -697,7 +699,6 @@ async function deleteAppByIdExclusive(
               DyadErrorKind.External,
             );
           }
-          await deleteTempPreviewForApp(appId);
           await db.delete(apps).where(eq(apps.id, appId));
           appRunDeletion.commit();
           deletionCommitted = true;

--- a/src/ipc/handlers/app_handlers.ts
+++ b/src/ipc/handlers/app_handlers.ts
@@ -419,6 +419,20 @@ async function removeAppFiles(appId: number, appPath: string): Promise<void> {
   }
 }
 
+async function cleanupDeletedAppTempPreview(appId: number): Promise<void> {
+  try {
+    await deleteTempPreviewForApp(appId);
+  } catch (error) {
+    // The app deletion is already committed. Keep the stored capability so a
+    // later recovery can retry revocation instead of making the public preview
+    // permanently unreachable.
+    logger.error(
+      `App ${appId} was deleted, but its temporary preview could not be revoked. The stored capability was retained for recovery.`,
+      error,
+    );
+  }
+}
+
 /**
  * Gate a relaunch on the app being back on its real database.
  *
@@ -656,10 +670,10 @@ async function deleteAppByIdExclusive(
 
         if (!app) {
           if (options.allowMissing && options.knownAppPath) {
-            await deleteTempPreviewForApp(appId);
             await appRunDeletion.seal();
             appRunDeletion.commit();
             deletionCommitted = true;
+            await cleanupDeletedAppTempPreview(appId);
             return { appPath: options.knownAppPath, doomedRow: null };
           }
           throw new DyadError("App not found", DyadErrorKind.NotFound);
@@ -686,7 +700,6 @@ async function deleteAppByIdExclusive(
         const doomedRow = await db.query.apps.findFirst({
           where: eq(apps.id, appId),
         });
-        await deleteTempPreviewForApp(appId);
         try {
           // `doomedRow` for the same reason it is re-read above: the test-user
           // id can land on the row after the first read, and deleting from the
@@ -716,6 +729,7 @@ async function deleteAppByIdExclusive(
             DyadErrorKind.External,
           );
         }
+        await cleanupDeletedAppTempPreview(appId);
         return {
           appPath: getDyadAppPath(app.path),
           doomedRow: doomedRow ?? null,

--- a/src/ipc/handlers/app_handlers.ts
+++ b/src/ipc/handlers/app_handlers.ts
@@ -176,7 +176,11 @@ import {
 } from "@/ipc/services/chat_actor_deletion_service";
 import { blockNewStreamsForApp } from "./chat_stream_handlers";
 import { beginAppChatDeletion } from "@/ipc/services/app_chat_creation_fence";
-import { deleteTempPreviewForApp } from "@/ipc/services/temp_preview_service";
+import {
+  clearTempPreviewAppDeletionMarker,
+  deleteTempPreviewForApp,
+  markTempPreviewForAppDeletion,
+} from "@/ipc/services/temp_preview_service";
 const logger = log.scope("app_handlers");
 const handle = createLoggedHandler(logger);
 
@@ -670,6 +674,7 @@ async function deleteAppByIdExclusive(
 
         if (!app) {
           if (options.allowMissing && options.knownAppPath) {
+            await markTempPreviewForAppDeletion(appId);
             await appRunDeletion.seal();
             appRunDeletion.commit();
             deletionCommitted = true;
@@ -700,6 +705,7 @@ async function deleteAppByIdExclusive(
         const doomedRow = await db.query.apps.findFirst({
           where: eq(apps.id, appId),
         });
+        let previewDeletionMarked = false;
         try {
           // `doomedRow` for the same reason it is re-read above: the test-user
           // id can land on the row after the first read, and deleting from the
@@ -712,6 +718,7 @@ async function deleteAppByIdExclusive(
               DyadErrorKind.External,
             );
           }
+          previewDeletionMarked = await markTempPreviewForAppDeletion(appId);
           await db.delete(apps).where(eq(apps.id, appId));
           appRunDeletion.commit();
           deletionCommitted = true;
@@ -723,6 +730,15 @@ async function deleteAppByIdExclusive(
             entityDisposalBus.publish({ kind: "app", id: appId });
           }
         } catch (error: any) {
+          if (previewDeletionMarked && !deletionCommitted) {
+            await clearTempPreviewAppDeletionMarker(appId).catch(
+              (markerError) =>
+                logger.error(
+                  `Failed to clear the temporary preview deletion marker for app ${appId}; startup reconciliation will repair it.`,
+                  markerError,
+                ),
+            );
+          }
           logger.error(`Error deleting app ${appId} from database:`, error);
           throw new DyadError(
             `Failed to delete app from database: ${error.message}`,

--- a/src/ipc/handlers/app_handlers.ts
+++ b/src/ipc/handlers/app_handlers.ts
@@ -423,10 +423,8 @@ async function removeAppFiles(appId: number, appPath: string): Promise<void> {
   }
 }
 
-async function cleanupDeletedAppTempPreview(appId: number): Promise<void> {
-  try {
-    await deleteTempPreviewForApp(appId);
-  } catch (error) {
+function scheduleDeletedAppTempPreviewCleanup(appId: number): void {
+  void deleteTempPreviewForApp(appId).catch((error) => {
     // The app deletion is already committed. Keep the stored capability so a
     // later recovery can retry revocation instead of making the public preview
     // permanently unreachable.
@@ -434,7 +432,7 @@ async function cleanupDeletedAppTempPreview(appId: number): Promise<void> {
       `App ${appId} was deleted, but its temporary preview could not be revoked. The stored capability was retained for recovery.`,
       error,
     );
-  }
+  });
 }
 
 /**
@@ -678,7 +676,7 @@ async function deleteAppByIdExclusive(
             await appRunDeletion.seal();
             appRunDeletion.commit();
             deletionCommitted = true;
-            await cleanupDeletedAppTempPreview(appId);
+            scheduleDeletedAppTempPreviewCleanup(appId);
             return { appPath: options.knownAppPath, doomedRow: null };
           }
           throw new DyadError("App not found", DyadErrorKind.NotFound);
@@ -745,7 +743,7 @@ async function deleteAppByIdExclusive(
             DyadErrorKind.External,
           );
         }
-        await cleanupDeletedAppTempPreview(appId);
+        scheduleDeletedAppTempPreviewCleanup(appId);
         return {
           appPath: getDyadAppPath(app.path),
           doomedRow: doomedRow ?? null,

--- a/src/ipc/handlers/app_handlers.ts
+++ b/src/ipc/handlers/app_handlers.ts
@@ -176,6 +176,7 @@ import {
 } from "@/ipc/services/chat_actor_deletion_service";
 import { blockNewStreamsForApp } from "./chat_stream_handlers";
 import { beginAppChatDeletion } from "@/ipc/services/app_chat_creation_fence";
+import { deleteTempPreviewForApp } from "@/ipc/services/temp_preview_service";
 const logger = log.scope("app_handlers");
 const handle = createLoggedHandler(logger);
 
@@ -696,6 +697,7 @@ async function deleteAppByIdExclusive(
               DyadErrorKind.External,
             );
           }
+          await deleteTempPreviewForApp(appId);
           await db.delete(apps).where(eq(apps.id, appId));
           appRunDeletion.commit();
           deletionCommitted = true;

--- a/src/ipc/handlers/app_naming_handlers.test.ts
+++ b/src/ipc/handlers/app_naming_handlers.test.ts
@@ -32,6 +32,9 @@ const createFromTemplateMock = vi.hoisted(() =>
 const deletionOrder = vi.hoisted(() => [] as string[]);
 const settleChatActorsForDeletionMock = vi.hoisted(() => vi.fn());
 const restoreAppFromTestBranchMock = vi.hoisted(() => vi.fn());
+const deleteTempPreviewForAppMock = vi.hoisted(() => vi.fn());
+const markTempPreviewForAppDeletionMock = vi.hoisted(() => vi.fn());
+const clearTempPreviewAppDeletionMarkerMock = vi.hoisted(() => vi.fn());
 
 vi.mock("electron", () => ({
   ipcMain: {
@@ -46,6 +49,19 @@ vi.mock("electron", () => ({
   },
   dialog: { showOpenDialog: vi.fn() },
 }));
+
+const electronLogMock = vi.hoisted(() => ({
+  default: {
+    scope: () => ({
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+    }),
+  },
+}));
+vi.mock("electron-log", () => electronLogMock);
+vi.mock("electron-log/main", () => electronLogMock);
 
 vi.mock("@/paths/paths", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/paths/paths")>();
@@ -79,6 +95,12 @@ vi.mock("@/ipc/handlers/createFromTemplate", () => ({
 
 vi.mock("@/ipc/handlers/gitignoreUtils", () => ({
   ensureDyadGitignored: vi.fn(async () => {}),
+}));
+
+vi.mock("@/ipc/services/temp_preview_service", () => ({
+  clearTempPreviewAppDeletionMarker: clearTempPreviewAppDeletionMarkerMock,
+  deleteTempPreviewForApp: deleteTempPreviewForAppMock,
+  markTempPreviewForAppDeletion: markTempPreviewForAppDeletionMock,
 }));
 
 vi.mock("@/ipc/handlers/chat_mode_resolution", () => ({
@@ -181,6 +203,12 @@ describe("app naming handlers", () => {
     createFromTemplateMock.mockClear();
     restoreAppFromTestBranchMock.mockReset();
     restoreAppFromTestBranchMock.mockResolvedValue(true);
+    deleteTempPreviewForAppMock.mockReset();
+    deleteTempPreviewForAppMock.mockResolvedValue(undefined);
+    markTempPreviewForAppDeletionMock.mockReset();
+    markTempPreviewForAppDeletionMock.mockResolvedValue(false);
+    clearTempPreviewAppDeletionMarkerMock.mockReset();
+    clearTempPreviewAppDeletionMarkerMock.mockResolvedValue(undefined);
     registerAppHandlers();
     registerImportHandlers();
   });
@@ -533,6 +561,31 @@ describe("app naming handlers", () => {
         "release-subagents",
         "release",
       ]);
+    });
+
+    it("does not wait for post-commit temporary preview cleanup", async () => {
+      const appId = seedAppWithFolder("Delete Me", "delete-me");
+      let finishCleanup!: () => void;
+      const cleanupPending = new Promise<void>((resolve) => {
+        finishCleanup = resolve;
+      });
+      deleteTempPreviewForAppMock.mockReturnValueOnce(cleanupPending);
+
+      const deletion = harness.invokeHandler("delete-app", { appId });
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+      const outcome = await Promise.race([
+        deletion.then(() => "finished" as const),
+        new Promise<"blocked">((resolve) => {
+          timeout = setTimeout(() => resolve("blocked"), 500);
+        }),
+      ]);
+      clearTimeout(timeout);
+      finishCleanup();
+      await deletion;
+
+      expect(outcome).toBe("finished");
+      expect(deleteTempPreviewForAppMock).toHaveBeenCalledWith(appId);
+      expect(getAppRow(appId)).toBeUndefined();
     });
   });
 

--- a/src/ipc/handlers/temp_preview_handlers.ts
+++ b/src/ipc/handlers/temp_preview_handlers.ts
@@ -1,0 +1,70 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { apps } from "@/db/schema";
+import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
+import { getDyadAppPath } from "@/paths/paths";
+import { appOperationCoordinator } from "@/ipc/services/app_operation_coordinator";
+import {
+  getTempPreviewStatus,
+  publishTempPreview,
+  revokeTempPreview,
+} from "@/ipc/services/temp_preview_service";
+import { tempPreviewContracts } from "@/ipc/types/temp_preview";
+import { createTypedHandler } from "./base";
+
+async function getApp(appId: number) {
+  const app = await db.query.apps.findFirst({ where: eq(apps.id, appId) });
+  if (!app) {
+    throw new DyadError(
+      `App with id ${appId} not found`,
+      DyadErrorKind.NotFound,
+    );
+  }
+  return app;
+}
+
+export function registerTempPreviewHandlers(): void {
+  createTypedHandler(tempPreviewContracts.getStatus, async (_, { appId }) => {
+    await getApp(appId);
+    return getTempPreviewStatus(appId);
+  });
+
+  createTypedHandler(tempPreviewContracts.publish, async (_, { appId }) => {
+    return appOperationCoordinator.run(
+      {
+        appId,
+        operation: "publish temporary preview",
+        resources: [
+          { resource: "app-path", mode: "read" },
+          { resource: "runtime-config", mode: "read" },
+          { resource: "repository-worktree", mode: "write" },
+          "provider",
+        ],
+        refuseWhenRecording: "publish a temporary preview",
+      },
+      async () => {
+        const app = await getApp(appId);
+        return publishTempPreview({
+          appId,
+          appPath: getDyadAppPath(app.path),
+          appName: app.name,
+        });
+      },
+    );
+  });
+
+  createTypedHandler(tempPreviewContracts.revoke, async (_, { appId }) => {
+    return appOperationCoordinator.run(
+      {
+        appId,
+        operation: "revoke temporary preview",
+        resources: ["provider"],
+        refuseWhenRecording: "revoke a temporary preview",
+      },
+      async () => {
+        await getApp(appId);
+        return revokeTempPreview(appId);
+      },
+    );
+  });
+}

--- a/src/ipc/ipc_host.ts
+++ b/src/ipc/ipc_host.ts
@@ -57,6 +57,7 @@ import { registerWindowInfrastructureHandlers } from "./handlers/window_infrastr
 import { registerDistributedMachineHandlers } from "./handlers/distributed_machine_handlers";
 import { registerImageGenerationHandlers } from "./handlers/image_generation_handlers";
 import { registerCoolifyHandlers } from "./handlers/coolify_handlers";
+import { registerTempPreviewHandlers } from "./handlers/temp_preview_handlers";
 
 export function registerIpcHandlers() {
   // Register all IPC handlers by category
@@ -119,4 +120,5 @@ export function registerIpcHandlers() {
   registerDistributedMachineHandlers();
   registerImageGenerationHandlers();
   registerCoolifyHandlers();
+  registerTempPreviewHandlers();
 }

--- a/src/ipc/services/temp_preview_cleanup_reconciler.test.ts
+++ b/src/ipc/services/temp_preview_cleanup_reconciler.test.ts
@@ -34,6 +34,7 @@ vi.mock("./temp_preview_service", () => ({
 }));
 
 import { reconcilePendingTempPreviewDeletions } from "./temp_preview_cleanup_reconciler";
+import { appOperationCoordinator } from "./app_operation_coordinator";
 
 describe("reconcilePendingTempPreviewDeletions", () => {
   beforeEach(() => {
@@ -67,6 +68,25 @@ describe("reconcilePendingTempPreviewDeletions", () => {
 
     expect(mocks.deletePreview).toHaveBeenCalledTimes(2);
     expect(mocks.clearMarker).not.toHaveBeenCalled();
+    expect(mocks.logWarn).toHaveBeenCalledWith(
+      expect.stringContaining("durable marker and capability remain for retry"),
+      expect.any(Error),
+    );
+  });
+
+  it("does not clear a marker while app deletion owns the app", async () => {
+    mocks.listPending.mockResolvedValue([7, 8]);
+    mocks.findApp.mockResolvedValue(null);
+    const deletion = appOperationCoordinator.beginAppDeletion(7);
+    try {
+      await reconcilePendingTempPreviewDeletions();
+    } finally {
+      deletion.release();
+    }
+
+    expect(mocks.clearMarker).not.toHaveBeenCalledWith(7);
+    expect(mocks.deletePreview).not.toHaveBeenCalledWith(7);
+    expect(mocks.deletePreview).toHaveBeenCalledWith(8);
     expect(mocks.logWarn).toHaveBeenCalledWith(
       expect.stringContaining("durable marker and capability remain for retry"),
       expect.any(Error),

--- a/src/ipc/services/temp_preview_cleanup_reconciler.test.ts
+++ b/src/ipc/services/temp_preview_cleanup_reconciler.test.ts
@@ -1,0 +1,87 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  clearMarker: vi.fn(),
+  deletePreview: vi.fn(),
+  findApp: vi.fn(),
+  listPending: vi.fn(),
+  logError: vi.fn(),
+  logInfo: vi.fn(),
+  logWarn: vi.fn(),
+}));
+
+vi.mock("electron-log", () => ({
+  default: {
+    scope: () => ({
+      error: mocks.logError,
+      info: mocks.logInfo,
+      warn: mocks.logWarn,
+    }),
+  },
+}));
+
+vi.mock("drizzle-orm", () => ({ eq: vi.fn(() => "where") }));
+vi.mock("@/db", () => ({
+  db: { query: { apps: { findFirst: mocks.findApp } } },
+}));
+vi.mock("@/db/schema", () => ({ apps: { id: "id" } }));
+vi.mock("./temp_preview_service", () => ({
+  clearTempPreviewAppDeletionMarker: mocks.clearMarker,
+  deleteTempPreviewForApp: mocks.deletePreview,
+  listPendingTempPreviewDeletionAppIds: mocks.listPending,
+}));
+
+import { reconcilePendingTempPreviewDeletions } from "./temp_preview_cleanup_reconciler";
+
+describe("reconcilePendingTempPreviewDeletions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.clearMarker.mockResolvedValue(undefined);
+    mocks.deletePreview.mockResolvedValue(undefined);
+    mocks.listPending.mockResolvedValue([]);
+  });
+
+  it("clears aborted markers for live apps and revokes previews for deleted apps", async () => {
+    mocks.listPending.mockResolvedValue([7, 8]);
+    mocks.findApp.mockResolvedValueOnce({ id: 7 }).mockResolvedValueOnce(null);
+
+    await reconcilePendingTempPreviewDeletions();
+
+    expect(mocks.clearMarker).toHaveBeenCalledWith(7);
+    expect(mocks.deletePreview).toHaveBeenCalledWith(8);
+    expect(mocks.deletePreview).not.toHaveBeenCalledWith(7);
+  });
+
+  it("retains a failed cleanup marker and continues reconciling", async () => {
+    mocks.listPending.mockResolvedValue([7, 8]);
+    mocks.findApp.mockResolvedValue(null);
+    mocks.deletePreview
+      .mockRejectedValueOnce(new Error("temp.md unavailable"))
+      .mockResolvedValueOnce(undefined);
+
+    await expect(
+      reconcilePendingTempPreviewDeletions(),
+    ).resolves.toBeUndefined();
+
+    expect(mocks.deletePreview).toHaveBeenCalledTimes(2);
+    expect(mocks.clearMarker).not.toHaveBeenCalled();
+    expect(mocks.logWarn).toHaveBeenCalledWith(
+      expect.stringContaining("durable marker and capability remain for retry"),
+      expect.any(Error),
+    );
+  });
+
+  it("runs from main only after database initialization", () => {
+    const mainSource = readFileSync(
+      resolve(process.cwd(), "src/main.ts"),
+      "utf8",
+    );
+
+    expect(mainSource.indexOf("initializeDatabase();")).toBeGreaterThan(-1);
+    expect(
+      mainSource.indexOf("reconcilePendingTempPreviewDeletions()"),
+    ).toBeGreaterThan(mainSource.indexOf("initializeDatabase();"));
+  });
+});

--- a/src/ipc/services/temp_preview_cleanup_reconciler.ts
+++ b/src/ipc/services/temp_preview_cleanup_reconciler.ts
@@ -1,0 +1,56 @@
+import log from "electron-log";
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { apps } from "@/db/schema";
+import {
+  clearTempPreviewAppDeletionMarker,
+  deleteTempPreviewForApp,
+  listPendingTempPreviewDeletionAppIds,
+} from "./temp_preview_service";
+
+const logger = log.scope("temp_preview_cleanup_reconciler");
+
+/**
+ * Retries preview revocation left behind by a crash or transient temp.md
+ * failure during app deletion. A marker created before the database delete is
+ * cleared when the app row still exists; otherwise the stored capability is
+ * used to finish remote cleanup and is removed only after success.
+ */
+export async function reconcilePendingTempPreviewDeletions(): Promise<void> {
+  let appIds: number[];
+  try {
+    appIds = await listPendingTempPreviewDeletionAppIds();
+  } catch (error) {
+    logger.error(
+      "Failed to read pending temporary preview deletion markers",
+      error,
+    );
+    return;
+  }
+
+  for (const appId of appIds) {
+    try {
+      const app = await db.query.apps.findFirst({
+        where: eq(apps.id, appId),
+        columns: { id: true },
+      });
+      if (app) {
+        await clearTempPreviewAppDeletionMarker(appId);
+        logger.info(
+          `Cleared stale temporary preview deletion marker for live app ${appId}`,
+        );
+        continue;
+      }
+
+      await deleteTempPreviewForApp(appId);
+      logger.info(
+        `Reconciled temporary preview cleanup for deleted app ${appId}`,
+      );
+    } catch (error) {
+      logger.warn(
+        `Failed to reconcile temporary preview cleanup for app ${appId}; the durable marker and capability remain for retry.`,
+        error,
+      );
+    }
+  }
+}

--- a/src/ipc/services/temp_preview_cleanup_reconciler.ts
+++ b/src/ipc/services/temp_preview_cleanup_reconciler.ts
@@ -2,6 +2,7 @@ import log from "electron-log";
 import { eq } from "drizzle-orm";
 import { db } from "@/db";
 import { apps } from "@/db/schema";
+import { appOperationCoordinator } from "./app_operation_coordinator";
 import {
   clearTempPreviewAppDeletionMarker,
   deleteTempPreviewForApp,
@@ -30,21 +31,30 @@ export async function reconcilePendingTempPreviewDeletions(): Promise<void> {
 
   for (const appId of appIds) {
     try {
-      const app = await db.query.apps.findFirst({
-        where: eq(apps.id, appId),
-        columns: { id: true },
-      });
-      if (app) {
-        await clearTempPreviewAppDeletionMarker(appId);
-        logger.info(
-          `Cleared stale temporary preview deletion marker for live app ${appId}`,
-        );
-        continue;
-      }
+      await appOperationCoordinator.run(
+        {
+          appId,
+          operation: "reconcile temporary preview deletion",
+          resources: ["provider"],
+        },
+        async () => {
+          const app = await db.query.apps.findFirst({
+            where: eq(apps.id, appId),
+            columns: { id: true },
+          });
+          if (app) {
+            await clearTempPreviewAppDeletionMarker(appId);
+            logger.info(
+              `Cleared stale temporary preview deletion marker for live app ${appId}`,
+            );
+            return;
+          }
 
-      await deleteTempPreviewForApp(appId);
-      logger.info(
-        `Reconciled temporary preview cleanup for deleted app ${appId}`,
+          await deleteTempPreviewForApp(appId);
+          logger.info(
+            `Reconciled temporary preview cleanup for deleted app ${appId}`,
+          );
+        },
       );
     } catch (error) {
       logger.warn(

--- a/src/ipc/services/temp_preview_safe_error.test.ts
+++ b/src/ipc/services/temp_preview_safe_error.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { safeTempPreviewErrorMessage } from "./temp_preview_safe_error";
+
+describe("safeTempPreviewErrorMessage", () => {
+  it("redacts build paths and credentials before presentation", () => {
+    const result = safeTempPreviewErrorMessage(
+      new Error(
+        "Build failed at '/Users/alice/Client Project/.env'\nAuthorization: Bearer private-token-value-12345",
+      ),
+    );
+
+    expect(result).toContain("Build failed");
+    expect(result).not.toContain("alice");
+    expect(result).not.toContain("Client Project");
+    expect(result).not.toContain("private-token-value-12345");
+  });
+
+  it("redacts upstream URLs and bounds oversized messages", () => {
+    const result = safeTempPreviewErrorMessage(
+      new Error(
+        `temp.md failed at https://internal.corp/upload?token=secret ${"x".repeat(50_000)}`,
+      ),
+    );
+
+    expect(result).not.toContain("internal.corp");
+    expect(result).not.toContain("token=secret");
+    expect(result.length).toBeLessThan(20_000);
+  });
+});

--- a/src/ipc/services/temp_preview_safe_error.ts
+++ b/src/ipc/services/temp_preview_safe_error.ts
@@ -1,0 +1,13 @@
+import { safeGithubOpsErrorMessage } from "./github_ops_safe_error";
+
+/**
+ * Build output and upstream API messages are untrusted renderer/telemetry
+ * input. Reuse the bounded main-process projection that redacts credentials,
+ * local paths, private remotes, identities, URLs, and internal hosts.
+ */
+export function safeTempPreviewErrorMessage(
+  error: unknown,
+  fallback = "Temporary preview failed.",
+): string {
+  return safeGithubOpsErrorMessage(error, fallback);
+}

--- a/src/ipc/services/temp_preview_service.test.ts
+++ b/src/ipc/services/temp_preview_service.test.ts
@@ -79,6 +79,7 @@ import {
 } from "./temp_preview_service";
 import { TempmdApiError } from "@/temp_preview/client";
 import { TempPreviewStoreUnreadableError } from "@/temp_preview/store";
+import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
 
 const roots: string[] = [];
 
@@ -138,8 +139,54 @@ describe("temp preview service", () => {
 
     await expect(
       publishTempPreview({ appId: 7, appPath, appName: "Demo" }),
-    ).rejects.toBe(persistenceError);
+    ).rejects.toMatchObject({
+      kind: DyadErrorKind.Unknown,
+      message: "disk full",
+      cause: undefined,
+    });
     expect(mocks.revoke).toHaveBeenCalledWith(published);
+  });
+
+  it("sanitizes build failures before returning them", async () => {
+    const appPath = await createApp();
+    mocks.simpleSpawn.mockRejectedValue(
+      new DyadError(
+        "Build failed in /Users/alice/Client-App with API_KEY=private-value",
+        DyadErrorKind.External,
+      ),
+    );
+
+    const error = await publishTempPreview({
+      appId: 7,
+      appPath,
+      appName: "Demo",
+    }).catch((caught) => caught);
+
+    expect(error).toMatchObject({
+      kind: DyadErrorKind.External,
+      cause: undefined,
+    });
+    expect(error.message).not.toMatch(/alice|private-value/);
+  });
+
+  it("sanitizes temp.md failures before returning them", async () => {
+    const appPath = await createApp();
+    mocks.publish.mockRejectedValue(
+      new TempmdApiError(
+        "Upload failed at https://private.internal/path?token=secret-value",
+        500,
+        undefined,
+        "session",
+      ),
+    );
+
+    await expect(
+      publishTempPreview({ appId: 7, appPath, appName: "Demo" }),
+    ).rejects.toMatchObject({
+      kind: DyadErrorKind.External,
+      cause: undefined,
+      message: expect.not.stringMatching(/private\.internal|secret-value/),
+    });
   });
 
   it("surfaces an unreadable capability without treating the preview as absent", async () => {

--- a/src/ipc/services/temp_preview_service.test.ts
+++ b/src/ipc/services/temp_preview_service.test.ts
@@ -296,21 +296,22 @@ describe("temp preview service", () => {
     expect(mocks.revoke).toHaveBeenCalledWith(updated);
   });
 
-  it("does not revoke an update when its stored capability remains valid", async () => {
+  it("revokes a same-capability update when renewed metadata cannot be persisted", async () => {
     const appPath = await createApp();
     mocks.storeRead.mockResolvedValue(previousRecord);
-    mocks.publish.mockResolvedValue({
+    const updated = {
       ...published,
       tempId: previousRecord.tempId,
       canonicalUrl: previousRecord.canonicalUrl,
       updateToken: previousRecord.updateToken,
-    });
+    };
+    mocks.publish.mockResolvedValue(updated);
     mocks.storeWrite.mockRejectedValueOnce(new Error("disk full"));
 
     await expect(
       publishTempPreview({ appId: 7, appPath, appName: "Demo" }),
     ).rejects.toThrow("disk full");
-    expect(mocks.revoke).not.toHaveBeenCalled();
+    expect(mocks.revoke).toHaveBeenCalledWith(updated);
   });
 
   it("retires a stale connection and creates a fresh preview", async () => {

--- a/src/ipc/services/temp_preview_service.test.ts
+++ b/src/ipc/services/temp_preview_service.test.ts
@@ -279,13 +279,31 @@ describe("temp preview service", () => {
     });
   });
 
-  it("does not revoke an existing preview when an update cannot be persisted", async () => {
+  it("revokes an update when its replacement capability cannot be persisted", async () => {
+    const appPath = await createApp();
+    mocks.storeRead.mockResolvedValue(previousRecord);
+    const updated = {
+      ...published,
+      tempId: previousRecord.tempId,
+      canonicalUrl: previousRecord.canonicalUrl,
+    };
+    mocks.publish.mockResolvedValue(updated);
+    mocks.storeWrite.mockRejectedValueOnce(new Error("disk full"));
+
+    await expect(
+      publishTempPreview({ appId: 7, appPath, appName: "Demo" }),
+    ).rejects.toThrow("disk full");
+    expect(mocks.revoke).toHaveBeenCalledWith(updated);
+  });
+
+  it("does not revoke an update when its stored capability remains valid", async () => {
     const appPath = await createApp();
     mocks.storeRead.mockResolvedValue(previousRecord);
     mocks.publish.mockResolvedValue({
       ...published,
       tempId: previousRecord.tempId,
       canonicalUrl: previousRecord.canonicalUrl,
+      updateToken: previousRecord.updateToken,
     });
     mocks.storeWrite.mockRejectedValueOnce(new Error("disk full"));
 

--- a/src/ipc/services/temp_preview_service.test.ts
+++ b/src/ipc/services/temp_preview_service.test.ts
@@ -42,13 +42,17 @@ vi.mock("@/temp_preview/bundle", () => ({
   discoverTempPreviewBundle: mocks.discoverBundle,
 }));
 
-vi.mock("@/temp_preview/store", () => ({
-  TempPreviewStore: class {
-    read = mocks.storeRead;
-    remove = mocks.storeRemove;
-    write = mocks.storeWrite;
-  },
-}));
+vi.mock("@/temp_preview/store", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/temp_preview/store")>();
+  return {
+    ...actual,
+    TempPreviewStore: class {
+      read = mocks.storeRead;
+      remove = mocks.storeRemove;
+      write = mocks.storeWrite;
+    },
+  };
+});
 
 vi.mock("@/temp_preview/client", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/temp_preview/client")>();
@@ -63,10 +67,12 @@ vi.mock("@/temp_preview/client", async (importOriginal) => {
 
 import {
   deleteTempPreviewForApp,
+  getTempPreviewStatus,
   publishTempPreview,
   revokeTempPreview,
 } from "./temp_preview_service";
 import { TempmdApiError } from "@/temp_preview/client";
+import { TempPreviewStoreUnreadableError } from "@/temp_preview/store";
 
 const roots: string[] = [];
 
@@ -125,6 +131,20 @@ describe("temp preview service", () => {
       publishTempPreview({ appId: 7, appPath, appName: "Demo" }),
     ).rejects.toBe(persistenceError);
     expect(mocks.revoke).toHaveBeenCalledWith(published);
+  });
+
+  it("surfaces an unreadable capability without treating the preview as absent", async () => {
+    mocks.storeRead.mockRejectedValue(
+      new TempPreviewStoreUnreadableError(7, {
+        cause: new Error("keychain unavailable"),
+      }),
+    );
+
+    await expect(getTempPreviewStatus(7)).rejects.toMatchObject({
+      message: expect.stringContaining(
+        "encrypted capability has been preserved",
+      ),
+    });
   });
 
   it("does not revoke an existing preview when an update cannot be persisted", async () => {
@@ -225,6 +245,21 @@ describe("temp preview service", () => {
     );
 
     await expect(deleteTempPreviewForApp(7)).rejects.toThrow("unavailable");
+    expect(mocks.storeRemove).not.toHaveBeenCalled();
+  });
+
+  it("does not remove an undecryptable capability during app deletion", async () => {
+    mocks.storeRead.mockRejectedValue(
+      new TempPreviewStoreUnreadableError(7, {
+        cause: new Error("keychain unavailable"),
+      }),
+    );
+
+    await expect(deleteTempPreviewForApp(7)).rejects.toMatchObject({
+      message: expect.stringContaining(
+        "encrypted capability has been preserved",
+      ),
+    });
     expect(mocks.storeRemove).not.toHaveBeenCalled();
   });
 

--- a/src/ipc/services/temp_preview_service.test.ts
+++ b/src/ipc/services/temp_preview_service.test.ts
@@ -296,7 +296,7 @@ describe("temp preview service", () => {
     expect(mocks.revoke).toHaveBeenCalledWith(updated);
   });
 
-  it("revokes a same-capability update when renewed metadata cannot be persisted", async () => {
+  it("keeps a same-capability update recoverable when renewed metadata cannot be persisted", async () => {
     const appPath = await createApp();
     mocks.storeRead.mockResolvedValue(previousRecord);
     const updated = {
@@ -311,7 +311,29 @@ describe("temp preview service", () => {
     await expect(
       publishTempPreview({ appId: 7, appPath, appName: "Demo" }),
     ).rejects.toThrow("disk full");
-    expect(mocks.revoke).toHaveBeenCalledWith(updated);
+    expect(mocks.revoke).not.toHaveBeenCalled();
+  });
+
+  it("reuses an expired stored capability for remote reconciliation", async () => {
+    const appPath = await createApp();
+    const expiredRecord = {
+      ...previousRecord,
+      expiresAt: "2026-08-01T00:00:00.000Z",
+    };
+    mocks.storeRead.mockResolvedValue(expiredRecord);
+
+    await publishTempPreview({ appId: 7, appPath, appName: "Demo" });
+
+    expect(mocks.publish).toHaveBeenCalledWith({
+      files: [],
+      title: "Demo",
+      previous: {
+        tempId: expiredRecord.tempId,
+        canonicalUrl: expiredRecord.canonicalUrl,
+        updateToken: expiredRecord.updateToken,
+        expiresAt: expiredRecord.expiresAt,
+      },
+    });
   });
 
   it("retires a stale connection and creates a fresh preview", async () => {

--- a/src/ipc/services/temp_preview_service.test.ts
+++ b/src/ipc/services/temp_preview_service.test.ts
@@ -11,6 +11,9 @@ const mocks = vi.hoisted(() => ({
   simpleSpawn: vi.fn(),
   storeRead: vi.fn(),
   storeRemove: vi.fn(),
+  storeMarkPendingDeletion: vi.fn(),
+  storeClearPendingDeletion: vi.fn(),
+  storeListPendingDeletionAppIds: vi.fn(),
   storeWrite: vi.fn(),
 }));
 
@@ -49,6 +52,9 @@ vi.mock("@/temp_preview/store", async (importOriginal) => {
     TempPreviewStore: class {
       read = mocks.storeRead;
       remove = mocks.storeRemove;
+      markPendingDeletion = mocks.storeMarkPendingDeletion;
+      clearPendingDeletion = mocks.storeClearPendingDeletion;
+      listPendingDeletionAppIds = mocks.storeListPendingDeletionAppIds;
       write = mocks.storeWrite;
     },
   };
@@ -113,6 +119,9 @@ describe("temp preview service", () => {
     mocks.simpleSpawn.mockResolvedValue(undefined);
     mocks.storeRead.mockResolvedValue(null);
     mocks.storeRemove.mockResolvedValue(undefined);
+    mocks.storeMarkPendingDeletion.mockResolvedValue(false);
+    mocks.storeClearPendingDeletion.mockResolvedValue(undefined);
+    mocks.storeListPendingDeletionAppIds.mockResolvedValue([]);
     mocks.storeWrite.mockResolvedValue(undefined);
   });
 

--- a/src/ipc/services/temp_preview_service.test.ts
+++ b/src/ipc/services/temp_preview_service.test.ts
@@ -167,6 +167,9 @@ describe("temp preview service", () => {
       cause: undefined,
     });
     expect(error.message).not.toMatch(/alice|private-value/);
+    expect(mocks.simpleSpawn).toHaveBeenCalledWith(
+      expect.objectContaining({ logOutput: false }),
+    );
   });
 
   it("sanitizes temp.md failures before returning them", async () => {

--- a/src/ipc/services/temp_preview_service.test.ts
+++ b/src/ipc/services/temp_preview_service.test.ts
@@ -1,0 +1,181 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TempPreviewRecord } from "@/temp_preview/store";
+
+const mocks = vi.hoisted(() => ({
+  discoverBundle: vi.fn(),
+  publish: vi.fn(),
+  revoke: vi.fn(),
+  simpleSpawn: vi.fn(),
+  storeRead: vi.fn(),
+  storeWrite: vi.fn(),
+}));
+
+vi.mock("@/ipc/utils/simpleSpawn", () => ({
+  simpleSpawn: mocks.simpleSpawn,
+}));
+
+vi.mock("@/ipc/utils/socket_firewall", () => ({
+  getPnpmMinimumReleaseAgeSupport: vi
+    .fn()
+    .mockResolvedValue({ available: true }),
+  getPackageManagerCommandEnv: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock("@/ipc/utils/package_manager_selection", () => ({
+  choosePackageManagerForApp: vi.fn().mockReturnValue("npm"),
+}));
+
+vi.mock("@/main/settings", () => ({
+  encrypt: vi.fn((value: string) => ({ value })),
+  decrypt: vi.fn((secret: { value: string }) => secret.value),
+}));
+
+vi.mock("@/paths/paths", () => ({
+  getUserDataPath: vi.fn().mockReturnValue("/tmp/dyad-test-user-data"),
+}));
+
+vi.mock("@/temp_preview/bundle", () => ({
+  discoverTempPreviewBundle: mocks.discoverBundle,
+}));
+
+vi.mock("@/temp_preview/store", () => ({
+  TempPreviewStore: class {
+    read = mocks.storeRead;
+    write = mocks.storeWrite;
+  },
+}));
+
+vi.mock("@/temp_preview/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/temp_preview/client")>();
+  return {
+    ...actual,
+    TempmdClient: class {
+      publish = mocks.publish;
+      revoke = mocks.revoke;
+    },
+  };
+});
+
+import { publishTempPreview, revokeTempPreview } from "./temp_preview_service";
+import { TempmdApiError } from "@/temp_preview/client";
+
+const roots: string[] = [];
+
+async function createApp(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "dyad-temp-preview-service-"));
+  roots.push(root);
+  await mkdir(join(root, "dist"));
+  await writeFile(
+    join(root, "package.json"),
+    JSON.stringify({ scripts: { build: "vite build" } }),
+    "utf8",
+  );
+  return root;
+}
+
+const previousRecord: TempPreviewRecord = {
+  tempId: "old-temp",
+  canonicalUrl: "https://old.temp.md",
+  updateToken: "old-token",
+  expiresAt: null,
+  lastPublishedAt: "2026-08-23T00:00:00.000Z",
+  state: "active",
+};
+
+const published = {
+  tempId: "new-temp",
+  canonicalUrl: "https://new.temp.md",
+  updateToken: "new-token",
+  expiresAt: "2026-08-30T00:00:00.000Z",
+};
+
+describe("temp preview service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.discoverBundle.mockResolvedValue([]);
+    mocks.publish.mockResolvedValue(published);
+    mocks.revoke.mockResolvedValue(undefined);
+    mocks.simpleSpawn.mockResolvedValue(undefined);
+    mocks.storeRead.mockResolvedValue(null);
+    mocks.storeWrite.mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    await Promise.all(
+      roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+    );
+  });
+
+  it("best-effort revokes a new preview when local persistence fails", async () => {
+    const appPath = await createApp();
+    const persistenceError = new Error("disk full");
+    mocks.storeWrite.mockRejectedValueOnce(persistenceError);
+
+    await expect(
+      publishTempPreview({ appId: 7, appPath, appName: "Demo" }),
+    ).rejects.toBe(persistenceError);
+    expect(mocks.revoke).toHaveBeenCalledWith(published);
+  });
+
+  it("does not revoke an existing preview when an update cannot be persisted", async () => {
+    const appPath = await createApp();
+    mocks.storeRead.mockResolvedValue(previousRecord);
+    mocks.publish.mockResolvedValue({
+      ...published,
+      tempId: previousRecord.tempId,
+      canonicalUrl: previousRecord.canonicalUrl,
+    });
+    mocks.storeWrite.mockRejectedValueOnce(new Error("disk full"));
+
+    await expect(
+      publishTempPreview({ appId: 7, appPath, appName: "Demo" }),
+    ).rejects.toThrow("disk full");
+    expect(mocks.revoke).not.toHaveBeenCalled();
+  });
+
+  it("retires a stale connection and creates a fresh preview", async () => {
+    const appPath = await createApp();
+    mocks.storeRead.mockResolvedValue(previousRecord);
+    mocks.publish
+      .mockRejectedValueOnce(new TempmdApiError("gone", 410))
+      .mockResolvedValueOnce(published);
+
+    await expect(
+      publishTempPreview({ appId: 7, appPath, appName: "Demo" }),
+    ).resolves.toMatchObject({
+      state: "active",
+      canonicalUrl: published.canonicalUrl,
+    });
+    expect(mocks.publish).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        previous: expect.objectContaining({ tempId: "old-temp" }),
+      }),
+    );
+    expect(mocks.publish).toHaveBeenNthCalledWith(
+      2,
+      expect.not.objectContaining({ previous: expect.anything() }),
+    );
+    expect(mocks.storeWrite).toHaveBeenNthCalledWith(
+      1,
+      7,
+      expect.objectContaining({ state: "revoked", updateToken: undefined }),
+    );
+  });
+
+  it("reconciles an already-missing remote preview as revoked", async () => {
+    mocks.storeRead.mockResolvedValue(previousRecord);
+    mocks.revoke.mockRejectedValue(new TempmdApiError("not found", 404));
+
+    await expect(revokeTempPreview(7)).resolves.toMatchObject({
+      state: "revoked",
+    });
+    expect(mocks.storeWrite).toHaveBeenCalledWith(
+      7,
+      expect.objectContaining({ state: "revoked", updateToken: undefined }),
+    );
+  });
+});

--- a/src/ipc/services/temp_preview_service.test.ts
+++ b/src/ipc/services/temp_preview_service.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   revoke: vi.fn(),
   simpleSpawn: vi.fn(),
   storeRead: vi.fn(),
+  storeRemove: vi.fn(),
   storeWrite: vi.fn(),
 }));
 
@@ -44,6 +45,7 @@ vi.mock("@/temp_preview/bundle", () => ({
 vi.mock("@/temp_preview/store", () => ({
   TempPreviewStore: class {
     read = mocks.storeRead;
+    remove = mocks.storeRemove;
     write = mocks.storeWrite;
   },
 }));
@@ -59,7 +61,11 @@ vi.mock("@/temp_preview/client", async (importOriginal) => {
   };
 });
 
-import { publishTempPreview, revokeTempPreview } from "./temp_preview_service";
+import {
+  deleteTempPreviewForApp,
+  publishTempPreview,
+  revokeTempPreview,
+} from "./temp_preview_service";
 import { TempmdApiError } from "@/temp_preview/client";
 
 const roots: string[] = [];
@@ -100,6 +106,7 @@ describe("temp preview service", () => {
     mocks.revoke.mockResolvedValue(undefined);
     mocks.simpleSpawn.mockResolvedValue(undefined);
     mocks.storeRead.mockResolvedValue(null);
+    mocks.storeRemove.mockResolvedValue(undefined);
     mocks.storeWrite.mockResolvedValue(undefined);
   });
 
@@ -195,5 +202,39 @@ describe("temp preview service", () => {
       7,
       expect.objectContaining({ state: "revoked", updateToken: undefined }),
     );
+  });
+
+  it("revokes and removes an active preview before app deletion", async () => {
+    mocks.storeRead.mockResolvedValue(previousRecord);
+
+    await expect(deleteTempPreviewForApp(7)).resolves.toBeUndefined();
+
+    expect(mocks.revoke).toHaveBeenCalledWith(
+      expect.objectContaining({ tempId: previousRecord.tempId }),
+    );
+    expect(mocks.storeRemove).toHaveBeenCalledWith(7);
+    expect(mocks.storeRemove.mock.invocationCallOrder[0]).toBeGreaterThan(
+      mocks.revoke.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("does not remove deletion state when remote revocation fails", async () => {
+    mocks.storeRead.mockResolvedValue(previousRecord);
+    mocks.revoke.mockRejectedValue(
+      new TempmdApiError("unavailable", 503, undefined, "revoke"),
+    );
+
+    await expect(deleteTempPreviewForApp(7)).rejects.toThrow("unavailable");
+    expect(mocks.storeRemove).not.toHaveBeenCalled();
+  });
+
+  it("removes deletion state when the remote preview is already gone", async () => {
+    mocks.storeRead.mockResolvedValue(previousRecord);
+    mocks.revoke.mockRejectedValue(
+      new TempmdApiError("gone", 410, undefined, "revoke"),
+    );
+
+    await expect(deleteTempPreviewForApp(7)).resolves.toBeUndefined();
+    expect(mocks.storeRemove).toHaveBeenCalledWith(7);
   });
 });

--- a/src/ipc/services/temp_preview_service.test.ts
+++ b/src/ipc/services/temp_preview_service.test.ts
@@ -188,6 +188,38 @@ describe("temp preview service", () => {
     expect(mocks.revoke).toHaveBeenCalledWith(published);
   });
 
+  it("derives the seven-day expiry when temp.md omits it", async () => {
+    const appPath = await createApp();
+    mocks.publish.mockResolvedValueOnce({ ...published, expiresAt: null });
+
+    const status = await publishTempPreview({
+      appId: 7,
+      appPath,
+      appName: "Demo",
+    });
+
+    expect(status).toMatchObject({ state: "active" });
+    const storedRecord = mocks.storeWrite.mock.calls[0][1];
+    expect(status.expiresAt).toBe(storedRecord.expiresAt);
+    expect(Date.parse(storedRecord.expiresAt)).toBe(
+      Date.parse(storedRecord.lastPublishedAt) + 7 * 24 * 60 * 60 * 1_000,
+    );
+  });
+
+  it("expires a stored preview seven days after publish when expiry is missing", async () => {
+    mocks.storeRead.mockResolvedValueOnce({
+      ...previousRecord,
+      lastPublishedAt: new Date(
+        Date.now() - 8 * 24 * 60 * 60 * 1_000,
+      ).toISOString(),
+    });
+
+    await expect(getTempPreviewStatus(7)).resolves.toMatchObject({
+      state: "expired",
+      expiresAt: expect.any(String),
+    });
+  });
+
   it("sanitizes build failures before returning them", async () => {
     const appPath = await createApp();
     mocks.simpleSpawn.mockRejectedValue(

--- a/src/ipc/services/temp_preview_service.test.ts
+++ b/src/ipc/services/temp_preview_service.test.ts
@@ -140,7 +140,9 @@ describe("temp preview service", () => {
     const appPath = await createApp();
     mocks.storeRead.mockResolvedValue(previousRecord);
     mocks.publish
-      .mockRejectedValueOnce(new TempmdApiError("gone", 410))
+      .mockRejectedValueOnce(
+        new TempmdApiError("gone", 410, undefined, "session"),
+      )
       .mockResolvedValueOnce(published);
 
     await expect(
@@ -166,9 +168,25 @@ describe("temp preview service", () => {
     );
   });
 
-  it("reconciles an already-missing remote preview as revoked", async () => {
+  it("does not create a second preview when update finalization fails", async () => {
+    const appPath = await createApp();
     mocks.storeRead.mockResolvedValue(previousRecord);
-    mocks.revoke.mockRejectedValue(new TempmdApiError("not found", 404));
+    mocks.publish.mockRejectedValue(
+      new TempmdApiError("finalize failed", 410, undefined, "finalize"),
+    );
+
+    await expect(
+      publishTempPreview({ appId: 7, appPath, appName: "Demo" }),
+    ).rejects.toThrow("finalize failed");
+    expect(mocks.publish).toHaveBeenCalledTimes(1);
+    expect(mocks.storeWrite).not.toHaveBeenCalled();
+  });
+
+  it("reconciles an already-revoked remote capability locally", async () => {
+    mocks.storeRead.mockResolvedValue(previousRecord);
+    mocks.revoke.mockRejectedValue(
+      new TempmdApiError("revoked", 403, undefined, "revoke"),
+    );
 
     await expect(revokeTempPreview(7)).resolves.toMatchObject({
       state: "revoked",

--- a/src/ipc/services/temp_preview_service.test.ts
+++ b/src/ipc/services/temp_preview_service.test.ts
@@ -72,8 +72,11 @@ vi.mock("@/temp_preview/client", async (importOriginal) => {
 });
 
 import {
+  clearTempPreviewAppDeletionMarker,
   deleteTempPreviewForApp,
   getTempPreviewStatus,
+  listPendingTempPreviewDeletionAppIds,
+  markTempPreviewForAppDeletion,
   publishTempPreview,
   revokeTempPreview,
 } from "./temp_preview_service";
@@ -130,6 +133,44 @@ describe("temp preview service", () => {
     await Promise.all(
       roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
     );
+  });
+
+  it("sanitizes deletion-marker store failures", async () => {
+    const operations = [
+      {
+        storeMethod: mocks.storeMarkPendingDeletion,
+        invoke: () => markTempPreviewForAppDeletion(7),
+      },
+      {
+        storeMethod: mocks.storeClearPendingDeletion,
+        invoke: () => clearTempPreviewAppDeletionMarker(7),
+      },
+      {
+        storeMethod: mocks.storeListPendingDeletionAppIds,
+        invoke: () => listPendingTempPreviewDeletionAppIds(),
+      },
+    ];
+
+    for (const { storeMethod, invoke } of operations) {
+      storeMethod.mockRejectedValueOnce(
+        Object.assign(
+          new Error(
+            "EACCES: permission denied, open '/Users/alice/Library/Application Support/Dyad/temp-preview-connections.json'",
+          ),
+          { code: "EACCES" },
+        ),
+      );
+
+      const error = await invoke().catch((caught) => caught);
+
+      expect(error).toMatchObject({
+        kind: DyadErrorKind.Unknown,
+        cause: undefined,
+      });
+      expect(error.message).not.toMatch(
+        /alice|Application Support|temp-preview-connections/,
+      );
+    }
   });
 
   it("best-effort revokes a new preview when local persistence fails", async () => {

--- a/src/ipc/services/temp_preview_service.ts
+++ b/src/ipc/services/temp_preview_service.ts
@@ -16,7 +16,11 @@ import {
   TempmdClient,
   type TempPreviewConnection,
 } from "@/temp_preview/client";
-import { TempPreviewStore, type TempPreviewRecord } from "@/temp_preview/store";
+import {
+  TempPreviewStore,
+  TempPreviewStoreUnreadableError,
+  type TempPreviewRecord,
+} from "@/temp_preview/store";
 
 const TEMP_PREVIEW_STORE_FILE = "temp-preview-connections.json";
 
@@ -34,7 +38,11 @@ function createClient(): TempmdClient {
 export async function getTempPreviewStatus(
   appId: number,
 ): Promise<TempPreviewStatus> {
-  return statusFromRecord(await createStore().read(appId));
+  try {
+    return statusFromRecord(await createStore().read(appId));
+  } catch (error) {
+    throw classifyTempPreviewError(error);
+  }
 }
 
 export async function publishTempPreview(input: {
@@ -248,6 +256,11 @@ function isStaleConnectionError(
 
 function classifyTempPreviewError(error: unknown): Error {
   if (isDyadError(error)) return error;
+  if (error instanceof TempPreviewStoreUnreadableError) {
+    return new DyadError(error.message, DyadErrorKind.External, {
+      cause: error,
+    });
+  }
   if (!(error instanceof TempmdApiError)) {
     return error instanceof Error
       ? error

--- a/src/ipc/services/temp_preview_service.ts
+++ b/src/ipc/services/temp_preview_service.ts
@@ -171,6 +171,24 @@ export async function deleteTempPreviewForApp(appId: number): Promise<void> {
   }
 }
 
+export async function markTempPreviewForAppDeletion(
+  appId: number,
+): Promise<boolean> {
+  return createStore().markPendingDeletion(appId);
+}
+
+export async function clearTempPreviewAppDeletionMarker(
+  appId: number,
+): Promise<void> {
+  await createStore().clearPendingDeletion(appId);
+}
+
+export async function listPendingTempPreviewDeletionAppIds(): Promise<
+  number[]
+> {
+  return createStore().listPendingDeletionAppIds();
+}
+
 async function assertBuildScript(appPath: string): Promise<void> {
   let packageJson: unknown;
   try {

--- a/src/ipc/services/temp_preview_service.ts
+++ b/src/ipc/services/temp_preview_service.ts
@@ -120,10 +120,15 @@ export async function publishTempPreview(input: {
     try {
       await store.write(input.appId, record);
     } catch (error) {
-      try {
-        await client.revoke(published);
-      } catch {
-        // Best-effort cleanup: preserve the local persistence failure.
+      const storedCapabilityCannotReconcile =
+        published.tempId !== previous?.tempId ||
+        published.updateToken !== previous?.updateToken;
+      if (storedCapabilityCannotReconcile) {
+        try {
+          await client.revoke(published);
+        } catch {
+          // Best-effort cleanup: preserve the local persistence failure.
+        }
       }
       throw error;
     }
@@ -246,12 +251,7 @@ function activeConnection(
   const expiresAt = record
     ? getEffectiveTempPreviewExpiry(record.expiresAt, record.lastPublishedAt)
     : null;
-  if (
-    !record ||
-    record.state !== "active" ||
-    !record.updateToken ||
-    isTempPreviewExpired(record.expiresAt, record.lastPublishedAt)
-  ) {
+  if (!record || record.state !== "active" || !record.updateToken) {
     return undefined;
   }
   return {

--- a/src/ipc/services/temp_preview_service.ts
+++ b/src/ipc/services/temp_preview_service.ts
@@ -64,6 +64,10 @@ export async function publishTempPreview(input: {
       env: getPackageManagerCommandEnv(),
       successMessage: "Temporary preview build completed",
       errorPrefix: "Failed to build the temporary preview",
+      // App-owned build output can contain secrets and local paths. Keep it in
+      // the bounded failure result for classifyTempPreviewError to sanitize,
+      // but do not persist the raw stream in application/debug-bundle logs.
+      logOutput: false,
     });
 
     let files;

--- a/src/ipc/services/temp_preview_service.ts
+++ b/src/ipc/services/temp_preview_service.ts
@@ -21,6 +21,7 @@ import {
   TempPreviewStoreUnreadableError,
   type TempPreviewRecord,
 } from "@/temp_preview/store";
+import { safeTempPreviewErrorMessage } from "./temp_preview_safe_error";
 
 const TEMP_PREVIEW_STORE_FILE = "temp-preview-connections.json";
 
@@ -273,16 +274,20 @@ function isStaleConnectionError(
 }
 
 function classifyTempPreviewError(error: unknown): Error {
-  if (isDyadError(error)) return error;
+  if (isDyadError(error)) {
+    return new DyadError(safeTempPreviewErrorMessage(error), error.kind);
+  }
   if (error instanceof TempPreviewStoreUnreadableError) {
-    return new DyadError(error.message, DyadErrorKind.External, {
-      cause: error,
-    });
+    return new DyadError(
+      safeTempPreviewErrorMessage(error),
+      DyadErrorKind.External,
+    );
   }
   if (!(error instanceof TempmdApiError)) {
-    return error instanceof Error
-      ? error
-      : new DyadError("Temporary preview failed.", DyadErrorKind.Unknown);
+    return new DyadError(
+      safeTempPreviewErrorMessage(error),
+      DyadErrorKind.Unknown,
+    );
   }
   let kind: DyadErrorKind;
   if (error.status === 400 || error.status === 413) {
@@ -300,5 +305,5 @@ function classifyTempPreviewError(error: unknown): Error {
   } else {
     kind = DyadErrorKind.External;
   }
-  return new DyadError(error.message, kind, { cause: error });
+  return new DyadError(safeTempPreviewErrorMessage(error), kind);
 }

--- a/src/ipc/services/temp_preview_service.ts
+++ b/src/ipc/services/temp_preview_service.ts
@@ -90,7 +90,6 @@ export async function publishTempPreview(input: {
     const previous = activeConnection(previousRecord);
     const client = createClient();
     let published: TempPreviewConnection;
-    let createdNewPreview = !previous;
     try {
       published = await client.publish({
         files,
@@ -107,7 +106,6 @@ export async function publishTempPreview(input: {
         });
       }
       published = await client.publish({ files, title: input.appName });
-      createdNewPreview = true;
     }
     const lastPublishedAt = new Date().toISOString();
     const record: TempPreviewRecord = {
@@ -122,16 +120,10 @@ export async function publishTempPreview(input: {
     try {
       await store.write(input.appId, record);
     } catch (error) {
-      const publishedCapabilityCannotBeRecovered =
-        createdNewPreview ||
-        published.tempId !== previous?.tempId ||
-        published.updateToken !== previous?.updateToken;
-      if (publishedCapabilityCannotBeRecovered) {
-        try {
-          await client.revoke(published);
-        } catch {
-          // Best-effort cleanup: preserve the local persistence failure.
-        }
+      try {
+        await client.revoke(published);
+      } catch {
+        // Best-effort cleanup: preserve the local persistence failure.
       }
       throw error;
     }

--- a/src/ipc/services/temp_preview_service.ts
+++ b/src/ipc/services/temp_preview_service.ts
@@ -122,7 +122,11 @@ export async function publishTempPreview(input: {
     try {
       await store.write(input.appId, record);
     } catch (error) {
-      if (createdNewPreview) {
+      const publishedCapabilityCannotBeRecovered =
+        createdNewPreview ||
+        published.tempId !== previous?.tempId ||
+        published.updateToken !== previous?.updateToken;
+      if (publishedCapabilityCannotBeRecovered) {
         try {
           await client.revoke(published);
         } catch {

--- a/src/ipc/services/temp_preview_service.ts
+++ b/src/ipc/services/temp_preview_service.ts
@@ -71,17 +71,44 @@ export async function publishTempPreview(input: {
     const store = createStore();
     const previousRecord = await store.read(input.appId);
     const previous = activeConnection(previousRecord);
-    const published = await createClient().publish({
-      files,
-      title: input.appName,
-      ...(previous ? { previous } : {}),
-    });
+    const client = createClient();
+    let published: TempPreviewConnection;
+    let createdNewPreview = !previous;
+    try {
+      published = await client.publish({
+        files,
+        title: input.appName,
+        ...(previous ? { previous } : {}),
+      });
+    } catch (error) {
+      if (!previous || !isStaleConnectionError(error)) throw error;
+      if (previousRecord) {
+        await store.write(input.appId, {
+          ...previousRecord,
+          updateToken: undefined,
+          state: "revoked",
+        });
+      }
+      published = await client.publish({ files, title: input.appName });
+      createdNewPreview = true;
+    }
     const record: TempPreviewRecord = {
       ...published,
       lastPublishedAt: new Date().toISOString(),
       state: "active",
     };
-    await store.write(input.appId, record);
+    try {
+      await store.write(input.appId, record);
+    } catch (error) {
+      if (createdNewPreview) {
+        try {
+          await client.revoke(published);
+        } catch {
+          // Best-effort cleanup: preserve the local persistence failure.
+        }
+      }
+      throw error;
+    }
     return statusFromRecord(record);
   } catch (error) {
     throw classifyTempPreviewError(error);
@@ -101,7 +128,11 @@ export async function revokeTempPreview(
         DyadErrorKind.Precondition,
       );
     }
-    await createClient().revoke(connection);
+    try {
+      await createClient().revoke(connection);
+    } catch (error) {
+      if (!isStaleConnectionError(error)) throw error;
+    }
     const revoked: TempPreviewRecord = {
       ...record,
       updateToken: undefined,
@@ -184,6 +215,13 @@ function statusFromRecord(record: TempPreviewRecord | null): TempPreviewStatus {
 
 function isExpired(expiresAt: string | null): boolean {
   return expiresAt !== null && new Date(expiresAt).getTime() <= Date.now();
+}
+
+function isStaleConnectionError(error: unknown): boolean {
+  return (
+    error instanceof TempmdApiError &&
+    (error.status === 404 || error.status === 410)
+  );
 }
 
 function classifyTempPreviewError(error: unknown): Error {

--- a/src/ipc/services/temp_preview_service.ts
+++ b/src/ipc/services/temp_preview_service.ts
@@ -179,19 +179,31 @@ export async function deleteTempPreviewForApp(appId: number): Promise<void> {
 export async function markTempPreviewForAppDeletion(
   appId: number,
 ): Promise<boolean> {
-  return createStore().markPendingDeletion(appId);
+  try {
+    return await createStore().markPendingDeletion(appId);
+  } catch (error) {
+    throw classifyTempPreviewError(error);
+  }
 }
 
 export async function clearTempPreviewAppDeletionMarker(
   appId: number,
 ): Promise<void> {
-  await createStore().clearPendingDeletion(appId);
+  try {
+    await createStore().clearPendingDeletion(appId);
+  } catch (error) {
+    throw classifyTempPreviewError(error);
+  }
 }
 
 export async function listPendingTempPreviewDeletionAppIds(): Promise<
   number[]
 > {
-  return createStore().listPendingDeletionAppIds();
+  try {
+    return await createStore().listPendingDeletionAppIds();
+  } catch (error) {
+    throw classifyTempPreviewError(error);
+  }
 }
 
 async function assertBuildScript(appPath: string): Promise<void> {

--- a/src/ipc/services/temp_preview_service.ts
+++ b/src/ipc/services/temp_preview_service.ts
@@ -1,0 +1,213 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { DyadError, DyadErrorKind, isDyadError } from "@/errors/dyad_error";
+import type { TempPreviewStatus } from "@/ipc/types/temp_preview";
+import { simpleSpawn } from "@/ipc/utils/simpleSpawn";
+import {
+  getPnpmMinimumReleaseAgeSupport,
+  getPackageManagerCommandEnv,
+} from "@/ipc/utils/socket_firewall";
+import { choosePackageManagerForApp } from "@/ipc/utils/package_manager_selection";
+import { encrypt, decrypt } from "@/main/settings";
+import { getUserDataPath } from "@/paths/paths";
+import { discoverTempPreviewBundle } from "@/temp_preview/bundle";
+import {
+  TempmdApiError,
+  TempmdClient,
+  type TempPreviewConnection,
+} from "@/temp_preview/client";
+import { TempPreviewStore, type TempPreviewRecord } from "@/temp_preview/store";
+
+const TEMP_PREVIEW_STORE_FILE = "temp-preview-connections.json";
+
+function createStore(): TempPreviewStore {
+  return new TempPreviewStore(
+    path.join(getUserDataPath(), TEMP_PREVIEW_STORE_FILE),
+    { encode: encrypt, decode: decrypt },
+  );
+}
+
+function createClient(): TempmdClient {
+  return new TempmdClient(process.env.TEMP_MD_API_URL);
+}
+
+export async function getTempPreviewStatus(
+  appId: number,
+): Promise<TempPreviewStatus> {
+  return statusFromRecord(await createStore().read(appId));
+}
+
+export async function publishTempPreview(input: {
+  appId: number;
+  appPath: string;
+  appName: string;
+}): Promise<TempPreviewStatus> {
+  try {
+    await assertBuildScript(input.appPath);
+    const pnpmSupport = await getPnpmMinimumReleaseAgeSupport();
+    const packageManager = choosePackageManagerForApp(
+      input.appPath,
+      pnpmSupport.available,
+    );
+    await simpleSpawn({
+      command: `${packageManager} run build`,
+      cwd: input.appPath,
+      env: getPackageManagerCommandEnv(),
+      successMessage: "Temporary preview build completed",
+      errorPrefix: "Failed to build the temporary preview",
+    });
+
+    let files;
+    try {
+      files = await discoverTempPreviewBundle(path.join(input.appPath, "dist"));
+    } catch (error) {
+      throw new DyadError(
+        error instanceof Error ? error.message : "The build output is invalid.",
+        DyadErrorKind.Validation,
+        { cause: error },
+      );
+    }
+
+    const store = createStore();
+    const previousRecord = await store.read(input.appId);
+    const previous = activeConnection(previousRecord);
+    const published = await createClient().publish({
+      files,
+      title: input.appName,
+      ...(previous ? { previous } : {}),
+    });
+    const record: TempPreviewRecord = {
+      ...published,
+      lastPublishedAt: new Date().toISOString(),
+      state: "active",
+    };
+    await store.write(input.appId, record);
+    return statusFromRecord(record);
+  } catch (error) {
+    throw classifyTempPreviewError(error);
+  }
+}
+
+export async function revokeTempPreview(
+  appId: number,
+): Promise<TempPreviewStatus> {
+  try {
+    const store = createStore();
+    const record = await store.read(appId);
+    const connection = activeConnection(record);
+    if (!record || !connection) {
+      throw new DyadError(
+        "This app does not have an active temporary preview to revoke.",
+        DyadErrorKind.Precondition,
+      );
+    }
+    await createClient().revoke(connection);
+    const revoked: TempPreviewRecord = {
+      ...record,
+      updateToken: undefined,
+      state: "revoked",
+    };
+    await store.write(appId, revoked);
+    return statusFromRecord(revoked);
+  } catch (error) {
+    throw classifyTempPreviewError(error);
+  }
+}
+
+async function assertBuildScript(appPath: string): Promise<void> {
+  let packageJson: unknown;
+  try {
+    packageJson = JSON.parse(
+      await readFile(path.join(appPath, "package.json"), "utf8"),
+    );
+  } catch (error) {
+    throw new DyadError(
+      "Temporary previews require an app with a readable package.json.",
+      DyadErrorKind.Precondition,
+      { cause: error },
+    );
+  }
+  const scripts =
+    packageJson && typeof packageJson === "object"
+      ? (packageJson as { scripts?: unknown }).scripts
+      : undefined;
+  if (
+    !scripts ||
+    typeof scripts !== "object" ||
+    typeof (scripts as { build?: unknown }).build !== "string"
+  ) {
+    throw new DyadError(
+      "Temporary previews require a package.json build script.",
+      DyadErrorKind.Precondition,
+    );
+  }
+}
+
+function activeConnection(
+  record: TempPreviewRecord | null,
+): TempPreviewConnection | undefined {
+  if (
+    !record ||
+    record.state !== "active" ||
+    !record.updateToken ||
+    isExpired(record.expiresAt)
+  ) {
+    return undefined;
+  }
+  return {
+    tempId: record.tempId,
+    canonicalUrl: record.canonicalUrl,
+    updateToken: record.updateToken,
+    expiresAt: record.expiresAt,
+  };
+}
+
+function statusFromRecord(record: TempPreviewRecord | null): TempPreviewStatus {
+  if (!record) {
+    return {
+      state: "none",
+      canonicalUrl: null,
+      expiresAt: null,
+      lastPublishedAt: null,
+    };
+  }
+  return {
+    state:
+      record.state === "active" && isExpired(record.expiresAt)
+        ? "expired"
+        : record.state,
+    canonicalUrl: record.canonicalUrl,
+    expiresAt: record.expiresAt,
+    lastPublishedAt: record.lastPublishedAt,
+  };
+}
+
+function isExpired(expiresAt: string | null): boolean {
+  return expiresAt !== null && new Date(expiresAt).getTime() <= Date.now();
+}
+
+function classifyTempPreviewError(error: unknown): Error {
+  if (isDyadError(error)) return error;
+  if (!(error instanceof TempmdApiError)) {
+    return error instanceof Error
+      ? error
+      : new DyadError("Temporary preview failed.", DyadErrorKind.Unknown);
+  }
+  let kind: DyadErrorKind;
+  if (error.status === 400 || error.status === 413) {
+    kind = DyadErrorKind.Validation;
+  } else if (error.status === 401 || error.status === 403) {
+    kind = DyadErrorKind.Auth;
+  } else if (error.status === 404) {
+    kind = DyadErrorKind.NotFound;
+  } else if (error.status === 409) {
+    kind = DyadErrorKind.Conflict;
+  } else if (error.status === 410) {
+    kind = DyadErrorKind.Precondition;
+  } else if (error.status === 429) {
+    kind = DyadErrorKind.RateLimited;
+  } else {
+    kind = DyadErrorKind.External;
+  }
+  return new DyadError(error.message, kind, { cause: error });
+}

--- a/src/ipc/services/temp_preview_service.ts
+++ b/src/ipc/services/temp_preview_service.ts
@@ -17,6 +17,10 @@ import {
   type TempPreviewConnection,
 } from "@/temp_preview/client";
 import {
+  getEffectiveTempPreviewExpiry,
+  isTempPreviewExpired,
+} from "@/temp_preview/expiry";
+import {
   TempPreviewStore,
   TempPreviewStoreUnreadableError,
   type TempPreviewRecord,
@@ -105,9 +109,14 @@ export async function publishTempPreview(input: {
       published = await client.publish({ files, title: input.appName });
       createdNewPreview = true;
     }
+    const lastPublishedAt = new Date().toISOString();
     const record: TempPreviewRecord = {
       ...published,
-      lastPublishedAt: new Date().toISOString(),
+      expiresAt: getEffectiveTempPreviewExpiry(
+        published.expiresAt,
+        lastPublishedAt,
+      ),
+      lastPublishedAt,
       state: "active",
     };
     try {
@@ -238,11 +247,14 @@ async function assertBuildScript(appPath: string): Promise<void> {
 function activeConnection(
   record: TempPreviewRecord | null,
 ): TempPreviewConnection | undefined {
+  const expiresAt = record
+    ? getEffectiveTempPreviewExpiry(record.expiresAt, record.lastPublishedAt)
+    : null;
   if (
     !record ||
     record.state !== "active" ||
     !record.updateToken ||
-    isExpired(record.expiresAt)
+    isTempPreviewExpired(record.expiresAt, record.lastPublishedAt)
   ) {
     return undefined;
   }
@@ -250,7 +262,7 @@ function activeConnection(
     tempId: record.tempId,
     canonicalUrl: record.canonicalUrl,
     updateToken: record.updateToken,
-    expiresAt: record.expiresAt,
+    expiresAt,
   };
 }
 
@@ -263,19 +275,20 @@ function statusFromRecord(record: TempPreviewRecord | null): TempPreviewStatus {
       lastPublishedAt: null,
     };
   }
+  const expiresAt = getEffectiveTempPreviewExpiry(
+    record.expiresAt,
+    record.lastPublishedAt,
+  );
   return {
     state:
-      record.state === "active" && isExpired(record.expiresAt)
+      record.state === "active" &&
+      isTempPreviewExpired(record.expiresAt, record.lastPublishedAt)
         ? "expired"
         : record.state,
     canonicalUrl: record.canonicalUrl,
-    expiresAt: record.expiresAt,
+    expiresAt,
     lastPublishedAt: record.lastPublishedAt,
   };
-}
-
-function isExpired(expiresAt: string | null): boolean {
-  return expiresAt !== null && new Date(expiresAt).getTime() <= Date.now();
 }
 
 function isStaleConnectionError(

--- a/src/ipc/services/temp_preview_service.ts
+++ b/src/ipc/services/temp_preview_service.ts
@@ -145,6 +145,24 @@ export async function revokeTempPreview(
   }
 }
 
+export async function deleteTempPreviewForApp(appId: number): Promise<void> {
+  try {
+    const store = createStore();
+    const record = await store.read(appId);
+    const connection = activeConnection(record);
+    if (connection) {
+      try {
+        await createClient().revoke(connection);
+      } catch (error) {
+        if (!isStaleConnectionError(error, "revoke")) throw error;
+      }
+    }
+    await store.remove(appId);
+  } catch (error) {
+    throw classifyTempPreviewError(error);
+  }
+}
+
 async function assertBuildScript(appPath: string): Promise<void> {
   let packageJson: unknown;
   try {

--- a/src/ipc/services/temp_preview_service.ts
+++ b/src/ipc/services/temp_preview_service.ts
@@ -81,7 +81,7 @@ export async function publishTempPreview(input: {
         ...(previous ? { previous } : {}),
       });
     } catch (error) {
-      if (!previous || !isStaleConnectionError(error)) throw error;
+      if (!previous || !isStaleConnectionError(error, "session")) throw error;
       if (previousRecord) {
         await store.write(input.appId, {
           ...previousRecord,
@@ -131,7 +131,7 @@ export async function revokeTempPreview(
     try {
       await createClient().revoke(connection);
     } catch (error) {
-      if (!isStaleConnectionError(error)) throw error;
+      if (!isStaleConnectionError(error, "revoke")) throw error;
     }
     const revoked: TempPreviewRecord = {
       ...record,
@@ -217,10 +217,14 @@ function isExpired(expiresAt: string | null): boolean {
   return expiresAt !== null && new Date(expiresAt).getTime() <= Date.now();
 }
 
-function isStaleConnectionError(error: unknown): boolean {
+function isStaleConnectionError(
+  error: unknown,
+  phase: "session" | "revoke",
+): boolean {
   return (
     error instanceof TempmdApiError &&
-    (error.status === 404 || error.status === 410)
+    error.phase === phase &&
+    (error.status === 403 || error.status === 404 || error.status === 410)
   );
 }
 

--- a/src/ipc/types/index.ts
+++ b/src/ipc/types/index.ts
@@ -49,6 +49,7 @@ export type {
 export { supabaseContracts, supabaseEvents } from "./supabase";
 export { neonContracts } from "./neon";
 export { migrationContracts } from "./migration";
+export { tempPreviewContracts } from "./temp_preview";
 export { systemContracts, systemEvents } from "./system";
 export {
   versionContracts,
@@ -109,6 +110,7 @@ export { vercelClient } from "./vercel";
 export { supabaseClient, supabaseEventClient } from "./supabase";
 export { neonClient } from "./neon";
 export { migrationClient } from "./migration";
+export { tempPreviewClient } from "./temp_preview";
 export { systemClient, systemEventClient } from "./system";
 export { versionClient } from "./version";
 export { languageModelClient } from "./language-model";
@@ -151,6 +153,7 @@ export {
   recordingEventClient,
   recordingEvents,
 } from "./recording";
+export type { TempPreviewStatus } from "./temp_preview";
 
 // =============================================================================
 // Type Exports
@@ -496,6 +499,7 @@ import { coolifyClient, coolifyEventClient } from "./coolify";
 import { supabaseClient, supabaseEventClient } from "./supabase";
 import { neonClient } from "./neon";
 import { migrationClient } from "./migration";
+import { tempPreviewClient } from "./temp_preview";
 import { systemClient, systemEventClient } from "./system";
 import { versionClient } from "./version";
 import { languageModelClient } from "./language-model";
@@ -574,6 +578,7 @@ export const ipc = {
   supabase: supabaseClient,
   neon: neonClient,
   migration: migrationClient,
+  tempPreview: tempPreviewClient,
 
   // Features
   system: systemClient,

--- a/src/ipc/types/temp_preview.ts
+++ b/src/ipc/types/temp_preview.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+import { createClient, defineContract } from "../contracts/core";
+
+export const TempPreviewStatusSchema = z.object({
+  state: z.enum(["none", "active", "expired", "revoked"]),
+  canonicalUrl: z.string().url().nullable(),
+  expiresAt: z.string().nullable(),
+  lastPublishedAt: z.string().nullable(),
+});
+
+export type TempPreviewStatus = z.infer<typeof TempPreviewStatusSchema>;
+
+const TempPreviewAppParamsSchema = z.object({
+  appId: z.number().int().positive(),
+});
+
+export const tempPreviewContracts = {
+  getStatus: defineContract({
+    channel: "temp-preview:get-status",
+    input: TempPreviewAppParamsSchema,
+    output: TempPreviewStatusSchema,
+  }),
+  publish: defineContract({
+    channel: "temp-preview:publish",
+    input: TempPreviewAppParamsSchema,
+    output: TempPreviewStatusSchema,
+  }),
+  revoke: defineContract({
+    channel: "temp-preview:revoke",
+    input: TempPreviewAppParamsSchema,
+    output: TempPreviewStatusSchema,
+  }),
+} as const;
+
+export const tempPreviewClient = createClient(tempPreviewContracts);

--- a/src/ipc/types/temp_preview.ts
+++ b/src/ipc/types/temp_preview.ts
@@ -24,11 +24,15 @@ export const tempPreviewContracts = {
     channel: "temp-preview:publish",
     input: TempPreviewAppParamsSchema,
     output: TempPreviewStatusSchema,
+    invalidates: (input) => [{ family: "temp-preview", appId: input.appId }],
+    originHandles: (input) => [{ family: "temp-preview", appId: input.appId }],
   }),
   revoke: defineContract({
     channel: "temp-preview:revoke",
     input: TempPreviewAppParamsSchema,
     output: TempPreviewStatusSchema,
+    invalidates: (input) => [{ family: "temp-preview", appId: input.appId }],
+    originHandles: (input) => [{ family: "temp-preview", appId: input.appId }],
   }),
 } as const;
 

--- a/src/ipc/utils/simpleSpawn.test.ts
+++ b/src/ipc/utils/simpleSpawn.test.ts
@@ -160,4 +160,42 @@ describe("simpleSpawn", () => {
         "Failed to spawn command: ENOENT\n\nSTDOUT:\nbounded stdout\n\nSTDERR:\nbounded stderr",
     });
   });
+
+  it("does not expose suppressed command output through logs", async () => {
+    const spawnError = new BufferedProcessSpawnError(
+      "ENOENT in /Users/alice/Client-App",
+      "API_KEY=private-value",
+      "TOKEN=other-secret",
+    );
+    runBufferedProcessMock.mockRejectedValue(spawnError);
+
+    await expect(
+      simpleSpawn({
+        command: "npm run build",
+        cwd: "/Users/alice/Client-App",
+        successMessage: "built successfully",
+        errorPrefix: "build failed",
+        logOutput: false,
+      }),
+    ).rejects.toMatchObject({
+      message: expect.stringContaining("API_KEY=private-value"),
+    });
+
+    expect(runBufferedProcessMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onStdout: undefined,
+        onStderr: undefined,
+      }),
+    );
+    expect(logger.error).toHaveBeenCalledWith(
+      "Failed to spawn command: npm run build",
+    );
+    expect(logger.error).not.toHaveBeenCalledWith(
+      expect.anything(),
+      spawnError,
+    );
+    expect(JSON.stringify(logger.error.mock.calls)).not.toMatch(
+      /alice|private-value|other-secret/,
+    );
+  });
 });

--- a/src/ipc/utils/simpleSpawn.ts
+++ b/src/ipc/utils/simpleSpawn.ts
@@ -17,6 +17,7 @@ export async function simpleSpawn({
   env,
   signal,
   timeoutMs = DEFAULT_BUFFERED_PROCESS_TIMEOUT_MS,
+  logOutput = true,
 }: {
   command: string;
   cwd: string;
@@ -28,6 +29,10 @@ export async function simpleSpawn({
   env?: NodeJS.ProcessEnv;
   signal?: AbortSignal;
   timeoutMs?: number;
+  // Disable when command output may contain app-owned credentials or paths.
+  // Failure output remains bounded and available to the caller for a safe
+  // projection, but is not decoded into or persisted by application logs.
+  logOutput?: boolean;
 }): Promise<void> {
   const spawnEnv = env ?? getPackageManagerCommandEnv();
   logger.info(`Running: ${command}`);
@@ -43,12 +48,16 @@ export async function simpleSpawn({
       // The output is only needed for failures. On success, release the
       // bounded byte buffers without decoding them into additional strings.
       captureOutputOnSuccess: false,
-      onStdout: (output) => logger.info(output),
-      onStderr: (output) => logger.error(output),
+      onStdout: logOutput ? (output) => logger.info(output) : undefined,
+      onStderr: logOutput ? (output) => logger.error(output) : undefined,
     });
   } catch (error) {
     if (error instanceof BufferedProcessSpawnError) {
-      logger.error(`Failed to spawn command: ${command}`, error);
+      if (logOutput) {
+        logger.error(`Failed to spawn command: ${command}`, error);
+      } else {
+        logger.error(`Failed to spawn command: ${command}`);
+      }
       throw new DyadError(
         `Failed to spawn command: ${error.message}\n\nSTDOUT:\n${error.stdout}\n\nSTDERR:\n${error.stderr}`,
         DyadErrorKind.External,

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -62,6 +62,13 @@ export const queryKeys = {
       ["apps", "search", query] as const,
   },
 
+  // Temporary previews
+  tempPreviews: {
+    all: ["temp-previews"] as const,
+    status: ({ appId }: { appId: number | null }) =>
+      ["temp-previews", "status", appId] as const,
+  },
+
   // ─────────────────────────────────────────────────────────────────────────────
   // App Collections
   // ─────────────────────────────────────────────────────────────────────────────
@@ -485,6 +492,9 @@ export type AppQueryKey =
   | QueryKeyOf<(typeof queryKeys.system)[keyof typeof queryKeys.system]>
   | QueryKeyOf<(typeof queryKeys.settings)[keyof typeof queryKeys.settings]>
   | QueryKeyOf<(typeof queryKeys.apps)[keyof typeof queryKeys.apps]>
+  | QueryKeyOf<
+      (typeof queryKeys.tempPreviews)[keyof typeof queryKeys.tempPreviews]
+    >
   | QueryKeyOf<
       (typeof queryKeys.appCollections)[keyof typeof queryKeys.appCollections]
     >

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,6 +49,7 @@ import { apps } from "./db/schema";
 import { eq } from "drizzle-orm";
 import { reconcileOrphanTestBranches } from "./ipc/utils/neon_test_branch";
 import { reconcileOrphanTestUsers } from "./ipc/utils/supabase_test_user";
+import { reconcilePendingTempPreviewDeletions } from "./ipc/services/temp_preview_cleanup_reconciler";
 import { UserSettings } from "./lib/schemas";
 import { handleNeonOAuthReturn } from "./neon_admin/neon_return_handler";
 import {
@@ -457,6 +458,7 @@ export async function onReady() {
   // must not block startup.
   void reconcileOrphanTestBranches();
   void reconcileOrphanTestUsers();
+  void reconcilePendingTempPreviewDeletions();
 
   // Cleanup old ai_messages_json entries to prevent database bloat
   cleanupOldAiMessagesJson();

--- a/src/temp_preview/bundle.test.ts
+++ b/src/temp_preview/bundle.test.ts
@@ -1,0 +1,52 @@
+import { mkdtemp, mkdir, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { discoverTempPreviewBundle, TEMP_PREVIEW_MAX_FILES } from "./bundle";
+
+async function createBundleRoot(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "dyad-temp-preview-bundle-"));
+}
+
+describe("discoverTempPreviewBundle", () => {
+  it("describes a static build with stable paths, hashes and content types", async () => {
+    const root = await createBundleRoot();
+    await mkdir(join(root, "assets"));
+    await writeFile(join(root, "index.html"), "<main>Hello</main>");
+    await writeFile(join(root, "assets", "app.js"), "console.log('hello')");
+
+    const files = await discoverTempPreviewBundle(root);
+
+    expect(files.map((file) => file.path)).toEqual([
+      "assets/app.js",
+      "index.html",
+    ]);
+    expect(files[0]).toMatchObject({ contentType: "text/javascript" });
+    expect(files[0].hash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("requires a root index.html and ignores symbolic links", async () => {
+    const root = await createBundleRoot();
+    const outside = join(root, "outside.html");
+    await writeFile(outside, "secret");
+    await symlink(outside, join(root, "linked.html"));
+
+    await expect(discoverTempPreviewBundle(root)).rejects.toThrow(
+      "dist/index.html",
+    );
+  });
+
+  it("rejects bundles over the public file-count limit", async () => {
+    const root = await createBundleRoot();
+    await writeFile(join(root, "index.html"), "ok");
+    await Promise.all(
+      Array.from({ length: TEMP_PREVIEW_MAX_FILES }, (_, index) =>
+        writeFile(join(root, `asset-${index}.txt`), "x"),
+      ),
+    );
+
+    await expect(discoverTempPreviewBundle(root)).rejects.toThrow(
+      `more than ${TEMP_PREVIEW_MAX_FILES} files`,
+    );
+  });
+});

--- a/src/temp_preview/bundle.test.ts
+++ b/src/temp_preview/bundle.test.ts
@@ -48,6 +48,14 @@ describe("discoverTempPreviewBundle", () => {
     expect(files[0]).toMatchObject({ contentType: "text/javascript" });
     expect(files[0].hash).toMatch(/^[a-f0-9]{64}$/);
     expect(files[1]).toMatchObject({ contentType: "application/wasm" });
+    expect(new TextDecoder().decode(files[0].contents)).toBe(
+      "console.log('hello')",
+    );
+
+    await writeFile(join(root, "assets", "app.js"), "changed after snapshot");
+    expect(new TextDecoder().decode(files[0].contents)).toBe(
+      "console.log('hello')",
+    );
   });
 
   it("requires a root index.html", async () => {

--- a/src/temp_preview/bundle.test.ts
+++ b/src/temp_preview/bundle.test.ts
@@ -1,38 +1,117 @@
-import { mkdtemp, mkdir, symlink, writeFile } from "node:fs/promises";
+import {
+  mkdtemp,
+  mkdir,
+  rm,
+  symlink,
+  truncate,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { discoverTempPreviewBundle, TEMP_PREVIEW_MAX_FILES } from "./bundle";
 
+const bundleRoots: string[] = [];
+
 async function createBundleRoot(): Promise<string> {
-  return mkdtemp(join(tmpdir(), "dyad-temp-preview-bundle-"));
+  const root = await mkdtemp(join(tmpdir(), "dyad-temp-preview-bundle-"));
+  bundleRoots.push(root);
+  return root;
 }
 
 describe("discoverTempPreviewBundle", () => {
+  afterEach(async () => {
+    await Promise.all(
+      bundleRoots.splice(0).map((root) =>
+        rm(root, {
+          recursive: true,
+          force: true,
+        }),
+      ),
+    );
+  });
+
   it("describes a static build with stable paths, hashes and content types", async () => {
     const root = await createBundleRoot();
     await mkdir(join(root, "assets"));
     await writeFile(join(root, "index.html"), "<main>Hello</main>");
     await writeFile(join(root, "assets", "app.js"), "console.log('hello')");
+    await writeFile(join(root, "assets", "module.wasm"), "wasm");
 
     const files = await discoverTempPreviewBundle(root);
 
     expect(files.map((file) => file.path)).toEqual([
       "assets/app.js",
+      "assets/module.wasm",
       "index.html",
     ]);
     expect(files[0]).toMatchObject({ contentType: "text/javascript" });
     expect(files[0].hash).toMatch(/^[a-f0-9]{64}$/);
+    expect(files[1]).toMatchObject({ contentType: "application/wasm" });
   });
 
-  it("requires a root index.html and ignores symbolic links", async () => {
+  it("requires a root index.html", async () => {
     const root = await createBundleRoot();
-    const outside = join(root, "outside.html");
-    await writeFile(outside, "secret");
-    await symlink(outside, join(root, "linked.html"));
 
     await expect(discoverTempPreviewBundle(root)).rejects.toThrow(
       "dist/index.html",
+    );
+  });
+
+  it("ignores symbolic links inside the build output", async () => {
+    const root = await createBundleRoot();
+    const outside = await createBundleRoot();
+    await writeFile(join(root, "index.html"), "ok");
+    await writeFile(join(outside, "secret.html"), "secret");
+    await symlink(
+      outside,
+      join(root, "linked-assets"),
+      process.platform === "win32" ? "junction" : "dir",
+    );
+
+    const files = await discoverTempPreviewBundle(root);
+
+    expect(files.map((file) => file.path)).toEqual(["index.html"]);
+  });
+
+  it("rejects a symbolic link used as the build-output root", async () => {
+    const parent = await createBundleRoot();
+    const target = await createBundleRoot();
+    await writeFile(join(target, "index.html"), "ok");
+    const linkedRoot = join(parent, "dist");
+    await symlink(
+      target,
+      linkedRoot,
+      process.platform === "win32" ? "junction" : "dir",
+    );
+
+    await expect(discoverTempPreviewBundle(linkedRoot)).rejects.toThrow(
+      "must not be a symbolic link",
+    );
+  });
+
+  it("reports a missing build-output directory clearly", async () => {
+    const root = await createBundleRoot();
+
+    await expect(
+      discoverTempPreviewBundle(join(root, "missing-dist")),
+    ).rejects.toThrow("did not produce a dist directory");
+  });
+
+  it("rejects an oversized bundle before hashing file contents", async () => {
+    const root = await createBundleRoot();
+    await writeFile(join(root, "index.html"), "ok");
+    await Promise.all(
+      Array.from({ length: 6 }, (_, index) => {
+        const filePath = join(root, `asset-${index}.bin`);
+        return writeFile(filePath, "").then(() =>
+          truncate(filePath, 9 * 1024 * 1024),
+        );
+      }),
+    );
+
+    await expect(discoverTempPreviewBundle(root)).rejects.toThrow(
+      "50 MB temporary preview limit",
     );
   });
 

--- a/src/temp_preview/bundle.test.ts
+++ b/src/temp_preview/bundle.test.ts
@@ -87,6 +87,9 @@ describe("discoverTempPreviewBundle", () => {
     "assets/.env.production",
     ".git/config",
     ".ssh/id_ed25519",
+    "keys/id_ed25519_sk",
+    "keys/id_ecdsa_sk",
+    "keys/id_xmss",
     ".aws/credentials",
     ".docker/config.json",
     ".kube/config",
@@ -98,6 +101,7 @@ describe("discoverTempPreviewBundle", () => {
     "config/serviceAccountKey.json",
     "config/demo-firebase-adminsdk-abc.json",
     "oauth/client_secret_123.apps.googleusercontent.com.json",
+    "oauth/client_secrets.json",
   ])("rejects an obvious secret-bearing build path: %s", async (bundlePath) => {
     const root = await createBundleRoot();
     await writeFile(join(root, "index.html"), "ok");

--- a/src/temp_preview/bundle.test.ts
+++ b/src/temp_preview/bundle.test.ts
@@ -7,7 +7,7 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { discoverTempPreviewBundle, TEMP_PREVIEW_MAX_FILES } from "./bundle";
 
@@ -80,6 +80,50 @@ describe("discoverTempPreviewBundle", () => {
     const files = await discoverTempPreviewBundle(root);
 
     expect(files.map((file) => file.path)).toEqual(["index.html"]);
+  });
+
+  it.each([
+    ".env",
+    "assets/.env.production",
+    ".git/config",
+    ".ssh/id_ed25519",
+    ".aws/credentials",
+    ".docker/config.json",
+    ".kube/config",
+    "keys/deploy.pem",
+    "keys/deploy.ppk",
+    "keys/signing.p12",
+    "config/credentials.json",
+    "config/service-account.json",
+    "config/serviceAccountKey.json",
+    "config/demo-firebase-adminsdk-abc.json",
+    "oauth/client_secret_123.apps.googleusercontent.com.json",
+  ])("rejects an obvious secret-bearing build path: %s", async (bundlePath) => {
+    const root = await createBundleRoot();
+    await writeFile(join(root, "index.html"), "ok");
+    await mkdir(dirname(join(root, bundlePath)), { recursive: true });
+    await writeFile(join(root, bundlePath), "sensitive");
+
+    await expect(discoverTempPreviewBundle(root)).rejects.toThrow(
+      `Temporary preview blocked because ${bundlePath}`,
+    );
+  });
+
+  it("allows ordinary assets whose names mention keys or secrets", async () => {
+    const root = await createBundleRoot();
+    await mkdir(join(root, "assets"));
+    await writeFile(join(root, "index.html"), "ok");
+    await writeFile(join(root, "assets", "key.svg"), "<svg />");
+    await writeFile(join(root, "assets", "secrets.png"), "image");
+    await writeFile(join(root, "assets", "environment-setup.md"), "docs");
+
+    await expect(discoverTempPreviewBundle(root)).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: "assets/key.svg" }),
+        expect.objectContaining({ path: "assets/secrets.png" }),
+        expect.objectContaining({ path: "assets/environment-setup.md" }),
+      ]),
+    );
   });
 
   it("rejects a symbolic link used as the build-output root", async () => {

--- a/src/temp_preview/bundle.test.ts
+++ b/src/temp_preview/bundle.test.ts
@@ -167,6 +167,20 @@ describe("discoverTempPreviewBundle", () => {
     ).rejects.toThrow("The build output changed");
   });
 
+  it("rejects a nested directory changed after traversal", async () => {
+    const root = await createBundleRoot();
+    const assets = join(root, "assets");
+    await mkdir(assets);
+    await writeFile(join(root, "index.html"), "ok");
+    await writeFile(join(assets, "app.js"), "original");
+
+    await expect(
+      discoverTempPreviewBundle(root, {
+        afterTraversal: () => writeFile(join(assets, "late.js"), "late"),
+      }),
+    ).rejects.toThrow("assets changed");
+  });
+
   it("reports a missing build-output directory clearly", async () => {
     const root = await createBundleRoot();
 

--- a/src/temp_preview/bundle.test.ts
+++ b/src/temp_preview/bundle.test.ts
@@ -1,6 +1,7 @@
 import {
   mkdtemp,
   mkdir,
+  rename,
   rm,
   symlink,
   truncate,
@@ -144,6 +145,26 @@ describe("discoverTempPreviewBundle", () => {
     await expect(discoverTempPreviewBundle(linkedRoot)).rejects.toThrow(
       "must not be a symbolic link",
     );
+  });
+
+  it("rejects a build-output root replaced before traversal", async () => {
+    const parent = await createBundleRoot();
+    const root = join(parent, "dist");
+    const replacement = join(parent, "replacement");
+    const original = join(parent, "original");
+    await mkdir(root);
+    await mkdir(replacement);
+    await writeFile(join(root, "index.html"), "original");
+    await writeFile(join(replacement, "index.html"), "replacement");
+
+    await expect(
+      discoverTempPreviewBundle(root, {
+        beforeTraversal: async () => {
+          await rename(root, original);
+          await rename(replacement, root);
+        },
+      }),
+    ).rejects.toThrow("The build output changed");
   });
 
   it("reports a missing build-output directory clearly", async () => {

--- a/src/temp_preview/bundle.ts
+++ b/src/temp_preview/bundle.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { constants, type Stats } from "node:fs";
-import { lstat, open, readdir } from "node:fs/promises";
-import { extname, join, relative, resolve, sep } from "node:path";
+import { lstat, open, readdir, realpath } from "node:fs/promises";
+import { extname, isAbsolute, join, relative, resolve, sep } from "node:path";
 
 export const TEMP_PREVIEW_MAX_FILES = 100;
 export const TEMP_PREVIEW_MAX_FILE_BYTES = 10 * 1024 * 1024;
@@ -17,6 +17,7 @@ export interface TempPreviewBundleFile {
 
 interface DiscoveredBundleFile {
   absolutePath: string;
+  rootRealPath: string;
   path: string;
   size: number;
   contentType: string;
@@ -47,9 +48,18 @@ export async function discoverTempPreviewBundle(
   if (!sourceStat.isDirectory()) {
     throw new Error("The temporary preview build output is not a directory.");
   }
+  const sourceRealPath = await realpath(source);
+  const currentSourceStat = await lstat(source);
+  if (
+    currentSourceStat.isSymbolicLink() ||
+    !currentSourceStat.isDirectory() ||
+    !isSameFile(sourceStat, currentSourceStat)
+  ) {
+    throw bundleFileChangedError("The build output");
+  }
 
   const paths: string[] = [];
-  await walk(source, source, paths);
+  await walk(source, source, sourceRealPath, paths);
   paths.sort((a, b) => a.localeCompare(b));
 
   if (!paths.includes("index.html")) {
@@ -62,6 +72,7 @@ export async function discoverTempPreviewBundle(
   let totalBytes = 0;
   for (const bundlePath of paths) {
     const absolutePath = join(source, ...bundlePath.split("/"));
+    await assertPathContained(sourceRealPath, absolutePath, bundlePath);
     const metadata = await lstat(absolutePath);
     if (metadata.isSymbolicLink() || !metadata.isFile()) {
       throw new Error(
@@ -79,6 +90,7 @@ export async function discoverTempPreviewBundle(
     }
     discovered.push({
       absolutePath,
+      rootRealPath: sourceRealPath,
       path: bundlePath,
       size: metadata.size,
       contentType: contentTypeFor(absolutePath),
@@ -96,9 +108,22 @@ export async function discoverTempPreviewBundle(
 async function walk(
   root: string,
   directory: string,
+  rootRealPath: string,
   paths: string[],
 ): Promise<void> {
+  const directoryPath = toPosix(relative(root, directory));
+  const displayPath = directoryPath || "The build output";
+  const beforeMetadata = await lstat(directory);
+  if (beforeMetadata.isSymbolicLink() || !beforeMetadata.isDirectory()) {
+    throw bundleFileChangedError(displayPath);
+  }
+  await assertPathContained(rootRealPath, directory, displayPath);
   const entries = await readdir(directory, { withFileTypes: true });
+  const afterMetadata = await lstat(directory);
+  await assertPathContained(rootRealPath, directory, displayPath);
+  if (!isSameFile(beforeMetadata, afterMetadata)) {
+    throw bundleFileChangedError(displayPath);
+  }
   entries.sort((a, b) => a.name.localeCompare(b.name));
 
   for (const entry of entries) {
@@ -107,7 +132,7 @@ async function walk(
     const absolutePath = join(directory, entry.name);
     const bundlePath = toPosix(relative(root, absolutePath));
     if (entry.isDirectory()) {
-      await walk(root, absolutePath, paths);
+      await walk(root, absolutePath, rootRealPath, paths);
       continue;
     }
     if (!entry.isFile()) continue;
@@ -127,17 +152,21 @@ async function snapshotFile(
   const noFollow = constants.O_NOFOLLOW ?? 0;
   let handle;
   try {
+    await assertPathContained(file.rootRealPath, file.absolutePath, file.path);
     handle = await open(file.absolutePath, constants.O_RDONLY | noFollow);
-    const [openedMetadata, currentPathMetadata] = await Promise.all([
-      handle.stat(),
-      lstat(file.absolutePath),
-    ]);
+    const [openedMetadata, currentPathMetadata, currentRealPath] =
+      await Promise.all([
+        handle.stat(),
+        lstat(file.absolutePath),
+        realpath(file.absolutePath),
+      ]);
     if (
       !openedMetadata.isFile() ||
       !currentPathMetadata.isFile() ||
       currentPathMetadata.isSymbolicLink() ||
       !isSameFile(file.metadata, openedMetadata) ||
       !isSameFile(openedMetadata, currentPathMetadata) ||
+      !isPathContained(file.rootRealPath, currentRealPath) ||
       openedMetadata.size !== file.size
     ) {
       throw bundleFileChangedError(file.path);
@@ -155,11 +184,15 @@ async function snapshotFile(
       if (bytesRead === 0) break;
       offset += bytesRead;
     }
-    const finalMetadata = await handle.stat();
+    const [finalMetadata, finalRealPath] = await Promise.all([
+      handle.stat(),
+      realpath(file.absolutePath),
+    ]);
     if (
       offset !== file.size ||
       finalMetadata.size !== file.size ||
-      !isSameFile(openedMetadata, finalMetadata)
+      !isSameFile(openedMetadata, finalMetadata) ||
+      !isPathContained(file.rootRealPath, finalRealPath)
     ) {
       throw bundleFileChangedError(file.path);
     }
@@ -179,6 +212,35 @@ async function snapshotFile(
   } finally {
     await handle?.close();
   }
+}
+
+async function assertPathContained(
+  rootRealPath: string,
+  candidatePath: string,
+  displayPath: string,
+): Promise<void> {
+  let candidateRealPath: string;
+  try {
+    candidateRealPath = await realpath(candidatePath);
+  } catch (error) {
+    if (isFileReplacementError(error)) {
+      throw bundleFileChangedError(displayPath, error);
+    }
+    throw error;
+  }
+  if (!isPathContained(rootRealPath, candidateRealPath)) {
+    throw bundleFileChangedError(displayPath);
+  }
+}
+
+function isPathContained(rootRealPath: string, candidateRealPath: string) {
+  const relativePath = relative(rootRealPath, candidateRealPath);
+  return (
+    relativePath === "" ||
+    (!isAbsolute(relativePath) &&
+      relativePath !== ".." &&
+      !relativePath.startsWith(`..${sep}`))
+  );
 }
 
 function isSameFile(first: Stats, second: Stats): boolean {

--- a/src/temp_preview/bundle.ts
+++ b/src/temp_preview/bundle.ts
@@ -1,0 +1,128 @@
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { readdir, stat } from "node:fs/promises";
+import { extname, join, relative, resolve, sep } from "node:path";
+
+export const TEMP_PREVIEW_MAX_FILES = 100;
+export const TEMP_PREVIEW_MAX_FILE_BYTES = 10 * 1024 * 1024;
+export const TEMP_PREVIEW_MAX_BUNDLE_BYTES = 50 * 1024 * 1024;
+
+export interface TempPreviewBundleFile {
+  absolutePath: string;
+  path: string;
+  size: number;
+  contentType: string;
+  hash: string;
+}
+
+export async function discoverTempPreviewBundle(
+  sourcePath: string,
+): Promise<TempPreviewBundleFile[]> {
+  const source = resolve(sourcePath);
+  const sourceStat = await stat(source);
+  if (!sourceStat.isDirectory()) {
+    throw new Error("The temporary preview build output is not a directory.");
+  }
+
+  const paths: string[] = [];
+  await walk(source, source, paths);
+  paths.sort((a, b) => a.localeCompare(b));
+
+  if (!paths.includes("index.html")) {
+    throw new Error(
+      "The build did not produce dist/index.html. Temporary previews currently support static Vite apps only.",
+    );
+  }
+
+  const files = await Promise.all(
+    paths.map(async (bundlePath) => {
+      const absolutePath = join(source, ...bundlePath.split("/"));
+      const metadata = await stat(absolutePath);
+      if (metadata.size > TEMP_PREVIEW_MAX_FILE_BYTES) {
+        throw new Error(
+          `${bundlePath} exceeds the 10 MB temporary preview file limit.`,
+        );
+      }
+      return {
+        absolutePath,
+        path: bundlePath,
+        size: metadata.size,
+        contentType: contentTypeFor(absolutePath),
+        hash: await hashFile(absolutePath),
+      };
+    }),
+  );
+
+  const totalBytes = files.reduce((total, file) => total + file.size, 0);
+  if (totalBytes > TEMP_PREVIEW_MAX_BUNDLE_BYTES) {
+    throw new Error("The build exceeds the 50 MB temporary preview limit.");
+  }
+
+  return files;
+}
+
+async function walk(
+  root: string,
+  directory: string,
+  paths: string[],
+): Promise<void> {
+  const entries = await readdir(directory, { withFileTypes: true });
+  entries.sort((a, b) => a.name.localeCompare(b.name));
+
+  for (const entry of entries) {
+    if (entry.isSymbolicLink()) continue;
+
+    const absolutePath = join(directory, entry.name);
+    const bundlePath = toPosix(relative(root, absolutePath));
+    if (entry.isDirectory()) {
+      await walk(root, absolutePath, paths);
+      continue;
+    }
+    if (!entry.isFile()) continue;
+
+    paths.push(bundlePath);
+    if (paths.length > TEMP_PREVIEW_MAX_FILES) {
+      throw new Error(
+        `The build contains more than ${TEMP_PREVIEW_MAX_FILES} files, which is the temporary preview limit.`,
+      );
+    }
+  }
+}
+
+async function hashFile(filePath: string): Promise<string> {
+  const hash = createHash("sha256");
+  for await (const chunk of createReadStream(filePath)) {
+    hash.update(chunk);
+  }
+  return hash.digest("hex");
+}
+
+function contentTypeFor(filePath: string): string {
+  const extension = extname(filePath).toLowerCase();
+  const types: Record<string, string> = {
+    ".html": "text/html",
+    ".htm": "text/html",
+    ".css": "text/css",
+    ".js": "text/javascript",
+    ".mjs": "text/javascript",
+    ".json": "application/json",
+    ".svg": "image/svg+xml",
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".ico": "image/x-icon",
+    ".woff": "font/woff",
+    ".woff2": "font/woff2",
+    ".ttf": "font/ttf",
+    ".txt": "text/plain",
+    ".xml": "application/xml",
+    ".webmanifest": "application/manifest+json",
+  };
+  return types[extension] ?? "application/octet-stream";
+}
+
+function toPosix(filePath: string): string {
+  return sep === "/" ? filePath : filePath.split(sep).join("/");
+}

--- a/src/temp_preview/bundle.ts
+++ b/src/temp_preview/bundle.ts
@@ -43,9 +43,18 @@ interface BundleRootIdentity {
   metadata: Stats;
 }
 
+interface BundleDirectoryIdentity {
+  absolutePath: string;
+  displayPath: string;
+  metadata: Stats;
+}
+
 export async function discoverTempPreviewBundle(
   sourcePath: string,
-  options: { beforeTraversal?: () => Promise<void> } = {},
+  options: {
+    beforeTraversal?: () => Promise<void>;
+    afterTraversal?: () => Promise<void>;
+  } = {},
 ): Promise<TempPreviewBundleFile[]> {
   const source = resolve(sourcePath);
   let sourceStat;
@@ -84,10 +93,13 @@ export async function discoverTempPreviewBundle(
   };
 
   const paths: string[] = [];
+  const directories: BundleDirectoryIdentity[] = [];
   await options.beforeTraversal?.();
   await assertRootUnchanged(root);
-  await walk(source, source, root, paths);
+  await walk(source, source, root, paths, directories);
+  await options.afterTraversal?.();
   await assertRootUnchanged(root);
+  await assertDirectoriesUnchanged(root.realPath, directories);
   paths.sort((a, b) => a.localeCompare(b));
 
   if (!paths.includes("index.html")) {
@@ -127,6 +139,7 @@ export async function discoverTempPreviewBundle(
     });
     await assertRootUnchanged(root);
   }
+  await assertDirectoriesUnchanged(root.realPath, directories);
 
   const files: TempPreviewBundleFile[] = [];
   for (const file of discovered) {
@@ -135,6 +148,7 @@ export async function discoverTempPreviewBundle(
     await assertRootUnchanged(root);
   }
   await assertRootUnchanged(root);
+  await assertDirectoriesUnchanged(root.realPath, directories);
   return files;
 }
 
@@ -143,6 +157,7 @@ async function walk(
   directory: string,
   rootIdentity: BundleRootIdentity,
   paths: string[],
+  directories: BundleDirectoryIdentity[],
 ): Promise<void> {
   await assertRootUnchanged(rootIdentity);
   const directoryPath = toPosix(relative(root, directory));
@@ -158,6 +173,12 @@ async function walk(
   if (!isSameFile(beforeMetadata, afterMetadata)) {
     throw bundleFileChangedError(displayPath);
   }
+  const directoryIdentity = {
+    absolutePath: directory,
+    displayPath,
+    metadata: afterMetadata,
+  };
+  directories.push(directoryIdentity);
   entries.sort((a, b) => a.name.localeCompare(b.name));
 
   for (const entry of entries) {
@@ -166,7 +187,7 @@ async function walk(
     const absolutePath = join(directory, entry.name);
     const bundlePath = toPosix(relative(root, absolutePath));
     if (entry.isDirectory()) {
-      await walk(root, absolutePath, rootIdentity, paths);
+      await walk(root, absolutePath, rootIdentity, paths, directories);
       continue;
     }
     if (!entry.isFile()) continue;
@@ -184,6 +205,7 @@ async function walk(
       );
     }
   }
+  await assertDirectoryUnchanged(rootIdentity.realPath, directoryIdentity);
   await assertRootUnchanged(rootIdentity);
 }
 
@@ -281,6 +303,41 @@ async function assertRootUnchanged(root: BundleRootIdentity): Promise<void> {
   } catch (error) {
     if (isFileReplacementError(error)) {
       throw bundleFileChangedError("The build output", error);
+    }
+    throw error;
+  }
+}
+
+async function assertDirectoriesUnchanged(
+  rootRealPath: string,
+  directories: BundleDirectoryIdentity[],
+): Promise<void> {
+  for (const directory of directories) {
+    await assertDirectoryUnchanged(rootRealPath, directory);
+  }
+}
+
+async function assertDirectoryUnchanged(
+  rootRealPath: string,
+  directory: BundleDirectoryIdentity,
+): Promise<void> {
+  try {
+    const metadata = await lstat(directory.absolutePath);
+    if (
+      metadata.isSymbolicLink() ||
+      !metadata.isDirectory() ||
+      !isSameFile(directory.metadata, metadata)
+    ) {
+      throw bundleFileChangedError(directory.displayPath);
+    }
+    await assertPathContained(
+      rootRealPath,
+      directory.absolutePath,
+      directory.displayPath,
+    );
+  } catch (error) {
+    if (isFileReplacementError(error)) {
+      throw bundleFileChangedError(directory.displayPath, error);
     }
     throw error;
   }

--- a/src/temp_preview/bundle.ts
+++ b/src/temp_preview/bundle.ts
@@ -2,10 +2,23 @@ import { createHash } from "node:crypto";
 import { constants, type Stats } from "node:fs";
 import { lstat, open, readdir, realpath } from "node:fs/promises";
 import { extname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { isDotenvFilePath } from "@/utils/dotenv_redaction";
 
 export const TEMP_PREVIEW_MAX_FILES = 100;
 export const TEMP_PREVIEW_MAX_FILE_BYTES = 10 * 1024 * 1024;
 export const TEMP_PREVIEW_MAX_BUNDLE_BYTES = 50 * 1024 * 1024;
+
+const SENSITIVE_BUNDLE_PATH_PATTERNS = [
+  /(^|\/)(?:\.git|\.ssh|\.aws|\.azure|\.kube|\.docker|\.config\/gcloud)(?:\/|$)/i,
+  /(^|\/)(?:\.npmrc|\.yarnrc(?:\.yml)?|\.pypirc|\.netrc|\.git-credentials)$/i,
+  /(^|\/)id_(?:rsa|dsa|ecdsa|ed25519)$/i,
+  /\.(?:key|pem|ppk|p12|pfx|jks|keystore|kdbx)$/i,
+  /(^|\/)(?:credentials(?:\.json|\.ya?ml|\.toml)?|secrets?\.(?:json|ya?ml|toml))$/i,
+  /(^|\/)(?:(?:[^/]+[-_])?service[-_]?account(?:[-_]?key)?|private[-_]?key)\.json$/i,
+  /(^|\/)[^/]*firebase-adminsdk[^/]*\.json$/i,
+  /(^|\/)client_secret(?:_[^/]+)?\.json$/i,
+  /(^|\/)application_default_credentials\.json$/i,
+];
 
 export interface TempPreviewBundleFile {
   path: string;
@@ -137,6 +150,12 @@ async function walk(
     }
     if (!entry.isFile()) continue;
 
+    if (isSensitiveBundlePath(bundlePath)) {
+      throw new Error(
+        `Temporary preview blocked because ${bundlePath} looks like a credential or secret file. Remove it from dist and retry.`,
+      );
+    }
+
     paths.push(bundlePath);
     if (paths.length > TEMP_PREVIEW_MAX_FILES) {
       throw new Error(
@@ -144,6 +163,13 @@ async function walk(
       );
     }
   }
+}
+
+function isSensitiveBundlePath(bundlePath: string): boolean {
+  return (
+    isDotenvFilePath(bundlePath) ||
+    SENSITIVE_BUNDLE_PATH_PATTERNS.some((pattern) => pattern.test(bundlePath))
+  );
 }
 
 async function snapshotFile(

--- a/src/temp_preview/bundle.ts
+++ b/src/temp_preview/bundle.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
-import { createReadStream } from "node:fs";
-import { lstat, readdir } from "node:fs/promises";
+import { constants, type Stats } from "node:fs";
+import { lstat, open, readdir } from "node:fs/promises";
 import { extname, join, relative, resolve, sep } from "node:path";
 
 export const TEMP_PREVIEW_MAX_FILES = 100;
@@ -8,11 +8,19 @@ export const TEMP_PREVIEW_MAX_FILE_BYTES = 10 * 1024 * 1024;
 export const TEMP_PREVIEW_MAX_BUNDLE_BYTES = 50 * 1024 * 1024;
 
 export interface TempPreviewBundleFile {
-  absolutePath: string;
   path: string;
   size: number;
   contentType: string;
   hash: string;
+  contents: Uint8Array;
+}
+
+interface DiscoveredBundleFile {
+  absolutePath: string;
+  path: string;
+  size: number;
+  contentType: string;
+  metadata: Stats;
 }
 
 export async function discoverTempPreviewBundle(
@@ -50,7 +58,7 @@ export async function discoverTempPreviewBundle(
     );
   }
 
-  const discovered: Omit<TempPreviewBundleFile, "hash">[] = [];
+  const discovered: DiscoveredBundleFile[] = [];
   let totalBytes = 0;
   for (const bundlePath of paths) {
     const absolutePath = join(source, ...bundlePath.split("/"));
@@ -74,12 +82,13 @@ export async function discoverTempPreviewBundle(
       path: bundlePath,
       size: metadata.size,
       contentType: contentTypeFor(absolutePath),
+      metadata,
     });
   }
 
   const files: TempPreviewBundleFile[] = [];
   for (const file of discovered) {
-    files.push({ ...file, hash: await hashFile(file.absolutePath) });
+    files.push(await snapshotFile(file));
   }
   return files;
 }
@@ -112,12 +121,84 @@ async function walk(
   }
 }
 
-async function hashFile(filePath: string): Promise<string> {
-  const hash = createHash("sha256");
-  for await (const chunk of createReadStream(filePath)) {
-    hash.update(chunk);
+async function snapshotFile(
+  file: DiscoveredBundleFile,
+): Promise<TempPreviewBundleFile> {
+  const noFollow = constants.O_NOFOLLOW ?? 0;
+  let handle;
+  try {
+    handle = await open(file.absolutePath, constants.O_RDONLY | noFollow);
+    const [openedMetadata, currentPathMetadata] = await Promise.all([
+      handle.stat(),
+      lstat(file.absolutePath),
+    ]);
+    if (
+      !openedMetadata.isFile() ||
+      !currentPathMetadata.isFile() ||
+      currentPathMetadata.isSymbolicLink() ||
+      !isSameFile(file.metadata, openedMetadata) ||
+      !isSameFile(openedMetadata, currentPathMetadata) ||
+      openedMetadata.size !== file.size
+    ) {
+      throw bundleFileChangedError(file.path);
+    }
+
+    const contents = Buffer.alloc(file.size);
+    let offset = 0;
+    while (offset < contents.length) {
+      const { bytesRead } = await handle.read(
+        contents,
+        offset,
+        contents.length - offset,
+        offset,
+      );
+      if (bytesRead === 0) break;
+      offset += bytesRead;
+    }
+    const finalMetadata = await handle.stat();
+    if (
+      offset !== file.size ||
+      finalMetadata.size !== file.size ||
+      !isSameFile(openedMetadata, finalMetadata)
+    ) {
+      throw bundleFileChangedError(file.path);
+    }
+
+    return {
+      path: file.path,
+      size: file.size,
+      contentType: file.contentType,
+      hash: createHash("sha256").update(contents).digest("hex"),
+      contents,
+    };
+  } catch (error) {
+    if (isFileReplacementError(error)) {
+      throw bundleFileChangedError(file.path, error);
+    }
+    throw error;
+  } finally {
+    await handle?.close();
   }
-  return hash.digest("hex");
+}
+
+function isSameFile(first: Stats, second: Stats): boolean {
+  return first.dev === second.dev && first.ino === second.ino;
+}
+
+function bundleFileChangedError(path: string, cause?: unknown): Error {
+  return new Error(
+    `${path} changed while the temporary preview was being prepared.`,
+    cause === undefined ? undefined : { cause },
+  );
+}
+
+function isFileReplacementError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error.code === "ELOOP" || error.code === "ENOENT")
+  );
 }
 
 function contentTypeFor(filePath: string): string {

--- a/src/temp_preview/bundle.ts
+++ b/src/temp_preview/bundle.ts
@@ -11,12 +11,12 @@ export const TEMP_PREVIEW_MAX_BUNDLE_BYTES = 50 * 1024 * 1024;
 const SENSITIVE_BUNDLE_PATH_PATTERNS = [
   /(^|\/)(?:\.git|\.ssh|\.aws|\.azure|\.kube|\.docker|\.config\/gcloud)(?:\/|$)/i,
   /(^|\/)(?:\.npmrc|\.yarnrc(?:\.yml)?|\.pypirc|\.netrc|\.git-credentials)$/i,
-  /(^|\/)id_(?:rsa|dsa|ecdsa|ed25519)$/i,
+  /(^|\/)id_(?:rsa|dsa|ecdsa|ed25519|xmss)(?:_sk)?$/i,
   /\.(?:key|pem|ppk|p12|pfx|jks|keystore|kdbx)$/i,
   /(^|\/)(?:credentials(?:\.json|\.ya?ml|\.toml)?|secrets?\.(?:json|ya?ml|toml))$/i,
   /(^|\/)(?:(?:[^/]+[-_])?service[-_]?account(?:[-_]?key)?|private[-_]?key)\.json$/i,
   /(^|\/)[^/]*firebase-adminsdk[^/]*\.json$/i,
-  /(^|\/)client_secret(?:_[^/]+)?\.json$/i,
+  /(^|\/)client_secrets?(?:_[^/]+)?\.json$/i,
   /(^|\/)application_default_credentials\.json$/i,
 ];
 

--- a/src/temp_preview/bundle.ts
+++ b/src/temp_preview/bundle.ts
@@ -12,7 +12,7 @@ export interface TempPreviewBundleFile {
   size: number;
   contentType: string;
   hash: string;
-  contents: Uint8Array;
+  contents: Uint8Array<ArrayBuffer>;
 }
 
 interface DiscoveredBundleFile {
@@ -182,7 +182,13 @@ async function snapshotFile(
 }
 
 function isSameFile(first: Stats, second: Stats): boolean {
-  return first.dev === second.dev && first.ino === second.ino;
+  return (
+    first.dev === second.dev &&
+    first.ino === second.ino &&
+    first.size === second.size &&
+    first.mtimeMs === second.mtimeMs &&
+    first.ctimeMs === second.ctimeMs
+  );
 }
 
 function bundleFileChangedError(path: string, cause?: unknown): Error {

--- a/src/temp_preview/bundle.ts
+++ b/src/temp_preview/bundle.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { createReadStream } from "node:fs";
-import { readdir, stat } from "node:fs/promises";
+import { lstat, readdir } from "node:fs/promises";
 import { extname, join, relative, resolve, sep } from "node:path";
 
 export const TEMP_PREVIEW_MAX_FILES = 100;
@@ -19,7 +19,23 @@ export async function discoverTempPreviewBundle(
   sourcePath: string,
 ): Promise<TempPreviewBundleFile[]> {
   const source = resolve(sourcePath);
-  const sourceStat = await stat(source);
+  let sourceStat;
+  try {
+    sourceStat = await lstat(source);
+  } catch (error) {
+    if (isMissingFileError(error)) {
+      throw new Error(
+        "The build did not produce a dist directory. Temporary previews currently support static Vite apps only.",
+        { cause: error },
+      );
+    }
+    throw error;
+  }
+  if (sourceStat.isSymbolicLink()) {
+    throw new Error(
+      "The temporary preview build output must not be a symbolic link.",
+    );
+  }
   if (!sourceStat.isDirectory()) {
     throw new Error("The temporary preview build output is not a directory.");
   }
@@ -34,30 +50,37 @@ export async function discoverTempPreviewBundle(
     );
   }
 
-  const files = await Promise.all(
-    paths.map(async (bundlePath) => {
-      const absolutePath = join(source, ...bundlePath.split("/"));
-      const metadata = await stat(absolutePath);
-      if (metadata.size > TEMP_PREVIEW_MAX_FILE_BYTES) {
-        throw new Error(
-          `${bundlePath} exceeds the 10 MB temporary preview file limit.`,
-        );
-      }
-      return {
-        absolutePath,
-        path: bundlePath,
-        size: metadata.size,
-        contentType: contentTypeFor(absolutePath),
-        hash: await hashFile(absolutePath),
-      };
-    }),
-  );
-
-  const totalBytes = files.reduce((total, file) => total + file.size, 0);
-  if (totalBytes > TEMP_PREVIEW_MAX_BUNDLE_BYTES) {
-    throw new Error("The build exceeds the 50 MB temporary preview limit.");
+  const discovered: Omit<TempPreviewBundleFile, "hash">[] = [];
+  let totalBytes = 0;
+  for (const bundlePath of paths) {
+    const absolutePath = join(source, ...bundlePath.split("/"));
+    const metadata = await lstat(absolutePath);
+    if (metadata.isSymbolicLink() || !metadata.isFile()) {
+      throw new Error(
+        `${bundlePath} changed while the temporary preview was being prepared.`,
+      );
+    }
+    if (metadata.size > TEMP_PREVIEW_MAX_FILE_BYTES) {
+      throw new Error(
+        `${bundlePath} exceeds the 10 MB temporary preview file limit.`,
+      );
+    }
+    totalBytes += metadata.size;
+    if (totalBytes > TEMP_PREVIEW_MAX_BUNDLE_BYTES) {
+      throw new Error("The build exceeds the 50 MB temporary preview limit.");
+    }
+    discovered.push({
+      absolutePath,
+      path: bundlePath,
+      size: metadata.size,
+      contentType: contentTypeFor(absolutePath),
+    });
   }
 
+  const files: TempPreviewBundleFile[] = [];
+  for (const file of discovered) {
+    files.push({ ...file, hash: await hashFile(file.absolutePath) });
+  }
   return files;
 }
 
@@ -119,8 +142,18 @@ function contentTypeFor(filePath: string): string {
     ".txt": "text/plain",
     ".xml": "application/xml",
     ".webmanifest": "application/manifest+json",
+    ".wasm": "application/wasm",
   };
   return types[extension] ?? "application/octet-stream";
+}
+
+function isMissingFileError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "ENOENT"
+  );
 }
 
 function toPosix(filePath: string): string {

--- a/src/temp_preview/bundle.ts
+++ b/src/temp_preview/bundle.ts
@@ -30,15 +30,22 @@ export interface TempPreviewBundleFile {
 
 interface DiscoveredBundleFile {
   absolutePath: string;
-  rootRealPath: string;
+  root: BundleRootIdentity;
   path: string;
   size: number;
   contentType: string;
   metadata: Stats;
 }
 
+interface BundleRootIdentity {
+  absolutePath: string;
+  realPath: string;
+  metadata: Stats;
+}
+
 export async function discoverTempPreviewBundle(
   sourcePath: string,
+  options: { beforeTraversal?: () => Promise<void> } = {},
 ): Promise<TempPreviewBundleFile[]> {
   const source = resolve(sourcePath);
   let sourceStat;
@@ -70,9 +77,17 @@ export async function discoverTempPreviewBundle(
   ) {
     throw bundleFileChangedError("The build output");
   }
+  const root: BundleRootIdentity = {
+    absolutePath: source,
+    realPath: sourceRealPath,
+    metadata: sourceStat,
+  };
 
   const paths: string[] = [];
-  await walk(source, source, sourceRealPath, paths);
+  await options.beforeTraversal?.();
+  await assertRootUnchanged(root);
+  await walk(source, source, root, paths);
+  await assertRootUnchanged(root);
   paths.sort((a, b) => a.localeCompare(b));
 
   if (!paths.includes("index.html")) {
@@ -84,6 +99,7 @@ export async function discoverTempPreviewBundle(
   const discovered: DiscoveredBundleFile[] = [];
   let totalBytes = 0;
   for (const bundlePath of paths) {
+    await assertRootUnchanged(root);
     const absolutePath = join(source, ...bundlePath.split("/"));
     await assertPathContained(sourceRealPath, absolutePath, bundlePath);
     const metadata = await lstat(absolutePath);
@@ -103,37 +119,42 @@ export async function discoverTempPreviewBundle(
     }
     discovered.push({
       absolutePath,
-      rootRealPath: sourceRealPath,
+      root,
       path: bundlePath,
       size: metadata.size,
       contentType: contentTypeFor(absolutePath),
       metadata,
     });
+    await assertRootUnchanged(root);
   }
 
   const files: TempPreviewBundleFile[] = [];
   for (const file of discovered) {
+    await assertRootUnchanged(root);
     files.push(await snapshotFile(file));
+    await assertRootUnchanged(root);
   }
+  await assertRootUnchanged(root);
   return files;
 }
 
 async function walk(
   root: string,
   directory: string,
-  rootRealPath: string,
+  rootIdentity: BundleRootIdentity,
   paths: string[],
 ): Promise<void> {
+  await assertRootUnchanged(rootIdentity);
   const directoryPath = toPosix(relative(root, directory));
   const displayPath = directoryPath || "The build output";
   const beforeMetadata = await lstat(directory);
   if (beforeMetadata.isSymbolicLink() || !beforeMetadata.isDirectory()) {
     throw bundleFileChangedError(displayPath);
   }
-  await assertPathContained(rootRealPath, directory, displayPath);
+  await assertPathContained(rootIdentity.realPath, directory, displayPath);
   const entries = await readdir(directory, { withFileTypes: true });
   const afterMetadata = await lstat(directory);
-  await assertPathContained(rootRealPath, directory, displayPath);
+  await assertPathContained(rootIdentity.realPath, directory, displayPath);
   if (!isSameFile(beforeMetadata, afterMetadata)) {
     throw bundleFileChangedError(displayPath);
   }
@@ -145,7 +166,7 @@ async function walk(
     const absolutePath = join(directory, entry.name);
     const bundlePath = toPosix(relative(root, absolutePath));
     if (entry.isDirectory()) {
-      await walk(root, absolutePath, rootRealPath, paths);
+      await walk(root, absolutePath, rootIdentity, paths);
       continue;
     }
     if (!entry.isFile()) continue;
@@ -163,6 +184,7 @@ async function walk(
       );
     }
   }
+  await assertRootUnchanged(rootIdentity);
 }
 
 function isSensitiveBundlePath(bundlePath: string): boolean {
@@ -178,7 +200,8 @@ async function snapshotFile(
   const noFollow = constants.O_NOFOLLOW ?? 0;
   let handle;
   try {
-    await assertPathContained(file.rootRealPath, file.absolutePath, file.path);
+    await assertRootUnchanged(file.root);
+    await assertPathContained(file.root.realPath, file.absolutePath, file.path);
     handle = await open(file.absolutePath, constants.O_RDONLY | noFollow);
     const [openedMetadata, currentPathMetadata, currentRealPath] =
       await Promise.all([
@@ -192,7 +215,7 @@ async function snapshotFile(
       currentPathMetadata.isSymbolicLink() ||
       !isSameFile(file.metadata, openedMetadata) ||
       !isSameFile(openedMetadata, currentPathMetadata) ||
-      !isPathContained(file.rootRealPath, currentRealPath) ||
+      !isPathContained(file.root.realPath, currentRealPath) ||
       openedMetadata.size !== file.size
     ) {
       throw bundleFileChangedError(file.path);
@@ -218,10 +241,11 @@ async function snapshotFile(
       offset !== file.size ||
       finalMetadata.size !== file.size ||
       !isSameFile(openedMetadata, finalMetadata) ||
-      !isPathContained(file.rootRealPath, finalRealPath)
+      !isPathContained(file.root.realPath, finalRealPath)
     ) {
       throw bundleFileChangedError(file.path);
     }
+    await assertRootUnchanged(file.root);
 
     return {
       path: file.path,
@@ -237,6 +261,28 @@ async function snapshotFile(
     throw error;
   } finally {
     await handle?.close();
+  }
+}
+
+async function assertRootUnchanged(root: BundleRootIdentity): Promise<void> {
+  try {
+    const [metadata, currentRealPath] = await Promise.all([
+      lstat(root.absolutePath),
+      realpath(root.absolutePath),
+    ]);
+    if (
+      metadata.isSymbolicLink() ||
+      !metadata.isDirectory() ||
+      !isSameFile(root.metadata, metadata) ||
+      relative(root.realPath, currentRealPath) !== ""
+    ) {
+      throw bundleFileChangedError("The build output");
+    }
+  } catch (error) {
+    if (isFileReplacementError(error)) {
+      throw bundleFileChangedError("The build output", error);
+    }
+    throw error;
   }
 }
 

--- a/src/temp_preview/client.test.ts
+++ b/src/temp_preview/client.test.ts
@@ -1,30 +1,21 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import type { TempPreviewBundleFile } from "./bundle";
 import { TempmdApiError, TempmdClient } from "./client";
 
-const clientRoots: string[] = [];
-
-async function createClientFile(name = "index.html"): Promise<string> {
-  const root = await mkdtemp(join(tmpdir(), "dyad-tempmd-client-"));
-  clientRoots.push(root);
-  const absolutePath = join(root, name);
-  await writeFile(absolutePath, "hello");
-  return absolutePath;
+function createBundleFile(path = "index.html"): TempPreviewBundleFile {
+  const contents = new TextEncoder().encode("hello");
+  return {
+    path,
+    size: contents.byteLength,
+    contentType: "text/html",
+    hash: `hash-${path}`,
+    contents,
+  };
 }
 
 describe("TempmdClient", () => {
-  afterEach(async () => {
-    await Promise.all(
-      clientRoots
-        .splice(0)
-        .map((root) => rm(root, { recursive: true, force: true })),
-    );
-  });
-
   it("creates, uploads and finalizes a temporary preview without exposing capabilities", async () => {
-    const absolutePath = await createClientFile();
+    const file = createBundleFile();
     const fetcher = vi.fn<typeof fetch>();
     fetcher
       .mockResolvedValueOnce(
@@ -59,15 +50,7 @@ describe("TempmdClient", () => {
       fetcher,
     ).publish({
       title: "Demo",
-      files: [
-        {
-          absolutePath,
-          path: "index.html",
-          size: 5,
-          contentType: "text/html",
-          hash: "hash",
-        },
-      ],
+      files: [file],
     });
 
     expect(result).toEqual({
@@ -86,6 +69,8 @@ describe("TempmdClient", () => {
         }),
       }),
     );
+    const uploadBody = fetcher.mock.calls[1][1]?.body;
+    expect(new TextDecoder().decode(uploadBody as Uint8Array)).toBe("hello");
   });
 
   it("uses the scoped update capability for update and revoke requests", async () => {
@@ -141,7 +126,7 @@ describe("TempmdClient", () => {
   });
 
   it("classifies upload transport failures", async () => {
-    const absolutePath = await createClientFile();
+    const file = createBundleFile();
     const fetcher = vi.fn<typeof fetch>();
     fetcher
       .mockResolvedValueOnce(
@@ -163,30 +148,25 @@ describe("TempmdClient", () => {
 
     const result = new TempmdClient("https://api.temp.md", fetcher).publish({
       title: "Demo",
-      files: [
-        {
-          absolutePath,
-          path: "index.html",
-          size: 5,
-          contentType: "text/html",
-          hash: "hash",
-        },
-      ],
+      files: [file],
     });
 
     await expect(result).rejects.toMatchObject({
       name: "TempmdApiError",
       status: 0,
       code: "transport_error",
+      phase: "upload",
     } satisfies Partial<TempmdApiError>);
   });
 
-  it("waits for sibling uploads to settle before rejecting", async () => {
-    const firstPath = await createClientFile("first.html");
-    const secondPath = await createClientFile("second.html");
-    let releaseSecondUpload!: () => void;
-    const secondUpload = new Promise<Response>((resolve) => {
-      releaseSecondUpload = () => resolve(new Response(null, { status: 200 }));
+  it("waits for in-flight uploads but skips queued work after a failure", async () => {
+    const files = Array.from({ length: 5 }, (_, index) =>
+      createBundleFile(`file-${index + 1}.html`),
+    );
+    let releaseInFlightUploads!: () => void;
+    const inFlightUpload = new Promise<Response>((resolve) => {
+      releaseInFlightUploads = () =>
+        resolve(new Response(null, { status: 200 }));
     });
     const fetcher = vi.fn<typeof fetch>(async (url) => {
       if (url === "https://api.temp.md/publish-sessions") {
@@ -194,26 +174,26 @@ describe("TempmdClient", () => {
           sessionId: "session-1",
           tempId: "temp-1",
           uploadToken: "upload-secret",
-          uploads: [
-            {
-              path: "first.html",
-              status: "expected",
-              url: "https://uploads.temp.md/first.html",
-            },
-            {
-              path: "second.html",
-              status: "expected",
-              url: "https://uploads.temp.md/second.html",
-            },
-          ],
+          uploads: files.map((file, index) => ({
+            path: file.path,
+            status: "expected",
+            url: `https://uploads.temp.md/${index + 1}`,
+          })),
           skipped: [],
         });
       }
-      if (url === "https://uploads.temp.md/first.html") {
+      if (url === "https://uploads.temp.md/1") {
         return new Response("failed", { status: 500 });
       }
-      if (url === "https://uploads.temp.md/second.html") {
-        return secondUpload;
+      if (
+        url === "https://uploads.temp.md/2" ||
+        url === "https://uploads.temp.md/3" ||
+        url === "https://uploads.temp.md/4"
+      ) {
+        return inFlightUpload;
+      }
+      if (url === "https://uploads.temp.md/5") {
+        return new Response(null, { status: 200 });
       }
       throw new Error(`Unexpected request: ${url}`);
     });
@@ -221,22 +201,7 @@ describe("TempmdClient", () => {
     const publish = new TempmdClient("https://api.temp.md", fetcher)
       .publish({
         title: "Demo",
-        files: [
-          {
-            absolutePath: firstPath,
-            path: "first.html",
-            size: 5,
-            contentType: "text/html",
-            hash: "hash-1",
-          },
-          {
-            absolutePath: secondPath,
-            path: "second.html",
-            size: 5,
-            contentType: "text/html",
-            hash: "hash-2",
-          },
-        ],
+        files,
       })
       .finally(() => {
         settled = true;
@@ -244,15 +209,19 @@ describe("TempmdClient", () => {
 
     await vi.waitFor(() => {
       expect(fetcher).toHaveBeenCalledWith(
-        "https://uploads.temp.md/second.html",
+        "https://uploads.temp.md/2",
         expect.anything(),
       );
     });
     await Promise.resolve();
     expect(settled).toBe(false);
-    releaseSecondUpload();
+    releaseInFlightUploads();
     await expect(publish).rejects.toBeInstanceOf(TempmdApiError);
     expect(settled).toBe(true);
+    expect(fetcher).not.toHaveBeenCalledWith(
+      "https://uploads.temp.md/5",
+      expect.anything(),
+    );
   });
 
   it("classifies invalid success response bodies", async () => {
@@ -269,6 +238,7 @@ describe("TempmdClient", () => {
       name: "TempmdApiError",
       status: 200,
       code: "invalid_response",
+      phase: "session",
     } satisfies Partial<TempmdApiError>);
   });
 });

--- a/src/temp_preview/client.test.ts
+++ b/src/temp_preview/client.test.ts
@@ -1,14 +1,30 @@
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it, vi } from "vitest";
-import { TempmdClient } from "./client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TempmdApiError, TempmdClient } from "./client";
+
+const clientRoots: string[] = [];
+
+async function createClientFile(name = "index.html"): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "dyad-tempmd-client-"));
+  clientRoots.push(root);
+  const absolutePath = join(root, name);
+  await writeFile(absolutePath, "hello");
+  return absolutePath;
+}
 
 describe("TempmdClient", () => {
+  afterEach(async () => {
+    await Promise.all(
+      clientRoots
+        .splice(0)
+        .map((root) => rm(root, { recursive: true, force: true })),
+    );
+  });
+
   it("creates, uploads and finalizes a temporary preview without exposing capabilities", async () => {
-    const root = await mkdtemp(join(tmpdir(), "dyad-tempmd-client-"));
-    const absolutePath = join(root, "index.html");
-    await writeFile(absolutePath, "hello");
+    const absolutePath = await createClientFile();
     const fetcher = vi.fn<typeof fetch>();
     fetcher
       .mockResolvedValueOnce(
@@ -93,7 +109,7 @@ describe("TempmdClient", () => {
           expiresAt: null,
         }),
       )
-      .mockResolvedValueOnce(Response.json({ ok: true }));
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
     const client = new TempmdClient("https://api.temp.md", fetcher);
     const previous = {
       tempId: "temp-1",
@@ -122,5 +138,137 @@ describe("TempmdClient", () => {
         headers: { Authorization: "Bearer update-secret" },
       }),
     );
+  });
+
+  it("classifies upload transport failures", async () => {
+    const absolutePath = await createClientFile();
+    const fetcher = vi.fn<typeof fetch>();
+    fetcher
+      .mockResolvedValueOnce(
+        Response.json({
+          sessionId: "session-1",
+          tempId: "temp-1",
+          uploadToken: "upload-secret",
+          uploads: [
+            {
+              path: "index.html",
+              status: "expected",
+              url: "https://uploads.temp.md/index.html",
+            },
+          ],
+          skipped: [],
+        }),
+      )
+      .mockRejectedValueOnce(new DOMException("timed out", "TimeoutError"));
+
+    const result = new TempmdClient("https://api.temp.md", fetcher).publish({
+      title: "Demo",
+      files: [
+        {
+          absolutePath,
+          path: "index.html",
+          size: 5,
+          contentType: "text/html",
+          hash: "hash",
+        },
+      ],
+    });
+
+    await expect(result).rejects.toMatchObject({
+      name: "TempmdApiError",
+      status: 0,
+      code: "transport_error",
+    } satisfies Partial<TempmdApiError>);
+  });
+
+  it("waits for sibling uploads to settle before rejecting", async () => {
+    const firstPath = await createClientFile("first.html");
+    const secondPath = await createClientFile("second.html");
+    let releaseSecondUpload!: () => void;
+    const secondUpload = new Promise<Response>((resolve) => {
+      releaseSecondUpload = () => resolve(new Response(null, { status: 200 }));
+    });
+    const fetcher = vi.fn<typeof fetch>(async (url) => {
+      if (url === "https://api.temp.md/publish-sessions") {
+        return Response.json({
+          sessionId: "session-1",
+          tempId: "temp-1",
+          uploadToken: "upload-secret",
+          uploads: [
+            {
+              path: "first.html",
+              status: "expected",
+              url: "https://uploads.temp.md/first.html",
+            },
+            {
+              path: "second.html",
+              status: "expected",
+              url: "https://uploads.temp.md/second.html",
+            },
+          ],
+          skipped: [],
+        });
+      }
+      if (url === "https://uploads.temp.md/first.html") {
+        return new Response("failed", { status: 500 });
+      }
+      if (url === "https://uploads.temp.md/second.html") {
+        return secondUpload;
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    let settled = false;
+    const publish = new TempmdClient("https://api.temp.md", fetcher)
+      .publish({
+        title: "Demo",
+        files: [
+          {
+            absolutePath: firstPath,
+            path: "first.html",
+            size: 5,
+            contentType: "text/html",
+            hash: "hash-1",
+          },
+          {
+            absolutePath: secondPath,
+            path: "second.html",
+            size: 5,
+            contentType: "text/html",
+            hash: "hash-2",
+          },
+        ],
+      })
+      .finally(() => {
+        settled = true;
+      });
+
+    await vi.waitFor(() => {
+      expect(fetcher).toHaveBeenCalledWith(
+        "https://uploads.temp.md/second.html",
+        expect.anything(),
+      );
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    releaseSecondUpload();
+    await expect(publish).rejects.toBeInstanceOf(TempmdApiError);
+    expect(settled).toBe(true);
+  });
+
+  it("classifies invalid success response bodies", async () => {
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response("not-json", { status: 200 }));
+
+    const result = new TempmdClient("https://api.temp.md", fetcher).publish({
+      title: "Demo",
+      files: [],
+    });
+
+    await expect(result).rejects.toMatchObject({
+      name: "TempmdApiError",
+      status: 200,
+      code: "invalid_response",
+    } satisfies Partial<TempmdApiError>);
   });
 });

--- a/src/temp_preview/client.test.ts
+++ b/src/temp_preview/client.test.ts
@@ -126,6 +126,95 @@ describe("TempmdClient", () => {
     );
   });
 
+  it("retries an ambiguous finalize result with the same publish session", async () => {
+    const retryDelay = vi.fn().mockResolvedValue(undefined);
+    const fetcher = vi.fn<typeof fetch>();
+    fetcher
+      .mockResolvedValueOnce(
+        Response.json({
+          sessionId: "session-1",
+          tempId: "temp-1",
+          uploadToken: "upload-secret",
+          uploads: [],
+          skipped: [],
+        }),
+      )
+      .mockRejectedValueOnce(new TypeError("connection closed"))
+      .mockResolvedValueOnce(
+        Response.json({
+          success: true,
+          tempId: "temp-1",
+          versionId: "version-1",
+          canonicalUrl: "https://example.temp.md",
+          expiresAt: "2026-08-30T00:00:00.000Z",
+          updateToken: "update-secret",
+        }),
+      );
+
+    await expect(
+      new TempmdClient("https://api.temp.md", fetcher, retryDelay).publish({
+        title: "Demo",
+        files: [],
+      }),
+    ).resolves.toMatchObject({
+      tempId: "temp-1",
+      updateToken: "update-secret",
+    });
+
+    expect(retryDelay).toHaveBeenCalledWith(250);
+    expect(fetcher).toHaveBeenNthCalledWith(
+      2,
+      "https://api.temp.md/publish-sessions/session-1/finalize",
+      expect.objectContaining({
+        method: "POST",
+        headers: { Authorization: "Bearer upload-secret" },
+      }),
+    );
+    expect(fetcher).toHaveBeenNthCalledWith(
+      3,
+      "https://api.temp.md/publish-sessions/session-1/finalize",
+      expect.objectContaining({
+        method: "POST",
+        headers: { Authorization: "Bearer upload-secret" },
+      }),
+    );
+  });
+
+  it("does not retry a definitive finalize rejection", async () => {
+    const retryDelay = vi.fn().mockResolvedValue(undefined);
+    const fetcher = vi.fn<typeof fetch>();
+    fetcher
+      .mockResolvedValueOnce(
+        Response.json({
+          sessionId: "session-1",
+          tempId: "temp-1",
+          uploadToken: "upload-secret",
+          uploads: [],
+          skipped: [],
+        }),
+      )
+      .mockResolvedValueOnce(
+        Response.json(
+          { error: "Publish session expired", code: "session_expired" },
+          { status: 410 },
+        ),
+      );
+
+    await expect(
+      new TempmdClient("https://api.temp.md", fetcher, retryDelay).publish({
+        title: "Demo",
+        files: [],
+      }),
+    ).rejects.toMatchObject({
+      status: 410,
+      code: "session_expired",
+      phase: "finalize",
+    });
+
+    expect(retryDelay).not.toHaveBeenCalled();
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
   it("classifies upload transport failures", async () => {
     const file = createBundleFile();
     const fetcher = vi.fn<typeof fetch>();

--- a/src/temp_preview/client.test.ts
+++ b/src/temp_preview/client.test.ts
@@ -126,6 +126,53 @@ describe("TempmdClient", () => {
     );
   });
 
+  it("does not reuse a previous capability for a different finalized preview", async () => {
+    const retryDelay = vi.fn().mockResolvedValue(undefined);
+    const fetcher = vi.fn<typeof fetch>();
+    const mismatchedFinalize = () =>
+      Response.json({
+        success: true,
+        tempId: "temp-2",
+        versionId: "version-2",
+        canonicalUrl: "https://different.temp.md",
+        expiresAt: "2026-08-30T00:00:00.000Z",
+      });
+    fetcher
+      .mockResolvedValueOnce(
+        Response.json({
+          sessionId: "session-2",
+          tempId: "temp-2",
+          uploadToken: "upload-secret",
+          uploads: [],
+          skipped: [],
+        }),
+      )
+      .mockResolvedValueOnce(mismatchedFinalize())
+      .mockResolvedValueOnce(mismatchedFinalize())
+      .mockResolvedValueOnce(mismatchedFinalize());
+
+    await expect(
+      new TempmdClient("https://api.temp.md", fetcher, retryDelay).publish({
+        title: "Demo",
+        files: [],
+        previous: {
+          tempId: "temp-1",
+          canonicalUrl: "https://example.temp.md",
+          updateToken: "old-update-secret",
+          expiresAt: null,
+        },
+      }),
+    ).rejects.toMatchObject({
+      status: 200,
+      code: "invalid_response",
+      phase: "finalize",
+    });
+
+    expect(retryDelay).toHaveBeenNthCalledWith(1, 250);
+    expect(retryDelay).toHaveBeenNthCalledWith(2, 1_000);
+    expect(fetcher).toHaveBeenCalledTimes(4);
+  });
+
   it("retries an ambiguous finalize result with the same publish session", async () => {
     const retryDelay = vi.fn().mockResolvedValue(undefined);
     const fetcher = vi.fn<typeof fetch>();

--- a/src/temp_preview/client.test.ts
+++ b/src/temp_preview/client.test.ts
@@ -215,6 +215,41 @@ describe("TempmdClient", () => {
     expect(fetcher).toHaveBeenCalledTimes(2);
   });
 
+  it("does not retry a 4xx response whose server code is invalid_response", async () => {
+    const retryDelay = vi.fn().mockResolvedValue(undefined);
+    const fetcher = vi.fn<typeof fetch>();
+    fetcher
+      .mockResolvedValueOnce(
+        Response.json({
+          sessionId: "session-1",
+          tempId: "temp-1",
+          uploadToken: "upload-secret",
+          uploads: [],
+          skipped: [],
+        }),
+      )
+      .mockResolvedValueOnce(
+        Response.json(
+          { error: "Invalid request", code: "invalid_response" },
+          { status: 400 },
+        ),
+      );
+
+    await expect(
+      new TempmdClient("https://api.temp.md", fetcher, retryDelay).publish({
+        title: "Demo",
+        files: [],
+      }),
+    ).rejects.toMatchObject({
+      status: 400,
+      code: "invalid_response",
+      phase: "finalize",
+    });
+
+    expect(retryDelay).not.toHaveBeenCalled();
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
   it("classifies upload transport failures", async () => {
     const file = createBundleFile();
     const fetcher = vi.fn<typeof fetch>();

--- a/src/temp_preview/client.test.ts
+++ b/src/temp_preview/client.test.ts
@@ -70,6 +70,7 @@ describe("TempmdClient", () => {
       }),
     );
     const uploadBody = fetcher.mock.calls[1][1]?.body;
+    expect(uploadBody).toBe(file.contents);
     expect(new TextDecoder().decode(uploadBody as Uint8Array)).toBe("hello");
   });
 

--- a/src/temp_preview/client.test.ts
+++ b/src/temp_preview/client.test.ts
@@ -1,0 +1,126 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { TempmdClient } from "./client";
+
+describe("TempmdClient", () => {
+  it("creates, uploads and finalizes a temporary preview without exposing capabilities", async () => {
+    const root = await mkdtemp(join(tmpdir(), "dyad-tempmd-client-"));
+    const absolutePath = join(root, "index.html");
+    await writeFile(absolutePath, "hello");
+    const fetcher = vi.fn<typeof fetch>();
+    fetcher
+      .mockResolvedValueOnce(
+        Response.json({
+          sessionId: "session-1",
+          tempId: "temp-1",
+          uploadToken: "upload-secret",
+          uploads: [
+            {
+              path: "index.html",
+              status: "expected",
+              url: "https://uploads.temp.md/index.html",
+            },
+          ],
+          skipped: [],
+        }),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+      .mockResolvedValueOnce(
+        Response.json({
+          success: true,
+          tempId: "temp-1",
+          versionId: "version-1",
+          canonicalUrl: "https://example.temp.md",
+          expiresAt: "2026-08-30T00:00:00.000Z",
+          updateToken: "update-secret",
+        }),
+      );
+
+    const result = await new TempmdClient(
+      "https://api.temp.md",
+      fetcher,
+    ).publish({
+      title: "Demo",
+      files: [
+        {
+          absolutePath,
+          path: "index.html",
+          size: 5,
+          contentType: "text/html",
+          hash: "hash",
+        },
+      ],
+    });
+
+    expect(result).toEqual({
+      tempId: "temp-1",
+      canonicalUrl: "https://example.temp.md",
+      expiresAt: "2026-08-30T00:00:00.000Z",
+      updateToken: "update-secret",
+    });
+    expect(fetcher).toHaveBeenNthCalledWith(
+      2,
+      "https://uploads.temp.md/index.html",
+      expect.objectContaining({
+        method: "PUT",
+        headers: expect.objectContaining({
+          Authorization: "Bearer upload-secret",
+        }),
+      }),
+    );
+  });
+
+  it("uses the scoped update capability for update and revoke requests", async () => {
+    const fetcher = vi.fn<typeof fetch>();
+    fetcher
+      .mockResolvedValueOnce(
+        Response.json({
+          sessionId: "session-2",
+          tempId: "temp-1",
+          uploadToken: "upload-secret",
+          uploads: [],
+          skipped: ["index.html"],
+        }),
+      )
+      .mockResolvedValueOnce(
+        Response.json({
+          success: true,
+          tempId: "temp-1",
+          versionId: "version-2",
+          canonicalUrl: "https://example.temp.md",
+          expiresAt: null,
+        }),
+      )
+      .mockResolvedValueOnce(Response.json({ ok: true }));
+    const client = new TempmdClient("https://api.temp.md", fetcher);
+    const previous = {
+      tempId: "temp-1",
+      canonicalUrl: "https://example.temp.md",
+      updateToken: "update-secret",
+      expiresAt: null,
+    };
+
+    await client.publish({ title: "Demo", files: [], previous });
+    await client.revoke(previous);
+
+    expect(fetcher).toHaveBeenNthCalledWith(
+      1,
+      "https://api.temp.md/publish-sessions",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer update-secret",
+        }),
+      }),
+    );
+    expect(fetcher).toHaveBeenNthCalledWith(
+      3,
+      "https://api.temp.md/temps/temp-1",
+      expect.objectContaining({
+        method: "DELETE",
+        headers: { Authorization: "Bearer update-secret" },
+      }),
+    );
+  });
+});

--- a/src/temp_preview/client.test.ts
+++ b/src/temp_preview/client.test.ts
@@ -74,6 +74,29 @@ describe("TempmdClient", () => {
     expect(new TextDecoder().decode(uploadBody as Uint8Array)).toBe("hello");
   });
 
+  it("normalizes malformed publish-session responses", async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValueOnce(
+      Response.json({
+        sessionId: "session-1",
+        tempId: "temp-1",
+        uploadToken: "upload-secret",
+        uploads: [],
+      }),
+    );
+
+    await expect(
+      new TempmdClient("https://api.temp.md", fetcher).publish({
+        title: "Demo",
+        files: [],
+      }),
+    ).rejects.toMatchObject({
+      message: "temp.md returned an invalid response",
+      status: 200,
+      code: "invalid_response",
+      phase: "session",
+    });
+  });
+
   it("uses the scoped update capability for update and revoke requests", async () => {
     const fetcher = vi.fn<typeof fetch>();
     fetcher

--- a/src/temp_preview/client.ts
+++ b/src/temp_preview/client.ts
@@ -25,6 +25,8 @@ const FinalizedPublishSchema = z.object({
   updateToken: z.string().optional(),
 });
 
+const FINALIZE_RETRY_DELAYS_MS = [250, 1_000] as const;
+
 export interface TempPreviewConnection {
   tempId: string;
   canonicalUrl: string;
@@ -57,6 +59,9 @@ export class TempmdClient {
   constructor(
     baseUrl = "https://api.temp.md",
     private readonly fetcher: typeof fetch = fetch,
+    private readonly delay: (
+      milliseconds: number,
+    ) => Promise<void> = waitForDelay,
   ) {
     this.baseUrl = baseUrl.replace(/\/+$/, "");
   }
@@ -128,15 +133,10 @@ export class TempmdClient {
       }
     });
 
-    const finalized = FinalizedPublishSchema.parse(
-      await this.json(
-        `/publish-sessions/${encodeURIComponent(session.sessionId)}/finalize`,
-        {
-          method: "POST",
-          headers: { Authorization: `Bearer ${session.uploadToken}` },
-        },
-        "finalize",
-      ),
+    const finalized = await this.finalizeSession(
+      session.sessionId,
+      session.uploadToken,
+      Boolean(input.previous),
     );
     const updateToken = finalized.updateToken ?? input.previous?.updateToken;
     if (!updateToken) {
@@ -159,6 +159,51 @@ export class TempmdClient {
       },
       "revoke",
     );
+  }
+
+  private async finalizeSession(
+    sessionId: string,
+    uploadToken: string,
+    canReusePreviousToken: boolean,
+  ): Promise<z.infer<typeof FinalizedPublishSchema>> {
+    for (let attempt = 0; ; attempt += 1) {
+      try {
+        const finalized = FinalizedPublishSchema.parse(
+          await this.json(
+            `/publish-sessions/${encodeURIComponent(sessionId)}/finalize`,
+            {
+              method: "POST",
+              headers: { Authorization: `Bearer ${uploadToken}` },
+            },
+            "finalize",
+          ),
+        );
+        if (!canReusePreviousToken && !finalized.updateToken) {
+          throw new TempmdApiError(
+            "temp.md returned an invalid response",
+            200,
+            "invalid_response",
+            "finalize",
+          );
+        }
+        return finalized;
+      } catch (error) {
+        const normalized =
+          error instanceof z.ZodError
+            ? new TempmdApiError(
+                "temp.md returned an invalid response",
+                200,
+                "invalid_response",
+                "finalize",
+              )
+            : error;
+        const retryDelay = FINALIZE_RETRY_DELAYS_MS[attempt];
+        if (retryDelay === undefined || !isAmbiguousFinalizeError(normalized)) {
+          throw normalized;
+        }
+        await this.delay(retryDelay);
+      }
+    }
   }
 
   private async json(
@@ -199,6 +244,21 @@ export class TempmdClient {
       throw transportError(error, fallback, phase);
     }
   }
+}
+
+function isAmbiguousFinalizeError(error: unknown): boolean {
+  return (
+    error instanceof TempmdApiError &&
+    error.phase === "finalize" &&
+    (error.status === 0 ||
+      error.status === 408 ||
+      error.status >= 500 ||
+      error.code === "invalid_response")
+  );
+}
+
+function waitForDelay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
 async function readJsonResponse(

--- a/src/temp_preview/client.ts
+++ b/src/temp_preview/client.ts
@@ -136,9 +136,13 @@ export class TempmdClient {
     const finalized = await this.finalizeSession(
       session.sessionId,
       session.uploadToken,
-      Boolean(input.previous),
+      input.previous?.tempId,
     );
-    const updateToken = finalized.updateToken ?? input.previous?.updateToken;
+    const updateToken =
+      finalized.updateToken ??
+      (finalized.tempId === input.previous?.tempId
+        ? input.previous.updateToken
+        : undefined);
     if (!updateToken) {
       throw new Error("temp.md did not return an update capability.");
     }
@@ -164,7 +168,7 @@ export class TempmdClient {
   private async finalizeSession(
     sessionId: string,
     uploadToken: string,
-    canReusePreviousToken: boolean,
+    previousTempId?: string,
   ): Promise<z.infer<typeof FinalizedPublishSchema>> {
     for (let attempt = 0; ; attempt += 1) {
       try {
@@ -178,7 +182,8 @@ export class TempmdClient {
             "finalize",
           ),
         );
-        if (!canReusePreviousToken && !finalized.updateToken) {
+        const canReusePreviousToken = finalized.tempId === previousTempId;
+        if (!finalized.updateToken && !canReusePreviousToken) {
           throw new TempmdApiError(
             "temp.md returned an invalid response",
             200,

--- a/src/temp_preview/client.ts
+++ b/src/temp_preview/client.ts
@@ -113,7 +113,7 @@ export class TempmdClient {
             "Content-Type": file.contentType,
             "Content-Length": String(file.size),
           },
-          body: new Uint8Array(file.contents),
+          body: file.contents,
         },
         120_000,
         `Upload failed for ${file.path}`,

--- a/src/temp_preview/client.ts
+++ b/src/temp_preview/client.ts
@@ -93,16 +93,20 @@ export class TempmdClient {
       if (!file) {
         throw new Error(`The local build no longer contains ${upload.path}.`);
       }
-      const response = await this.fetcher(upload.url, {
-        method: "PUT",
-        headers: {
-          Authorization: `Bearer ${session.uploadToken}`,
-          "Content-Type": file.contentType,
-          "Content-Length": String(file.size),
+      const response = await this.request(
+        upload.url,
+        {
+          method: "PUT",
+          headers: {
+            Authorization: `Bearer ${session.uploadToken}`,
+            "Content-Type": file.contentType,
+            "Content-Length": String(file.size),
+          },
+          body: new Uint8Array(await readFile(file.absolutePath)),
         },
-        body: new Uint8Array(await readFile(file.absolutePath)),
-        signal: AbortSignal.timeout(120_000),
-      });
+        120_000,
+        `Upload failed for ${file.path}`,
+      );
       if (!response.ok) {
         await throwApiError(response, `Upload failed for ${file.path}`);
       }
@@ -137,23 +141,59 @@ export class TempmdClient {
   }
 
   private async json(path: string, init: RequestInit): Promise<unknown> {
-    let response: Response;
-    try {
-      response = await this.fetcher(`${this.baseUrl}${path}`, {
-        ...init,
-        signal: AbortSignal.timeout(60_000),
-      });
-    } catch (error) {
-      throw new TempmdApiError(
-        error instanceof Error ? error.message : "temp.md request failed",
-        0,
-      );
-    }
+    const response = await this.request(
+      `${this.baseUrl}${path}`,
+      init,
+      60_000,
+      "temp.md request failed",
+    );
     if (!response.ok) {
       await throwApiError(response, "temp.md request failed");
     }
-    return response.json();
+    return readJsonResponse(response, "temp.md returned an invalid response");
   }
+
+  private async request(
+    url: string,
+    init: RequestInit,
+    timeoutMs: number,
+    fallback: string,
+  ): Promise<Response> {
+    try {
+      return await this.fetcher(url, {
+        ...init,
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+    } catch (error) {
+      throw transportError(error, fallback);
+    }
+  }
+}
+
+async function readJsonResponse(
+  response: Response,
+  fallback: string,
+): Promise<unknown> {
+  let contents: string;
+  try {
+    contents = await response.text();
+  } catch (error) {
+    throw transportError(error, fallback);
+  }
+  if (contents.trim() === "") return null;
+  try {
+    return JSON.parse(contents);
+  } catch {
+    throw new TempmdApiError(fallback, response.status, "invalid_response");
+  }
+}
+
+function transportError(error: unknown, fallback: string): TempmdApiError {
+  return new TempmdApiError(
+    error instanceof Error ? error.message : fallback,
+    0,
+    "transport_error",
+  );
 }
 
 async function throwApiError(
@@ -196,5 +236,9 @@ async function uploadConcurrently<T>(
       }
     },
   );
-  await Promise.all(runners);
+  const results = await Promise.allSettled(runners);
+  const failure = results.find(
+    (result): result is PromiseRejectedResult => result.status === "rejected",
+  );
+  if (failure) throw failure.reason;
 }

--- a/src/temp_preview/client.ts
+++ b/src/temp_preview/client.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from "node:crypto";
-import { readFile } from "node:fs/promises";
 import { z } from "zod";
 import type { TempPreviewBundleFile } from "./bundle";
 
@@ -33,11 +32,19 @@ export interface TempPreviewConnection {
   expiresAt: string | null;
 }
 
+export type TempmdRequestPhase =
+  | "session"
+  | "upload"
+  | "finalize"
+  | "revoke"
+  | "request";
+
 export class TempmdApiError extends Error {
   constructor(
     message: string,
     readonly status: number,
     readonly code?: string,
+    readonly phase: TempmdRequestPhase = "request",
   ) {
     super(message);
     this.name = "TempmdApiError";
@@ -60,27 +67,31 @@ export class TempmdClient {
     previous?: TempPreviewConnection;
   }): Promise<TempPreviewConnection> {
     const session = SessionSchema.parse(
-      await this.json("/publish-sessions", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "Idempotency-Key": randomUUID(),
-          ...(input.previous
-            ? { Authorization: `Bearer ${input.previous.updateToken}` }
-            : {}),
+      await this.json(
+        "/publish-sessions",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "Idempotency-Key": randomUUID(),
+            ...(input.previous
+              ? { Authorization: `Bearer ${input.previous.updateToken}` }
+              : {}),
+          },
+          body: JSON.stringify({
+            files: input.files.map((file) => ({
+              path: file.path,
+              size: file.size,
+              contentType: file.contentType,
+              hash: file.hash,
+            })),
+            title: input.title,
+            spaMode: true,
+            ...(input.previous ? { tempId: input.previous.tempId } : {}),
+          }),
         },
-        body: JSON.stringify({
-          files: input.files.map((file) => ({
-            path: file.path,
-            size: file.size,
-            contentType: file.contentType,
-            hash: file.hash,
-          })),
-          title: input.title,
-          spaMode: true,
-          ...(input.previous ? { tempId: input.previous.tempId } : {}),
-        }),
-      }),
+        "session",
+      ),
     );
 
     const outstanding = session.uploads.filter(
@@ -102,13 +113,18 @@ export class TempmdClient {
             "Content-Type": file.contentType,
             "Content-Length": String(file.size),
           },
-          body: new Uint8Array(await readFile(file.absolutePath)),
+          body: new Uint8Array(file.contents),
         },
         120_000,
         `Upload failed for ${file.path}`,
+        "upload",
       );
       if (!response.ok) {
-        await throwApiError(response, `Upload failed for ${file.path}`);
+        await throwApiError(
+          response,
+          `Upload failed for ${file.path}`,
+          "upload",
+        );
       }
     });
 
@@ -119,6 +135,7 @@ export class TempmdClient {
           method: "POST",
           headers: { Authorization: `Bearer ${session.uploadToken}` },
         },
+        "finalize",
       ),
     );
     const updateToken = finalized.updateToken ?? input.previous?.updateToken;
@@ -134,23 +151,36 @@ export class TempmdClient {
   }
 
   async revoke(connection: TempPreviewConnection): Promise<void> {
-    await this.json(`/temps/${encodeURIComponent(connection.tempId)}`, {
-      method: "DELETE",
-      headers: { Authorization: `Bearer ${connection.updateToken}` },
-    });
+    await this.json(
+      `/temps/${encodeURIComponent(connection.tempId)}`,
+      {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${connection.updateToken}` },
+      },
+      "revoke",
+    );
   }
 
-  private async json(path: string, init: RequestInit): Promise<unknown> {
+  private async json(
+    path: string,
+    init: RequestInit,
+    phase: TempmdRequestPhase,
+  ): Promise<unknown> {
     const response = await this.request(
       `${this.baseUrl}${path}`,
       init,
       60_000,
       "temp.md request failed",
+      phase,
     );
     if (!response.ok) {
-      await throwApiError(response, "temp.md request failed");
+      await throwApiError(response, "temp.md request failed", phase);
     }
-    return readJsonResponse(response, "temp.md returned an invalid response");
+    return readJsonResponse(
+      response,
+      "temp.md returned an invalid response",
+      phase,
+    );
   }
 
   private async request(
@@ -158,6 +188,7 @@ export class TempmdClient {
     init: RequestInit,
     timeoutMs: number,
     fallback: string,
+    phase: TempmdRequestPhase,
   ): Promise<Response> {
     try {
       return await this.fetcher(url, {
@@ -165,7 +196,7 @@ export class TempmdClient {
         signal: AbortSignal.timeout(timeoutMs),
       });
     } catch (error) {
-      throw transportError(error, fallback);
+      throw transportError(error, fallback, phase);
     }
   }
 }
@@ -173,32 +204,44 @@ export class TempmdClient {
 async function readJsonResponse(
   response: Response,
   fallback: string,
+  phase: TempmdRequestPhase,
 ): Promise<unknown> {
   let contents: string;
   try {
     contents = await response.text();
   } catch (error) {
-    throw transportError(error, fallback);
+    throw transportError(error, fallback, phase);
   }
   if (contents.trim() === "") return null;
   try {
     return JSON.parse(contents);
   } catch {
-    throw new TempmdApiError(fallback, response.status, "invalid_response");
+    throw new TempmdApiError(
+      fallback,
+      response.status,
+      "invalid_response",
+      phase,
+    );
   }
 }
 
-function transportError(error: unknown, fallback: string): TempmdApiError {
+function transportError(
+  error: unknown,
+  fallback: string,
+  phase: TempmdRequestPhase,
+): TempmdApiError {
   return new TempmdApiError(
     error instanceof Error ? error.message : fallback,
     0,
     "transport_error",
+    phase,
   );
 }
 
 async function throwApiError(
   response: Response,
   fallback: string,
+  phase: TempmdRequestPhase,
 ): Promise<never> {
   let body: unknown;
   try {
@@ -218,6 +261,7 @@ async function throwApiError(
     message,
     response.status,
     typeof record.code === "string" ? record.code : undefined,
+    phase,
   );
 }
 
@@ -227,18 +271,25 @@ async function uploadConcurrently<T>(
   concurrency = 4,
 ): Promise<void> {
   let next = 0;
+  const failure: { occurred: boolean; reason?: unknown } = {
+    occurred: false,
+  };
   const runners = Array.from(
     { length: Math.min(concurrency, values.length) },
     async () => {
-      while (next < values.length) {
+      while (next < values.length && !failure.occurred) {
         const index = next++;
-        await worker(values[index]);
+        try {
+          await worker(values[index]);
+        } catch (error) {
+          if (!failure.occurred) {
+            failure.occurred = true;
+            failure.reason = error;
+          }
+        }
       }
     },
   );
-  const results = await Promise.allSettled(runners);
-  const failure = results.find(
-    (result): result is PromiseRejectedResult => result.status === "rejected",
-  );
-  if (failure) throw failure.reason;
+  await Promise.all(runners);
+  if (failure.occurred) throw failure.reason;
 }

--- a/src/temp_preview/client.ts
+++ b/src/temp_preview/client.ts
@@ -1,0 +1,200 @@
+import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { z } from "zod";
+import type { TempPreviewBundleFile } from "./bundle";
+
+const SessionSchema = z.object({
+  sessionId: z.string(),
+  tempId: z.string(),
+  uploadToken: z.string(),
+  uploads: z.array(
+    z.object({
+      path: z.string(),
+      status: z.enum(["expected", "uploaded"]),
+      url: z.string().url(),
+    }),
+  ),
+  skipped: z.array(z.string()),
+});
+
+const FinalizedPublishSchema = z.object({
+  success: z.literal(true),
+  tempId: z.string(),
+  versionId: z.string(),
+  canonicalUrl: z.string().url(),
+  expiresAt: z.string().nullable(),
+  updateToken: z.string().optional(),
+});
+
+export interface TempPreviewConnection {
+  tempId: string;
+  canonicalUrl: string;
+  updateToken: string;
+  expiresAt: string | null;
+}
+
+export class TempmdApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly code?: string,
+  ) {
+    super(message);
+    this.name = "TempmdApiError";
+  }
+}
+
+export class TempmdClient {
+  private readonly baseUrl: string;
+
+  constructor(
+    baseUrl = "https://api.temp.md",
+    private readonly fetcher: typeof fetch = fetch,
+  ) {
+    this.baseUrl = baseUrl.replace(/\/+$/, "");
+  }
+
+  async publish(input: {
+    files: TempPreviewBundleFile[];
+    title: string;
+    previous?: TempPreviewConnection;
+  }): Promise<TempPreviewConnection> {
+    const session = SessionSchema.parse(
+      await this.json("/publish-sessions", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Idempotency-Key": randomUUID(),
+          ...(input.previous
+            ? { Authorization: `Bearer ${input.previous.updateToken}` }
+            : {}),
+        },
+        body: JSON.stringify({
+          files: input.files.map((file) => ({
+            path: file.path,
+            size: file.size,
+            contentType: file.contentType,
+            hash: file.hash,
+          })),
+          title: input.title,
+          spaMode: true,
+          ...(input.previous ? { tempId: input.previous.tempId } : {}),
+        }),
+      }),
+    );
+
+    const outstanding = session.uploads.filter(
+      (upload) => upload.status === "expected",
+    );
+    await uploadConcurrently(outstanding, async (upload) => {
+      const file = input.files.find(
+        (candidate) => candidate.path === upload.path,
+      );
+      if (!file) {
+        throw new Error(`The local build no longer contains ${upload.path}.`);
+      }
+      const response = await this.fetcher(upload.url, {
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${session.uploadToken}`,
+          "Content-Type": file.contentType,
+          "Content-Length": String(file.size),
+        },
+        body: new Uint8Array(await readFile(file.absolutePath)),
+        signal: AbortSignal.timeout(120_000),
+      });
+      if (!response.ok) {
+        await throwApiError(response, `Upload failed for ${file.path}`);
+      }
+    });
+
+    const finalized = FinalizedPublishSchema.parse(
+      await this.json(
+        `/publish-sessions/${encodeURIComponent(session.sessionId)}/finalize`,
+        {
+          method: "POST",
+          headers: { Authorization: `Bearer ${session.uploadToken}` },
+        },
+      ),
+    );
+    const updateToken = finalized.updateToken ?? input.previous?.updateToken;
+    if (!updateToken) {
+      throw new Error("temp.md did not return an update capability.");
+    }
+    return {
+      tempId: finalized.tempId,
+      canonicalUrl: finalized.canonicalUrl,
+      updateToken,
+      expiresAt: finalized.expiresAt,
+    };
+  }
+
+  async revoke(connection: TempPreviewConnection): Promise<void> {
+    await this.json(`/temps/${encodeURIComponent(connection.tempId)}`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${connection.updateToken}` },
+    });
+  }
+
+  private async json(path: string, init: RequestInit): Promise<unknown> {
+    let response: Response;
+    try {
+      response = await this.fetcher(`${this.baseUrl}${path}`, {
+        ...init,
+        signal: AbortSignal.timeout(60_000),
+      });
+    } catch (error) {
+      throw new TempmdApiError(
+        error instanceof Error ? error.message : "temp.md request failed",
+        0,
+      );
+    }
+    if (!response.ok) {
+      await throwApiError(response, "temp.md request failed");
+    }
+    return response.json();
+  }
+}
+
+async function throwApiError(
+  response: Response,
+  fallback: string,
+): Promise<never> {
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    body = null;
+  }
+  const record =
+    body && typeof body === "object" ? (body as Record<string, unknown>) : {};
+  const message =
+    typeof record.message === "string"
+      ? record.message
+      : typeof record.error === "string"
+        ? record.error
+        : fallback;
+  throw new TempmdApiError(
+    message,
+    response.status,
+    typeof record.code === "string" ? record.code : undefined,
+  );
+}
+
+async function uploadConcurrently<T>(
+  values: T[],
+  worker: (value: T) => Promise<void>,
+  concurrency = 4,
+): Promise<void> {
+  let next = 0;
+  const runners = Array.from(
+    { length: Math.min(concurrency, values.length) },
+    async () => {
+      while (next < values.length) {
+        const index = next++;
+        await worker(values[index]);
+      }
+    },
+  );
+  await Promise.all(runners);
+}

--- a/src/temp_preview/client.ts
+++ b/src/temp_preview/client.ts
@@ -71,7 +71,7 @@ export class TempmdClient {
     title: string;
     previous?: TempPreviewConnection;
   }): Promise<TempPreviewConnection> {
-    const session = SessionSchema.parse(
+    const sessionResult = SessionSchema.safeParse(
       await this.json(
         "/publish-sessions",
         {
@@ -98,6 +98,15 @@ export class TempmdClient {
         "session",
       ),
     );
+    if (!sessionResult.success) {
+      throw new TempmdApiError(
+        "temp.md returned an invalid response",
+        200,
+        "invalid_response",
+        "session",
+      );
+    }
+    const session = sessionResult.data;
 
     const outstanding = session.uploads.filter(
       (upload) => upload.status === "expected",

--- a/src/temp_preview/client.ts
+++ b/src/temp_preview/client.ts
@@ -253,7 +253,9 @@ function isAmbiguousFinalizeError(error: unknown): boolean {
     (error.status === 0 ||
       error.status === 408 ||
       error.status >= 500 ||
-      error.code === "invalid_response")
+      (error.code === "invalid_response" &&
+        error.status >= 200 &&
+        error.status < 300))
   );
 }
 

--- a/src/temp_preview/expiry.test.ts
+++ b/src/temp_preview/expiry.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import {
+  getEffectiveTempPreviewExpiry,
+  isTempPreviewExpired,
+  TEMP_PREVIEW_LIFETIME_MS,
+} from "./expiry";
+
+describe("temporary preview expiry", () => {
+  it("derives a seven-day expiry when the provider omits one", () => {
+    const lastPublishedAt = "2026-08-24T00:00:00.000Z";
+
+    expect(getEffectiveTempPreviewExpiry(null, lastPublishedAt)).toBe(
+      new Date(
+        Date.parse(lastPublishedAt) + TEMP_PREVIEW_LIFETIME_MS,
+      ).toISOString(),
+    );
+  });
+
+  it("fails closed when no valid expiry can be derived", () => {
+    expect(isTempPreviewExpired(null, "not-a-timestamp")).toBe(true);
+    expect(
+      isTempPreviewExpired("also-not-a-timestamp", "not-a-timestamp"),
+    ).toBe(true);
+  });
+});

--- a/src/temp_preview/expiry.ts
+++ b/src/temp_preview/expiry.ts
@@ -22,6 +22,6 @@ export function isTempPreviewExpired(
     expiresAt,
     lastPublishedAt,
   );
-  if (effectiveExpiry === null) return false;
+  if (effectiveExpiry === null) return true;
   return Date.parse(effectiveExpiry) <= now;
 }

--- a/src/temp_preview/expiry.ts
+++ b/src/temp_preview/expiry.ts
@@ -1,0 +1,27 @@
+export const TEMP_PREVIEW_LIFETIME_MS = 7 * 24 * 60 * 60 * 1_000;
+
+export function getEffectiveTempPreviewExpiry(
+  expiresAt: string | null,
+  lastPublishedAt: string,
+): string | null {
+  if (expiresAt !== null && Number.isFinite(Date.parse(expiresAt))) {
+    return expiresAt;
+  }
+
+  const lastPublishedAtMs = Date.parse(lastPublishedAt);
+  if (!Number.isFinite(lastPublishedAtMs)) return null;
+  return new Date(lastPublishedAtMs + TEMP_PREVIEW_LIFETIME_MS).toISOString();
+}
+
+export function isTempPreviewExpired(
+  expiresAt: string | null,
+  lastPublishedAt: string,
+  now = Date.now(),
+): boolean {
+  const effectiveExpiry = getEffectiveTempPreviewExpiry(
+    expiresAt,
+    lastPublishedAt,
+  );
+  if (effectiveExpiry === null) return false;
+  return Date.parse(effectiveExpiry) <= now;
+}

--- a/src/temp_preview/store.test.ts
+++ b/src/temp_preview/store.test.ts
@@ -246,6 +246,45 @@ describe("TempPreviewStore", () => {
     await expect(store.listPendingDeletionAppIds()).resolves.toEqual([]);
   });
 
+  it("recovers a seven-day-old record with a missing expiry", async () => {
+    const root = await createStoreRoot();
+    const filePath = join(root, "previews.json");
+    const store = new TempPreviewStore(filePath, {
+      encode: (token) => ({ value: `encrypted:${token}` }),
+      decode: () => {
+        throw new Error("keychain identity changed");
+      },
+    });
+    const lastPublishedAt = new Date(
+      Date.now() - 8 * 24 * 60 * 60 * 1_000,
+    ).toISOString();
+    await writeFile(
+      filePath,
+      JSON.stringify({
+        version: 1,
+        records: {
+          7: {
+            tempId: "temp-expired",
+            canonicalUrl: "https://expired.temp.md",
+            updateToken: { value: "encrypted:update-secret" },
+            expiresAt: null,
+            lastPublishedAt,
+            state: "active",
+          },
+        },
+      }),
+      "utf8",
+    );
+
+    await expect(store.read(7)).resolves.toMatchObject({
+      tempId: "temp-expired",
+      expiresAt: new Date(
+        Date.parse(lastPublishedAt) + 7 * 24 * 60 * 60 * 1_000,
+      ).toISOString(),
+      updateToken: undefined,
+    });
+  });
+
   it("removes only the requested app record", async () => {
     const root = await createStoreRoot();
     const filePath = join(root, "previews.json");

--- a/src/temp_preview/store.test.ts
+++ b/src/temp_preview/store.test.ts
@@ -56,9 +56,12 @@ describe("TempPreviewStore", () => {
     });
 
     await expect(store.read(7)).resolves.toBeNull();
-    expect(await readdir(root)).toEqual([
-      expect.stringMatching(/^previews\.json\.corrupt-/),
-    ]);
+    expect(await readdir(root)).toEqual(
+      expect.arrayContaining([
+        "previews.json",
+        expect.stringMatching(/^previews\.json\.corrupt-/),
+      ]),
+    );
 
     await store.write(7, {
       tempId: "temp-2",
@@ -69,5 +72,39 @@ describe("TempPreviewStore", () => {
       state: "active",
     });
     await expect(store.read(7)).resolves.toMatchObject({ tempId: "temp-2" });
+  });
+
+  it("salvages valid app records when one record is malformed", async () => {
+    const root = await createStoreRoot();
+    const filePath = join(root, "previews.json");
+    const store = new TempPreviewStore(filePath, {
+      encode: (token) => ({ value: `encrypted:${token}` }),
+      decode: (secret) => secret.value.replace(/^encrypted:/, ""),
+    });
+    await store.write(7, {
+      tempId: "temp-valid",
+      canonicalUrl: "https://valid.temp.md",
+      updateToken: "update-secret",
+      expiresAt: null,
+      lastPublishedAt: "2026-08-23T00:00:00.000Z",
+      state: "active",
+    });
+    const contents = JSON.parse(await readFile(filePath, "utf8"));
+    contents.records[8] = { invalid: true };
+    await writeFile(filePath, JSON.stringify(contents), "utf8");
+
+    await expect(store.read(7)).resolves.toMatchObject({
+      tempId: "temp-valid",
+      updateToken: "update-secret",
+    });
+    await expect(store.read(8)).resolves.toBeNull();
+    const repaired = JSON.parse(await readFile(filePath, "utf8"));
+    expect(Object.keys(repaired.records)).toEqual(["7"]);
+    expect(await readdir(root)).toEqual(
+      expect.arrayContaining([
+        "previews.json",
+        expect.stringMatching(/^previews\.json\.corrupt-/),
+      ]),
+    );
   });
 });

--- a/src/temp_preview/store.test.ts
+++ b/src/temp_preview/store.test.ts
@@ -183,4 +183,33 @@ describe("TempPreviewStore", () => {
     await expect(store.read(7)).resolves.toBeNull();
     await expect(store.read(8)).resolves.toMatchObject({ tempId: "temp-8" });
   });
+
+  it("persists and clears pending app-deletion markers", async () => {
+    const root = await createStoreRoot();
+    const filePath = join(root, "previews.json");
+    const codec = {
+      encode: (token: string) => ({ value: `encrypted:${token}` }),
+      decode: (secret: { value: string }) =>
+        secret.value.replace(/^encrypted:/, ""),
+    };
+    const store = new TempPreviewStore(filePath, codec);
+    await store.write(7, {
+      tempId: "temp-7",
+      canonicalUrl: "https://example.temp.md",
+      updateToken: "update-secret",
+      expiresAt: null,
+      lastPublishedAt: "2026-08-23T00:00:00.000Z",
+      state: "active",
+    });
+
+    await expect(store.markPendingDeletion(7)).resolves.toBe(true);
+    await expect(store.markPendingDeletion(8)).resolves.toBe(false);
+    await expect(
+      new TempPreviewStore(filePath, codec).listPendingDeletionAppIds(),
+    ).resolves.toEqual([7]);
+    await expect(store.read(7)).resolves.toMatchObject({ tempId: "temp-7" });
+
+    await store.clearPendingDeletion(7);
+    await expect(store.listPendingDeletionAppIds()).resolves.toEqual([]);
+  });
 });

--- a/src/temp_preview/store.test.ts
+++ b/src/temp_preview/store.test.ts
@@ -1,12 +1,28 @@
-import { mkdtemp, readFile } from "node:fs/promises";
+import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { TempPreviewStore } from "./store";
 
+const storeRoots: string[] = [];
+
+async function createStoreRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "dyad-temp-preview-store-"));
+  storeRoots.push(root);
+  return root;
+}
+
 describe("TempPreviewStore", () => {
+  afterEach(async () => {
+    await Promise.all(
+      storeRoots
+        .splice(0)
+        .map((root) => rm(root, { recursive: true, force: true })),
+    );
+  });
+
   it("persists an encoded update capability and returns its decoded value", async () => {
-    const root = await mkdtemp(join(tmpdir(), "dyad-temp-preview-store-"));
+    const root = await createStoreRoot();
     const filePath = join(root, "previews.json");
     const store = new TempPreviewStore(filePath, {
       encode: (token) => ({ value: `encrypted:${token}` }),
@@ -28,5 +44,30 @@ describe("TempPreviewStore", () => {
     const contents = await readFile(filePath, "utf8");
     expect(contents).toContain("encrypted:update-secret");
     expect(contents).not.toContain('"value": "update-secret"');
+  });
+
+  it("backs up a malformed store and recovers with an empty store", async () => {
+    const root = await createStoreRoot();
+    const filePath = join(root, "previews.json");
+    await writeFile(filePath, "not-json", "utf8");
+    const store = new TempPreviewStore(filePath, {
+      encode: (token) => ({ value: `encrypted:${token}` }),
+      decode: (secret) => secret.value.replace(/^encrypted:/, ""),
+    });
+
+    await expect(store.read(7)).resolves.toBeNull();
+    expect(await readdir(root)).toEqual([
+      expect.stringMatching(/^previews\.json\.corrupt-/),
+    ]);
+
+    await store.write(7, {
+      tempId: "temp-2",
+      canonicalUrl: "https://recovered.temp.md",
+      updateToken: "update-secret",
+      expiresAt: null,
+      lastPublishedAt: "2026-08-23T00:00:00.000Z",
+      state: "active",
+    });
+    await expect(store.read(7)).resolves.toMatchObject({ tempId: "temp-2" });
   });
 });

--- a/src/temp_preview/store.test.ts
+++ b/src/temp_preview/store.test.ts
@@ -9,7 +9,7 @@ vi.mock("electron-log", () => ({
   default: { scope: () => ({ warn: mocks.warn }) },
 }));
 
-import { TempPreviewStore } from "./store";
+import { TempPreviewStore, TempPreviewStoreUnreadableError } from "./store";
 
 const storeRoots: string[] = [];
 
@@ -125,7 +125,7 @@ describe("TempPreviewStore", () => {
     );
   });
 
-  it("quarantines a record whose update capability cannot be decoded", async () => {
+  it("preserves a record whose update capability cannot be decoded", async () => {
     const root = await createStoreRoot();
     const filePath = join(root, "previews.json");
     const store = new TempPreviewStore(filePath, {
@@ -134,35 +134,28 @@ describe("TempPreviewStore", () => {
         throw new Error("keychain identity changed");
       },
     });
-    await writeFile(
-      filePath,
-      JSON.stringify({
-        version: 1,
-        records: {
-          7: {
-            tempId: "temp-unreadable",
-            canonicalUrl: "https://unreadable.temp.md",
-            updateToken: { value: "encrypted:update-secret" },
-            expiresAt: null,
-            lastPublishedAt: "2026-08-23T00:00:00.000Z",
-            state: "active",
-          },
+    const originalContents = JSON.stringify({
+      version: 1,
+      records: {
+        7: {
+          tempId: "temp-unreadable",
+          canonicalUrl: "https://unreadable.temp.md",
+          updateToken: { value: "encrypted:update-secret" },
+          expiresAt: null,
+          lastPublishedAt: "2026-08-23T00:00:00.000Z",
+          state: "active",
         },
-      }),
-      "utf8",
-    );
+      },
+    });
+    await writeFile(filePath, originalContents, "utf8");
 
-    await expect(store.read(7)).resolves.toBeNull();
-    const repaired = JSON.parse(await readFile(filePath, "utf8"));
-    expect(repaired.records).toEqual({});
-    expect(await readdir(root)).toEqual(
-      expect.arrayContaining([
-        "previews.json",
-        expect.stringMatching(/^previews\.json\.corrupt-/),
-      ]),
+    await expect(store.read(7)).rejects.toBeInstanceOf(
+      TempPreviewStoreUnreadableError,
     );
+    expect(await readFile(filePath, "utf8")).toBe(originalContents);
+    expect(await readdir(root)).toEqual(["previews.json"]);
     expect(mocks.warn).toHaveBeenCalledWith(
-      expect.stringContaining("app IDs 7"),
+      expect.stringContaining("preserving the encrypted record"),
       expect.any(Error),
     );
   });

--- a/src/temp_preview/store.test.ts
+++ b/src/temp_preview/store.test.ts
@@ -1,0 +1,32 @@
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { TempPreviewStore } from "./store";
+
+describe("TempPreviewStore", () => {
+  it("persists an encoded update capability and returns its decoded value", async () => {
+    const root = await mkdtemp(join(tmpdir(), "dyad-temp-preview-store-"));
+    const filePath = join(root, "previews.json");
+    const store = new TempPreviewStore(filePath, {
+      encode: (token) => ({ value: `encrypted:${token}` }),
+      decode: (secret) => secret.value.replace(/^encrypted:/, ""),
+    });
+
+    await store.write(7, {
+      tempId: "temp-1",
+      canonicalUrl: "https://example.temp.md",
+      updateToken: "update-secret",
+      expiresAt: "2026-08-30T00:00:00.000Z",
+      lastPublishedAt: "2026-08-23T00:00:00.000Z",
+      state: "active",
+    });
+
+    await expect(store.read(7)).resolves.toMatchObject({
+      updateToken: "update-secret",
+    });
+    const contents = await readFile(filePath, "utf8");
+    expect(contents).toContain("encrypted:update-secret");
+    expect(contents).not.toContain('"value": "update-secret"');
+  });
+});

--- a/src/temp_preview/store.test.ts
+++ b/src/temp_preview/store.test.ts
@@ -160,6 +160,44 @@ describe("TempPreviewStore", () => {
     );
   });
 
+  it("recovers an expired record whose capability cannot be decoded", async () => {
+    const root = await createStoreRoot();
+    const filePath = join(root, "previews.json");
+    const store = new TempPreviewStore(filePath, {
+      encode: (token) => ({ value: `encrypted:${token}` }),
+      decode: () => {
+        throw new Error("keychain identity changed");
+      },
+    });
+    const expiresAt = new Date(Date.now() - 60_000).toISOString();
+    await writeFile(
+      filePath,
+      JSON.stringify({
+        version: 1,
+        records: {
+          7: {
+            tempId: "temp-expired",
+            canonicalUrl: "https://expired.temp.md",
+            updateToken: { value: "encrypted:update-secret" },
+            expiresAt,
+            lastPublishedAt: "2026-08-01T00:00:00.000Z",
+            state: "active",
+            pendingDeletion: true,
+          },
+        },
+      }),
+      "utf8",
+    );
+
+    await expect(store.read(7)).resolves.toMatchObject({
+      tempId: "temp-expired",
+      expiresAt,
+      updateToken: undefined,
+    });
+    await store.remove(7);
+    await expect(store.listPendingDeletionAppIds()).resolves.toEqual([]);
+  });
+
   it("removes only the requested app record", async () => {
     const root = await createStoreRoot();
     const filePath = join(root, "previews.json");

--- a/src/temp_preview/store.test.ts
+++ b/src/temp_preview/store.test.ts
@@ -1,7 +1,14 @@
 import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ warn: vi.fn() }));
+
+vi.mock("electron-log", () => ({
+  default: { scope: () => ({ warn: mocks.warn }) },
+}));
+
 import { TempPreviewStore } from "./store";
 
 const storeRoots: string[] = [];
@@ -13,6 +20,10 @@ async function createStoreRoot(): Promise<string> {
 }
 
 describe("TempPreviewStore", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   afterEach(async () => {
     await Promise.all(
       storeRoots
@@ -62,6 +73,9 @@ describe("TempPreviewStore", () => {
         expect.stringMatching(/^previews\.json\.corrupt-/),
       ]),
     );
+    expect(mocks.warn).toHaveBeenCalledWith(
+      expect.stringContaining("unknown app records"),
+    );
 
     await store.write(7, {
       tempId: "temp-2",
@@ -106,5 +120,74 @@ describe("TempPreviewStore", () => {
         expect.stringMatching(/^previews\.json\.corrupt-/),
       ]),
     );
+    expect(mocks.warn).toHaveBeenCalledWith(
+      expect.stringContaining("app IDs 8"),
+    );
+  });
+
+  it("quarantines a record whose update capability cannot be decoded", async () => {
+    const root = await createStoreRoot();
+    const filePath = join(root, "previews.json");
+    const store = new TempPreviewStore(filePath, {
+      encode: (token) => ({ value: `encrypted:${token}` }),
+      decode: () => {
+        throw new Error("keychain identity changed");
+      },
+    });
+    await writeFile(
+      filePath,
+      JSON.stringify({
+        version: 1,
+        records: {
+          7: {
+            tempId: "temp-unreadable",
+            canonicalUrl: "https://unreadable.temp.md",
+            updateToken: { value: "encrypted:update-secret" },
+            expiresAt: null,
+            lastPublishedAt: "2026-08-23T00:00:00.000Z",
+            state: "active",
+          },
+        },
+      }),
+      "utf8",
+    );
+
+    await expect(store.read(7)).resolves.toBeNull();
+    const repaired = JSON.parse(await readFile(filePath, "utf8"));
+    expect(repaired.records).toEqual({});
+    expect(await readdir(root)).toEqual(
+      expect.arrayContaining([
+        "previews.json",
+        expect.stringMatching(/^previews\.json\.corrupt-/),
+      ]),
+    );
+    expect(mocks.warn).toHaveBeenCalledWith(
+      expect.stringContaining("app IDs 7"),
+      expect.any(Error),
+    );
+  });
+
+  it("removes only the requested app record", async () => {
+    const root = await createStoreRoot();
+    const filePath = join(root, "previews.json");
+    const store = new TempPreviewStore(filePath, {
+      encode: (token) => ({ value: `encrypted:${token}` }),
+      decode: (secret) => secret.value.replace(/^encrypted:/, ""),
+    });
+    const record = {
+      tempId: "temp",
+      canonicalUrl: "https://example.temp.md",
+      updateToken: "update-secret",
+      expiresAt: null,
+      lastPublishedAt: "2026-08-23T00:00:00.000Z",
+      state: "active" as const,
+    };
+    await store.write(7, record);
+    await store.write(8, { ...record, tempId: "temp-8" });
+
+    await store.remove(7);
+
+    await expect(store.read(7)).resolves.toBeNull();
+    await expect(store.read(8)).resolves.toMatchObject({ tempId: "temp-8" });
   });
 });

--- a/src/temp_preview/store.test.ts
+++ b/src/temp_preview/store.test.ts
@@ -125,6 +125,54 @@ describe("TempPreviewStore", () => {
     );
   });
 
+  it("keeps the canonical store when a corruption repair cannot be written", async () => {
+    const root = await createStoreRoot();
+    const filePath = join(root, "previews.json");
+    const store = new TempPreviewStore(filePath, {
+      encode: (token) => ({ value: `encrypted:${token}` }),
+      decode: (secret) => secret.value.replace(/^encrypted:/, ""),
+    });
+    const originalContents = JSON.stringify({
+      version: 1,
+      records: {
+        7: {
+          tempId: "temp-valid",
+          canonicalUrl: "https://valid.temp.md",
+          updateToken: { value: "encrypted:update-secret" },
+          expiresAt: null,
+          lastPublishedAt: "2026-08-23T00:00:00.000Z",
+          state: "active",
+        },
+        8: { invalid: true },
+      },
+    });
+    await writeFile(filePath, originalContents, "utf8");
+    const writeStoreFile = vi
+      .spyOn(
+        store as unknown as {
+          writeStoreFile: (contents: unknown) => Promise<void>;
+        },
+        "writeStoreFile",
+      )
+      .mockRejectedValueOnce(new Error("disk full"));
+
+    await expect(store.read(7)).rejects.toThrow("disk full");
+    expect(await readFile(filePath, "utf8")).toBe(originalContents);
+    const backupName = (await readdir(root)).find((name) =>
+      name.startsWith("previews.json.corrupt-"),
+    );
+    expect(backupName).toBeDefined();
+    expect(await readFile(join(root, backupName!), "utf8")).toBe(
+      originalContents,
+    );
+
+    writeStoreFile.mockRestore();
+    await expect(store.read(7)).resolves.toMatchObject({
+      tempId: "temp-valid",
+      updateToken: "update-secret",
+    });
+  });
+
   it("preserves a record whose update capability cannot be decoded", async () => {
     const root = await createStoreRoot();
     const filePath = join(root, "previews.json");

--- a/src/temp_preview/store.ts
+++ b/src/temp_preview/store.ts
@@ -1,0 +1,85 @@
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { z } from "zod";
+import { getFileWriteKey, withLock } from "@/ipc/utils/lock_utils";
+import { SecretSchema, type Secret } from "@/lib/schemas";
+
+const StoredRecordSchema = z.object({
+  tempId: z.string(),
+  canonicalUrl: z.string().url(),
+  updateToken: SecretSchema.optional(),
+  expiresAt: z.string().nullable(),
+  lastPublishedAt: z.string(),
+  state: z.enum(["active", "revoked"]),
+});
+
+const StoreSchema = z.object({
+  version: z.literal(1),
+  records: z.record(z.string(), StoredRecordSchema),
+});
+
+export interface TempPreviewRecord {
+  tempId: string;
+  canonicalUrl: string;
+  updateToken?: string;
+  expiresAt: string | null;
+  lastPublishedAt: string;
+  state: "active" | "revoked";
+}
+
+export interface TempPreviewTokenCodec {
+  encode(token: string): Secret;
+  decode(secret: Secret): string;
+}
+
+export class TempPreviewStore {
+  constructor(
+    private readonly filePath: string,
+    private readonly tokenCodec: TempPreviewTokenCodec,
+  ) {}
+
+  async read(appId: number): Promise<TempPreviewRecord | null> {
+    const store = await this.readStore();
+    const record = store.records[String(appId)];
+    if (!record) return null;
+    return {
+      ...record,
+      updateToken: record.updateToken
+        ? this.tokenCodec.decode(record.updateToken)
+        : undefined,
+    };
+  }
+
+  async write(appId: number, record: TempPreviewRecord): Promise<void> {
+    await withLock(getFileWriteKey(this.filePath), async () => {
+      const store = await this.readStore();
+      store.records[String(appId)] = {
+        ...record,
+        updateToken: record.updateToken
+          ? this.tokenCodec.encode(record.updateToken)
+          : undefined,
+      };
+      const temporaryPath = `${this.filePath}.tmp-${process.pid}-${Date.now()}`;
+      await mkdir(dirname(this.filePath), { recursive: true });
+      await writeFile(temporaryPath, JSON.stringify(store, null, 2), "utf8");
+      await rename(temporaryPath, this.filePath);
+    });
+  }
+
+  private async readStore(): Promise<z.infer<typeof StoreSchema>> {
+    try {
+      const contents = await readFile(this.filePath, "utf8");
+      return StoreSchema.parse(JSON.parse(contents));
+    } catch (error) {
+      if (
+        typeof error === "object" &&
+        error !== null &&
+        "code" in error &&
+        error.code === "ENOENT"
+      ) {
+        return { version: 1, records: {} };
+      }
+      throw error;
+    }
+  }
+}

--- a/src/temp_preview/store.ts
+++ b/src/temp_preview/store.ts
@@ -14,6 +14,7 @@ const StoredRecordSchema = z.object({
   expiresAt: z.string().nullable(),
   lastPublishedAt: z.string(),
   state: z.enum(["active", "revoked"]),
+  pendingDeletion: z.boolean().optional(),
 });
 
 const StoreSchema = z.object({
@@ -75,7 +76,11 @@ export class TempPreviewStore {
         throw new TempPreviewStoreUnreadableError(appId, { cause: error });
       }
       return {
-        ...record,
+        tempId: record.tempId,
+        canonicalUrl: record.canonicalUrl,
+        expiresAt: record.expiresAt,
+        lastPublishedAt: record.lastPublishedAt,
+        state: record.state,
         updateToken,
       };
     });
@@ -101,6 +106,37 @@ export class TempPreviewStore {
       if (!(appIdKey in store.records)) return;
       delete store.records[appIdKey];
       await this.writeStoreFile(store);
+    });
+  }
+
+  async markPendingDeletion(appId: number): Promise<boolean> {
+    return withLock(getFileWriteKey(this.filePath), async () => {
+      const store = await this.readStore();
+      const record = store.records[String(appId)];
+      if (!record) return false;
+      record.pendingDeletion = true;
+      await this.writeStoreFile(store);
+      return true;
+    });
+  }
+
+  async clearPendingDeletion(appId: number): Promise<void> {
+    await withLock(getFileWriteKey(this.filePath), async () => {
+      const store = await this.readStore();
+      const record = store.records[String(appId)];
+      if (!record?.pendingDeletion) return;
+      delete record.pendingDeletion;
+      await this.writeStoreFile(store);
+    });
+  }
+
+  async listPendingDeletionAppIds(): Promise<number[]> {
+    return withLock(getFileWriteKey(this.filePath), async () => {
+      const store = await this.readStore();
+      return Object.entries(store.records)
+        .filter(([, record]) => record.pendingDeletion)
+        .map(([appId]) => Number(appId))
+        .filter((appId) => Number.isSafeInteger(appId) && appId > 0);
     });
   }
 

--- a/src/temp_preview/store.ts
+++ b/src/temp_preview/store.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { z } from "zod";
 import { getFileWriteKey, withLock } from "@/ipc/utils/lock_utils";
@@ -39,15 +39,17 @@ export class TempPreviewStore {
   ) {}
 
   async read(appId: number): Promise<TempPreviewRecord | null> {
-    const store = await this.readStore();
-    const record = store.records[String(appId)];
-    if (!record) return null;
-    return {
-      ...record,
-      updateToken: record.updateToken
-        ? this.tokenCodec.decode(record.updateToken)
-        : undefined,
-    };
+    return withLock(getFileWriteKey(this.filePath), async () => {
+      const store = await this.readStore();
+      const record = store.records[String(appId)];
+      if (!record) return null;
+      return {
+        ...record,
+        updateToken: record.updateToken
+          ? this.tokenCodec.decode(record.updateToken)
+          : undefined,
+      };
+    });
   }
 
   async write(appId: number, record: TempPreviewRecord): Promise<void> {
@@ -61,8 +63,12 @@ export class TempPreviewStore {
       };
       const temporaryPath = `${this.filePath}.tmp-${process.pid}-${Date.now()}`;
       await mkdir(dirname(this.filePath), { recursive: true });
-      await writeFile(temporaryPath, JSON.stringify(store, null, 2), "utf8");
-      await rename(temporaryPath, this.filePath);
+      try {
+        await writeFile(temporaryPath, JSON.stringify(store, null, 2), "utf8");
+        await rename(temporaryPath, this.filePath);
+      } finally {
+        await rm(temporaryPath, { force: true }).catch(() => undefined);
+      }
     });
   }
 
@@ -78,6 +84,27 @@ export class TempPreviewStore {
         error.code === "ENOENT"
       ) {
         return { version: 1, records: {} };
+      }
+      if (error instanceof SyntaxError || error instanceof z.ZodError) {
+        await this.backUpCorruptedStore();
+        return { version: 1, records: {} };
+      }
+      throw error;
+    }
+  }
+
+  private async backUpCorruptedStore(): Promise<void> {
+    const backupPath = `${this.filePath}.corrupt-${process.pid}-${Date.now()}`;
+    try {
+      await rename(this.filePath, backupPath);
+    } catch (error) {
+      if (
+        typeof error === "object" &&
+        error !== null &&
+        "code" in error &&
+        error.code === "ENOENT"
+      ) {
+        return;
       }
       throw error;
     }

--- a/src/temp_preview/store.ts
+++ b/src/temp_preview/store.ts
@@ -40,6 +40,16 @@ export interface TempPreviewTokenCodec {
   decode(secret: Secret): string;
 }
 
+export class TempPreviewStoreUnreadableError extends Error {
+  constructor(appId: number, options: ErrorOptions) {
+    super(
+      `Dyad could not unlock the temporary preview capability for app ${appId}. Retry after checking the system keychain; the encrypted capability has been preserved.`,
+      options,
+    );
+    this.name = "TempPreviewStoreUnreadableError";
+  }
+}
+
 export class TempPreviewStore {
   constructor(
     private readonly filePath: string,
@@ -58,9 +68,11 @@ export class TempPreviewStore {
           ? this.tokenCodec.decode(record.updateToken)
           : undefined;
       } catch (error) {
-        delete store.records[appIdKey];
-        await this.recoverCorruptedStore(store, [appId], error);
-        return null;
+        logger.warn(
+          `Could not decrypt the temporary preview capability for app ${appId}; preserving the encrypted record for retry.`,
+          error,
+        );
+        throw new TempPreviewStoreUnreadableError(appId, { cause: error });
       }
       return {
         ...record,

--- a/src/temp_preview/store.ts
+++ b/src/temp_preview/store.ts
@@ -1,8 +1,11 @@
 import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
+import log from "electron-log";
 import { z } from "zod";
 import { getFileWriteKey, withLock } from "@/ipc/utils/lock_utils";
 import { SecretSchema, type Secret } from "@/lib/schemas";
+
+const logger = log.scope("temp_preview_store");
 
 const StoredRecordSchema = z.object({
   tempId: z.string(),
@@ -46,13 +49,22 @@ export class TempPreviewStore {
   async read(appId: number): Promise<TempPreviewRecord | null> {
     return withLock(getFileWriteKey(this.filePath), async () => {
       const store = await this.readStore();
-      const record = store.records[String(appId)];
+      const appIdKey = String(appId);
+      const record = store.records[appIdKey];
       if (!record) return null;
+      let updateToken: string | undefined;
+      try {
+        updateToken = record.updateToken
+          ? this.tokenCodec.decode(record.updateToken)
+          : undefined;
+      } catch (error) {
+        delete store.records[appIdKey];
+        await this.recoverCorruptedStore(store, [appId], error);
+        return null;
+      }
       return {
         ...record,
-        updateToken: record.updateToken
-          ? this.tokenCodec.decode(record.updateToken)
-          : undefined,
+        updateToken,
       };
     });
   }
@@ -66,6 +78,16 @@ export class TempPreviewStore {
           ? this.tokenCodec.encode(record.updateToken)
           : undefined,
       };
+      await this.writeStoreFile(store);
+    });
+  }
+
+  async remove(appId: number): Promise<void> {
+    await withLock(getFileWriteKey(this.filePath), async () => {
+      const store = await this.readStore();
+      const appIdKey = String(appId);
+      if (!(appIdKey in store.records)) return;
+      delete store.records[appIdKey];
       await this.writeStoreFile(store);
     });
   }
@@ -100,25 +122,43 @@ export class TempPreviewStore {
     }
 
     const records: z.infer<typeof StoreSchema>["records"] = {};
-    let discardedRecord = false;
+    const discardedAppIds: number[] = [];
     for (const [appId, candidate] of Object.entries(envelope.data.records)) {
       const result = StoredRecordSchema.safeParse(candidate);
       if (result.success) {
         records[appId] = result.data;
       } else {
-        discardedRecord = true;
+        const numericAppId = Number(appId);
+        if (Number.isSafeInteger(numericAppId))
+          discardedAppIds.push(numericAppId);
       }
     }
     const salvaged = { version: 1 as const, records };
-    if (discardedRecord) return this.recoverCorruptedStore(salvaged);
+    if (
+      Object.keys(records).length !== Object.keys(envelope.data.records).length
+    ) {
+      return this.recoverCorruptedStore(salvaged, discardedAppIds);
+    }
     return salvaged;
   }
 
   private async recoverCorruptedStore(
     salvaged: z.infer<typeof StoreSchema>,
+    discardedAppIds: number[] = [],
+    cause?: unknown,
   ): Promise<z.infer<typeof StoreSchema>> {
-    await this.backUpCorruptedStore();
+    const backupPath = await this.backUpCorruptedStore();
     await this.writeStoreFile(salvaged);
+    const affectedApps =
+      discardedAppIds.length === 0
+        ? "unknown app records"
+        : `app IDs ${discardedAppIds.join(", ")}`;
+    const warning = `Quarantined unreadable temporary preview data for ${affectedApps}. Any active preview represented only by that data may require manual cleanup. Original data was backed up${backupPath ? ` to ${backupPath}` : ""}.`;
+    if (cause === undefined) {
+      logger.warn(warning);
+    } else {
+      logger.warn(warning, cause);
+    }
     return salvaged;
   }
 
@@ -135,7 +175,7 @@ export class TempPreviewStore {
     }
   }
 
-  private async backUpCorruptedStore(): Promise<void> {
+  private async backUpCorruptedStore(): Promise<string | null> {
     const backupPath = `${this.filePath}.corrupt-${process.pid}-${Date.now()}`;
     try {
       await rename(this.filePath, backupPath);
@@ -146,9 +186,10 @@ export class TempPreviewStore {
         "code" in error &&
         error.code === "ENOENT"
       ) {
-        return;
+        return null;
       }
       throw error;
     }
+    return backupPath;
   }
 }

--- a/src/temp_preview/store.ts
+++ b/src/temp_preview/store.ts
@@ -18,6 +18,11 @@ const StoreSchema = z.object({
   records: z.record(z.string(), StoredRecordSchema),
 });
 
+const StoreEnvelopeSchema = z.object({
+  version: z.literal(1),
+  records: z.record(z.string(), z.unknown()),
+});
+
 export interface TempPreviewRecord {
   tempId: string;
   canonicalUrl: string;
@@ -61,21 +66,14 @@ export class TempPreviewStore {
           ? this.tokenCodec.encode(record.updateToken)
           : undefined,
       };
-      const temporaryPath = `${this.filePath}.tmp-${process.pid}-${Date.now()}`;
-      await mkdir(dirname(this.filePath), { recursive: true });
-      try {
-        await writeFile(temporaryPath, JSON.stringify(store, null, 2), "utf8");
-        await rename(temporaryPath, this.filePath);
-      } finally {
-        await rm(temporaryPath, { force: true }).catch(() => undefined);
-      }
+      await this.writeStoreFile(store);
     });
   }
 
   private async readStore(): Promise<z.infer<typeof StoreSchema>> {
+    let contents: string;
     try {
-      const contents = await readFile(this.filePath, "utf8");
-      return StoreSchema.parse(JSON.parse(contents));
+      contents = await readFile(this.filePath, "utf8");
     } catch (error) {
       if (
         typeof error === "object" &&
@@ -85,11 +83,55 @@ export class TempPreviewStore {
       ) {
         return { version: 1, records: {} };
       }
-      if (error instanceof SyntaxError || error instanceof z.ZodError) {
-        await this.backUpCorruptedStore();
-        return { version: 1, records: {} };
-      }
       throw error;
+    }
+
+    let decoded: unknown;
+    try {
+      decoded = JSON.parse(contents);
+    } catch (error) {
+      if (!(error instanceof SyntaxError)) throw error;
+      return this.recoverCorruptedStore({ version: 1, records: {} });
+    }
+
+    const envelope = StoreEnvelopeSchema.safeParse(decoded);
+    if (!envelope.success) {
+      return this.recoverCorruptedStore({ version: 1, records: {} });
+    }
+
+    const records: z.infer<typeof StoreSchema>["records"] = {};
+    let discardedRecord = false;
+    for (const [appId, candidate] of Object.entries(envelope.data.records)) {
+      const result = StoredRecordSchema.safeParse(candidate);
+      if (result.success) {
+        records[appId] = result.data;
+      } else {
+        discardedRecord = true;
+      }
+    }
+    const salvaged = { version: 1 as const, records };
+    if (discardedRecord) return this.recoverCorruptedStore(salvaged);
+    return salvaged;
+  }
+
+  private async recoverCorruptedStore(
+    salvaged: z.infer<typeof StoreSchema>,
+  ): Promise<z.infer<typeof StoreSchema>> {
+    await this.backUpCorruptedStore();
+    await this.writeStoreFile(salvaged);
+    return salvaged;
+  }
+
+  private async writeStoreFile(
+    store: z.infer<typeof StoreSchema>,
+  ): Promise<void> {
+    const temporaryPath = `${this.filePath}.tmp-${process.pid}-${Date.now()}`;
+    await mkdir(dirname(this.filePath), { recursive: true });
+    try {
+      await writeFile(temporaryPath, JSON.stringify(store, null, 2), "utf8");
+      await rename(temporaryPath, this.filePath);
+    } finally {
+      await rm(temporaryPath, { force: true }).catch(() => undefined);
     }
   }
 

--- a/src/temp_preview/store.ts
+++ b/src/temp_preview/store.ts
@@ -1,4 +1,11 @@
-import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import {
+  copyFile,
+  mkdir,
+  readFile,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { dirname } from "node:path";
 import log from "electron-log";
 import { z } from "zod";
@@ -226,7 +233,10 @@ export class TempPreviewStore {
   private async backUpCorruptedStore(): Promise<string | null> {
     const backupPath = `${this.filePath}.corrupt-${process.pid}-${Date.now()}`;
     try {
-      await rename(this.filePath, backupPath);
+      // Keep the canonical file in place until writeStoreFile atomically
+      // replaces it. If repair cannot be persisted, the next read can retry
+      // salvaging valid capabilities from the original store.
+      await copyFile(this.filePath, backupPath);
     } catch (error) {
       if (
         typeof error === "object" &&

--- a/src/temp_preview/store.ts
+++ b/src/temp_preview/store.ts
@@ -69,20 +69,20 @@ export class TempPreviewStore {
           ? this.tokenCodec.decode(record.updateToken)
           : undefined;
       } catch (error) {
+        if (isExpired(record.expiresAt)) {
+          logger.warn(
+            `Could not decrypt the expired temporary preview capability for app ${appId}; treating it as expired without exposing the ciphertext.`,
+            error,
+          );
+          return projectRecord(record);
+        }
         logger.warn(
           `Could not decrypt the temporary preview capability for app ${appId}; preserving the encrypted record for retry.`,
           error,
         );
         throw new TempPreviewStoreUnreadableError(appId, { cause: error });
       }
-      return {
-        tempId: record.tempId,
-        canonicalUrl: record.canonicalUrl,
-        expiresAt: record.expiresAt,
-        lastPublishedAt: record.lastPublishedAt,
-        state: record.state,
-        updateToken,
-      };
+      return projectRecord(record, updateToken);
     });
   }
 
@@ -240,4 +240,24 @@ export class TempPreviewStore {
     }
     return backupPath;
   }
+}
+
+function projectRecord(
+  record: z.infer<typeof StoredRecordSchema>,
+  updateToken?: string,
+): TempPreviewRecord {
+  return {
+    tempId: record.tempId,
+    canonicalUrl: record.canonicalUrl,
+    expiresAt: record.expiresAt,
+    lastPublishedAt: record.lastPublishedAt,
+    state: record.state,
+    updateToken,
+  };
+}
+
+function isExpired(expiresAt: string | null): boolean {
+  if (expiresAt === null) return false;
+  const expiresAtMs = new Date(expiresAt).getTime();
+  return Number.isFinite(expiresAtMs) && expiresAtMs <= Date.now();
 }

--- a/src/temp_preview/store.ts
+++ b/src/temp_preview/store.ts
@@ -11,6 +11,7 @@ import log from "electron-log";
 import { z } from "zod";
 import { getFileWriteKey, withLock } from "@/ipc/utils/lock_utils";
 import { SecretSchema, type Secret } from "@/lib/schemas";
+import { getEffectiveTempPreviewExpiry, isTempPreviewExpired } from "./expiry";
 
 const logger = log.scope("temp_preview_store");
 
@@ -76,7 +77,7 @@ export class TempPreviewStore {
           ? this.tokenCodec.decode(record.updateToken)
           : undefined;
       } catch (error) {
-        if (isExpired(record.expiresAt)) {
+        if (isTempPreviewExpired(record.expiresAt, record.lastPublishedAt)) {
           logger.warn(
             `Could not decrypt the expired temporary preview capability for app ${appId}; treating it as expired without exposing the ciphertext.`,
             error,
@@ -259,15 +260,12 @@ function projectRecord(
   return {
     tempId: record.tempId,
     canonicalUrl: record.canonicalUrl,
-    expiresAt: record.expiresAt,
+    expiresAt: getEffectiveTempPreviewExpiry(
+      record.expiresAt,
+      record.lastPublishedAt,
+    ),
     lastPublishedAt: record.lastPublishedAt,
     state: record.state,
     updateToken,
   };
-}
-
-function isExpired(expiresAt: string | null): boolean {
-  if (expiresAt === null) return false;
-  const expiresAtMs = new Date(expiresAt).getTime();
-  return Number.isFinite(expiresAtMs) && expiresAtMs <= Date.now();
 }

--- a/src/window_infrastructure/main/query_invalidation_bus.test.ts
+++ b/src/window_infrastructure/main/query_invalidation_bus.test.ts
@@ -70,6 +70,10 @@ describe("QueryInvalidationBus", () => {
     bus.publish([{ family: "branches", appId: 1 }]);
     bus.publish([{ family: "problems", appId: 1 }]);
     bus.publish([{ family: "uncommitted-files", appId: 1 }]);
+    bus.publish([
+      { family: "temp-preview", appId: 1 },
+      { family: "temp-preview", appId: 2 },
+    ]);
 
     expect(bus.synchronize(0).recoveryScopes).toEqual([
       { family: "apps" },
@@ -78,6 +82,7 @@ describe("QueryInvalidationBus", () => {
       { family: "branches" },
       { family: "problems" },
       { family: "uncommitted-files" },
+      { family: "temp-preview" },
     ]);
   });
 });

--- a/src/window_infrastructure/main/query_invalidation_bus.ts
+++ b/src/window_infrastructure/main/query_invalidation_bus.ts
@@ -143,6 +143,7 @@ export class QueryInvalidationBus {
       case "problems":
       case "uncommitted-files":
       case "coolify":
+      case "temp-preview":
         return { family: scope.family };
       case "mcp-tools":
         return { family: "mcp-tools" };

--- a/src/window_infrastructure/query_keys.test.ts
+++ b/src/window_infrastructure/query_keys.test.ts
@@ -25,3 +25,14 @@ describe("the coolify scope", () => {
     expect(others).not.toContainEqual(queryKeys.coolify.status({ appId: 7 }));
   });
 });
+
+describe("the temporary-preview scope", () => {
+  it("reaches one app's status query or the whole family", () => {
+    expect(
+      queryKeysForInvalidationScope({ family: "temp-preview", appId: 7 }),
+    ).toEqual([queryKeys.tempPreviews.status({ appId: 7 })]);
+    expect(queryKeysForInvalidationScope({ family: "temp-preview" })).toEqual([
+      queryKeys.tempPreviews.all,
+    ]);
+  });
+});

--- a/src/window_infrastructure/query_keys.ts
+++ b/src/window_infrastructure/query_keys.ts
@@ -22,6 +22,12 @@ export function queryKeysForInvalidationScope(
       return [queryKeys.freeAgentQuota.status];
     case "free-model-quota":
       return [queryKeys.freeModelQuota.status];
+    case "temp-preview":
+      return [
+        scope.appId === undefined
+          ? queryKeys.tempPreviews.all
+          : queryKeys.tempPreviews.status({ appId: scope.appId }),
+      ];
     case "app":
       return [queryKeys.apps.detail({ appId: scope.appId })];
     case "coolify":

--- a/src/window_infrastructure/renderer_query_invalidation.test.ts
+++ b/src/window_infrastructure/renderer_query_invalidation.test.ts
@@ -15,6 +15,15 @@ describe("queryInvalidationScopeKey", () => {
     );
     expect(queryInvalidationScopeKey({ family: "coolify" })).toBe("coolify:*");
   });
+
+  it("tells two apps' temporary-preview scopes apart", () => {
+    expect(
+      queryInvalidationScopeKey({ family: "temp-preview", appId: 1 }),
+    ).not.toBe(queryInvalidationScopeKey({ family: "temp-preview", appId: 2 }));
+    expect(queryInvalidationScopeKey({ family: "temp-preview" })).toBe(
+      "temp-preview:*",
+    );
+  });
 });
 
 describe("RendererQueryInvalidationConsumer", () => {

--- a/src/window_infrastructure/types.ts
+++ b/src/window_infrastructure/types.ts
@@ -172,6 +172,10 @@ export const QueryInvalidationScopeSchema = z.discriminatedUnion("family", [
   z.object({ family: z.literal("free-agent-quota") }),
   z.object({ family: z.literal("free-model-quota") }),
   z.object({
+    family: z.literal("temp-preview"),
+    appId: z.number().int().positive().optional(),
+  }),
+  z.object({
     family: z.literal("app"),
     appId: z.number().int().positive(),
   }),

--- a/src/window_infrastructure/types.ts
+++ b/src/window_infrastructure/types.ts
@@ -268,6 +268,7 @@ export function queryInvalidationScopeKey(
   scope: QueryInvalidationScope,
 ): string {
   switch (scope.family) {
+    case "temp-preview":
     case "app":
     case "versions":
     case "branches":


### PR DESCRIPTION
Closes #4362.

This adds temp.md as an accountless option between GitHub sync and full deployment in the Publish panel. Dyad runs the app's existing build command, validates a bounded static `dist` bundle, publishes a seven-day public preview, and lets the user copy, open, update, or revoke it.

The integration follows Dyad's contract-driven IPC boundary and app-operation coordinator. The renderer receives only public status; the Temp-scoped update capability stays in main-process storage and is encrypted through Electron safeStorage. File-count and byte limits mirror temp.md's public limits, symbolic links are ignored, and the UI explicitly discloses that the result is public, static, and excludes server-side features and secrets.

The client talks directly to temp.md's manifest upload API so the feature does not add a package dependency. Updates reuse the same scoped Temp while it is active; expired or revoked previews get a fresh Temp. The scoped `DELETE /temps/:id` endpoint backing the Revoke action is deployed in production.

I verified the focused unit/UI suite, formatting, lint, TypeScript checks, and a complete macOS Electron package build.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

