### PR TITLE
Authenticate OAuth deep-link callbacks

### DIFF
--- a/rules/electron-ipc.md
+++ b/rules/electron-ipc.md
@@ -168,6 +168,13 @@ pre-hydration atoms can erase unrelated restored entities.
 
 **Custom-protocol debugging:** Before using `git bisect` on a `dyad://` flow, quit every dev and packaged Dyad instance and verify which build owns the protocol registration. macOS may route the link to a different running/registered build, producing a convincing but false good/bad result.
 
+Custom-protocol delivery (`open-url`, argv, or `second-instance`) carries only
+the callback URL, not a trustworthy web origin. Credential-bearing callbacks
+must present a provider-bound, expiring, single-use correlation value minted at
+the authoritative flow-start boundary; an unmatched or unsolicited callback
+must not perform the credential write. Browser protocol-launch prompts are UX,
+not an authentication boundary.
+
 ## Handler expectations
 
 - Keep handler registration free of database-dependent startup work. Handlers

--- a/src/components/NeonConnector.tsx
+++ b/src/components/NeonConnector.tsx
@@ -4,8 +4,8 @@ import {
   cancelConnectionFlow,
   startConnectionFlow,
   useConnectionFlow,
-  useUnsolicitedConnectionReturn,
 } from "@/hooks/useConnectionFlow";
+import { buildOAuthLoginUrl } from "@/connection_flow/oauth_deep_link";
 import { useTranslation } from "react-i18next";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -136,18 +136,6 @@ export function NeonConnector({ appId }: { appId: number }) {
     }
   }, [flowState, t]);
 
-  // A dyad://neon-oauth-return processed with no active flow (cold start,
-  // app restarted mid-flow, or a return that arrived after the flow timed
-  // out): tokens are already stored — refresh what we show and confirm the
-  // (late but real) success, matching the pre-machine behavior where every
-  // processed return toasted success.
-  useUnsolicitedConnectionReturn("neon", () => {
-    void (async () => {
-      await refreshAfterConnectRef.current();
-      toast.success(t("integrations.neon.connectedSuccess"));
-    })();
-  });
-
   const handleConnect = async () => {
     try {
       // Starting is a no-op while a flow is already active (double-click).
@@ -160,7 +148,7 @@ export function NeonConnector({ appId }: { appId: number }) {
           await ipc.neon.fakeConnect();
         } else {
           await ipc.system.openExternalUrl(
-            "https://oauth.dyad.sh/api/integrations/neon/login",
+            buildOAuthLoginUrl("neon", invocationRef),
           );
         }
       } catch (error) {

--- a/src/components/SupabaseConnector.test.tsx
+++ b/src/components/SupabaseConnector.test.tsx
@@ -28,7 +28,7 @@ const {
   providerErrorState,
   settingsLoadingState,
   appLoadingState,
-  unsolicitedReturnCallback,
+  connectionFlowState,
   refreshedSettings,
 } = vi.hoisted(() => ({
   detectLegacyAppKeyMock: vi.fn(),
@@ -71,8 +71,8 @@ const {
   },
   settingsLoadingState: { current: false },
   appLoadingState: { current: false },
-  unsolicitedReturnCallback: {
-    current: null as null | (() => void),
+  connectionFlowState: {
+    current: { status: "idle" } as Record<string, unknown>,
   },
   refreshedSettings: { refreshed: true },
   redeployState: {
@@ -168,12 +168,9 @@ vi.mock("@/hooks/useSupabase", () => ({
 
 vi.mock("@/hooks/useConnectionFlow", () => ({
   useConnectionFlow: () => ({
-    flowState: { status: "idle" },
+    flowState: connectionFlowState.current,
     isFlowActive: false,
   }),
-  useUnsolicitedConnectionReturn: (_provider: string, callback: () => void) => {
-    unsolicitedReturnCallback.current = callback;
-  },
   acknowledgeConnectionFlow: vi.fn(),
   cancelConnectionFlow: vi.fn(),
   startConnectionFlow: vi.fn(),
@@ -187,6 +184,20 @@ function renderConnector() {
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );
   return render(<SupabaseConnector appId={7} />, { wrapper });
+}
+
+function renderSuccessfulConnection() {
+  connectionFlowState.current = {
+    status: "connected",
+    provider: "supabase",
+    revision: 3,
+    invocationRef: {
+      kind: "connection-flow",
+      entityKey: "supabase",
+      operationId: "connection-flow:test",
+    },
+  };
+  return renderConnector();
 }
 
 const BUTTON = "supabase-update-api-key-button";
@@ -214,7 +225,7 @@ beforeEach(() => {
   providerErrorState.projects = null;
   settingsLoadingState.current = false;
   appLoadingState.current = false;
-  unsolicitedReturnCallback.current = null;
+  connectionFlowState.current = { status: "idle" };
   refreshSettingsMock.mockResolvedValue(refreshedSettings);
   refreshAppMock.mockResolvedValue(undefined);
   refetchOrganizationsMock.mockResolvedValue({ data: [] });
@@ -240,9 +251,7 @@ it("migrates a legacy project link to the organization found after reconnect", a
     ],
   });
 
-  renderConnector();
-  expect(unsolicitedReturnCallback.current).not.toBeNull();
-  unsolicitedReturnCallback.current?.();
+  renderSuccessfulConnection();
 
   await waitFor(() =>
     expect(recoverAppProjectMock).toHaveBeenCalledWith({
@@ -273,8 +282,7 @@ it("uses the parent project to migrate a legacy branch link", async () => {
     ],
   });
 
-  renderConnector();
-  unsolicitedReturnCallback.current?.();
+  renderSuccessfulConnection();
 
   await waitFor(() =>
     expect(recoverAppProjectMock).toHaveBeenCalledWith({
@@ -347,8 +355,7 @@ it("refreshes app state when automatic legacy relinking fails", async () => {
   });
   recoverAppProjectMock.mockRejectedValue(new Error("write failed"));
 
-  renderConnector();
-  unsolicitedReturnCallback.current?.();
+  renderSuccessfulConnection();
 
   await waitFor(() => expect(refreshAppMock).toHaveBeenCalled());
   expect(recoverAppProjectMock).toHaveBeenCalled();
@@ -374,8 +381,7 @@ it("migrates a link whose stored organization is stale", async () => {
     ],
   });
 
-  renderConnector();
-  unsolicitedReturnCallback.current?.();
+  renderSuccessfulConnection();
 
   await waitFor(() =>
     expect(recoverAppProjectMock).toHaveBeenCalledWith({
@@ -404,8 +410,7 @@ it("does not recover a legacy link from stale project data after a failed refetc
     isError: true,
   });
 
-  renderConnector();
-  unsolicitedReturnCallback.current?.();
+  renderSuccessfulConnection();
 
   await waitFor(() => expect(refreshAppMock).toHaveBeenCalled());
   expect(recoverAppProjectMock).not.toHaveBeenCalled();
@@ -426,8 +431,7 @@ it("does not recover a legacy link without refreshed organization credentials", 
     isError: false,
   });
 
-  renderConnector();
-  unsolicitedReturnCallback.current?.();
+  renderSuccessfulConnection();
 
   await waitFor(() => expect(refreshAppMock).toHaveBeenCalled());
   expect(recoverAppProjectMock).not.toHaveBeenCalled();

--- a/src/components/SupabaseConnector.tsx
+++ b/src/components/SupabaseConnector.tsx
@@ -4,8 +4,8 @@ import {
   cancelConnectionFlow,
   startConnectionFlow,
   useConnectionFlow,
-  useUnsolicitedConnectionReturn,
 } from "@/hooks/useConnectionFlow";
+import { buildOAuthLoginUrl } from "@/connection_flow/oauth_deep_link";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 
@@ -201,13 +201,6 @@ export function SupabaseConnector({ appId }: { appId: number }) {
     }
   }, [flowState, t]);
 
-  // A dyad://supabase-oauth-return processed with no active flow (cold
-  // start, app restarted mid-flow, or a return that arrived after the flow
-  // timed out): tokens are already stored, just refresh what we show.
-  useUnsolicitedConnectionReturn("supabase", () => {
-    void refreshAfterConnectRef.current();
-  });
-
   const handleProjectSelect = async (projectValue: string) => {
     try {
       // projectValue format: "organizationSlug:projectId"
@@ -271,7 +264,7 @@ export function SupabaseConnector({ appId }: { appId: number }) {
           });
         } else {
           await ipc.system.openExternalUrl(
-            "https://supabase-oauth.dyad.sh/api/connect-supabase/login",
+            buildOAuthLoginUrl("supabase", invocationRef),
           );
         }
       } catch (error) {

--- a/src/connection_flow/oauth_deep_link.test.ts
+++ b/src/connection_flow/oauth_deep_link.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildOAuthLoginUrl,
+  parseOAuthCallbackInvocationRef,
+} from "./oauth_deep_link";
+
+describe("OAuth deep-link state", () => {
+  const neonRef = {
+    kind: "connection-flow" as const,
+    entityKey: "neon" as const,
+    operationId: "connection-flow:123e4567-e89b-12d3-a456-426614174000",
+  };
+
+  it("binds the login URL to the main-owned invocation", () => {
+    const url = new URL(buildOAuthLoginUrl("neon", neonRef));
+
+    expect(url.origin + url.pathname).toBe(
+      "https://oauth.dyad.sh/api/integrations/neon/login",
+    );
+    expect(url.searchParams.get("state")).toBe(neonRef.operationId);
+  });
+
+  it("rejects cross-provider refs and malformed callback state", () => {
+    expect(() => buildOAuthLoginUrl("supabase", neonRef)).toThrow(
+      "OAuth invocation does not belong to supabase",
+    );
+    expect(parseOAuthCallbackInvocationRef("neon", null)).toBeNull();
+    expect(
+      parseOAuthCallbackInvocationRef("neon", "contains spaces"),
+    ).toBeNull();
+    expect(parseOAuthCallbackInvocationRef("neon", "x".repeat(201))).toBeNull();
+  });
+
+  it("reconstructs a provider-bound invocation ref", () => {
+    expect(
+      parseOAuthCallbackInvocationRef("supabase", neonRef.operationId),
+    ).toEqual({
+      ...neonRef,
+      entityKey: "supabase",
+    });
+  });
+});

--- a/src/connection_flow/oauth_deep_link.ts
+++ b/src/connection_flow/oauth_deep_link.ts
@@ -1,0 +1,44 @@
+import {
+  CONNECTION_FLOW_INVOCATION_KIND,
+  type ConnectionFlowInvocationRef,
+} from "./state";
+
+export type DeepLinkOAuthProvider = "neon" | "supabase";
+
+const LOGIN_URLS: Record<DeepLinkOAuthProvider, string> = {
+  neon: "https://oauth.dyad.sh/api/integrations/neon/login",
+  supabase: "https://supabase-oauth.dyad.sh/api/connect-supabase/login",
+};
+
+const OAUTH_STATE_PATTERN = /^[A-Za-z0-9:._~-]{1,200}$/;
+
+export function buildOAuthLoginUrl(
+  provider: DeepLinkOAuthProvider,
+  invocationRef: ConnectionFlowInvocationRef,
+): string {
+  if (
+    invocationRef.kind !== CONNECTION_FLOW_INVOCATION_KIND ||
+    invocationRef.entityKey !== provider
+  ) {
+    throw new Error(`OAuth invocation does not belong to ${provider}`);
+  }
+
+  const url = new URL(LOGIN_URLS[provider]);
+  url.searchParams.set("state", invocationRef.operationId);
+  return url.toString();
+}
+
+export function parseOAuthCallbackInvocationRef(
+  provider: DeepLinkOAuthProvider,
+  state: string | null,
+): ConnectionFlowInvocationRef | null {
+  if (!state || !OAUTH_STATE_PATTERN.test(state)) {
+    return null;
+  }
+
+  return {
+    kind: CONNECTION_FLOW_INVOCATION_KIND,
+    entityKey: provider,
+    operationId: state,
+  };
+}

--- a/src/connection_flow/registry.test.ts
+++ b/src/connection_flow/registry.test.ts
@@ -132,7 +132,7 @@ describe("connection flow registry", () => {
     });
   });
 
-  it("structurally claims deep-link returns that cannot echo the ref", () => {
+  it("structurally claims trusted callbacks that cannot echo the ref", () => {
     const { registry } = setup();
     const started = admittedStart(registry, "supabase");
     registry.markPrepared("supabase", started.invocationRef);

--- a/src/connection_flow/registry.ts
+++ b/src/connection_flow/registry.ts
@@ -248,7 +248,7 @@ export function createConnectionFlowRegistry(
             provider,
             {
               structuralSafety:
-                "Supabase and Neon deep links cannot echo application state; one active flow per provider and no active-flow replacement makes the awaiting invocation the only possible claim.",
+                "Test-only provider callbacks execute inside the trusted main process immediately after the one active flow is started.",
             },
           )
         : invocations.claim(expectedInvocationRef);

--- a/src/ipc/handlers/connection_flow_handlers.ts
+++ b/src/ipc/handlers/connection_flow_handlers.ts
@@ -8,6 +8,7 @@ import {
 import {
   createConnectionFlowRegistry,
   type ClaimReturnResult,
+  type ConnectionFlowRegistry,
 } from "../../connection_flow/registry";
 import {
   isTerminalFlowState,
@@ -137,30 +138,15 @@ export type OAuthReturnExchangeOutcome =
 
 /**
  * Wraps a provider's OAuth-return token write so the flow machine observes
- * it: claims the active flow (if any), runs the token write, and advances or
- * fails the flow accordingly. Unsolicited returns (no active flow, or the
- * flow already ended — e.g. it timed out first) still perform the token
- * write; the renderer is then told to refresh connection state without
- * transitioning any flow.
+ * it: claims the active flow, runs the token write, and advances or fails the
+ * flow accordingly. By default, an unmatched return never runs the token
+ * write. Authenticated internal producers may explicitly preserve a completed
+ * exchange that raced UI cancellation without claiming a newer flow.
  *
  * `expectedInvocationRef` correlates the return with the flow that produced it.
  * The GitHub device poll chain carries the ref it was started for and
  * MUST pass it, so a stale poll result can never claim (and advance) a
  * newer flow.
- *
- * The Supabase/Neon deep-link returns cannot pass it: the dyad.sh OAuth
- * proxy's login endpoints take no client-supplied state parameter, so the
- * dyad://…-oauth-return URL carries only tokens — there is nothing to
- * round-trip an invocation ref. The closest safe correlation holds structurally
- * instead: the registry keeps at most one flow per provider and `start` is
- * a no-op while one is active, so the awaiting flow a return claims is
- * always the *newest* flow for that provider (an older flow must have
- * reached a terminal state before a new one could start, and terminal flows
- * can never be claimed). A stale browser tab completing after a retry can
- * therefore only be attributed to the newest awaiting flow — which is
- * benign for these providers, because the login URL carries no per-flow
- * parameters either: every return is the same account-level token grant the
- * awaiting flow is waiting for.
  *
  * Failures are recorded on the claimed flow (surfaced by the renderer as a
  * flow-failure toast) and reported in the returned outcome instead of being
@@ -172,20 +158,36 @@ export async function runOAuthReturnExchange(
   {
     failureReason = "token_invalid",
     expectedInvocationRef,
+    allowUnclaimedExchange = false,
   }: {
     failureReason?: ConnectionFlowFailureReason;
     expectedInvocationRef?: ConnectionFlowInvocationRef;
+    allowUnclaimedExchange?: boolean;
   } = {},
+  registry: Pick<
+    ConnectionFlowRegistry,
+    "claimReturn" | "completeTokenExchange" | "fail" | "notifyUnsolicitedReturn"
+  > = connectionFlowRegistry,
 ): Promise<OAuthReturnExchangeOutcome> {
-  const claim: ClaimReturnResult = connectionFlowRegistry.claimReturn(
+  const claim: ClaimReturnResult = registry.claimReturn(
     provider,
     expectedInvocationRef,
   );
+  if (!claim.claimed && !allowUnclaimedExchange) {
+    return {
+      ok: false,
+      claimed: false,
+      error: new DyadError(
+        `The ${provider} OAuth return did not match an active connection flow.`,
+        DyadErrorKind.Auth,
+      ),
+    };
+  }
   try {
     await exchange();
   } catch (error) {
     if (claim.claimed) {
-      connectionFlowRegistry.fail(
+      registry.fail(
         provider,
         claim.invocationRef,
         failureReason,
@@ -195,9 +197,9 @@ export async function runOAuthReturnExchange(
     return { ok: false, claimed: claim.claimed, error };
   }
   if (claim.claimed) {
-    connectionFlowRegistry.completeTokenExchange(provider, claim.invocationRef);
+    registry.completeTokenExchange(provider, claim.invocationRef);
   } else {
-    connectionFlowRegistry.notifyUnsolicitedReturn(provider);
+    registry.notifyUnsolicitedReturn(provider);
   }
   // Persistence completed before this global epoch event. Every live window
   // invalidates independently, and a reloaded window recovers the scope from

--- a/src/ipc/handlers/connection_flow_oauth_return.test.ts
+++ b/src/ipc/handlers/connection_flow_oauth_return.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from "vitest";
+import { createConnectionFlowRegistry } from "@/connection_flow/registry";
+import {
+  createFakeClock,
+  createSequentialIdSource,
+} from "@/state_machines/testing";
+import { runOAuthReturnExchange } from "./connection_flow_handlers";
+
+vi.mock("electron", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  BrowserWindow: { getAllWindows: () => [] },
+}));
+
+function setupAwaitingFlow() {
+  const registry = createConnectionFlowRegistry({
+    clock: createFakeClock(),
+    ids: createSequentialIdSource(),
+    observer: undefined,
+  });
+  const started = registry.start("neon", 0);
+  if (!started.admitted) throw new Error("expected admitted start");
+  registry.markPrepared("neon", started.invocationRef);
+  return { registry, invocationRef: started.invocationRef };
+}
+
+describe("OAuth return exchange", () => {
+  it("does not write credentials for a mismatched callback", async () => {
+    const { registry, invocationRef } = setupAwaitingFlow();
+    const exchange = vi.fn();
+
+    await expect(
+      runOAuthReturnExchange(
+        "neon",
+        exchange,
+        {
+          expectedInvocationRef: {
+            ...invocationRef,
+            operationId: "connection-flow:stale",
+          },
+        },
+        registry,
+      ),
+    ).resolves.toMatchObject({ ok: false, claimed: false });
+
+    expect(exchange).not.toHaveBeenCalled();
+    expect(registry.getState("neon")).toMatchObject({
+      status: "awaiting-return",
+      invocationRef,
+    });
+  });
+
+  it("consumes a matching callback exactly once", async () => {
+    const { registry, invocationRef } = setupAwaitingFlow();
+    const exchange = vi.fn();
+
+    await expect(
+      runOAuthReturnExchange(
+        "neon",
+        exchange,
+        { expectedInvocationRef: invocationRef },
+        registry,
+      ),
+    ).resolves.toEqual({ ok: true, claimed: true });
+    await expect(
+      runOAuthReturnExchange(
+        "neon",
+        exchange,
+        { expectedInvocationRef: invocationRef },
+        registry,
+      ),
+    ).resolves.toMatchObject({ ok: false, claimed: false });
+
+    expect(exchange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/ipc/handlers/github_handlers.ts
+++ b/src/ipc/handlers/github_handlers.ts
@@ -343,7 +343,14 @@ async function pollForAccessToken(invocationRef: ConnectionFlowInvocationRef) {
             },
           });
         },
-        { expectedInvocationRef: invocationRef },
+        {
+          expectedInvocationRef: invocationRef,
+          // Device-flow polling is an authenticated producer. Preserve a
+          // successfully authorized token if the UI flow was cancelled while
+          // the final poll was in flight, without allowing it to claim a newer
+          // invocation.
+          allowUnclaimedExchange: true,
+        },
       );
       if (!outcome.ok) {
         // A claimed failure was already recorded on the flow; rethrow only

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,6 +55,7 @@ import {
   disposeConnectionFlowsForShutdown,
   runOAuthReturnExchange,
 } from "./ipc/handlers/connection_flow_handlers";
+import { parseOAuthCallbackInvocationRef } from "./connection_flow/oauth_deep_link";
 import {
   AddMcpServerConfigSchema,
   AddMcpServerPayload,
@@ -1455,20 +1456,33 @@ async function handleDeepLinkReturn(url: string) {
       );
       return;
     }
+    const expectedInvocationRef = parseOAuthCallbackInvocationRef(
+      "neon",
+      parsed.searchParams.get("state"),
+    );
+    if (!expectedInvocationRef) {
+      dialog.showErrorBox(
+        "Invalid URL",
+        "This Neon sign-in could not be verified. Please connect again from Dyad.",
+      );
+      return;
+    }
     {
-      // Runs the token write through the connection flow machine: an active
-      // flow advances (awaiting-return -> exchanging-token -> ...), while a
-      // return with no matching flow (cold start, restart mid-flow, or a
-      // return that lost the race against a timeout) still stores tokens and
-      // is broadcast as unsolicited so the renderer refreshes.
-      const outcome = await runOAuthReturnExchange("neon", () => {
-        handleNeonOAuthReturn({ token, refreshToken, expiresIn });
-      });
+      // Runs the token write through the connection flow machine. Only the
+      // exact active invocation may advance and persist credentials.
+      const outcome = await runOAuthReturnExchange(
+        "neon",
+        () => {
+          handleNeonOAuthReturn({ token, refreshToken, expiresIn });
+        },
+        { expectedInvocationRef },
+      );
       if (!outcome.ok) {
-        // A claimed failure is surfaced by the renderer as a flow-failure
-        // toast; only unclaimed (unsolicited) failures need the dialog.
         if (!outcome.claimed) {
-          showDeepLinkSettingsError("save Neon credentials", outcome.error);
+          dialog.showErrorBox(
+            "Sign-in Could Not Be Verified",
+            "This Neon sign-in expired or no longer matches the connection started by Dyad. Please connect again.",
+          );
         }
         return;
       }
@@ -1486,17 +1500,33 @@ async function handleDeepLinkReturn(url: string) {
       );
       return;
     }
+    const expectedInvocationRef = parseOAuthCallbackInvocationRef(
+      "supabase",
+      parsed.searchParams.get("state"),
+    );
+    if (!expectedInvocationRef) {
+      dialog.showErrorBox(
+        "Invalid URL",
+        "This Supabase sign-in could not be verified. Please connect again from Dyad.",
+      );
+      return;
+    }
     {
       // See the neon-oauth-return branch above for why the token write is
       // wrapped by the connection flow machine.
-      const outcome = await runOAuthReturnExchange("supabase", async () => {
-        await handleSupabaseOAuthReturn({ token, refreshToken, expiresIn });
-      });
+      const outcome = await runOAuthReturnExchange(
+        "supabase",
+        async () => {
+          await handleSupabaseOAuthReturn({ token, refreshToken, expiresIn });
+        },
+        { expectedInvocationRef },
+      );
       if (!outcome.ok) {
-        // A claimed failure is surfaced by the renderer as a flow-failure
-        // toast; only unclaimed (unsolicited) failures need the dialog.
         if (!outcome.claimed) {
-          showDeepLinkSettingsError("save Supabase credentials", outcome.error);
+          dialog.showErrorBox(
+            "Sign-in Could Not Be Verified",
+            "This Supabase sign-in expired or no longer matches the connection started by Dyad. Please connect again.",
+          );
         }
         return;
       }


### PR DESCRIPTION
## Summary

Require Neon and Supabase credential callbacks to prove they belong to the exact connection flow started by Dyad, closing the custom-protocol account-injection path.

- The existing main-owned invocation ID becomes a bounded OAuth state value and is attached to each proxy login URL; no additional renderer-owned lifecycle state is introduced.
- Missing, malformed, stale, cross-provider, expired, cancelled, and replayed callback state is rejected before the credential exchange callback can write settings. Restarting Dyad during browser authentication now intentionally requires the user to start Connect again.
- GitHub device-flow completion remains explicitly allowed to preserve an authenticated token that races UI cancellation, while it still cannot claim a newer invocation. Dyad Pro and the focus-only MCP return are unchanged.
- Deploy the companion cloud change first: https://github.com/dyad-sh/dyad-cloud/pull/435. The cloud login endpoints remain compatible with old desktop clients, while this desktop version requires the echoed state.
- This does not yet replace bearer tokens in the custom-protocol URL with an authorization-code + desktop PKCE exchange; state prevents injection but does not address protocol-handler interception.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

