### PR TITLE
Prune deleted remote branches when refreshing the branch list

### DIFF
--- a/src/components/GithubBranchManager.test.tsx
+++ b/src/components/GithubBranchManager.test.tsx
@@ -121,6 +121,19 @@ describe("GithubBranchManager machine projection", () => {
     ).toBe(true);
   });
 
+  it("asks the remote to refresh branches instead of re-reading local refs", () => {
+    render(<GithubBranchManager appId={1} />);
+
+    fireEvent.click(screen.getByTestId("branch-actions-menu-trigger"));
+    fireEvent.click(screen.getByTestId("refresh-branches-button"));
+
+    expect(mocks.send).toHaveBeenCalledWith({
+      type: "OP_REQUESTED",
+      op: { type: "fetch" },
+    });
+    expect(mocks.inventory.refetch).not.toHaveBeenCalled();
+  });
+
   it("preserves create input on failure and closes only after success", async () => {
     const view = render(<GithubBranchManager appId={1} />);
 

--- a/src/components/GithubBranchManager.tsx
+++ b/src/components/GithubBranchManager.tsx
@@ -68,7 +68,7 @@ interface BranchManagerProps {
 }
 
 export function GithubBranchManager({ appId }: BranchManagerProps) {
-  const { data, isFetching, refetch } = useGithubBranchInventory(appId);
+  const { data, isFetching } = useGithubBranchInventory(appId);
   const { projection, send } = useGithubOps(appId);
   const {
     capabilities: {
@@ -236,7 +236,9 @@ export function GithubBranchManager({ appId }: BranchManagerProps) {
               Create new branch
             </DropdownMenuItem>
             <DropdownMenuItem
-              onClick={() => void refetch()}
+              onClick={() =>
+                send({ type: "OP_REQUESTED", op: { type: "fetch" } })
+              }
               disabled={!canMutateBranches || isFetching}
               data-testid="refresh-branches-button"
             >

--- a/src/ipc/git_types.ts
+++ b/src/ipc/git_types.ts
@@ -93,6 +93,8 @@ export interface GitAuthorParam {
 export interface GitFetchParams extends GitBaseParams {
   remote?: string;
   accessToken?: string;
+  /** Drop remote-tracking refs for branches that no longer exist on the remote. */
+  prune?: boolean;
 }
 
 export interface GitPullParams extends GitBaseParams {

--- a/src/ipc/handlers/git_branch_handlers.test.ts
+++ b/src/ipc/handlers/git_branch_handlers.test.ts
@@ -118,13 +118,16 @@ vi.mock("@/main/settings", () => ({
 
 import {
   handleDeleteBranch,
+  handleFetchFromGithub,
   registerGithubBranchHandlers,
 } from "@/ipc/handlers/git_branch_handlers";
 import {
+  gitFetch,
   gitListBranches,
   gitListRemoteBranches,
   gitDeleteBranch,
 } from "@/ipc/utils/git_utils";
+import { readSettings } from "@/main/settings";
 import { db } from "@/db";
 import { gitContracts, gitEvents } from "@/ipc/types/github";
 import { createAppOperationHandler } from "@/ipc/utils/app_mutation_lock";
@@ -496,5 +499,26 @@ describe("handleDeleteBranch", () => {
     await expect(
       handleDeleteBranch(mockEvent, { appId: 999, branch: "feature" }),
     ).rejects.toThrow("App not found");
+  });
+});
+
+describe("handleFetchFromGithub", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(db.query.apps.findFirst).mockResolvedValue(mockApp as any);
+    vi.mocked(readSettings).mockReturnValue({
+      githubAccessToken: { value: "token" },
+    } as any);
+  });
+
+  it("prunes so branches deleted on GitHub leave the branch list", async () => {
+    await handleFetchFromGithub(mockEvent, { appId: 1 });
+
+    expect(gitFetch).toHaveBeenCalledWith({
+      path: "/mock/apps/test-app",
+      remote: "origin",
+      accessToken: "token",
+      prune: true,
+    });
   });
 });

--- a/src/ipc/handlers/git_branch_handlers.ts
+++ b/src/ipc/handlers/git_branch_handlers.ts
@@ -96,6 +96,7 @@ export async function handleFetchFromGithub(
     path: appPath,
     remote: "origin",
     accessToken,
+    prune: true,
   });
 }
 

--- a/src/ipc/utils/git_utils.test.ts
+++ b/src/ipc/utils/git_utils.test.ts
@@ -17,7 +17,7 @@ vi.mock("electron-log", () => ({
   },
 }));
 
-import { gitListFilesNative, gitLog } from "@/ipc/utils/git_utils";
+import { gitFetch, gitListFilesNative, gitLog } from "@/ipc/utils/git_utils";
 import {
   classifyGitOperationError,
   ensureGitLineEndingPolicy,
@@ -1087,4 +1087,50 @@ describe("index entry snapshot and restore", () => {
       await runGitOutput(repoDir, ["diff", "--name-only", "--diff-filter=U"]),
     ).toBe("c.txt");
   });
+});
+
+describe("gitFetch", () => {
+  let workspaceDir: string | undefined;
+
+  afterEach(async () => {
+    if (workspaceDir) {
+      await fs.promises.rm(workspaceDir, {
+        recursive: true,
+        force: true,
+        maxRetries: 3,
+        retryDelay: 100,
+      });
+      workspaceDir = undefined;
+    }
+  });
+
+  it("only drops remote-tracking refs for deleted branches when pruning", async () => {
+    workspaceDir = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), "git-fetch-prune-"),
+    );
+    const remoteDir = path.join(workspaceDir, "remote.git");
+    const appDir = path.join(workspaceDir, "app");
+    await runGit(workspaceDir, ["init", "--bare", remoteDir]);
+    await runGit(workspaceDir, ["clone", remoteDir, appDir]);
+    // The first assertion below depends on fetch not pruning by default, which
+    // a contributor's global `fetch.prune = true` would otherwise override.
+    await runGit(appDir, ["config", "fetch.prune", "false"]);
+    await fs.promises.writeFile(path.join(appDir, "file.txt"), "content\n");
+    await commitAll(appDir, "init");
+    await runGit(appDir, ["push", "origin", "HEAD:main"]);
+    await runGit(appDir, ["push", "origin", "HEAD:feature/gone"]);
+
+    // Someone else (e.g. the GitHub web UI) deletes the branch on the remote.
+    await runGit(remoteDir, ["update-ref", "-d", "refs/heads/feature/gone"]);
+
+    await gitFetch({ path: appDir });
+    expect(await runGitOutput(appDir, ["branch", "-r", "--list"])).toContain(
+      "origin/feature/gone",
+    );
+
+    await gitFetch({ path: appDir, prune: true });
+    const remaining = await runGitOutput(appDir, ["branch", "-r", "--list"]);
+    expect(remaining).not.toContain("origin/feature/gone");
+    expect(remaining).toContain("origin/main");
+  }, 30_000);
 });

--- a/src/ipc/utils/git_utils.ts
+++ b/src/ipc/utils/git_utils.ts
@@ -2852,9 +2852,10 @@ export async function gitFetch({
   path,
   remote = "origin",
   accessToken,
+  prune,
 }: GitFetchParams): Promise<void> {
   await execOrThrow(
-    ["fetch", remote],
+    ["fetch", ...(prune ? ["--prune"] : []), remote],
     path,
     "Failed to fetch from remote",
     undefined,


### PR DESCRIPTION
Fixes #4171.

## The bug

Delete a branch on GitHub (web UI, another machine, a merged PR's auto-delete) and it stays in dyad's branch list forever. Hitting Delete on it then fails with the exact opposite of the truth:

> Branch 'foo' only exists on the remote. To delete it, please delete the branch on GitHub directly.

It has already been deleted on GitHub. There is no way out of that state from inside dyad.

## Two things are wrong

**1. Nothing ever prunes.** `gitFetch()` runs `git fetch <remote>` with no `--prune`, so `refs/remotes/origin/*` keeps entries for branches that are gone. `gitListRemoteBranches()` reads exactly those refs (`git branch -r --list`), and `handleDeleteBranch()` trusts the result, so a stale ref becomes a phantom "remote-only" branch.

**2. "Refresh branches" never talks to the remote.** It calls `refetch()` on the React Query inventory, which re-reads the same stale local refs. So the one control named for this job is a no-op against it.

There is already a `fetch` operation wired end to end for this: it is in the `GithubOperation` union, the transport allowlist, `transition.ts`'s `completionCommands` (which emits `invalidate-branches`), and it has a success banner reading "Fetched latest remote branches". Nothing in the renderer ever dispatches it. `handleFetchFromGithub` is unreachable from the UI today.

## Fix

Two small changes:

- Thread an opt-in `prune` through `gitFetch` and set it on `handleFetchFromGithub`.
- Point "Refresh branches" at the existing `fetch` operation instead of the local `refetch()`.

`invalidate-branches` already refreshes the inventory on completion, so the list updates on its own. The button becomes what its label and the existing banner already claim it is.

Two notes on the judgment calls, since both are yours to make:

- Refresh now costs a network round-trip. That is the point, but it is a behaviour change; the button already sits behind the same `canMutateBranches` idle gate as the rest of that menu, and `GithubBranchManager` only renders once a repo is connected, so the handler's auth and link preconditions cannot fire from here.
- Scope stops at the fetch primitive. Pruning inside `handleListRemoteBranches` instead would put a fetch on every branch-list render and need throttling. The other two `gitFetch` call sites are untouched: fetch-before-rebase does not read the branch list, and connect-repo's fetch does (`prepareLocalBranch` decides whether to create a tracking branch off `origin/<branch>`), so a stale ref there can branch off dead state. That looked like a separate pre-existing bug, so I left it rather than widen this.

You had #2997 open on this in March with a wider scope (prune plus a local/remote badge overhaul with a throttle race) and closed it unmerged. This is a narrower cut. Happy to close it if you would rather take a different one.

## Tests

- `git_utils.test.ts`: real bare remote plus a clone; a branch is deleted directly on the remote, then it asserts plain `gitFetch()` still lists `origin/feature/gone` (pins the bug) and `gitFetch({ prune: true })` drops it while keeping `origin/main`.
- `GithubBranchManager.test.tsx`: pins that "Refresh branches" dispatches the fetch op and no longer re-reads local refs.
- `git_branch_handlers.test.ts`: pins that the Fetch handler passes `prune: true`.

All three verified failing before the change.

`npx oxfmt --check`, `npx oxlint` and `npx tsgo -p tsconfig.app.json --noEmit` are clean.

I used an AI assistant to help investigate and write this; I reproduced the bug and reviewed and tested the change myself.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
---
Disclosure: this change was prepared with AI assistance (Claude Code). The repro and tests described above were run before it was opened.
