### PR TITLE
Use Responses API for OpenAI models across chat modes

### DIFF
--- a/rules/dyad-errors.md
+++ b/rules/dyad-errors.md
@@ -26,6 +26,8 @@ Use `DyadError` from `src/errors/dyad_error.ts` when throwing from **main proces
 
 Prefer **`DyadError`** over growing `FILTERED_EXCEPTION_MESSAGES` in `telemetry.ts` when the failure is stable and classified.
 
+Responses API stream errors can arrive through AI SDK `onError` as plain objects with nested `error.message`, even with HTTP 200. Extract that message before classifying authentication failures; `String(error)` produces `[object Object]`. Cover both HTTP failures and streamed errors when changing provider validation.
+
 ## Non-Pro event sampling (renderer)
 
 The renderer PostHog `before_send` (in `src/renderer.tsx`) drops ~90% of events for **non-Pro** users. Any event whose audience is primarily free users (conversion funnels like `promo_click`, upgrade CTAs) must be added to `shouldBypassNonProTelemetrySampling` in `src/lib/posthogTelemetry.ts`, or it will be silently undercounted 10x. Errors, `app:initial-load`, and `sandbox.script.*` already bypass sampling.

--- a/src/ipc/services/provider_api_key_validation_service.integration.test.ts
+++ b/src/ipc/services/provider_api_key_validation_service.integration.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { DyadErrorKind } from "@/errors/dyad_error";
+import { setModelClientFetchForTesting } from "@/ipc/utils/test_fetch_override";
+import { validateProviderApiKey } from "./provider_api_key_validation_service";
+
+vi.mock("@/main/settings", () => ({
+  readEffectiveSettings: vi.fn(async () => ({
+    selectedModel: {
+      provider: "anthropic",
+      name: "claude-sonnet-4-6",
+      effortLevel: "high",
+    },
+  })),
+}));
+
+function eventStream(events: unknown[]) {
+  return new Response(
+    events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(""),
+    { headers: { "content-type": "text/event-stream" } },
+  );
+}
+
+afterEach(() => {
+  setModelClientFetchForTesting(undefined);
+  vi.unstubAllEnvs();
+});
+
+describe("Dyad API-key validation", () => {
+  it("sends a Responses request with a dedicated model and reasoning budget", async () => {
+    vi.stubEnv("DYAD_ENGINE_URL", "https://engine.example.test/v1");
+    const fetch = vi.fn(async () =>
+      eventStream([
+        {
+          type: "response.created",
+          response: { id: "resp_1", created_at: 1, model: "gpt-5.6-luna" },
+        },
+        {
+          type: "response.output_item.added",
+          output_index: 0,
+          item: { type: "message", id: "msg_1" },
+        },
+        {
+          type: "response.output_text.delta",
+          item_id: "msg_1",
+          output_index: 0,
+          content_index: 0,
+          delta: "5",
+        },
+        {
+          type: "response.completed",
+          response: { usage: { input_tokens: 10, output_tokens: 1 } },
+        },
+      ]),
+    );
+    setModelClientFetchForTesting(fetch);
+
+    await expect(
+      validateProviderApiKey({ provider: "auto", apiKey: " test-key " }),
+    ).resolves.toEqual({ ok: true });
+
+    expect(fetch).toHaveBeenCalledOnce();
+    const [url, init] = fetch.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe("https://engine.example.test/v1/responses");
+    expect(new Headers(init.headers).get("authorization")).toBe(
+      "Bearer test-key",
+    );
+    const body = JSON.parse(String(init.body));
+    expect(body).toMatchObject({
+      model: "gpt-5.6-luna",
+      stream: true,
+      input: [
+        {
+          role: "user",
+          content: [{ type: "input_text", text: expect.any(String) }],
+        },
+      ],
+      reasoning: { effort: "low" },
+      max_output_tokens: 128,
+      store: false,
+    });
+    expect(body).not.toHaveProperty("messages");
+    expect(body).not.toHaveProperty("temperature");
+  });
+
+  it("classifies HTTP authentication failures", async () => {
+    setModelClientFetchForTesting(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: { message: "Invalid API key", type: "authentication_error" },
+          }),
+          { status: 401, headers: { "content-type": "application/json" } },
+        ),
+    );
+    await expect(
+      validateProviderApiKey({ provider: "auto", apiKey: "invalid-key" }),
+    ).rejects.toMatchObject({ kind: DyadErrorKind.Auth });
+  });
+
+  it("classifies authentication errors inside a successful HTTP stream", async () => {
+    setModelClientFetchForTesting(async () =>
+      eventStream([
+        {
+          type: "error",
+          sequence_number: 0,
+          error: {
+            type: "authentication_error",
+            code: "invalid_api_key",
+            message: "Invalid API key",
+          },
+        },
+      ]),
+    );
+    await expect(
+      validateProviderApiKey({ provider: "auto", apiKey: "invalid-key" }),
+    ).rejects.toMatchObject({ kind: DyadErrorKind.Auth });
+  });
+});

--- a/src/ipc/services/provider_api_key_validation_service.ts
+++ b/src/ipc/services/provider_api_key_validation_service.ts
@@ -11,19 +11,25 @@ import {
   formatInvalidProviderApiKeyMessage,
   normalizeProviderApiKeyInput,
 } from "@/lib/providerApiKey";
-import type { UserSettings } from "@/lib/schemas";
+import type { ModelSelection, UserSettings } from "@/lib/schemas";
 import { createDyadEngine } from "@/ipc/utils/llm_engine_provider";
 import { fastTextOutput } from "@/ipc/utils/stream_text_utils";
 import { IS_TEST_BUILD } from "@/ipc/utils/test_utils";
 import { getDyadEngineBaseUrl } from "@/ipc/utils/dyad_engine_url";
 import { getTestFetchOption } from "@/ipc/utils/test_fetch_override";
 import { getOpenRouterAppAttributionHeaders } from "@/ipc/utils/openrouter_attribution";
+import { GPT_5_6_LUNA_MODEL_NAME } from "@/ipc/shared/language_model_constants";
 
 const logger = log.scope("provider_api_key_validation");
 
 const VALIDATION_PROMPT =
   "What number is after four? Reply with only the number.";
 const VALIDATION_TIMEOUT_MS = 20_000;
+const DYAD_VALIDATION_MODEL = {
+  provider: "openai",
+  name: GPT_5_6_LUNA_MODEL_NAME,
+  effortLevel: "low",
+} satisfies ModelSelection;
 
 const PROVIDER_DISPLAY_NAMES: Record<ProviderApiKeyValidationProvider, string> =
   {
@@ -80,8 +86,9 @@ export async function validateProviderApiKey({
     const stream = streamText({
       output: fastTextOutput(),
       model: await createValidationModel(provider, normalizedApiKey),
-      maxOutputTokens: 8,
-      temperature: 0,
+      // Responses counts reasoning tokens against the output budget too.
+      maxOutputTokens: provider === "auto" ? 128 : 8,
+      temperature: provider === "auto" ? undefined : 0,
       maxRetries: 0,
       abortSignal: controller.signal,
       onError: ({ error }) => {
@@ -134,6 +141,7 @@ async function createValidationModel(
       const settings = await readEffectiveSettings();
       const dyad = createDyadEngine({
         apiKey,
+        modelSelection: DYAD_VALIDATION_MODEL,
         baseURL: getDyadEngineBaseUrl(),
         ...getTestFetchOption(),
         dyadOptions: {
@@ -153,7 +161,9 @@ async function createValidationModel(
           },
         } satisfies UserSettings,
       });
-      return dyad("dyad/auto", { providerId: "openai" });
+      return dyad.responses(DYAD_VALIDATION_MODEL.name, {
+        providerId: DYAD_VALIDATION_MODEL.provider,
+      });
     }
   }
 }
@@ -211,12 +221,21 @@ function classifyValidationError(
   );
 }
 
-function extractErrorMessage(error: unknown): string {
+function extractErrorMessage(error: unknown, depth = 0): string {
   if (error instanceof Error) {
     return error.message;
   }
   if (typeof error === "string") {
     return error;
+  }
+  // Responses stream errors are objects with a nested error.message.
+  if (error && typeof error === "object" && depth < 5) {
+    if ("message" in error && typeof error.message === "string") {
+      return error.message;
+    }
+    if ("error" in error) {
+      return extractErrorMessage(error.error, depth + 1);
+    }
   }
   return String(error);
 }

--- a/src/ipc/utils/ai_messages_utils.ts
+++ b/src/ipc/utils/ai_messages_utils.ts
@@ -2,7 +2,7 @@ import { AI_MESSAGES_SDK_VERSION, AiMessagesJsonV6 } from "@/db/schema";
 import type { ModelMessage } from "ai";
 import { createHash } from "node:crypto";
 import log from "electron-log";
-import { usesOpenAIResponsesApiInLocalAgent } from "./openai_responses_utils";
+import { usesOpenAIResponsesApi } from "./openai_responses_utils";
 
 const logger = log.scope("ai_messages_utils");
 
@@ -24,7 +24,7 @@ export function shouldNormalizeToolCallIdsForOpenAIResponses(
     // path working across provider switches; a rare same-turn fallback to
     // Gemini may lose its encoded thought signature after normalization.
     (selectedProviderId === "auto" && selectedModelName === "auto") ||
-    usesOpenAIResponsesApiInLocalAgent({
+    usesOpenAIResponsesApi({
       provider: selectedProviderId,
       name: selectedModelName,
     })

--- a/src/ipc/utils/get_model_client.test.ts
+++ b/src/ipc/utils/get_model_client.test.ts
@@ -411,79 +411,101 @@ describe("getModelClient", () => {
     });
   });
 
-  test("routes the Value model through the Responses API in local agent mode", async () => {
-    let capturedUrl: string | undefined;
-    let capturedBody: Record<string, unknown> | undefined;
-    setModelClientFetchForTesting(
-      vi.fn(async (url, init) => {
-        capturedUrl = url.toString();
-        capturedBody = JSON.parse(init?.body as string);
-        return new Response(
-          JSON.stringify({
-            id: "resp-test",
-            created_at: 1_700_000_000,
-            model: "dyad/value",
-            output: [
-              {
-                type: "message",
-                role: "assistant",
-                id: "msg-test",
-                content: [
-                  {
-                    type: "output_text",
-                    text: "ok",
-                    annotations: [],
-                  },
-                ],
+  test.each([
+    ...(["local-agent", "ask", "plan", "build", undefined] as const).flatMap(
+      (mode) =>
+        ["gpt-6-astra", "gpt-5.5"].map((name) => ({
+          provider: "openai",
+          name,
+          mode,
+          modelId: name,
+        })),
+    ),
+    {
+      provider: "auto",
+      name: "value",
+      mode: "local-agent" as const,
+      modelId: "dyad/value",
+    },
+  ])(
+    "routes $provider/$name through Responses in $mode mode",
+    async ({ provider, name, mode, modelId }) => {
+      let capturedUrl: string | undefined;
+      let capturedBody: Record<string, unknown> | undefined;
+      setModelClientFetchForTesting(
+        vi.fn(async (url, init) => {
+          capturedUrl = url.toString();
+          capturedBody = JSON.parse(init?.body as string);
+          return new Response(
+            JSON.stringify({
+              id: "resp-test",
+              created_at: 1_700_000_000,
+              model: modelId,
+              output: [
+                {
+                  type: "message",
+                  role: "assistant",
+                  id: "msg-test",
+                  content: [
+                    {
+                      type: "output_text",
+                      text: "ok",
+                      annotations: [],
+                    },
+                  ],
+                },
+              ],
+              usage: {
+                input_tokens: 1,
+                output_tokens: 1,
               },
-            ],
-            usage: {
-              input_tokens: 1,
-              output_tokens: 1,
-            },
-          }),
-          { headers: { "Content-Type": "application/json" } },
-        );
-      }),
-    );
+            }),
+            { headers: { "Content-Type": "application/json" } },
+          );
+        }),
+      );
 
-    const { modelClient } = await getModelClient(
-      {
-        provider: "auto",
-        name: "value",
-      },
-      {
-        enableDyadPro: true,
-        selectedChatMode: "local-agent",
-        providerSettings: {
-          auto: {
-            apiKey: {
-              value: "dyad-pro-key",
+      const { modelClient } = await getModelClient(
+        {
+          provider,
+          name,
+        },
+        {
+          enableDyadPro: true,
+          selectedChatMode: mode,
+          providerSettings: {
+            auto: {
+              apiKey: {
+                value: "dyad-pro-key",
+              },
             },
           },
+        } as unknown as UserSettings,
+      );
+
+      await generateText({
+        model: modelClient.model,
+        prompt: "hi",
+        maxOutputTokens: 128000,
+        maxRetries: 0,
+      });
+
+      expect(capturedUrl).toMatch(/\/v1\/responses$/);
+      expect(capturedBody).not.toHaveProperty("max_tokens");
+      expect(capturedBody).not.toHaveProperty("reasoning_effort");
+      expect(capturedBody).toMatchObject({
+        model: modelId,
+        max_output_tokens: 128000,
+        reasoning: {
+          summary: "detailed",
+          effort: "medium",
         },
-      } as unknown as UserSettings,
-    );
-
-    await generateText({
-      model: modelClient.model,
-      prompt: "hi",
-      maxRetries: 0,
-    });
-
-    expect(capturedUrl).toMatch(/\/v1\/responses$/);
-    expect(capturedBody).toMatchObject({
-      reasoning: {
-        summary: "detailed",
-        effort: "medium",
-      },
-      include: ["reasoning.encrypted_content"],
-      store: false,
-    });
-    expect((modelClient.model as { modelId: string }).modelId).toBe(
-      "dyad/value",
-    );
-  });
+        include: ["reasoning.encrypted_content"],
+        store: false,
+      });
+      expect((modelClient.model as { modelId: string }).modelId).toBe(modelId);
+    },
+  );
 
   test("sends OpenRouter app attribution headers", async () => {
     let capturedHeaders: Headers | undefined;

--- a/src/ipc/utils/get_model_client.test.ts
+++ b/src/ipc/utils/get_model_client.test.ts
@@ -411,23 +411,19 @@ describe("getModelClient", () => {
     });
   });
 
-  test.each([
-    ...(["local-agent", "ask", "plan", "build", undefined] as const).flatMap(
-      (mode) =>
-        ["gpt-6-astra", "gpt-5.5"].map((name) => ({
+  test.each(
+    (["local-agent", "ask", "plan", "build", undefined] as const).flatMap(
+      (mode) => [
+        ...["gpt-6-astra", "gpt-5.5"].map((name) => ({
           provider: "openai",
           name,
           mode,
           modelId: name,
         })),
+        { provider: "auto", name: "value", mode, modelId: "dyad/value" },
+      ],
     ),
-    {
-      provider: "auto",
-      name: "value",
-      mode: "local-agent" as const,
-      modelId: "dyad/value",
-    },
-  ])(
+  )(
     "routes $provider/$name through Responses in $mode mode",
     async ({ provider, name, mode, modelId }) => {
       let capturedUrl: string | undefined;

--- a/src/ipc/utils/get_model_client.ts
+++ b/src/ipc/utils/get_model_client.ts
@@ -44,7 +44,7 @@ import { getOpenRouterAppAttributionHeaders } from "./openrouter_attribution";
 import { resolveModelSelection } from "./model_effort";
 import { getModelPreferenceKey } from "@/lib/modelEffort";
 import { getAutoSidekickRuntimeModel } from "@/lib/autoSidekick";
-import { usesOpenAIResponsesApiInLocalAgent } from "./openai_responses_utils";
+import { usesOpenAIResponsesApi } from "./openai_responses_utils";
 
 // The test-only fetch seam lives in ./test_fetch_override (dependency-free,
 // so secondary factories can use it without import cycles). Re-exported here
@@ -484,11 +484,7 @@ async function getProModelClient({
       builtinProviderId: "openai",
     };
   }
-  if (
-    model.provider === "openai" ||
-    (settings.selectedChatMode === "local-agent" &&
-      usesOpenAIResponsesApiInLocalAgent(model))
-  ) {
+  if (usesOpenAIResponsesApi(model)) {
     return {
       model: provider.responses(modelId, {
         providerId: "openai",

--- a/src/ipc/utils/get_model_client.ts
+++ b/src/ipc/utils/get_model_client.ts
@@ -485,8 +485,9 @@ async function getProModelClient({
     };
   }
   if (
-    settings.selectedChatMode === "local-agent" &&
-    usesOpenAIResponsesApiInLocalAgent(model)
+    model.provider === "openai" ||
+    (settings.selectedChatMode === "local-agent" &&
+      usesOpenAIResponsesApiInLocalAgent(model))
   ) {
     return {
       model: provider.responses(modelId, {

--- a/src/ipc/utils/llm_engine_provider.ts
+++ b/src/ipc/utils/llm_engine_provider.ts
@@ -171,11 +171,7 @@ export function createDyadEngine(
         // Parse the request body to manipulate it
         const parsedBody = {
           ...JSON.parse(init.body),
-          ...getExtraProviderOptionsForEngine(
-            providerId,
-            options.settings,
-            modelSelection,
-          ),
+          ...getExtraProviderOptionsForEngine(providerId, modelSelection),
         };
 
         const getDyadOption = (key: string) =>

--- a/src/ipc/utils/openai_responses_utils.ts
+++ b/src/ipc/utils/openai_responses_utils.ts
@@ -1,4 +1,4 @@
-export function usesOpenAIResponsesApiInLocalAgent(model: {
+export function usesOpenAIResponsesApi(model: {
   provider: string;
   name: string;
 }): boolean {

--- a/src/ipc/utils/thinking_utils.test.ts
+++ b/src/ipc/utils/thinking_utils.test.ts
@@ -24,24 +24,31 @@ describe("getModelEffort", () => {
 });
 
 describe("getOpenAIProviderOptions", () => {
-  it("maps effort to reasoning_effort for build mode", () => {
-    expect(getOpenAIProviderOptions(baseSettings, selection("medium"))).toEqual(
-      { reasoning_effort: "medium" },
-    );
+  it("preserves chat reasoning options for the Value alias in build mode", () => {
+    expect(
+      getOpenAIProviderOptions(baseSettings, {
+        provider: "auto",
+        name: "value",
+        effortLevel: "medium",
+      }),
+    ).toEqual({ reasoning_effort: "medium" });
   });
 
-  it("maps effort to reasoning options for local-agent mode", () => {
-    expect(
-      getOpenAIProviderOptions(
-        { ...baseSettings, selectedChatMode: "local-agent" },
-        selection("high"),
-      ),
-    ).toEqual({
-      reasoning: { summary: "detailed", effort: "high" },
-      include: ["reasoning.encrypted_content"],
-      store: false,
-    });
-  });
+  it.each(["local-agent", "ask", "plan", "build", undefined] as const)(
+    "maps OpenAI effort to Responses options in %s mode",
+    (mode) => {
+      expect(
+        getOpenAIProviderOptions(
+          { ...baseSettings, selectedChatMode: mode },
+          selection("high"),
+        ),
+      ).toEqual({
+        reasoning: { summary: "detailed", effort: "high" },
+        include: ["reasoning.encrypted_content"],
+        store: false,
+      });
+    },
+  );
 });
 
 describe("getExtraProviderOptions", () => {
@@ -52,7 +59,11 @@ describe("getExtraProviderOptions", () => {
         baseSettings,
         selection("low"),
       ),
-    ).toEqual({ reasoning_effort: "low" });
+    ).toEqual({
+      reasoning: { summary: "detailed", effort: "low" },
+      include: ["reasoning.encrypted_content"],
+      store: false,
+    });
   });
 
   it("returns Anthropic engine body thinking options", () => {

--- a/src/ipc/utils/thinking_utils.test.ts
+++ b/src/ipc/utils/thinking_utils.test.ts
@@ -24,14 +24,18 @@ describe("getModelEffort", () => {
 });
 
 describe("getOpenAIProviderOptions", () => {
-  it("preserves chat reasoning options for the Value alias in build mode", () => {
+  it("uses Responses reasoning options for the Value alias in build mode", () => {
     expect(
       getOpenAIProviderOptions(baseSettings, {
         provider: "auto",
         name: "value",
         effortLevel: "medium",
       }),
-    ).toEqual({ reasoning_effort: "medium" });
+    ).toEqual({
+      reasoning: { summary: "detailed", effort: "medium" },
+      include: ["reasoning.encrypted_content"],
+      store: false,
+    });
   });
 
   it.each(["local-agent", "ask", "plan", "build", undefined] as const)(

--- a/src/ipc/utils/thinking_utils.test.ts
+++ b/src/ipc/utils/thinking_utils.test.ts
@@ -5,12 +5,8 @@ import {
   getModelEffort,
   getOpenAIProviderOptions,
 } from "@/ipc/utils/thinking_utils";
-import type { ModelSelection, UserSettings } from "@/lib/schemas";
+import type { ModelSelection } from "@/lib/schemas";
 
-const baseSettings = {
-  selectedModel: { provider: "openai", name: "test-model" },
-  selectedChatMode: "build",
-} as unknown as UserSettings;
 const selection = (effortLevel: string): ModelSelection => ({
   provider: "openai",
   name: "test-model",
@@ -24,9 +20,9 @@ describe("getModelEffort", () => {
 });
 
 describe("getOpenAIProviderOptions", () => {
-  it("uses Responses reasoning options for the Value alias in build mode", () => {
+  it("uses Responses reasoning options for the Value alias", () => {
     expect(
-      getOpenAIProviderOptions(baseSettings, {
+      getOpenAIProviderOptions({
         provider: "auto",
         name: "value",
         effortLevel: "medium",
@@ -38,31 +34,36 @@ describe("getOpenAIProviderOptions", () => {
     });
   });
 
-  it.each(["local-agent", "ask", "plan", "build", undefined] as const)(
-    "maps OpenAI effort to Responses options in %s mode",
-    (mode) => {
-      expect(
-        getOpenAIProviderOptions(
-          { ...baseSettings, selectedChatMode: mode },
-          selection("high"),
-        ),
-      ).toEqual({
-        reasoning: { summary: "detailed", effort: "high" },
+  it.each(["low", "medium", "high", "xhigh", "max"])(
+    "maps %s effort to Responses options",
+    (effort) => {
+      expect(getOpenAIProviderOptions(selection(effort))).toEqual({
+        reasoning: { summary: "detailed", effort },
         include: ["reasoning.encrypted_content"],
         store: false,
       });
     },
   );
+
+  it("uses the resolved OpenAI provider for an Auto selection", () => {
+    expect(
+      getExtraProviderOptionsForEngine("openai", {
+        provider: "auto",
+        name: "auto",
+        effortLevel: "high",
+      }),
+    ).toEqual({
+      reasoning: { summary: "detailed", effort: "high" },
+      include: ["reasoning.encrypted_content"],
+      store: false,
+    });
+  });
 });
 
 describe("getExtraProviderOptions", () => {
   it("returns OpenAI engine body reasoning options", () => {
     expect(
-      getExtraProviderOptionsForEngine(
-        "openai",
-        baseSettings,
-        selection("low"),
-      ),
+      getExtraProviderOptionsForEngine("openai", selection("low")),
     ).toEqual({
       reasoning: { summary: "detailed", effort: "low" },
       include: ["reasoning.encrypted_content"],
@@ -72,11 +73,7 @@ describe("getExtraProviderOptions", () => {
 
   it("returns Anthropic engine body thinking options", () => {
     expect(
-      getExtraProviderOptionsForEngine(
-        "anthropic",
-        baseSettings,
-        selection("medium"),
-      ),
+      getExtraProviderOptionsForEngine("anthropic", selection("medium")),
     ).toEqual({
       thinking: { type: "adaptive", display: "summarized" },
       output_config: { effort: "medium" },
@@ -90,11 +87,7 @@ describe("getExtraProviderOptions", () => {
     ["minimal", 0],
   ])("maps Gemini %s effort to gateway budget %s", (effort, budget) => {
     expect(
-      getExtraProviderOptionsForEngine(
-        "google",
-        baseSettings,
-        selection(effort),
-      ),
+      getExtraProviderOptionsForEngine("google", selection(effort)),
     ).toEqual({
       thinking: {
         type: "enabled",

--- a/src/ipc/utils/thinking_utils.ts
+++ b/src/ipc/utils/thinking_utils.ts
@@ -1,20 +1,15 @@
-import { usesOpenAIResponsesApi } from "./openai_responses_utils";
 import { PROVIDERS_THAT_SUPPORT_THINKING as GEMINI_PROVIDERS } from "../shared/language_model_constants";
 import type { AnthropicProviderOptions } from "@ai-sdk/anthropic";
-import type { ModelSelection, UserSettings } from "../../lib/schemas";
+import type { ModelSelection } from "../../lib/schemas";
 
 export function getModelEffort(modelSelection: ModelSelection): string {
   return modelSelection.effortLevel;
 }
 
-// The Dyad Engine is backed by LiteLLM using the
-// OpenAI-compatible chat completions API. This means
-// we need to configure thinking differently depending
-// on whether user is enabling Dyad Pro (uses engine)
-// or uses the regular AI-SDK provider.
+// The engine fetch wrapper adds reasoning options for the resolved provider
+// family. OpenAI requests use the Responses API body format.
 export function getExtraProviderOptionsForEngine(
   providerId: string | undefined,
-  settings: UserSettings,
   modelSelection: ModelSelection,
 ): Record<string, any> {
   if (!providerId) {
@@ -23,7 +18,7 @@ export function getExtraProviderOptionsForEngine(
   if (providerId === "openai") {
     // OpenAI uses the same provider options because the Dyad Engine
     // is implemented as an OpenAI-compatible provider.
-    return getOpenAIProviderOptions(settings, modelSelection);
+    return getOpenAIProviderOptions(modelSelection);
   }
   if (providerId === "anthropic") {
     return getAnthropicEngineThinkingOptions(modelSelection);
@@ -89,25 +84,15 @@ export function getAnthropicProviderOptions(
   };
 }
 
-export function getOpenAIProviderOptions(
-  settings: UserSettings,
-  modelSelection: ModelSelection,
-) {
+export function getOpenAIProviderOptions(modelSelection: ModelSelection) {
   const effort = getModelEffort(modelSelection);
 
-  if (
-    usesOpenAIResponsesApi(modelSelection) ||
-    settings.selectedChatMode === "local-agent"
-  ) {
-    return {
-      reasoning: {
-        summary: "detailed",
-        effort,
-      },
-      include: ["reasoning.encrypted_content"],
-      store: false,
-    };
-  }
-
-  return { reasoning_effort: effort };
+  return {
+    reasoning: {
+      summary: "detailed",
+      effort,
+    },
+    include: ["reasoning.encrypted_content"],
+    store: false,
+  };
 }

--- a/src/ipc/utils/thinking_utils.ts
+++ b/src/ipc/utils/thinking_utils.ts
@@ -94,7 +94,10 @@ export function getOpenAIProviderOptions(
 ) {
   const effort = getModelEffort(modelSelection);
 
-  if (settings.selectedChatMode === "local-agent") {
+  if (
+    modelSelection.provider === "openai" ||
+    settings.selectedChatMode === "local-agent"
+  ) {
     return {
       reasoning: {
         summary: "detailed",

--- a/src/ipc/utils/thinking_utils.ts
+++ b/src/ipc/utils/thinking_utils.ts
@@ -1,3 +1,4 @@
+import { usesOpenAIResponsesApi } from "./openai_responses_utils";
 import { PROVIDERS_THAT_SUPPORT_THINKING as GEMINI_PROVIDERS } from "../shared/language_model_constants";
 import type { AnthropicProviderOptions } from "@ai-sdk/anthropic";
 import type { ModelSelection, UserSettings } from "../../lib/schemas";
@@ -95,7 +96,7 @@ export function getOpenAIProviderOptions(
   const effort = getModelEffort(modelSelection);
 
   if (
-    modelSelection.provider === "openai" ||
+    usesOpenAIResponsesApi(modelSelection) ||
     settings.selectedChatMode === "local-agent"
   ) {
     return {


### PR DESCRIPTION
## Summary

OpenAI models and Value now use Responses across all chat modes, fixing unsupported Chat Completions parameters when selecting models such as GPT-6 Astra in Ask, Plan, or Build. Dyad API-key validation also uses Responses with GPT-5.6 Luna instead of the legacy auto alias.

- Routing and OpenAI engine reasoning options no longer depend on chat mode; encrypted reasoning content and disabled storage are preserved. Catalog-based Auto fallback and balanced routing retain their existing behavior.
- Validation uses a dedicated low-effort model selection, a 128-token output budget, and no temperature override. Structured Responses stream errors are classified alongside HTTP authentication failures.
- Request-level regression tests cover OpenAI and Value across all four modes and an omitted mode, plus validation request shaping and authentication failures. Live engine validation has not been exercised for the new validation model.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core model routing and Dyad engine request bodies for all chat modes and API key checks; regression risk is mitigated by expanded integration and parametric tests.
> 
> **Overview**
> **OpenAI models and the Auto Value/balanced aliases now route through the Responses API in every chat mode**, not only `local-agent`. The shared predicate is renamed to `usesOpenAIResponsesApi` and the mode guard is removed from `get_model_client`, fixing unsupported-parameter failures (e.g. `max_tokens`) when using models like GPT-6 Astra in Ask, Plan, or Build.
> 
> **Engine and thinking options** always emit Responses-style bodies for OpenAI (`reasoning`, encrypted reasoning `include`, `store: false`) instead of chat-completions `reasoning_effort`; `getExtraProviderOptionsForEngine` and `getOpenAIProviderOptions` no longer depend on `UserSettings` or chat mode.
> 
> **Dyad API key validation** (`provider: auto`) switches to a streamed `/responses` probe with a dedicated Luna model, a larger output budget for reasoning tokens, and **nested stream error message extraction** so auth failures inside HTTP 200 streams classify as `DyadErrorKind.Auth`. Integration tests cover the request shape plus HTTP and in-stream auth errors; `get_model_client` tests now parametrize Astra, GPT-5.5, and Value across modes.
> 
> Documentation in `rules/dyad-errors.md` notes Responses stream errors arriving as plain objects in AI SDK `onError`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2231a2fb13183d4b41a0680c334763ca4a76d6e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

