### PR TITLE
fix: make the MCP transport dropdown readable in dark mode

### DIFF
--- a/src/components/plugins/AddPluginDialog.tsx
+++ b/src/components/plugins/AddPluginDialog.tsx
@@ -242,7 +242,7 @@ export function AddPluginDialog({
                 data-testid="mcp-transport-select"
                 value={transport}
                 onChange={(e) => setTransport(e.target.value as Transport)}
-                className="w-full h-9 rounded-md border bg-transparent px-3 text-sm"
+                className="w-full h-9 rounded-md border border-input bg-background text-foreground px-3 text-sm"
               >
                 <option value="stdio">stdio</option>
                 <option value="http">http</option>


### PR DESCRIPTION
The Transport select in the add-plugin dialog used bg-transparent, so the native option list fell back to the browser's white popup while the text inherited the light foreground color. This led to a visual bug where the dropdown items were unreadable.

Give the control the same background and foreground tokens as the other fields in the form.

Before:
<img width="1268" height="694" alt="DarkModeMCPBefore" src="https://github.com/user-attachments/assets/c5133fb0-c567-41a9-9502-b7f16e925be4" />

After:
<img width="1278" height="694" alt="DarkModeMCPFixed" src="https://github.com/user-attachments/assets/34710f0f-98fd-4536-a9ca-feb278c12781" />



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

