### PR TITLE
Refine model picker navigation and recent rows

### DIFF
--- a/e2e-tests/helpers/page-objects/components/ModelPicker.ts
+++ b/e2e-tests/helpers/page-objects/components/ModelPicker.ts
@@ -137,14 +137,14 @@ export class ModelPicker {
 
   async selectTestOllamaModel() {
     await this.page.getByTestId("model-picker").click();
-    await this.getMenuItem("Local models", false).click();
+    await this.getMenuItem("All models").click();
     await this.getMenuItem("Ollama", false).click();
     await this.getMenuItem("Testollama", false).click();
   }
 
   async selectTestLMStudioModel() {
     await this.page.getByTestId("model-picker").click();
-    await this.getMenuItem("Local models", false).click();
+    await this.getMenuItem("All models").click();
     await this.getMenuItem("LM Studio", false).click();
     await this.getMenuItem("lmstudio-model-1", false).click();
   }

--- a/src/components/ModelPicker.test.tsx
+++ b/src/components/ModelPicker.test.tsx
@@ -560,7 +560,7 @@ describe("ModelPicker", () => {
     ).toContain("New");
     expect(screen.queryByText("GPT 5")).toBeNull();
     expect(screen.queryByText("Premium")).toBeNull();
-    expect(screen.getByText("Local models")).toBeTruthy();
+    expect(screen.queryByText("Local models")).toBeNull();
     expect(screen.queryByText("Free (OpenRouter)")).toBeNull();
     expect(screen.getByText("Dyad Free")).toBeTruthy();
     expect(screen.getByText("2/5 left")).toBeTruthy();
@@ -594,19 +594,13 @@ describe("ModelPicker", () => {
     ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
   });
 
-  it("puts common catalog navigation before local models and quick choices", () => {
+  it("keeps All models as the only catalog entry before quick choices", () => {
     render(<ModelPicker />);
 
     const allModels = screen.getByText("All models").closest("button")!;
-    const localModels = screen.getByText("Local models").closest("button")!;
-    const localNavigationGroup = localModels.parentElement!;
-
+    expect(screen.queryByText("Local models")).toBeNull();
     expect(
-      allModels.compareDocumentPosition(localModels) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
-    expect(
-      localNavigationGroup.nextElementSibling?.getAttribute("data-slot"),
+      allModels.parentElement?.nextElementSibling?.getAttribute("data-slot"),
     ).toBe("dropdown-menu-separator");
   });
 
@@ -626,8 +620,8 @@ describe("ModelPicker", () => {
     expect(screen.getByText("GPT 5")).toBeTruthy();
     expect(screen.getByText("Claude Sonnet 4.5")).toBeTruthy();
     const gptRow = screen.getByText("GPT 5").closest("button")!;
-    expect(within(gptRow).getByText("OpenAI")).toBeTruthy();
-    expect(gptRow.getAttribute("aria-label")).toContain("GPT 5. OpenAI");
+    expect(within(gptRow).queryByText("OpenAI")).toBeNull();
+    expect(gptRow.getAttribute("aria-label")).not.toContain("OpenAI");
     expect(screen.getAllByText("Auto Sidekick")).toHaveLength(1);
   });
 
@@ -848,7 +842,7 @@ describe("ModelPicker", () => {
     });
   });
 
-  it("identifies providers on pending Recent local model rows", () => {
+  it("does not show providers on pending Recent local model rows", () => {
     mocks.settings.recentModels = [
       { provider: "ollama", name: "shared-model" },
       { provider: "lmstudio", name: "shared-model" },
@@ -856,14 +850,10 @@ describe("ModelPicker", () => {
 
     render(<ModelPicker />);
 
-    const ollamaRow = screen.getByLabelText(
-      "shared-model. Ollama. Loading local model",
-    );
-    const lmStudioRow = screen.getByLabelText(
-      "shared-model. LM Studio. Loading local model",
-    );
-    expect(within(ollamaRow).getByText("Ollama")).toBeTruthy();
-    expect(within(lmStudioRow).getByText("LM Studio")).toBeTruthy();
+    const rows = screen.getAllByLabelText("shared-model. Loading local model");
+    expect(rows).toHaveLength(2);
+    expect(screen.queryByText("Ollama")).toBeNull();
+    expect(screen.queryByText("LM Studio")).toBeNull();
   });
 
   it("hides cached local recents after the provider refresh fails", () => {
@@ -885,7 +875,7 @@ describe("ModelPicker", () => {
     expect(screen.queryByText("Qwen3 Coder 30B")).toBeNull();
   });
 
-  it("identifies providers on ambiguous Recent local model rows", () => {
+  it("does not show providers on ambiguous Recent local model rows", () => {
     mocks.ollamaModels = [
       {
         provider: "ollama",
@@ -907,20 +897,12 @@ describe("ModelPicker", () => {
 
     render(<ModelPicker />);
 
-    const ollamaRow = screen.getByLabelText(/Shared Local\. Ollama\./);
-    const lmStudioRow = screen.getByLabelText(/Shared Local\. LM Studio\./);
-    expect(
-      within(ollamaRow as HTMLElement).getByText("Ollama · shared-model"),
-    ).toBeTruthy();
-    expect(
-      within(lmStudioRow as HTMLElement).getByText("LM Studio · shared-model"),
-    ).toBeTruthy();
-    expect(ollamaRow.getAttribute("aria-label")).toContain(
-      "Shared Local. Ollama.",
-    );
-    expect(lmStudioRow.getAttribute("aria-label")).toContain(
-      "Shared Local. LM Studio.",
-    );
+    const rows = screen.getAllByLabelText(/^Shared Local\. Effort:/);
+    expect(rows).toHaveLength(2);
+    for (const row of rows) {
+      expect(within(row).getByText("shared-model")).toBeTruthy();
+      expect(row.getAttribute("aria-label")).not.toMatch(/Ollama|LM Studio/);
+    }
   });
 
   it("keeps local models reachable while the cloud catalog loads", () => {
@@ -930,18 +912,25 @@ describe("ModelPicker", () => {
     render(<ModelPicker />);
 
     expect(screen.getAllByText("All models").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Local models").length).toBeGreaterThan(0);
+    expect(screen.getByText("Local providers")).toBeTruthy();
+    expect(screen.getByText("Ollama")).toBeTruthy();
+    expect(screen.getByText("LM Studio")).toBeTruthy();
     expect(screen.getByText("Loading cloud models...")).toBeTruthy();
   });
 
   it("shows a cloud catalog error without hiding local models", () => {
     mocks.catalogUnavailable = true;
     mocks.catalogError = new Error("catalog unavailable");
+    mocks.renderSubContent = true;
 
     render(<ModelPicker />);
 
-    expect(screen.getByText("Couldn’t load cloud models")).toBeTruthy();
-    expect(screen.getAllByText("Local models").length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText("Couldn’t load cloud models").length,
+    ).toBeGreaterThan(0);
+    expect(screen.getByText("Local providers")).toBeTruthy();
+    expect(screen.getByText("Ollama")).toBeTruthy();
+    expect(screen.getByText("LM Studio")).toBeTruthy();
   });
 
   it("does not leave a trailing separator after Recent", () => {
@@ -958,15 +947,21 @@ describe("ModelPicker", () => {
     );
   });
 
-  it("keeps Ollama and LM Studio in a separate Local models submenu", () => {
+  it("lists Ollama and LM Studio directly under Local providers", () => {
     mocks.renderSubContent = true;
 
     render(<ModelPicker />);
 
-    const localModelsMenu = screen.getByTestId("local-models-submenu");
-    expect(within(localModelsMenu).getByText("Ollama")).toBeTruthy();
-    expect(within(localModelsMenu).getByText("LM Studio")).toBeTruthy();
-    expect(within(localModelsMenu).queryByText("xAI")).toBeNull();
+    const allModelsMenu = screen.getByTestId("more-models-submenu");
+    const localProviders = within(allModelsMenu).getByText("Local providers");
+    const cloudProviders = within(allModelsMenu).getByText("Cloud providers");
+    expect(
+      localProviders.compareDocumentPosition(cloudProviders) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(within(allModelsMenu).getByText("Ollama")).toBeTruthy();
+    expect(within(allModelsMenu).getByText("LM Studio")).toBeTruthy();
+    expect(screen.queryByText("Local models")).toBeNull();
   });
 
   it("opens nested navigation submenus on hover with forgiving pointer timing", () => {
@@ -980,7 +975,12 @@ describe("ModelPicker", () => {
         .map((element) => element.closest("button"))
         .find((element): element is HTMLButtonElement => element !== null)!;
 
-    for (const label of ["Google Vertex AI", "Ollama", "LM Studio"]) {
+    for (const label of [
+      "All models",
+      "Google Vertex AI",
+      "Ollama",
+      "LM Studio",
+    ]) {
       const trigger = getTrigger(label);
       expect(trigger.dataset.openOnHover).toBe("true");
       expect(trigger.dataset.hoverDelay).toBe("120");
@@ -997,10 +997,6 @@ describe("ModelPicker", () => {
     expect(
       screen.getByText("GPT 5").closest("button")?.dataset.openOnHover,
     ).toBeUndefined();
-
-    for (const label of ["Local models", "All models"]) {
-      expect(getTrigger(label).dataset.openOnHover).toBeUndefined();
-    }
   });
 
   it("gives model-list menus room while keeping model metadata separate", () => {
@@ -1020,11 +1016,13 @@ describe("ModelPicker", () => {
     );
   });
 
-  it("groups secondary providers under Other providers regardless of price", () => {
+  it("groups secondary providers under Cloud providers regardless of price", () => {
     mocks.renderSubContent = true;
 
     render(<ModelPicker />);
 
+    expect(screen.getByText("Cloud providers")).toBeTruthy();
+    expect(screen.queryByText("Other providers")).toBeNull();
     const vertexModels = screen.getByTestId("other-provider-models-vertex");
     expect(
       within(vertexModels).getByText("Vertex Gemini 2.5 Pro"),

--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -737,12 +737,10 @@ export function ModelPicker() {
   const renderCloudModelItem = ({
     providerId,
     model,
-    showProvider = false,
     showPrice = true,
   }: {
     providerId: string;
     model: LanguageModel;
-    showProvider?: boolean;
     showPrice?: boolean;
   }) => {
     const modelRef = {
@@ -793,7 +791,6 @@ export function ModelPicker() {
     const compactEffortLabel = formatCompactEffortLevel(currentEffort);
     const unlockedAriaLabel = [
       model.displayName,
-      showProvider ? getProviderDisplayName(providerId) : null,
       showPrice && model.dollarSigns != null
         ? model.dollarSigns === 0
           ? "Free"
@@ -825,11 +822,6 @@ export function ModelPicker() {
             >
               {model.displayName}
             </span>
-            {showProvider && (
-              <span className="block max-w-full truncate text-xs text-muted-foreground">
-                {getProviderDisplayName(providerId)}
-              </span>
-            )}
           </span>
         </span>
         <span className="flex min-w-fit items-center gap-1.5">
@@ -1076,7 +1068,6 @@ export function ModelPicker() {
   const renderLocalModelItem = (
     providerId: "ollama" | "lmstudio",
     model: LocalModel,
-    showProvider = false,
   ) => {
     const modelRef = { name: model.modelName, provider: providerId };
     const isSelected =
@@ -1092,8 +1083,6 @@ export function ModelPicker() {
         }).effortLevel;
     const effortLabel = formatEffortLevel(currentEffort);
     const compactEffortLabel = formatCompactEffortLevel(currentEffort);
-    const providerDisplayName =
-      providerId === "ollama" ? "Ollama" : "LM Studio";
     const selectLocalModel = (effortLevel?: string) => {
       void onModelSelect({
         model: modelRef,
@@ -1107,7 +1096,7 @@ export function ModelPicker() {
       <DropdownMenuSub key={`${providerId}-${model.modelName}`}>
         <DropdownMenuSubTrigger
           hideChevron
-          aria-label={`${model.displayName}.${showProvider ? ` ${providerDisplayName}.` : ""} Effort: ${effortLabel}. Press Enter to select; press Right Arrow to configure effort.`}
+          aria-label={`${model.displayName}. Effort: ${effortLabel}. Press Enter to select; press Right Arrow to configure effort.`}
           className={cn(
             "relative py-1.5 w-full",
             isSelected &&
@@ -1137,15 +1126,9 @@ export function ModelPicker() {
                 </span>
                 <span
                   className="block max-w-full truncate text-xs text-muted-foreground"
-                  title={
-                    showProvider
-                      ? `${providerDisplayName} · ${model.modelName}`
-                      : model.modelName
-                  }
+                  title={model.modelName}
                 >
-                  {showProvider
-                    ? `${providerDisplayName} · ${model.modelName}`
-                    : model.modelName}
+                  {model.modelName}
                 </span>
               </div>
             </div>
@@ -1277,32 +1260,6 @@ export function ModelPicker() {
       </DropdownMenuSub>
     );
   };
-
-  const renderLocalModelsSubmenu = (testId: string) => (
-    <DropdownMenuSub>
-      <DropdownMenuSubTrigger className="w-full font-normal">
-        <span>Local models</span>
-      </DropdownMenuSubTrigger>
-      <DropdownMenuSubContent className="w-64" data-testid={testId}>
-        <DropdownMenuLabel>Local models</DropdownMenuLabel>
-        <DropdownMenuSeparator />
-        {renderLocalProviderSubmenu({
-          providerId: "ollama",
-          label: "Ollama",
-          models: ollamaModels,
-          loading: ollamaLoading,
-          error: ollamaError,
-        })}
-        {renderLocalProviderSubmenu({
-          providerId: "lmstudio",
-          label: "LM Studio",
-          models: lmStudioModels,
-          loading: lmStudioLoading,
-          error: lmStudioError,
-        })}
-      </DropdownMenuSubContent>
-    </DropdownMenuSub>
-  );
 
   const cloudCatalogGroups = PRICE_TIERS.map((tier) => ({
     tier,
@@ -1452,7 +1409,10 @@ export function ModelPicker() {
           {!isTrial && (
             <>
               <DropdownMenuSub>
-                <DropdownMenuSubTrigger className="w-full font-normal">
+                <DropdownMenuSubTrigger
+                  className="w-full font-normal"
+                  {...NAVIGATION_SUBMENU_HOVER_PROPS}
+                >
                   <span>All models</span>
                 </DropdownMenuSubTrigger>
                 <DropdownMenuSubContent
@@ -1511,24 +1471,46 @@ export function ModelPicker() {
                         );
                         return nodes;
                       })()}
-
-                      {otherProviderEntries.length > 0 && (
-                        <>
-                          <DropdownMenuSeparator />
-                          <div className="px-2 pt-1.5 pb-1 text-[10px] uppercase tracking-wider font-medium text-muted-foreground">
-                            Other providers
-                          </div>
-                          {otherProviderEntries.map(([providerId, models]) =>
-                            renderProviderSubmenu(providerId, models),
-                          )}
-                        </>
+                    </>
+                  )}
+                  <DropdownMenuSeparator />
+                  <div
+                    className="px-2 pt-1.5 pb-1 text-[10px] uppercase tracking-wider font-medium text-muted-foreground"
+                    data-testid="local-providers-section"
+                  >
+                    Local providers
+                  </div>
+                  {renderLocalProviderSubmenu({
+                    providerId: "ollama",
+                    label: "Ollama",
+                    models: ollamaModels,
+                    loading: ollamaLoading,
+                    error: ollamaError,
+                  })}
+                  {renderLocalProviderSubmenu({
+                    providerId: "lmstudio",
+                    label: "LM Studio",
+                    models: lmStudioModels,
+                    loading: lmStudioLoading,
+                    error: lmStudioError,
+                  })}
+                  {otherProviderEntries.length > 0 && (
+                    <>
+                      <DropdownMenuSeparator />
+                      <div
+                        className="px-2 pt-1.5 pb-1 text-[10px] uppercase tracking-wider font-medium text-muted-foreground"
+                        data-testid="cloud-providers-section"
+                      >
+                        Cloud providers
+                      </div>
+                      {otherProviderEntries.map(([providerId, models]) =>
+                        renderProviderSubmenu(providerId, models),
                       )}
                     </>
                   )}
                 </DropdownMenuSubContent>
               </DropdownMenuSub>
 
-              {renderLocalModelsSubmenu("local-models-submenu")}
               <DropdownMenuSeparator />
 
               {loading ? (
@@ -1568,33 +1550,24 @@ export function ModelPicker() {
                           return renderCloudModelItem({
                             providerId: entry.providerId,
                             model: entry.model,
-                            showProvider: true,
                           });
                         }
                         if (entry.type === "local") {
                           return renderLocalModelItem(
                             entry.providerId,
                             entry.model,
-                            true,
                           );
                         }
-                        const providerDisplayName =
-                          entry.providerId === "ollama"
-                            ? "Ollama"
-                            : "LM Studio";
                         return (
                           <DropdownMenuItem
                             key={`${entry.providerId}-${entry.modelName}-loading`}
                             disabled
-                            aria-label={`${entry.modelName}. ${providerDisplayName}. Loading local model`}
+                            aria-label={`${entry.modelName}. Loading local model`}
                             className="py-1.5"
                           >
                             <ProviderIcon providerId={entry.providerId} />
                             <span className="min-w-0 truncate text-[13px]">
                               {entry.modelName}
-                            </span>
-                            <span className="text-xs text-muted-foreground">
-                              {providerDisplayName}
                             </span>
                             <span className="ml-auto text-xs text-muted-foreground">
                               Loading...


### PR DESCRIPTION
## Summary

Refines the compact model picker so recent selections stay visually concise and the complete catalog has a simpler navigation hierarchy. Local provider access now lives alongside the cloud catalog under a single hover-open entry point.

- Removes provider-name subtitles from recent cloud and local model rows, including pending local rows; provider icons and catalog context remain, while model rows avoid the added vertical height.
- Makes `All models` open on hover with the same intent and close delays used by provider navigation, while model rows remain click-to-select so effort configuration stays unambiguous.
- Consolidates Ollama and LM Studio directly into `All models` under `Local providers`, placed before the renamed `Cloud providers` group instead of adding another nested `Local models` submenu.
- Keeps local providers reachable when the cloud catalog is loading or unavailable, and updates the packaged-app helpers to follow the consolidated navigation path.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only model picker navigation and labeling changes; selection logic is largely unchanged aside from removed provider subtitles on Recent rows.
> 
> **Overview**
> Simplifies the compact **Model picker** by removing the root **Local models** entry and folding Ollama/LM Studio into **All models** under a **Local providers** section (before **Cloud providers**, renamed from **Other providers**). Local catalogs stay visible when the cloud catalog is loading or fails.
> 
> **All models** now uses the same hover-open navigation timing as provider submenus. **Recent** rows drop provider-name subtitles and related aria-label text for cloud, local, and loading local entries; icons and model IDs remain.
> 
> E2E helpers for Ollama/LM Studio follow **All models** instead of **Local models**. Unit tests are updated for the new hierarchy and row presentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8364a57f3471534e8e479043c637e62c47b57bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->