### PR TITLE
Track concurrent chat stream telemetry

### DIFF
--- a/src/ipc/handlers/chat_stream_handlers.test.ts
+++ b/src/ipc/handlers/chat_stream_handlers.test.ts
@@ -10,6 +10,7 @@ import {
 import { processFullResponseActions } from "@/ipc/processors/response_processor";
 import {
   addTrackedValue,
+  markStreamAdmitted,
   removeDyadTags,
   removeTrackedValue,
   setPartialResponseForStream,
@@ -40,6 +41,19 @@ describe("stream invocation tracking", () => {
     removeTrackedValue(trackedInvocations, 42, olderInvocation);
 
     expect(trackedInvocations.get(42)).toEqual(new Set([newerInvocation]));
+  });
+
+  it("reports concurrency only when a distinct second chat is admitted", () => {
+    const admittedStreams = new Map<number, Set<object>>();
+    const firstChatStream = {};
+    const duplicateFirstChatStream = {};
+    const secondChatStream = {};
+
+    expect(markStreamAdmitted(admittedStreams, 42, firstChatStream)).toBeNull();
+    expect(
+      markStreamAdmitted(admittedStreams, 42, duplicateFirstChatStream),
+    ).toBeNull();
+    expect(markStreamAdmitted(admittedStreams, 84, secondChatStream)).toBe(2);
   });
 
   it("keeps partial responses isolated between concurrent streams", () => {

--- a/src/ipc/handlers/chat_stream_handlers.ts
+++ b/src/ipc/handlers/chat_stream_handlers.ts
@@ -406,6 +406,7 @@ interface TrackedStream {
 // Track active streams for cancellation together with the renderer correlation
 // identity. Legacy callers may omit InvocationRef and/or use numeric streamId.
 const activeStreams = new Map<number, Set<TrackedStream>>();
+const admittedStreams = new Map<number, Set<TrackedStream>>();
 const admissionPendingStreams = new Set<AbortController>();
 
 // How many chats are currently streaming a response. Used by the
@@ -443,6 +444,16 @@ export function removeTrackedValue<T>(
   if (values.size === 0) {
     trackedValues.delete(chatId);
   }
+}
+
+export function markStreamAdmitted<T>(
+  admitted: Map<number, Set<T>>,
+  chatId: number,
+  stream: T,
+): number | null {
+  const isNewConcurrentChat = !admitted.has(chatId);
+  addTrackedValue(admitted, chatId, stream);
+  return isNewConcurrentChat && admitted.size > 1 ? admitted.size : null;
 }
 
 // A restore must drain existing streams and prevent new ones from entering the
@@ -1021,6 +1032,16 @@ export function registerChatStreamHandlers() {
         // installed and is then a plain in-flight stream the restore cancels.
         // Do NOT introduce an `await` between the checks above and this line.
         admissionPendingStreams.delete(abortController);
+        const concurrentChatCount = markStreamAdmitted(
+          admittedStreams,
+          req.chatId,
+          trackedStream,
+        );
+        if (concurrentChatCount !== null) {
+          sendTelemetryEvent("chat:concurrent-stream-started", {
+            concurrentChatCount,
+          });
+        }
         break;
       }
 
@@ -2825,6 +2846,7 @@ This conversation includes one or more image attachments. When the user uploads 
       // Clean up the abort controller
       if (trackedStream) {
         removeTrackedValue(activeStreams, req.chatId, trackedStream);
+        removeTrackedValue(admittedStreams, req.chatId, trackedStream);
       }
       admissionPendingStreams.delete(abortController);
       partialResponses.delete(abortController);

--- a/src/lib/posthogTelemetry.test.ts
+++ b/src/lib/posthogTelemetry.test.ts
@@ -159,6 +159,14 @@ describe("getSettingsPersonTelemetryProperties", () => {
 });
 
 describe("shouldBypassNonProTelemetrySampling", () => {
+  it("always sends concurrent chat starts", () => {
+    expect(
+      shouldBypassNonProTelemetrySampling({
+        event: "chat:concurrent-stream-started",
+      }),
+    ).toBe(true);
+  });
+
   it("always sends sandbox.script.* events for non-Pro sampling", () => {
     expect(
       shouldBypassNonProTelemetrySampling({

--- a/src/lib/posthogTelemetry.ts
+++ b/src/lib/posthogTelemetry.ts
@@ -104,6 +104,10 @@ export function shouldBypassNonProTelemetrySampling(
     return true;
   }
 
+  if (eventName === "chat:concurrent-stream-started") {
+    return true;
+  }
+
   // PostHog people.set emits a $set event. Sampling it would leave person
   // properties stale even though the corresponding settings update succeeded.
   if (eventName === "$set") {


### PR DESCRIPTION
## Summary

Track when users run chat streams concurrently so product telemetry can measure multi-chat usage without counting duplicate streams for the same chat.

- Emit `chat:concurrent-stream-started` only when admission introduces a second or later distinct chat, while allowing multiple tracked streams for one chat without inflating the count.
- Remove admitted streams during the existing terminal cleanup path so later concurrency counts reflect only live work.
- Bypass non-Pro event sampling for this conversion signal; reviewers should verify that always-on collection is appropriate for the expected event volume.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

