### PR TITLE
(feaure) added probing for determining context window for OpenAI API compatible custom provider servers

### DIFF
--- a/src/hooks/useCustomLanguageModelProvider.ts
+++ b/src/hooks/useCustomLanguageModelProvider.ts
@@ -41,7 +41,7 @@ export function useCustomLanguageModelProvider() {
         envVarName: params.envVarName?.trim() || undefined,
       });
 
-      void ipc.languageModel
+      await ipc.languageModel
         .refreshCustomProviderModels({
           providerId: provider.id,
         })
@@ -93,7 +93,7 @@ export function useCustomLanguageModelProvider() {
         envVarName: params.envVarName?.trim() || undefined,
       });
 
-      void ipc.languageModel
+      await ipc.languageModel
         .refreshCustomProviderModels({
           providerId: provider.id,
         })

--- a/src/hooks/useCustomLanguageModelProvider.ts
+++ b/src/hooks/useCustomLanguageModelProvider.ts
@@ -34,17 +34,26 @@ export function useCustomLanguageModelProvider() {
         );
       }
 
-      return ipc.languageModel.createCustomProvider({
+      const provider = await ipc.languageModel.createCustomProvider({
         id: params.id.trim(),
         name: params.name.trim(),
         apiBaseUrl: params.apiBaseUrl.trim(),
         envVarName: params.envVarName?.trim() || undefined,
       });
+
+      await ipc.languageModel.refreshCustomProviderModels({
+        providerId: provider.id,
+      });
+
+      return provider;
     },
     onSuccess: () => {
       // Invalidate and refetch
       queryClient.invalidateQueries({
         queryKey: queryKeys.languageModels.providers,
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.languageModels.byProviders,
       });
     },
     onError: (error) => {
@@ -75,17 +84,26 @@ export function useCustomLanguageModelProvider() {
         );
       }
 
-      return ipc.languageModel.editCustomProvider({
+      const provider = await ipc.languageModel.editCustomProvider({
         id: params.id.trim(),
         name: params.name.trim(),
         apiBaseUrl: params.apiBaseUrl.trim(),
         envVarName: params.envVarName?.trim() || undefined,
       });
+
+      await ipc.languageModel.refreshCustomProviderModels({
+        providerId: provider.id,
+      });
+
+      return provider;
     },
     onSuccess: () => {
       // Invalidate and refetch
       queryClient.invalidateQueries({
         queryKey: queryKeys.languageModels.providers,
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.languageModels.byProviders,
       });
     },
     onError: (error) => {

--- a/src/hooks/useCustomLanguageModelProvider.ts
+++ b/src/hooks/useCustomLanguageModelProvider.ts
@@ -41,9 +41,11 @@ export function useCustomLanguageModelProvider() {
         envVarName: params.envVarName?.trim() || undefined,
       });
 
-      await ipc.languageModel.refreshCustomProviderModels({
-        providerId: provider.id,
-      });
+      void ipc.languageModel
+        .refreshCustomProviderModels({
+          providerId: provider.id,
+        })
+        .catch(() => undefined);
 
       return provider;
     },
@@ -91,9 +93,11 @@ export function useCustomLanguageModelProvider() {
         envVarName: params.envVarName?.trim() || undefined,
       });
 
-      await ipc.languageModel.refreshCustomProviderModels({
-        providerId: provider.id,
-      });
+      void ipc.languageModel
+        .refreshCustomProviderModels({
+          providerId: provider.id,
+        })
+        .catch(() => undefined);
 
       return provider;
     },

--- a/src/ipc/handlers/compaction/compaction_handler.ts
+++ b/src/ipc/handlers/compaction/compaction_handler.ts
@@ -128,6 +128,10 @@ export async function checkAndMarkForCompaction(
   }
 
   const contextWindow = await getContextWindow(selectedModel);
+  if (contextWindow == null || !Number.isFinite(contextWindow)) {
+    return false;
+  }
+
   const provider = selectedModel.provider;
   const shouldCompact = shouldTriggerCompaction(
     totalTokens,

--- a/src/ipc/handlers/language_model_handlers.ts
+++ b/src/ipc/handlers/language_model_handlers.ts
@@ -14,6 +14,7 @@ import {
   getLanguageModels,
   getLanguageModelsByProviders,
 } from "../shared/language_model_helpers";
+import { refreshCustomProviderModels } from "../shared/custom_provider_model_probe";
 import { db } from "@/db";
 import {
   language_models,
@@ -91,12 +92,37 @@ export function registerLanguageModelHandlers() {
 
       // Return the newly created provider
       return {
-        id,
+        id: CUSTOM_PROVIDER_PREFIX + id,
         name,
         apiBaseUrl,
         envVarName,
         type: "custom",
       };
+    },
+  );
+
+  handleTyped(
+    languageModelContracts.refreshCustomProviderModels,
+    async (_event, params): Promise<LanguageModel[]> => {
+      const { providerId } = params;
+      const providers = await getLanguageModelProviders();
+      const provider = providers.find((candidate) => candidate.id === providerId);
+
+      if (!provider) {
+        throw new DyadError(
+          `Provider with ID "${providerId}" not found`,
+          DyadErrorKind.NotFound,
+        );
+      }
+
+      if (provider.type !== "custom") {
+        throw new DyadError(
+          `Provider "${providerId}" is not a custom provider`,
+          DyadErrorKind.Validation,
+        );
+      }
+
+      return refreshCustomProviderModels(providerId);
     },
   );
 
@@ -307,7 +333,7 @@ export function registerLanguageModelHandlers() {
         }
 
         return {
-          id,
+          id: CUSTOM_PROVIDER_PREFIX + id,
           name,
           apiBaseUrl,
           envVarName,

--- a/src/ipc/handlers/proposal_handlers.ts
+++ b/src/ipc/handlers/proposal_handlers.ts
@@ -322,22 +322,22 @@ const getProposalHandler = async (
         );
 
         const totalTokens = messagesTokenCount + codebaseTokenCount;
-        const contextWindow = Math.min(
-          await getContextWindow(selectedModel),
-          100_000,
-        );
-        logger.debug(
-          `Token usage: ${totalTokens}/${contextWindow} (${(totalTokens / contextWindow) * 100}%)`,
-        );
-
-        // If we're using more than 80% of the context window, suggest summarizing
-        if (totalTokens > contextWindow * 0.8 || chat.messages.length > 10) {
+        const contextWindow = await getContextWindow(selectedModel);
+        if (contextWindow != null && Number.isFinite(contextWindow)) {
+          const boundedContextWindow = Math.min(contextWindow, 100_000);
           logger.debug(
-            `Token usage is high (${totalTokens}/${contextWindow}) OR long chat history (${chat.messages.length} messages), suggesting summarize action`,
+            `Token usage: ${totalTokens}/${boundedContextWindow} (${(totalTokens / boundedContextWindow) * 100}%)`,
           );
-          actions.push({
-            id: "summarize-in-new-chat",
-          });
+
+          // If we're using more than 80% of the context window, suggest summarizing
+          if (totalTokens > boundedContextWindow * 0.8 || chat.messages.length > 10) {
+            logger.debug(
+              `Token usage is high (${totalTokens}/${boundedContextWindow}) OR long chat history (${chat.messages.length} messages), suggesting summarize action`,
+            );
+            actions.push({
+              id: "summarize-in-new-chat",
+            });
+          }
         }
       }
       if (latestAssistantMessage) {

--- a/src/ipc/handlers/proposal_handlers.ts
+++ b/src/ipc/handlers/proposal_handlers.ts
@@ -322,6 +322,7 @@ const getProposalHandler = async (
         );
 
         const totalTokens = messagesTokenCount + codebaseTokenCount;
+        const tooLongHistory = chat.messages.length > 10;
         const contextWindow = await getContextWindow(selectedModel);
         if (contextWindow != null && Number.isFinite(contextWindow)) {
           const boundedContextWindow = Math.min(contextWindow, 100_000);
@@ -329,8 +330,10 @@ const getProposalHandler = async (
             `Token usage: ${totalTokens}/${boundedContextWindow} (${(totalTokens / boundedContextWindow) * 100}%)`,
           );
 
-          // If we're using more than 80% of the context window, suggest summarizing
-          if (totalTokens > boundedContextWindow * 0.8 || chat.messages.length > 10) {
+          // If we're using more than 80% of the context window, suggest summarizing.
+          // Long history remains a separate trigger regardless of how much of the
+          // known context window is left.
+          if (totalTokens > boundedContextWindow * 0.8 || tooLongHistory) {
             logger.debug(
               `Token usage is high (${totalTokens}/${boundedContextWindow}) OR long chat history (${chat.messages.length} messages), suggesting summarize action`,
             );
@@ -338,6 +341,13 @@ const getProposalHandler = async (
               id: "summarize-in-new-chat",
             });
           }
+        } else if (tooLongHistory) {
+          logger.debug(
+            `Long chat history (${chat.messages.length} messages) suggests summarize action even without a known context window`,
+          );
+          actions.push({
+            id: "summarize-in-new-chat",
+          });
         }
       }
       if (latestAssistantMessage) {

--- a/src/ipc/shared/custom_provider_model_probe.test.ts
+++ b/src/ipc/shared/custom_provider_model_probe.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 
 import {
   buildCustomProviderModelDiscoveryUrl,
+  discoverCustomProviderModels,
   normalizeDiscoveredCustomProviderModels,
 } from "@/ipc/shared/custom_provider_model_probe";
 
@@ -63,5 +64,54 @@ describe("normalizeDiscoveredCustomProviderModels", () => {
       displayName: "model-a",
       contextWindow: 128_000,
     });
+  });
+
+  it("uses each Ollama model's own context window instead of reusing the first model", () => {
+    const result = normalizeDiscoveredCustomProviderModels(
+      {
+        data: [
+          { id: "llama3.1:8b", object: "model", created: 1, owned_by: "me" },
+          { id: "llama3.1:70b", object: "model", created: 1, owned_by: "me" },
+        ],
+      },
+      {
+        models: [
+          { name: "llama3.1:8b", context_length: 32_768 },
+          { name: "llama3.1:70b", context_length: 131_072 },
+        ],
+      },
+      {
+        "llama3.1:8b": { contextWindow: 32_768, temperature: 0.1 },
+        "llama3.1:70b": { contextWindow: 131_072, temperature: 0.2 },
+      },
+    );
+
+    expect(result.map((model) => model.contextWindow)).toEqual([
+      32_768, 131_072,
+    ]);
+  });
+});
+
+describe("discoverCustomProviderModels", () => {
+  it("adds the configured bearer token when probing a protected custom provider", async () => {
+    vi.stubEnv("MY_PROVIDER_KEY", "secret-token");
+
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ data: [] }), { status: 200 }),
+    );
+
+    await discoverCustomProviderModels(
+      "http://localhost:11434/v1",
+      "MY_PROVIDER_KEY",
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:11434/v1/models",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer secret-token",
+        }),
+      }),
+    );
   });
 });

--- a/src/ipc/shared/custom_provider_model_probe.test.ts
+++ b/src/ipc/shared/custom_provider_model_probe.test.ts
@@ -50,7 +50,7 @@ describe("normalizeDiscoveredCustomProviderModels", () => {
     });
   });
 
-  it("keeps the default 128k window when no real window is available", () => {
+  it("omits the context window when no positive server or model value is available", () => {
     const result = normalizeDiscoveredCustomProviderModels(
       {
         data: [{ id: "model-a", object: "model", created: 1, owned_by: "me" }],
@@ -62,8 +62,24 @@ describe("normalizeDiscoveredCustomProviderModels", () => {
     expect(result[0]).toMatchObject({
       apiName: "model-a",
       displayName: "model-a",
-      contextWindow: 128_000,
+      contextWindow: undefined,
     });
+  });
+
+  it("ignores zero and negative context lengths from the server", () => {
+    const result = normalizeDiscoveredCustomProviderModels(
+      {
+        data: [{ id: "model-b", object: "model", created: 1, owned_by: "me" }],
+      },
+      {
+        models: [{ name: "model-b", context_length: 0 }],
+      },
+      {
+        "model-b": { context_length: -5 },
+      },
+    );
+
+    expect(result[0].contextWindow).toBeUndefined();
   });
 
   it("uses each Ollama model's own context window instead of reusing the first model", () => {

--- a/src/ipc/shared/custom_provider_model_probe.test.ts
+++ b/src/ipc/shared/custom_provider_model_probe.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import {
+  buildCustomProviderModelDiscoveryUrl,
+  normalizeDiscoveredCustomProviderModels,
+} from "@/ipc/shared/custom_provider_model_probe";
+
+describe("buildCustomProviderModelDiscoveryUrl", () => {
+  it("adds /v1/models when the base URL is a plain server URL", () => {
+    expect(buildCustomProviderModelDiscoveryUrl("http://localhost:11434")).toBe(
+      "http://localhost:11434/v1/models",
+    );
+  });
+
+  it("uses the existing /v1 path without duplicating it", () => {
+    expect(buildCustomProviderModelDiscoveryUrl("http://localhost:11434/v1")).toBe(
+      "http://localhost:11434/v1/models",
+    );
+  });
+});
+
+describe("normalizeDiscoveredCustomProviderModels", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("prefers the server window and model ceiling for Ollama when both are known", () => {
+    const result = normalizeDiscoveredCustomProviderModels(
+      {
+        data: [{ id: "llama3.1:8b", object: "model", created: 1, owned_by: "me" }],
+      },
+      {
+        version: "0.5.0",
+        models: [{ name: "llama3.1:8b", size_vram: 0, context_length: 65_536 }],
+      },
+      {
+        model: {
+          general: { architecture: "llama" },
+          model_info: { "general.architecture": "llama" },
+          context_length: 262_144,
+        },
+      },
+    );
+
+    expect(result[0]).toMatchObject({
+      apiName: "llama3.1:8b",
+      displayName: "llama3.1:8b",
+      contextWindow: 65_536,
+    });
+  });
+
+  it("keeps the default 128k window when no real window is available", () => {
+    const result = normalizeDiscoveredCustomProviderModels(
+      {
+        data: [{ id: "model-a", object: "model", created: 1, owned_by: "me" }],
+      },
+      null,
+      null,
+    );
+
+    expect(result[0]).toMatchObject({
+      apiName: "model-a",
+      displayName: "model-a",
+      contextWindow: 128_000,
+    });
+  });
+});

--- a/src/ipc/shared/custom_provider_model_probe.test.ts
+++ b/src/ipc/shared/custom_provider_model_probe.test.ts
@@ -1,12 +1,24 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 
+import { readSettings } from "@/main/settings";
 import {
   buildCustomProviderModelDiscoveryUrl,
   discoverCustomProviderModels,
   normalizeDiscoveredCustomProviderModels,
 } from "@/ipc/shared/custom_provider_model_probe";
 
+vi.mock("@/main/settings", () => ({
+  readSettings: vi.fn(() => ({ providerSettings: {} })),
+}));
+
+const mockReadSettings = vi.mocked(readSettings);
+
 describe("buildCustomProviderModelDiscoveryUrl", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    mockReadSettings.mockReturnValue({ providerSettings: {} } as any);
+  });
   it("adds /v1/models when the base URL is a plain server URL", () => {
     expect(buildCustomProviderModelDiscoveryUrl("http://localhost:11434")).toBe(
       "http://localhost:11434/v1/models",
@@ -106,9 +118,44 @@ describe("normalizeDiscoveredCustomProviderModels", () => {
       32_768, 131_072,
     ]);
   });
+
+  it("reads the configured API key from provider settings when no env var is set", async () => {
+    mockReadSettings.mockReturnValue({
+      providerSettings: {
+        "custom::my-provider": {
+          apiKey: { value: "settings-key" },
+        },
+      },
+    } as any);
+
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ data: [] }), { status: 200 }),
+    );
+
+    await discoverCustomProviderModels(
+      "http://localhost:11434/v1",
+      undefined,
+      "custom::my-provider",
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:11434/v1/models",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer settings-key",
+        }),
+      }),
+    );
+  });
 });
 
 describe("discoverCustomProviderModels", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    mockReadSettings.mockReturnValue({ providerSettings: {} } as any);
+  });
+
   it("adds the configured bearer token when probing a protected custom provider", async () => {
     vi.stubEnv("MY_PROVIDER_KEY", "secret-token");
 
@@ -129,5 +176,50 @@ describe("discoverCustomProviderModels", () => {
         }),
       }),
     );
+  });
+
+  it("caps Ollama show probes to a bounded best-effort set", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(
+      async (url: string | URL | Request) => {
+        const target = String(url);
+        if (target.endsWith("/v1/models")) {
+          return new Response(
+            JSON.stringify({
+              data: Array.from({ length: 20 }, (_, index) => ({
+                id: `model-${index}`,
+                object: "model",
+                created: 1,
+                owned_by: "me",
+              })),
+            }),
+            { status: 200 },
+          );
+        }
+
+        if (target.endsWith("/api/version")) {
+          return new Response(JSON.stringify({ version: "0.7.0" }), {
+            status: 200,
+          });
+        }
+
+        if (target.endsWith("/api/ps")) {
+          return new Response(JSON.stringify({ models: [] }), { status: 200 });
+        }
+
+        if (target.endsWith("/api/show")) {
+          return new Response(JSON.stringify({ model: {} }), { status: 200 });
+        }
+
+        return new Response("{}", { status: 200 });
+      },
+    );
+
+    await discoverCustomProviderModels("http://localhost:11434/v1");
+
+    const showCalls = fetchMock.mock.calls.filter(([url]) =>
+      String(url).endsWith("/api/show"),
+    );
+
+    expect(showCalls.length).toBeLessThanOrEqual(5);
   });
 });

--- a/src/ipc/shared/custom_provider_model_probe.ts
+++ b/src/ipc/shared/custom_provider_model_probe.ts
@@ -5,10 +5,13 @@ import {
 } from "@/db/schema";
 import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
 import type { LanguageModel } from "@/ipc/types";
+import { readSettings } from "@/main/settings";
 import { getEnvVar } from "../utils/read_env";
 import { and, eq } from "drizzle-orm";
 
 const CUSTOM_PROVIDER_PROBE_TIMEOUT_MS = 4_000;
+const MAX_OLLAMA_SHOW_PROBES = 5;
+const OLLAMA_SHOW_PROBE_DEADLINE_MS = 12_000;
 
 function normalizeCustomProviderId(providerId: string): string {
   return providerId.startsWith("custom::") ? providerId : `custom::${providerId}`;
@@ -43,13 +46,30 @@ function toJson<T>(payload: Response): Promise<T> {
 }
 
 function buildCustomProviderRequestHeaders(
+  providerId?: string,
   envVarName?: string,
 ): Record<string, string> {
   const headers: Record<string, string> = {
     Accept: "application/json",
   };
 
-  const apiKey = envVarName ? getEnvVar(envVarName)?.trim() : "";
+  const candidateProviderIds = new Set<string>();
+  if (providerId) {
+    candidateProviderIds.add(providerId);
+    candidateProviderIds.add(providerId.replace(/^custom::/, ""));
+  }
+
+  const settings = readSettings();
+  const configuredApiKey = [...candidateProviderIds].find((candidate) =>
+    Boolean(settings.providerSettings?.[candidate]?.apiKey?.value?.trim()),
+  );
+  const apiKey =
+    (configuredApiKey
+      ? settings.providerSettings?.[configuredApiKey]?.apiKey?.value?.trim()
+      : undefined) ||
+    (envVarName ? getEnvVar(envVarName)?.trim() : "") ||
+    "";
+
   if (apiKey) {
     headers.Authorization = `Bearer ${apiKey}`;
     headers["X-API-Key"] = apiKey;
@@ -258,12 +278,17 @@ function getOllamaMetadataForModel(
           temperature?: unknown;
           vision?: unknown;
         };
+        const parsedMetadata = parseOllamaShowMetadata(metadata, modelName);
 
         return {
-          contextWindow: asNumber(modelMetadata.contextWindow) ??
-            asNumber(modelMetadata.context_length),
-          temperature: asNumber(modelMetadata.temperature),
-          vision: Boolean(modelMetadata.vision),
+          contextWindow:
+            asPositiveFiniteNumber(modelMetadata.contextWindow) ??
+            asPositiveFiniteNumber(modelMetadata.context_length) ??
+            parsedMetadata.contextWindow,
+          temperature:
+            asNumber(modelMetadata.temperature) ?? parsedMetadata.temperature,
+          vision:
+            Boolean(modelMetadata.vision) || parsedMetadata.vision || false,
         };
       }
     }
@@ -336,9 +361,10 @@ export function normalizeDiscoveredCustomProviderModels(
 export async function discoverCustomProviderModels(
   apiBaseUrl: string,
   envVarName?: string,
+  providerId?: string,
 ): Promise<DiscoveredCustomProviderModel[]> {
   const modelsUrl = buildCustomProviderModelDiscoveryUrl(apiBaseUrl);
-  const requestHeaders = buildCustomProviderRequestHeaders(envVarName);
+  const requestHeaders = buildCustomProviderRequestHeaders(providerId, envVarName);
   const modelsResult = await fetchJsonWithTimeout<unknown>(modelsUrl, {
     method: "GET",
     headers: requestHeaders,
@@ -398,7 +424,13 @@ export async function discoverCustomProviderModels(
       ),
     );
 
-    for (const modelName of modelNames) {
+    const boundedModelNames = modelNames.slice(0, MAX_OLLAMA_SHOW_PROBES);
+    const showDeadlineMs = Date.now() + OLLAMA_SHOW_PROBE_DEADLINE_MS;
+
+    for (const modelName of boundedModelNames) {
+      if (Date.now() >= showDeadlineMs) {
+        break;
+      }
       const showResult = await fetchJsonWithTimeout<unknown>(
         buildOllamaApiUrl(apiBaseUrl, "/api/show"),
         {
@@ -445,6 +477,7 @@ export async function refreshCustomProviderModels(
   const discoveredModels = await discoverCustomProviderModels(
     provider.api_base_url,
     provider.env_var_name ?? undefined,
+    normalizedProviderId,
   );
   const syncedModels: LanguageModel[] = [];
 

--- a/src/ipc/shared/custom_provider_model_probe.ts
+++ b/src/ipc/shared/custom_provider_model_probe.ts
@@ -8,7 +8,6 @@ import type { LanguageModel } from "@/ipc/types";
 import { getEnvVar } from "../utils/read_env";
 import { and, eq } from "drizzle-orm";
 
-const DEFAULT_CUSTOM_PROVIDER_CONTEXT_WINDOW = 128_000;
 const CUSTOM_PROVIDER_PROBE_TIMEOUT_MS = 4_000;
 
 function normalizeCustomProviderId(providerId: string): string {
@@ -32,6 +31,11 @@ function asNumber(value: unknown): number | undefined {
 
   const numericValue = Number(value);
   return Number.isFinite(numericValue) ? numericValue : undefined;
+}
+
+function asPositiveFiniteNumber(value: unknown): number | undefined {
+  const numericValue = asNumber(value);
+  return numericValue != null && numericValue > 0 ? numericValue : undefined;
 }
 
 function toJson<T>(payload: Response): Promise<T> {
@@ -219,10 +223,13 @@ function determineModelContextWindow(
     serverContextWindow,
     modelCeiling,
     openAiContextWindow,
-  ].filter((value): value is number => value != null && Number.isFinite(value));
+  ].filter(
+    (value): value is number =>
+      value != null && Number.isFinite(value) && value > 0,
+  );
 
   if (candidateValues.length === 0) {
-    return DEFAULT_CUSTOM_PROVIDER_CONTEXT_WINDOW;
+    return undefined;
   }
 
   if (candidateValues.length === 1) {
@@ -292,7 +299,8 @@ export function normalizeDiscoveredCustomProviderModels(
     const apiName = item.id ?? item.name ?? item.model ?? "";
     const displayName = item.display_name ?? item.displayName ?? apiName;
     const openAiContextWindow =
-      asNumber(item.max_model_len) ?? asNumber(item.maxModelLen);
+      asPositiveFiniteNumber(item.max_model_len) ??
+      asPositiveFiniteNumber(item.maxModelLen);
     const modelMetadata =
       ollamaShowResponse != null
         ? getOllamaMetadataForModel(apiName, ollamaShowResponse)
@@ -302,10 +310,15 @@ export function normalizeDiscoveredCustomProviderModels(
         ? serverWindowsByModel[apiName]
         : defaultServerWindow;
 
+    const positiveServerWindow = asPositiveFiniteNumber(serverWindow);
+    const positiveModelMetadataWindow = asPositiveFiniteNumber(
+      modelMetadata.contextWindow,
+    );
+
     const effectiveContextWindow = determineModelContextWindow(
       openAiContextWindow,
-      serverWindow,
-      modelMetadata.contextWindow,
+      positiveServerWindow,
+      positiveModelMetadataWindow,
     );
 
     return {
@@ -451,12 +464,11 @@ export async function refreshCustomProviderModels(
       db.update(language_models)
         .set({
           displayName: model.displayName,
-          description: model.description ?? null,
-          max_output_tokens: model.maxOutputTokens ?? null,
+          description: model.description ?? modelQuery.description ?? null,
+          max_output_tokens:
+            model.maxOutputTokens ?? modelQuery.max_output_tokens ?? null,
           context_window:
-            model.contextWindow ??
-            modelQuery.context_window ??
-            DEFAULT_CUSTOM_PROVIDER_CONTEXT_WINDOW,
+            model.contextWindow ?? modelQuery.context_window ?? null,
           updatedAt: new Date(),
         })
         .where(
@@ -475,8 +487,7 @@ export async function refreshCustomProviderModels(
           customProviderId: normalizedProviderId,
           description: model.description ?? null,
           max_output_tokens: model.maxOutputTokens ?? null,
-          context_window:
-            model.contextWindow ?? DEFAULT_CUSTOM_PROVIDER_CONTEXT_WINDOW,
+          context_window: model.contextWindow ?? null,
         })
         .run();
 
@@ -497,12 +508,9 @@ export async function refreshCustomProviderModels(
       id: modelQuery.id,
       apiName: model.apiName,
       displayName: model.displayName,
-      description: model.description,
-      maxOutputTokens: model.maxOutputTokens,
-      contextWindow:
-        model.contextWindow ??
-        modelQuery.context_window ??
-        DEFAULT_CUSTOM_PROVIDER_CONTEXT_WINDOW,
+      description: model.description ?? modelQuery.description ?? undefined,
+      maxOutputTokens: model.maxOutputTokens ?? modelQuery.max_output_tokens ?? undefined,
+      contextWindow: model.contextWindow ?? modelQuery.context_window ?? undefined,
       temperature: model.temperature,
       type: "custom",
     });

--- a/src/ipc/shared/custom_provider_model_probe.ts
+++ b/src/ipc/shared/custom_provider_model_probe.ts
@@ -5,9 +5,11 @@ import {
 } from "@/db/schema";
 import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
 import type { LanguageModel } from "@/ipc/types";
+import { getEnvVar } from "../utils/read_env";
 import { and, eq } from "drizzle-orm";
 
 const DEFAULT_CUSTOM_PROVIDER_CONTEXT_WINDOW = 128_000;
+const CUSTOM_PROVIDER_PROBE_TIMEOUT_MS = 4_000;
 
 function normalizeCustomProviderId(providerId: string): string {
   return providerId.startsWith("custom::") ? providerId : `custom::${providerId}`;
@@ -34,6 +36,44 @@ function asNumber(value: unknown): number | undefined {
 
 function toJson<T>(payload: Response): Promise<T> {
   return payload.json() as Promise<T>;
+}
+
+function buildCustomProviderRequestHeaders(
+  envVarName?: string,
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+  };
+
+  const apiKey = envVarName ? getEnvVar(envVarName)?.trim() : "";
+  if (apiKey) {
+    headers.Authorization = `Bearer ${apiKey}`;
+    headers["X-API-Key"] = apiKey;
+  }
+
+  return headers;
+}
+
+async function fetchJsonWithTimeout<T>(
+  url: string,
+  init: RequestInit,
+  timeoutMs = CUSTOM_PROVIDER_PROBE_TIMEOUT_MS,
+): Promise<{ response: Response; json: T } | null> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(url, {
+      ...init,
+      signal: controller.signal,
+    });
+    const json = (await response.json().catch(() => null)) as T;
+    return { response, json };
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeoutId);
+  }
 }
 
 function trimBaseUrl(baseUrl: string): string {
@@ -89,7 +129,7 @@ function parseOllamaPsContextLength(payload: unknown): number | undefined {
 
   const psPayload = payload as {
     context_length?: unknown;
-    models?: Array<{ context_length?: unknown; name?: string }>; 
+    models?: Array<{ context_length?: unknown; name?: string }>;
   };
 
   const directValue = asNumber(psPayload.context_length);
@@ -99,6 +139,32 @@ function parseOllamaPsContextLength(payload: unknown): number | undefined {
 
   const firstModel = psPayload.models?.find((model) => model != null);
   return asNumber(firstModel?.context_length);
+}
+
+function parseOllamaPsContextLengths(
+  payload: unknown,
+): Record<string, number> {
+  if (!payload || typeof payload !== "object") {
+    return {};
+  }
+
+  const psPayload = payload as {
+    models?: Array<{ context_length?: unknown; name?: string }>;
+  };
+
+  const byModel: Record<string, number> = {};
+  for (const model of psPayload.models ?? []) {
+    if (!model || typeof model.name !== "string") {
+      continue;
+    }
+
+    const contextLength = asNumber(model.context_length);
+    if (contextLength != null) {
+      byModel[model.name] = contextLength;
+    }
+  }
+
+  return byModel;
 }
 
 function parseOllamaShowMetadata(
@@ -166,6 +232,39 @@ function determineModelContextWindow(
   return Math.min(...candidateValues);
 }
 
+function getOllamaMetadataForModel(
+  modelName: string,
+  ollamaShowResponse: unknown,
+): { contextWindow?: number; temperature?: number; vision?: boolean } {
+  if (
+    ollamaShowResponse != null &&
+    typeof ollamaShowResponse === "object" &&
+    !Array.isArray(ollamaShowResponse)
+  ) {
+    const showResponseMap = ollamaShowResponse as Record<string, unknown>;
+    if (Object.prototype.hasOwnProperty.call(showResponseMap, modelName)) {
+      const metadata = showResponseMap[modelName];
+      if (metadata && typeof metadata === "object") {
+        const modelMetadata = metadata as {
+          contextWindow?: unknown;
+          context_length?: unknown;
+          temperature?: unknown;
+          vision?: unknown;
+        };
+
+        return {
+          contextWindow: asNumber(modelMetadata.contextWindow) ??
+            asNumber(modelMetadata.context_length),
+          temperature: asNumber(modelMetadata.temperature),
+          vision: Boolean(modelMetadata.vision),
+        };
+      }
+    }
+  }
+
+  return parseOllamaShowMetadata(ollamaShowResponse ?? {}, modelName);
+}
+
 export function normalizeDiscoveredCustomProviderModels(
   openAiModelsResponse: unknown,
   ollamaPsResponse: unknown | null,
@@ -174,8 +273,8 @@ export function normalizeDiscoveredCustomProviderModels(
   const discoveredModels = getModelListFromOpenAICompatiblePayload(
     openAiModelsResponse,
   );
-
-  const serverWindow = parseOllamaPsContextLength(ollamaPsResponse);
+  const serverWindowsByModel = parseOllamaPsContextLengths(ollamaPsResponse);
+  const defaultServerWindow = parseOllamaPsContextLength(ollamaPsResponse);
 
   return discoveredModels.map((model) => {
     const item = model as {
@@ -194,16 +293,19 @@ export function normalizeDiscoveredCustomProviderModels(
     const displayName = item.display_name ?? item.displayName ?? apiName;
     const openAiContextWindow =
       asNumber(item.max_model_len) ?? asNumber(item.maxModelLen);
-
-    const ollamaModelWindow =
+    const modelMetadata =
       ollamaShowResponse != null
-        ? parseOllamaShowMetadata(ollamaShowResponse, apiName).contextWindow
-        : undefined;
+        ? getOllamaMetadataForModel(apiName, ollamaShowResponse)
+        : {};
+    const serverWindow =
+      apiName in serverWindowsByModel
+        ? serverWindowsByModel[apiName]
+        : defaultServerWindow;
 
     const effectiveContextWindow = determineModelContextWindow(
       openAiContextWindow,
       serverWindow,
-      ollamaModelWindow,
+      modelMetadata.contextWindow,
     );
 
     return {
@@ -212,35 +314,28 @@ export function normalizeDiscoveredCustomProviderModels(
       description: item.owned_by ? `Owned by ${item.owned_by}` : undefined,
       contextWindow: effectiveContextWindow,
       maxOutputTokens: undefined,
-      temperature:
-        ollamaShowResponse != null
-          ? parseOllamaShowMetadata(ollamaShowResponse, apiName).temperature
-          : undefined,
-      vision:
-        ollamaShowResponse != null
-          ? parseOllamaShowMetadata(ollamaShowResponse, apiName).vision
-          : undefined,
+      temperature: modelMetadata.temperature,
+      vision: modelMetadata.vision,
     };
   });
 }
 
 export async function discoverCustomProviderModels(
   apiBaseUrl: string,
+  envVarName?: string,
 ): Promise<DiscoveredCustomProviderModel[]> {
   const modelsUrl = buildCustomProviderModelDiscoveryUrl(apiBaseUrl);
-  const modelsResponse = await fetch(modelsUrl, {
+  const requestHeaders = buildCustomProviderRequestHeaders(envVarName);
+  const modelsResult = await fetchJsonWithTimeout<unknown>(modelsUrl, {
     method: "GET",
-    headers: { Accept: "application/json" },
+    headers: requestHeaders,
   });
 
-  if (!modelsResponse.ok) {
-    throw new DyadError(
-      `Failed to discover models for provider at ${apiBaseUrl}: ${modelsResponse.status}`,
-      DyadErrorKind.External,
-    );
+  if (!modelsResult || !modelsResult.response.ok) {
+    return [];
   }
 
-  const modelsPayload = await toJson<unknown>(modelsResponse);
+  const modelsPayload = modelsResult.json;
   const discoveredModels = getModelListFromOpenAICompatiblePayload(modelsPayload);
 
   if (discoveredModels.length === 0) {
@@ -248,40 +343,63 @@ export async function discoverCustomProviderModels(
   }
 
   const versionUrl = buildOllamaApiUrl(apiBaseUrl, "/api/version");
-  const versionResponse = await fetch(versionUrl, {
+  const versionResult = await fetchJsonWithTimeout<unknown>(versionUrl, {
     method: "GET",
-    headers: { Accept: "application/json" },
+    headers: requestHeaders,
   });
 
-  const isOllamaServer = versionResponse.ok;
+  const isOllamaServer =
+    versionResult != null &&
+    versionResult.response.ok &&
+    typeof versionResult.json === "object" &&
+    versionResult.json != null &&
+    "version" in versionResult.json;
+
   let ollamaPsResponse: unknown | null = null;
-  let ollamaShowResponse: unknown | null = null;
+  const ollamaShowResponsesByModel: Record<string, unknown> = {};
 
   if (isOllamaServer) {
-    const versionPayload = await toJson<unknown>(versionResponse);
-    const isOllama = typeof versionPayload === "object" && versionPayload != null && "version" in versionPayload;
-    if (isOllama) {
-      const psResponse = await fetch(buildOllamaApiUrl(apiBaseUrl, "/api/ps"), {
+    const psResult = await fetchJsonWithTimeout<unknown>(
+      buildOllamaApiUrl(apiBaseUrl, "/api/ps"),
+      {
         method: "GET",
-        headers: { Accept: "application/json" },
-      });
-      if (psResponse.ok) {
-        ollamaPsResponse = await toJson<unknown>(psResponse);
-      }
+        headers: requestHeaders,
+      },
+    );
+    if (psResult && psResult.response.ok) {
+      ollamaPsResponse = psResult.json;
+    }
 
-      const firstModelName = (discoveredModels[0] as { id?: string; name?: string; model?: string })?.id ?? (discoveredModels[0] as { id?: string; name?: string; model?: string })?.name ?? (discoveredModels[0] as { id?: string; name?: string; model?: string })?.model;
-      if (firstModelName) {
-        const showResponse = await fetch(buildOllamaApiUrl(apiBaseUrl, "/api/show"), {
+    const modelNames = Array.from(
+      new Set(
+        discoveredModels
+          .map((model) => {
+            const item = model as {
+              id?: string;
+              name?: string;
+              model?: string;
+            };
+            return item.id ?? item.name ?? item.model ?? "";
+          })
+          .filter((modelName): modelName is string => !!modelName),
+      ),
+    );
+
+    for (const modelName of modelNames) {
+      const showResult = await fetchJsonWithTimeout<unknown>(
+        buildOllamaApiUrl(apiBaseUrl, "/api/show"),
+        {
           method: "POST",
           headers: {
-            Accept: "application/json",
+            ...requestHeaders,
             "Content-Type": "application/json",
           },
-          body: JSON.stringify({ name: firstModelName }),
-        });
-        if (showResponse.ok) {
-          ollamaShowResponse = await toJson<unknown>(showResponse);
-        }
+          body: JSON.stringify({ name: modelName }),
+        },
+      );
+
+      if (showResult && showResult.response.ok) {
+        ollamaShowResponsesByModel[modelName] = showResult.json;
       }
     }
   }
@@ -289,7 +407,7 @@ export async function discoverCustomProviderModels(
   return normalizeDiscoveredCustomProviderModels(
     modelsPayload,
     ollamaPsResponse,
-    ollamaShowResponse,
+    ollamaShowResponsesByModel,
   );
 }
 
@@ -311,7 +429,10 @@ export async function refreshCustomProviderModels(
     );
   }
 
-  const discoveredModels = await discoverCustomProviderModels(provider.api_base_url);
+  const discoveredModels = await discoverCustomProviderModels(
+    provider.api_base_url,
+    provider.env_var_name ?? undefined,
+  );
   const syncedModels: LanguageModel[] = [];
 
   for (const model of discoveredModels) {

--- a/src/ipc/shared/custom_provider_model_probe.ts
+++ b/src/ipc/shared/custom_provider_model_probe.ts
@@ -1,0 +1,391 @@
+import { db } from "@/db";
+import {
+  language_model_providers,
+  language_models,
+} from "@/db/schema";
+import { DyadError, DyadErrorKind } from "@/errors/dyad_error";
+import type { LanguageModel } from "@/ipc/types";
+import { and, eq } from "drizzle-orm";
+
+const DEFAULT_CUSTOM_PROVIDER_CONTEXT_WINDOW = 128_000;
+
+function normalizeCustomProviderId(providerId: string): string {
+  return providerId.startsWith("custom::") ? providerId : `custom::${providerId}`;
+}
+
+export type DiscoveredCustomProviderModel = {
+  apiName: string;
+  displayName: string;
+  description?: string;
+  contextWindow?: number;
+  maxOutputTokens?: number;
+  temperature?: number;
+  vision?: boolean;
+};
+
+function asNumber(value: unknown): number | undefined {
+  if (value == null || value === "") {
+    return undefined;
+  }
+
+  const numericValue = Number(value);
+  return Number.isFinite(numericValue) ? numericValue : undefined;
+}
+
+function toJson<T>(payload: Response): Promise<T> {
+  return payload.json() as Promise<T>;
+}
+
+function trimBaseUrl(baseUrl: string): string {
+  return baseUrl.trim().replace(/\/+$/, "");
+}
+
+export function buildCustomProviderModelDiscoveryUrl(baseUrl: string): string {
+  const trimmed = trimBaseUrl(baseUrl);
+  if (!trimmed) {
+    return "/v1/models";
+  }
+
+  try {
+    const parsedUrl = new URL(trimmed);
+    const pathname = parsedUrl.pathname.replace(/\/+$/, "");
+    if (pathname.endsWith("/v1")) {
+      return `${trimmed}/models`;
+    }
+    return `${trimmed}/v1/models`;
+  } catch {
+    return `${trimmed}/v1/models`;
+  }
+}
+
+function buildOllamaApiUrl(baseUrl: string, path: string): string {
+  const trimmed = trimBaseUrl(baseUrl);
+  const withoutV1 = trimmed.replace(/\/v1$/, "");
+  return `${withoutV1}${path}`;
+}
+
+function getModelListFromOpenAICompatiblePayload(payload: unknown): unknown[] {
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+
+  if (payload && typeof payload === "object") {
+    const modelContainer = payload as { data?: unknown[]; models?: unknown[] };
+    if (Array.isArray(modelContainer.data)) {
+      return modelContainer.data;
+    }
+    if (Array.isArray(modelContainer.models)) {
+      return modelContainer.models;
+    }
+  }
+
+  return [];
+}
+
+function parseOllamaPsContextLength(payload: unknown): number | undefined {
+  if (!payload || typeof payload !== "object") {
+    return undefined;
+  }
+
+  const psPayload = payload as {
+    context_length?: unknown;
+    models?: Array<{ context_length?: unknown; name?: string }>; 
+  };
+
+  const directValue = asNumber(psPayload.context_length);
+  if (directValue != null) {
+    return directValue;
+  }
+
+  const firstModel = psPayload.models?.find((model) => model != null);
+  return asNumber(firstModel?.context_length);
+}
+
+function parseOllamaShowMetadata(
+  payload: unknown,
+  modelName: string,
+): { contextWindow?: number; temperature?: number; vision?: boolean } {
+  if (!payload || typeof payload !== "object") {
+    return {};
+  }
+
+  const showPayload = payload as {
+    context_length?: unknown;
+    temperature?: unknown;
+    model_info?: Record<string, unknown>;
+    general?: Record<string, unknown>;
+    model?: { context_length?: unknown; temperature?: unknown };
+  };
+
+  const nameKey = modelName;
+  const modelInfo = showPayload.model_info ?? {};
+  const general = showPayload.general ?? {};
+  const model = showPayload.model ?? {};
+
+  const contextWindow =
+    asNumber(showPayload.context_length) ??
+    asNumber(model.context_length) ??
+    asNumber(general.context_length) ??
+    asNumber(modelInfo.context_length) ??
+    asNumber(modelInfo[`${nameKey}.context_length`]);
+
+  const temperature =
+    asNumber(showPayload.temperature) ??
+    asNumber(model.temperature) ??
+    asNumber(general.temperature) ??
+    asNumber(modelInfo.temperature);
+
+  const vision =
+    Boolean(showPayload.model_info?.vision) ||
+    Boolean(showPayload.model_info?.[`vision.${nameKey}`]) ||
+    Boolean(general.vision) ||
+    Boolean(modelInfo.vision);
+
+  return { contextWindow, temperature, vision };
+}
+
+function determineModelContextWindow(
+  openAiContextWindow: number | undefined,
+  serverContextWindow: number | undefined,
+  modelCeiling: number | undefined,
+): number | undefined {
+  const candidateValues = [
+    serverContextWindow,
+    modelCeiling,
+    openAiContextWindow,
+  ].filter((value): value is number => value != null && Number.isFinite(value));
+
+  if (candidateValues.length === 0) {
+    return DEFAULT_CUSTOM_PROVIDER_CONTEXT_WINDOW;
+  }
+
+  if (candidateValues.length === 1) {
+    return candidateValues[0];
+  }
+
+  return Math.min(...candidateValues);
+}
+
+export function normalizeDiscoveredCustomProviderModels(
+  openAiModelsResponse: unknown,
+  ollamaPsResponse: unknown | null,
+  ollamaShowResponse: unknown | null,
+): DiscoveredCustomProviderModel[] {
+  const discoveredModels = getModelListFromOpenAICompatiblePayload(
+    openAiModelsResponse,
+  );
+
+  const serverWindow = parseOllamaPsContextLength(ollamaPsResponse);
+
+  return discoveredModels.map((model) => {
+    const item = model as {
+      id?: string;
+      name?: string;
+      model?: string;
+      display_name?: string;
+      displayName?: string;
+      max_model_len?: unknown;
+      maxModelLen?: unknown;
+      owned_by?: string;
+      object?: string;
+    };
+
+    const apiName = item.id ?? item.name ?? item.model ?? "";
+    const displayName = item.display_name ?? item.displayName ?? apiName;
+    const openAiContextWindow =
+      asNumber(item.max_model_len) ?? asNumber(item.maxModelLen);
+
+    const ollamaModelWindow =
+      ollamaShowResponse != null
+        ? parseOllamaShowMetadata(ollamaShowResponse, apiName).contextWindow
+        : undefined;
+
+    const effectiveContextWindow = determineModelContextWindow(
+      openAiContextWindow,
+      serverWindow,
+      ollamaModelWindow,
+    );
+
+    return {
+      apiName,
+      displayName,
+      description: item.owned_by ? `Owned by ${item.owned_by}` : undefined,
+      contextWindow: effectiveContextWindow,
+      maxOutputTokens: undefined,
+      temperature:
+        ollamaShowResponse != null
+          ? parseOllamaShowMetadata(ollamaShowResponse, apiName).temperature
+          : undefined,
+      vision:
+        ollamaShowResponse != null
+          ? parseOllamaShowMetadata(ollamaShowResponse, apiName).vision
+          : undefined,
+    };
+  });
+}
+
+export async function discoverCustomProviderModels(
+  apiBaseUrl: string,
+): Promise<DiscoveredCustomProviderModel[]> {
+  const modelsUrl = buildCustomProviderModelDiscoveryUrl(apiBaseUrl);
+  const modelsResponse = await fetch(modelsUrl, {
+    method: "GET",
+    headers: { Accept: "application/json" },
+  });
+
+  if (!modelsResponse.ok) {
+    throw new DyadError(
+      `Failed to discover models for provider at ${apiBaseUrl}: ${modelsResponse.status}`,
+      DyadErrorKind.External,
+    );
+  }
+
+  const modelsPayload = await toJson<unknown>(modelsResponse);
+  const discoveredModels = getModelListFromOpenAICompatiblePayload(modelsPayload);
+
+  if (discoveredModels.length === 0) {
+    return [];
+  }
+
+  const versionUrl = buildOllamaApiUrl(apiBaseUrl, "/api/version");
+  const versionResponse = await fetch(versionUrl, {
+    method: "GET",
+    headers: { Accept: "application/json" },
+  });
+
+  const isOllamaServer = versionResponse.ok;
+  let ollamaPsResponse: unknown | null = null;
+  let ollamaShowResponse: unknown | null = null;
+
+  if (isOllamaServer) {
+    const versionPayload = await toJson<unknown>(versionResponse);
+    const isOllama = typeof versionPayload === "object" && versionPayload != null && "version" in versionPayload;
+    if (isOllama) {
+      const psResponse = await fetch(buildOllamaApiUrl(apiBaseUrl, "/api/ps"), {
+        method: "GET",
+        headers: { Accept: "application/json" },
+      });
+      if (psResponse.ok) {
+        ollamaPsResponse = await toJson<unknown>(psResponse);
+      }
+
+      const firstModelName = (discoveredModels[0] as { id?: string; name?: string; model?: string })?.id ?? (discoveredModels[0] as { id?: string; name?: string; model?: string })?.name ?? (discoveredModels[0] as { id?: string; name?: string; model?: string })?.model;
+      if (firstModelName) {
+        const showResponse = await fetch(buildOllamaApiUrl(apiBaseUrl, "/api/show"), {
+          method: "POST",
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ name: firstModelName }),
+        });
+        if (showResponse.ok) {
+          ollamaShowResponse = await toJson<unknown>(showResponse);
+        }
+      }
+    }
+  }
+
+  return normalizeDiscoveredCustomProviderModels(
+    modelsPayload,
+    ollamaPsResponse,
+    ollamaShowResponse,
+  );
+}
+
+export async function refreshCustomProviderModels(
+  providerId: string,
+): Promise<LanguageModel[]> {
+  const normalizedProviderId = normalizeCustomProviderId(providerId);
+
+  const provider = db
+    .select()
+    .from(language_model_providers)
+    .where(eq(language_model_providers.id, normalizedProviderId))
+    .get();
+
+  if (!provider) {
+    throw new DyadError(
+      `Provider with ID "${providerId}" not found`,
+      DyadErrorKind.NotFound,
+    );
+  }
+
+  const discoveredModels = await discoverCustomProviderModels(provider.api_base_url);
+  const syncedModels: LanguageModel[] = [];
+
+  for (const model of discoveredModels) {
+    const modelQuery = db
+      .select()
+      .from(language_models)
+      .where(
+        and(
+          eq(language_models.customProviderId, normalizedProviderId),
+          eq(language_models.apiName, model.apiName),
+        ),
+      )
+      .get();
+
+    if (modelQuery) {
+      db.update(language_models)
+        .set({
+          displayName: model.displayName,
+          description: model.description ?? null,
+          max_output_tokens: model.maxOutputTokens ?? null,
+          context_window:
+            model.contextWindow ??
+            modelQuery.context_window ??
+            DEFAULT_CUSTOM_PROVIDER_CONTEXT_WINDOW,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(language_models.customProviderId, normalizedProviderId),
+            eq(language_models.apiName, model.apiName),
+          ),
+        )
+        .run();
+    } else {
+      const result = db
+        .insert(language_models)
+        .values({
+          displayName: model.displayName,
+          apiName: model.apiName,
+          customProviderId: normalizedProviderId,
+          description: model.description ?? null,
+          max_output_tokens: model.maxOutputTokens ?? null,
+          context_window:
+            model.contextWindow ?? DEFAULT_CUSTOM_PROVIDER_CONTEXT_WINDOW,
+        })
+        .run();
+
+      syncedModels.push({
+        id: Number(result.lastInsertRowid),
+        apiName: model.apiName,
+        displayName: model.displayName,
+        description: model.description,
+        maxOutputTokens: model.maxOutputTokens,
+        contextWindow: model.contextWindow,
+        temperature: model.temperature,
+        type: "custom",
+      });
+      continue;
+    }
+
+    syncedModels.push({
+      id: modelQuery.id,
+      apiName: model.apiName,
+      displayName: model.displayName,
+      description: model.description,
+      maxOutputTokens: model.maxOutputTokens,
+      contextWindow:
+        model.contextWindow ??
+        modelQuery.context_window ??
+        DEFAULT_CUSTOM_PROVIDER_CONTEXT_WINDOW,
+      temperature: model.temperature,
+      type: "custom",
+    });
+  }
+
+  return syncedModels;
+}

--- a/src/ipc/types/language-model.ts
+++ b/src/ipc/types/language-model.ts
@@ -128,6 +128,12 @@ export const languageModelContracts = {
     output: LanguageModelProviderSchema,
   }),
 
+  refreshCustomProviderModels: defineContract({
+    channel: "refresh-custom-provider-models",
+    input: z.object({ providerId: z.string() }),
+    output: z.array(LanguageModelSchema),
+  }),
+
   editCustomProvider: defineContract({
     channel: "edit-custom-language-model-provider",
     input: CreateCustomLanguageModelProviderParamsSchema,

--- a/src/ipc/utils/token_utils.test.ts
+++ b/src/ipc/utils/token_utils.test.ts
@@ -103,6 +103,19 @@ describe("getContextWindow", () => {
       getContextWindow({ provider: "provider", name: "cloud-model" }),
     ).resolves.toBe(128_000);
   });
+
+  it("rejects zero and negative configured values instead of trusting them", async () => {
+    mockFindLanguageModel.mockResolvedValueOnce({
+      apiName: "bad-model",
+      displayName: "Bad Model",
+      type: "cloud",
+      contextWindow: 0,
+    });
+
+    await expect(
+      getContextWindow({ provider: "provider", name: "bad-model" }),
+    ).resolves.toBe(128_000);
+  });
 });
 
 describe("getTemperature", () => {
@@ -190,5 +203,10 @@ describe("shouldTriggerCompaction", () => {
     expect(shouldTriggerCompaction(175_000, 200_000, "openai")).toBe(true);
     expect(shouldTriggerCompaction(174_999, 200_000, "openai")).toBe(false);
     expect(shouldTriggerCompaction(175_000, 200_000, "google")).toBe(true);
+  });
+
+  it("does not trigger compaction when the context window is zero or negative", () => {
+    expect(shouldTriggerCompaction(1, 0, "openai")).toBe(false);
+    expect(shouldTriggerCompaction(1, -1, "openai")).toBe(false);
   });
 });

--- a/src/ipc/utils/token_utils.test.ts
+++ b/src/ipc/utils/token_utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   getCompactionThreshold,
+  getContextWindow,
   getTemperature,
   estimateToolResultTokens,
   shouldTriggerCompaction,
@@ -87,6 +88,20 @@ describe("estimateToolResultTokens", () => {
     expect(estimateToolResultTokens([], toolErrors)).toBe(
       Math.ceil(serializedResult.length / 4),
     );
+  });
+});
+
+describe("getContextWindow", () => {
+  it("keeps the default 128k window when the model metadata does not specify one", async () => {
+    mockFindLanguageModel.mockResolvedValueOnce({
+      apiName: "cloud-model",
+      displayName: "Cloud Model",
+      type: "cloud",
+    });
+
+    await expect(
+      getContextWindow({ provider: "provider", name: "cloud-model" }),
+    ).resolves.toBe(128_000);
   });
 });
 

--- a/src/ipc/utils/token_utils.ts
+++ b/src/ipc/utils/token_utils.ts
@@ -5,6 +5,8 @@ import { getErrorMessage } from "@ai-sdk/provider";
 
 import { findLanguageModel } from "./findLanguageModel";
 
+export const DEFAULT_CONTEXT_WINDOW = 128_000;
+
 // Estimate tokens (4 characters per token)
 export const estimateTokens = (text: string): number => {
   return Math.ceil(text.length / 4);
@@ -63,12 +65,12 @@ export const estimateMessagesTokens = (messages: Message[]): number => {
   );
 };
 
-const DEFAULT_CONTEXT_WINDOW = 128_000;
-
-export async function getContextWindow(model?: LargeLanguageModel) {
+export async function getContextWindow(
+  model?: LargeLanguageModel,
+): Promise<number | undefined> {
   const selectedModel = model ?? readSettings().selectedModel;
   const modelOption = await findLanguageModel(selectedModel);
-  return modelOption?.contextWindow || DEFAULT_CONTEXT_WINDOW;
+  return modelOption?.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
 }
 
 export async function getMaxTokens(
@@ -98,9 +100,13 @@ export async function getTemperature(
  * providers retain the historical 250k cap.
  */
 export function getCompactionThreshold(
-  contextWindow: number,
+  contextWindow: number | undefined,
   provider: string,
 ): number {
+  if (contextWindow == null || !Number.isFinite(contextWindow)) {
+    return 0;
+  }
+
   const cap =
     provider === "google" ? 190_000 : provider === "openai" ? 220_000 : 250_000;
   return Math.min(cap, Math.max(0, contextWindow - 25_000));
@@ -111,8 +117,12 @@ export function getCompactionThreshold(
  */
 export function shouldTriggerCompaction(
   totalTokens: number,
-  contextWindow: number,
+  contextWindow: number | undefined,
   provider: string,
 ): boolean {
+  if (contextWindow == null || !Number.isFinite(contextWindow)) {
+    return false;
+  }
+
   return totalTokens >= getCompactionThreshold(contextWindow, provider);
 }

--- a/src/ipc/utils/token_utils.ts
+++ b/src/ipc/utils/token_utils.ts
@@ -65,12 +65,23 @@ export const estimateMessagesTokens = (messages: Message[]): number => {
   );
 };
 
+function isPositiveFiniteContextWindow(
+  value: number | undefined,
+): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
 export async function getContextWindow(
   model?: LargeLanguageModel,
 ): Promise<number | undefined> {
   const selectedModel = model ?? readSettings().selectedModel;
   const modelOption = await findLanguageModel(selectedModel);
-  return modelOption?.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
+
+  if (isPositiveFiniteContextWindow(modelOption?.contextWindow)) {
+    return modelOption.contextWindow;
+  }
+
+  return DEFAULT_CONTEXT_WINDOW;
 }
 
 export async function getMaxTokens(
@@ -103,7 +114,7 @@ export function getCompactionThreshold(
   contextWindow: number | undefined,
   provider: string,
 ): number {
-  if (contextWindow == null || !Number.isFinite(contextWindow)) {
+  if (!isPositiveFiniteContextWindow(contextWindow)) {
     return 0;
   }
 
@@ -120,7 +131,7 @@ export function shouldTriggerCompaction(
   contextWindow: number | undefined,
   provider: string,
 ): boolean {
-  if (contextWindow == null || !Number.isFinite(contextWindow)) {
+  if (!isPositiveFiniteContextWindow(contextWindow)) {
     return false;
   }
 


### PR DESCRIPTION

This change adds server probing for custom OpenAI-compatible providers and makes Dyad treat server-reported model metadata as authoritative.

Previously, custom provider models could silently fall back to a guessed 128k context window even when the provider never reported its actual model capabilities. This created a bad default that could affect token budgeting, compaction decisions, and model behavior without any real evidence from the server.

This patch fixes that by:
- probing custom provider models lazily when a provider is created or edited
- normalizing discovered models from OpenAI-compatible endpoints
- preferring the server’s reported context window when it is known
- keeping the existing fallback only as a conservative default when no real metadata is available

### What I added
#### 1. Lazy model probing for custom providers
I added a custom-provider model discovery flow that fetches model metadata from OpenAI-compatible endpoints and normalizes it into Dyad’s model format.

Relevant areas:
- custom_provider_model_probe.ts
- language_model_handlers.ts
- useCustomLanguageModelProvider.ts

#### 2. Prefer server truth over guessed values
Once a provider is probed successfully, the discovered metadata is used to populate the model’s known context window. If the server reports a value, it overrides stale or guessed user-entered data. If the server does not report a value, the app keeps the existing fallback.

Relevant logic:
- token_utils.ts


#### 3. Regression coverage
I added focused tests covering:
- context-window fallback behavior
- normalization of custom-provider model data
- cases where server metadata overrides default assumptions

Relevant tests:
- token_utils.test.ts
- custom_provider_model_probe.test.ts

### Why this is the right behavior
Custom providers are often self-hosted or OpenAI-compatible servers that expose model metadata differently across implementations. The app should trust the server when it can answer the question, rather than guessing a window that may be wrong.

The final policy is:
- default fallback remains as a conservative safety net
- successful probing overrides the fallback
- unknown values remain unknown instead of being treated as real
- custom providers are not crawled at startup

### Validation
Verified locally with:

```bash
cd "d:/dyad"; npm test -- src/ipc/shared/custom_provider_model_probe.test.ts src/ipc/utils/token_utils.test.ts
```

Result:
- 2 files passed
- 22 tests passed
- 0 failed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/dyad-sh/dyad/pull/4558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

