### PR TITLE
Show cursor actions during preview tests

### DIFF
--- a/src/ipc/handlers/tests_handlers.preview.test.ts
+++ b/src/ipc/handlers/tests_handlers.preview.test.ts
@@ -69,6 +69,8 @@ import {
 import {
   PREVIEW_CDP_ENDPOINT_ENV,
   PREVIEW_CDP_TOKEN_ENV,
+  PREVIEW_SLOW_MO_DELAY_MS,
+  PREVIEW_SLOW_MO_ENV,
 } from "../utils/playwright_bootstrap";
 import { buildWindowsCommandInvocation } from "../utils/windows_command";
 
@@ -196,6 +198,9 @@ describe("preview runs", () => {
 
     expect(lastSpawn().env[PREVIEW_CDP_ENDPOINT_ENV]).toBe(CDP_ENDPOINT);
     expect(lastSpawn().env[PREVIEW_CDP_TOKEN_ENV]).toBe(CDP_TOKEN);
+    expect(lastSpawn().env[PREVIEW_SLOW_MO_ENV]).toBe(
+      String(PREVIEW_SLOW_MO_DELAY_MS),
+    );
   });
 
   it("asks the bootstrap to generate the shim", async () => {
@@ -497,6 +502,7 @@ describe("ordinary runs are untouched", () => {
     await runAppTestsCore({ appId: 1 });
 
     expect(lastSpawn().env[PREVIEW_CDP_ENDPOINT_ENV]).toBeUndefined();
+    expect(lastSpawn().env[PREVIEW_SLOW_MO_ENV]).toBeUndefined();
     expect(h.ensurePlaywrightBootstrap).toHaveBeenCalledWith(
       expect.objectContaining({ ensurePreviewShim: false }),
     );

--- a/src/ipc/handlers/tests_handlers.ts
+++ b/src/ipc/handlers/tests_handlers.ts
@@ -55,6 +55,8 @@ import {
   DYAD_CONFIG_FILENAME,
   PREVIEW_CDP_ENDPOINT_ENV,
   PREVIEW_CDP_TOKEN_ENV,
+  PREVIEW_SLOW_MO_DELAY_MS,
+  PREVIEW_SLOW_MO_ENV,
   SLOW_MO_DELAY_MS,
   SLOW_MO_TEST_TIMEOUT_MS,
   TEST_BASE_URL_ENV,
@@ -446,6 +448,9 @@ async function runPreviewTestBatch({
       [TEST_BASE_URL_ENV]: baseUrl,
       [PREVIEW_CDP_ENDPOINT_ENV]: previewEndpoint,
       [PREVIEW_CDP_TOKEN_ENV]: previewToken,
+      [PREVIEW_SLOW_MO_ENV]: String(
+        slowMo ? SLOW_MO_DELAY_MS : PREVIEW_SLOW_MO_DELAY_MS,
+      ),
       PLAYWRIGHT_NO_COPY_PROMPT: "1",
       ...(slowMo ? { [TEST_SLOW_MO_ENV]: String(SLOW_MO_DELAY_MS) } : {}),
       PLAYWRIGHT_JSON_OUTPUT_NAME: reportPath,

--- a/src/ipc/utils/playwright_bootstrap.test.ts
+++ b/src/ipc/utils/playwright_bootstrap.test.ts
@@ -25,8 +25,11 @@ import {
   refreshGeneratedE2eTsconfig,
   PREVIEW_CDP_ENDPOINT_ENV,
   PREVIEW_CDP_TOKEN_ENV,
+  PREVIEW_SLOW_MO_ENV,
   PREVIEW_SHIM_RELATIVE_PATH,
   SHIM_TSCONFIG_RELATIVE_PATH,
+  SLOW_MO_DELAY_MS,
+  SLOW_MO_TEST_TIMEOUT_MS,
   TEST_BASE_URL_ENV,
   TEST_RESULTS_JSON,
   TEST_SLOW_MO_ENV,
@@ -83,6 +86,11 @@ afterEach(() => {
 describe("buildPreviewShimSource", () => {
   const source = buildPreviewShimSource();
 
+  it("makes slow-motion runs deliberate without shrinking their action budget", () => {
+    expect(SLOW_MO_DELAY_MS).toBe(1_500);
+    expect(SLOW_MO_TEST_TIMEOUT_MS).toBe(360_000);
+  });
+
   it("re-exports the real runner from the app's direct dependency", () => {
     // NOT `playwright/test`: that package is only a transitive dependency, so
     // pnpm/Yarn keep it out of the app's top-level node_modules and the import
@@ -109,9 +117,59 @@ describe("buildPreviewShimSource", () => {
   it("carries the slow-motion delay on the connection", () => {
     // No browser is launched here, so the generated config's
     // `launchOptions.slowMo` never applies to a preview run.
-    expect(source).toContain(`process.env.${TEST_SLOW_MO_ENV}`);
+    expect(source).toContain(`process.env.${PREVIEW_SLOW_MO_ENV}`);
     expect(source).toContain("connectOverCDP(endpoint, {");
     expect(source).toContain("headers: { Authorization:");
+  });
+
+  it("injects and removes the synthetic cursor only for preview runs", () => {
+    expect(source).toContain("context.addInitScript(installCursorRuntime)");
+    expect(source).toContain("patchPointerActions(page)");
+    expect(source).toContain("const locatorTargetMethods = [");
+    for (const method of [
+      "fill",
+      "focus",
+      "press",
+      "setInputFiles",
+      "_expect",
+    ]) {
+      expect(source).toContain(`"${method}"`);
+    }
+    expect(source).toContain('createElementNS(svgNamespace, "svg")');
+    expect(source).toContain('attachShadow({ mode: "open" })');
+    expect(source).toContain(":root, :root * { cursor: none !important; }");
+    expect(source).toContain("nativeCursorStyle.remove()");
+    expect(source).not.toContain("cursor.innerHTML");
+    expect(source).toContain("The arrow's tip is the pointer hotspot");
+    expect(source).toContain("window.__dyadTestCursor?.show(point)");
+    expect(source).toContain("await page.evaluate(installCursorRuntime)");
+    expect(source).toContain("window.__dyadTestCursor?.glide");
+    expect(source).toContain('testInfo.attach("dyad-cursor-trace"');
+    expect(source).toContain("cursorTraces.get(page)");
+    expect(source).toContain("cursor.animate(");
+    expect(source).toContain(
+      "await new Promise((resolve) => setTimeout(resolve, duration))",
+    );
+    expect(source).toContain("const found = await target.evaluate(");
+    expect(source).toContain("const actionableSelector = [");
+    expect(source).toContain("actionableChildren.length === 1");
+    expect(source).toContain("const targetBox = visibleBox(preciseRect)");
+    expect(source).toContain("x: targetBox.x + targetBox.width / 2");
+    expect(source).toContain("range.getClientRects()");
+    expect(source).not.toContain("setTimeout(resolve, 1100)");
+    expect(source).not.toContain("requestAnimationFrame(frame)");
+    expect(source).toContain("window.__dyadTestCursor?.press");
+    expect(source).toContain("window.__dyadTestCursor?.destroy()");
+    // addInitScript executes before documentElement is guaranteed to exist.
+    // The cursor must mount lazily rather than throwing during navigation.
+    expect(source).toContain("const ensureMounted = () =>");
+    expect(source).toContain("if (root && !cursor.isConnected)");
+    expect(source).toContain(
+      'document.addEventListener("DOMContentLoaded", ensureMounted, { once: true })',
+    );
+    expect(source).not.toContain(
+      "const root = document.documentElement;\n  const cursor",
+    );
   });
 
   it("attaches to the existing page instead of opening one", () => {
@@ -267,9 +325,11 @@ describe("preview shim fixtures", () => {
   async function runPageFixture({
     initialUrl,
     contextOptions,
+    exerciseCursor = false,
   }: {
     initialUrl: string;
     contextOptions?: { baseURL?: string };
+    exerciseCursor?: boolean;
   }) {
     const fixtures = await loadShimFixtures();
 
@@ -282,19 +342,86 @@ describe("preview shim fixtures", () => {
       goto: (url: string) => Promise<null>;
       url: () => string;
       evaluate: (fn: unknown, arg: unknown) => Promise<unknown>;
+      locator: (selector: string) => object;
+      getByPlaceholder: (text: string, options?: { exact?: boolean }) => object;
+      getByRole: (
+        role: string,
+        options?: { name?: string; exact?: boolean },
+      ) => object;
+      mouse: object;
     };
     const browserAuthRequests: unknown[] = [];
     page.url = () => initialUrl;
     page.evaluate = async (_fn, arg) => {
       if (typeof arg === "string") return arg === "selected-preview";
-      browserAuthRequests.push(arg);
-      return { ok: true, status: 200 };
+      if (arg && typeof arg === "object" && "signInUrl" in arg) {
+        browserAuthRequests.push(arg);
+        return { ok: true, status: 200 };
+      }
+      return (_fn as (value?: unknown) => unknown)(arg);
     };
+    const locatorPrototype = {
+      click: async () => {},
+      fill: async (_value: string) => {},
+      hover: async () => {},
+      press: async (_key: string) => {},
+      evaluate: async function (this: { selector?: string }) {
+        const locatorBox = await locatorPrototype.boundingBox.call(this);
+        if (!locatorBox) return null;
+        const targetBox =
+          this.selector === "[data-action-wrapper]"
+            ? { x: 210, y: 160, width: 20, height: 30 }
+            : locatorBox;
+        return {
+          locatorBox,
+          targetBox,
+          point: {
+            x: targetBox.x + targetBox.width / 2,
+            y: targetBox.y + targetBox.height / 2,
+          },
+        };
+      },
+      first: function () {
+        return this;
+      },
+      nth: function (_index: number) {
+        return this;
+      },
+      boundingBox: async function (this: { selector?: string }) {
+        if (this.selector === "[data-fillable]") {
+          return { x: 100, y: 80, width: 40, height: 20 };
+        }
+        if (this.selector === "placeholder:Add a new task") {
+          return { x: 160, y: 120, width: 240, height: 40 };
+        }
+        if (this.selector === "role:button:Mark completed") {
+          return { x: 40, y: 240, width: 32, height: 32 };
+        }
+        if (this.selector === "[data-action-wrapper]") {
+          return { x: 120, y: 100, width: 300, height: 180 };
+        }
+        return null;
+      },
+      waitFor: async () => {},
+      scrollIntoViewIfNeeded: async () => {},
+    };
+    page.locator = (selector) =>
+      Object.assign(Object.create(locatorPrototype), { selector });
+    page.getByPlaceholder = (text) =>
+      page.locator(
+        text.startsWith("Add a new task")
+          ? "placeholder:Add a new task"
+          : `placeholder:${text}`,
+      );
+    page.getByRole = (role, options) =>
+      page.locator(`role:${role}:${options?.name ?? ""}`);
+    page.mouse = { move: async () => {}, click: async () => {} };
 
     const { calls, api } = makeApiStub();
     const originalApi = { ...api };
     const context = {
       pages: () => [page],
+      addInitScript: async () => {},
       _options: contextOptions,
       request: api,
     };
@@ -311,6 +438,12 @@ describe("preview shim fixtures", () => {
       gotoOnPrototype: typeof gotoOnPrototype;
       apiDuringRun: Record<string, unknown>;
       originalApi: Record<string, unknown>;
+      cursorWasMounted: boolean;
+      nativeCursorWasHidden: boolean;
+      cursorWasShownWithoutMeasurement: boolean;
+      cursorMovedToFilledElement: boolean;
+      cursorTargetedActionableDescendant: boolean;
+      cursorFollowedRecordedTestLocators: boolean;
     };
 
     await fixtures.context(
@@ -321,6 +454,55 @@ describe("preview shim fixtures", () => {
           { context: usedContext },
           async (usedPage) => {
             const target = usedPage as typeof page;
+            const cursor = document.querySelector("[data-dyad-test-cursor]");
+            let cursorWasShownWithoutMeasurement = false;
+            let cursorMovedToFilledElement = false;
+            let cursorTargetedActionableDescendant = false;
+            let cursorFollowedRecordedTestLocators = false;
+            if (exerciseCursor && cursor instanceof HTMLElement) {
+              cursor.style.opacity = "0";
+              await (
+                target.locator("[data-unmeasurable]") as {
+                  click: () => Promise<void>;
+                }
+              ).click();
+              cursorWasShownWithoutMeasurement = cursor.style.opacity === "1";
+              await (
+                target.locator("[data-fillable]") as {
+                  fill: (value: string) => Promise<void>;
+                }
+              ).fill("hello");
+              cursorMovedToFilledElement =
+                cursor.style.transform === "translate3d(118px, 88.5px, 0)";
+              await (
+                target.locator("[data-action-wrapper]") as {
+                  click: () => Promise<void>;
+                }
+              ).click();
+              cursorTargetedActionableDescendant =
+                cursor.style.transform === "translate3d(218px, 173.5px, 0)";
+              const taskInput = target.getByPlaceholder(
+                "Add a new task... (press Enter to save)",
+                { exact: true },
+              ) as {
+                fill: (value: string) => Promise<void>;
+                press: (key: string) => Promise<void>;
+              };
+              await taskInput.fill("aaa");
+              const movedToTaskInput =
+                cursor.style.transform === "translate3d(278px, 138.5px, 0)";
+              await taskInput.press("Enter");
+              const completedButton = target.getByRole("button", {
+                name: "Mark completed",
+                exact: true,
+              }) as {
+                nth: (index: number) => { click: () => Promise<void> };
+              };
+              await completedButton.nth(0).click();
+              cursorFollowedRecordedTestLocators =
+                movedToTaskInput &&
+                cursor.style.transform === "translate3d(54px, 254.5px, 0)";
+            }
             await target.goto("/");
             await target.goto("/todos?done=1");
             await target.goto("https://example.com/elsewhere");
@@ -338,6 +520,16 @@ describe("preview shim fixtures", () => {
               gotoOnPrototype,
               apiDuringRun,
               originalApi,
+              cursorWasMounted: Boolean(
+                cursor?.shadowRoot?.querySelector('svg path[fill="#111827"]'),
+              ),
+              nativeCursorWasHidden: Boolean(
+                document.querySelector("[data-dyad-test-native-cursor]"),
+              ),
+              cursorWasShownWithoutMeasurement,
+              cursorMovedToFilledElement,
+              cursorTargetedActionableDescendant,
+              cursorFollowedRecordedTestLocators,
             };
           },
           PASSING_TEST_INFO,
@@ -369,6 +561,30 @@ describe("preview shim fixtures", () => {
     });
 
     expect(context._options).toEqual({ baseURL: "http://localhost:32100" });
+  });
+
+  it("moves the isolated arrow to locator actions and removes it afterward", async () => {
+    const {
+      cursorWasMounted,
+      nativeCursorWasHidden,
+      cursorWasShownWithoutMeasurement,
+      cursorMovedToFilledElement,
+      cursorTargetedActionableDescendant,
+      cursorFollowedRecordedTestLocators,
+    } = await runPageFixture({
+      initialUrl: "http://localhost:32100/",
+      contextOptions: {},
+      exerciseCursor: true,
+    });
+
+    expect(cursorWasMounted).toBe(true);
+    expect(nativeCursorWasHidden).toBe(true);
+    expect(cursorWasShownWithoutMeasurement).toBe(true);
+    expect(cursorMovedToFilledElement).toBe(true);
+    expect(cursorTargetedActionableDescendant).toBe(true);
+    expect(cursorFollowedRecordedTestLocators).toBe(true);
+    expect(document.querySelector("[data-dyad-test-cursor]")).toBeNull();
+    expect(document.querySelector("[data-dyad-test-native-cursor]")).toBeNull();
   });
 
   it("resolves relative API request URLs and restores the methods after", async () => {

--- a/src/ipc/utils/playwright_bootstrap.ts
+++ b/src/ipc/utils/playwright_bootstrap.ts
@@ -80,20 +80,20 @@ export const TEST_BASE_URL_ENV = "DYAD_TEST_BASE_URL";
 export const TEST_SLOW_MO_ENV = "DYAD_TEST_SLOW_MO";
 
 /**
- * How long Playwright pauses between actions when slow motion is on. Slow
- * enough to follow each click by eye, short enough that a normal spec doesn't
- * turn into a multi-minute run.
+ * How long Playwright pauses between actions when slow motion is on. A
+ * second-and-a-half leaves enough time to follow each action and read the
+ * resulting UI state before the next one begins.
  */
-export const SLOW_MO_DELAY_MS = 500;
+export const SLOW_MO_DELAY_MS = 1_500;
 
 /**
  * Per-test timeout for a slow-motion run, replacing Playwright's 30s default.
  * The inserted delays are wall-clock time inside the test, so at
- * `SLOW_MO_DELAY_MS` a spec only needs ~60 actions to blow the default budget —
+ * `SLOW_MO_DELAY_MS` a spec only needs ~20 actions to blow the default budget —
  * a green spec would start failing purely from the toggle. Passed as
  * `--timeout` on slow-motion runs only, so ordinary runs keep the default.
  */
-export const SLOW_MO_TEST_TIMEOUT_MS = 120_000;
+export const SLOW_MO_TEST_TIMEOUT_MS = 360_000;
 
 /**
  * The generated config's slow-motion lines. Shared by the template and the
@@ -168,6 +168,12 @@ export const PREVIEW_CDP_ENDPOINT_ENV = "DYAD_PREVIEW_CDP_ENDPOINT";
 
 /** Bearer token for the run-scoped, one-preview CDP broker. */
 export const PREVIEW_CDP_TOKEN_ENV = "DYAD_PREVIEW_CDP_TOKEN";
+
+/** Preview-only pacing for the borrowed CDP connection. */
+export const PREVIEW_SLOW_MO_ENV = "DYAD_PREVIEW_SLOWMO_MS";
+
+/** Default pacing keeps preview runs watchable without affecting other runs. */
+export const PREVIEW_SLOW_MO_DELAY_MS = 250;
 
 /**
  * Directory holding the fixture shim and nothing else. It gets its own tsconfig
@@ -432,7 +438,540 @@ const endpoint = process.env.${PREVIEW_CDP_ENDPOINT_ENV};
 const cdpToken = process.env.${PREVIEW_CDP_TOKEN_ENV};
 // No browser is launched here, so the config's \`launchOptions.slowMo\` never
 // applies — the connection carries it instead.
-const slowMo = Number(process.env.${TEST_SLOW_MO_ENV}) || 0;
+const slowMo = Number(process.env.${PREVIEW_SLOW_MO_ENV}) || ${PREVIEW_SLOW_MO_DELAY_MS};
+
+type CursorPoint = { x: number; y: number };
+type CursorBox = CursorPoint & { width: number; height: number };
+type CursorTargetMeasurement = {
+  locatorBox: CursorBox;
+  targetBox: CursorBox;
+  point: CursorPoint;
+};
+type CursorTraceEntry = {
+  action: string;
+  from?: CursorPoint;
+  to?: CursorPoint;
+  transform?: string;
+  connected?: boolean;
+  error?: string;
+};
+type CursorActionOptions = {
+  force?: boolean;
+  position?: CursorPoint;
+  sourcePosition?: CursorPoint;
+  targetPosition?: CursorPoint;
+  trial?: boolean;
+};
+type CursorRuntime = {
+  show: (point: CursorPoint) => void;
+  glide: (from: CursorPoint, to: CursorPoint, duration: number) => void;
+  press: (box: CursorBox, point: CursorPoint) => void;
+  destroy: () => void;
+};
+
+declare global {
+  interface Window { __dyadTestCursor?: CursorRuntime }
+}
+
+// Serialized by Playwright and installed in every document. Keep it entirely
+// self-contained: addInitScript cannot see bindings from this module.
+function installCursorRuntime() {
+  if (window.__dyadTestCursor) return;
+  const nativeCursorStyle = document.createElement("style");
+  nativeCursorStyle.setAttribute("data-dyad-test-native-cursor", "");
+  // Electron cannot move the physical OS pointer when Playwright dispatches
+  // CDP mouse input. Hide that stationary pointer during the run so it cannot
+  // be mistaken for Dyad's locator-following pointer.
+  nativeCursorStyle.textContent = ":root, :root * { cursor: none !important; }";
+  // A custom host plus a shadow root keeps app-wide div/svg rules from
+  // changing the pointer's size, color, or transform.
+  const cursor = document.createElement("dyad-test-cursor");
+  cursor.setAttribute("data-dyad-test-cursor", "");
+  cursor.setAttribute("aria-hidden", "true");
+  // Build the arrow without innerHTML (which strict Trusted Types policies can
+  // reject) and isolate it from broad SVG/path styles in the app under test.
+  const shadow = cursor.attachShadow({ mode: "open" });
+  const svgNamespace = "http://www.w3.org/2000/svg";
+  const arrow = document.createElementNS(svgNamespace, "svg");
+  arrow.setAttribute("viewBox", "0 0 24 28");
+  arrow.setAttribute("width", "30");
+  arrow.setAttribute("height", "35");
+  Object.assign(arrow.style, { display: "block", overflow: "visible" });
+  const arrowPath = document.createElementNS(svgNamespace, "path");
+  arrowPath.setAttribute("d", "M2 1.5v21l5.5-5.2 4.1 8.7 4.6-2.2-4-8.1h8.3L2 1.5Z");
+  // Match a familiar native pointer while retaining an outline that works on
+  // both light and dark application surfaces.
+  arrowPath.setAttribute("fill", "#111827");
+  arrowPath.setAttribute("stroke", "white");
+  arrowPath.setAttribute("stroke-width", "2.4");
+  arrowPath.setAttribute("stroke-linejoin", "round");
+  arrow.appendChild(arrowPath);
+  shadow.appendChild(arrow);
+  Object.assign(cursor.style, {
+    all: "initial", position: "fixed", left: "0", top: "0", width: "30px", height: "35px",
+    filter: "drop-shadow(0 2px 3px rgba(0,0,0,.65))", pointerEvents: "none",
+    zIndex: "2147483647", opacity: "1", willChange: "transform",
+    transition: "opacity 120ms ease, scale 100ms ease",
+  });
+  // addInitScript runs at document start, before documentElement necessarily
+  // exists. Mount lazily so a navigation does not abort the runtime setup.
+  const ensureMounted = () => {
+    const root = document.documentElement;
+    if (root && !nativeCursorStyle.isConnected) root.appendChild(nativeCursorStyle);
+    if (root && !cursor.isConnected) root.appendChild(cursor);
+    return root;
+  };
+  if (!ensureMounted()) {
+    document.addEventListener("DOMContentLoaded", ensureMounted, { once: true });
+  }
+  let position = { x: innerWidth / 2, y: innerHeight / 2 };
+  let moveAnimation: Animation | undefined;
+  const transformFor = (point: CursorPoint) =>
+    \`translate3d(\${point.x - 2}px, \${point.y - 1.5}px, 0)\`;
+  const place = (point: CursorPoint) => {
+    position = point;
+    // The arrow's tip is the pointer hotspot, matching a native mouse cursor.
+    cursor.style.transform = transformFor(point);
+  };
+  place(position);
+
+  window.__dyadTestCursor = {
+    show(point) {
+      ensureMounted();
+      place(point);
+      cursor.style.opacity = "1";
+    },
+    glide(from, to, duration) {
+      ensureMounted();
+      cursor.style.opacity = "1";
+      moveAnimation?.cancel();
+      // Commit the destination before starting the visual effect. Electron can
+      // temporarily hide the native preview while setup UI is over it; when it
+      // becomes visible again the cursor is therefore at the correct element,
+      // even if Chromium skipped an intermediate paint while hidden.
+      position = to;
+      cursor.style.transform = transformFor(to);
+      moveAnimation =
+        typeof cursor.animate === "function"
+          ? cursor.animate(
+              [
+                { transform: transformFor(from) },
+                { transform: transformFor(to) },
+              ],
+              {
+                duration,
+                easing: "cubic-bezier(0.22, 1, 0.36, 1)",
+              },
+            )
+          : undefined;
+    },
+    press(box, point) {
+      const root = ensureMounted();
+      if (!root) return;
+      cursor.animate(
+        [{ scale: "1" }, { scale: ".72" }, { scale: "1" }],
+        { duration: 180, easing: "ease-out" },
+      );
+      const flash = document.createElement("div");
+      Object.assign(flash.style, {
+        position: "fixed", left: \`\${box.x}px\`, top: \`\${box.y}px\`,
+        width: \`\${box.width}px\`, height: \`\${box.height}px\`,
+        boxSizing: "border-box", border: "2px solid #8b5cf6",
+        background: "rgba(139,92,246,.16)", pointerEvents: "none",
+        zIndex: "2147483646",
+      });
+      const ripple = document.createElement("div");
+      Object.assign(ripple.style, {
+        position: "fixed", left: \`\${point.x - 5}px\`, top: \`\${point.y - 5}px\`,
+        width: "10px", height: "10px", border: "2px solid #8b5cf6",
+        borderRadius: "50%", pointerEvents: "none", zIndex: "2147483647",
+      });
+      root.append(flash, ripple);
+      flash.animate([{ opacity: "1" }, { opacity: "0" }], { duration: 350 });
+      ripple.animate(
+        [{ transform: "scale(1)", opacity: "1" }, { transform: "scale(4)", opacity: "0" }],
+        { duration: 350, easing: "ease-out" },
+      );
+      setTimeout(() => { flash.remove(); ripple.remove(); }, 360);
+    },
+    destroy() {
+      moveAnimation?.cancel();
+      nativeCursorStyle.remove();
+      cursor.remove();
+      delete window.__dyadTestCursor;
+    },
+  };
+}
+
+const cursorPositions = new WeakMap<pw.Page, CursorPoint>();
+const cursorTraces = new WeakMap<pw.Page, CursorTraceEntry[]>();
+const patchedPrototypes = new WeakSet<object>();
+const activeLocatorActions = new WeakSet<object>();
+
+async function animatePointer(
+  page: pw.Page,
+  target: pw.Locator | CursorPoint,
+  options: { force?: boolean; position?: CursorPoint } | undefined,
+  action = "locator",
+): Promise<{ box: CursorBox; point: CursorPoint } | undefined> {
+  const guardedTarget = "boundingBox" in target ? target : undefined;
+  const ownsGuard = !!guardedTarget && !activeLocatorActions.has(guardedTarget);
+  if (ownsGuard && guardedTarget) activeLocatorActions.add(guardedTarget);
+  let from: CursorPoint | undefined;
+  const trace = cursorTraces.get(page) ?? [];
+  cursorTraces.set(page, trace);
+  try {
+    from = cursorPositions.get(page) ?? await page.evaluate(() => ({
+      x: innerWidth / 2, y: innerHeight / 2,
+    }));
+    // Navigation can replace the document between targeted actions. Reinstall
+    // synchronously and reveal the cursor before target measurement, so a slow
+    // or unmeasurable locator cannot make the cursor disappear from the run.
+    await page.evaluate(installCursorRuntime);
+    await page.evaluate(
+      (point) => window.__dyadTestCursor?.show(point),
+      from,
+    );
+    let box: CursorBox;
+    let point: CursorPoint;
+    if ("boundingBox" in target) {
+      // One locator round trip is important here: connectOverCDP's slowMo is
+      // applied to client operations, so the old wait + scroll + boundingBox
+      // sequence was slower than its own 1.1s bailout and cancelled every
+      // cursor move whenever Slow motion was enabled.
+      const found = await target.evaluate(
+        (element) => {
+          element.scrollIntoView({
+            behavior: "instant",
+            block: "center",
+            inline: "center",
+          });
+          const style = getComputedStyle(element);
+          if (
+            style.display === "none" ||
+            style.visibility === "hidden"
+          ) {
+            return null;
+          }
+
+          const toBox = (rect: DOMRect | DOMRectReadOnly): CursorBox => ({
+            x: rect.x,
+            y: rect.y,
+            width: rect.width,
+            height: rect.height,
+          });
+          const visibleBox = (
+            rect: DOMRect | DOMRectReadOnly,
+          ): CursorBox | null => {
+            const left = Math.max(0, rect.left);
+            const top = Math.max(0, rect.top);
+            const right = Math.min(innerWidth, rect.right);
+            const bottom = Math.min(innerHeight, rect.bottom);
+            return right > left && bottom > top
+              ? { x: left, y: top, width: right - left, height: bottom - top }
+              : null;
+          };
+
+          const locatorRect = element.getBoundingClientRect();
+          const actionableSelector = [
+            "a[href]",
+            "button",
+            "input:not([type=hidden])",
+            "select",
+            "textarea",
+            "[contenteditable=true]",
+            "[role=button]",
+            "[role=checkbox]",
+            "[role=combobox]",
+            "[role=link]",
+            "[role=menuitem]",
+            "[role=option]",
+            "[role=radio]",
+            "[role=slider]",
+            "[role=spinbutton]",
+            "[role=switch]",
+            "[role=tab]",
+            "[tabindex]:not([tabindex='-1'])",
+          ].join(",");
+          const isUsable = (candidate: Element) => {
+            const candidateStyle = getComputedStyle(candidate);
+            const candidateRect = candidate.getBoundingClientRect();
+            return candidateStyle.display !== "none" &&
+              candidateStyle.visibility !== "hidden" &&
+              candidateRect.width > 0 &&
+              candidateRect.height > 0 &&
+              visibleBox(candidateRect) !== null;
+          };
+
+          // Some high-level locators resolve a label or component wrapper
+          // around the one real control. Point at that control when it is
+          // unambiguous; a wrapper with several controls stays the target so
+          // we never invent which child the test meant.
+          let preciseElement = element;
+          const elementIsActionable = element.matches(actionableSelector);
+          const actionableChildren = elementIsActionable
+            ? []
+            : Array.from(
+              element.querySelectorAll(actionableSelector),
+            ).filter(isUsable);
+          if (actionableChildren.length === 1) {
+            preciseElement = actionableChildren[0];
+          }
+
+          let preciseRect = preciseElement.getBoundingClientRect();
+          if (
+            preciseElement === element &&
+            !elementIsActionable &&
+            actionableChildren.length === 0
+          ) {
+            // Text locators can resolve a padded block rather than the glyphs
+            // the user recognizes. Use the rendered text content when it has
+            // measurable pixels, keeping the arrow off empty parent padding.
+            const walker = document.createTreeWalker(
+              element,
+              NodeFilter.SHOW_TEXT,
+            );
+            const textRects: DOMRect[] = [];
+            for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+              if (!node.textContent?.trim()) continue;
+              const parent = node.parentElement;
+              if (!parent) continue;
+              const parentStyle = getComputedStyle(parent);
+              if (
+                parentStyle.display === "none" ||
+                parentStyle.visibility === "hidden"
+              ) {
+                continue;
+              }
+              const range = document.createRange();
+              range.selectNodeContents(node);
+              for (const rect of range.getClientRects()) {
+                if (rect.width > 0 && rect.height > 0 && visibleBox(rect)) {
+                  textRects.push(rect);
+                }
+              }
+            }
+            if (textRects.length > 0) {
+              const left = Math.min(...textRects.map((rect) => rect.left));
+              const top = Math.min(...textRects.map((rect) => rect.top));
+              const right = Math.max(...textRects.map((rect) => rect.right));
+              const bottom = Math.max(...textRects.map((rect) => rect.bottom));
+              preciseRect = new DOMRect(left, top, right - left, bottom - top);
+            }
+          }
+
+          const locatorBox = toBox(locatorRect);
+          const targetBox = visibleBox(preciseRect);
+          if (!targetBox) return null;
+          return {
+            locatorBox,
+            targetBox,
+            point: {
+              x: targetBox.x + targetBox.width / 2,
+              y: targetBox.y + targetBox.height / 2,
+            },
+          } satisfies CursorTargetMeasurement;
+        },
+        { timeout: Math.max(1_000, slowMo + 1_000) },
+      );
+      if (!found) {
+        trace.push({ action, from, error: "target could not be measured" });
+        return;
+      }
+      const explicitPoint = options?.position
+        ? {
+            x: found.locatorBox.x + options.position.x,
+            y: found.locatorBox.y + options.position.y,
+          }
+        : undefined;
+      box = explicitPoint ? found.locatorBox : found.targetBox;
+      point = explicitPoint ?? found.point;
+    } else {
+      box = { ...target, width: 0, height: 0 };
+      point = target;
+    }
+    const measured = { box, point };
+    if (!measured) {
+      trace.push({ action, from, error: "target could not be measured" });
+      return;
+    }
+    const distance = Math.hypot(measured.point.x - from.x, measured.point.y - from.y);
+    const deliberateMotion = slowMo >= ${SLOW_MO_DELAY_MS};
+    const duration = deliberateMotion
+      ? Math.min(1_400, Math.max(700, distance * 2.5))
+      : Math.min(900, Math.max(350, distance * 1.8));
+    await page.evaluate(
+      ({ from, to, duration }) => window.__dyadTestCursor?.glide(from, to, duration),
+      { from, to: measured.point, duration },
+    );
+    // Time the animation outside the page. Browser timers and animation-frame
+    // callbacks are throttled when Electron briefly hides a WebContentsView;
+    // the Playwright worker remains reliable throughout that lifecycle.
+    await new Promise((resolve) => setTimeout(resolve, duration));
+    if (deliberateMotion) {
+      // Let the eye settle on each located element before the action proceeds.
+      await new Promise((resolve) => setTimeout(resolve, 350));
+    }
+    const runtimeState = await page.evaluate(() => {
+      const cursor = document.querySelector<HTMLElement>("[data-dyad-test-cursor]");
+      return {
+        connected: Boolean(cursor?.isConnected),
+        transform: cursor?.style.transform,
+      };
+    });
+    trace.push({
+      action,
+      from,
+      to: measured.point,
+      connected: runtimeState.connected,
+      transform: runtimeState.transform,
+    });
+    cursorPositions.set(page, measured.point);
+    return measured;
+  } catch (error) {
+    trace.push({
+      action,
+      from,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return undefined;
+  } finally {
+    if (ownsGuard && guardedTarget) activeLocatorActions.delete(guardedTarget);
+  }
+}
+
+async function showPress(
+  page: pw.Page,
+  measured: { box: CursorBox; point: CursorPoint } | undefined,
+): Promise<void> {
+  if (!measured) return;
+  try {
+    await page.evaluate(
+      ({ box, point }) => window.__dyadTestCursor?.press(box, point),
+      measured,
+    );
+  } catch {
+    // Visual choreography must never change the action's outcome.
+  }
+}
+
+function patchPointerActions(page: pw.Page): () => void {
+  const restorers: Array<() => void> = [];
+  const locatorPositionMethods = new Set([
+    "check", "click", "dblclick", "hover", "setChecked", "tap", "uncheck",
+  ]);
+  const patch = (prototype: Record<string, unknown>, name: string, effect: boolean) => {
+    if (patchedPrototypes.has(prototype) && name === "click") return;
+    const original = prototype[name];
+    if (typeof original !== "function") return;
+    prototype[name] = async function (this: pw.Locator, ...args: unknown[]) {
+      if (activeLocatorActions.has(this)) {
+        return await (original as (...values: unknown[]) => unknown).apply(this, args);
+      }
+      activeLocatorActions.add(this);
+      try {
+        const rawOptions = args.at(-1) as CursorActionOptions | undefined;
+        const options = name === "dragTo"
+          ? { force: rawOptions?.force, position: rawOptions?.sourcePosition }
+          : locatorPositionMethods.has(name)
+            ? rawOptions
+            : undefined;
+        const measured = await animatePointer(page, this, options, \`locator.\${name}\`);
+        const dragTarget = args[0];
+        if (
+          name === "dragTo" &&
+          dragTarget &&
+          typeof dragTarget === "object" &&
+          "boundingBox" in dragTarget
+        ) {
+          await animatePointer(
+            page,
+            dragTarget as pw.Locator,
+            { force: rawOptions?.force, position: rawOptions?.targetPosition },
+            "locator.dragTo.target",
+          );
+        }
+        const result = await (original as (...values: unknown[]) => unknown).apply(this, args);
+        if (effect && !rawOptions?.trial && measured) {
+          await showPress(page, measured);
+        }
+        return result;
+      } finally {
+        activeLocatorActions.delete(this);
+      }
+    };
+    restorers.push(() => { prototype[name] = original; });
+  };
+  const locatorPrototype = Object.getPrototypeOf(page.locator("html")) as Record<string, unknown>;
+  const locatorPressMethods = new Set([
+    "check", "click", "dblclick", "selectOption", "setChecked", "tap", "uncheck",
+  ]);
+  const locatorTargetMethods = [
+    "_expect", "ariaSnapshot", "blur", "boundingBox", "check", "clear", "click",
+    "dblclick", "dispatchEvent", "dragTo", "elementHandle", "evaluate",
+    "evaluateHandle", "fill", "focus", "getAttribute", "highlight", "hover",
+    "innerHTML", "innerText", "inputValue", "isChecked", "isDisabled",
+    "isEditable", "isEnabled", "isHidden", "isVisible", "press",
+    "pressSequentially", "screenshot", "scrollIntoViewIfNeeded", "selectOption",
+    "selectText", "setChecked", "setInputFiles", "tap", "textContent", "type",
+    "uncheck", "waitFor",
+  ];
+  for (const name of locatorTargetMethods) {
+    patch(locatorPrototype, name, locatorPressMethods.has(name));
+  }
+  patchedPrototypes.add(locatorPrototype);
+  const pageObject = page as unknown as Record<string, unknown>;
+  const pagePressMethods = new Set([
+    "check", "click", "dblclick", "selectOption", "tap", "uncheck",
+  ]);
+  const pageTargetMethods = [
+    "check", "click", "dblclick", "dispatchEvent", "dragAndDrop", "fill", "focus",
+    "hover", "press", "selectOption", "setInputFiles", "tap", "type", "uncheck",
+  ];
+  for (const name of pageTargetMethods) {
+    const original = pageObject[name];
+    if (typeof original !== "function") continue;
+    pageObject[name] = async (...args: unknown[]) => {
+      const selector = args[0];
+      const rawOptions = args.at(-1) as CursorActionOptions | undefined;
+      const options = name === "dragAndDrop"
+        ? { force: rawOptions?.force, position: rawOptions?.sourcePosition }
+        : rawOptions;
+      const measured = typeof selector === "string"
+        ? await animatePointer(page, page.locator(selector), options, \`page.\${name}\`)
+        : undefined;
+      if (name === "dragAndDrop" && typeof args[1] === "string") {
+        await animatePointer(
+          page,
+          page.locator(args[1]),
+          { force: rawOptions?.force, position: rawOptions?.targetPosition },
+          "page.dragAndDrop.target",
+        );
+      }
+      const result = await (original as (...values: unknown[]) => unknown).apply(page, args);
+      if (pagePressMethods.has(name) && !rawOptions?.trial && measured) {
+        await showPress(page, measured);
+      }
+      return result;
+    };
+    restorers.push(() => { pageObject[name] = original; });
+  }
+  const mouse = page.mouse as unknown as Record<string, unknown>;
+  for (const name of ["move", "click"]) {
+    const original = mouse[name];
+    if (typeof original !== "function") continue;
+    mouse[name] = async (x: number, y: number, ...args: unknown[]) => {
+      const measured = await animatePointer(page, { x, y }, undefined, \`mouse.\${name}\`);
+      const result = await (original as (...values: unknown[]) => unknown).call(mouse, x, y, ...args);
+      if (name === "click" && measured) {
+        await showPress(page, measured);
+      }
+      return result;
+    };
+    restorers.push(() => { mouse[name] = original; });
+  }
+  return () => { for (const restore of restorers.reverse()) restore(); patchedPrototypes.delete(locatorPrototype); };
+}
 
 function requireBaseUrl(): string {
   const baseUrl = process.env.${TEST_BASE_URL_ENV};
@@ -633,6 +1172,9 @@ export const test = !endpoint
             \`Dyad preview: no page serving \${origin} — is the preview panel showing this app?\`,
           );
         }
+        await context.addInitScript(installCursorRuntime);
+        await page.evaluate(installCursorRuntime);
+        const restorePointerActions = patchPointerActions(page);
         // page.goto resolves relative URLs in Playwright's server half, from
         // the options the context was CREATED with — out of reach of the
         // assignment above, so "/" would reach Chromium verbatim and fail as an
@@ -647,6 +1189,22 @@ export const test = !endpoint
           // single-test process finishes.
           await use(page);
         } finally {
+          const cursorTrace = cursorTraces.get(page) ?? [];
+          try {
+            await testInfo.attach("dyad-cursor-trace", {
+              body: Buffer.from(JSON.stringify(cursorTrace, null, 2)),
+              contentType: "application/json",
+            });
+          } catch {
+            // Diagnostics must not affect the test's result.
+          }
+          cursorTraces.delete(page);
+          restorePointerActions();
+          try {
+            await page.evaluate(() => window.__dyadTestCursor?.destroy());
+          } catch {
+            // The page may have closed or navigated during teardown.
+          }
           page.goto = originalGoto;
           // Playwright's built-in screenshot/trace recorder is off for preview
           // runs (see the config) because tracing needs browser-global CDP


### PR DESCRIPTION
This is still a work in progress
## Summary

Preview Playwright runs now show a synthetic pointer that follows test actions, making in-app test playback easier to understand while keeping the borrowed preview browser isolated and recoverable.

- Animate locator, page, and mouse actions toward the most precise visible target, including an unambiguous actionable descendant or rendered text bounds, without letting cursor diagnostics change test outcomes.
- Mount the cursor in an isolated shadow root, hide the native cursor only during preview execution, attach a cursor trace for debugging, and restore all patched APIs and visual state during teardown.
- Give preview runs a watchable default pace and increase explicit slow-motion pacing and timeout together so deliberate playback does not reduce the available action budget.
- Keep ordinary non-preview runs unchanged and cover the preview environment, generated shim source, action targeting, and cleanup behavior with focused tests.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

