### PR TITLE
Restore Supabase as default integration provider

### DIFF
--- a/src/components/chat/DyadAddIntegration.test.tsx
+++ b/src/components/chat/DyadAddIntegration.test.tsx
@@ -95,15 +95,15 @@ describe("DyadAddIntegration", () => {
     mocks.requestId = crypto.randomUUID();
   });
 
-  it("shows Neon first and selects it by default", () => {
+  it("shows Supabase first and selects it by default", () => {
     renderCard();
 
     const radios = screen.getAllByRole("radio");
     expect(radios).toHaveLength(2);
-    expect(radios[0].textContent).toContain("Neon");
+    expect(radios[0].textContent).toContain("Supabase");
     expect(radios[0].textContent).toContain("Recommended");
     expect(radios[0].getAttribute("aria-checked")).toBe("true");
-    expect(radios[1].textContent).toContain("Supabase");
+    expect(radios[1].textContent).toContain("Neon");
     expect(radios[1].textContent).not.toContain("Recommended");
     expect(radios[1].getAttribute("aria-checked")).toBe("false");
   });
@@ -111,34 +111,38 @@ describe("DyadAddIntegration", () => {
   it("tracks each provider once when setup starts", () => {
     const view = renderCard();
 
-    fireEvent.click(screen.getByRole("button", { name: "Continue with Neon" }));
-    view.unmount();
-    renderCard();
-    fireEvent.click(screen.getByRole("button", { name: "Continue with Neon" }));
-    fireEvent.click(
-      screen.getByRole("button", {
-        name: "integrations.databaseSetup.back",
-      }),
-    );
-    fireEvent.click(screen.getByRole("button", { name: "Continue with Neon" }));
-    fireEvent.click(
-      screen.getByRole("button", {
-        name: "integrations.databaseSetup.back",
-      }),
-    );
-    fireEvent.click(screen.getByRole("radio", { name: /Supabase/ }));
     fireEvent.click(
       screen.getByRole("button", { name: "Continue with Supabase" }),
     );
+    view.unmount();
+    renderCard();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Continue with Supabase" }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "integrations.databaseSetup.back",
+      }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Continue with Supabase" }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "integrations.databaseSetup.back",
+      }),
+    );
+    fireEvent.click(screen.getByRole("radio", { name: /Neon/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Continue with Neon" }));
 
     expect(mocks.posthogCapture.mock.calls).toEqual([
       [
         "integration-setup:start",
-        { provider: "neon", requestId: mocks.requestId },
+        { provider: "supabase", requestId: mocks.requestId },
       ],
       [
         "integration-setup:start",
-        { provider: "supabase", requestId: mocks.requestId },
+        { provider: "neon", requestId: mocks.requestId },
       ],
     ]);
   });
@@ -150,12 +154,12 @@ describe("DyadAddIntegration", () => {
 
     const radios = screen.getAllByRole("radio");
     expect(radios).toHaveLength(2);
-    expect(radios[0].textContent).toContain("Neon");
+    expect(radios[0].textContent).toContain("Supabase");
     expect(radios[0].getAttribute("aria-checked")).toBe("true");
     expect(
       (
         screen.getByRole("button", {
-          name: "Continue with Neon",
+          name: "Continue with Supabase",
         }) as HTMLButtonElement
       ).disabled,
     ).toBe(true);

--- a/src/components/chat/DyadAddIntegration.tsx
+++ b/src/components/chat/DyadAddIntegration.tsx
@@ -68,18 +68,18 @@ export const DyadAddIntegration: React.FC<DyadAddIntegrationProps> = ({
 
   const providerOptions = [
     {
-      id: "neon" as const,
-      name: t("integrations.databaseSetup.providers.neon.name"),
-      description: t("integrations.databaseSetup.providers.neon.description"),
-      url: "https://neon.tech",
-    },
-    {
       id: "supabase" as const,
       name: t("integrations.databaseSetup.providers.supabase.name"),
       description: t(
         "integrations.databaseSetup.providers.supabase.description",
       ),
       url: "https://supabase.com",
+    },
+    {
+      id: "neon" as const,
+      name: t("integrations.databaseSetup.providers.neon.name"),
+      description: t("integrations.databaseSetup.providers.neon.description"),
+      url: "https://neon.tech",
     },
   ];
 
@@ -90,7 +90,7 @@ export const DyadAddIntegration: React.FC<DyadAddIntegrationProps> = ({
     userSelectedProvider ??
     requestedProvider ??
     pendingIntegration?.provider ??
-    "neon";
+    "supabase";
 
   const lockedProvider = requestedProvider ?? pendingIntegration?.provider;
 
@@ -108,8 +108,8 @@ export const DyadAddIntegration: React.FC<DyadAddIntegrationProps> = ({
       }
       return providerOptions.filter((p) => p.id === lockedProvider);
     }
-    // Keep the intended Neon-first choice visible while framework support is
-    // unknown, but do not let the user commit until app metadata has loaded.
+    // Keep both choices visible while framework support is unknown, but do not
+    // let the user commit until app metadata has loaded.
     if (isAppLoading) return providerOptions;
     // No provider specified: show neon only for frameworks that support it
     if (!isNeonSupported) {
@@ -403,7 +403,7 @@ export const DyadAddIntegration: React.FC<DyadAddIntegrationProps> = ({
                         <span className="text-sm font-semibold text-foreground">
                           {option.name}
                         </span>
-                        {option.id === "neon" && (
+                        {option.id === "supabase" && (
                           <span className="rounded-full bg-blue-100 px-2 py-0.5 text-[10px] font-medium text-blue-700 dark:bg-blue-900/60 dark:text-blue-200">
                             {t("integrations.databaseSetup.recommended")}
                           </span>


### PR DESCRIPTION
## Summary

Restore Supabase as the initial database choice while retaining the provider-level setup funnel analytics added in #4459.

- Supabase is again the initial and recommended database provider when no provider was explicitly requested.
- Explicit provider requests and the existing unsupported-framework fallback remain unchanged.
- Keep the metadata-loading guard that prevents committing a provider before framework support is known.
- Keep start/completion telemetry, request-level correlation, provider-switch tracking, and the non-Pro sampling exemption intact.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only default and ordering in the chat integration card; behavior for locked or framework-filtered providers is unchanged aside from the new fallback default.
> 
> **Overview**
> Reverts the **Neon-first** database integration picker from the prior rollout: **Supabase** is listed first, pre-selected when nothing else is locked, and carries the **Recommended** badge again (Neon is second with no badge).
> 
> `DyadAddIntegration` tests are updated for the new default order, continue-button labels, and the provider order in `integration-setup:start` analytics when users switch providers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 556bdce344eae1a4b6b6ed4e910d022d673cd736. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->