### PR TITLE
Add actionable diagnostics for bundled Git launch failures

### DIFF
--- a/rules/dyad-errors.md
+++ b/rules/dyad-errors.md
@@ -30,6 +30,11 @@ Prefer **`DyadError`** over growing `FILTERED_EXCEPTION_MESSAGES` in `telemetry.
 
 The renderer PostHog `before_send` (in `src/renderer.tsx`) drops ~90% of events for **non-Pro** users. Any event whose audience is primarily free users (conversion funnels like `promo_click`, upgrade CTAs) must be added to `shouldBypassNonProTelemetrySampling` in `src/lib/posthogTelemetry.ts`, or it will be silently undercounted 10x. Errors, `app:initial-load`, and `sandbox.script.*` already bypass sampling.
 
+Do not treat PostHog's renderer-derived macOS version as the real OS version:
+Chromium caps the macOS user-agent token at `10.15.7`, including on Apple
+Silicon. Capture the actual version in the main process (for example with
+`app.getSystemVersion()`) when OS-version diagnosis matters.
+
 Keep cross-source error throttling in renderer `before_send`: PostHog's internal exception rate limiter does not uniformly cover manually captured IPC exceptions or custom error-shaped events. `PostHogErrorDeduper` applies the shared tier-aware policy there and persists only bounded fingerprint hashes and counters, never raw error payloads.
 
 Sampling exemptions and error deduplication serve different purposes. An error-shaped event such as `sandbox.script.failed` can bypass the non-Pro random sampler and still be deduplicated; use `dyad_error_suppressed_count` on the next admitted event when reconstructing its volume.

--- a/src/ipc/utils/git_launch_diagnostics.test.ts
+++ b/src/ipc/utils/git_launch_diagnostics.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  collectGitLaunchDiagnostics,
+  getGitLaunchTelemetryProperties,
+  inspectGitLaunchPath,
+} from "./git_launch_diagnostics";
+
+describe("Git launch diagnostics", () => {
+  let tempDir: string | undefined;
+
+  afterEach(async () => {
+    if (tempDir) {
+      await fs.promises.rm(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    }
+  });
+
+  it("distinguishes an executable from a missing path", async () => {
+    tempDir = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), "git-launch-diagnostics-"),
+    );
+    const executablePath = path.join(tempDir, "git");
+    await fs.promises.writeFile(executablePath, "#!/bin/sh\n");
+    await fs.promises.chmod(executablePath, 0o755);
+
+    const executableInspection = await inspectGitLaunchPath(executablePath);
+    expect(executableInspection).toMatchObject({
+      entryExists: true,
+      targetExists: true,
+      isSymbolicLink: false,
+      kind: "file",
+      executable: true,
+      errorCode: null,
+    });
+    expect(executableInspection.mode).toMatch(/^0[0-7]{3}$/);
+    await expect(
+      inspectGitLaunchPath(path.join(tempDir, "missing")),
+    ).resolves.toMatchObject({
+      entryExists: false,
+      targetExists: false,
+      kind: null,
+      executable: null,
+      errorCode: "ENOENT",
+    });
+  });
+
+  it("retains local launch evidence while excluding paths from telemetry", async () => {
+    tempDir = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), "git-launch-diagnostics-"),
+    );
+    const gitDirectory = path.join(tempDir, "embedded-git");
+    const gitLocation = path.join(gitDirectory, "bin", "git");
+    await fs.promises.mkdir(path.dirname(gitLocation), { recursive: true });
+    await fs.promises.writeFile(gitLocation, "#!/bin/sh\n");
+    await fs.promises.chmod(gitLocation, 0o755);
+
+    const cause = Object.assign(new Error("spawn failed"), {
+      code: "ENOENT",
+      errno: -2,
+      syscall: `spawn ${gitLocation}`,
+      path: gitLocation,
+    });
+    const error = new Error("Git failed to execute", { cause });
+    const diagnostics = await collectGitLaunchDiagnostics({
+      gitLocation,
+      cwd: tempDir,
+      localGitDirectory: gitDirectory,
+      error,
+    });
+
+    expect(diagnostics).toMatchObject({
+      gitLocation,
+      cwd: tempDir,
+      localGitDirectory: gitDirectory,
+      gitBinary: { targetExists: true, executable: true },
+      cwdPath: { targetExists: true, kind: "directory" },
+      localGitDirectoryPath: { targetExists: true, kind: "directory" },
+      cause: {
+        code: "ENOENT",
+        errno: -2,
+        syscall: `spawn ${gitLocation}`,
+        path: gitLocation,
+      },
+    });
+
+    const telemetry = getGitLaunchTelemetryProperties(diagnostics);
+    expect(telemetry).toMatchObject({
+      cause_code: "ENOENT",
+      cause_errno: -2,
+      cause_path_matches_git_location: true,
+      git_binary_target_exists: true,
+      git_binary_executable: true,
+      cwd_exists: true,
+      local_git_directory_exists: true,
+    });
+    expect(JSON.stringify(telemetry)).not.toContain(tempDir);
+  });
+});

--- a/src/ipc/utils/git_launch_diagnostics.ts
+++ b/src/ipc/utils/git_launch_diagnostics.ts
@@ -1,0 +1,214 @@
+import fs from "node:fs";
+import path from "node:path";
+import { release as getOsRelease } from "node:os";
+
+type ElectronProcess = NodeJS.Process & {
+  getSystemVersion?: () => string;
+  resourcesPath?: string;
+};
+
+type SpawnErrorCause = {
+  code?: unknown;
+  errno?: unknown;
+  syscall?: unknown;
+  path?: unknown;
+};
+
+export interface GitLaunchPathInspection {
+  entryExists: boolean;
+  targetExists: boolean;
+  isSymbolicLink: boolean | null;
+  kind: "file" | "directory" | "other" | null;
+  executable: boolean | null;
+  mode: string | null;
+  errorCode: string | null;
+}
+
+export interface GitLaunchDiagnostics {
+  platform: NodeJS.Platform;
+  arch: string;
+  systemVersion: string;
+  processExecPath: string;
+  resourcesPath: string | null;
+  localGitDirectory: string | null;
+  gitLocation: string;
+  cwd: string;
+  gitBinary: GitLaunchPathInspection;
+  gitBinaryParent: GitLaunchPathInspection;
+  cwdPath: GitLaunchPathInspection;
+  localGitDirectoryPath: GitLaunchPathInspection | null;
+  resourcesPathInspection: GitLaunchPathInspection | null;
+  cause: {
+    code: string | null;
+    errno: string | number | null;
+    syscall: string | null;
+    path: string | null;
+  };
+}
+
+function getErrorCode(error: unknown): string | null {
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    typeof error.code === "string"
+  ) {
+    return error.code;
+  }
+  return null;
+}
+
+export async function inspectGitLaunchPath(
+  targetPath: string,
+): Promise<GitLaunchPathInspection> {
+  let entryExists = false;
+  let isSymbolicLink: boolean | null = null;
+  let errorCode: string | null = null;
+
+  try {
+    const entry = await fs.promises.lstat(targetPath);
+    entryExists = true;
+    isSymbolicLink = entry.isSymbolicLink();
+  } catch (error) {
+    errorCode = getErrorCode(error);
+  }
+
+  let stats: fs.Stats | null = null;
+  try {
+    stats = await fs.promises.stat(targetPath);
+  } catch (error) {
+    errorCode ??= getErrorCode(error);
+  }
+
+  let executable: boolean | null = null;
+  if (stats) {
+    try {
+      await fs.promises.access(targetPath, fs.constants.X_OK);
+      executable = true;
+    } catch {
+      executable = false;
+    }
+  }
+
+  return {
+    entryExists,
+    targetExists: stats !== null,
+    isSymbolicLink,
+    kind: stats
+      ? stats.isFile()
+        ? "file"
+        : stats.isDirectory()
+          ? "directory"
+          : "other"
+      : null,
+    executable,
+    mode: stats ? `0${(stats.mode & 0o777).toString(8)}` : null,
+    errorCode,
+  };
+}
+
+function readSystemVersion(electronProcess: ElectronProcess): string {
+  try {
+    return electronProcess.getSystemVersion?.() ?? getOsRelease();
+  } catch {
+    return getOsRelease();
+  }
+}
+
+function normalizeCause(error: unknown): GitLaunchDiagnostics["cause"] {
+  const cause =
+    error instanceof Error && typeof error.cause === "object"
+      ? (error.cause as SpawnErrorCause)
+      : typeof error === "object" && error !== null
+        ? (error as SpawnErrorCause)
+        : {};
+
+  return {
+    code: typeof cause.code === "string" ? cause.code : null,
+    errno:
+      typeof cause.errno === "string" || typeof cause.errno === "number"
+        ? cause.errno
+        : null,
+    syscall: typeof cause.syscall === "string" ? cause.syscall : null,
+    path: typeof cause.path === "string" ? cause.path : null,
+  };
+}
+
+export async function collectGitLaunchDiagnostics({
+  gitLocation,
+  cwd,
+  localGitDirectory,
+  error,
+}: {
+  gitLocation: string;
+  cwd: string;
+  localGitDirectory?: string;
+  error: unknown;
+}): Promise<GitLaunchDiagnostics> {
+  const electronProcess = process as ElectronProcess;
+  const resourcesPath = electronProcess.resourcesPath ?? null;
+  const normalizedLocalGitDirectory = localGitDirectory ?? null;
+  const [
+    gitBinary,
+    gitBinaryParent,
+    cwdPath,
+    localGitDirectoryPath,
+    resourcesPathInspection,
+  ] = await Promise.all([
+    inspectGitLaunchPath(gitLocation),
+    inspectGitLaunchPath(path.dirname(gitLocation)),
+    inspectGitLaunchPath(cwd),
+    normalizedLocalGitDirectory
+      ? inspectGitLaunchPath(normalizedLocalGitDirectory)
+      : null,
+    resourcesPath ? inspectGitLaunchPath(resourcesPath) : null,
+  ]);
+
+  return {
+    platform: process.platform,
+    arch: process.arch,
+    systemVersion: readSystemVersion(electronProcess),
+    processExecPath: process.execPath,
+    resourcesPath,
+    localGitDirectory: normalizedLocalGitDirectory,
+    gitLocation,
+    cwd,
+    gitBinary,
+    gitBinaryParent,
+    cwdPath,
+    localGitDirectoryPath,
+    resourcesPathInspection,
+    cause: normalizeCause(error),
+  };
+}
+
+/** Project diagnostics into properties that are safe to send to telemetry. */
+export function getGitLaunchTelemetryProperties(
+  diagnostics: GitLaunchDiagnostics,
+): Record<string, string | number | boolean | null> {
+  return {
+    platform: diagnostics.platform,
+    architecture: diagnostics.arch,
+    system_version: diagnostics.systemVersion,
+    cause_code: diagnostics.cause.code,
+    cause_errno: diagnostics.cause.errno,
+    cause_syscall: diagnostics.cause.syscall?.split(/\s/, 1)[0] ?? null,
+    cause_path_matches_git_location:
+      diagnostics.cause.path === diagnostics.gitLocation,
+    git_binary_entry_exists: diagnostics.gitBinary.entryExists,
+    git_binary_target_exists: diagnostics.gitBinary.targetExists,
+    git_binary_is_symlink: diagnostics.gitBinary.isSymbolicLink,
+    git_binary_kind: diagnostics.gitBinary.kind,
+    git_binary_executable: diagnostics.gitBinary.executable,
+    git_binary_mode: diagnostics.gitBinary.mode,
+    git_binary_parent_exists: diagnostics.gitBinaryParent.targetExists,
+    cwd_exists: diagnostics.cwdPath.targetExists,
+    cwd_kind: diagnostics.cwdPath.kind,
+    local_git_directory_configured: diagnostics.localGitDirectory !== null,
+    local_git_directory_exists:
+      diagnostics.localGitDirectoryPath?.targetExists ?? null,
+    resources_path_available: diagnostics.resourcesPath !== null,
+    resources_path_exists:
+      diagnostics.resourcesPathInspection?.targetExists ?? null,
+  };
+}

--- a/src/ipc/utils/git_utils.ts
+++ b/src/ipc/utils/git_utils.ts
@@ -25,6 +25,11 @@ import {
   selectTextLineRange,
 } from "@/utils/dotenv_redaction";
 import { runBufferedProcess } from "./buffered_process";
+import {
+  collectGitLaunchDiagnostics,
+  getGitLaunchTelemetryProperties,
+} from "./git_launch_diagnostics";
+import { sendTelemetryEvent } from "./telemetry";
 
 export { GIT_ERROR_CODES } from "@/shared/git_error_codes";
 
@@ -33,6 +38,7 @@ const logger = log.scope("git_utils");
 const GIT_STATE_FINGERPRINT_TIMEOUT_MS = 30_000;
 const GIT_STATE_FINGERPRINT_MAX_PATH_BYTES = 16 * 1024 * 1024;
 const GIT_STATE_FINGERPRINT_MAX_UNTRACKED_PATHS = 10_000;
+let didReportGitLaunchFailure = false;
 
 function isUserVisibleGitPath(filePath: string) {
   return !filePath.startsWith(".dyad/") && filePath !== "pnpm-workspace.yaml";
@@ -203,10 +209,40 @@ export async function execGit(
   path: string,
   options?: IGitStringExecutionOptions,
 ): Promise<IGitStringResult> {
-  return exec(args, path, {
-    ...options,
-    env: getSanitizedGitEnv(options?.env),
-  });
+  const env = getSanitizedGitEnv(options?.env);
+  try {
+    return await exec(args, path, {
+      ...options,
+      env,
+    });
+  } catch (error) {
+    if (error instanceof ExecError && error.code === "ENOENT") {
+      try {
+        const { env: gitEnv, gitLocation } = setupEnvironment(env);
+        const diagnostics = await collectGitLaunchDiagnostics({
+          gitLocation,
+          cwd: path,
+          localGitDirectory: gitEnv.LOCAL_GIT_DIRECTORY,
+          error,
+        });
+
+        if (!didReportGitLaunchFailure) {
+          didReportGitLaunchFailure = true;
+          logger.error("Git process failed to launch", diagnostics);
+          sendTelemetryEvent(
+            "git:launch_error",
+            getGitLaunchTelemetryProperties(diagnostics),
+          );
+        }
+      } catch (diagnosticError) {
+        logger.warn(
+          "Failed to collect Git launch diagnostics",
+          diagnosticError,
+        );
+      }
+    }
+    throw error;
+  }
 }
 
 async function hashGitOutput(


### PR DESCRIPTION
## Summary

Adds one-shot diagnostics for bundled Git `ENOENT` launch failures such as #4250, distinguishing a missing working directory from a missing, inaccessible, or incorrectly resolved Dugite binary without changing the user-facing error or Git behavior.

- Keeps full paths and the raw spawn cause in the local main log, while sending PostHog only a path-free projection with existence, symlink, executable-bit, mode, architecture, actual main-process OS version, and sanitized spawn fields.
- Reports only the first launch failure in each app process to avoid amplifying a persistent failure loop; the custom event follows the existing error sampling and deduplication policy.
- Intentionally does not fall back to system Git or otherwise mask the underlying packaged-Git failure.
- Records that Chromium freezes the renderer macOS user-agent at `10.15.7`, so future telemetry investigations use a main-process OS version instead.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only on an existing error path; behavior for users is unchanged aside from one telemetry event and a main-process log per process lifetime.
> 
> **Overview**
> When bundled Git fails to spawn with **ENOENT**, `execGit` now gathers launch diagnostics (binary/cwd/resources path checks, spawn cause fields, main-process OS version via `getSystemVersion`) and **rethrows the original error**—no fallback to system Git.
> 
> **Locally**, the first failure per app process logs full diagnostics (including paths). **PostHog** gets a single `git:launch_error` event with path-free properties (existence, executable bit, mode, architecture, sanitized syscall/cause codes).
> 
> New module `git_launch_diagnostics.ts` plus Vitest coverage ensures telemetry payloads never contain user paths. `rules/dyad-errors.md` now warns not to trust Chromium’s capped macOS user-agent (`10.15.7`) for OS-version analysis.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e42d6098fc99c10a7b29575a08fbe4a175f418d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->