### PR TITLE
Use macOS 26 Intel runner for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           - { name: "windows", image: "windows-2022" }
           # See https://github.com/dyad-sh/dyad/issues/96
           - { name: "linux", image: "ubuntu-22.04" }
-          - { name: "macos-intel", image: "macos-15-intel" }
+          - { name: "macos-intel", image: "macos-26-intel" }
           - { name: "macos", image: "macos-latest" }
     runs-on: ${{ matrix.os.image }}
     steps:


### PR DESCRIPTION
## Summary

Move release builds for Intel macOS from GitHub's capacity-constrained macOS 15 runner pool to the standard macOS 26 Intel runner pool.

- Keeps the build on x86_64 so the existing Intel release artifact and native-module build behavior remain unchanged.
- Leaves the Apple Silicon release matrix entry untouched.

#skip-bugbot

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit d3df583f61f6072498e19fcdbfec32e51539aaee. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

