### PR TITLE
Clear worker caches for repeated preview auth failures

### DIFF
--- a/src/ipc/handlers/session_handlers.test.ts
+++ b/src/ipc/handlers/session_handlers.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  clearStorageData: vi.fn().mockResolvedValue(undefined),
+  handlers: new Map<string, () => Promise<void>>(),
+  rm: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("electron", () => ({
+  session: { defaultSession: { clearStorageData: mocks.clearStorageData } },
+}));
+vi.mock("node:fs/promises", () => ({
+  default: { rm: mocks.rm },
+}));
+vi.mock("@/paths/paths", () => ({
+  getTypeScriptCachePath: () => "/tmp/dyad-typescript-cache",
+}));
+vi.mock("./base", () => ({
+  createTypedHandler: (
+    contract: { channel: string },
+    handler: () => Promise<void>,
+  ) => {
+    mocks.handlers.set(contract.channel, handler);
+  },
+}));
+
+import { registerSessionHandlers } from "./session_handlers";
+
+registerSessionHandlers();
+
+describe("registerSessionHandlers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("clears authentication and worker cache storage", async () => {
+    await mocks.handlers.get("clear-session-data")!();
+
+    expect(mocks.clearStorageData).toHaveBeenCalledWith({
+      storages: ["cookies", "localstorage", "serviceworkers", "cachestorage"],
+    });
+  });
+});

--- a/src/ipc/handlers/session_handlers.ts
+++ b/src/ipc/handlers/session_handlers.ts
@@ -9,7 +9,7 @@ export const registerSessionHandlers = () => {
     const defaultAppSession = session.defaultSession;
 
     await defaultAppSession.clearStorageData({
-      storages: ["cookies", "localstorage"],
+      storages: ["cookies", "localstorage", "serviceworkers", "cachestorage"],
     });
     console.info(`[IPC] All session data cleared for default session`);
 

--- a/src/prompts/__snapshots__/local_agent_prompt.test.ts.snap
+++ b/src/prompts/__snapshots__/local_agent_prompt.test.ts.snap
@@ -14,7 +14,7 @@ Do *not* tell the user to run shell commands. To refresh the app preview page wi
 
 If you output this command, tell the user to look for the action button above the chat input.
 
-If the user has repeated authentication issues in the preview, suggest opening the right-side Preview panel's **More options (⋮)** menu and selecting **Clear Cache** to clear cookies, local storage, and other cached browser data, then retrying. Warn that this may sign them out of other app previews.
+If the user has repeated authentication issues in the preview, suggest opening the right-side Preview panel's **More options (⋮)** menu and selecting **Clear Cache** to clear cookies, local storage, service workers, and cached data, then retrying. Warn that this may sign them out of other app previews.
 </app_commands>
 
 <app_lifecycle>
@@ -186,7 +186,7 @@ Do *not* tell the user to run shell commands. To refresh the app preview page wi
 
 If you output this command, tell the user to look for the action button above the chat input.
 
-If the user has repeated authentication issues in the preview, suggest opening the right-side Preview panel's **More options (⋮)** menu and selecting **Clear Cache** to clear cookies, local storage, and other cached browser data, then retrying. Warn that this may sign them out of other app previews.
+If the user has repeated authentication issues in the preview, suggest opening the right-side Preview panel's **More options (⋮)** menu and selecting **Clear Cache** to clear cookies, local storage, service workers, and cached data, then retrying. Warn that this may sign them out of other app previews.
 </app_commands>
 
 <app_lifecycle>
@@ -359,7 +359,7 @@ Do *not* tell the user to run shell commands. To refresh the app preview page wi
 
 If you output this command, tell the user to look for the action button above the chat input.
 
-If the user has repeated authentication issues in the preview, suggest opening the right-side Preview panel's **More options (⋮)** menu and selecting **Clear Cache** to clear cookies, local storage, and other cached browser data, then retrying. Warn that this may sign them out of other app previews.
+If the user has repeated authentication issues in the preview, suggest opening the right-side Preview panel's **More options (⋮)** menu and selecting **Clear Cache** to clear cookies, local storage, service workers, and cached data, then retrying. Warn that this may sign them out of other app previews.
 </app_commands>
 
 <app_lifecycle>
@@ -519,7 +519,7 @@ Do *not* tell the user to run shell commands. To refresh the app preview page wi
 
 If you output this command, tell the user to look for the action button above the chat input.
 
-If the user has repeated authentication issues in the preview, suggest opening the right-side Preview panel's **More options (⋮)** menu and selecting **Clear Cache** to clear cookies, local storage, and other cached browser data, then retrying. Warn that this may sign them out of other app previews.
+If the user has repeated authentication issues in the preview, suggest opening the right-side Preview panel's **More options (⋮)** menu and selecting **Clear Cache** to clear cookies, local storage, service workers, and cached data, then retrying. Warn that this may sign them out of other app previews.
 </app_commands>
 
 <app_lifecycle>
@@ -679,7 +679,7 @@ Do *not* tell the user to run shell commands. To refresh the app preview page wi
 
 If you output this command, tell the user to look for the action button above the chat input.
 
-If the user has repeated authentication issues in the preview, suggest opening the right-side Preview panel's **More options (⋮)** menu and selecting **Clear Cache** to clear cookies, local storage, and other cached browser data, then retrying. Warn that this may sign them out of other app previews.
+If the user has repeated authentication issues in the preview, suggest opening the right-side Preview panel's **More options (⋮)** menu and selecting **Clear Cache** to clear cookies, local storage, service workers, and cached data, then retrying. Warn that this may sign them out of other app previews.
 </app_commands>
 
 <app_lifecycle>
@@ -851,7 +851,7 @@ Do *not* tell the user to run shell commands. To refresh the app preview page wi
 
 If you output this command, tell the user to look for the action button above the chat input.
 
-If the user has repeated authentication issues in the preview, suggest opening the right-side Preview panel's **More options (⋮)** menu and selecting **Clear Cache** to clear cookies, local storage, and other cached browser data, then retrying. Warn that this may sign them out of other app previews.
+If the user has repeated authentication issues in the preview, suggest opening the right-side Preview panel's **More options (⋮)** menu and selecting **Clear Cache** to clear cookies, local storage, service workers, and cached data, then retrying. Warn that this may sign them out of other app previews.
 </app_commands>
 
 <app_lifecycle>
@@ -1092,7 +1092,7 @@ Do *not* tell the user to run shell commands. To refresh the app preview page wi
 
 If you output this command, tell the user to look for the action button above the chat input.
 
-If the user has repeated authentication issues in the preview, suggest opening the right-side Preview panel's **More options (⋮)** menu and selecting **Clear Cache** to clear cookies, local storage, and other cached browser data, then retrying. Warn that this may sign them out of other app previews.
+If the user has repeated authentication issues in the preview, suggest opening the right-side Preview panel's **More options (⋮)** menu and selecting **Clear Cache** to clear cookies, local storage, service workers, and cached data, then retrying. Warn that this may sign them out of other app previews.
 </app_commands>
 
 <app_lifecycle>
@@ -1252,7 +1252,7 @@ Do *not* tell the user to run shell commands. To refresh the app preview page wi
 
 If you output this command, tell the user to look for the action button above the chat input.
 
-If the user has repeated authentication issues in the preview, suggest opening the right-side Preview panel's **More options (⋮)** menu and selecting **Clear Cache** to clear cookies, local storage, and other cached browser data, then retrying. Warn that this may sign them out of other app previews.
+If the user has repeated authentication issues in the preview, suggest opening the right-side Preview panel's **More options (⋮)** menu and selecting **Clear Cache** to clear cookies, local storage, service workers, and cached data, then retrying. Warn that this may sign them out of other app previews.
 </app_commands>
 
 <app_lifecycle>
@@ -1399,7 +1399,7 @@ Do *not* tell the user to run shell commands. To refresh the app preview page wi
 
 If you output this command, tell the user to look for the action button above the chat input.
 
-If the user has repeated authentication issues in the preview, suggest opening the right-side Preview panel's **More options (⋮)** menu and selecting **Clear Cache** to clear cookies, local storage, and other cached browser data, then retrying. Warn that this may sign them out of other app previews.
+If the user has repeated authentication issues in the preview, suggest opening the right-side Preview panel's **More options (⋮)** menu and selecting **Clear Cache** to clear cookies, local storage, service workers, and cached data, then retrying. Warn that this may sign them out of other app previews.
 </app_commands>
 
 <app_lifecycle>

--- a/src/prompts/__snapshots__/local_agent_prompt.test.ts.snap
+++ b/src/prompts/__snapshots__/local_agent_prompt.test.ts.snap
@@ -13,6 +13,8 @@ Do *not* tell the user to run shell commands. To refresh the app preview page wi
 <dyad-command type="refresh"></dyad-command>
 
 If you output this command, tell the user to look for the action button above the chat input.
+
+If the user has repeated authentication issues in the preview, suggest opening the right-side Preview panel's **More options (⋮)** menu and selecting **Clear Cache** to clear cookies, local storage, and other cached browser data, then retrying. Warn that this may sign them out of other app previews.
 </app_commands>
 
 <app_lifecycle>
@@ -183,6 +185,8 @@ Do *not* tell the user to run shell commands. To refresh the app preview page wi
 <dyad-command type="refresh"></dyad-command>
 
 If you output this command, tell the user to look for the action button above the chat input.
+
+If the user has repeated authentication issues in the preview, suggest opening the right-side Preview panel's **More options (⋮)** menu and selecting **Clear Cache** to clear cookies, local storage, and other cached browser data, then retrying. Warn that this may sign them out of other app previews.
 </app_commands>
 
 <app_lifecycle>
@@ -354,6 +358,8 @@ Do *not* tell the user to run shell commands. To refresh the app preview page wi
 <dyad-command type="refresh"></dyad-command>
 
 If you output this command, tell the user to look for the action button above the chat input.
+
+If the user has repeated authentication issues in the preview, suggest opening the right-side Preview panel's **More options (⋮)** menu and selecting **Clear Cache** to clear cookies, local storage, and other cached browser data, then retrying. Warn that this may sign them out of other app previews.
 </app_commands>
 
 <app_lifecycle>
@@ -512,6 +518,8 @@ Do *not* tell the user to run shell commands. To refresh the app preview page wi
 <dyad-command type="refresh"></dyad-command>
 
 If you output this command, tell the user to look for the action button above the chat input.
+
+If the user has repeated authentication issues in the preview, suggest opening the right-side Preview panel's **More options (⋮)** menu and selecting **Clear Cache** to clear cookies, local storage, and other cached browser data, then retrying. Warn that this may sign them out of other app previews.
 </app_commands>
 
 <app_lifecycle>
@@ -670,6 +678,8 @@ Do *not* tell the user to run shell commands. To refresh the app preview page wi
 <dyad-command type="refresh"></dyad-command>
 
 If you output this command, tell the user to look for the action button above the chat input.
+
+If the user has repeated authentication issues in the preview, suggest opening the right-side Preview panel's **More options (⋮)** menu and selecting **Clear Cache** to clear cookies, local storage, and other cached browser data, then retrying. Warn that this may sign them out of other app previews.
 </app_commands>
 
 <app_lifecycle>
@@ -840,6 +850,8 @@ Do *not* tell the user to run shell commands. To refresh the app preview page wi
 <dyad-command type="refresh"></dyad-command>
 
 If you output this command, tell the user to look for the action button above the chat input.
+
+If the user has repeated authentication issues in the preview, suggest opening the right-side Preview panel's **More options (⋮)** menu and selecting **Clear Cache** to clear cookies, local storage, and other cached browser data, then retrying. Warn that this may sign them out of other app previews.
 </app_commands>
 
 <app_lifecycle>
@@ -1079,6 +1091,8 @@ Do *not* tell the user to run shell commands. To refresh the app preview page wi
 <dyad-command type="refresh"></dyad-command>
 
 If you output this command, tell the user to look for the action button above the chat input.
+
+If the user has repeated authentication issues in the preview, suggest opening the right-side Preview panel's **More options (⋮)** menu and selecting **Clear Cache** to clear cookies, local storage, and other cached browser data, then retrying. Warn that this may sign them out of other app previews.
 </app_commands>
 
 <app_lifecycle>
@@ -1237,6 +1251,8 @@ Do *not* tell the user to run shell commands. To refresh the app preview page wi
 <dyad-command type="refresh"></dyad-command>
 
 If you output this command, tell the user to look for the action button above the chat input.
+
+If the user has repeated authentication issues in the preview, suggest opening the right-side Preview panel's **More options (⋮)** menu and selecting **Clear Cache** to clear cookies, local storage, and other cached browser data, then retrying. Warn that this may sign them out of other app previews.
 </app_commands>
 
 <app_lifecycle>
@@ -1382,6 +1398,8 @@ Do *not* tell the user to run shell commands. To refresh the app preview page wi
 <dyad-command type="refresh"></dyad-command>
 
 If you output this command, tell the user to look for the action button above the chat input.
+
+If the user has repeated authentication issues in the preview, suggest opening the right-side Preview panel's **More options (⋮)** menu and selecting **Clear Cache** to clear cookies, local storage, and other cached browser data, then retrying. Warn that this may sign them out of other app previews.
 </app_commands>
 
 <app_lifecycle>

--- a/src/prompts/local_agent_prompt.test.ts
+++ b/src/prompts/local_agent_prompt.test.ts
@@ -114,7 +114,7 @@ describe("local_agent_prompt", () => {
     );
     expect(prompt).toContain('<dyad-command type="refresh"></dyad-command>');
     expect(prompt).toContain(
-      "selecting **Clear Cache** to clear cookies, local storage, and other cached browser data",
+      "selecting **Clear Cache** to clear cookies, local storage, service workers, and cached data",
     );
     expect(prompt).toContain("this may sign them out of other app previews");
   });

--- a/src/prompts/local_agent_prompt.test.ts
+++ b/src/prompts/local_agent_prompt.test.ts
@@ -113,6 +113,10 @@ describe("local_agent_prompt", () => {
       '<dyad-command type="rebuild"></dyad-command>',
     );
     expect(prompt).toContain('<dyad-command type="refresh"></dyad-command>');
+    expect(prompt).toContain(
+      "selecting **Clear Cache** to clear cookies, local storage, and other cached browser data",
+    );
+    expect(prompt).toContain("this may sign them out of other app previews");
   });
 
   it("agent mode system prompt with code explorer available", () => {

--- a/src/prompts/local_agent_prompt.ts
+++ b/src/prompts/local_agent_prompt.ts
@@ -43,6 +43,8 @@ Do *not* tell the user to run shell commands. To refresh the app preview page wi
 <dyad-command type="refresh"></dyad-command>
 
 If you output this command, tell the user to look for the action button above the chat input.
+
+If the user has repeated authentication issues in the preview, suggest opening the right-side Preview panel's **More options (⋮)** menu and selecting **Clear Cache** to clear cookies, local storage, and other cached browser data, then retrying. Warn that this may sign them out of other app previews.
 </app_commands>`;
 
 function appLifecycleBlock({

--- a/src/prompts/local_agent_prompt.ts
+++ b/src/prompts/local_agent_prompt.ts
@@ -44,7 +44,7 @@ Do *not* tell the user to run shell commands. To refresh the app preview page wi
 
 If you output this command, tell the user to look for the action button above the chat input.
 
-If the user has repeated authentication issues in the preview, suggest opening the right-side Preview panel's **More options (⋮)** menu and selecting **Clear Cache** to clear cookies, local storage, and other cached browser data, then retrying. Warn that this may sign them out of other app previews.
+If the user has repeated authentication issues in the preview, suggest opening the right-side Preview panel's **More options (⋮)** menu and selecting **Clear Cache** to clear cookies, local storage, service workers, and cached data, then retrying. Warn that this may sign them out of other app previews.
 </app_commands>`;
 
 function appLifecycleBlock({


### PR DESCRIPTION
## Summary

Expands the Preview panel's cache reset and adds recovery guidance for repeated authentication failures in app previews.

- Directs users to the Preview panel's **More options (⋮) → Clear Cache** action only after authentication problems repeat.
- Clears cookies, local storage, service workers, and Cache Storage so the action also removes stale worker-controlled auth behavior.
- Intentionally preserves IndexedDB because it may contain durable user-created app data.
- Warns that clearing the shared preview session may sign users out of other app previews.
- Keeps this scoped to a recovery workaround; it does not change preview session isolation tracked in #4260.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Clear Cache affects the shared default Electron session and may sign users out of other previews; broader storage clearing is intentional but user-visible.
> 
> **Overview**
> Teaches the local agent to suggest **Preview → More options → Clear Cache** when users hit repeated preview auth failures, including what gets cleared and that other app previews may be signed out.
> 
> **Clear session data** now wipes **service workers** and **cache storage** in addition to cookies and local storage, matching the prompt copy. A new Vitest suite asserts the `clear-session-data` IPC handler passes the expanded `storages` list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d21a5ac1c18bfd59eb2bff97e426203a79c1ad45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->