### PR TITLE
Fix PR review validation for hyphenated issue paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "fmt": "npx oxfmt",
     "presubmit": "npm run fmt:check && npm run lint",
     "eval": "cross-env NODE_OPTIONS=--no-deprecation vitest run --config vitest.eval.config.ts",
-    "test": "node --test scripts/start-supervisor.test.mjs scripts/copy-data-to-dev.test.mjs scripts/unauthorized-release-alert.test.mjs && cross-env NODE_OPTIONS=--no-deprecation VITE_CJS_IGNORE_WARNING=true vitest run",
+    "test": "node --test scripts/start-supervisor.test.mjs scripts/copy-data-to-dev.test.mjs scripts/unauthorized-release-alert.test.mjs scripts/pr-review/validate-review.test.mjs && cross-env NODE_OPTIONS=--no-deprecation VITE_CJS_IGNORE_WARNING=true vitest run",
     "test:watch": "cross-env NODE_OPTIONS=--no-deprecation VITE_CJS_IGNORE_WARNING=true vitest",
     "test:ui": "cross-env NODE_OPTIONS=--no-deprecation VITE_CJS_IGNORE_WARNING=true vitest --ui",
     "extract-codebase": "ts-node scripts/extract-codebase.ts",

--- a/rules/claude-github-workflows.md
+++ b/rules/claude-github-workflows.md
@@ -20,6 +20,8 @@ When a Claude workflow needs write credentials, prefer a two-job shape: the Clau
 
 When a headless Claude job must write local handoff artifacts, exclude project/local settings with `claude_args --setting-sources user`, explicitly pre-approve its inspection tools, and scope `Edit(...)` to the output directory via `--allowedTools`. Without the setting-source restriction, the repository's broad project allowlist merges with the scoped rule and defeats the intended boundary. After the action, verify every mandatory file with `test -s` before upload: `actions/upload-artifact`'s `if-no-files-found: error` still succeeds when only one of several listed paths exists, and Claude Code can report a successful session after denied tool calls.
 
+When validating Markdown tables from an agent artifact, recognize separator rows by matching the complete row or every cell, not with a substring check such as `line.includes("---")`. Valid filenames and issue titles can contain three consecutive hyphens, and dropping one such row makes the summary and structured findings disagree.
+
 ## Harden the agent's permissions — `.claude/settings.json` merges into CI
 
 Both `claude-code-action` and `claude-code-base-action` read `.claude/settings.json` from the workspace after `actions/checkout`, and the project's file is committed (tracked in git). **`permissions.allow` arrays merge across scopes — they do not replace each other.** From the Claude Code docs: _"Array settings merge across scopes. When the same array-valued setting (such as `permissions.allow`) appears in multiple scopes, the arrays are concatenated and deduplicated, not replaced."_ ([source](https://code.claude.com/docs/en/settings)).

--- a/scripts/pr-review/validate-review.mjs
+++ b/scripts/pr-review/validate-review.mjs
@@ -66,13 +66,13 @@ const parseSummaryIssues = (value) => {
   const rows = [];
   for (const line of lines) {
     if (!line.startsWith("|")) continue;
-    if (line.includes("---")) continue;
 
     const cells = line
       .split("|")
       .slice(1, -1)
       .map((cell) => cell.trim());
     if (cells.length !== 3) continue;
+    if (cells.every((cell) => /^:?-{3,}:?$/.test(cell))) continue;
 
     const severity = cells[0]
       .replace(/^:[^:]+:\s*/, "")

--- a/scripts/pr-review/validate-review.test.mjs
+++ b/scripts/pr-review/validate-review.test.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const validatorPath = path.join(scriptDirectory, "validate-review.mjs");
+
+test("accepts issue rows whose filenames contain Markdown separator text", () => {
+  const fixtureDirectory = fs.mkdtempSync(
+    path.join(os.tmpdir(), "dyad-pr-review-validation-"),
+  );
+
+  try {
+    const contextPath = path.join(fixtureDirectory, "context.json");
+    const reviewPath = path.join(fixtureDirectory, "review.md");
+    const findingsPath = path.join(fixtureDirectory, "findings.json");
+    const finding = {
+      severity: "HIGH",
+      path: "e2e-tests/snapshots/local-agent---auto-model.txt",
+      line: 44,
+      title: "Preserve max_output_tokens in the request",
+      body: "The regenerated snapshot unexpectedly drops the token limit.",
+    };
+    const context = JSON.stringify({
+      files: [
+        {
+          path: finding.path,
+          commentableLineRanges: [{ start: finding.line, end: finding.line }],
+        },
+      ],
+    });
+
+    fs.writeFileSync(contextPath, context);
+    fs.writeFileSync(
+      reviewPath,
+      [
+        "**Recommendation: human-review**",
+        "",
+        "### Issues Summary",
+        "",
+        "| Severity | File | Issue |",
+        "| --- | --- | --- |",
+        `| :red_circle: HIGH | \`${finding.path}:${finding.line}\` | ${finding.title} |`,
+      ].join("\n"),
+    );
+    fs.writeFileSync(
+      findingsPath,
+      `${JSON.stringify({ findings: [finding] }, null, 2)}\n`,
+    );
+
+    const result = spawnSync(process.execPath, [validatorPath], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CONTEXT_PATH: contextPath,
+        REVIEW_PATH: reviewPath,
+        FINDINGS_PATH: findingsPath,
+        EXPECTED_CONTEXT_SHA: crypto
+          .createHash("sha256")
+          .update(context)
+          .digest("hex"),
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.deepEqual(JSON.parse(fs.readFileSync(findingsPath, "utf8")), {
+      findings: [finding],
+    });
+  } finally {
+    fs.rmSync(fixtureDirectory, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Prevent automated PR reviews from dropping valid issue rows when a filename or title contains three consecutive hyphens, so inline review threads are posted instead of being silently skipped.

- Treat a table row as a Markdown separator only when every cell matches separator syntax; the strict summary/findings consistency check remains unchanged.
- Add an end-to-end Node regression test that invokes the validator with the filename shape that exposed the bug on PR #4403, and include it in the root test command.
- Record the parser guardrail in the Claude workflow rules for future artifact validators.

#skip-bugbot

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to PR review artifact parsing plus tests and docs; no auth, data, or production runtime paths.
> 
> **Overview**
> Fixes automated PR review handoff so **Issues Summary** table rows are not mistaken for Markdown separator lines when a file path or title includes three consecutive hyphens (e.g. `local-agent---auto-model.txt`).
> 
> In `validate-review.mjs`, separator detection now skips a row only when **every** cell matches `:?-{3,}:?` instead of using `line.includes("---")`, so those rows stay in the parsed summary and still align with `findings.json` for inline comments.
> 
> Adds a Node regression test that runs the validator end-to-end with that path shape, wires it into the root `npm test` script, and documents the table-parsing rule in `rules/claude-github-workflows.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dd8230a848071f79642a488e56e08070257a570. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

