### PR TITLE
Format manifest.json

### DIFF
--- a/src/__tests__/evals/recorded_calls/manifest.json
+++ b/src/__tests__/evals/recorded_calls/manifest.json
@@ -5,18 +5,12 @@
       {
         "case": "extract-a-helper-function",
         "fixture": "order_processor.ts",
-        "calls": [
-          "01.txt"
-        ]
+        "calls": ["01.txt"]
       },
       {
         "case": "add-zod-validation",
         "fixture": "user_handler.ts",
-        "calls": [
-          "01.txt",
-          "02.txt",
-          "03.txt"
-        ]
+        "calls": ["01.txt", "02.txt", "03.txt"]
       },
       {
         "case": "refactor-giant-component",
@@ -44,19 +38,12 @@
       {
         "case": "add-error-handling",
         "fixture": "fetch_client.ts",
-        "calls": [
-          "01.txt",
-          "02.txt",
-          "03.txt"
-        ]
+        "calls": ["01.txt", "02.txt", "03.txt"]
       },
       {
         "case": "add-zod-validation",
         "fixture": "user_handler.ts",
-        "calls": [
-          "01.txt",
-          "02.txt"
-        ]
+        "calls": ["01.txt", "02.txt"]
       }
     ]
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Cosmetic JSON layout only; eval manifest data and consumers like `recorded_calls.spec.ts` are unchanged.
> 
> **Overview**
> Reformats **`src/__tests__/evals/recorded_calls/manifest.json`** so shorter **`calls`** arrays are on a single line instead of one entry per line. The long **`refactor-giant-component`** list (12 files) stays multi-line; no keys, values, or case definitions change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7291946fc72f868fbdafb6c2fe956611b9e2ef2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

